### PR TITLE
feat(discord): add hero intro + internal links to lift 'discord fonts…

### DIFF
--- a/category/bold-fonts/index.html
+++ b/category/bold-fonts/index.html
@@ -291,7 +291,7 @@
     Instagram, Facebook, X (Twitter), LinkedIn, and TikTok.
     <br><br>
     <strong>Messaging apps</strong><br>
-    WhatsApp, Telegram, Messenger, Discord, and Slack.
+    WhatsApp, Telegram, Messenger, <a href="/discord/">Discord</a>, and Slack.
     <br><br>
     <strong>Email and documents</strong><br>
     Gmail, Outlook, Apple Mail, Google Docs, and Notion.

--- a/category/gothic-fonts/index.html
+++ b/category/gothic-fonts/index.html
@@ -312,7 +312,7 @@
   </button>
   <div class="faq-answer">
     After generating your Gothic text on UltraTextGen, click the copy button to copy the styled text to your clipboard.
-    Then paste it directly into any app such as Instagram, Twitter/X, TikTok, Facebook, Discord, or anywhere that accepts text.
+    Then paste it directly into any app such as Instagram, Twitter/X, TikTok, Facebook, <a href="/discord/">Discord</a>, or anywhere that accepts text.
     It uses Unicode characters, so no special apps or fonts are needed.
     <br><br>
     Test your pasted text in the app before publishing, as some platforms handle certain Unicode styles better than others.

--- a/discord/index.html
+++ b/discord/index.html
@@ -156,6 +156,7 @@
     <div class="hero-inner">
       <div class="hero-card">
         <h1 class="hero-headline">Discord Fonts Generator — Copy and Paste.</h1>
+        <p class="hero-tagline">Turn plain text into copy-and-paste Discord fonts for your display name, server nickname, chat, and About Me — 100+ styles that work without Nitro.</p>
 
         <div class="input-wrapper">
           <textarea class="main-input" id="mainInput" placeholder="Type your text here..." maxlength="500"></textarea>


### PR DESCRIPTION
…' head term

The /discord/ page jumped from <1% to ~4-5% CTR after the native generator merge, but the head term "discord fonts" (2,378 impr, 0 clicks, pos ~10) and desktop (0.24% CTR, pos ~13 / page 2) still underconvert. Add a concise hero tagline that surfaces the head term, the four paste surfaces, and the no-Nitro hook above the fold — strengthening relevance, the desktop first impression, and the SERP snippet source. Reinforce with exact-context internal links to /discord/ from the bold and gothic category pages by linking their existing Discord mentions. No new tool; reuses .hero-tagline.