### PR TITLE
Optimize vertical text page for stacked-text demand + cross-link with zalgo

### DIFF
--- a/usecase/vertical-text/index.html
+++ b/usecase/vertical-text/index.html
@@ -444,7 +444,7 @@ o</pre></div>
 
       <div class="editorial-block">
         <h3>🔼 Text Stacked On Top of Each Other (Combining marks)</h3>
-        <p>Some "stacked text" or "double stack font" generators do something different — they layer one short line of text <em>on top of another</em> on a single line using Unicode combining marks, producing the Le&#869;ge&#867;n&#875;d <strong>over-text</strong> look (sometimes called the "double stack" or "legend" style). That style only works with a handful of letters and often breaks when pasted. This generator focuses on clean top-to-bottom stacking that pastes reliably everywhere.</p>
+        <p>Some "stacked text" or "double stack font" generators do something different — they layer one short line of text <em>on top of another</em> on a single line using Unicode combining marks, producing the Le&#869;ge&#867;n&#875;d <strong>over-text</strong> look (sometimes called the "double stack" or "legend" style). That style only works with a handful of letters and often breaks when pasted. This generator focuses on clean top-to-bottom stacking that pastes reliably everywhere — for the layered combining-mark effect, see the <a href="/usecase/zalgo-text/">Zalgo Text Generator</a>.</p>
       </div>
 
       <div class="editorial-block">

--- a/usecase/zalgo-text/index.html
+++ b/usecase/zalgo-text/index.html
@@ -206,6 +206,7 @@
       <p><strong>Shape</strong> controls how mark density <em>varies across your text</em>. Uniform applies even density everywhere. Slope Up starts clean and builds chaos. Wave oscillates. Pyramid peaks in the middle. Each shape creates a different visual rhythm.</p>
       <p><strong>Frequency</strong> is the probability that any given character receives marks at all. At 50%, roughly half your characters stay clean — great for a "corruption spreading" look. At 100%, every character is affected.</p>
       <p><strong>Amplitude</strong> is how many marks stack on each affected character. At 1, it's a subtle accent. At 20, it's maximum visual chaos.</p>
+      <p><strong>Combining marks vs. "double stack" text:</strong> The same Unicode marks behind zalgo also power the "double stack" or Le&#869;ge&#867;n&#875;d look, where a small letter sits on top of each character — that's simply zalgo with Characters set to <em>Letters</em>, Position <em>Up</em>, and Amplitude <em>1</em>. For clean, readable top-to-bottom stacking instead of layered marks, use the <a href="https://ultratextgen.com/usecase/vertical-text/">Vertical &amp; Stacked Text Generator</a>.</p>
     </section>
 
     <section class="editorial-section">


### PR DESCRIPTION
## Summary

Data-driven content + SEO refresh of the **Vertical Text Generator** page (the site's second-largest page), plus accurate cross-linking with the **Zalgo Text Generator**. Built from three inputs: Google Search Console performance, SEMRush volume, and forum/competitor analysis.

## The opportunity

GSC shows the page already ranks for a large **"stacked"** keyword cluster it wasn't targeting in its title/H1:

| Query | Impressions | CTR | Position |
|---|---|---|---|
| `stacked text` | 747 | 0.94% | 9.56 |
| `stacked text generator` | 164 | — | 11.44 |
| `text stacker` | 142 | — | 7.35 |
| `stack text` | 51 | — | — |

SEMRush corroborates the volume: `stacked text` 170, `stacked text generator` 170, `stacked letters` 140, `stacked font generator` 110 — a "stacked" cluster roughly matching the "vertical" cluster (`vertical text` 880, `vertical font generator` 260). Question keywords were dominated by Word/Excel/Canva intent, so those were intentionally **not** targeted.

Forum/competitor analysis surfaced two things: (1) **"stacked text" is ambiguous** — competitors use it for the `Leͥgeͣnͫd` *text-on-top-of-text* combining-mark style, which this tool doesn't do; (2) the **#1 real pain point** is platforms collapsing line breaks / blank lines in bios.

## Changes

**`usecase/vertical-text/index.html`**
- Folded **"Stacked Text Generator"** into `<title>`, meta description, OG/Twitter tags, `<h1>`, and WebApplication schema (`alternateName`: Stacked Text Generator / Text Stacker / Vertical Font Generator).
- Added a disambiguation block distinguishing top-to-bottom stacking (this tool) from the "double stack / legend" on-top style.
- Added two forum-driven FAQs: *"text stacker vs double stack font"* and *"My vertical text collapses into one line on Instagram — how do I fix it?"* — kept FAQPage JSON-LD in sync (now 16 entries).

**Cross-linking (vertical ↔ zalgo)**
- The "double stack / legend" effect is the controlled, single-mark corner of the same combining-mark mechanism that powers zalgo — not a separate engine.
- Vertical page → routes the "stacked on top" mention to the **Zalgo Text Generator**.
- Zalgo page → explains the "double stack" relationship (Characters = Letters, Position = Up, Amplitude = 1) and links back to the **Vertical & Stacked Text Generator**.

## Notes
- No new frameworks, dependencies, or tools — pure HTML/JSON-LD edits consistent with `CLAUDE.md`.
- All three JSON-LD blocks validated as parseable.

https://claude.ai/code/session_01DQm4xXoBLuUtSnihRMHRo5

---
_Generated by [Claude Code](https://claude.ai/code/session_01DQm4xXoBLuUtSnihRMHRo5)_