### PR TITLE
feat: add alternateName to all WebApplication structured data

### DIFF
--- a/de/index.html
+++ b/de/index.html
@@ -82,6 +82,7 @@
     "@context": "https://schema.org",
     "@type": "WebApplication",
     "name": "UltraTextGen",
+    "alternateName": ["Unicode-Schriftgenerator", "Schriftartengenerator", "Stylischer Textgenerator", "Schrift zum Kopieren und Einfügen"],
     "url": "https://ultratextgen.com/",
     "applicationCategory": "UtilitiesApplication",
     "operatingSystem": "All",

--- a/de/usecase/zalgo-text/index.html
+++ b/de/usecase/zalgo-text/index.html
@@ -127,6 +127,7 @@
   "@context": "https://schema.org",
   "@type": "WebApplication",
   "name": "Zalgo-Textgenerator",
+  "alternateName": ["Glitch-Textgenerator", "Verfluchter Textgenerator", "Gruseliger Textgenerator", "Beschädigter Text"],
   "url": "https://ultratextgen.com/de/usecase/zalgo-text/",
   "applicationCategory": "UtilityApplication",
   "operatingSystem": "All",

--- a/es/index.html
+++ b/es/index.html
@@ -87,6 +87,7 @@
     "@context": "https://schema.org",
     "@type": "WebApplication",
     "name": "UltraTextGen",
+    "alternateName": ["Generador de fuentes Unicode", "Generador de letras bonitas", "Cambiador de fuentes", "Texto para copiar y pegar"],
     "url": "https://ultratextgen.com/es/",
     "inLanguage": "es",
     "applicationCategory": "UtilitiesApplication",

--- a/es/usecase/zalgo-text/index.html
+++ b/es/usecase/zalgo-text/index.html
@@ -127,6 +127,7 @@
   "@context": "https://schema.org",
   "@type": "WebApplication",
   "name": "Generador de Texto Zalgo",
+  "alternateName": ["Generador de texto glitch", "Generador de texto maldito", "Generador de texto espeluznante", "Texto corrupto"],
   "url": "https://ultratextgen.com/es/usecase/zalgo-text/",
   "applicationCategory": "UtilityApplication",
   "operatingSystem": "All",

--- a/fr/index.html
+++ b/fr/index.html
@@ -82,6 +82,7 @@
     "@context": "https://schema.org",
     "@type": "WebApplication",
     "name": "UltraTextGen",
+    "alternateName": ["Générateur de polices Unicode", "Générateur de texte stylé", "Générateur de polices fantaisie", "Polices à copier-coller"],
     "url": "https://ultratextgen.com/",
     "applicationCategory": "UtilitiesApplication",
     "operatingSystem": "All",

--- a/fr/usecase/zalgo-text/index.html
+++ b/fr/usecase/zalgo-text/index.html
@@ -127,6 +127,7 @@
   "@context": "https://schema.org",
   "@type": "WebApplication",
   "name": "Générateur de Texte Zalgo",
+  "alternateName": ["Générateur de texte glitch", "Générateur de texte maudit", "Générateur de texte effrayant", "Texte corrompu"],
   "url": "https://ultratextgen.com/fr/usecase/zalgo-text/",
   "applicationCategory": "UtilityApplication",
   "operatingSystem": "All",

--- a/id/index.html
+++ b/id/index.html
@@ -82,6 +82,7 @@
     "@context": "https://schema.org",
     "@type": "WebApplication",
     "name": "UltraTextGen",
+    "alternateName": ["Generator Font Unicode", "Generator Teks Keren", "Pengubah Font", "Font Salin dan Tempel"],
     "url": "https://ultratextgen.com/",
     "applicationCategory": "UtilitiesApplication",
     "operatingSystem": "All",

--- a/id/usecase/zalgo-text/index.html
+++ b/id/usecase/zalgo-text/index.html
@@ -127,6 +127,7 @@
   "@context": "https://schema.org",
   "@type": "WebApplication",
   "name": "Generator Teks Zalgo",
+  "alternateName": ["Generator Teks Glitch", "Generator Teks Terkutuk", "Generator Teks Seram", "Teks Rusak"],
   "url": "https://ultratextgen.com/id/usecase/zalgo-text/",
   "applicationCategory": "UtilityApplication",
   "operatingSystem": "All",

--- a/it/index.html
+++ b/it/index.html
@@ -83,6 +83,7 @@
     "@context": "https://schema.org",
     "@type": "WebApplication",
     "name": "UltraTextGen",
+    "alternateName": ["Generatore di font Unicode", "Generatore di testo elegante", "Cambia font", "Font da copiare e incollare"],
     "url": "https://ultratextgen.com/it/",
     "applicationCategory": "UtilitiesApplication",
     "operatingSystem": "All",

--- a/it/usecase/zalgo-text/index.html
+++ b/it/usecase/zalgo-text/index.html
@@ -127,6 +127,7 @@
   "@context": "https://schema.org",
   "@type": "WebApplication",
   "name": "Generatore di Testo Zalgo",
+  "alternateName": ["Generatore di testo glitch", "Generatore di testo maledetto", "Generatore di testo inquietante", "Testo corrotto"],
   "url": "https://ultratextgen.com/it/usecase/zalgo-text/",
   "applicationCategory": "UtilityApplication",
   "operatingSystem": "All",

--- a/nl/index.html
+++ b/nl/index.html
@@ -82,6 +82,7 @@
     "@context": "https://schema.org",
     "@type": "WebApplication",
     "name": "UltraTextGen",
+    "alternateName": ["Unicode-lettertypegenerator", "Mooie tekstgenerator", "Lettertype wijzigen", "Lettertypes om te kopiëren en plakken"],
     "url": "https://ultratextgen.com/",
     "applicationCategory": "UtilitiesApplication",
     "operatingSystem": "All",

--- a/nl/usecase/zalgo-text/index.html
+++ b/nl/usecase/zalgo-text/index.html
@@ -127,6 +127,7 @@
   "@context": "https://schema.org",
   "@type": "WebApplication",
   "name": "Zalgo Tekstgenerator",
+  "alternateName": ["Glitch-tekstgenerator", "Vervloekte tekstgenerator", "Enge tekstgenerator", "Beschadigde tekst"],
   "url": "https://ultratextgen.com/nl/usecase/zalgo-text/",
   "applicationCategory": "UtilityApplication",
   "operatingSystem": "All",

--- a/pl/index.html
+++ b/pl/index.html
@@ -82,6 +82,7 @@
     "@context": "https://schema.org",
     "@type": "WebApplication",
     "name": "UltraTextGen",
+    "alternateName": ["Generator czcionek Unicode", "Generator ładnego tekstu", "Zmieniacz czcionek", "Czcionki do kopiowania i wklejania"],
     "url": "https://ultratextgen.com/",
     "applicationCategory": "UtilitiesApplication",
     "operatingSystem": "All",

--- a/pl/usecase/zalgo-text/index.html
+++ b/pl/usecase/zalgo-text/index.html
@@ -127,6 +127,7 @@
   "@context": "https://schema.org",
   "@type": "WebApplication",
   "name": "Generator Tekstu Zalgo",
+  "alternateName": ["Generator tekstu glitch", "Generator przeklętego tekstu", "Generator strasznego tekstu", "Uszkodzony tekst"],
   "url": "https://ultratextgen.com/pl/usecase/zalgo-text/",
   "applicationCategory": "UtilityApplication",
   "operatingSystem": "All",

--- a/pt/index.html
+++ b/pt/index.html
@@ -82,6 +82,7 @@
     "@context": "https://schema.org",
     "@type": "WebApplication",
     "name": "UltraTextGen",
+    "alternateName": ["Gerador de fontes Unicode", "Gerador de texto estiloso", "Alterador de fontes", "Fontes para copiar e colar"],
     "url": "https://ultratextgen.com/",
     "applicationCategory": "UtilitiesApplication",
     "operatingSystem": "All",

--- a/pt/usecase/zalgo-text/index.html
+++ b/pt/usecase/zalgo-text/index.html
@@ -127,6 +127,7 @@
   "@context": "https://schema.org",
   "@type": "WebApplication",
   "name": "Gerador de Texto Zalgo",
+  "alternateName": ["Gerador de texto glitch", "Gerador de texto amaldiçoado", "Gerador de texto assustador", "Texto corrompido"],
   "url": "https://ultratextgen.com/pt/usecase/zalgo-text/",
   "applicationCategory": "UtilityApplication",
   "operatingSystem": "All",

--- a/tr/index.html
+++ b/tr/index.html
@@ -83,6 +83,7 @@
     "@context": "https://schema.org",
     "@type": "WebApplication",
     "name": "UltraTextGen",
+    "alternateName": ["Unicode Yazı Tipi Oluşturucu", "Şık Metin Oluşturucu", "Yazı Tipi Değiştirici", "Kopyala Yapıştır Yazı Tipleri"],
     "url": "https://ultratextgen.com/tr/",
     "applicationCategory": "UtilitiesApplication",
     "operatingSystem": "All",

--- a/tr/usecase/zalgo-text/index.html
+++ b/tr/usecase/zalgo-text/index.html
@@ -127,6 +127,7 @@
   "@context": "https://schema.org",
   "@type": "WebApplication",
   "name": "Zalgo Metin Oluşturucu",
+  "alternateName": ["Glitch Metin Oluşturucu", "Lanetli Metin Oluşturucu", "Korkunç Metin Oluşturucu", "Bozuk Metin"],
   "url": "https://ultratextgen.com/tr/usecase/zalgo-text/",
   "applicationCategory": "UtilityApplication",
   "operatingSystem": "All",

--- a/vi/index.html
+++ b/vi/index.html
@@ -82,6 +82,7 @@
     "@context": "https://schema.org",
     "@type": "WebApplication",
     "name": "UltraTextGen",
+    "alternateName": ["Trình tạo phông chữ Unicode", "Trình tạo chữ kiểu", "Trình đổi phông chữ", "Phông chữ sao chép và dán"],
     "url": "https://ultratextgen.com/",
     "applicationCategory": "UtilitiesApplication",
     "operatingSystem": "All",

--- a/vi/usecase/zalgo-text/index.html
+++ b/vi/usecase/zalgo-text/index.html
@@ -127,6 +127,7 @@
   "@context": "https://schema.org",
   "@type": "WebApplication",
   "name": "Trình Tạo Chữ Zalgo",
+  "alternateName": ["Trình tạo chữ lỗi (Glitch)", "Trình tạo chữ ma quái", "Trình tạo chữ đáng sợ", "Chữ bị hỏng"],
   "url": "https://ultratextgen.com/vi/usecase/zalgo-text/",
   "applicationCategory": "UtilityApplication",
   "operatingSystem": "All",


### PR DESCRIPTION
## Summary

Adds a schema.org `alternateName` property to every `WebApplication` JSON-LD block that was missing one, giving search engines additional brand/keyword variants for each tool. Coverage goes from **3/25 → 25/25** WebApplication blocks.

## What changed

**English usecase pages** (`fdd77aa`) — page-specific alternate names:
- `usecase/comment-font/` → Fancy Comment Text Generator, YouTube Comment Font Generator, Cool Comment Fonts, Copy and Paste Comment Fonts
- `usecase/zalgo-text/` → Glitch Text Generator, Cursed Text Generator, Creepy Text Generator, Corrupted Text Generator

**Localized pages** (`5d30dc6`) — translated alternate names on 20 blocks:
- 10 localized homepages (`de/es/fr/id/it/nl/pl/pt/tr/vi`)
- 10 localized `zalgo-text` pages

## Scope notes

- Only `WebApplication` blocks were touched (per request). `WebSite` and `Organization` blocks were intentionally left unchanged.
- The homepage `index.html` / `_root.html` and `usecase/vertical-text/` already had `alternateName`, so they were untouched.

## Validation

- All 276 static JSON-LD blocks across the repo parse cleanly after the change.
- No build step or framework changes; pure structured-data additions.

https://claude.ai/code/session_017XAtgc3FfLAFXRPu3jXWiG

---
_Generated by [Claude Code](https://claude.ai/code/session_017XAtgc3FfLAFXRPu3jXWiG)_