### PR TITLE
SEO: rewrite English homepage for fancy-text-generator intent

### DIFF
--- a/_root.html
+++ b/_root.html
@@ -12,8 +12,8 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title data-i18n="meta.title">Stylish Text Generator — Copy &amp; Paste Fancy Unicode Fonts</title>
-<meta name="description" data-i18n-content="meta.description" content="Turn plain text into stylish Unicode fonts you can copy and paste. Choose bold, cursive, gothic, and decorative styles for bios, usernames, comments, and posts.">
+<title data-i18n="meta.title">Fancy Text Generator — 60+ Unicode Fonts (Copy &amp; Paste)</title>
+<meta name="description" data-i18n-content="meta.description" content="Turn plain text into 60+ Unicode fonts — bold, italic, cursive, gothic, bubble, small caps, aesthetic, upside-down and Zalgo. Copy and paste straight into Instagram bios, TikTok captions, Discord names, LinkedIn headlines, and WhatsApp. Free, instant, no sign-up.">
 
 <link rel="canonical" href="https://ultratextgen.com/">
 
@@ -33,15 +33,15 @@
 <meta name="robots" content="index, follow">
 
 <meta property="og:site_name" content="UltraTextGen">
-<meta property="og:title" content="Stylish Text Generator — Copy & Paste Fancy Unicode Fonts">
-<meta property="og:description" content="Turn plain text into stylish Unicode fonts you can copy and paste. Choose bold, cursive, gothic, and decorative styles for bios, usernames, comments, and posts.">
+<meta property="og:title" content="Fancy Text Generator — 60+ Unicode Fonts (Copy & Paste)">
+<meta property="og:description" content="Turn plain text into 60+ Unicode fonts — bold, italic, cursive, gothic, bubble, small caps, aesthetic, upside-down and Zalgo. Paste straight into Instagram, TikTok, Discord, LinkedIn, and WhatsApp.">
 <meta property="og:url" content="https://ultratextgen.com/">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://ultratextgen.com/og.png">
 
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Stylish Text Generator — Copy & Paste Fancy Unicode Fonts">
-<meta name="twitter:description" content="Turn plain text into stylish Unicode fonts you can copy and paste. Choose bold, cursive, gothic, and decorative styles for bios, usernames, comments, and posts.">
+<meta name="twitter:title" content="Fancy Text Generator — 60+ Unicode Fonts (Copy & Paste)">
+<meta name="twitter:description" content="Turn plain text into 60+ Unicode fonts — bold, italic, cursive, gothic, bubble, small caps, aesthetic, upside-down and Zalgo. Paste straight into Instagram, TikTok, Discord, LinkedIn, and WhatsApp.">
 <meta name="twitter:image" content="https://ultratextgen.com/og.png">
 
 <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
@@ -81,17 +81,30 @@
   {
     "@context": "https://schema.org",
     "@type": "WebApplication",
-    "name": "UltraTextGen",
+    "name": "UltraTextGen Fancy Text Generator",
+    "alternateName": ["Unicode Font Generator", "Fancy Font Generator", "Stylish Text Generator", "Font Changer", "Copy and Paste Fonts"],
     "url": "https://ultratextgen.com/",
     "applicationCategory": "UtilitiesApplication",
+    "applicationSubCategory": "Text Generator",
     "operatingSystem": "All",
     "browserRequirements": "Requires JavaScript",
+    "isAccessibleForFree": true,
     "offers": {
       "@type": "Offer",
       "price": "0",
       "priceCurrency": "USD"
     },
-    "description": "Generate stylish Unicode text instantly for Instagram, TikTok, X, WhatsApp, and Discord. Copy and paste text styles for social bios, usernames, and posts."
+    "featureList": [
+      "60+ Unicode font styles (bold, italic, cursive, gothic, bubble, small caps, fullwidth, squared, parenthesized)",
+      "Aesthetic and decorative styles for Instagram, TikTok and Pinterest bios",
+      "Upside-down, mirror, backwards and Zalgo (glitch) text",
+      "One-click style mixing and decorative frames, borders, dividers and symbols",
+      "Vertical and stacked text generator",
+      "Copy and paste into Instagram, TikTok, Discord, LinkedIn, WhatsApp, X (Twitter), Snapchat, Roblox, Steam and email subject lines",
+      "Real-time preview as you type",
+      "Runs entirely in the browser — no sign-up, no account, no tracking of input text"
+    ],
+    "description": "Free fancy text generator that turns plain text into 60+ copy-and-paste Unicode fonts — bold, italic, cursive, gothic, bubble, small caps, aesthetic, upside-down and Zalgo — for Instagram, TikTok, Discord, LinkedIn and WhatsApp bios, captions and usernames."
   }
 ]
 </script>
@@ -106,90 +119,106 @@
   "mainEntity": [
     {
       "@type": "Question",
-      "name": "What can a Unicode text generator do that a rich text editor cannot?",
+      "name": "What is a fancy text generator?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Rich text editors like Google Docs or Microsoft Word give you bold, italic, and underline — but those styles vanish the moment you paste into a social media bio, a username field, or a plain-text email. A Unicode text generator unlocks styles and effects that no rich text editor can produce in those contexts. <br><br> <strong>Things UltraTextGen can do that rich text cannot</strong><br> — Bold and italic text inside Instagram bios, TikTok captions, and YouTube descriptions where no formatting toolbar exists.<br> — Gothic, Bubble, and Cursive font styles that rich text editors don't offer at all.<br> — Upside-down and flipped text — impossible in any word processor.<br> — Zalgo (glitch) text with stacked diacritics for a creepy, corrupted look.<br> — Decorative frames, borders, and wrappers around your text using Unicode symbols.<br> — Styled usernames and display names on Discord, Roblox, Steam, and other platforms.<br> — Strikethrough and underline text in places that don't support those formatting options natively. <br><br> In short, UltraTextGen gives you visual text effects that travel with the characters, so they work wherever plain text is accepted."
+        "text": "A fancy text generator is a tool that replaces each letter you type with a different Unicode character that already looks bold, italic, cursive, gothic, bubble, or otherwise styled. Because the output is real Unicode — not a font file or Markdown — you can copy and paste it into Instagram bios, TikTok captions, Discord names, LinkedIn headlines, WhatsApp statuses, and anywhere else that only accepts plain text."
       }
     },
     {
       "@type": "Question",
-      "name": "Why should I choose UltraTextGen over other text generators?",
+      "name": "How do I make my Instagram bio bold or italic?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "UltraTextGen is built to be the most complete and easiest-to-use Unicode text generator available. <br><br> <strong>What sets it apart</strong><br> — One of the largest collections of premium \"Ultra\" styled fonts.<br> — True style mixing: combine multiple styles in one click, something most generators don't support.<br> — One-click decorations: add frames, borders, symbols, and dividers without manual copy-pasting.<br> — Dedicated platform pages for TikTok, Discord, Instagram, and more — so you get styles tested for your platform.<br> — Fast, clean interface with no pop-ups slowing you down.<br> — Constantly updated with new styles and decorations."
+        "text": "Instagram has no formatting toolbar in the bio, caption, or comment fields, so the only way to get bold or italic is to paste in Unicode characters that already look styled. Type your bio in UltraTextGen, pick a bold or italic style, tap Copy, then paste into the bio field in the Instagram app. The bold and italic sans-serif styles have the widest device support; avoid Zalgo and fullwidth in the username field because Instagram's username filter will reject them."
       }
     },
     {
       "@type": "Question",
-      "name": "What font styles does UltraTextGen offer?",
+      "name": "Can I bold text on Discord without Nitro?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "UltraTextGen has one of the largest collections of high-quality Unicode text styles, all prefixed with \"Ultra\" for superior look and coverage. <br><br> <strong>Core styles</strong><br> Ultra Bold and Ultra Bold Serif, Ultra Italic (multiple variants), Ultra Script and Ultra Script Bold, Ultra Gothic, Ultra Bubble (Filled, Light, Tiles, Curly, Angle, Spaced, and more), Ultra Strike, and Ultra Underline. <br><br> <strong>Special styles</strong><br> Upside Down and Flipped, Small Caps, Zalgo (Glitch), Word Wrappers and Frames, Backwards and Mirror, Double Struck, Fullwidth, Squared, Parenthesized, and many more. <br><br> New styles are added regularly, so bookmark the site or check back often."
+        "text": "Yes. Discord uses Markdown (**text** for bold, *text* for italic) inside chat messages, but Markdown does not work in your display name, server nickname, status, or About me. Unicode bold and italic work in all of those places without Nitro, because the characters themselves are bold — Discord doesn't have to render them as bold. Paste 𝗯𝗼𝗹𝗱 into your nickname and it stays bold everywhere your name appears."
       }
     },
     {
       "@type": "Question",
-      "name": "Are there any characters that don't convert?",
+      "name": "What font does LinkedIn use, and why does Unicode bold work in headlines?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Most English letters (A–Z, a–z), numbers (0–9), and basic punctuation convert perfectly across all styles. Some very rare symbols or special characters may have fewer style options because Unicode doesn't include styled variants for every character. <br><br> If a character cannot be converted, it simply stays as normal text — it never breaks or produces errors. Your output will always be usable."
+        "text": "LinkedIn uses its own typeface called LinkedIn Sans for almost all on-platform text. LinkedIn does not provide a formatting toolbar for your headline, About section, or post body — there's no bold button. Unicode bold works because the characters are different code points entirely, so LinkedIn Sans simply renders them as the bold-looking glyphs they already are. Use sans-serif bold for a professional look; avoid Zalgo, fullwidth, and heavily decorated styles, which trip recruiter search filters and cause issues for screen readers."
       }
     },
     {
       "@type": "Question",
-      "name": "What is Zalgo or glitch text and how do I use it?",
+      "name": "How do I make vertical or stacked text (top-to-bottom)?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Zalgo text is the creepy, glitchy, \"cursed\" style that adds stacked diacritics above and below each character, making the text look corrupted or haunted. <br><br> <strong>Example</strong><br> \"hello\" → h̷e̷l̷l̷o̷ <br><br> It's popular for horror-themed memes, edgy social media bios, spooky usernames, and pranking friends in group chats. Just type your text, select the Zalgo style, copy, and paste — UltraTextGen handles the stacking automatically."
+        "text": "Vertical text — sometimes called stacked text — places each letter on its own line so the word reads top to bottom. It's popular for Pinterest pins, Discord channel banners, and aesthetic Instagram posts. UltraTextGen's vertical text generator handles the line breaks and lets you pick a style (bold, cursive, fullwidth) for the stacked letters."
       }
     },
     {
       "@type": "Question",
-      "name": "How is Unicode text different from bold and italic in Word, Instagram, or Discord?",
+      "name": "How is a Unicode font different from a regular font like Arial or Helvetica?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Regular bold and italic use formatting codes — often called markup or rich text — that only work inside the app that supports them. For example, Discord uses **text** for bold, and Instagram captions have no formatting options at all. <br><br> UltraTextGen works differently. It replaces each letter with a unique Unicode character that already looks styled. The result is plain text that appears bold, italic, cursive, or decorated without any formatting engine behind it. <br><br> <strong>Why this matters</strong><br> Rich text bold disappears if you copy it into a TikTok caption, an email subject line, or a username field — those places strip formatting. Unicode text keeps its style because the characters themselves are styled. There is nothing to strip. <br><br> <strong>Example</strong><br> A rich text editor makes the word \"Sale\" bold by wrapping it in invisible codes. Copy that into a TikTok bio and it becomes plain \"Sale.\" With UltraTextGen, \"Sale\" becomes 𝗦𝗮𝗹𝗲 — and it stays that way in your bio, your username, your email subject, and everywhere else."
+        "text": "A regular font is a file stored on your device that tells the screen how to draw each letter. If a website doesn't load the font, the letter still says \"A\" — it just gets drawn differently. Unicode \"fonts\" are not fonts in that sense. They are separate characters in the Unicode standard with different code points: A, 𝐀, 𝘈, 𝓐, 𝔄, 𝕬, Ⓐ. That's why they survive copy-paste — you are using a different letter that happens to look styled, not styling the letter you typed."
       }
     },
     {
       "@type": "Question",
-      "name": "Can I use bold Unicode text in email subject lines?",
+      "name": "Why does some of my styled text show up as boxes (□) or question marks?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes — and this is a perfect example of something a rich text editor cannot do. Email subject lines are plain text, so regular bold formatting is stripped out before the recipient sees it. <br><br> With UltraTextGen, you can paste Unicode bold characters directly into the subject line and the recipient sees them as bold in their inbox. <br><br> <strong>Example</strong><br> Normal subject line: \"Flash Sale — 50% Off Today\"<br> Unicode subject line: \"𝗙𝗹𝗮𝘀𝗵 𝗦𝗮𝗹𝗲 — 𝟱𝟬% 𝗢𝗳𝗳 𝗧𝗼𝗱𝗮𝘆\" <br><br> The bold version stands out in a crowded inbox without any special email tools. Most major email clients — Gmail, Outlook, Apple Mail — render Unicode characters correctly."
+        "text": "Boxes or tofu (□ ▯ �) appear when the device viewing the text has no installed font that contains a glyph for that specific Unicode code point. It's a rendering gap on the viewer's side, not a problem with your copied text. To get the widest compatibility, stick to bold (sans and serif), italic, monospace, small caps, fullwidth, and circled — these are covered by the default system fonts on iOS, Android, Windows, macOS, and Chrome OS. Cursive script and bubble variants render on most phones from 2018 onwards. Zalgo can look clipped or misaligned in apps with tight line spacing — that's by design."
       }
     },
     {
       "@type": "Question",
-      "name": "Can I combine multiple styles and add decorations to my text?",
+      "name": "Are these Unicode fonts safe to use for screen readers and accessibility?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes — style mixing and one-click decorations are two of UltraTextGen's biggest advantages over other generators. <br><br> You can layer styles together, such as Bubble + Zalgo, Gothic + Upside Down, or Small Caps + Underline, and then wrap the result with decorative elements. <br><br> <strong>Available decorations</strong><br> Frames and borders (for example ★彡[ text ]彡★ or ╭─▸ text ╰─▸), arrows, symbols, minimal dividers, emojis, and flags. <br><br> <strong>Example</strong><br> Start with \"hello\" → apply Ultra Gothic → add a star frame → result: ★彡[ 𝔥𝔢𝔩𝔩𝔬 ]彡★ <br><br> No other generator makes mixing and decorating this easy."
+        "text": "Mostly no — and this is the honest answer most generators won't give you. Screen readers like VoiceOver, TalkBack, and JAWS read each Unicode code point literally. The character 𝐀 is announced as \"Mathematical Bold Capital A,\" not as \"A.\" That makes styled text a poor choice for body content, captions someone might rely on, and anything in a professional or accessibility-sensitive setting. Use it sparingly: a couple of styled words in a headline are fine, a whole bio in Zalgo is not. Keep your @username or handle in plain text whenever the platform shows a separate display name."
       }
     },
     {
       "@type": "Question",
-      "name": "Why does some styled text show as boxes or question marks on certain platforms?",
+      "name": "What is Zalgo (glitch) text and where do people actually use it?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "This happens when the font installed on the viewer's device does not include glyphs for those particular Unicode characters. It is not a problem with the text itself — on most modern devices and browsers, the vast majority of styles display correctly. <br><br> <strong>What to do</strong><br> If you notice boxes or missing characters, try a different style. Core styles like Ultra Bold, Ultra Italic, and Ultra Bubble have the widest device support. You can also use our platform-specific pages (like Discord or Instagram) to find styles tested for that app."
+        "text": "Zalgo text is the cursed, glitched, dripping look made by stacking dozens of combining diacritic marks above and below each character — for example h̷̢̛e̴̜͝l̸̼͝l̷͔͠o̵̗͝. It's a meme aesthetic that originated on 4chan around 2009 and stuck around through r/creepypasta, horror TikTok edits, dark academia tumblrs, and edgy Discord display names. Avoid it in usernames most platforms will reject the combining marks and in LinkedIn headlines unless your brand actively benefits from looking unhinged."
       }
     },
     {
       "@type": "Question",
-      "name": "Can I use Unicode text for usernames and display names?",
+      "name": "Can I stack multiple styles together (e.g., bubble + small caps)?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Absolutely. Unicode characters are accepted in most username and display name fields — including Instagram, TikTok, Discord, Roblox, Steam, and many other platforms. <br><br> <strong>Example</strong><br> Normal username: \"DarkWolf\"<br> Unicode username: \"𝔇𝔞𝔯𝔨𝔚𝔬𝔩𝔣\" (Gothic) or \"ⒹⓐⓡⓚⓌⓞⓛⓕ\" (Bubble) <br><br> This is something a rich text editor can never do — username fields only accept plain text, and Unicode styled characters count as plain text. <br><br> <strong>Tip</strong><br> If a platform rejects certain characters in the username field, try a different style. Some styles have wider compatibility than others."
+        "text": "Yes — style mixing is one of the things you can't do with a normal font. Type your text, apply a base style like Ultra Bubble, then layer Small Caps or Underline on top, and add a frame or divider on either side. Example: hello → apply Gothic → wrap in a star frame → ★彡[ 𝔥𝔢𝔩𝔩𝔬 ]彡★. The combinations that look cleanest are Bold + Underline, Italic + Small Caps, and Bubble + Spaced for aesthetic posts."
       }
     },
     {
       "@type": "Question",
-      "name": "How do I find the right font style or tool for my needs?",
+      "name": "What languages and alphabets work?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "UltraTextGen organises styles and tools in three ways: <br><br> <strong>By font style</strong><br> Browse all font categories — bold, cursive, gothic, bubble, strikethrough, underline, upside-down, and more. <br><br> <strong>By platform</strong><br> Use a platform-specific generator for styles optimised for that platform's rules. <br><br> <strong>By task</strong><br> Visit the use case page for task-specific tools — comment fonts, emoji combinations, and more."
+        "text": "Unicode styled variants only exist for the Latin alphabet (A–Z) and Arabic digits (0–9). That means every language using Latin script works for styling — English, Spanish, French, Portuguese, German, Italian, Dutch, Polish, Vietnamese, Turkish, Indonesian, Tagalog, Afrikaans, Swahili, and dozens more. Languages written in Arabic, Hebrew, Devanagari (Hindi, Marathi), Bengali, Tamil, Thai, Chinese, Japanese, Korean, Cyrillic, or Greek will not transform — there are no styled variants of those characters in Unicode. Latin-script words inside non-Latin sentences (brand names, hashtags) will still convert."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is the text I type stored, logged, or shared?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. All transformation happens in your browser using JavaScript — nothing you type is sent to a server. There are no hidden tracking characters or zero-width spaces added to the output. What you copy is clean Unicode and nothing else. The site uses Google Tag Manager for anonymous usage analytics (page views, which styles get used) but it never sees the contents of your input."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is UltraTextGen free, and is there a catch?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Free, no account, no daily limit, no watermark, no email capture, no paid tiers. The site is funded by Google AdSense — that's the catch. We do not charge per copy, we do not gate styles behind a sign-up, and we do not insert affiliate links into the styled text you paste."
       }
     }
   ]
@@ -208,8 +237,8 @@
   <section class="hero">
     <div class="hero-inner">
       <div class="hero-card">
-        <h1 class="hero-headline" data-i18n="hero.title">Stylish Font Generator</h1>
-        <p class="hero-tagline" data-i18n="hero.subtitle">Turn plain text into bold, cursive, gothic, and decorative Unicode fonts you can copy and paste instantly.</p>
+        <h1 class="hero-headline" data-i18n="hero.title">Fancy Text Generator</h1>
+        <p class="hero-tagline" data-i18n="hero.subtitle">Type once, get 60+ Unicode fonts you can copy and paste anywhere — Instagram bios, TikTok captions, Discord names, LinkedIn headlines, WhatsApp, email subject lines, even game profiles.</p>
         <div class="input-wrapper">
           <textarea class="main-input" id="mainInput" placeholder="Type your text here..." data-i18n-placeholder="ui.placeholder" maxlength="500" autofocus></textarea>
           <button class="input-clear-btn" id="inputClearBtn" aria-label="Clear input" hidden>✕</button>
@@ -252,24 +281,79 @@
     <div class="results-grid" id="resultsGrid"></div>
   </main>
 
+  <!-- Intro / topical anchor -->
+  <section class="editorial-section" aria-labelledby="intro-heading">
+    <h2 id="intro-heading">What this fancy text generator actually does</h2>
+    <p>
+      UltraTextGen is a free Unicode font generator. You type plain text, it swaps each letter for a styled character that lives inside the Unicode standard, and you copy the result wherever you want it: an Instagram bio, a TikTok caption, a Discord display name, a LinkedIn headline, a Roblox profile, a WhatsApp status, even an email subject line. Because the styled letters <em>are</em> the text — not a font file your phone has to load, and not Markdown that gets stripped — they survive copy-paste into apps that don&rsquo;t allow formatting.
+    </p>
+    <p>
+      Type <code>hello</code> and you get:
+      𝗵𝗲𝗹𝗹𝗼 (bold),
+      𝘩𝘦𝘭𝘭𝘰 (italic),
+      𝒽ℯ𝓁𝓁ℴ (cursive script),
+      𝔥𝔢𝔩𝔩𝔬 (gothic),
+      🅗🅔🅛🅛🅞 (bubble),
+      ʰᵉˡˡᵒ (tiny / superscript),
+      ʜᴇʟʟᴏ (small caps),
+      ⓗⓔⓛⓛⓞ (circled),
+      ｈｅｌｌｏ (fullwidth),
+      h̶e̶l̶l̶o̶ (strikethrough),
+      h̳e̳l̳l̳o̳ (underline),
+      oʅʅǝɥ (upside-down),
+      ollǝɥ (mirror),
+      h̷̢̛e̴̜͝l̸̼͝l̷͔͠o̵̗͝ (Zalgo / glitch),
+      and roughly 50 more — including aesthetic spaced styles like <strong>𝓱 𝓮 𝓵 𝓵 𝓸</strong> people use for Pinterest pins and Y2K-style usernames.
+    </p>
+    <h3>Where these fonts actually work (and where they don&rsquo;t)</h3>
+    <p>
+      Compatibility varies because Unicode rendering depends on the device font, not the website. Here&rsquo;s what we&rsquo;ve tested:
+    </p>
+    <ul class="compat-list">
+      <li><strong>Instagram</strong> — bio, post caption, comments, story stickers: works in every style. Username field: works only with Latin-script styles (bold, italic, cursive, bubble); won&rsquo;t accept Zalgo or fullwidth.</li>
+      <li><strong>TikTok</strong> — bio, caption, comments, video description: works in all core styles. The "nickname" field is more permissive than Instagram&rsquo;s username.</li>
+      <li><strong>Discord</strong> — server nickname, display name, messages, &ldquo;About me&rdquo;: Unicode fonts work without Nitro. Markdown bold (<code>**text**</code>) only renders inside messages; Unicode bold renders <em>everywhere</em>, including your nickname.</li>
+      <li><strong>LinkedIn</strong> — headline, About section, post body: bold, italic and small caps render reliably. Avoid Zalgo and heavily decorated styles on a professional profile — they trigger recruiter filters and screen-reader issues.</li>
+      <li><strong>WhatsApp</strong> — status, group names, broadcasts: all Unicode fonts work. WhatsApp&rsquo;s own <code>*bold*</code>, <code>_italic_</code> and <code>~strike~</code> only render inside chat messages, so Unicode is the only option for status and group names.</li>
+      <li><strong>X (Twitter)</strong> — display name, bio, tweets: works everywhere. Some Zalgo styles get visually clipped on mobile.</li>
+      <li><strong>Snapchat, Pinterest, Telegram, Signal, iMessage</strong> — bios, captions, messages: all work.</li>
+      <li><strong>Roblox, Steam, Minecraft, Fortnite</strong> — display names usually accept bold/italic/gothic. Each platform&rsquo;s name filter rejects different characters — try a different style if one is blocked.</li>
+      <li><strong>Email subject lines</strong> (Gmail, Outlook, Apple Mail) — render Unicode fonts as written. This is the one place where there is no rich-text alternative.</li>
+      <li><strong>Won&rsquo;t work:</strong> Microsoft Word, Google Docs body text styling (use the built-in toolbar instead), printed documents with non-Unicode fonts, and anywhere the recipient&rsquo;s device is missing the glyph (rare on phones made after 2018).</li>
+    </ul>
+    <h3>Why Unicode fonts ≠ regular fonts</h3>
+    <p>
+      A regular font (Helvetica, Arial, the LinkedIn Sans typeface, etc.) is a file that lives on your device and tells the screen how to draw a letter. If the website doesn&rsquo;t load that font, the letter still says "A" — it just gets drawn in a default font instead. Unicode &ldquo;fonts&rdquo; aren&rsquo;t fonts at all in that sense. They&rsquo;re separate characters in the Unicode standard — A, 𝐀, 𝘈, 𝓐, 𝔄, 𝕬, Ⓐ are all different characters with different code points. That&rsquo;s why they travel: you&rsquo;re not styling the letter A, you&rsquo;re using a different letter entirely that happens to look styled.
+    </p>
+    <h3>What&rsquo;s in the library</h3>
+    <p>
+      About 65 styles across twelve families: <strong>bold</strong> (sans, serif, italic-bold), <strong>italic</strong>, <strong>cursive / script</strong> (regular and bold), <strong>gothic / fraktur</strong>, <strong>bubble</strong> (filled, light, tiles, curly, angle, spaced, and more — 12 variants), <strong>strikethrough</strong> (slash, tilde, short, long), <strong>underline</strong>, <strong>monospace / fullwidth</strong>, <strong>small caps and superscript</strong>, <strong>aesthetic / spaced</strong>, <strong>upside-down + mirror + backwards</strong>, <strong>Zalgo (glitch)</strong>, and ten decorative <strong>word wrappers</strong> that auto-bracket each word with symbols. Stack two styles together with one click, or wrap the whole result in a frame, divider, arrow, emoji or flag.
+    </p>
+  </section>
+
   <!-- Popular Use Cases -->
   <section class="editorial-section">
-    <h2 data-i18n="useCases.title">Popular Use Cases</h2>
+    <h2 data-i18n="useCases.title">What people actually use this for</h2>
     <div class="tips-grid">
-      <a class="tip-card" href="/usecase/linkedin-headline/" aria-label="LinkedIn Headline use case">
+      <a class="tip-card" href="/usecase/linkedin-headline/" aria-label="LinkedIn headline font generator">
         <div class="tip-icon">💼</div>
-        <h3 data-i18n="useCases.items.0.title">LinkedIn Headline</h3>
-        <p data-i18n="useCases.items.0.description">Make your LinkedIn headline stand out with bold and italic Unicode text that grabs attention in search results.</p>
+        <h3 data-i18n="useCases.items.0.title">LinkedIn headlines &amp; posts</h3>
+        <p data-i18n="useCases.items.0.description">𝗕𝗼𝗹𝗱 your title, italicise your role, or break long posts with small caps. Unicode is the only way to format a LinkedIn headline — there&rsquo;s no toolbar.</p>
       </a>
-      <a class="tip-card" href="/usecase/comment-font/" aria-label="Comment Fonts use case">
+      <a class="tip-card" href="/usecase/comment-font/" aria-label="Comment fonts for Instagram, YouTube and TikTok">
         <div class="tip-icon">💬</div>
-        <h3 data-i18n="useCases.items.1.title">Comment Fonts</h3>
-        <p data-i18n="useCases.items.1.description">Post eye-catching comments on Instagram, YouTube, and TikTok with styled Unicode fonts that pop.</p>
+        <h3 data-i18n="useCases.items.1.title">Comments that stop the scroll</h3>
+        <p data-i18n="useCases.items.1.description">Reply on Instagram, YouTube, TikTok or Reddit with 𝓼𝓬𝓻𝓲𝓹𝓽, 🅑🅤🅑🅑🅛🅔 or ᵗⁱⁿʸ text so your comment isn&rsquo;t lost in a wall of identical replies.</p>
       </a>
-      <a class="tip-card" href="/usecase/text-to-emoji/" aria-label="Text to Emoji use case">
-        <div class="tip-icon">😊</div>
-        <h3 data-i18n="useCases.items.2.title">Text to Emoji</h3>
-        <p data-i18n="useCases.items.2.description">Convert your text into emoji letter sequences — perfect for creative bios, stories, and group chats.</p>
+      <a class="tip-card" href="/usecase/vertical-text/" aria-label="Vertical and stacked text generator">
+        <div class="tip-icon">↕️</div>
+        <h3 data-i18n="useCases.items.2.title">Vertical &amp; stacked text</h3>
+        <p data-i18n="useCases.items.2.description">Stack letters top-to-bottom for Pinterest pins, Discord banners, and Instagram aesthetic posts — the format people search for as "stacked text" or "vertical font generator."</p>
+      </a>
+      <a class="tip-card" href="/discord/" aria-label="Discord font generator">
+        <div class="tip-icon">🎮</div>
+        <h3 data-i18n="useCases.items.3.title">Discord names (no Nitro)</h3>
+        <p data-i18n="useCases.items.3.description">Style your display name, server nickname or "About me" with fonts Discord renders natively. No Nitro required, and they show up in every server.</p>
       </a>
     </div>
     <p style="text-align:center;margin-top:1.5rem"><a class="cat-cta" href="/usecase/" data-i18n="useCases.viewAll">View all use cases →</a></p>
@@ -300,22 +384,27 @@
 
   <!-- Popular Categories -->
   <section class="editorial-section">
-    <h2>Popular Font Categories</h2>
+    <h2>Popular font categories</h2>
     <div class="tips-grid">
-      <a class="tip-card" href="/category/bold-fonts/" aria-label="Bold Fonts category">
+      <a class="tip-card" href="/category/bold-fonts/" aria-label="Bold font generator">
         <div class="tip-icon">🅱️</div>
-        <h3>Bold Fonts</h3>
-        <p>Command attention with strong, confident Unicode bold text for headlines, LinkedIn posts, and key messages.</p>
+        <h3>Bold (𝗕𝗼𝗹𝗱 / 𝐁𝐨𝐥𝐝)</h3>
+        <p>The most-used style on the site. Sans and serif variants, plus bold-italic. Use it for the first line of a LinkedIn post, the hook in an Instagram caption, or to make a single word in a paragraph carry weight.</p>
       </a>
-      <a class="tip-card" href="/category/cursive-fonts/" aria-label="Cursive Fonts category">
+      <a class="tip-card" href="/category/cursive-fonts/" aria-label="Cursive and script font generator">
         <div class="tip-icon">✍️</div>
-        <h3>Cursive Fonts</h3>
-        <p>Add elegance and personality with flowing cursive Unicode styles — perfect for Instagram bios and aesthetic captions.</p>
+        <h3>Cursive &amp; script (𝓒𝓾𝓻𝓼𝓲𝓿𝓮)</h3>
+        <p>Two flowing script variants. People paste these into Instagram bios, Pinterest pin titles, wedding-y captions, and aesthetic usernames. Bold script reads better at small sizes — use it on TikTok.</p>
       </a>
-      <a class="tip-card" href="/category/gothic-fonts/" aria-label="Gothic Fonts category">
+      <a class="tip-card" href="/category/gothic-fonts/" aria-label="Gothic and fraktur font generator">
         <div class="tip-icon">🖤</div>
-        <h3>Gothic Fonts</h3>
-        <p>Make a dramatic statement with bold gothic letterforms that stand out in gaming profiles and edgy branding.</p>
+        <h3>Gothic / fraktur (𝔊𝔬𝔱𝔥𝔦𝔠)</h3>
+        <p>Old-English / Fraktur letterforms. Common in gaming clan tags, metal/horror branding, dark academia bios, and Discord display names. Looks heaviest at large sizes — pair with one decorative symbol, not five.</p>
+      </a>
+      <a class="tip-card" href="/category/bubble-fonts/" aria-label="Bubble and aesthetic font generator">
+        <div class="tip-icon">🫧</div>
+        <h3>Bubble &amp; aesthetic (🅑🅤🅑🅑🅛🅔)</h3>
+        <p>12 bubble variants plus aesthetic spaced styles. Top pick for Y2K, kidcore, and "aesthetic font copy and paste" energy on TikTok, Pinterest, and Tumblr. Filled-bubble has the widest device support; the rest can break on older Android.</p>
       </a>
     </div>
     <p style="text-align:center;margin-top:1.5rem"><a class="cat-cta" href="/category/">Browse all font categories →</a></p>
@@ -325,425 +414,317 @@
   <section class="faq-section-wrapper" aria-label="Frequently asked questions">
     <div class="faq-inner">
 
-<!-- Getting Started -->
-<h2 class="faq-category" data-i18n="faq.categories.0.title">Getting Started with UltraTextGen</h2>
+<!-- Basics -->
+<h2 class="faq-category" data-i18n="faq.categories.0.title">Fancy text generator basics</h2>
 
 <div class="faq-item">
   <button class="faq-question" type="button">
-    <span data-i18n="faq.categories.0.items.0.question">What is UltraTextGen and how does it work?</span>
+    <span data-i18n="faq.categories.0.items.0.question">What is a fancy text generator?</span>
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
     </svg>
   </button>
   <div class="faq-answer" data-i18n-html="faq.categories.0.items.0.answer">
-    UltraTextGen is a free online Unicode text generator that instantly converts your normal text into stylish, fancy fonts and decorations.
-    Unlike formatting tools that rely on app-specific markup, UltraTextGen replaces each letter with a real Unicode character that looks bold, italic, cursive, gothic, or decorated.
+    A fancy text generator is a tool that replaces each letter you type with a different Unicode character that already looks bold, italic, cursive, gothic, bubble, or otherwise styled. Type <code>hello</code>, get 𝗵𝗲𝗹𝗹𝗼, 𝘩𝘦𝘭𝘭𝘰, 𝒽ℯ𝓁𝓁ℴ, 𝔥𝔢𝔩𝔩𝔬, 🅗🅔🅛🅛🅞.
     <br><br>
-    <strong>Example</strong><br>
-    Type "hello" → get 𝗵𝗲𝗹𝗹𝗼 (Ultra Bold), 𝘩𝘦𝘭𝘭𝘰 (Ultra Italic), 𝒽ℯ𝓁𝓁ℴ (Ultra Script), or ⓗⓔⓛⓛⓞ (Ultra Bubble).
-    <br><br>
-    Because these are real characters — not formatting codes — they work everywhere plain text is accepted: social media bios, usernames, captions, messages, emails, and more.
-    No apps to install, no sign-up, and no limits.
+    Because the output is real Unicode — not a font file or Markdown — you can copy and paste it into Instagram bios, TikTok captions, Discord names, LinkedIn headlines, WhatsApp statuses, email subject lines, and anywhere else that only accepts plain text.
   </div>
 </div>
 
 <div class="faq-item">
   <button class="faq-question" type="button">
-    <span data-i18n="faq.categories.0.items.1.question">How do I generate and copy styled text?</span>
+    <span data-i18n="faq.categories.0.items.1.question">How is a Unicode font different from a regular font like Arial or Helvetica?</span>
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
     </svg>
   </button>
   <div class="faq-answer" data-i18n-html="faq.categories.0.items.1.answer">
-    Generating styled text takes just a few seconds.
+    A regular font is a file stored on your device that tells the screen how to draw each letter. If a website doesn&rsquo;t load the font, the letter still says "A" — it just gets drawn in a default font.
     <br><br>
-    <strong>Step-by-step</strong><br>
-    1. Type or paste your text into the input box on the homepage.<br>
-    2. Styled versions appear instantly below the input.<br>
-    3. Browse styles or pick a category like Bold, Cursive, or Gothic.<br>
-    4. Optionally click "Add decoration" to add frames, symbols, or dividers.<br>
-    5. Click "Copy" next to any style and paste it wherever you want.
+    Unicode "fonts" are not fonts in that sense. They&rsquo;re separate characters in the Unicode standard with their own code points: A, 𝐀, 𝘈, 𝓐, 𝔄, 𝕬, Ⓐ are six different letters. That&rsquo;s why they survive copy-paste — you&rsquo;re not styling the letter A, you&rsquo;re using a different letter that happens to look styled.
     <br><br>
-    That's it — no account needed and the tool works on both desktop and mobile.
+    The downside: screen readers will read 𝐀 as "Mathematical Bold Capital A," not "A." Use Unicode fonts for headlines and accents, not whole paragraphs.
   </div>
 </div>
 
 <div class="faq-item">
   <button class="faq-question" type="button">
-    <span data-i18n="faq.categories.0.items.2.question">Is UltraTextGen completely free to use?</span>
+    <span data-i18n="faq.categories.0.items.2.question">Is it free, and what&rsquo;s the catch?</span>
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
     </svg>
   </button>
   <div class="faq-answer" data-i18n-html="faq.categories.0.items.2.answer">
-    Yes — 100% free with no daily limits, no account required, no watermarks, and no hidden fees.
-    You can generate and copy as much styled text as you need, anytime.
+    Free, no account, no daily limit, no watermark, no email capture, no paid tier. The site is funded by Google AdSense — that&rsquo;s the catch. We don&rsquo;t charge per copy, we don&rsquo;t gate styles behind a sign-up, and we don&rsquo;t insert affiliate links or zero-width tracking characters into the text you paste.
   </div>
 </div>
 
 
-<!-- Unicode vs Rich Text -->
-<h2 class="faq-category" data-i18n="faq.categories.1.title">Unicode Text vs Rich Text Formatting</h2>
+<!-- Platform how-tos -->
+<h2 class="faq-category" data-i18n="faq.categories.1.title">Bold, italic and styled text on each platform</h2>
 
 <div class="faq-item">
   <button class="faq-question" type="button">
-    <span data-i18n="faq.categories.1.items.0.question">How is Unicode text different from bold and italic in Word, Instagram, or Discord?</span>
+    <span data-i18n="faq.categories.1.items.0.question">How do I make my Instagram bio bold or italic?</span>
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
     </svg>
   </button>
   <div class="faq-answer" data-i18n-html="faq.categories.1.items.0.answer">
-    Regular bold and italic use formatting codes — often called markup or rich text — that only work inside the app that supports them.
-    For example, Discord uses **text** for bold, and Instagram captions have no formatting options at all.
+    Instagram has no formatting toolbar in the bio, caption, or comment fields — which is why everyone uses a fancy text generator for it.
     <br><br>
-    UltraTextGen works differently. It replaces each letter with a unique Unicode character that already looks styled.
-    The result is plain text that appears bold, italic, cursive, or decorated without any formatting engine behind it.
+    <strong>Steps:</strong><br>
+    1. Type your bio into UltraTextGen.<br>
+    2. Pick a bold (𝗕𝗼𝗹𝗱), italic (𝘐𝘵𝘢𝘭𝘪𝘤), or cursive (𝓒𝓾𝓻𝓼𝓲𝓿𝓮) style.<br>
+    3. Tap Copy.<br>
+    4. Paste it into the Instagram bio field on your phone.
     <br><br>
-    <strong>Why this matters</strong><br>
-    Rich text bold disappears if you copy it into a TikTok caption, an email subject line, or a username field — those places strip formatting.
-    Unicode text keeps its style because the characters themselves are styled. There is nothing to strip.
-    <br><br>
-    <strong>Example</strong><br>
-    A rich text editor makes the word "Sale" bold by wrapping it in invisible codes. Copy that into a TikTok bio and it becomes plain "Sale."
-    With UltraTextGen, "Sale" becomes 𝗦𝗮𝗹𝗲 — and it stays that way in your bio, your username, your email subject, and everywhere else.
+    Use sans-serif bold (𝗕𝗼𝗹𝗱) for the widest device support. The Instagram <em>username</em> field is stricter than the bio — it rejects Zalgo, fullwidth, and most decorative variants. Stick to plain bold/italic/cursive if you want to style your @ handle.
   </div>
 </div>
 
 <div class="faq-item">
   <button class="faq-question" type="button">
-    <span data-i18n="faq.categories.1.items.1.question">What can a Unicode text generator do that a rich text editor cannot?</span>
+    <span data-i18n="faq.categories.1.items.1.question">Can I bold text on Discord without Nitro?</span>
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
     </svg>
   </button>
   <div class="faq-answer" data-i18n-html="faq.categories.1.items.1.answer">
-    Rich text editors like Google Docs or Microsoft Word give you bold, italic, and underline — but those styles vanish the moment you paste into a social media bio, a username field, or a plain-text email.
-    A Unicode text generator unlocks styles and effects that no rich text editor can produce in those contexts.
+    Yes. Discord supports Markdown (<code>**text**</code> for bold, <code>*text*</code> for italic, <code>~~text~~</code> for strikethrough) inside chat messages — that&rsquo;s always been free. What Markdown <em>can&rsquo;t</em> do is render in your display name, server nickname, status, or "About me" — those fields ignore <code>**</code> entirely.
     <br><br>
-    <strong>Things UltraTextGen can do that rich text cannot</strong><br>
-    — Bold and italic text inside Instagram bios, TikTok captions, and YouTube descriptions where no formatting toolbar exists.<br>
-    — Gothic, Bubble, and Cursive font styles that rich text editors don't offer at all.<br>
-    — Upside-down and flipped text — impossible in any word processor.<br>
-    — Zalgo (glitch) text with stacked diacritics for a creepy, corrupted look.<br>
-    — Decorative frames, borders, and wrappers around your text using Unicode symbols.<br>
-    — Styled usernames and display names on Discord, Roblox, Steam, and other platforms.<br>
-    — Strikethrough and underline text in places that don't support those formatting options natively.
+    Unicode bold and italic work in all those places without Nitro, because the characters themselves are bold. Discord doesn&rsquo;t need to interpret anything. Paste 𝗯𝗼𝗹𝗱 into your nickname and it stays bold across every server you&rsquo;re in.
     <br><br>
-    In short, UltraTextGen gives you visual text effects that travel with the characters, so they work wherever plain text is accepted.
+    Use the <a href="/discord/">Discord-specific generator</a> for styles tested in nickname and message fields.
   </div>
 </div>
 
 <div class="faq-item">
   <button class="faq-question" type="button">
-    <span data-i18n="faq.categories.1.items.2.question">Can I use bold Unicode text in email subject lines?</span>
+    <span data-i18n="faq.categories.1.items.2.question">What font does LinkedIn use, and why does Unicode bold work in headlines?</span>
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
     </svg>
   </button>
   <div class="faq-answer" data-i18n-html="faq.categories.1.items.2.answer">
-    Yes — and this is a perfect example of something a rich text editor cannot do.
-    Email subject lines are plain text, so regular bold formatting is stripped out before the recipient sees it.
+    LinkedIn uses its own typeface, <strong>LinkedIn Sans</strong> (with Inter as the web fallback), for nearly all on-platform text. The platform deliberately doesn&rsquo;t expose a formatting toolbar for your headline, About section, or post body — there&rsquo;s no bold button.
     <br><br>
-    With UltraTextGen, you can paste Unicode bold characters directly into the subject line and the recipient sees them as bold in their inbox.
+    Unicode bold works because the characters are separate code points, so LinkedIn Sans just renders the bold-shaped glyphs that already exist in the font.
     <br><br>
-    <strong>Example</strong><br>
-    Normal subject line: "Flash Sale — 50% Off Today"<br>
-    Unicode subject line: "𝗙𝗹𝗮𝘀𝗵 𝗦𝗮𝗹𝗲 — 𝟱𝟬% 𝗢𝗳𝗳 𝗧𝗼𝗱𝗮𝘆"
+    <strong>What to use:</strong> sans-serif bold for headlines and the first line of posts, italic for nuance, small caps for section breaks.<br>
+    <strong>What to avoid:</strong> Zalgo, fullwidth, gothic — they hurt recruiter search filters (LinkedIn search doesn&rsquo;t normalise these back to ASCII) and break screen readers.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.1.items.3.question">How do I make vertical or stacked text (top-to-bottom)?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.1.items.3.answer">
+    Vertical text — also called stacked text — places each letter on its own line so the word reads top to bottom. It&rsquo;s the format people search for as "stacked text," "vertical font generator," "text top to bottom," or "comment that stacks down the feed."
     <br><br>
-    The bold version stands out in a crowded inbox without any special email tools. Most major email clients — Gmail, Outlook, Apple Mail — render Unicode characters correctly.
+    Use the <a href="/usecase/vertical-text/">vertical text generator</a> to handle the line breaks automatically and pick a style (bold, cursive, fullwidth) for the stacked letters. Popular for Pinterest pins, Discord channel banners, and aesthetic Instagram comments.
   </div>
 </div>
 
 
-<!-- Styles and Decorations -->
-<h2 class="faq-category" data-i18n="faq.categories.2.title">Styles, Fonts, and Decorations</h2>
+<!-- Styles & decoration -->
+<h2 class="faq-category" data-i18n="faq.categories.2.title">Styles, decorations, and how to mix them</h2>
 
 <div class="faq-item">
   <button class="faq-question" type="button">
-    <span data-i18n="faq.categories.2.items.0.question">What font styles does UltraTextGen offer?</span>
+    <span data-i18n="faq.categories.2.items.0.question">What styles are in the library?</span>
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
     </svg>
   </button>
   <div class="faq-answer" data-i18n-html="faq.categories.2.items.0.answer">
-    UltraTextGen has one of the largest collections of high-quality Unicode text styles, all prefixed with "Ultra" for superior look and coverage.
+    Around 65 styles, organised into twelve families:
     <br><br>
-    <strong>Core styles</strong><br>
-    Ultra Bold and Ultra Bold Serif, Ultra Italic (multiple variants), Ultra Script and Ultra Script Bold, Ultra Gothic, Ultra Bubble (Filled, Light, Tiles, Curly, Angle, Spaced, and more), Ultra Strike, and Ultra Underline.
-    <br><br>
-    <strong>Special styles</strong><br>
-    Upside Down and Flipped, Small Caps, Zalgo (Glitch), Word Wrappers and Frames, Backwards and Mirror, Double Struck, Fullwidth, Squared, Parenthesized, and many more.
-    <br><br>
-    New styles are added regularly, so bookmark the site or check back often.
+    <strong>Bold</strong> — sans, serif, italic-bold (6 variants).<br>
+    <strong>Italic</strong> — 4 variants including monospace italic.<br>
+    <strong>Cursive / script</strong> — regular and bold script.<br>
+    <strong>Gothic / fraktur</strong> — Old English and bold fraktur.<br>
+    <strong>Bubble</strong> — 12 variants (filled, light, tiles, curly, angle, spaced, and more).<br>
+    <strong>Strikethrough</strong> — slash, tilde, short, long.<br>
+    <strong>Underline</strong> — solid and double.<br>
+    <strong>Special</strong> — small caps, superscript / tiny, fullwidth, squared, parenthesized.<br>
+    <strong>Cool / aesthetic</strong> — spaced styles for Y2K and Tumblr energy.<br>
+    <strong>Fancy</strong> — double-struck and outlined.<br>
+    <strong>Word wrappers</strong> — 10 styles that auto-bracket each word (★彡[ word ]彡★, ╭─▸ word ╰─▸, etc.).<br>
+    <strong>Classified</strong> — upside-down, mirror, backwards, Zalgo (glitch), plus 8 more transforms.
   </div>
 </div>
 
 <div class="faq-item">
   <button class="faq-question" type="button">
-    <span data-i18n="faq.categories.2.items.1.question">Can I combine multiple styles and add decorations to my text?</span>
+    <span data-i18n="faq.categories.2.items.1.question">Can I stack multiple styles together?</span>
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
     </svg>
   </button>
   <div class="faq-answer" data-i18n-html="faq.categories.2.items.1.answer">
-    Yes — style mixing and one-click decorations are two of UltraTextGen's biggest advantages over other generators.
+    Yes — style mixing is one of the things you can&rsquo;t do with a normal font. Apply a base style, then layer another on top, then wrap the whole thing in a frame, divider, arrow, emoji or flag.
     <br><br>
-    You can layer styles together, such as Bubble + Zalgo, Gothic + Upside Down, or Small Caps + Underline, and then wrap the result with decorative elements.
+    <strong>Combos that look clean:</strong><br>
+    — Bold + Underline → <strong>𝗯𝗼𝗹𝗱</strong> u̳n̳d̳e̳r̳l̳i̳n̳e̳<br>
+    — Italic + Small Caps → ɪᴛᴀʟɪᴄ-ish, great for LinkedIn section breaks<br>
+    — Bubble + Spaced → 🅑 🅤 🅑 🅑 🅛 🅔, aesthetic Pinterest/TikTok vibe<br>
+    — Gothic + Star frame → ★彡[ 𝔥𝔢𝔩𝔩𝔬 ]彡★, for gaming clan tags
     <br><br>
-    <strong>Available decorations</strong><br>
-    Frames and borders (for example ★彡[ text ]彡★ or ╭─▸ text ╰─▸), arrows, symbols, minimal dividers, emojis, and flags.
-    <br><br>
-    <strong>Example</strong><br>
-    Start with "hello" → apply Ultra Gothic → add a star frame → result: ★彡[ 𝔥𝔢𝔩𝔩𝔬 ]彡★
-    <br><br>
-    No other generator makes mixing and decorating this easy.
+    Avoid stacking Zalgo with bubble — the diacritics collide and the result is unreadable on most phones.
   </div>
 </div>
 
 <div class="faq-item">
   <button class="faq-question" type="button">
-    <span data-i18n="faq.categories.2.items.2.question">What is Zalgo or glitch text and how do I use it?</span>
+    <span data-i18n="faq.categories.2.items.2.question">What is Zalgo (glitch) text and where do people actually use it?</span>
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
     </svg>
   </button>
   <div class="faq-answer" data-i18n-html="faq.categories.2.items.2.answer">
-    Zalgo text is the creepy, glitchy, "cursed" style that adds stacked diacritics above and below each character, making the text look corrupted or haunted.
+    Zalgo text is the cursed, glitched, dripping look made by stacking dozens of combining diacritic marks above and below each letter — for example h̷̢̛e̴̜͝l̸̼͝l̷͔͠o̵̗͝.
     <br><br>
-    <strong>Example</strong><br>
-    "hello" → h̷e̷l̷l̷o̷
+    The meme started on 4chan around 2009 and stuck around through r/creepypasta, horror TikTok edits, dark academia tumblrs, and edgy Discord display names. It&rsquo;s also the canonical Halloween / "we are corrupted" font for indie horror games and viral creepypasta accounts.
     <br><br>
-    It's popular for horror-themed memes, edgy social media bios, spooky usernames, and pranking friends in group chats.
-    Just type your text, select the Zalgo style, copy, and paste — UltraTextGen handles the stacking automatically.
+    Don&rsquo;t use it in usernames (most platforms reject combining marks), professional bios, or anything a screen reader will read aloud — every diacritic gets announced.
   </div>
 </div>
 
 
-<!-- Platform Compatibility -->
-<h2 class="faq-category" data-i18n="faq.categories.3.title">Platform Compatibility</h2>
+<!-- Compatibility & troubleshooting -->
+<h2 class="faq-category" data-i18n="faq.categories.3.title">Compatibility &amp; troubleshooting</h2>
 
 <div class="faq-item">
   <button class="faq-question" type="button">
-    <span data-i18n="faq.categories.3.items.0.question">Where can I use text generated by UltraTextGen?</span>
+    <span data-i18n="faq.categories.3.items.0.question">Why does my styled text show up as boxes (□) or question marks?</span>
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
     </svg>
   </button>
   <div class="faq-answer" data-i18n-html="faq.categories.3.items.0.answer">
-    Everywhere plain text is accepted. Because the styled characters are real Unicode — not formatting codes — they travel with your text no matter where you paste.
+    Boxes or "tofu" (□ ▯ �) appear when the device viewing the text has no installed font with a glyph for that Unicode code point. It&rsquo;s a rendering gap on the viewer&rsquo;s side, not a problem with your copied text.
     <br><br>
-    <strong>Social media</strong><br>
-    Instagram, TikTok, YouTube, X (Twitter), Facebook, LinkedIn, Pinterest, and Snapchat.
-    <br><br>
-    <strong>Messaging apps</strong><br>
-    WhatsApp, Telegram, Discord, Signal, and iMessage.
-    <br><br>
-    <strong>Other</strong><br>
-    Email subject lines and signatures, game profiles (Roblox, Minecraft, Steam), forum posts, resumes, presentations, and more.
-    <br><br>
-    We also have dedicated generator pages optimized for each major platform if you want styles tested specifically for that app.
+    <strong>Widest compatibility:</strong> bold (sans &amp; serif), italic, monospace, small caps, fullwidth, circled. Covered by default system fonts on iOS, Android, Windows, macOS and Chrome OS.<br>
+    <strong>Usually fine:</strong> cursive script, bubble, gothic — render on most phones from 2018 onwards.<br>
+    <strong>Occasionally clipped:</strong> Zalgo can look misaligned in apps with tight line spacing — that&rsquo;s by design, not a bug.
   </div>
 </div>
 
 <div class="faq-item">
   <button class="faq-question" type="button">
-    <span data-i18n="faq.categories.3.items.1.question">Can I use Unicode text for usernames and display names?</span>
+    <span data-i18n="faq.categories.3.items.1.question">Can I use these fonts in usernames and display names?</span>
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
     </svg>
   </button>
   <div class="faq-answer" data-i18n-html="faq.categories.3.items.1.answer">
-    Absolutely. Unicode characters are accepted in most username and display name fields — including Instagram, TikTok, Discord, Roblox, Steam, and many other platforms.
+    Mostly yes, with caveats per platform:
     <br><br>
-    <strong>Example</strong><br>
-    Normal username: "DarkWolf"<br>
-    Unicode username: "𝔇𝔞𝔯𝔨𝔚𝔬𝔩𝔣" (Gothic) or "ⒹⓐⓡⓚⓌⓞⓛⓕ" (Bubble)
+    <strong>Display names</strong> (Discord, Instagram, TikTok, Roblox, Steam, Telegram): almost any style works. 𝔇𝔞𝔯𝔨𝔚𝔬𝔩𝔣, ⒹⓐⓡⓚⓌⓞⓛⓕ, 𝓓𝓪𝓻𝓴𝓦𝓸𝓵𝓯 — all fine.<br>
+    <strong>@usernames / handles</strong>: stricter. Instagram&rsquo;s @ field only accepts Latin letters, digits, dots and underscores; Unicode goes in your display name instead. Discord usernames (lowercase, post-2023) reject most styled characters. X (Twitter) handles are ASCII-only.
     <br><br>
-    This is something a rich text editor can never do — username fields only accept plain text, and Unicode styled characters count as plain text.
-    <br><br>
-    <strong>Tip</strong><br>
-    If a platform rejects certain characters in the username field, try a different style. Some styles have wider compatibility than others.
+    Rule of thumb: if a platform shows a separate "display name" or "nickname" field, that&rsquo;s where Unicode goes. Leave the @ handle plain.
   </div>
 </div>
 
 <div class="faq-item">
   <button class="faq-question" type="button">
-    <span data-i18n="faq.categories.3.items.2.question">Why does some styled text show as boxes or question marks on certain platforms?</span>
+    <span data-i18n="faq.categories.3.items.2.question">Are these fonts safe for screen readers and accessibility?</span>
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
     </svg>
   </button>
   <div class="faq-answer" data-i18n-html="faq.categories.3.items.2.answer">
-    This happens when the font installed on the viewer's device does not include glyphs for those particular Unicode characters.
-    It is not a problem with the text itself — on most modern devices and browsers, the vast majority of styles display correctly.
+    Honestly: mostly no, and this is something most generators won&rsquo;t tell you.
     <br><br>
-    <strong>What to do</strong><br>
-    If you notice boxes or missing characters, try a different style. Core styles like Ultra Bold, Ultra Italic, and Ultra Bubble have the widest device support.
-    You can also use our platform-specific pages (like Discord or Instagram) to find styles tested for that app.
+    Screen readers — VoiceOver on iOS, TalkBack on Android, NVDA and JAWS on Windows — read each Unicode code point literally. 𝐀 is announced as "Mathematical Bold Capital A," not "A." A LinkedIn headline written entirely in Unicode bold becomes hostile to anyone using a screen reader.
+    <br><br>
+    <strong>How to use Unicode fonts responsibly:</strong><br>
+    — Style a word or phrase, not an entire bio.<br>
+    — Keep your name, contact info, and anything actionable in plain text.<br>
+    — Avoid Zalgo, fullwidth, and decorative wrappers in professional contexts.<br>
+    — If a platform has a separate plain-text name field (Discord, Instagram), put the readable version there.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.3.items.3.question">Can I use bold Unicode in email subject lines?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.3.items.3.answer">
+    Yes — this is one of the few places Unicode is the only option. Email subject lines are plain text by spec, so the "B" button in your email composer can&rsquo;t bold them. Unicode bold lets the recipient see 𝗙𝗹𝗮𝘀𝗵 𝗦𝗮𝗹𝗲 — 𝟱𝟬% 𝗢𝗳𝗳 𝗧𝗼𝗱𝗮𝘆 in their inbox preview.
+    <br><br>
+    Caveats: spam filters at Gmail and Outlook do score heavy Unicode use as a mild spam signal, so use it on one or two words per subject line rather than the whole thing. Avoid it entirely in transactional emails (receipts, password resets).
   </div>
 </div>
 
 
-<!-- Language and Script Support -->
-<h2 class="faq-category" data-i18n="faq.categories.4.title">Language and Script Support</h2>
+<!-- Languages -->
+<h2 class="faq-category" data-i18n="faq.categories.4.title">Languages and alphabets</h2>
 
 <div class="faq-item">
   <button class="faq-question" type="button">
-    <span data-i18n="faq.categories.4.items.0.question">What languages does UltraTextGen support for bold and styled text?</span>
+    <span data-i18n="faq.categories.4.items.0.question">What languages and alphabets work?</span>
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
     </svg>
   </button>
   <div class="faq-answer" data-i18n-html="faq.categories.4.items.0.answer">
-    UltraTextGen supports any language written using the Latin alphabet.
-    If a language uses A to Z, including accented characters such as á, é, ñ, ü, and ç, the text can be converted into bold, italic, cursive, and other Unicode styles.
-    This works because Unicode provides styled character variants for Latin script letters and digits.
+    Unicode styled variants only exist for the Latin alphabet (A–Z, a–z) and Arabic digits (0–9). So every language written in Latin script works: English, Spanish, French, Portuguese, German, Italian, Dutch, Polish, Vietnamese, Turkish, Indonesian, Malay, Tagalog, Afrikaans, Swahili, Hungarian, Czech — all fine.
     <br><br>
-    <strong>Supported Latin-alphabet languages</strong><br>
-    English, Spanish, French, Portuguese, German, Italian, Dutch, Afrikaans, Indonesian, Malay, Filipino, Tagalog, Vietnamese, and Turkish — among many others.
-    <br><br>
-    These languages can be styled reliably across social media platforms, messaging apps, and emails.
+    Accented characters (á, é, ñ, ü, ç) keep their accents in most styles. A handful of decorative styles drop the accent because Unicode doesn&rsquo;t define a styled variant for it — try a different style if that matters.
   </div>
 </div>
 
 <div class="faq-item">
   <button class="faq-question" type="button">
-    <span data-i18n="faq.categories.4.items.1.question">Which languages are not supported for styled text?</span>
+    <span data-i18n="faq.categories.4.items.1.question">Why doesn&rsquo;t Arabic, Cyrillic, Hindi, Chinese, or Japanese text transform?</span>
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
     </svg>
   </button>
   <div class="faq-answer" data-i18n-html="faq.categories.4.items.1.answer">
-    Languages that use non-Latin scripts cannot be converted into bold, italic, or other Unicode font styles.
-    These scripts do not have styled Unicode character variants, so the text will remain unchanged after conversion.
+    Unicode simply doesn&rsquo;t define styled variants for non-Latin scripts. There&rsquo;s no "bold Arabic" or "italic Devanagari" character in the standard, so there&rsquo;s nothing to swap in. Arabic, Urdu, Persian, Hebrew, Hindi, Bengali, Tamil, Telugu, Thai, Chinese (Hanzi), Japanese (Kanji, Hiragana, Katakana), Korean (Hangul), Cyrillic and Greek all pass through unchanged.
     <br><br>
-    <strong>Not supported for styled text</strong><br>
-    Arabic, Urdu, Persian, Hebrew, Hindi, Bengali, Tamil, Thai, Chinese, Japanese, Korean, and Sinhala.
-    <br><br>
-    This is a limitation of the Unicode standard itself, not a limitation of UltraTextGen.
-    If you write in one of these languages, your Latin-script words (brand names, English phrases, etc.) within the text will still convert.
-  </div>
-</div>
-
-<div class="faq-item">
-  <button class="faq-question" type="button">
-    <span data-i18n="faq.categories.4.items.2.question">Are there any characters that don't convert?</span>
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-    </svg>
-  </button>
-  <div class="faq-answer" data-i18n-html="faq.categories.4.items.2.answer">
-    Most English letters (A–Z, a–z), numbers (0–9), and basic punctuation convert perfectly across all styles.
-    Some very rare symbols or special characters may have fewer style options because Unicode doesn't include styled variants for every character.
-    <br><br>
-    If a character cannot be converted, it simply stays as normal text — it never breaks or produces errors.
-    Your output will always be usable.
+    The exception: Latin-script words inside a non-Latin sentence — brand names, English loanwords, hashtags — will still convert. The non-Latin characters around them stay as they are.
   </div>
 </div>
 
 
-<!-- Privacy and Safety -->
-<h2 class="faq-category" data-i18n="faq.categories.5.title">Privacy and Safety</h2>
+<!-- Privacy -->
+<h2 class="faq-category" data-i18n="faq.categories.5.title">Privacy &amp; safety</h2>
 
 <div class="faq-item">
   <button class="faq-question" type="button">
-    <span data-i18n="faq.categories.5.items.0.question">Is the text I type stored or tracked?</span>
+    <span data-i18n="faq.categories.5.items.0.question">Is the text I type stored, logged, or sent to a server?</span>
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
     </svg>
   </button>
   <div class="faq-answer" data-i18n-html="faq.categories.5.items.0.answer">
-    No. UltraTextGen does not store your text and does not add any hidden or tracking characters to the output.
-    The conversion happens in your browser, and what you copy is clean Unicode — nothing more.
+    No. All transformation happens in your browser using JavaScript — nothing you type is sent to a server. There are no hidden tracking characters, no zero-width spaces, no invisible watermarks added to the output. What you copy is clean Unicode and nothing else.
+    <br><br>
+    The site uses Google Tag Manager for anonymous usage analytics (page views and which styles get used most) but it never sees the contents of your input box.
   </div>
 </div>
 
 <div class="faq-item">
   <button class="faq-question" type="button">
-    <span data-i18n="faq.categories.5.items.1.question">Is the generated text safe to copy and paste?</span>
+    <span data-i18n="faq.categories.5.items.1.question">Does the generated text work on phones and tablets?</span>
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
     </svg>
   </button>
   <div class="faq-answer" data-i18n-html="faq.categories.5.items.1.answer">
-    Yes — completely safe. The output is standard Unicode text with no embedded scripts, no hidden formatting, and no tracking codes.
-    You can paste it into any app or website without any security concerns.
-  </div>
-</div>
-
-
-<!-- Mobile and Device Support -->
-<h2 class="faq-category" data-i18n="faq.categories.6.title">Mobile and Device Support</h2>
-
-<div class="faq-item">
-  <button class="faq-question" type="button">
-    <span data-i18n="faq.categories.6.items.0.question">Does UltraTextGen work on phones and tablets?</span>
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-    </svg>
-  </button>
-  <div class="faq-answer" data-i18n-html="faq.categories.6.items.0.answer">
-    Yes — the site is fully responsive and works great on phones, tablets, and desktops.
-    There is no app to download. Just open UltraTextGen in your mobile browser, type your text, pick a style, and copy.
-    It works on iPhone, Android, iPad, and any device with a modern browser.
-  </div>
-</div>
-
-
-<!-- Why UltraTextGen -->
-<h2 class="faq-category" data-i18n="faq.categories.7.title">Why Choose UltraTextGen</h2>
-
-<div class="faq-item">
-  <button class="faq-question" type="button">
-    <span data-i18n="faq.categories.7.items.0.question">Why should I choose UltraTextGen over other text generators?</span>
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-    </svg>
-  </button>
-  <div class="faq-answer" data-i18n-html="faq.categories.7.items.0.answer">
-    UltraTextGen is built to be the most complete and easiest-to-use Unicode text generator available.
-    <br><br>
-    <strong>What sets it apart</strong><br>
-    — One of the largest collections of premium "Ultra" styled fonts.<br>
-    — True style mixing: combine multiple styles in one click, something most generators don't support.<br>
-    — One-click decorations: add frames, borders, symbols, and dividers without manual copy-pasting.<br>
-    — Dedicated platform pages for TikTok, Discord, Instagram, and more — so you get styles tested for your platform.<br>
-    — Fast, clean interface with no pop-ups slowing you down.<br>
-    — Constantly updated with new styles and decorations.
-  </div>
-</div>
-
-<div class="faq-item">
-  <button class="faq-question" type="button">
-    <span data-i18n="faq.categories.7.items.1.question">Does UltraTextGen add new styles?</span>
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-    </svg>
-  </button>
-  <div class="faq-answer" data-i18n-html="faq.categories.7.items.1.answer">
-    Yes — new Ultra styles and decorations are added regularly.
-    Bookmark the site to stay updated on the latest additions.
-  </div>
-</div>
-
-<div class="faq-item">
-  <button class="faq-question" type="button">
-    <span data-i18n="faq.categories.7.items.2.question">How do I find the right font style or tool for my needs?</span>
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-    </svg>
-  </button>
-  <div class="faq-answer" data-i18n-html="faq.categories.7.items.2.answer">
-    UltraTextGen organises styles and tools in three ways:
-    <br><br>
-    <strong>By font style</strong><br>
-    Browse all font categories — bold, cursive, gothic, bubble, strikethrough, underline, upside-down, and more. Each category page has its own generator focused on that style.
-    <br><br>
-    <strong>By platform</strong><br>
-    Use a platform-specific generator (like Instagram, TikTok, or LinkedIn) for styles and tips optimised for that platform's rules.
-    <br><br>
-    <strong>By task</strong><br>
-    Visit the use case page for task-specific tools — comment fonts, emoji combinations, before-and-after emoji, and more.
+    Yes. The site is fully responsive — iPhone, Android, iPad, any modern mobile browser. There&rsquo;s no app to install. The Copy button uses the device&rsquo;s native clipboard API, so you can paste straight into Instagram, TikTok, or Discord without leaving the browser.
   </div>
 </div>
 

--- a/index.html
+++ b/index.html
@@ -12,8 +12,8 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title data-i18n="meta.title">Stylish Text Generator — Copy &amp; Paste Fancy Unicode Fonts</title>
-<meta name="description" data-i18n-content="meta.description" content="Turn plain text into stylish Unicode fonts you can copy and paste. Choose bold, cursive, gothic, and decorative styles for bios, usernames, comments, and posts.">
+<title data-i18n="meta.title">Fancy Text Generator — 60+ Unicode Fonts (Copy &amp; Paste)</title>
+<meta name="description" data-i18n-content="meta.description" content="Turn plain text into 60+ Unicode fonts — bold, italic, cursive, gothic, bubble, small caps, aesthetic, upside-down and Zalgo. Copy and paste straight into Instagram bios, TikTok captions, Discord names, LinkedIn headlines, and WhatsApp. Free, instant, no sign-up.">
 
 <link rel="canonical" href="https://ultratextgen.com/">
 
@@ -33,15 +33,15 @@
 <meta name="robots" content="index, follow">
 
 <meta property="og:site_name" content="UltraTextGen">
-<meta property="og:title" content="Stylish Text Generator — Copy & Paste Fancy Unicode Fonts">
-<meta property="og:description" content="Turn plain text into stylish Unicode fonts you can copy and paste. Choose bold, cursive, gothic, and decorative styles for bios, usernames, comments, and posts.">
+<meta property="og:title" content="Fancy Text Generator — 60+ Unicode Fonts (Copy & Paste)">
+<meta property="og:description" content="Turn plain text into 60+ Unicode fonts — bold, italic, cursive, gothic, bubble, small caps, aesthetic, upside-down and Zalgo. Paste straight into Instagram, TikTok, Discord, LinkedIn, and WhatsApp.">
 <meta property="og:url" content="https://ultratextgen.com/">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://ultratextgen.com/og.png">
 
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Stylish Text Generator — Copy & Paste Fancy Unicode Fonts">
-<meta name="twitter:description" content="Turn plain text into stylish Unicode fonts you can copy and paste. Choose bold, cursive, gothic, and decorative styles for bios, usernames, comments, and posts.">
+<meta name="twitter:title" content="Fancy Text Generator — 60+ Unicode Fonts (Copy & Paste)">
+<meta name="twitter:description" content="Turn plain text into 60+ Unicode fonts — bold, italic, cursive, gothic, bubble, small caps, aesthetic, upside-down and Zalgo. Paste straight into Instagram, TikTok, Discord, LinkedIn, and WhatsApp.">
 <meta name="twitter:image" content="https://ultratextgen.com/og.png">
 
 <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
@@ -81,17 +81,30 @@
   {
     "@context": "https://schema.org",
     "@type": "WebApplication",
-    "name": "UltraTextGen",
+    "name": "UltraTextGen Fancy Text Generator",
+    "alternateName": ["Unicode Font Generator", "Fancy Font Generator", "Stylish Text Generator", "Font Changer", "Copy and Paste Fonts"],
     "url": "https://ultratextgen.com/",
     "applicationCategory": "UtilitiesApplication",
+    "applicationSubCategory": "Text Generator",
     "operatingSystem": "All",
     "browserRequirements": "Requires JavaScript",
+    "isAccessibleForFree": true,
     "offers": {
       "@type": "Offer",
       "price": "0",
       "priceCurrency": "USD"
     },
-    "description": "Generate stylish Unicode text instantly for Instagram, TikTok, X, WhatsApp, and Discord. Copy and paste text styles for social bios, usernames, and posts."
+    "featureList": [
+      "60+ Unicode font styles (bold, italic, cursive, gothic, bubble, small caps, fullwidth, squared, parenthesized)",
+      "Aesthetic and decorative styles for Instagram, TikTok and Pinterest bios",
+      "Upside-down, mirror, backwards and Zalgo (glitch) text",
+      "One-click style mixing and decorative frames, borders, dividers and symbols",
+      "Vertical and stacked text generator",
+      "Copy and paste into Instagram, TikTok, Discord, LinkedIn, WhatsApp, X (Twitter), Snapchat, Roblox, Steam and email subject lines",
+      "Real-time preview as you type",
+      "Runs entirely in the browser — no sign-up, no account, no tracking of input text"
+    ],
+    "description": "Free fancy text generator that turns plain text into 60+ copy-and-paste Unicode fonts — bold, italic, cursive, gothic, bubble, small caps, aesthetic, upside-down and Zalgo — for Instagram, TikTok, Discord, LinkedIn and WhatsApp bios, captions and usernames."
   }
 ]
 </script>
@@ -106,90 +119,106 @@
   "mainEntity": [
     {
       "@type": "Question",
-      "name": "What can a Unicode text generator do that a rich text editor cannot?",
+      "name": "What is a fancy text generator?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Rich text editors like Google Docs or Microsoft Word give you bold, italic, and underline — but those styles vanish the moment you paste into a social media bio, a username field, or a plain-text email. A Unicode text generator unlocks styles and effects that no rich text editor can produce in those contexts. <br><br> <strong>Things UltraTextGen can do that rich text cannot</strong><br> — Bold and italic text inside Instagram bios, TikTok captions, and YouTube descriptions where no formatting toolbar exists.<br> — Gothic, Bubble, and Cursive font styles that rich text editors don't offer at all.<br> — Upside-down and flipped text — impossible in any word processor.<br> — Zalgo (glitch) text with stacked diacritics for a creepy, corrupted look.<br> — Decorative frames, borders, and wrappers around your text using Unicode symbols.<br> — Styled usernames and display names on Discord, Roblox, Steam, and other platforms.<br> — Strikethrough and underline text in places that don't support those formatting options natively. <br><br> In short, UltraTextGen gives you visual text effects that travel with the characters, so they work wherever plain text is accepted."
+        "text": "A fancy text generator is a tool that replaces each letter you type with a different Unicode character that already looks bold, italic, cursive, gothic, bubble, or otherwise styled. Because the output is real Unicode — not a font file or Markdown — you can copy and paste it into Instagram bios, TikTok captions, Discord names, LinkedIn headlines, WhatsApp statuses, and anywhere else that only accepts plain text."
       }
     },
     {
       "@type": "Question",
-      "name": "Why should I choose UltraTextGen over other text generators?",
+      "name": "How do I make my Instagram bio bold or italic?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "UltraTextGen is built to be the most complete and easiest-to-use Unicode text generator available. <br><br> <strong>What sets it apart</strong><br> — One of the largest collections of premium \"Ultra\" styled fonts.<br> — True style mixing: combine multiple styles in one click, something most generators don't support.<br> — One-click decorations: add frames, borders, symbols, and dividers without manual copy-pasting.<br> — Dedicated platform pages for TikTok, Discord, Instagram, and more — so you get styles tested for your platform.<br> — Fast, clean interface with no pop-ups slowing you down.<br> — Constantly updated with new styles and decorations."
+        "text": "Instagram has no formatting toolbar in the bio, caption, or comment fields, so the only way to get bold or italic is to paste in Unicode characters that already look styled. Type your bio in UltraTextGen, pick a bold or italic style, tap Copy, then paste into the bio field in the Instagram app. The bold and italic sans-serif styles have the widest device support; avoid Zalgo and fullwidth in the username field because Instagram's username filter will reject them."
       }
     },
     {
       "@type": "Question",
-      "name": "What font styles does UltraTextGen offer?",
+      "name": "Can I bold text on Discord without Nitro?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "UltraTextGen has one of the largest collections of high-quality Unicode text styles, all prefixed with \"Ultra\" for superior look and coverage. <br><br> <strong>Core styles</strong><br> Ultra Bold and Ultra Bold Serif, Ultra Italic (multiple variants), Ultra Script and Ultra Script Bold, Ultra Gothic, Ultra Bubble (Filled, Light, Tiles, Curly, Angle, Spaced, and more), Ultra Strike, and Ultra Underline. <br><br> <strong>Special styles</strong><br> Upside Down and Flipped, Small Caps, Zalgo (Glitch), Word Wrappers and Frames, Backwards and Mirror, Double Struck, Fullwidth, Squared, Parenthesized, and many more. <br><br> New styles are added regularly, so bookmark the site or check back often."
+        "text": "Yes. Discord uses Markdown (**text** for bold, *text* for italic) inside chat messages, but Markdown does not work in your display name, server nickname, status, or About me. Unicode bold and italic work in all of those places without Nitro, because the characters themselves are bold — Discord doesn't have to render them as bold. Paste 𝗯𝗼𝗹𝗱 into your nickname and it stays bold everywhere your name appears."
       }
     },
     {
       "@type": "Question",
-      "name": "Are there any characters that don't convert?",
+      "name": "What font does LinkedIn use, and why does Unicode bold work in headlines?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Most English letters (A–Z, a–z), numbers (0–9), and basic punctuation convert perfectly across all styles. Some very rare symbols or special characters may have fewer style options because Unicode doesn't include styled variants for every character. <br><br> If a character cannot be converted, it simply stays as normal text — it never breaks or produces errors. Your output will always be usable."
+        "text": "LinkedIn uses its own typeface called LinkedIn Sans for almost all on-platform text. LinkedIn does not provide a formatting toolbar for your headline, About section, or post body — there's no bold button. Unicode bold works because the characters are different code points entirely, so LinkedIn Sans simply renders them as the bold-looking glyphs they already are. Use sans-serif bold for a professional look; avoid Zalgo, fullwidth, and heavily decorated styles, which trip recruiter search filters and cause issues for screen readers."
       }
     },
     {
       "@type": "Question",
-      "name": "What is Zalgo or glitch text and how do I use it?",
+      "name": "How do I make vertical or stacked text (top-to-bottom)?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Zalgo text is the creepy, glitchy, \"cursed\" style that adds stacked diacritics above and below each character, making the text look corrupted or haunted. <br><br> <strong>Example</strong><br> \"hello\" → h̷e̷l̷l̷o̷ <br><br> It's popular for horror-themed memes, edgy social media bios, spooky usernames, and pranking friends in group chats. Just type your text, select the Zalgo style, copy, and paste — UltraTextGen handles the stacking automatically."
+        "text": "Vertical text — sometimes called stacked text — places each letter on its own line so the word reads top to bottom. It's popular for Pinterest pins, Discord channel banners, and aesthetic Instagram posts. UltraTextGen's vertical text generator handles the line breaks and lets you pick a style (bold, cursive, fullwidth) for the stacked letters."
       }
     },
     {
       "@type": "Question",
-      "name": "How is Unicode text different from bold and italic in Word, Instagram, or Discord?",
+      "name": "How is a Unicode font different from a regular font like Arial or Helvetica?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Regular bold and italic use formatting codes — often called markup or rich text — that only work inside the app that supports them. For example, Discord uses **text** for bold, and Instagram captions have no formatting options at all. <br><br> UltraTextGen works differently. It replaces each letter with a unique Unicode character that already looks styled. The result is plain text that appears bold, italic, cursive, or decorated without any formatting engine behind it. <br><br> <strong>Why this matters</strong><br> Rich text bold disappears if you copy it into a TikTok caption, an email subject line, or a username field — those places strip formatting. Unicode text keeps its style because the characters themselves are styled. There is nothing to strip. <br><br> <strong>Example</strong><br> A rich text editor makes the word \"Sale\" bold by wrapping it in invisible codes. Copy that into a TikTok bio and it becomes plain \"Sale.\" With UltraTextGen, \"Sale\" becomes 𝗦𝗮𝗹𝗲 — and it stays that way in your bio, your username, your email subject, and everywhere else."
+        "text": "A regular font is a file stored on your device that tells the screen how to draw each letter. If a website doesn't load the font, the letter still says \"A\" — it just gets drawn differently. Unicode \"fonts\" are not fonts in that sense. They are separate characters in the Unicode standard with different code points: A, 𝐀, 𝘈, 𝓐, 𝔄, 𝕬, Ⓐ. That's why they survive copy-paste — you are using a different letter that happens to look styled, not styling the letter you typed."
       }
     },
     {
       "@type": "Question",
-      "name": "Can I use bold Unicode text in email subject lines?",
+      "name": "Why does some of my styled text show up as boxes (□) or question marks?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes — and this is a perfect example of something a rich text editor cannot do. Email subject lines are plain text, so regular bold formatting is stripped out before the recipient sees it. <br><br> With UltraTextGen, you can paste Unicode bold characters directly into the subject line and the recipient sees them as bold in their inbox. <br><br> <strong>Example</strong><br> Normal subject line: \"Flash Sale — 50% Off Today\"<br> Unicode subject line: \"𝗙𝗹𝗮𝘀𝗵 𝗦𝗮𝗹𝗲 — 𝟱𝟬% 𝗢𝗳𝗳 𝗧𝗼𝗱𝗮𝘆\" <br><br> The bold version stands out in a crowded inbox without any special email tools. Most major email clients — Gmail, Outlook, Apple Mail — render Unicode characters correctly."
+        "text": "Boxes or tofu (□ ▯ �) appear when the device viewing the text has no installed font that contains a glyph for that specific Unicode code point. It's a rendering gap on the viewer's side, not a problem with your copied text. To get the widest compatibility, stick to bold (sans and serif), italic, monospace, small caps, fullwidth, and circled — these are covered by the default system fonts on iOS, Android, Windows, macOS, and Chrome OS. Cursive script and bubble variants render on most phones from 2018 onwards. Zalgo can look clipped or misaligned in apps with tight line spacing — that's by design."
       }
     },
     {
       "@type": "Question",
-      "name": "Can I combine multiple styles and add decorations to my text?",
+      "name": "Are these Unicode fonts safe to use for screen readers and accessibility?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes — style mixing and one-click decorations are two of UltraTextGen's biggest advantages over other generators. <br><br> You can layer styles together, such as Bubble + Zalgo, Gothic + Upside Down, or Small Caps + Underline, and then wrap the result with decorative elements. <br><br> <strong>Available decorations</strong><br> Frames and borders (for example ★彡[ text ]彡★ or ╭─▸ text ╰─▸), arrows, symbols, minimal dividers, emojis, and flags. <br><br> <strong>Example</strong><br> Start with \"hello\" → apply Ultra Gothic → add a star frame → result: ★彡[ 𝔥𝔢𝔩𝔩𝔬 ]彡★ <br><br> No other generator makes mixing and decorating this easy."
+        "text": "Mostly no — and this is the honest answer most generators won't give you. Screen readers like VoiceOver, TalkBack, and JAWS read each Unicode code point literally. The character 𝐀 is announced as \"Mathematical Bold Capital A,\" not as \"A.\" That makes styled text a poor choice for body content, captions someone might rely on, and anything in a professional or accessibility-sensitive setting. Use it sparingly: a couple of styled words in a headline are fine, a whole bio in Zalgo is not. Keep your @username or handle in plain text whenever the platform shows a separate display name."
       }
     },
     {
       "@type": "Question",
-      "name": "Why does some styled text show as boxes or question marks on certain platforms?",
+      "name": "What is Zalgo (glitch) text and where do people actually use it?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "This happens when the font installed on the viewer's device does not include glyphs for those particular Unicode characters. It is not a problem with the text itself — on most modern devices and browsers, the vast majority of styles display correctly. <br><br> <strong>What to do</strong><br> If you notice boxes or missing characters, try a different style. Core styles like Ultra Bold, Ultra Italic, and Ultra Bubble have the widest device support. You can also use our platform-specific pages (like Discord or Instagram) to find styles tested for that app."
+        "text": "Zalgo text is the cursed, glitched, dripping look made by stacking dozens of combining diacritic marks above and below each character — for example h̷̢̛e̴̜͝l̸̼͝l̷͔͠o̵̗͝. It's a meme aesthetic that originated on 4chan around 2009 and stuck around through r/creepypasta, horror TikTok edits, dark academia tumblrs, and edgy Discord display names. Avoid it in usernames most platforms will reject the combining marks and in LinkedIn headlines unless your brand actively benefits from looking unhinged."
       }
     },
     {
       "@type": "Question",
-      "name": "Can I use Unicode text for usernames and display names?",
+      "name": "Can I stack multiple styles together (e.g., bubble + small caps)?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Absolutely. Unicode characters are accepted in most username and display name fields — including Instagram, TikTok, Discord, Roblox, Steam, and many other platforms. <br><br> <strong>Example</strong><br> Normal username: \"DarkWolf\"<br> Unicode username: \"𝔇𝔞𝔯𝔨𝔚𝔬𝔩𝔣\" (Gothic) or \"ⒹⓐⓡⓚⓌⓞⓛⓕ\" (Bubble) <br><br> This is something a rich text editor can never do — username fields only accept plain text, and Unicode styled characters count as plain text. <br><br> <strong>Tip</strong><br> If a platform rejects certain characters in the username field, try a different style. Some styles have wider compatibility than others."
+        "text": "Yes — style mixing is one of the things you can't do with a normal font. Type your text, apply a base style like Ultra Bubble, then layer Small Caps or Underline on top, and add a frame or divider on either side. Example: hello → apply Gothic → wrap in a star frame → ★彡[ 𝔥𝔢𝔩𝔩𝔬 ]彡★. The combinations that look cleanest are Bold + Underline, Italic + Small Caps, and Bubble + Spaced for aesthetic posts."
       }
     },
     {
       "@type": "Question",
-      "name": "How do I find the right font style or tool for my needs?",
+      "name": "What languages and alphabets work?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "UltraTextGen organises styles and tools in three ways: <br><br> <strong>By font style</strong><br> Browse all font categories — bold, cursive, gothic, bubble, strikethrough, underline, upside-down, and more. <br><br> <strong>By platform</strong><br> Use a platform-specific generator for styles optimised for that platform's rules. <br><br> <strong>By task</strong><br> Visit the use case page for task-specific tools — comment fonts, emoji combinations, and more."
+        "text": "Unicode styled variants only exist for the Latin alphabet (A–Z) and Arabic digits (0–9). That means every language using Latin script works for styling — English, Spanish, French, Portuguese, German, Italian, Dutch, Polish, Vietnamese, Turkish, Indonesian, Tagalog, Afrikaans, Swahili, and dozens more. Languages written in Arabic, Hebrew, Devanagari (Hindi, Marathi), Bengali, Tamil, Thai, Chinese, Japanese, Korean, Cyrillic, or Greek will not transform — there are no styled variants of those characters in Unicode. Latin-script words inside non-Latin sentences (brand names, hashtags) will still convert."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is the text I type stored, logged, or shared?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. All transformation happens in your browser using JavaScript — nothing you type is sent to a server. There are no hidden tracking characters or zero-width spaces added to the output. What you copy is clean Unicode and nothing else. The site uses Google Tag Manager for anonymous usage analytics (page views, which styles get used) but it never sees the contents of your input."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is UltraTextGen free, and is there a catch?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Free, no account, no daily limit, no watermark, no email capture, no paid tiers. The site is funded by Google AdSense — that's the catch. We do not charge per copy, we do not gate styles behind a sign-up, and we do not insert affiliate links into the styled text you paste."
       }
     }
   ]
@@ -208,8 +237,8 @@
   <section class="hero">
     <div class="hero-inner">
       <div class="hero-card">
-        <h1 class="hero-headline" data-i18n="hero.title">Stylish Font Generator</h1>
-        <p class="hero-tagline" data-i18n="hero.subtitle">Turn plain text into bold, cursive, gothic, and decorative Unicode fonts you can copy and paste instantly.</p>
+        <h1 class="hero-headline" data-i18n="hero.title">Fancy Text Generator</h1>
+        <p class="hero-tagline" data-i18n="hero.subtitle">Type once, get 60+ Unicode fonts you can copy and paste anywhere — Instagram bios, TikTok captions, Discord names, LinkedIn headlines, WhatsApp, email subject lines, even game profiles.</p>
         <div class="input-wrapper">
           <textarea class="main-input" id="mainInput" placeholder="Type your text here..." data-i18n-placeholder="ui.placeholder" maxlength="500" autofocus></textarea>
           <button class="input-clear-btn" id="inputClearBtn" aria-label="Clear input" hidden>✕</button>
@@ -252,24 +281,79 @@
     <div class="results-grid" id="resultsGrid"></div>
   </main>
 
+  <!-- Intro / topical anchor -->
+  <section class="editorial-section" aria-labelledby="intro-heading">
+    <h2 id="intro-heading">What this fancy text generator actually does</h2>
+    <p>
+      UltraTextGen is a free Unicode font generator. You type plain text, it swaps each letter for a styled character that lives inside the Unicode standard, and you copy the result wherever you want it: an Instagram bio, a TikTok caption, a Discord display name, a LinkedIn headline, a Roblox profile, a WhatsApp status, even an email subject line. Because the styled letters <em>are</em> the text — not a font file your phone has to load, and not Markdown that gets stripped — they survive copy-paste into apps that don&rsquo;t allow formatting.
+    </p>
+    <p>
+      Type <code>hello</code> and you get:
+      𝗵𝗲𝗹𝗹𝗼 (bold),
+      𝘩𝘦𝘭𝘭𝘰 (italic),
+      𝒽ℯ𝓁𝓁ℴ (cursive script),
+      𝔥𝔢𝔩𝔩𝔬 (gothic),
+      🅗🅔🅛🅛🅞 (bubble),
+      ʰᵉˡˡᵒ (tiny / superscript),
+      ʜᴇʟʟᴏ (small caps),
+      ⓗⓔⓛⓛⓞ (circled),
+      ｈｅｌｌｏ (fullwidth),
+      h̶e̶l̶l̶o̶ (strikethrough),
+      h̳e̳l̳l̳o̳ (underline),
+      oʅʅǝɥ (upside-down),
+      ollǝɥ (mirror),
+      h̷̢̛e̴̜͝l̸̼͝l̷͔͠o̵̗͝ (Zalgo / glitch),
+      and roughly 50 more — including aesthetic spaced styles like <strong>𝓱 𝓮 𝓵 𝓵 𝓸</strong> people use for Pinterest pins and Y2K-style usernames.
+    </p>
+    <h3>Where these fonts actually work (and where they don&rsquo;t)</h3>
+    <p>
+      Compatibility varies because Unicode rendering depends on the device font, not the website. Here&rsquo;s what we&rsquo;ve tested:
+    </p>
+    <ul class="compat-list">
+      <li><strong>Instagram</strong> — bio, post caption, comments, story stickers: works in every style. Username field: works only with Latin-script styles (bold, italic, cursive, bubble); won&rsquo;t accept Zalgo or fullwidth.</li>
+      <li><strong>TikTok</strong> — bio, caption, comments, video description: works in all core styles. The "nickname" field is more permissive than Instagram&rsquo;s username.</li>
+      <li><strong>Discord</strong> — server nickname, display name, messages, &ldquo;About me&rdquo;: Unicode fonts work without Nitro. Markdown bold (<code>**text**</code>) only renders inside messages; Unicode bold renders <em>everywhere</em>, including your nickname.</li>
+      <li><strong>LinkedIn</strong> — headline, About section, post body: bold, italic and small caps render reliably. Avoid Zalgo and heavily decorated styles on a professional profile — they trigger recruiter filters and screen-reader issues.</li>
+      <li><strong>WhatsApp</strong> — status, group names, broadcasts: all Unicode fonts work. WhatsApp&rsquo;s own <code>*bold*</code>, <code>_italic_</code> and <code>~strike~</code> only render inside chat messages, so Unicode is the only option for status and group names.</li>
+      <li><strong>X (Twitter)</strong> — display name, bio, tweets: works everywhere. Some Zalgo styles get visually clipped on mobile.</li>
+      <li><strong>Snapchat, Pinterest, Telegram, Signal, iMessage</strong> — bios, captions, messages: all work.</li>
+      <li><strong>Roblox, Steam, Minecraft, Fortnite</strong> — display names usually accept bold/italic/gothic. Each platform&rsquo;s name filter rejects different characters — try a different style if one is blocked.</li>
+      <li><strong>Email subject lines</strong> (Gmail, Outlook, Apple Mail) — render Unicode fonts as written. This is the one place where there is no rich-text alternative.</li>
+      <li><strong>Won&rsquo;t work:</strong> Microsoft Word, Google Docs body text styling (use the built-in toolbar instead), printed documents with non-Unicode fonts, and anywhere the recipient&rsquo;s device is missing the glyph (rare on phones made after 2018).</li>
+    </ul>
+    <h3>Why Unicode fonts ≠ regular fonts</h3>
+    <p>
+      A regular font (Helvetica, Arial, the LinkedIn Sans typeface, etc.) is a file that lives on your device and tells the screen how to draw a letter. If the website doesn&rsquo;t load that font, the letter still says "A" — it just gets drawn in a default font instead. Unicode &ldquo;fonts&rdquo; aren&rsquo;t fonts at all in that sense. They&rsquo;re separate characters in the Unicode standard — A, 𝐀, 𝘈, 𝓐, 𝔄, 𝕬, Ⓐ are all different characters with different code points. That&rsquo;s why they travel: you&rsquo;re not styling the letter A, you&rsquo;re using a different letter entirely that happens to look styled.
+    </p>
+    <h3>What&rsquo;s in the library</h3>
+    <p>
+      About 65 styles across twelve families: <strong>bold</strong> (sans, serif, italic-bold), <strong>italic</strong>, <strong>cursive / script</strong> (regular and bold), <strong>gothic / fraktur</strong>, <strong>bubble</strong> (filled, light, tiles, curly, angle, spaced, and more — 12 variants), <strong>strikethrough</strong> (slash, tilde, short, long), <strong>underline</strong>, <strong>monospace / fullwidth</strong>, <strong>small caps and superscript</strong>, <strong>aesthetic / spaced</strong>, <strong>upside-down + mirror + backwards</strong>, <strong>Zalgo (glitch)</strong>, and ten decorative <strong>word wrappers</strong> that auto-bracket each word with symbols. Stack two styles together with one click, or wrap the whole result in a frame, divider, arrow, emoji or flag.
+    </p>
+  </section>
+
   <!-- Popular Use Cases -->
   <section class="editorial-section">
-    <h2 data-i18n="useCases.title">Popular Use Cases</h2>
+    <h2 data-i18n="useCases.title">What people actually use this for</h2>
     <div class="tips-grid">
-      <a class="tip-card" href="/usecase/linkedin-headline/" aria-label="LinkedIn Headline use case">
+      <a class="tip-card" href="/usecase/linkedin-headline/" aria-label="LinkedIn headline font generator">
         <div class="tip-icon">💼</div>
-        <h3 data-i18n="useCases.items.0.title">LinkedIn Headline</h3>
-        <p data-i18n="useCases.items.0.description">Make your LinkedIn headline stand out with bold and italic Unicode text that grabs attention in search results.</p>
+        <h3 data-i18n="useCases.items.0.title">LinkedIn headlines &amp; posts</h3>
+        <p data-i18n="useCases.items.0.description">𝗕𝗼𝗹𝗱 your title, italicise your role, or break long posts with small caps. Unicode is the only way to format a LinkedIn headline — there&rsquo;s no toolbar.</p>
       </a>
-      <a class="tip-card" href="/usecase/comment-font/" aria-label="Comment Fonts use case">
+      <a class="tip-card" href="/usecase/comment-font/" aria-label="Comment fonts for Instagram, YouTube and TikTok">
         <div class="tip-icon">💬</div>
-        <h3 data-i18n="useCases.items.1.title">Comment Fonts</h3>
-        <p data-i18n="useCases.items.1.description">Post eye-catching comments on Instagram, YouTube, and TikTok with styled Unicode fonts that pop.</p>
+        <h3 data-i18n="useCases.items.1.title">Comments that stop the scroll</h3>
+        <p data-i18n="useCases.items.1.description">Reply on Instagram, YouTube, TikTok or Reddit with 𝓼𝓬𝓻𝓲𝓹𝓽, 🅑🅤🅑🅑🅛🅔 or ᵗⁱⁿʸ text so your comment isn&rsquo;t lost in a wall of identical replies.</p>
       </a>
-      <a class="tip-card" href="/usecase/text-to-emoji/" aria-label="Text to Emoji use case">
-        <div class="tip-icon">😊</div>
-        <h3 data-i18n="useCases.items.2.title">Text to Emoji</h3>
-        <p data-i18n="useCases.items.2.description">Convert your text into emoji letter sequences — perfect for creative bios, stories, and group chats.</p>
+      <a class="tip-card" href="/usecase/vertical-text/" aria-label="Vertical and stacked text generator">
+        <div class="tip-icon">↕️</div>
+        <h3 data-i18n="useCases.items.2.title">Vertical &amp; stacked text</h3>
+        <p data-i18n="useCases.items.2.description">Stack letters top-to-bottom for Pinterest pins, Discord banners, and Instagram aesthetic posts — the format people search for as "stacked text" or "vertical font generator."</p>
+      </a>
+      <a class="tip-card" href="/discord/" aria-label="Discord font generator">
+        <div class="tip-icon">🎮</div>
+        <h3 data-i18n="useCases.items.3.title">Discord names (no Nitro)</h3>
+        <p data-i18n="useCases.items.3.description">Style your display name, server nickname or "About me" with fonts Discord renders natively. No Nitro required, and they show up in every server.</p>
       </a>
     </div>
     <p style="text-align:center;margin-top:1.5rem"><a class="cat-cta" href="/usecase/" data-i18n="useCases.viewAll">View all use cases →</a></p>
@@ -300,22 +384,27 @@
 
   <!-- Popular Categories -->
   <section class="editorial-section">
-    <h2>Popular Font Categories</h2>
+    <h2>Popular font categories</h2>
     <div class="tips-grid">
-      <a class="tip-card" href="/category/bold-fonts/" aria-label="Bold Fonts category">
+      <a class="tip-card" href="/category/bold-fonts/" aria-label="Bold font generator">
         <div class="tip-icon">🅱️</div>
-        <h3>Bold Fonts</h3>
-        <p>Command attention with strong, confident Unicode bold text for headlines, LinkedIn posts, and key messages.</p>
+        <h3>Bold (𝗕𝗼𝗹𝗱 / 𝐁𝐨𝐥𝐝)</h3>
+        <p>The most-used style on the site. Sans and serif variants, plus bold-italic. Use it for the first line of a LinkedIn post, the hook in an Instagram caption, or to make a single word in a paragraph carry weight.</p>
       </a>
-      <a class="tip-card" href="/category/cursive-fonts/" aria-label="Cursive Fonts category">
+      <a class="tip-card" href="/category/cursive-fonts/" aria-label="Cursive and script font generator">
         <div class="tip-icon">✍️</div>
-        <h3>Cursive Fonts</h3>
-        <p>Add elegance and personality with flowing cursive Unicode styles — perfect for Instagram bios and aesthetic captions.</p>
+        <h3>Cursive &amp; script (𝓒𝓾𝓻𝓼𝓲𝓿𝓮)</h3>
+        <p>Two flowing script variants. People paste these into Instagram bios, Pinterest pin titles, wedding-y captions, and aesthetic usernames. Bold script reads better at small sizes — use it on TikTok.</p>
       </a>
-      <a class="tip-card" href="/category/gothic-fonts/" aria-label="Gothic Fonts category">
+      <a class="tip-card" href="/category/gothic-fonts/" aria-label="Gothic and fraktur font generator">
         <div class="tip-icon">🖤</div>
-        <h3>Gothic Fonts</h3>
-        <p>Make a dramatic statement with bold gothic letterforms that stand out in gaming profiles and edgy branding.</p>
+        <h3>Gothic / fraktur (𝔊𝔬𝔱𝔥𝔦𝔠)</h3>
+        <p>Old-English / Fraktur letterforms. Common in gaming clan tags, metal/horror branding, dark academia bios, and Discord display names. Looks heaviest at large sizes — pair with one decorative symbol, not five.</p>
+      </a>
+      <a class="tip-card" href="/category/bubble-fonts/" aria-label="Bubble and aesthetic font generator">
+        <div class="tip-icon">🫧</div>
+        <h3>Bubble &amp; aesthetic (🅑🅤🅑🅑🅛🅔)</h3>
+        <p>12 bubble variants plus aesthetic spaced styles. Top pick for Y2K, kidcore, and "aesthetic font copy and paste" energy on TikTok, Pinterest, and Tumblr. Filled-bubble has the widest device support; the rest can break on older Android.</p>
       </a>
     </div>
     <p style="text-align:center;margin-top:1.5rem"><a class="cat-cta" href="/category/">Browse all font categories →</a></p>
@@ -325,425 +414,317 @@
   <section class="faq-section-wrapper" aria-label="Frequently asked questions">
     <div class="faq-inner">
 
-<!-- Getting Started -->
-<h2 class="faq-category" data-i18n="faq.categories.0.title">Getting Started with UltraTextGen</h2>
+<!-- Basics -->
+<h2 class="faq-category" data-i18n="faq.categories.0.title">Fancy text generator basics</h2>
 
 <div class="faq-item">
   <button class="faq-question" type="button">
-    <span data-i18n="faq.categories.0.items.0.question">What is UltraTextGen and how does it work?</span>
+    <span data-i18n="faq.categories.0.items.0.question">What is a fancy text generator?</span>
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
     </svg>
   </button>
   <div class="faq-answer" data-i18n-html="faq.categories.0.items.0.answer">
-    UltraTextGen is a free online Unicode text generator that instantly converts your normal text into stylish, fancy fonts and decorations.
-    Unlike formatting tools that rely on app-specific markup, UltraTextGen replaces each letter with a real Unicode character that looks bold, italic, cursive, gothic, or decorated.
+    A fancy text generator is a tool that replaces each letter you type with a different Unicode character that already looks bold, italic, cursive, gothic, bubble, or otherwise styled. Type <code>hello</code>, get 𝗵𝗲𝗹𝗹𝗼, 𝘩𝘦𝘭𝘭𝘰, 𝒽ℯ𝓁𝓁ℴ, 𝔥𝔢𝔩𝔩𝔬, 🅗🅔🅛🅛🅞.
     <br><br>
-    <strong>Example</strong><br>
-    Type "hello" → get 𝗵𝗲𝗹𝗹𝗼 (Ultra Bold), 𝘩𝘦𝘭𝘭𝘰 (Ultra Italic), 𝒽ℯ𝓁𝓁ℴ (Ultra Script), or ⓗⓔⓛⓛⓞ (Ultra Bubble).
-    <br><br>
-    Because these are real characters — not formatting codes — they work everywhere plain text is accepted: social media bios, usernames, captions, messages, emails, and more.
-    No apps to install, no sign-up, and no limits.
+    Because the output is real Unicode — not a font file or Markdown — you can copy and paste it into Instagram bios, TikTok captions, Discord names, LinkedIn headlines, WhatsApp statuses, email subject lines, and anywhere else that only accepts plain text.
   </div>
 </div>
 
 <div class="faq-item">
   <button class="faq-question" type="button">
-    <span data-i18n="faq.categories.0.items.1.question">How do I generate and copy styled text?</span>
+    <span data-i18n="faq.categories.0.items.1.question">How is a Unicode font different from a regular font like Arial or Helvetica?</span>
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
     </svg>
   </button>
   <div class="faq-answer" data-i18n-html="faq.categories.0.items.1.answer">
-    Generating styled text takes just a few seconds.
+    A regular font is a file stored on your device that tells the screen how to draw each letter. If a website doesn&rsquo;t load the font, the letter still says "A" — it just gets drawn in a default font.
     <br><br>
-    <strong>Step-by-step</strong><br>
-    1. Type or paste your text into the input box on the homepage.<br>
-    2. Styled versions appear instantly below the input.<br>
-    3. Browse styles or pick a category like Bold, Cursive, or Gothic.<br>
-    4. Optionally click "Add decoration" to add frames, symbols, or dividers.<br>
-    5. Click "Copy" next to any style and paste it wherever you want.
+    Unicode "fonts" are not fonts in that sense. They&rsquo;re separate characters in the Unicode standard with their own code points: A, 𝐀, 𝘈, 𝓐, 𝔄, 𝕬, Ⓐ are six different letters. That&rsquo;s why they survive copy-paste — you&rsquo;re not styling the letter A, you&rsquo;re using a different letter that happens to look styled.
     <br><br>
-    That's it — no account needed and the tool works on both desktop and mobile.
+    The downside: screen readers will read 𝐀 as "Mathematical Bold Capital A," not "A." Use Unicode fonts for headlines and accents, not whole paragraphs.
   </div>
 </div>
 
 <div class="faq-item">
   <button class="faq-question" type="button">
-    <span data-i18n="faq.categories.0.items.2.question">Is UltraTextGen completely free to use?</span>
+    <span data-i18n="faq.categories.0.items.2.question">Is it free, and what&rsquo;s the catch?</span>
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
     </svg>
   </button>
   <div class="faq-answer" data-i18n-html="faq.categories.0.items.2.answer">
-    Yes — 100% free with no daily limits, no account required, no watermarks, and no hidden fees.
-    You can generate and copy as much styled text as you need, anytime.
+    Free, no account, no daily limit, no watermark, no email capture, no paid tier. The site is funded by Google AdSense — that&rsquo;s the catch. We don&rsquo;t charge per copy, we don&rsquo;t gate styles behind a sign-up, and we don&rsquo;t insert affiliate links or zero-width tracking characters into the text you paste.
   </div>
 </div>
 
 
-<!-- Unicode vs Rich Text -->
-<h2 class="faq-category" data-i18n="faq.categories.1.title">Unicode Text vs Rich Text Formatting</h2>
+<!-- Platform how-tos -->
+<h2 class="faq-category" data-i18n="faq.categories.1.title">Bold, italic and styled text on each platform</h2>
 
 <div class="faq-item">
   <button class="faq-question" type="button">
-    <span data-i18n="faq.categories.1.items.0.question">How is Unicode text different from bold and italic in Word, Instagram, or Discord?</span>
+    <span data-i18n="faq.categories.1.items.0.question">How do I make my Instagram bio bold or italic?</span>
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
     </svg>
   </button>
   <div class="faq-answer" data-i18n-html="faq.categories.1.items.0.answer">
-    Regular bold and italic use formatting codes — often called markup or rich text — that only work inside the app that supports them.
-    For example, Discord uses **text** for bold, and Instagram captions have no formatting options at all.
+    Instagram has no formatting toolbar in the bio, caption, or comment fields — which is why everyone uses a fancy text generator for it.
     <br><br>
-    UltraTextGen works differently. It replaces each letter with a unique Unicode character that already looks styled.
-    The result is plain text that appears bold, italic, cursive, or decorated without any formatting engine behind it.
+    <strong>Steps:</strong><br>
+    1. Type your bio into UltraTextGen.<br>
+    2. Pick a bold (𝗕𝗼𝗹𝗱), italic (𝘐𝘵𝘢𝘭𝘪𝘤), or cursive (𝓒𝓾𝓻𝓼𝓲𝓿𝓮) style.<br>
+    3. Tap Copy.<br>
+    4. Paste it into the Instagram bio field on your phone.
     <br><br>
-    <strong>Why this matters</strong><br>
-    Rich text bold disappears if you copy it into a TikTok caption, an email subject line, or a username field — those places strip formatting.
-    Unicode text keeps its style because the characters themselves are styled. There is nothing to strip.
-    <br><br>
-    <strong>Example</strong><br>
-    A rich text editor makes the word "Sale" bold by wrapping it in invisible codes. Copy that into a TikTok bio and it becomes plain "Sale."
-    With UltraTextGen, "Sale" becomes 𝗦𝗮𝗹𝗲 — and it stays that way in your bio, your username, your email subject, and everywhere else.
+    Use sans-serif bold (𝗕𝗼𝗹𝗱) for the widest device support. The Instagram <em>username</em> field is stricter than the bio — it rejects Zalgo, fullwidth, and most decorative variants. Stick to plain bold/italic/cursive if you want to style your @ handle.
   </div>
 </div>
 
 <div class="faq-item">
   <button class="faq-question" type="button">
-    <span data-i18n="faq.categories.1.items.1.question">What can a Unicode text generator do that a rich text editor cannot?</span>
+    <span data-i18n="faq.categories.1.items.1.question">Can I bold text on Discord without Nitro?</span>
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
     </svg>
   </button>
   <div class="faq-answer" data-i18n-html="faq.categories.1.items.1.answer">
-    Rich text editors like Google Docs or Microsoft Word give you bold, italic, and underline — but those styles vanish the moment you paste into a social media bio, a username field, or a plain-text email.
-    A Unicode text generator unlocks styles and effects that no rich text editor can produce in those contexts.
+    Yes. Discord supports Markdown (<code>**text**</code> for bold, <code>*text*</code> for italic, <code>~~text~~</code> for strikethrough) inside chat messages — that&rsquo;s always been free. What Markdown <em>can&rsquo;t</em> do is render in your display name, server nickname, status, or "About me" — those fields ignore <code>**</code> entirely.
     <br><br>
-    <strong>Things UltraTextGen can do that rich text cannot</strong><br>
-    — Bold and italic text inside Instagram bios, TikTok captions, and YouTube descriptions where no formatting toolbar exists.<br>
-    — Gothic, Bubble, and Cursive font styles that rich text editors don't offer at all.<br>
-    — Upside-down and flipped text — impossible in any word processor.<br>
-    — Zalgo (glitch) text with stacked diacritics for a creepy, corrupted look.<br>
-    — Decorative frames, borders, and wrappers around your text using Unicode symbols.<br>
-    — Styled usernames and display names on Discord, Roblox, Steam, and other platforms.<br>
-    — Strikethrough and underline text in places that don't support those formatting options natively.
+    Unicode bold and italic work in all those places without Nitro, because the characters themselves are bold. Discord doesn&rsquo;t need to interpret anything. Paste 𝗯𝗼𝗹𝗱 into your nickname and it stays bold across every server you&rsquo;re in.
     <br><br>
-    In short, UltraTextGen gives you visual text effects that travel with the characters, so they work wherever plain text is accepted.
+    Use the <a href="/discord/">Discord-specific generator</a> for styles tested in nickname and message fields.
   </div>
 </div>
 
 <div class="faq-item">
   <button class="faq-question" type="button">
-    <span data-i18n="faq.categories.1.items.2.question">Can I use bold Unicode text in email subject lines?</span>
+    <span data-i18n="faq.categories.1.items.2.question">What font does LinkedIn use, and why does Unicode bold work in headlines?</span>
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
     </svg>
   </button>
   <div class="faq-answer" data-i18n-html="faq.categories.1.items.2.answer">
-    Yes — and this is a perfect example of something a rich text editor cannot do.
-    Email subject lines are plain text, so regular bold formatting is stripped out before the recipient sees it.
+    LinkedIn uses its own typeface, <strong>LinkedIn Sans</strong> (with Inter as the web fallback), for nearly all on-platform text. The platform deliberately doesn&rsquo;t expose a formatting toolbar for your headline, About section, or post body — there&rsquo;s no bold button.
     <br><br>
-    With UltraTextGen, you can paste Unicode bold characters directly into the subject line and the recipient sees them as bold in their inbox.
+    Unicode bold works because the characters are separate code points, so LinkedIn Sans just renders the bold-shaped glyphs that already exist in the font.
     <br><br>
-    <strong>Example</strong><br>
-    Normal subject line: "Flash Sale — 50% Off Today"<br>
-    Unicode subject line: "𝗙𝗹𝗮𝘀𝗵 𝗦𝗮𝗹𝗲 — 𝟱𝟬% 𝗢𝗳𝗳 𝗧𝗼𝗱𝗮𝘆"
+    <strong>What to use:</strong> sans-serif bold for headlines and the first line of posts, italic for nuance, small caps for section breaks.<br>
+    <strong>What to avoid:</strong> Zalgo, fullwidth, gothic — they hurt recruiter search filters (LinkedIn search doesn&rsquo;t normalise these back to ASCII) and break screen readers.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.1.items.3.question">How do I make vertical or stacked text (top-to-bottom)?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.1.items.3.answer">
+    Vertical text — also called stacked text — places each letter on its own line so the word reads top to bottom. It&rsquo;s the format people search for as "stacked text," "vertical font generator," "text top to bottom," or "comment that stacks down the feed."
     <br><br>
-    The bold version stands out in a crowded inbox without any special email tools. Most major email clients — Gmail, Outlook, Apple Mail — render Unicode characters correctly.
+    Use the <a href="/usecase/vertical-text/">vertical text generator</a> to handle the line breaks automatically and pick a style (bold, cursive, fullwidth) for the stacked letters. Popular for Pinterest pins, Discord channel banners, and aesthetic Instagram comments.
   </div>
 </div>
 
 
-<!-- Styles and Decorations -->
-<h2 class="faq-category" data-i18n="faq.categories.2.title">Styles, Fonts, and Decorations</h2>
+<!-- Styles & decoration -->
+<h2 class="faq-category" data-i18n="faq.categories.2.title">Styles, decorations, and how to mix them</h2>
 
 <div class="faq-item">
   <button class="faq-question" type="button">
-    <span data-i18n="faq.categories.2.items.0.question">What font styles does UltraTextGen offer?</span>
+    <span data-i18n="faq.categories.2.items.0.question">What styles are in the library?</span>
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
     </svg>
   </button>
   <div class="faq-answer" data-i18n-html="faq.categories.2.items.0.answer">
-    UltraTextGen has one of the largest collections of high-quality Unicode text styles, all prefixed with "Ultra" for superior look and coverage.
+    Around 65 styles, organised into twelve families:
     <br><br>
-    <strong>Core styles</strong><br>
-    Ultra Bold and Ultra Bold Serif, Ultra Italic (multiple variants), Ultra Script and Ultra Script Bold, Ultra Gothic, Ultra Bubble (Filled, Light, Tiles, Curly, Angle, Spaced, and more), Ultra Strike, and Ultra Underline.
-    <br><br>
-    <strong>Special styles</strong><br>
-    Upside Down and Flipped, Small Caps, Zalgo (Glitch), Word Wrappers and Frames, Backwards and Mirror, Double Struck, Fullwidth, Squared, Parenthesized, and many more.
-    <br><br>
-    New styles are added regularly, so bookmark the site or check back often.
+    <strong>Bold</strong> — sans, serif, italic-bold (6 variants).<br>
+    <strong>Italic</strong> — 4 variants including monospace italic.<br>
+    <strong>Cursive / script</strong> — regular and bold script.<br>
+    <strong>Gothic / fraktur</strong> — Old English and bold fraktur.<br>
+    <strong>Bubble</strong> — 12 variants (filled, light, tiles, curly, angle, spaced, and more).<br>
+    <strong>Strikethrough</strong> — slash, tilde, short, long.<br>
+    <strong>Underline</strong> — solid and double.<br>
+    <strong>Special</strong> — small caps, superscript / tiny, fullwidth, squared, parenthesized.<br>
+    <strong>Cool / aesthetic</strong> — spaced styles for Y2K and Tumblr energy.<br>
+    <strong>Fancy</strong> — double-struck and outlined.<br>
+    <strong>Word wrappers</strong> — 10 styles that auto-bracket each word (★彡[ word ]彡★, ╭─▸ word ╰─▸, etc.).<br>
+    <strong>Classified</strong> — upside-down, mirror, backwards, Zalgo (glitch), plus 8 more transforms.
   </div>
 </div>
 
 <div class="faq-item">
   <button class="faq-question" type="button">
-    <span data-i18n="faq.categories.2.items.1.question">Can I combine multiple styles and add decorations to my text?</span>
+    <span data-i18n="faq.categories.2.items.1.question">Can I stack multiple styles together?</span>
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
     </svg>
   </button>
   <div class="faq-answer" data-i18n-html="faq.categories.2.items.1.answer">
-    Yes — style mixing and one-click decorations are two of UltraTextGen's biggest advantages over other generators.
+    Yes — style mixing is one of the things you can&rsquo;t do with a normal font. Apply a base style, then layer another on top, then wrap the whole thing in a frame, divider, arrow, emoji or flag.
     <br><br>
-    You can layer styles together, such as Bubble + Zalgo, Gothic + Upside Down, or Small Caps + Underline, and then wrap the result with decorative elements.
+    <strong>Combos that look clean:</strong><br>
+    — Bold + Underline → <strong>𝗯𝗼𝗹𝗱</strong> u̳n̳d̳e̳r̳l̳i̳n̳e̳<br>
+    — Italic + Small Caps → ɪᴛᴀʟɪᴄ-ish, great for LinkedIn section breaks<br>
+    — Bubble + Spaced → 🅑 🅤 🅑 🅑 🅛 🅔, aesthetic Pinterest/TikTok vibe<br>
+    — Gothic + Star frame → ★彡[ 𝔥𝔢𝔩𝔩𝔬 ]彡★, for gaming clan tags
     <br><br>
-    <strong>Available decorations</strong><br>
-    Frames and borders (for example ★彡[ text ]彡★ or ╭─▸ text ╰─▸), arrows, symbols, minimal dividers, emojis, and flags.
-    <br><br>
-    <strong>Example</strong><br>
-    Start with "hello" → apply Ultra Gothic → add a star frame → result: ★彡[ 𝔥𝔢𝔩𝔩𝔬 ]彡★
-    <br><br>
-    No other generator makes mixing and decorating this easy.
+    Avoid stacking Zalgo with bubble — the diacritics collide and the result is unreadable on most phones.
   </div>
 </div>
 
 <div class="faq-item">
   <button class="faq-question" type="button">
-    <span data-i18n="faq.categories.2.items.2.question">What is Zalgo or glitch text and how do I use it?</span>
+    <span data-i18n="faq.categories.2.items.2.question">What is Zalgo (glitch) text and where do people actually use it?</span>
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
     </svg>
   </button>
   <div class="faq-answer" data-i18n-html="faq.categories.2.items.2.answer">
-    Zalgo text is the creepy, glitchy, "cursed" style that adds stacked diacritics above and below each character, making the text look corrupted or haunted.
+    Zalgo text is the cursed, glitched, dripping look made by stacking dozens of combining diacritic marks above and below each letter — for example h̷̢̛e̴̜͝l̸̼͝l̷͔͠o̵̗͝.
     <br><br>
-    <strong>Example</strong><br>
-    "hello" → h̷e̷l̷l̷o̷
+    The meme started on 4chan around 2009 and stuck around through r/creepypasta, horror TikTok edits, dark academia tumblrs, and edgy Discord display names. It&rsquo;s also the canonical Halloween / "we are corrupted" font for indie horror games and viral creepypasta accounts.
     <br><br>
-    It's popular for horror-themed memes, edgy social media bios, spooky usernames, and pranking friends in group chats.
-    Just type your text, select the Zalgo style, copy, and paste — UltraTextGen handles the stacking automatically.
+    Don&rsquo;t use it in usernames (most platforms reject combining marks), professional bios, or anything a screen reader will read aloud — every diacritic gets announced.
   </div>
 </div>
 
 
-<!-- Platform Compatibility -->
-<h2 class="faq-category" data-i18n="faq.categories.3.title">Platform Compatibility</h2>
+<!-- Compatibility & troubleshooting -->
+<h2 class="faq-category" data-i18n="faq.categories.3.title">Compatibility &amp; troubleshooting</h2>
 
 <div class="faq-item">
   <button class="faq-question" type="button">
-    <span data-i18n="faq.categories.3.items.0.question">Where can I use text generated by UltraTextGen?</span>
+    <span data-i18n="faq.categories.3.items.0.question">Why does my styled text show up as boxes (□) or question marks?</span>
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
     </svg>
   </button>
   <div class="faq-answer" data-i18n-html="faq.categories.3.items.0.answer">
-    Everywhere plain text is accepted. Because the styled characters are real Unicode — not formatting codes — they travel with your text no matter where you paste.
+    Boxes or "tofu" (□ ▯ �) appear when the device viewing the text has no installed font with a glyph for that Unicode code point. It&rsquo;s a rendering gap on the viewer&rsquo;s side, not a problem with your copied text.
     <br><br>
-    <strong>Social media</strong><br>
-    Instagram, TikTok, YouTube, X (Twitter), Facebook, LinkedIn, Pinterest, and Snapchat.
-    <br><br>
-    <strong>Messaging apps</strong><br>
-    WhatsApp, Telegram, Discord, Signal, and iMessage.
-    <br><br>
-    <strong>Other</strong><br>
-    Email subject lines and signatures, game profiles (Roblox, Minecraft, Steam), forum posts, resumes, presentations, and more.
-    <br><br>
-    We also have dedicated generator pages optimized for each major platform if you want styles tested specifically for that app.
+    <strong>Widest compatibility:</strong> bold (sans &amp; serif), italic, monospace, small caps, fullwidth, circled. Covered by default system fonts on iOS, Android, Windows, macOS and Chrome OS.<br>
+    <strong>Usually fine:</strong> cursive script, bubble, gothic — render on most phones from 2018 onwards.<br>
+    <strong>Occasionally clipped:</strong> Zalgo can look misaligned in apps with tight line spacing — that&rsquo;s by design, not a bug.
   </div>
 </div>
 
 <div class="faq-item">
   <button class="faq-question" type="button">
-    <span data-i18n="faq.categories.3.items.1.question">Can I use Unicode text for usernames and display names?</span>
+    <span data-i18n="faq.categories.3.items.1.question">Can I use these fonts in usernames and display names?</span>
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
     </svg>
   </button>
   <div class="faq-answer" data-i18n-html="faq.categories.3.items.1.answer">
-    Absolutely. Unicode characters are accepted in most username and display name fields — including Instagram, TikTok, Discord, Roblox, Steam, and many other platforms.
+    Mostly yes, with caveats per platform:
     <br><br>
-    <strong>Example</strong><br>
-    Normal username: "DarkWolf"<br>
-    Unicode username: "𝔇𝔞𝔯𝔨𝔚𝔬𝔩𝔣" (Gothic) or "ⒹⓐⓡⓚⓌⓞⓛⓕ" (Bubble)
+    <strong>Display names</strong> (Discord, Instagram, TikTok, Roblox, Steam, Telegram): almost any style works. 𝔇𝔞𝔯𝔨𝔚𝔬𝔩𝔣, ⒹⓐⓡⓚⓌⓞⓛⓕ, 𝓓𝓪𝓻𝓴𝓦𝓸𝓵𝓯 — all fine.<br>
+    <strong>@usernames / handles</strong>: stricter. Instagram&rsquo;s @ field only accepts Latin letters, digits, dots and underscores; Unicode goes in your display name instead. Discord usernames (lowercase, post-2023) reject most styled characters. X (Twitter) handles are ASCII-only.
     <br><br>
-    This is something a rich text editor can never do — username fields only accept plain text, and Unicode styled characters count as plain text.
-    <br><br>
-    <strong>Tip</strong><br>
-    If a platform rejects certain characters in the username field, try a different style. Some styles have wider compatibility than others.
+    Rule of thumb: if a platform shows a separate "display name" or "nickname" field, that&rsquo;s where Unicode goes. Leave the @ handle plain.
   </div>
 </div>
 
 <div class="faq-item">
   <button class="faq-question" type="button">
-    <span data-i18n="faq.categories.3.items.2.question">Why does some styled text show as boxes or question marks on certain platforms?</span>
+    <span data-i18n="faq.categories.3.items.2.question">Are these fonts safe for screen readers and accessibility?</span>
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
     </svg>
   </button>
   <div class="faq-answer" data-i18n-html="faq.categories.3.items.2.answer">
-    This happens when the font installed on the viewer's device does not include glyphs for those particular Unicode characters.
-    It is not a problem with the text itself — on most modern devices and browsers, the vast majority of styles display correctly.
+    Honestly: mostly no, and this is something most generators won&rsquo;t tell you.
     <br><br>
-    <strong>What to do</strong><br>
-    If you notice boxes or missing characters, try a different style. Core styles like Ultra Bold, Ultra Italic, and Ultra Bubble have the widest device support.
-    You can also use our platform-specific pages (like Discord or Instagram) to find styles tested for that app.
+    Screen readers — VoiceOver on iOS, TalkBack on Android, NVDA and JAWS on Windows — read each Unicode code point literally. 𝐀 is announced as "Mathematical Bold Capital A," not "A." A LinkedIn headline written entirely in Unicode bold becomes hostile to anyone using a screen reader.
+    <br><br>
+    <strong>How to use Unicode fonts responsibly:</strong><br>
+    — Style a word or phrase, not an entire bio.<br>
+    — Keep your name, contact info, and anything actionable in plain text.<br>
+    — Avoid Zalgo, fullwidth, and decorative wrappers in professional contexts.<br>
+    — If a platform has a separate plain-text name field (Discord, Instagram), put the readable version there.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.3.items.3.question">Can I use bold Unicode in email subject lines?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.3.items.3.answer">
+    Yes — this is one of the few places Unicode is the only option. Email subject lines are plain text by spec, so the "B" button in your email composer can&rsquo;t bold them. Unicode bold lets the recipient see 𝗙𝗹𝗮𝘀𝗵 𝗦𝗮𝗹𝗲 — 𝟱𝟬% 𝗢𝗳𝗳 𝗧𝗼𝗱𝗮𝘆 in their inbox preview.
+    <br><br>
+    Caveats: spam filters at Gmail and Outlook do score heavy Unicode use as a mild spam signal, so use it on one or two words per subject line rather than the whole thing. Avoid it entirely in transactional emails (receipts, password resets).
   </div>
 </div>
 
 
-<!-- Language and Script Support -->
-<h2 class="faq-category" data-i18n="faq.categories.4.title">Language and Script Support</h2>
+<!-- Languages -->
+<h2 class="faq-category" data-i18n="faq.categories.4.title">Languages and alphabets</h2>
 
 <div class="faq-item">
   <button class="faq-question" type="button">
-    <span data-i18n="faq.categories.4.items.0.question">What languages does UltraTextGen support for bold and styled text?</span>
+    <span data-i18n="faq.categories.4.items.0.question">What languages and alphabets work?</span>
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
     </svg>
   </button>
   <div class="faq-answer" data-i18n-html="faq.categories.4.items.0.answer">
-    UltraTextGen supports any language written using the Latin alphabet.
-    If a language uses A to Z, including accented characters such as á, é, ñ, ü, and ç, the text can be converted into bold, italic, cursive, and other Unicode styles.
-    This works because Unicode provides styled character variants for Latin script letters and digits.
+    Unicode styled variants only exist for the Latin alphabet (A–Z, a–z) and Arabic digits (0–9). So every language written in Latin script works: English, Spanish, French, Portuguese, German, Italian, Dutch, Polish, Vietnamese, Turkish, Indonesian, Malay, Tagalog, Afrikaans, Swahili, Hungarian, Czech — all fine.
     <br><br>
-    <strong>Supported Latin-alphabet languages</strong><br>
-    English, Spanish, French, Portuguese, German, Italian, Dutch, Afrikaans, Indonesian, Malay, Filipino, Tagalog, Vietnamese, and Turkish — among many others.
-    <br><br>
-    These languages can be styled reliably across social media platforms, messaging apps, and emails.
+    Accented characters (á, é, ñ, ü, ç) keep their accents in most styles. A handful of decorative styles drop the accent because Unicode doesn&rsquo;t define a styled variant for it — try a different style if that matters.
   </div>
 </div>
 
 <div class="faq-item">
   <button class="faq-question" type="button">
-    <span data-i18n="faq.categories.4.items.1.question">Which languages are not supported for styled text?</span>
+    <span data-i18n="faq.categories.4.items.1.question">Why doesn&rsquo;t Arabic, Cyrillic, Hindi, Chinese, or Japanese text transform?</span>
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
     </svg>
   </button>
   <div class="faq-answer" data-i18n-html="faq.categories.4.items.1.answer">
-    Languages that use non-Latin scripts cannot be converted into bold, italic, or other Unicode font styles.
-    These scripts do not have styled Unicode character variants, so the text will remain unchanged after conversion.
+    Unicode simply doesn&rsquo;t define styled variants for non-Latin scripts. There&rsquo;s no "bold Arabic" or "italic Devanagari" character in the standard, so there&rsquo;s nothing to swap in. Arabic, Urdu, Persian, Hebrew, Hindi, Bengali, Tamil, Telugu, Thai, Chinese (Hanzi), Japanese (Kanji, Hiragana, Katakana), Korean (Hangul), Cyrillic and Greek all pass through unchanged.
     <br><br>
-    <strong>Not supported for styled text</strong><br>
-    Arabic, Urdu, Persian, Hebrew, Hindi, Bengali, Tamil, Thai, Chinese, Japanese, Korean, and Sinhala.
-    <br><br>
-    This is a limitation of the Unicode standard itself, not a limitation of UltraTextGen.
-    If you write in one of these languages, your Latin-script words (brand names, English phrases, etc.) within the text will still convert.
-  </div>
-</div>
-
-<div class="faq-item">
-  <button class="faq-question" type="button">
-    <span data-i18n="faq.categories.4.items.2.question">Are there any characters that don't convert?</span>
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-    </svg>
-  </button>
-  <div class="faq-answer" data-i18n-html="faq.categories.4.items.2.answer">
-    Most English letters (A–Z, a–z), numbers (0–9), and basic punctuation convert perfectly across all styles.
-    Some very rare symbols or special characters may have fewer style options because Unicode doesn't include styled variants for every character.
-    <br><br>
-    If a character cannot be converted, it simply stays as normal text — it never breaks or produces errors.
-    Your output will always be usable.
+    The exception: Latin-script words inside a non-Latin sentence — brand names, English loanwords, hashtags — will still convert. The non-Latin characters around them stay as they are.
   </div>
 </div>
 
 
-<!-- Privacy and Safety -->
-<h2 class="faq-category" data-i18n="faq.categories.5.title">Privacy and Safety</h2>
+<!-- Privacy -->
+<h2 class="faq-category" data-i18n="faq.categories.5.title">Privacy &amp; safety</h2>
 
 <div class="faq-item">
   <button class="faq-question" type="button">
-    <span data-i18n="faq.categories.5.items.0.question">Is the text I type stored or tracked?</span>
+    <span data-i18n="faq.categories.5.items.0.question">Is the text I type stored, logged, or sent to a server?</span>
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
     </svg>
   </button>
   <div class="faq-answer" data-i18n-html="faq.categories.5.items.0.answer">
-    No. UltraTextGen does not store your text and does not add any hidden or tracking characters to the output.
-    The conversion happens in your browser, and what you copy is clean Unicode — nothing more.
+    No. All transformation happens in your browser using JavaScript — nothing you type is sent to a server. There are no hidden tracking characters, no zero-width spaces, no invisible watermarks added to the output. What you copy is clean Unicode and nothing else.
+    <br><br>
+    The site uses Google Tag Manager for anonymous usage analytics (page views and which styles get used most) but it never sees the contents of your input box.
   </div>
 </div>
 
 <div class="faq-item">
   <button class="faq-question" type="button">
-    <span data-i18n="faq.categories.5.items.1.question">Is the generated text safe to copy and paste?</span>
+    <span data-i18n="faq.categories.5.items.1.question">Does the generated text work on phones and tablets?</span>
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
     </svg>
   </button>
   <div class="faq-answer" data-i18n-html="faq.categories.5.items.1.answer">
-    Yes — completely safe. The output is standard Unicode text with no embedded scripts, no hidden formatting, and no tracking codes.
-    You can paste it into any app or website without any security concerns.
-  </div>
-</div>
-
-
-<!-- Mobile and Device Support -->
-<h2 class="faq-category" data-i18n="faq.categories.6.title">Mobile and Device Support</h2>
-
-<div class="faq-item">
-  <button class="faq-question" type="button">
-    <span data-i18n="faq.categories.6.items.0.question">Does UltraTextGen work on phones and tablets?</span>
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-    </svg>
-  </button>
-  <div class="faq-answer" data-i18n-html="faq.categories.6.items.0.answer">
-    Yes — the site is fully responsive and works great on phones, tablets, and desktops.
-    There is no app to download. Just open UltraTextGen in your mobile browser, type your text, pick a style, and copy.
-    It works on iPhone, Android, iPad, and any device with a modern browser.
-  </div>
-</div>
-
-
-<!-- Why UltraTextGen -->
-<h2 class="faq-category" data-i18n="faq.categories.7.title">Why Choose UltraTextGen</h2>
-
-<div class="faq-item">
-  <button class="faq-question" type="button">
-    <span data-i18n="faq.categories.7.items.0.question">Why should I choose UltraTextGen over other text generators?</span>
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-    </svg>
-  </button>
-  <div class="faq-answer" data-i18n-html="faq.categories.7.items.0.answer">
-    UltraTextGen is built to be the most complete and easiest-to-use Unicode text generator available.
-    <br><br>
-    <strong>What sets it apart</strong><br>
-    — One of the largest collections of premium "Ultra" styled fonts.<br>
-    — True style mixing: combine multiple styles in one click, something most generators don't support.<br>
-    — One-click decorations: add frames, borders, symbols, and dividers without manual copy-pasting.<br>
-    — Dedicated platform pages for TikTok, Discord, Instagram, and more — so you get styles tested for your platform.<br>
-    — Fast, clean interface with no pop-ups slowing you down.<br>
-    — Constantly updated with new styles and decorations.
-  </div>
-</div>
-
-<div class="faq-item">
-  <button class="faq-question" type="button">
-    <span data-i18n="faq.categories.7.items.1.question">Does UltraTextGen add new styles?</span>
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-    </svg>
-  </button>
-  <div class="faq-answer" data-i18n-html="faq.categories.7.items.1.answer">
-    Yes — new Ultra styles and decorations are added regularly.
-    Bookmark the site to stay updated on the latest additions.
-  </div>
-</div>
-
-<div class="faq-item">
-  <button class="faq-question" type="button">
-    <span data-i18n="faq.categories.7.items.2.question">How do I find the right font style or tool for my needs?</span>
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-    </svg>
-  </button>
-  <div class="faq-answer" data-i18n-html="faq.categories.7.items.2.answer">
-    UltraTextGen organises styles and tools in three ways:
-    <br><br>
-    <strong>By font style</strong><br>
-    Browse all font categories — bold, cursive, gothic, bubble, strikethrough, underline, upside-down, and more. Each category page has its own generator focused on that style.
-    <br><br>
-    <strong>By platform</strong><br>
-    Use a platform-specific generator (like Instagram, TikTok, or LinkedIn) for styles and tips optimised for that platform's rules.
-    <br><br>
-    <strong>By task</strong><br>
-    Visit the use case page for task-specific tools — comment fonts, emoji combinations, before-and-after emoji, and more.
+    Yes. The site is fully responsive — iPhone, Android, iPad, any modern mobile browser. There&rsquo;s no app to install. The Copy button uses the device&rsquo;s native clipboard API, so you can paste straight into Instagram, TikTok, or Discord without leaving the browser.
   </div>
 </div>
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,11 +1,11 @@
 {
   "meta": {
-    "title": "Stylish Text Generator — Copy & Paste Fancy Unicode Fonts",
-    "description": "Turn plain text into stylish Unicode fonts you can copy and paste. Choose bold, cursive, gothic, and decorative styles for bios, usernames, comments, and posts."
+    "title": "Fancy Text Generator — 60+ Unicode Fonts (Copy & Paste)",
+    "description": "Turn plain text into 60+ Unicode fonts — bold, italic, cursive, gothic, bubble, small caps, aesthetic, upside-down and Zalgo. Copy and paste straight into Instagram bios, TikTok captions, Discord names, LinkedIn headlines, and WhatsApp. Free, instant, no sign-up."
   },
   "hero": {
-    "title": "Stylish Font Generator",
-    "subtitle": "Turn plain text into bold, cursive, gothic, and decorative Unicode fonts you can copy and paste instantly."
+    "title": "Fancy Text Generator",
+    "subtitle": "Type once, get 60+ Unicode fonts you can copy and paste anywhere — Instagram bios, TikTok captions, Discord names, LinkedIn headlines, WhatsApp, email subject lines, even game profiles."
   },
   "decorations": {
     "label": "Add decoration to results",
@@ -24,20 +24,24 @@
     "advertisement": "Advertisement"
   },
   "useCases": {
-    "title": "Popular Use Cases",
+    "title": "What people actually use this for",
     "viewAll": "View all use cases →",
     "items": [
       {
-        "title": "LinkedIn Headline",
-        "description": "Make your LinkedIn headline stand out with bold and italic Unicode text that grabs attention in search results."
+        "title": "LinkedIn headlines & posts",
+        "description": "𝗕𝗼𝗹𝗱 your title, italicise your role, or break long posts with small caps. Unicode is the only way to format a LinkedIn headline — there's no toolbar."
       },
       {
-        "title": "Comment Fonts",
-        "description": "Post eye-catching comments on Instagram, YouTube, and TikTok with styled Unicode fonts that pop."
+        "title": "Comments that stop the scroll",
+        "description": "Reply on Instagram, YouTube, TikTok or Reddit with 𝓼𝓬𝓻𝓲𝓹𝓽, 🅑🅤🅑🅑🅛🅔 or ᵗⁱⁿʸ text so your comment isn't lost in a wall of identical replies."
       },
       {
-        "title": "Text to Emoji",
-        "description": "Convert your text into emoji letter sequences — perfect for creative bios, stories, and group chats."
+        "title": "Vertical & stacked text",
+        "description": "Stack letters top-to-bottom for Pinterest pins, Discord banners, and Instagram aesthetic posts — the format people search for as \"stacked text\" or \"vertical font generator.\""
+      },
+      {
+        "title": "Discord names (no Nitro)",
+        "description": "Style your display name, server nickname or \"About me\" with fonts Discord renders natively. No Nitro required, and they show up in every server."
       }
     ]
   },
@@ -62,126 +66,104 @@
   "faq": {
     "categories": [
       {
-        "title": "Getting Started with UltraTextGen",
+        "title": "Fancy text generator basics",
         "items": [
           {
-            "question": "What is UltraTextGen and how does it work?",
-            "answer": "UltraTextGen is a free online Unicode text generator that instantly converts your normal text into stylish, fancy fonts and decorations.\n    Unlike formatting tools that rely on app-specific markup, UltraTextGen replaces each letter with a real Unicode character that looks bold, italic, cursive, gothic, or decorated.\n    <br><br>\n    <strong>Example</strong><br>\n    Type \"hello\" → get 𝗵𝗲𝗹𝗹𝗼 (Ultra Bold), 𝘩𝘦𝘭𝘭𝘰 (Ultra Italic), 𝒽ℯ𝓁𝓁ℴ (Ultra Script), or ⓗⓔⓛⓛⓞ (Ultra Bubble).\n    <br><br>\n    Because these are real characters — not formatting codes — they work everywhere plain text is accepted: social media bios, usernames, captions, messages, emails, and more.\n    No apps to install, no sign-up, and no limits."
+            "question": "What is a fancy text generator?",
+            "answer": "A fancy text generator is a tool that replaces each letter you type with a different Unicode character that already looks bold, italic, cursive, gothic, bubble, or otherwise styled. Type <code>hello</code>, get 𝗵𝗲𝗹𝗹𝗼, 𝘩𝘦𝘭𝘭𝘰, 𝒽ℯ𝓁𝓁ℴ, 𝔥𝔢𝔩𝔩𝔬, 🅗🅔🅛🅛🅞.<br><br>Because the output is real Unicode — not a font file or Markdown — you can copy and paste it into Instagram bios, TikTok captions, Discord names, LinkedIn headlines, WhatsApp statuses, email subject lines, and anywhere else that only accepts plain text."
           },
           {
-            "question": "How do I generate and copy styled text?",
-            "answer": "Generating styled text takes just a few seconds.\n    <br><br>\n    <strong>Step-by-step</strong><br>\n    1. Type or paste your text into the input box on the homepage.<br>\n    2. Styled versions appear instantly below the input.<br>\n    3. Browse styles or pick a category like Bold, Cursive, or Gothic.<br>\n    4. Optionally click \"Add decoration\" to add frames, symbols, or dividers.<br>\n    5. Click \"Copy\" next to any style and paste it wherever you want.\n    <br><br>\n    That's it — no account needed and the tool works on both desktop and mobile."
+            "question": "How is a Unicode font different from a regular font like Arial or Helvetica?",
+            "answer": "A regular font is a file stored on your device that tells the screen how to draw each letter. If a website doesn't load the font, the letter still says \"A\" — it just gets drawn in a default font.<br><br>Unicode \"fonts\" are not fonts in that sense. They're separate characters in the Unicode standard with their own code points: A, 𝐀, 𝘈, 𝓐, 𝔄, 𝕬, Ⓐ are six different letters. That's why they survive copy-paste — you're not styling the letter A, you're using a different letter that happens to look styled.<br><br>The downside: screen readers will read 𝐀 as \"Mathematical Bold Capital A,\" not \"A.\" Use Unicode fonts for headlines and accents, not whole paragraphs."
           },
           {
-            "question": "Is UltraTextGen completely free to use?",
-            "answer": "Yes — 100% free with no daily limits, no account required, no watermarks, and no hidden fees.\n    You can generate and copy as much styled text as you need, anytime."
+            "question": "Is it free, and what's the catch?",
+            "answer": "Free, no account, no daily limit, no watermark, no email capture, no paid tier. The site is funded by Google AdSense — that's the catch. We don't charge per copy, we don't gate styles behind a sign-up, and we don't insert affiliate links or zero-width tracking characters into the text you paste."
           }
         ]
       },
       {
-        "title": "Unicode Text vs Rich Text Formatting",
+        "title": "Bold, italic and styled text on each platform",
         "items": [
           {
-            "question": "How is Unicode text different from bold and italic in Word, Instagram, or Discord?",
-            "answer": "Regular bold and italic use formatting codes — often called markup or rich text — that only work inside the app that supports them.\n    For example, Discord uses **text** for bold, and Instagram captions have no formatting options at all.\n    <br><br>\n    UltraTextGen works differently. It replaces each letter with a unique Unicode character that already looks styled.\n    The result is plain text that appears bold, italic, cursive, or decorated without any formatting engine behind it.\n    <br><br>\n    <strong>Why this matters</strong><br>\n    Rich text bold disappears if you copy it into a TikTok caption, an email subject line, or a username field — those places strip formatting.\n    Unicode text keeps its style because the characters themselves are styled. There is nothing to strip.\n    <br><br>\n    <strong>Example</strong><br>\n    A rich text editor makes the word \"Sale\" bold by wrapping it in invisible codes. Copy that into a TikTok bio and it becomes plain \"Sale.\"\n    With UltraTextGen, \"Sale\" becomes 𝗦𝗮𝗹𝗲 — and it stays that way in your bio, your username, your email subject, and everywhere else."
+            "question": "How do I make my Instagram bio bold or italic?",
+            "answer": "Instagram has no formatting toolbar in the bio, caption, or comment fields — which is why everyone uses a fancy text generator for it.<br><br><strong>Steps:</strong><br>1. Type your bio into UltraTextGen.<br>2. Pick a bold (𝗕𝗼𝗹𝗱), italic (𝘐𝘵𝘢𝘭𝘪𝘤), or cursive (𝓒𝓾𝓻𝓼𝓲𝓿𝓮) style.<br>3. Tap Copy.<br>4. Paste it into the Instagram bio field on your phone.<br><br>Use sans-serif bold (𝗕𝗼𝗹𝗱) for the widest device support. The Instagram <em>username</em> field is stricter than the bio — it rejects Zalgo, fullwidth, and most decorative variants. Stick to plain bold/italic/cursive if you want to style your @ handle."
           },
           {
-            "question": "What can a Unicode text generator do that a rich text editor cannot?",
-            "answer": "Rich text editors like Google Docs or Microsoft Word give you bold, italic, and underline — but those styles vanish the moment you paste into a social media bio, a username field, or a plain-text email.\n    A Unicode text generator unlocks styles and effects that no rich text editor can produce in those contexts.\n    <br><br>\n    <strong>Things UltraTextGen can do that rich text cannot</strong><br>\n    — Bold and italic text inside Instagram bios, TikTok captions, and YouTube descriptions where no formatting toolbar exists.<br>\n    — Gothic, Bubble, and Cursive font styles that rich text editors don't offer at all.<br>\n    — Upside-down and flipped text — impossible in any word processor.<br>\n    — Zalgo (glitch) text with stacked diacritics for a creepy, corrupted look.<br>\n    — Decorative frames, borders, and wrappers around your text using Unicode symbols.<br>\n    — Styled usernames and display names on Discord, Roblox, Steam, and other platforms.<br>\n    — Strikethrough and underline text in places that don't support those formatting options natively.\n    <br><br>\n    In short, UltraTextGen gives you visual text effects that travel with the characters, so they work wherever plain text is accepted."
+            "question": "Can I bold text on Discord without Nitro?",
+            "answer": "Yes. Discord supports Markdown (<code>**text**</code> for bold, <code>*text*</code> for italic, <code>~~text~~</code> for strikethrough) inside chat messages — that's always been free. What Markdown <em>can't</em> do is render in your display name, server nickname, status, or \"About me\" — those fields ignore <code>**</code> entirely.<br><br>Unicode bold and italic work in all those places without Nitro, because the characters themselves are bold. Discord doesn't need to interpret anything. Paste 𝗯𝗼𝗹𝗱 into your nickname and it stays bold across every server you're in.<br><br>Use the <a href=\"/discord/\">Discord-specific generator</a> for styles tested in nickname and message fields."
           },
           {
-            "question": "Can I use bold Unicode text in email subject lines?",
-            "answer": "Yes — and this is a perfect example of something a rich text editor cannot do.\n    Email subject lines are plain text, so regular bold formatting is stripped out before the recipient sees it.\n    <br><br>\n    With UltraTextGen, you can paste Unicode bold characters directly into the subject line and the recipient sees them as bold in their inbox.\n    <br><br>\n    <strong>Example</strong><br>\n    Normal subject line: \"Flash Sale — 50% Off Today\"<br>\n    Unicode subject line: \"𝗙𝗹𝗮𝘀𝗵 𝗦𝗮𝗹𝗲 — 𝟱𝟬% 𝗢𝗳𝗳 𝗧𝗼𝗱𝗮𝘆\"\n    <br><br>\n    The bold version stands out in a crowded inbox without any special email tools. Most major email clients — Gmail, Outlook, Apple Mail — render Unicode characters correctly."
+            "question": "What font does LinkedIn use, and why does Unicode bold work in headlines?",
+            "answer": "LinkedIn uses its own typeface, <strong>LinkedIn Sans</strong> (with Inter as the web fallback), for nearly all on-platform text. The platform deliberately doesn't expose a formatting toolbar for your headline, About section, or post body — there's no bold button.<br><br>Unicode bold works because the characters are separate code points, so LinkedIn Sans just renders the bold-shaped glyphs that already exist in the font.<br><br><strong>What to use:</strong> sans-serif bold for headlines and the first line of posts, italic for nuance, small caps for section breaks.<br><strong>What to avoid:</strong> Zalgo, fullwidth, gothic — they hurt recruiter search filters (LinkedIn search doesn't normalise these back to ASCII) and break screen readers."
+          },
+          {
+            "question": "How do I make vertical or stacked text (top-to-bottom)?",
+            "answer": "Vertical text — also called stacked text — places each letter on its own line so the word reads top to bottom. It's the format people search for as \"stacked text,\" \"vertical font generator,\" \"text top to bottom,\" or \"comment that stacks down the feed.\"<br><br>Use the <a href=\"/usecase/vertical-text/\">vertical text generator</a> to handle the line breaks automatically and pick a style (bold, cursive, fullwidth) for the stacked letters. Popular for Pinterest pins, Discord channel banners, and aesthetic Instagram comments."
           }
         ]
       },
       {
-        "title": "Styles, Fonts, and Decorations",
+        "title": "Styles, decorations, and how to mix them",
         "items": [
           {
-            "question": "What font styles does UltraTextGen offer?",
-            "answer": "UltraTextGen has one of the largest collections of high-quality Unicode text styles, all prefixed with \"Ultra\" for superior look and coverage.\n    <br><br>\n    <strong>Core styles</strong><br>\n    Ultra Bold and Ultra Bold Serif, Ultra Italic (multiple variants), Ultra Script and Ultra Script Bold, Ultra Gothic, Ultra Bubble (Filled, Light, Tiles, Curly, Angle, Spaced, and more), Ultra Strike, and Ultra Underline.\n    <br><br>\n    <strong>Special styles</strong><br>\n    Upside Down and Flipped, Small Caps, Zalgo (Glitch), Word Wrappers and Frames, Backwards and Mirror, Double Struck, Fullwidth, Squared, Parenthesized, and many more.\n    <br><br>\n    New styles are added regularly, so bookmark the site or check back often."
+            "question": "What styles are in the library?",
+            "answer": "Around 65 styles, organised into twelve families:<br><br><strong>Bold</strong> — sans, serif, italic-bold (6 variants).<br><strong>Italic</strong> — 4 variants including monospace italic.<br><strong>Cursive / script</strong> — regular and bold script.<br><strong>Gothic / fraktur</strong> — Old English and bold fraktur.<br><strong>Bubble</strong> — 12 variants (filled, light, tiles, curly, angle, spaced, and more).<br><strong>Strikethrough</strong> — slash, tilde, short, long.<br><strong>Underline</strong> — solid and double.<br><strong>Special</strong> — small caps, superscript / tiny, fullwidth, squared, parenthesized.<br><strong>Cool / aesthetic</strong> — spaced styles for Y2K and Tumblr energy.<br><strong>Fancy</strong> — double-struck and outlined.<br><strong>Word wrappers</strong> — 10 styles that auto-bracket each word (★彡[ word ]彡★, ╭─▸ word ╰─▸, etc.).<br><strong>Classified</strong> — upside-down, mirror, backwards, Zalgo (glitch), plus 8 more transforms."
           },
           {
-            "question": "Can I combine multiple styles and add decorations to my text?",
-            "answer": "Yes — style mixing and one-click decorations are two of UltraTextGen's biggest advantages over other generators.\n    <br><br>\n    You can layer styles together, such as Bubble + Zalgo, Gothic + Upside Down, or Small Caps + Underline, and then wrap the result with decorative elements.\n    <br><br>\n    <strong>Available decorations</strong><br>\n    Frames and borders (for example ★彡[ text ]彡★ or ╭─▸ text ╰─▸), arrows, symbols, minimal dividers, emojis, and flags.\n    <br><br>\n    <strong>Example</strong><br>\n    Start with \"hello\" → apply Ultra Gothic → add a star frame → result: ★彡[ 𝔥𝔢𝔩𝔩𝔬 ]彡★\n    <br><br>\n    No other generator makes mixing and decorating this easy."
+            "question": "Can I stack multiple styles together?",
+            "answer": "Yes — style mixing is one of the things you can't do with a normal font. Apply a base style, then layer another on top, then wrap the whole thing in a frame, divider, arrow, emoji or flag.<br><br><strong>Combos that look clean:</strong><br>— Bold + Underline → <strong>𝗯𝗼𝗹𝗱</strong> u̳n̳d̳e̳r̳l̳i̳n̳e̳<br>— Italic + Small Caps → ɪᴛᴀʟɪᴄ-ish, great for LinkedIn section breaks<br>— Bubble + Spaced → 🅑 🅤 🅑 🅑 🅛 🅔, aesthetic Pinterest/TikTok vibe<br>— Gothic + Star frame → ★彡[ 𝔥𝔢𝔩𝔩𝔬 ]彡★, for gaming clan tags<br><br>Avoid stacking Zalgo with bubble — the diacritics collide and the result is unreadable on most phones."
           },
           {
-            "question": "What is Zalgo or glitch text and how do I use it?",
-            "answer": "Zalgo text is the creepy, glitchy, \"cursed\" style that adds stacked diacritics above and below each character, making the text look corrupted or haunted.\n    <br><br>\n    <strong>Example</strong><br>\n    \"hello\" → h̷e̷l̷l̷o̷\n    <br><br>\n    It's popular for horror-themed memes, edgy social media bios, spooky usernames, and pranking friends in group chats.\n    Just type your text, select the Zalgo style, copy, and paste — UltraTextGen handles the stacking automatically."
+            "question": "What is Zalgo (glitch) text and where do people actually use it?",
+            "answer": "Zalgo text is the cursed, glitched, dripping look made by stacking dozens of combining diacritic marks above and below each letter — for example h̷̢̛e̴̜͝l̸̼͝l̷͔͠o̵̗͝.<br><br>The meme started on 4chan around 2009 and stuck around through r/creepypasta, horror TikTok edits, dark academia tumblrs, and edgy Discord display names. It's also the canonical Halloween / \"we are corrupted\" font for indie horror games and viral creepypasta accounts.<br><br>Don't use it in usernames (most platforms reject combining marks), professional bios, or anything a screen reader will read aloud — every diacritic gets announced."
           }
         ]
       },
       {
-        "title": "Platform Compatibility",
+        "title": "Compatibility & troubleshooting",
         "items": [
           {
-            "question": "Where can I use text generated by UltraTextGen?",
-            "answer": "Everywhere plain text is accepted. Because the styled characters are real Unicode — not formatting codes — they travel with your text no matter where you paste.\n    <br><br>\n    <strong>Social media</strong><br>\n    Instagram, TikTok, YouTube, X (Twitter), Facebook, LinkedIn, Pinterest, and Snapchat.\n    <br><br>\n    <strong>Messaging apps</strong><br>\n    WhatsApp, Telegram, Discord, Signal, and iMessage.\n    <br><br>\n    <strong>Other</strong><br>\n    Email subject lines and signatures, game profiles (Roblox, Minecraft, Steam), forum posts, resumes, presentations, and more.\n    <br><br>\n    We also have dedicated generator pages optimized for each major platform if you want styles tested specifically for that app."
+            "question": "Why does my styled text show up as boxes (□) or question marks?",
+            "answer": "Boxes or \"tofu\" (□ ▯ �) appear when the device viewing the text has no installed font with a glyph for that Unicode code point. It's a rendering gap on the viewer's side, not a problem with your copied text.<br><br><strong>Widest compatibility:</strong> bold (sans & serif), italic, monospace, small caps, fullwidth, circled. Covered by default system fonts on iOS, Android, Windows, macOS and Chrome OS.<br><strong>Usually fine:</strong> cursive script, bubble, gothic — render on most phones from 2018 onwards.<br><strong>Occasionally clipped:</strong> Zalgo can look misaligned in apps with tight line spacing — that's by design, not a bug."
           },
           {
-            "question": "Can I use Unicode text for usernames and display names?",
-            "answer": "Absolutely. Unicode characters are accepted in most username and display name fields — including Instagram, TikTok, Discord, Roblox, Steam, and many other platforms.\n    <br><br>\n    <strong>Example</strong><br>\n    Normal username: \"DarkWolf\"<br>\n    Unicode username: \"𝔇𝔞𝔯𝔨𝔚𝔬𝔩𝔣\" (Gothic) or \"ⒹⓐⓡⓚⓌⓞⓛⓕ\" (Bubble)\n    <br><br>\n    This is something a rich text editor can never do — username fields only accept plain text, and Unicode styled characters count as plain text.\n    <br><br>\n    <strong>Tip</strong><br>\n    If a platform rejects certain characters in the username field, try a different style. Some styles have wider compatibility than others."
+            "question": "Can I use these fonts in usernames and display names?",
+            "answer": "Mostly yes, with caveats per platform:<br><br><strong>Display names</strong> (Discord, Instagram, TikTok, Roblox, Steam, Telegram): almost any style works. 𝔇𝔞𝔯𝔨𝔚𝔬𝔩𝔣, ⒹⓐⓡⓚⓌⓞⓛⓕ, 𝓓𝓪𝓻𝓴𝓦𝓸𝓵𝓯 — all fine.<br><strong>@usernames / handles</strong>: stricter. Instagram's @ field only accepts Latin letters, digits, dots and underscores; Unicode goes in your display name instead. Discord usernames (lowercase, post-2023) reject most styled characters. X (Twitter) handles are ASCII-only.<br><br>Rule of thumb: if a platform shows a separate \"display name\" or \"nickname\" field, that's where Unicode goes. Leave the @ handle plain."
           },
           {
-            "question": "Why does some styled text show as boxes or question marks on certain platforms?",
-            "answer": "This happens when the font installed on the viewer's device does not include glyphs for those particular Unicode characters.\n    It is not a problem with the text itself — on most modern devices and browsers, the vast majority of styles display correctly.\n    <br><br>\n    <strong>What to do</strong><br>\n    If you notice boxes or missing characters, try a different style. Core styles like Ultra Bold, Ultra Italic, and Ultra Bubble have the widest device support.\n    You can also use our platform-specific pages (like Discord or Instagram) to find styles tested for that app."
+            "question": "Are these fonts safe for screen readers and accessibility?",
+            "answer": "Honestly: mostly no, and this is something most generators won't tell you.<br><br>Screen readers — VoiceOver on iOS, TalkBack on Android, NVDA and JAWS on Windows — read each Unicode code point literally. 𝐀 is announced as \"Mathematical Bold Capital A,\" not \"A.\" A LinkedIn headline written entirely in Unicode bold becomes hostile to anyone using a screen reader.<br><br><strong>How to use Unicode fonts responsibly:</strong><br>— Style a word or phrase, not an entire bio.<br>— Keep your name, contact info, and anything actionable in plain text.<br>— Avoid Zalgo, fullwidth, and decorative wrappers in professional contexts.<br>— If a platform has a separate plain-text name field (Discord, Instagram), put the readable version there."
+          },
+          {
+            "question": "Can I use bold Unicode in email subject lines?",
+            "answer": "Yes — this is one of the few places Unicode is the only option. Email subject lines are plain text by spec, so the \"B\" button in your email composer can't bold them. Unicode bold lets the recipient see 𝗙𝗹𝗮𝘀𝗵 𝗦𝗮𝗹𝗲 — 𝟱𝟬% 𝗢𝗳𝗳 𝗧𝗼𝗱𝗮𝘆 in their inbox preview.<br><br>Caveats: spam filters at Gmail and Outlook do score heavy Unicode use as a mild spam signal, so use it on one or two words per subject line rather than the whole thing. Avoid it entirely in transactional emails (receipts, password resets)."
           }
         ]
       },
       {
-        "title": "Language and Script Support",
+        "title": "Languages and alphabets",
         "items": [
           {
-            "question": "What languages does UltraTextGen support for bold and styled text?",
-            "answer": "UltraTextGen supports any language written using the Latin alphabet.\n    If a language uses A to Z, including accented characters such as á, é, ñ, ü, and ç, the text can be converted into bold, italic, cursive, and other Unicode styles.\n    This works because Unicode provides styled character variants for Latin script letters and digits.\n    <br><br>\n    <strong>Supported Latin-alphabet languages</strong><br>\n    English, Spanish, French, Portuguese, German, Italian, Dutch, Afrikaans, Indonesian, Malay, Filipino, Tagalog, Vietnamese, and Turkish — among many others.\n    <br><br>\n    These languages can be styled reliably across social media platforms, messaging apps, and emails."
+            "question": "What languages and alphabets work?",
+            "answer": "Unicode styled variants only exist for the Latin alphabet (A–Z, a–z) and Arabic digits (0–9). So every language written in Latin script works: English, Spanish, French, Portuguese, German, Italian, Dutch, Polish, Vietnamese, Turkish, Indonesian, Malay, Tagalog, Afrikaans, Swahili, Hungarian, Czech — all fine.<br><br>Accented characters (á, é, ñ, ü, ç) keep their accents in most styles. A handful of decorative styles drop the accent because Unicode doesn't define a styled variant for it — try a different style if that matters."
           },
           {
-            "question": "Which languages are not supported for styled text?",
-            "answer": "Languages that use non-Latin scripts cannot be converted into bold, italic, or other Unicode font styles.\n    These scripts do not have styled Unicode character variants, so the text will remain unchanged after conversion.\n    <br><br>\n    <strong>Not supported for styled text</strong><br>\n    Arabic, Urdu, Persian, Hebrew, Hindi, Bengali, Tamil, Thai, Chinese, Japanese, Korean, and Sinhala.\n    <br><br>\n    This is a limitation of the Unicode standard itself, not a limitation of UltraTextGen.\n    If you write in one of these languages, your Latin-script words (brand names, English phrases, etc.) within the text will still convert."
-          },
-          {
-            "question": "Are there any characters that don't convert?",
-            "answer": "Most English letters (A–Z, a–z), numbers (0–9), and basic punctuation convert perfectly across all styles.\n    Some very rare symbols or special characters may have fewer style options because Unicode doesn't include styled variants for every character.\n    <br><br>\n    If a character cannot be converted, it simply stays as normal text — it never breaks or produces errors.\n    Your output will always be usable."
+            "question": "Why doesn't Arabic, Cyrillic, Hindi, Chinese, or Japanese text transform?",
+            "answer": "Unicode simply doesn't define styled variants for non-Latin scripts. There's no \"bold Arabic\" or \"italic Devanagari\" character in the standard, so there's nothing to swap in. Arabic, Urdu, Persian, Hebrew, Hindi, Bengali, Tamil, Telugu, Thai, Chinese (Hanzi), Japanese (Kanji, Hiragana, Katakana), Korean (Hangul), Cyrillic and Greek all pass through unchanged.<br><br>The exception: Latin-script words inside a non-Latin sentence — brand names, English loanwords, hashtags — will still convert. The non-Latin characters around them stay as they are."
           }
         ]
       },
       {
-        "title": "Privacy and Safety",
+        "title": "Privacy & safety",
         "items": [
           {
-            "question": "Is the text I type stored or tracked?",
-            "answer": "No. UltraTextGen does not store your text and does not add any hidden or tracking characters to the output.\n    The conversion happens in your browser, and what you copy is clean Unicode — nothing more."
+            "question": "Is the text I type stored, logged, or sent to a server?",
+            "answer": "No. All transformation happens in your browser using JavaScript — nothing you type is sent to a server. There are no hidden tracking characters, no zero-width spaces, no invisible watermarks added to the output. What you copy is clean Unicode and nothing else.<br><br>The site uses Google Tag Manager for anonymous usage analytics (page views and which styles get used most) but it never sees the contents of your input box."
           },
           {
-            "question": "Is the generated text safe to copy and paste?",
-            "answer": "Yes — completely safe. The output is standard Unicode text with no embedded scripts, no hidden formatting, and no tracking codes.\n    You can paste it into any app or website without any security concerns."
-          }
-        ]
-      },
-      {
-        "title": "Mobile and Device Support",
-        "items": [
-          {
-            "question": "Does UltraTextGen work on phones and tablets?",
-            "answer": "Yes — the site is fully responsive and works great on phones, tablets, and desktops.\n    There is no app to download. Just open UltraTextGen in your mobile browser, type your text, pick a style, and copy.\n    It works on iPhone, Android, iPad, and any device with a modern browser."
-          }
-        ]
-      },
-      {
-        "title": "Why Choose UltraTextGen",
-        "items": [
-          {
-            "question": "Why should I choose UltraTextGen over other text generators?",
-            "answer": "UltraTextGen is built to be the most complete and easiest-to-use Unicode text generator available.\n    <br><br>\n    <strong>What sets it apart</strong><br>\n    — One of the largest collections of premium \"Ultra\" styled fonts.<br>\n    — True style mixing: combine multiple styles in one click, something most generators don't support.<br>\n    — One-click decorations: add frames, borders, symbols, and dividers without manual copy-pasting.<br>\n    — Dedicated platform pages for TikTok, Discord, Instagram, and more — so you get styles tested for your platform.<br>\n    — Fast, clean interface with no pop-ups slowing you down.<br>\n    — Constantly updated with new styles and decorations."
-          },
-          {
-            "question": "Does UltraTextGen add new styles?",
-            "answer": "Yes — new Ultra styles and decorations are added regularly.\n    Bookmark the site to stay updated on the latest additions."
-          },
-          {
-            "question": "How do I find the right font style or tool for my needs?",
-            "answer": "UltraTextGen organises styles and tools in three ways:\n    <br><br>\n    <strong>By font style</strong><br>\n    Browse all font categories — bold, cursive, gothic, bubble, strikethrough, underline, upside-down, and more. Each category page has its own generator focused on that style.\n    <br><br>\n    <strong>By platform</strong><br>\n    Use a platform-specific generator (like Instagram, TikTok, or LinkedIn) for styles and tips optimised for that platform's rules.\n    <br><br>\n    <strong>By task</strong><br>\n    Visit the use case page for task-specific tools — comment fonts, emoji combinations, before-and-after emoji, and more."
+            "question": "Does the generated text work on phones and tablets?",
+            "answer": "Yes. The site is fully responsive — iPhone, Android, iPad, any modern mobile browser. There's no app to install. The Copy button uses the device's native clipboard API, so you can paste straight into Instagram, TikTok, or Discord without leaving the browser."
           }
         ]
       }

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -143,7 +143,7 @@
 
   <url>
     <loc>https://ultratextgen.com/de/</loc>
-    <lastmod>2026-05-07</lastmod>
+    <lastmod>2026-05-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -171,7 +171,7 @@
 
   <url>
     <loc>https://ultratextgen.com/es/</loc>
-    <lastmod>2026-05-07</lastmod>
+    <lastmod>2026-05-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -192,7 +192,7 @@
 
   <url>
     <loc>https://ultratextgen.com/fr/</loc>
-    <lastmod>2026-05-07</lastmod>
+    <lastmod>2026-05-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -262,7 +262,7 @@
 
   <url>
     <loc>https://ultratextgen.com/id/</loc>
-    <lastmod>2026-05-07</lastmod>
+    <lastmod>2026-05-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -283,7 +283,7 @@
 
   <url>
     <loc>https://ultratextgen.com/it/</loc>
-    <lastmod>2026-05-07</lastmod>
+    <lastmod>2026-05-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -738,7 +738,7 @@
 
   <url>
     <loc>https://ultratextgen.com/nl/</loc>
-    <lastmod>2026-05-07</lastmod>
+    <lastmod>2026-05-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -759,7 +759,7 @@
 
   <url>
     <loc>https://ultratextgen.com/pl/</loc>
-    <lastmod>2026-05-07</lastmod>
+    <lastmod>2026-05-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -780,7 +780,7 @@
 
   <url>
     <loc>https://ultratextgen.com/pt/</loc>
-    <lastmod>2026-05-07</lastmod>
+    <lastmod>2026-05-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -822,7 +822,7 @@
 
   <url>
     <loc>https://ultratextgen.com/tr/</loc>
-    <lastmod>2026-04-28</lastmod>
+    <lastmod>2026-05-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -906,7 +906,7 @@
 
   <url>
     <loc>https://ultratextgen.com/vi/</loc>
-    <lastmod>2026-04-28</lastmod>
+    <lastmod>2026-05-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/style.css
+++ b/style.css
@@ -975,6 +975,43 @@
   padding: 0 1rem;
 }
 
+.editorial-section p,
+.editorial-section ul {
+  color: var(--text-primary);
+  line-height: 1.65;
+}
+
+.editorial-section > h3 {
+  margin-top: 2rem;
+  margin-bottom: 0.75rem;
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.editorial-section .compat-list {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.editorial-section .compat-list li {
+  padding: 0.6rem 0.85rem;
+  background: var(--bg-white);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius);
+  font-size: 0.95rem;
+}
+
+.editorial-section code {
+  background: var(--bg-light, rgba(0, 0, 0, 0.06));
+  padding: 0.05em 0.35em;
+  border-radius: 4px;
+  font-size: 0.9em;
+}
+
 /* Section headings */
 .how-to-use h2,
 .why-section h2,


### PR DESCRIPTION
Reworks the English homepage based on the GSC/Bing/SEMrush data:

- Title and meta description now lead with "fancy text generator" (60.5K/mo) and "copy & paste Unicode fonts" — the head terms the page was ignoring. Adds platform mentions (Instagram, TikTok, Discord, LinkedIn, WhatsApp) so SERP snippets match real user queries.
- H1 changed from "Stylish Font Generator" to "Fancy Text Generator" and the hero tagline now states the count (60+ fonts) and the actual destinations users paste into.
- WebApplication JSON-LD gets alternateName entities, isAccessibleForFree, and a concrete featureList covering vertical text, style mixing, and privacy guarantees so AI Overviews can cite specifics.
- New topical intro section adds inline rendered examples of every major style family and a platform-by-platform compatibility list (Instagram bio vs username, Discord no-Nitro, LinkedIn Sans, WhatsApp, email subject lines, gaming profiles) — real information gain that generic competitors don't publish.
- Popular Use Cases: dropped "Text to Emoji" (low-traffic) for "Vertical & stacked text" (matches /usecase/vertical-text/'s 4170 monthly impressions and the stacked-text query cluster) and added a Discord names card (matches the discord-fonts long-tail demand).
- Popular Categories: replaced generic "command attention" SaaS copy with category-specific copy that names the platforms the style is actually used on, plus a fourth Bubble/aesthetic card targeting the aesthetic-fonts cluster.
- FAQ overhaul: replaced documentation-style questions with community-phrased ones tied to actual GSC queries — "How do I make my Instagram bio bold?", "Can I bold text on Discord without Nitro?", "What font does LinkedIn use?", "How do I make vertical/stacked text?", "Are these fonts safe for screen readers?". Definition-first answers for AEO. JSON-LD FAQ schema rewritten to match.
- Dropped the "Why Choose UltraTextGen" SaaS section.
- Mirrored all canonical English copy into locales/en.json so future translation regeneration starts from the new source of truth.
- Minor style.css additions for .compat-list and .editorial-section prose styling.

Sitemap was auto-regenerated by `npm run build` (last-mod dates only).