### PR TITLE
feat: tighten Discord page for GSC intent — no-Nitro framing, schema …

### DIFF
--- a/discord/index.html
+++ b/discord/index.html
@@ -12,17 +12,17 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-  <title>Discord Fonts (𝒸𝑜𝓅𝓎 & 𝕡𝕒𝕤𝕥𝕖) — Free Discord Font Generator | UltraTextGen</title>
-  <meta name="description" content="Generate cool, fancy, and bold Discord fonts for your display name, server, and chat. 100+ styles — type, copy, and paste. Works on desktop & mobile. Free.">
+  <title>Discord Font Generator — Copy and Paste, No Nitro | UltraTextGen</title>
+  <meta name="description" content="Free Discord font generator. Style your display name, server nickname, bio, and chat with 100+ Unicode fonts — bold, italic, cursive, gothic, bubble. Copy and paste. No Nitro required.">
   <link rel="canonical" href="https://ultratextgen.com/discord/">
-  <meta property="og:title" content="Discord Fonts (𝒸𝑜𝓅𝓎 & 𝕡𝕒𝕤𝕥𝕖) — Free Discord Font Generator | UltraTextGen">
-  <meta property="og:description" content="Generate cool, fancy, and bold Discord fonts for your display name, server, and chat. 100+ styles — type, copy, and paste. Works on desktop & mobile. Free.">
+  <meta property="og:title" content="Discord Font Generator — Copy and Paste, No Nitro | UltraTextGen">
+  <meta property="og:description" content="Free Discord font generator. Style your display name, server nickname, bio, and chat with 100+ Unicode fonts — no Nitro required. Copy and paste.">
   <meta property="og:url" content="https://ultratextgen.com/discord/">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://ultratextgen.com/logo.png">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Discord Fonts (𝒸𝑜𝓅𝓎 & 𝕡𝕒𝕤𝕥𝕖) — Free Discord Font Generator | UltraTextGen">
-  <meta name="twitter:description" content="Generate cool, fancy, and bold Discord fonts for your display name, server, and chat. 100+ styles — type, copy, and paste. Works on desktop & mobile. Free.">
+  <meta name="twitter:title" content="Discord Font Generator — Copy and Paste, No Nitro | UltraTextGen">
+  <meta name="twitter:description" content="Free Discord font generator. Style your display name, server nickname, bio, and chat with 100+ Unicode fonts — no Nitro required. Copy and paste.">
   <meta name="twitter:image" content="https://ultratextgen.com/logo.png">
 
   <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
@@ -40,15 +40,31 @@
       "name": "What is the difference between a Discord username and a display name?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Your <strong>username</strong> is your unique identifier on Discord, used for friend requests and identity verification. It follows strict character rules — lowercase only, no spaces, no emojis. Your <strong>display name</strong> is a cosmetic label shown in servers and DMs. It can include uppercase, spaces, emojis, and Unicode characters."
+        "text": "Your <strong>username</strong> is your unique identifier (the @handle), used for friend requests and identity verification. It only allows lowercase letters, numbers, underscores, and periods. Your <strong>display name</strong> is the cosmetic name shown in servers and DMs — it supports uppercase, spaces, emojis, and Unicode font styles like bold, cursive, and gothic."
       }
     },
     {
       "@type": "Question",
-      "name": "What usernames are not allowed on Discord?",
+      "name": "What characters are allowed in a Discord display name?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Discord prohibits usernames that impersonate Discord, Discord staff, or Discord system messages; impersonate an individual, group, or organization; attack other people or promote hate; or contain sexually explicit content."
+        "text": "Display names support almost anything: uppercase and lowercase letters, spaces, special characters, emojis, Unicode font styles, and non-Latin characters — as long as the name follows Discord's Community Guidelines."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the character limit for a Discord display name?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Display names must be at least 1 character and at most 32 characters long. Note that some Unicode font characters may count as more than one character toward the limit."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I use a different font for each Discord server?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Discord lets you set a different display name per server through per-server profiles. Right-click your avatar in any server and select <strong>Edit Per-server Profile</strong>, then paste a different styled name for that server."
       }
     },
     {
@@ -56,7 +72,47 @@
       "name": "Can I make my Discord name invisible?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "You can make your display name (nickname) look blank using special invisible characters. This won't work for the @username handle, which follows Discord's stricter rules. If invisible text fails, Discord may have patched that particular character."
+        "text": "You can make your display name (or server nickname) appear blank using special invisible Unicode characters. This won't work for the @username handle, which follows stricter rules. If invisible text fails, Discord may have patched that particular character."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Why do some fancy fonts show as boxes or squares in Discord?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "That usually means the device doesn't have a font that supports those Unicode characters. Try a different style, or view it on another device. Simple <a href=\"https://ultratextgen.com/category/bold-fonts/\">bold</a> and <a href=\"https://ultratextgen.com/category/italic-fonts/\">italic</a> styles tend to render most reliably across desktop and mobile."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I use colored or rainbow fonts on Discord?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Unicode font generators don't support colors — the styled characters are plain text and inherit Discord's default text color. To get colored text in Discord chat, you can use syntax highlighting inside code blocks (e.g., <code>```diff</code> for green/red text). For colored display names, Discord's <strong>Display Name Styles</strong> Nitro feature allows custom font colors and gradients."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is it safe to use Unicode fonts on Discord?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Unicode fonts are standard text characters — not hacks, scripts, or third-party modifications. Discord officially supports Unicode in display names, chat messages, server names, and bios. Using styled text from a font generator will not get your account banned or flagged, as long as your content follows Discord's Community Guidelines."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What characters are allowed in a Discord username?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Discord usernames only allow lowercase Latin characters (a–z), numbers (0–9), underscores ( _ ), and periods ( . ). No special characters, spaces, emojis, or Unicode fonts are permitted in usernames."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the character limit for a Discord username?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Usernames must be at least 2 characters and at most 32 characters long."
       }
     },
     {
@@ -69,10 +125,66 @@
     },
     {
       "@type": "Question",
-      "name": "Can I add spoiler tags to images or links in Discord?",
+      "name": "Can I use two periods in a row in my Discord username?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes. For images, click the <strong>Mark as Spoiler</strong> eye icon on the attachment before sending. For links, wrap the URL in double pipes: <code>||https://example.com||</code>. Note that Discord may still show a link preview."
+        "text": "No. Discord does not allow two consecutive periods ( .. ) in a username. For example, <code>a.b.c</code> is valid, but <code>a..b</code> is not."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can two users have the same Discord username?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. Every Discord username must be unique. No two users can share the same username."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I use spaces or emojis in my Discord username?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. Spaces and emojis are not allowed in Discord usernames. You can use underscores or periods as separators instead. Emojis and special characters are supported in display names."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I change my Discord username?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Navigate to <strong>User Settings &gt; My Account</strong> to update it. Your new username must be unique and follow all username rules."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What usernames are not allowed on Discord?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Discord prohibits usernames that impersonate Discord, Discord staff, or Discord system messages; impersonate an individual, group, or organization; attack other people or promote hate; or contain sexually explicit content."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is a server nickname and how is it different from a display name?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "A server nickname is a name set within a specific Discord server. It overrides your display name in that server only. Server nicknames support Unicode characters, so you can use styled fonts in them."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I use custom fonts in Discord server nicknames?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Server nicknames accept Unicode characters just like display names. Generate a styled version of your name using the tool above and paste it as your server nickname."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is a friend nickname on Discord?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "A friend nickname is a name you assign to another user. It overrides their display name in your view only — no one else sees it. Right-click on their profile avatar and select <strong>Add Friend Nickname</strong>."
       }
     },
     {
@@ -85,34 +197,58 @@
     },
     {
       "@type": "Question",
-      "name": "What is a server nickname and how is it different from a display name?",
+      "name": "How do I create a code block in Discord?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "A server nickname is a name set within a specific Discord server. It overrides your display name in that server only. For example, if your display name is \"Phibi\" but your server nickname is \"Wumpus\", members of that server see \"Wumpus\"."
+        "text": "Wrap text in single backticks for inline code. For multi-line code blocks, wrap your text in triple backticks on their own lines before and after the code. You can add a language name after the opening backticks (e.g., <code>```python</code>) for syntax highlighting."
       }
     },
     {
       "@type": "Question",
-      "name": "Why do some fancy fonts show as boxes in Discord?",
+      "name": "How do I use spoiler tags in Discord?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "That usually means your device doesn't have a font that supports those characters. Try a different style, or view it on another device. Simple <a href=\"https://ultratextgen.com/category/bold-fonts/\">bold</a> and <a href=\"https://ultratextgen.com/category/italic-fonts/\">italic</a> styles tend to render most reliably."
+        "text": "Wrap your text in double pipe characters: <code>||spoiler text||</code>. The text will be hidden until the reader clicks on it. For images, click the <strong>Mark as Spoiler</strong> eye icon on the attachment before sending."
       }
     },
     {
       "@type": "Question",
-      "name": "What is a friend nickname on Discord?",
+      "name": "How do I use introduction fonts on Discord?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "A friend nickname is a name you assign to another user. It overrides their display name in your view. You can set a friend nickname by right-clicking on their profile avatar and selecting <strong>Add Friend Nickname</strong>."
+        "text": "Many Discord servers have introduction channels. Use the font generator above to style your introduction text — bold for your name, cursive for a tagline, decorated text for section headers — then copy and paste it into the channel."
       }
     },
     {
       "@type": "Question",
-      "name": "How do I create headers in Discord?",
+      "name": "Can I use fancy fonts in Discord embeds or bots?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Use the hash symbol at the start of a new line followed by a space. Use <code>#</code> for a big header, <code>##</code> for a medium header, or <code>###</code> for a small header. You can also combine headers with other formatting."
+        "text": "Yes. Discord embeds render Unicode characters, so you can use styled text in embed titles, descriptions, and field values. Note that embed font size cannot be changed — Discord controls the rendering."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What font does Discord use for messages?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Discord uses <strong>gg sans</strong> for all text — messages, usernames, channel names, and the interface. Code blocks use a monospace font. Before 2023, Discord used <strong>Whitney</strong> by Hoefler &amp; Co. You cannot change Discord's default font, but you can use Unicode characters from a font generator."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Do I need Nitro to use custom fonts on Discord?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. Unicode fonts are not a Nitro feature. The styled text from this generator works for every Discord user on free or paid accounts because the characters themselves are part of the Unicode standard. Nitro's <strong>Display Name Styles</strong> are different — proprietary fonts, colours, and animated effects rendered by Discord, locked behind a subscription and limited to the display-name field."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What font styles work best on Discord?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Discord supports all Unicode styles. For display names and bios, cursive adds personality, bold creates emphasis, and gothic gives a dramatic edge. For chat and server names, bubble fonts and small caps stand out. For channel names, try clean styles like bold or small caps."
       }
     }
   ]
@@ -155,6 +291,7 @@
     <div class="hero-inner">
       <div class="hero-card">
         <h1 class="hero-headline">Discord Fonts Generator — Copy and Paste.</h1>
+        <p class="hero-tagline">Style your display name, server nickname, bio, and chat with 100+ Unicode fonts. Paste them straight into Discord — no Nitro required.</p>
 
         <div class="input-wrapper">
           <textarea class="main-input" id="mainInput" placeholder="Type your text here..." maxlength="500"></textarea>
@@ -205,30 +342,30 @@
 
 <!-- SECTION 1: Popular Discord Font Styles
      Uses: .editorial-section > h2 (for the heading)
-     Uses: .style-grid / .style-grid-card (NEW — compact grid) -->
+     Uses: .style-grid / .style-grid-card (compact grid) -->
 <section class="editorial-section">
   <h2>Popular Discord Font Styles</h2>
   <div class="style-grid">
-    <div class="style-grid-card">
+    <a class="style-grid-card" href="/category/bold-fonts/">
       <span class="style-grid-label">Bold</span>
       <span class="style-grid-preview">𝗗𝗶𝘀𝗰𝗼𝗿𝗱 𝗙𝗼𝗻𝘁𝘀</span>
-    </div>
-    <div class="style-grid-card">
+    </a>
+    <a class="style-grid-card" href="/category/bold-fonts/bold-italic/">
       <span class="style-grid-label">Bold Italic</span>
       <span class="style-grid-preview">𝘿𝙞𝙨𝙘𝙤𝙧𝙙 𝙁𝙤𝙣𝙩𝙨</span>
-    </div>
-    <div class="style-grid-card">
+    </a>
+    <a class="style-grid-card" href="/category/cursive-fonts/">
       <span class="style-grid-label">Cursive</span>
       <span class="style-grid-preview">𝒟𝒾𝓈𝒸𝑜𝓇𝒹 𝐹𝑜𝓃𝓉𝓈</span>
-    </div>
-    <div class="style-grid-card">
+    </a>
+    <a class="style-grid-card" href="/category/gothic-fonts/">
       <span class="style-grid-label">Gothic</span>
       <span class="style-grid-preview">𝔇𝔦𝔰𝔠𝔬𝔯𝔡 𝔉𝔬𝔫𝔱𝔰</span>
-    </div>
-    <div class="style-grid-card">
+    </a>
+    <a class="style-grid-card" href="/category/bubble-fonts/">
       <span class="style-grid-label">Bubble</span>
       <span class="style-grid-preview">Ⓓⓘⓢⓒⓞⓡⓓ Ⓕⓞⓝⓣⓢ</span>
-    </div>
+    </a>
     <div class="style-grid-card">
       <span class="style-grid-label">Small Caps</span>
       <span class="style-grid-preview">ᴅɪꜱᴄᴏʀᴅ ꜰᴏɴᴛꜱ</span>
@@ -241,14 +378,14 @@
       <span class="style-grid-label">Monospace</span>
       <span class="style-grid-preview">𝙳𝚒𝚜𝚌𝚘𝚛𝚍 𝙵𝚘𝚗𝚝𝚜</span>
     </div>
-    <div class="style-grid-card">
-      <span class="style-grid-label">Fancy</span>
-      <span class="style-grid-preview">⊹ ⋆ 𝒟𝒾𝓈𝒸𝑜𝓇𝒹 ⋆ ⊹</span>
-    </div>
-    <div class="style-grid-card">
+    <a class="style-grid-card" href="/category/italic-fonts/">
+      <span class="style-grid-label">Italic</span>
+      <span class="style-grid-preview">𝘋𝘪𝘴𝘤𝘰𝘳𝘥 𝘍𝘰𝘯𝘵𝘴</span>
+    </a>
+    <a class="style-grid-card" href="/category/strikethrough-text/">
       <span class="style-grid-label">Strikethrough</span>
       <span class="style-grid-preview">D̶i̶s̶c̶o̶r̶d̶ ̶F̶o̶n̶t̶s̶</span>
-    </div>
+    </a>
   </div>
 </section>
 
@@ -262,23 +399,28 @@
   <h2>Where to Use Fonts on Discord</h2>
 
   <div class="editorial-block">
-    <h3>Display Names</h3>
-    <p>Display names fully support Unicode. This is the most popular use case for Discord fonts — copy a styled version of your name and paste it in <strong>User Settings &gt; My Account &gt; Profiles</strong>. You can change it as often as you like.</p>
+    <h3>Display Name (32 characters)</h3>
+    <p>Your display name is the cosmetic name shown across all of Discord and fully supports Unicode. Generate a styled version, then paste it in <strong>User Settings &gt; My Account &gt; Profiles</strong>. Up to 32 characters; some decorative Unicode characters count as more than one.</p>
+  </div>
+
+  <div class="editorial-block">
+    <h3>Server Nickname (32 characters, per server)</h3>
+    <p>Server nicknames override your display name in a specific server only. Right-click your avatar in any server and choose <strong>Edit Per-server Profile</strong>, then paste a styled name. You can run a different font in every server you're in.</p>
+  </div>
+
+  <div class="editorial-block">
+    <h3>About Me / Bio (190 characters)</h3>
+    <p>Your Discord bio supports Unicode text up to roughly 190 characters. For styles designed specifically for bios, visit the <a href="https://ultratextgen.com/usecase/bio-font/">Bio Font page</a>, and add aesthetic decorations like ✦ ⊹ ⋆ from the <a href="https://ultratextgen.com/library/discord-symbols/">Discord Symbols library</a>. See also <a href="/guide/stop-the-scroll-with-font-variation/">Stop the Scroll with Font Variation</a> for mixing weights to build hierarchy.</p>
   </div>
 
   <div class="editorial-block">
     <h3>Chat Messages</h3>
-    <p>Paste any Unicode-styled text into channels, DMs, or group chats. The styled text appears exactly as copied for all users on desktop and mobile.</p>
+    <p>Paste any Unicode-styled text into channels, DMs, or group chats. The styled text appears exactly as copied for everyone on desktop and mobile — no Markdown needed.</p>
   </div>
 
   <div class="editorial-block">
-    <h3>Server &amp; Channel Names</h3>
-    <p>Server owners can use styled text and symbols in server names, channel names, category names, and role names. Channel names have a 100-character limit. This is a popular way to make servers look more professional or themed.</p>
-  </div>
-
-  <div class="editorial-block">
-    <h3>Bios &amp; About Me</h3>
-    <p>Your Discord bio supports Unicode text with a 190-character limit. For styles designed specifically for bios, visit the <a href="https://ultratextgen.com/usecase/bio-font/">Bio Font page</a>. You can also read <a href="/guide/stop-the-scroll-with-font-variation/">Stop the Scroll with Font Variation</a> for tips on mixing font weights to create visual hierarchy in your Discord About Me section.</p>
+    <h3>Server, Channel &amp; Role Names</h3>
+    <p>Server owners and moderators can use styled text and symbols in server names, channel names (100-character limit), category names, and role names. Common pattern: a clean Unicode style for headline channels and a symbol prefix for sub-channels.</p>
   </div>
 
   <div class="editorial-block">
@@ -291,11 +433,32 @@
 <section class="editorial-section">
   <h2>How to Change Your Font on Discord</h2>
 
-  <div class="editorial-block">
-    <p>Discord doesn't have a built-in font setting. To use custom fonts, type your text in the generator at the top of this page, pick a style (bold, cursive, gothic, etc.), click to copy, then paste it into Discord — your display name, any chat message, server name, channel, or bio.</p>
+  <p class="section-subline">Discord doesn't have a font picker. Generate a Unicode style, copy, and paste it wherever Discord accepts text — display name, server nickname, bio, chat, server names, channels, and role names.</p>
+
+  <div class="steps-grid">
+    <div class="step-card">
+      <div class="step-number">1</div>
+      <h3>Type your text</h3>
+      <p>Use the input box at the top of this page.</p>
+    </div>
+    <div class="step-card">
+      <div class="step-number">2</div>
+      <h3>Pick a style</h3>
+      <p>Filter by Bold, Cursive, Gothic, Bubble, or browse all.</p>
+    </div>
+    <div class="step-card">
+      <div class="step-number">3</div>
+      <h3>Copy</h3>
+      <p>Click the styled result to copy it to your clipboard.</p>
+    </div>
+    <div class="step-card">
+      <div class="step-number">4</div>
+      <h3>Paste into Discord</h3>
+      <p>Display name, nickname, bio, message, channel, or role — wherever you need it.</p>
+    </div>
   </div>
 
-  <div class="editorial-block">
+  <div class="editorial-block" style="margin-top:2rem;">
     <h3>Change Your Display Name Font</h3>
     <p>Generate a styled version of your name above, then go to <strong>User Settings &gt; My Account &gt; Profiles</strong> and paste it into the display name field. For per-server names, right-click your avatar in a server and select <strong>Edit Per-server Profile</strong>.</p>
   </div>
@@ -314,6 +477,17 @@
   <div class="editorial-block">
     <h3>What Font Does Discord Use?</h3>
     <p>Discord uses <strong>gg sans</strong>, a proprietary typeface created by Discord. Before 2023, Discord used a customized version of <strong>Whitney</strong> by Hoefler&amp;Co. The gg sans font is not available for download or use outside of Discord.</p>
+  </div>
+</section>
+
+
+<section class="editorial-section">
+  <h2>Discord Fonts Without Nitro</h2>
+
+  <div class="editorial-block">
+    <p>Unicode fonts are not a Nitro feature. The styled text you generate on this page works for every Discord user — free accounts, classic accounts, and Nitro accounts alike. That's because the characters themselves are part of the Unicode standard; Discord doesn't have to interpret them as bold or italic, they already <em>are</em> the bold or italic version of the letter.</p>
+    <p>Paste 𝗯𝗼𝗹𝗱 into your display name and it stays bold on every device that opens Discord. The same is true for 𝘐𝘵𝘢𝘭𝘪𝘤, 𝒸𝓊𝓇𝓈𝒾𝓋𝑒, 𝔤𝔬𝔱𝔥𝔦𝔠, Ⓑⓤⓑⓑⓛⓔ, and every other style on this page.</p>
+    <p><strong>What Nitro actually unlocks for text:</strong> Discord's built-in <em>Display Name Styles</em> — proprietary fonts, colour gradients, and animated effects rendered by Discord on your display name only. They're locked behind Nitro and only apply to the display-name field. See the <a href="#nitro-compare">comparison below</a> for which one fits which goal.</p>
   </div>
 </section>
 
@@ -351,7 +525,7 @@
 </section>
 
 
-<section class="editorial-section">
+<section class="editorial-section" id="nitro-compare">
   <h2>Discord Display Name Styles vs. Unicode Fonts</h2>
 
   <div class="editorial-block">
@@ -381,6 +555,17 @@
         </ul>
       </div>
     </div>
+  </div>
+</section>
+
+
+<section class="editorial-section">
+  <h2>Discord Symbols for Aesthetic Bios &amp; Nicknames</h2>
+
+  <div class="editorial-block">
+    <p>Most aesthetic Discord profiles pair a styled name with a few decorative symbols — sparkles, dots, dividers, or brackets — that frame the name without breaking the 32-character display-name limit. Common examples:</p>
+    <div class="block-example">✦ 𝒶𝓁𝑒𝓍 ✦ &nbsp;·&nbsp; ⊹ ࣪ ˖ 𝗮𝗹𝗲𝘅 ˖ ࣪ ⊹ &nbsp;·&nbsp; ⋆｡˚ 𝒶𝓁𝑒𝓍 ˚｡⋆ &nbsp;·&nbsp; ꒰ 𝓪𝓵𝓮𝔁 ꒱</div>
+    <p>Browse the full set on the <a href="https://ultratextgen.com/library/discord-symbols/">Discord Symbols library</a> — sparkles, hearts, frames, dividers, and ready-to-paste combos sized for display names, server nicknames, and bios.</p>
   </div>
 </section>
   </main>
@@ -604,6 +789,16 @@
 
   <!-- ======================== DISCORD FONTS — COMMON QUESTIONS ======================== -->
   <h2 class="faq-category">Discord Fonts — Common Questions</h2>
+
+  <div class="faq-item">
+    <button class="faq-question">
+      Do I need Nitro to use custom fonts on Discord?
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+    </button>
+    <div class="faq-answer">
+      No. Unicode fonts are not a Nitro feature. The styled text from this generator works for every Discord user on free or paid accounts, because the characters themselves are part of the Unicode standard — Discord doesn't need to interpret them as bold or italic, they already are. Nitro's <strong>Display Name Styles</strong> are different: proprietary fonts, colours, and animated effects rendered by Discord, locked behind a subscription and limited to the display-name field.
+    </div>
+  </div>
 
   <div class="faq-item">
     <button class="faq-question">


### PR DESCRIPTION
…sync, internal links

Page-level CTR and intent alignment improvements informed by 3-month GSC data (2,201 imp / 0 clicks for "discord fonts" at position 9.7; large unserved "without Nitro" cluster at positions 6-10):

- Title: drop rendered Unicode glyphs (SERP rendering risk); add "No Nitro"
- Meta description: name the four surfaces + "no Nitro required"
- Hero: add tagline matching dominant query intent
- Popular Discord Font Styles: convert preview cards into category links
- Where to Use: split Display Name vs Server Nickname; inline 32/190 limits; link to /library/discord-symbols/ (previously missing key internal link)
- How to Change: lead-in converted to 4-step .steps-grid
- New section: Discord Fonts Without Nitro (addresses largest missing cluster)
- New section: Discord Symbols for Aesthetic Bios & Nicknames
- New FAQ: Do I need Nitro to use custom fonts on Discord?
- FAQPage JSON-LD: rewrite to mirror on-page FAQ (was 10, now 27 — matches on-page button count exactly)
- Anchor id="nitro-compare" added for jump-link from Without Nitro section

No framework, no bundler, no inline <style>, no new inline <script>. Single file changed: discord/index.html (688 -> 884 lines).