### PR TITLE
feat: add page-specific alternateName to comment-font and zalgo-text …

### DIFF
--- a/usecase/comment-font/index.html
+++ b/usecase/comment-font/index.html
@@ -151,6 +151,7 @@
   "@context": "https://schema.org",
   "@type": "WebApplication",
   "name": "Comment Font Generator",
+  "alternateName": ["Fancy Comment Text Generator", "YouTube Comment Font Generator", "Cool Comment Fonts", "Copy and Paste Comment Fonts"],
   "url": "https://ultratextgen.com/usecase/comment-font/",
   "applicationCategory": "UtilityApplication",
   "operatingSystem": "All",

--- a/usecase/zalgo-text/index.html
+++ b/usecase/zalgo-text/index.html
@@ -133,6 +133,7 @@
   "@context": "https://schema.org",
   "@type": "WebApplication",
   "name": "Zalgo Text Generator",
+  "alternateName": ["Glitch Text Generator", "Cursed Text Generator", "Creepy Text Generator", "Corrupted Text Generator"],
   "url": "https://ultratextgen.com/usecase/zalgo-text/",
   "applicationCategory": "UtilityApplication",
   "operatingSystem": "All",


### PR DESCRIPTION
…WebApplication schema

Adds schema.org alternateName arrays to the two English usecase pages that carried a WebApplication block without one, using search terms specific to each tool (glitch/cursed/creepy for Zalgo; YouTube/fancy comment fonts for the comment generator).