### PR TITLE
UX: convert before-after-emoji decorators into scannable card grid

### DIFF
--- a/usecase/before-after-emoji/index.html
+++ b/usecase/before-after-emoji/index.html
@@ -247,15 +247,53 @@
       <div class="editorial-block">
         <h3>The 9 Emotional Journey Decorators</h3>
         <p>This generator offers nine distinct emotional arcs, each with multiple emoji combinations so your text never looks the same twice:</p>
-        <div class="block-example"><strong>Confidence Shift</strong> — from hesitation to self-assurance. For encouragement, reassurance, or proving a point.🤔 → 💪</div>
-        <div class="block-example"><strong>Clarity Breakthrough</strong> — from overwhelm to understanding. For insights, realizations, or simplifying something complex.😵 → 😌 </div>
-        <div class="block-example"><strong>Motivation Lift</strong> — from low energy to fired up. For calls to action, hype, or pushing through resistance.😴 → 🔥</div>
-        <div class="block-example"><strong>Acceptance Turn</strong> — from resistance to agreement. For mindset shifts, conceding a good point, or coming around.🙄 → 👍</div>
-        <div class="block-example"><strong>Relief Release</strong> — from pressure to exhale. For reassurance, letting go, or emotional release.😓 → 😮‍💨</div>
-        <div class="block-example"><strong>Growth Reframe</strong> — from rejection to growth. For lessons learned, boundaries, or turning setbacks into wins.❌ → 📈 </div>
-        <div class="block-example"><strong>Cool Defiance</strong> — from playful sarcasm to composed confidence. For witty refusals or casual dominance.🙃 → 😎</div>
-        <div class="block-example"><strong>Courage Activation</strong> — from fear to bravery. For bold moves, risk-taking, or stepping up.😰 → 🦁</div>
-        <div class="block-example"><strong>Understanding Moment</strong> — from confusion to insight. For explanations, teaching, or lightbulb moments.❓ → 💡</div>
+      </div>
+      <div class="editorial-grid">
+        <div class="editorial-block">
+          <h3><span class="mood-label">Confidence Shift</span><span class="mood-when">From hesitation to self-assurance</span></h3>
+          <p>For encouragement, reassurance, or proving a point.</p>
+          <div class="block-example">🤔 → 💪</div>
+        </div>
+        <div class="editorial-block">
+          <h3><span class="mood-label">Clarity Breakthrough</span><span class="mood-when">From overwhelm to understanding</span></h3>
+          <p>For insights, realizations, or simplifying something complex.</p>
+          <div class="block-example">😵 → 😌</div>
+        </div>
+        <div class="editorial-block">
+          <h3><span class="mood-label">Motivation Lift</span><span class="mood-when">From low energy to fired up</span></h3>
+          <p>For calls to action, hype, or pushing through resistance.</p>
+          <div class="block-example">😴 → 🔥</div>
+        </div>
+        <div class="editorial-block">
+          <h3><span class="mood-label">Acceptance Turn</span><span class="mood-when">From resistance to agreement</span></h3>
+          <p>For mindset shifts, conceding a good point, or coming around.</p>
+          <div class="block-example">🙄 → 👍</div>
+        </div>
+        <div class="editorial-block">
+          <h3><span class="mood-label">Relief Release</span><span class="mood-when">From pressure to exhale</span></h3>
+          <p>For reassurance, letting go, or emotional release.</p>
+          <div class="block-example">😓 → 😮‍💨</div>
+        </div>
+        <div class="editorial-block">
+          <h3><span class="mood-label">Growth Reframe</span><span class="mood-when">From rejection to growth</span></h3>
+          <p>For lessons learned, boundaries, or turning setbacks into wins.</p>
+          <div class="block-example">❌ → 📈</div>
+        </div>
+        <div class="editorial-block">
+          <h3><span class="mood-label">Cool Defiance</span><span class="mood-when">From playful sarcasm to composed confidence</span></h3>
+          <p>For witty refusals or casual dominance.</p>
+          <div class="block-example">🙃 → 😎</div>
+        </div>
+        <div class="editorial-block">
+          <h3><span class="mood-label">Courage Activation</span><span class="mood-when">From fear to bravery</span></h3>
+          <p>For bold moves, risk-taking, or stepping up.</p>
+          <div class="block-example">😰 → 🦁</div>
+        </div>
+        <div class="editorial-block">
+          <h3><span class="mood-label">Understanding Moment</span><span class="mood-when">From confusion to insight</span></h3>
+          <p>For explanations, teaching, or lightbulb moments.</p>
+          <div class="block-example">❓ → 💡</div>
+        </div>
       </div>
     </section> 
       <div class="cta-card">


### PR DESCRIPTION
## Summary
Finishes the editorial-block scannability work started in #210 and continued in #212. PR #212 merged the `emoji-combinations` and `linkedin-headline` migrations, but the `before-after-emoji` change was pushed after that PR had already merged and was left behind. This PR brings that remaining change onto `main`.

## Changes
**HTML (`usecase/before-after-emoji/index.html`)**
- Restructured "The 9 Emotional Journey Decorators" from a tall single-column stack of `.block-example` rows into the `.editorial-grid` mood-card layout introduced in #210:
  - decorator name → `.mood-label`
  - the "from → to" transition → `.mood-when`
  - the usage sentence → card body `<p>`
  - the emoji arc → `.block-example` callout pinned to the bottom of each card
- The prose intro block ("What is Before & After Emoji Text?") is left untouched.
- No wording changes — only structural reorganization for improved scannability.

## Notes
- Reuses the global `.editorial-grid` / `.mood-label` / `.mood-when` CSS already shipped in #210 — no CSS changes needed.
- Grid collapses to a single column on small screens via the existing `@media (max-width: 768px)` breakpoint.

https://claude.ai/code/session_01UXz9YARritGmWABvCS4HJX

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXz9YARritGmWABvCS4HJX)_