### PR TITLE
feat: redesign bio-font generator around JTBD from GSC/Semrush/forum …

### DIFF
--- a/usecase/bio-font/bio-font.css
+++ b/usecase/bio-font/bio-font.css
@@ -1,0 +1,238 @@
+/* ==========================================================================
+   Bio Font Generator — page-specific styles
+   Reuses global tokens from style.css (colors, radius, shadows).
+   All classes are prefixed `bf-` to avoid collisions with shared components.
+   ========================================================================== */
+
+/* ---- Platform selector (drives counter + preview + compatibility) ---- */
+.bf-platform-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 14px;
+}
+.bf-platform-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 14px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  background: var(--bg-base);
+  border: 1px solid var(--border-light);
+  border-radius: 999px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+.bf-platform-tab:hover {
+  color: var(--text-primary);
+  border-color: var(--accent-purple);
+}
+.bf-platform-tab.active {
+  color: #fff;
+  background: var(--accent-purple);
+  border-color: var(--accent-purple);
+}
+
+/* ---- Live character counter (platform-aware) ---- */
+.bf-counter {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+.bf-counter.over {
+  color: #ef4444;
+}
+.bf-counter.over #charCount {
+  color: #ef4444;
+}
+
+/* ---- Compatibility note ---- */
+.bf-compat {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin-top: 12px;
+  padding: 10px 14px;
+  font-size: 0.85rem;
+  line-height: 1.45;
+  color: var(--text-secondary);
+  background: var(--bg-base);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius);
+}
+.bf-compat svg {
+  flex: 0 0 auto;
+  width: 16px;
+  height: 16px;
+  margin-top: 1px;
+  color: var(--accent-purple);
+}
+
+/* ---- Live profile preview (mock card) ---- */
+.bf-preview {
+  margin-top: 16px;
+  padding: 16px;
+  background: var(--bg-base);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-lg);
+}
+.bf-preview-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.bf-preview-avatar {
+  flex: 0 0 auto;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  color: #fff;
+  background: linear-gradient(135deg, var(--accent-purple), var(--accent-blue));
+}
+.bf-preview-meta {
+  min-width: 0;
+}
+.bf-preview-name {
+  font-weight: 700;
+  color: var(--text-primary);
+  font-size: 0.95rem;
+}
+.bf-preview-platform {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+.bf-preview-bio {
+  margin-top: 12px;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: var(--text-primary);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.bf-preview-bio.placeholder {
+  color: var(--text-muted);
+}
+
+/* ---- "How it works" 3-step strip ---- */
+.bf-steps {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 14px;
+  margin: 28px 0 8px;
+}
+.bf-step {
+  position: relative;
+  padding: 16px 16px 16px 52px;
+  background: var(--bg-white);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-soft);
+}
+.bf-step-num {
+  position: absolute;
+  left: 16px;
+  top: 16px;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: #fff;
+  background: var(--accent-purple);
+}
+.bf-step-title {
+  font-weight: 700;
+  font-size: 0.92rem;
+  color: var(--text-primary);
+  margin-bottom: 2px;
+}
+.bf-step-desc {
+  font-size: 0.82rem;
+  line-height: 1.4;
+  color: var(--text-secondary);
+}
+
+/* ---- Generic section wrapper for symbols / templates ---- */
+.bf-section {
+  margin-top: 36px;
+}
+.bf-section-title {
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: 4px;
+}
+.bf-section-sub {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  margin-bottom: 14px;
+}
+
+/* ---- Symbols & dividers: click-to-copy chips ---- */
+.bf-chip-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.bf-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 8px 12px;
+  font-size: 1rem;
+  color: var(--text-primary);
+  background: var(--bg-white);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: all 0.12s ease;
+  user-select: none;
+}
+.bf-chip:hover {
+  border-color: var(--accent-purple);
+  box-shadow: var(--shadow-soft);
+}
+.bf-chip.copied {
+  color: #fff;
+  background: var(--accent-purple);
+  border-color: var(--accent-purple);
+}
+
+/* ---- Bio templates: ready-made copy-paste blocks ---- */
+.bf-template-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 14px;
+}
+.bf-template {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 16px;
+  background: var(--bg-white);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-soft);
+}
+.bf-template-text {
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: var(--text-primary);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* ---- Responsive ---- */
+@media (max-width: 640px) {
+  .bf-steps {
+    grid-template-columns: 1fr;
+  }
+}

--- a/usecase/bio-font/bio-font.js
+++ b/usecase/bio-font/bio-font.js
@@ -1,0 +1,271 @@
+/* ==========================================================================
+   Bio Font Generator — page controller
+   Enhances the shared generator (script.js) with:
+   - platform selector → platform-aware character counter + compatibility note
+   - a live profile preview so users see how the bio fits before saving
+   - font-style (mood) filtering via window.STYLE_MAP / window.UTG_FONT_SLUGS
+   - click-to-copy Symbols & Dividers and ready-made Bio Templates
+   Follows the repo IIFE pattern; no frameworks, no ES modules.
+   ========================================================================== */
+(function () {
+  "use strict";
+
+  const $ = (sel, root = document) => root.querySelector(sel);
+  const $$ = (sel, root = document) => Array.from(root.querySelectorAll(sel));
+
+  /* ----------------------------------------------------------------------
+     DATA: platforms (bio character limits + compatibility guidance)
+     Sourced from each platform's profile/bio field limits.
+     ---------------------------------------------------------------------- */
+  const PLATFORMS = {
+    all:       { label: "All platforms", limit: 500, note: "Unicode fonts and symbols work anywhere text is supported — bios, usernames, captions and more. Always paste-test in the field before saving." },
+    instagram: { label: "Instagram bio",  limit: 150, note: "Instagram bios support most Unicode fonts and emoji. A few characters are blocked in usernames specifically — paste-test before saving." },
+    tiktok:    { label: "TikTok bio",      limit: 80,  note: "TikTok bios render Unicode fonts well. The field is short — only 80 characters — so style a key phrase, not everything." },
+    discord:   { label: "Discord About Me", limit: 190, note: "Discord “About Me” supports full Unicode — styled fonts, symbols and emoji all work in bios, nicknames and server names." },
+    x:         { label: "X (Twitter) bio", limit: 160, note: "X supports Unicode in both your bio and display name. Bold or script styles help a personal brand stand out." },
+    tinder:    { label: "Tinder About me", limit: 500, note: "Tinder has no native font option, so Unicode is the only way to style your profile. Style your name or one key line so it stays readable." }
+  };
+
+  /* ----------------------------------------------------------------------
+     DATA: Symbols & dividers (click-to-copy) — what “aesthetic” searchers
+     actually assemble alongside fonts.
+     ---------------------------------------------------------------------- */
+  const SYMBOL_TABS = {
+    hearts:   { label: "♡ Hearts",  items: ["♡", "♥", "❤︎", "❥", "❣", "ღ", "♡̆", "❦", "❧", "💗", "💖", "🤍", "🩷", "💞", "💝"] },
+    stars:    { label: "✦ Stars",   items: ["✦", "✧", "⋆", "✩", "✯", "✰", "✵", "✷", "✸", "✹", "✻", "❂", "⁑", "⁕", "✨"] },
+    celestial:{ label: "☾ Celestial", items: ["☾", "☽", "★", "☆", "☀", "✦", "✷", "⊹", "⟡", "⋆｡°✩", "☄", "✺", "❈", "✶", "✴"] },
+    cute:     { label: "❀ Cute",    items: ["❀", "✿", "❁", "✾", "⚘", "♧", "♤", "ꕥ", "꒰꒱", "ʚɞ", "𖧧", "𖦹", "ꕤ", "⌗", "ᯓ"] },
+    dividers: { label: "— Dividers", items: [
+      "─────────",
+      "━━━━━━━━━",
+      "·  ·  ·  ·  ·",
+      "✦ ·············· ✦",
+      "⋆｡°✩ ────── ✩°｡⋆",
+      "˚｡⋆｡˚☽˚｡⋆｡˚",
+      "꒰ ꒱",
+      "♡ ⸝⸝ ♡ ⸝⸝ ♡",
+      "❀ ────── ❀",
+      "❦ ────── ❦",
+      "·˚ ༘ ⋆｡˚",
+      "▸ ◂ ▸ ◂ ▸ ◂"
+    ] }
+  };
+
+  /* ----------------------------------------------------------------------
+     DATA: ready-made bio templates ({name} is swapped for the typed text)
+     ---------------------------------------------------------------------- */
+  const TEMPLATES = [
+    "✦ {name} ✦ · dreamer · creator ·",
+    "🌙 {name} ✦ just vibes ✦",
+    "✧⁕·˙˚ {name} ˚˙·⁕✧",
+    "♡ {name} ♡ | living my best life",
+    "『 {name} 』 ⚔ grind · win · repeat",
+    "⋆ {name} ⋆ — keep it simple",
+    "☾ {name} · coffee · chaos · ✨",
+    "❀ {name} ❀ · she/her · 🌸"
+  ];
+
+  /* ----------------------------------------------------------------------
+     STATE + ELEMENTS
+     ---------------------------------------------------------------------- */
+  let currentPlatform = "all";
+
+  const el = {
+    mainInput: $("#mainInput"),
+    charCount: $("#charCount"),
+    charLimit: $("#charLimit"),
+    counter: $("#bfCounter"),
+    compat: $("#bfCompat"),
+    compatText: $("#bfCompatText"),
+    previewBio: $("#bfPreviewBio"),
+    previewName: $("#bfPreviewName"),
+    previewAvatar: $("#bfPreviewAvatar"),
+    previewPlatform: $("#bfPreviewPlatform"),
+    platformRow: $("#bfPlatformRow"),
+    symbolTabs: $("#bfSymbolTabs"),
+    symbolGrid: $("#bfSymbolGrid"),
+    templateGrid: $("#bfTemplateGrid")
+  };
+
+  function inputValue() {
+    return el.mainInput ? el.mainInput.value : "";
+  }
+
+  function firstName() {
+    const v = inputValue().trim();
+    if (!v) return "";
+    return v.split(/\s+/)[0];
+  }
+
+  /* ----------------------------------------------------------------------
+     Platform-aware counter + compatibility + preview sync
+     ---------------------------------------------------------------------- */
+  function syncPlatform() {
+    const p = PLATFORMS[currentPlatform] || PLATFORMS.all;
+    const len = inputValue().length;
+
+    if (el.charLimit) el.charLimit.textContent = String(p.limit);
+    if (el.counter) el.counter.classList.toggle("over", len > p.limit);
+    if (el.compatText) el.compatText.textContent = p.note;
+    if (el.previewPlatform) el.previewPlatform.textContent = p.label;
+
+    syncPreview();
+  }
+
+  function syncPreview() {
+    const v = inputValue();
+    if (el.previewBio) {
+      el.previewBio.textContent = v || "Your styled bio will appear here as you type…";
+      el.previewBio.classList.toggle("placeholder", !v);
+    }
+    const name = firstName();
+    if (el.previewName) el.previewName.textContent = name || "your_handle";
+    if (el.previewAvatar) el.previewAvatar.textContent = (name || "U").charAt(0).toUpperCase();
+  }
+
+  /* ----------------------------------------------------------------------
+     Font-style (mood) filtering — drives the shared #resultsGrid
+     ---------------------------------------------------------------------- */
+  function bindMoodTabs() {
+    const map = window.STYLE_MAP || null;
+    const moodTabs = $$("#moodTabs [data-mood]");
+    moodTabs.forEach((tab) => {
+      tab.addEventListener("click", () => {
+        moodTabs.forEach((t) => t.classList.remove("active"));
+        tab.classList.add("active");
+        const mood = tab.dataset.mood;
+        if (map && map[mood]) window.UTG_FONT_SLUGS = map[mood];
+        // Trigger script.js re-render
+        if (el.mainInput) el.mainInput.dispatchEvent(new Event("input", { bubbles: true }));
+      });
+    });
+  }
+
+  /* ----------------------------------------------------------------------
+     Platform tabs
+     ---------------------------------------------------------------------- */
+  function bindPlatformTabs() {
+    if (!el.platformRow) return;
+    $$(".bf-platform-tab", el.platformRow).forEach((tab) => {
+      tab.addEventListener("click", () => {
+        $$(".bf-platform-tab", el.platformRow).forEach((t) => t.classList.remove("active"));
+        tab.classList.add("active");
+        currentPlatform = tab.dataset.platform || "all";
+        syncPlatform();
+      });
+    });
+  }
+
+  /* ----------------------------------------------------------------------
+     Copy helper (shared visual + analytics behavior)
+     ---------------------------------------------------------------------- */
+  async function copyText(text) {
+    try {
+      await navigator.clipboard.writeText(text);
+      window.dataLayer = window.dataLayer || [];
+      window.dataLayer.push({ event: "copy_text", copy_method: "button" });
+      return true;
+    } catch (err) {
+      console.error("Copy failed:", err);
+      return false;
+    }
+  }
+
+  /* ----------------------------------------------------------------------
+     Symbols & dividers
+     ---------------------------------------------------------------------- */
+  function renderSymbols(tabKey) {
+    if (!el.symbolGrid) return;
+    const tab = SYMBOL_TABS[tabKey] || SYMBOL_TABS.hearts;
+    el.symbolGrid.innerHTML = "";
+    tab.items.forEach((sym) => {
+      const chip = document.createElement("span");
+      chip.className = "bf-chip";
+      chip.textContent = sym;
+      chip.setAttribute("role", "button");
+      chip.setAttribute("tabindex", "0");
+      chip.setAttribute("aria-label", "Copy " + sym);
+      el.symbolGrid.appendChild(chip);
+    });
+  }
+
+  function bindSymbols() {
+    if (el.symbolTabs) {
+      $$("[data-symbol-tab]", el.symbolTabs).forEach((tab) => {
+        tab.addEventListener("click", () => {
+          $$("[data-symbol-tab]", el.symbolTabs).forEach((t) => t.classList.remove("active"));
+          tab.classList.add("active");
+          renderSymbols(tab.dataset.symbolTab);
+        });
+      });
+    }
+    if (el.symbolGrid) {
+      const handleChip = async (chip) => {
+        const ok = await copyText(chip.textContent);
+        if (!ok) return;
+        chip.classList.add("copied");
+        setTimeout(() => chip.classList.remove("copied"), 900);
+      };
+      el.symbolGrid.addEventListener("click", (e) => {
+        const chip = e.target.closest(".bf-chip");
+        if (chip) handleChip(chip);
+      });
+      el.symbolGrid.addEventListener("keydown", (e) => {
+        if (e.key !== "Enter" && e.key !== " ") return;
+        const chip = e.target.closest(".bf-chip");
+        if (chip) { e.preventDefault(); handleChip(chip); }
+      });
+    }
+  }
+
+  /* ----------------------------------------------------------------------
+     Bio templates ({name} swapped for the first word of the input)
+     Rendered with .copy-btn[data-text] so the global script.js copy
+     handler (and analytics) work without duplication.
+     ---------------------------------------------------------------------- */
+  function escapeAttr(s) {
+    return String(s || "").replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  }
+  function escapeHtml(s) {
+    return String(s || "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  }
+
+  function renderTemplates() {
+    if (!el.templateGrid) return;
+    const name = firstName() || "name";
+    el.templateGrid.innerHTML = TEMPLATES.map((tpl) => {
+      const filled = tpl.replace(/\{name\}/g, name);
+      return (
+        '<div class="bf-template">' +
+          '<div class="bf-template-text">' + escapeHtml(filled) + "</div>" +
+          '<button class="copy-btn" data-text="' + escapeAttr(filled) + '" title="Copy to clipboard">Copy</button>' +
+        "</div>"
+      );
+    }).join("");
+  }
+
+  /* ----------------------------------------------------------------------
+     INIT
+     ---------------------------------------------------------------------- */
+  function init() {
+    bindPlatformTabs();
+    bindMoodTabs();
+    bindSymbols();
+    renderSymbols("hearts");
+    renderTemplates();
+    syncPlatform();
+
+    if (el.mainInput) {
+      el.mainInput.addEventListener("input", () => {
+        syncPlatform();
+        renderTemplates();
+      });
+    }
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/usecase/bio-font/index.html
+++ b/usecase/bio-font/index.html
@@ -8,32 +8,69 @@
   <!-- End Google Tag Manager -->
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8242324164413945"
        crossorigin="anonymous"></script>
-  
+
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Bio Fonts Generator — Stylish Unicode Fonts for Instagram, TikTok, Discord &amp; Social Media Bios | UltraTextGen</title>
-  <meta name="description" content="Generate stylish, eye-catching Unicode fonts designed for social media bios. Fonts organized by style — cursive, bold, gothic, bubble. Copy and paste instantly into Instagram, TikTok, Discord &amp; more.">
+  <title>Bio Font Generator — Fonts, Symbols &amp; Dividers for Instagram, TikTok, Discord &amp; Tinder Bios | UltraTextGen</title>
+  <meta name="description" content="Free bio font generator: turn your text into stylish Unicode fonts, then add symbols, dividers and ready-made templates. Platform-aware previews and character limits for Instagram, TikTok, Discord, X and Tinder — copy and paste in seconds.">
   <link rel="canonical" href="https://ultratextgen.com/usecase/bio-font/">
-  <meta property="og:title" content="Bio Fonts Generator — Stylish Unicode Fonts for Instagram, TikTok, Discord &amp; Social Media Bios | UltraTextGen">
-  <meta property="og:description" content="Generate stylish, eye-catching Unicode fonts designed for social media bios. Fonts organized by style — cursive, bold, gothic, bubble. Copy and paste instantly into Instagram, TikTok, Discord &amp; more.">
+  <meta property="og:title" content="Bio Font Generator — Fonts, Symbols &amp; Dividers for Social Media Bios | UltraTextGen">
+  <meta property="og:description" content="Turn your text into stylish Unicode fonts, then add symbols, dividers and ready-made templates. Platform-aware previews and limits for Instagram, TikTok, Discord, X and Tinder.">
   <meta property="og:url" content="https://ultratextgen.com/usecase/bio-font/">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://ultratextgen.com/logo.png">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Bio Fonts Generator — Stylish Unicode Fonts for Instagram, TikTok, Discord &amp; Social Media Bios | UltraTextGen">
-  <meta name="twitter:description" content="Generate stylish, eye-catching Unicode fonts designed for social media bios. Fonts organized by style — cursive, bold, gothic, bubble. Copy and paste instantly into Instagram, TikTok, Discord &amp; more.">
+  <meta name="twitter:title" content="Bio Font Generator — Fonts, Symbols &amp; Dividers for Social Media Bios | UltraTextGen">
+  <meta name="twitter:description" content="Turn your text into stylish Unicode fonts, then add symbols, dividers and ready-made templates. Platform-aware previews and limits for Instagram, TikTok, Discord, X and Tinder.">
   <meta name="twitter:image" content="https://ultratextgen.com/logo.png">
 
   <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/style.css">
+  <link rel="stylesheet" href="/usecase/bio-font/bio-font.css">
 
-
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "How to find and add a font to your bio",
+  "description": "Use a free bio font generator to turn plain bio text into stylish Unicode fonts, then copy and paste it into your social media profile.",
+  "totalTime": "PT1M",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Type your bio text",
+      "text": "Choose your platform (Instagram, TikTok, Discord, X or Tinder) so the character counter matches its bio limit, then type the text you want to style."
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Pick a font, symbol or template",
+      "text": "Browse the font styles (cursive, bold, gothic, bubble), add symbols or dividers, or start from a ready-made bio template. Watch the live preview update."
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Copy and paste into your profile",
+      "text": "Click Copy on the style you like, switch to your app, and paste it straight into your bio field. No app or sign-up required."
+    }
+  ]
+}
+</script>
 
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
   "@type": "FAQPage",
   "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "How do I find fonts for my bio?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "You don't install a font — you use a bio font generator like this one. Type your text, pick a Unicode style (cursive, bold, gothic or bubble), then copy and paste the result directly into your <a href=\"https://ultratextgen.com/instagram/\">Instagram</a>, <a href=\"https://ultratextgen.com/tiktok/\">TikTok</a>, <a href=\"https://ultratextgen.com/discord/\">Discord</a> or other profile. The style is built from special Unicode characters, so it travels with the text wherever you paste it."
+      }
+    },
     {
       "@type": "Question",
       "name": "Do these decorated usernames work on all platforms?",
@@ -44,10 +81,18 @@
     },
     {
       "@type": "Question",
+      "name": "Which Unicode characters are allowed in a Discord About Me / bio?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Discord's “About Me” supports up to 190 characters of full Unicode, including styled fonts (cursive, gothic, bold), symbols and emoji. The same Unicode works in usernames, server nicknames and channel names. A handful of rare characters may show as boxes on very old Android devices, but the common styles render everywhere. Select Discord in the platform picker to see the 190-character limit live as you type."
+      }
+    },
+    {
+      "@type": "Question",
       "name": "Why can't I use certain characters or very long decorations?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Platforms enforce character limits: <br><br> <strong>Instagram:</strong> 150 characters for bio, 30 characters for username (only letters, numbers, periods, underscores)<br> <strong>TikTok:</strong> 80 characters for bio<br> <strong>Discord:</strong> 190 characters for \"About Me\"<br> <strong>X (Twitter):</strong> 160 characters for bio<br><br> Our previews show realistic results, but trim if the final bio exceeds the platform's limit."
+        "text": "Platforms enforce character limits: <br><br> <strong>Instagram:</strong> 150 characters for bio, 30 characters for username (only letters, numbers, periods, underscores)<br> <strong>TikTok:</strong> 80 characters for bio<br> <strong>Discord:</strong> 190 characters for \"About Me\"<br> <strong>X (Twitter):</strong> 160 characters for bio<br> <strong>Tinder:</strong> 500 characters for \"About me\"<br><br> Our platform picker shows the right limit live as you type — trim if the counter turns red."
       }
     },
     {
@@ -68,34 +113,10 @@
     },
     {
       "@type": "Question",
-      "name": "What bio font styles are available?",
+      "name": "Can I use a styled font in my Tinder or dating profile?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "The generator offers four style categories optimized for bios: <br><br> ✍️ <strong>Cursive &amp; Script</strong> — Ultra Script (lighter cursive, clean and stylish) and Ultra Script Bold (elegant cursive, very popular for bios)<br> 🖤 <strong>Bold &amp; Italic</strong> — Ultra Bold, Ultra Bold Italic, Ultra Bold Italic Serif, Ultra Italic Serif, and Ultra Alternating Bold<br> 🏰 <strong>Gothic</strong> — Ultra Gothic (distinctive Fraktur style) and Ultra Gothic Bold (heavier Gothic for emphasis)<br> 🫧 <strong>Bubble</strong> — Ultra Bubble (fun and friendly), Ultra Bubble Filled (bold statement), and Ultra Bubble Light (softer variant)"
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Do the decorations work in bios, posts, or just usernames?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Almost all generated styles work everywhere Unicode is supported — bios, usernames, captions, comments, Discord nicknames, channel names, video descriptions, and more. Emojis and fancy text are especially popular in bios and display names."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Are there accessibility concerns with bio fonts?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Yes — screen readers often struggle to interpret Unicode-styled characters correctly. Instead of reading \"hello,\" a screen reader might announce individual character codes. <br><br> <strong>Best practice:</strong> Style just a key phrase or your display name and keep the rest of your bio in plain text. This gives you visual impact while keeping your profile accessible to everyone."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Will my styled bio get me banned or flagged?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "No — using Unicode symbols and emojis is allowed on most platforms as long as the bio follows their general rules (no impersonation, hate speech, etc.). It's a common way people customize profiles. These are standard characters in the Unicode specification, not hacks or exploits."
+        "text": "Yes. Tinder, Hinge and Bumble have no built-in font options, so Unicode fonts are the only way to style your name or bio. Style your display name or one key line so your profile stands out while staying easy to read. Pick Tinder in the platform picker to preview against its 500-character About me limit."
       }
     },
     {
@@ -104,14 +125,6 @@
       "acceptedAnswer": {
         "@type": "Answer",
         "text": "Decorators wrap your styled text with special Unicode symbols and brackets to match a specific vibe or identity. Toggle \"Add decoration to results\" in the generator and pick a category — from Gaming (『sharp brackets』) to Aesthetic (·˚ ♡ soft symbols ♡ ˚·) to Mystical (☾ crescent frames ☽). They're best used sparingly — one well-chosen decorator set makes your bio look intentional, while too many looks cluttered."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Can I combine multiple decorators?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Yes! Select a main theme (e.g., Gaming), then mix in individual symbols or emoji from other categories. You can also layer a font style with decorators — for example, cursive text wrapped in aesthetic symbols. Experiment in the preview to find your perfect combination."
       }
     }
   ]
@@ -164,15 +177,45 @@
   <section class="hero">
     <div class="hero-inner">
       <div class="hero-card">
-        <h1 class="hero-headline">Bio Fonts That Define Your Profile</h1>
-        <p class="hero-tagline">Your bio is your identity — make it unforgettable. Pick the font style that matches your vibe and paste it straight into your profile.</p>
-        
-        <div class="input-wrapper">
-          <textarea class="main-input" id="mainInput" placeholder="Type your bio text here..." maxlength="500"></textarea>
-          <span class="char-count"><span id="charCount">0</span>/500</span>
+        <h1 class="hero-headline">Bio Font Generator</h1>
+        <p class="hero-tagline">Turn your bio into something people remember. Pick your platform, style your text, add symbols or a template — then copy and paste straight into your profile.</p>
+
+        <!-- Platform selector: drives the live character counter + preview + compatibility note -->
+        <div class="bf-platform-row" id="bfPlatformRow" role="tablist" aria-label="Choose a platform">
+          <button class="bf-platform-tab active" data-platform="all" type="button">All</button>
+          <button class="bf-platform-tab" data-platform="instagram" type="button">📸 Instagram</button>
+          <button class="bf-platform-tab" data-platform="tiktok" type="button">🎵 TikTok</button>
+          <button class="bf-platform-tab" data-platform="discord" type="button">🎮 Discord</button>
+          <button class="bf-platform-tab" data-platform="x" type="button">𝕏 Twitter/X</button>
+          <button class="bf-platform-tab" data-platform="tinder" type="button">🔥 Tinder</button>
         </div>
 
-        <!-- Decoration Selector -->
+        <div class="input-wrapper">
+          <textarea class="main-input" id="mainInput" placeholder="Type your bio text here..." maxlength="500"></textarea>
+          <span class="char-count bf-counter" id="bfCounter"><span id="charCount">0</span>/<span id="charLimit">500</span></span>
+        </div>
+
+        <!-- Platform compatibility note -->
+        <div class="bf-compat" id="bfCompat">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+          </svg>
+          <span id="bfCompatText">Unicode fonts and symbols work anywhere text is supported — bios, usernames, captions and more. Always paste-test in the field before saving.</span>
+        </div>
+
+        <!-- Live profile preview -->
+        <div class="bf-preview" aria-live="polite">
+          <div class="bf-preview-head">
+            <div class="bf-preview-avatar" id="bfPreviewAvatar">U</div>
+            <div class="bf-preview-meta">
+              <div class="bf-preview-name" id="bfPreviewName">your_handle</div>
+              <div class="bf-preview-platform" id="bfPreviewPlatform">All platforms</div>
+            </div>
+          </div>
+          <div class="bf-preview-bio placeholder" id="bfPreviewBio">Your styled bio will appear here as you type…</div>
+        </div>
+
+        <!-- Decoration Selector (wraps the font results below) -->
         <div class="decoration-section">
           <div class="decoration-label">
             <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -202,30 +245,73 @@
 
   <!-- Main Content -->
   <main class="container">
-    <!-- Custom Style Tabs (bio-font specific) -->
-    <div class="category-section">
-      <div class="category-tabs" id="categoryTabs" style="display: none;">
-        <!-- Hidden - script.js will try to populate this, we ignore it -->
-      </div>
-      
-      <div class="category-tabs" id="moodTabs">
-        <button class="category-tab active" data-mood="all">All</button>
-        <button class="category-tab" data-mood="cursive">✍️ Cursive &amp; Script</button>
-        <button class="category-tab" data-mood="bold">🖤 Bold &amp; Italic</button>
-        <button class="category-tab" data-mood="gothic">🏰 Gothic</button>
-        <button class="category-tab" data-mood="bubble">🫧 Bubble</button>
-      </div>
-    </div>
 
-    <!-- Results -->
-    <div class="results-grid" id="resultsGrid"></div>
+    <!-- How it works (captures the dominant "how to find fonts for bio" intent) -->
+    <section class="bf-steps" aria-label="How it works">
+      <div class="bf-step">
+        <span class="bf-step-num">1</span>
+        <div class="bf-step-title">Pick your platform &amp; type</div>
+        <div class="bf-step-desc">Choose Instagram, TikTok, Discord, X or Tinder so the counter matches its bio limit, then type your text.</div>
+      </div>
+      <div class="bf-step">
+        <span class="bf-step-num">2</span>
+        <div class="bf-step-title">Style it</div>
+        <div class="bf-step-desc">Choose a font, add symbols or dividers, or start from a ready-made template. The preview updates live.</div>
+      </div>
+      <div class="bf-step">
+        <span class="bf-step-num">3</span>
+        <div class="bf-step-title">Copy &amp; paste</div>
+        <div class="bf-step-desc">Hit Copy, open your app, and paste it into your bio. No sign-up, no app, no watermark.</div>
+      </div>
+    </section>
+
+    <!-- Fonts -->
+    <section class="bf-section" aria-label="Bio fonts">
+      <h2 class="bf-section-title">Bio Fonts</h2>
+      <p class="bf-section-sub">Tap a style group, then copy the look you like. Decorations above wrap every result.</p>
+
+      <div class="category-section">
+        <div class="category-tabs" id="categoryTabs" style="display: none;"></div>
+
+        <div class="category-tabs" id="moodTabs">
+          <button class="category-tab active" data-mood="all">All</button>
+          <button class="category-tab" data-mood="cursive">✍️ Cursive &amp; Script</button>
+          <button class="category-tab" data-mood="bold">🖤 Bold &amp; Italic</button>
+          <button class="category-tab" data-mood="gothic">🏰 Gothic</button>
+          <button class="category-tab" data-mood="bubble">🫧 Bubble</button>
+        </div>
+      </div>
+
+      <div class="results-grid" id="resultsGrid"></div>
+    </section>
+
+    <!-- Symbols & Dividers (click to copy) -->
+    <section class="bf-section" aria-label="Symbols and dividers">
+      <h2 class="bf-section-title">Symbols &amp; Dividers</h2>
+      <p class="bf-section-sub">Tap any symbol to copy it instantly — sprinkle them around your name or use a divider to break up sections.</p>
+
+      <div class="decoration-tabs" id="bfSymbolTabs" role="tablist" aria-label="Symbol category">
+        <button class="bf-platform-tab active" data-symbol-tab="hearts" type="button">♡ Hearts</button>
+        <button class="bf-platform-tab" data-symbol-tab="stars" type="button">✦ Stars</button>
+        <button class="bf-platform-tab" data-symbol-tab="celestial" type="button">☾ Celestial</button>
+        <button class="bf-platform-tab" data-symbol-tab="cute" type="button">❀ Cute</button>
+        <button class="bf-platform-tab" data-symbol-tab="dividers" type="button">— Dividers</button>
+      </div>
+
+      <div class="bf-chip-grid" id="bfSymbolGrid"></div>
+    </section>
+
+    <!-- Bio templates -->
+    <section class="bf-section" aria-label="Bio templates">
+      <h2 class="bf-section-title">Ready-Made Bio Templates</h2>
+      <p class="bf-section-sub">Not sure what to write? Start from a template — type your name above and it fills in automatically.</p>
+      <div class="bf-template-grid" id="bfTemplateGrid"></div>
+    </section>
 
     <!-- ===================== ALL CATEGORIES AT A GLANCE ===================== -->
     <section class="categories-glance">
-      <h2 class="categories-glance-heading">All Categories at a Glance</h2>
-      <div class="categories-glance-grid" id="categoriesGlanceGrid">
-        <!-- Populated by script below -->
-      </div>
+      <h2 class="categories-glance-heading">All Decorator Categories at a Glance</h2>
+      <div class="categories-glance-grid" id="categoriesGlanceGrid"></div>
     </section>
 
     <script>
@@ -292,8 +378,87 @@
   <!-- Footer -->
   <footer class="footer">
     <div class="footer-inner">
+<!-- Getting Started -->
+<h2 class="faq-category">Getting Started</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    How do I find fonts for my bio?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer">
+    You don't install a font — you use a bio font generator like this one. Type your text, pick a Unicode style (cursive, bold, gothic or bubble), then copy and paste the result directly into your
+    <a href="https://ultratextgen.com/instagram/">Instagram</a>,
+    <a href="https://ultratextgen.com/tiktok/">TikTok</a>,
+    <a href="https://ultratextgen.com/discord/">Discord</a> or other profile. The style is built from special Unicode characters, so it travels with the text wherever you paste it.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    How do I use the bio font generator?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer">
+    It takes about 5 seconds:
+    <br><br>
+    1. Pick your platform so the character counter matches its bio limit<br>
+    2. Type your bio text in the text box<br>
+    3. Pick a style — Cursive &amp; Script, Bold &amp; Italic, Gothic, or Bubble — or add symbols / a template<br>
+    4. Click "Copy" on the style you like<br>
+    5. Paste directly into your bio field (Instagram, TikTok, Discord, etc.)
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Does the bio font generator work on mobile?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer">
+    100%. The tool is fully responsive — open it in your phone's browser, type your bio, copy, switch to your app, and paste. No app download needed. Works on both iOS and Android.
+  </div>
+</div>
+
 <!-- Platform Compatibility -->
-<h2 class="faq-category">Platform Compatibility</h2>
+<h2 class="faq-category">Platform Compatibility &amp; Limits</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Which Unicode characters are allowed in a Discord About Me / bio?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer">
+    <a href="https://ultratextgen.com/discord/">Discord</a>'s "About Me" supports up to <strong>190 characters</strong> of full Unicode, including styled fonts (cursive, gothic, bold), symbols and emoji. The same Unicode works in usernames, server nicknames and channel names. A handful of rare characters may show as boxes on very old Android devices, but the common styles render everywhere. Select Discord in the platform picker above to see the 190-character limit live as you type.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Why can't I use certain characters or very long decorations?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer">
+    Platforms enforce character limits:
+    <br><br>
+    <strong>Instagram:</strong> 150 characters for bio, 30 characters for username (only letters, numbers, periods, underscores)<br>
+    <strong>TikTok:</strong> 80 characters for bio<br>
+    <strong>Discord:</strong> 190 characters for "About Me"<br>
+    <strong>X (Twitter):</strong> 160 characters for bio<br>
+    <strong>Tinder:</strong> 500 characters for "About me"<br><br>
+    Our platform picker shows the right limit live as you type — trim if the counter turns red.
+  </div>
+</div>
 
 <div class="faq-item">
   <button class="faq-question" type="button">
@@ -329,20 +494,62 @@
   </div>
 </div>
 
+<!-- Use Cases -->
+<h2 class="faq-category">Instagram, TikTok, Discord &amp; Dating Profiles</h2>
+
 <div class="faq-item">
   <button class="faq-question" type="button">
-    Can I use emojis in my bio?
+    How do I change my Instagram bio font?
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
     </svg>
   </button>
   <div class="faq-answer">
-    Yes — many platforms (especially <a href="https://ultratextgen.com/instagram/">Instagram</a>, <a href="https://ultratextgen.com/tiktok/">TikTok</a>, and <a href="https://ultratextgen.com/discord/">Discord</a>) allow emojis as part of your bio, display name, or username. Our tool includes emoji-friendly decorators in categories like Cute/Kawaii and Nature/Organic. Note: Not every platform permits emojis directly in usernames (e.g., some gaming sites don't), so check availability.
+    <a href="https://ultratextgen.com/instagram/">Instagram</a> doesn't offer native font options in bios. The only way to get styled text is by using Unicode fancy fonts — which is exactly what this generator creates. Type your bio text, pick a style, copy, and paste it directly into your Instagram bio edit field. Instagram bios have a 150-character limit, and Unicode characters count the same as regular letters.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    What bio font style works best on TikTok?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer">
+    The most popular <a href="https://ultratextgen.com/tiktok/">TikTok</a> bio styles are
+    <strong><a href="https://ultratextgen.com/category/cursive-fonts/">Cursive / Script</a></strong> (elegant, the go-to for creator bios),
+    <strong><a href="https://ultratextgen.com/category/bold-fonts/">Bold</a></strong> (𝗟𝗶𝗸𝗲 𝘁𝗵𝗶𝘀, punchy for personal brands), and
+    <strong><a href="https://ultratextgen.com/category/gothic-fonts/">Gothic</a></strong> (𝔏𝔦𝔨𝔢 𝔱𝔥𝔦𝔰, trending in alt and music communities). TikTok bios are short — only 80 characters — so style a key phrase.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Does fancy text work in Discord bios and nicknames?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer">
+    Yes — <a href="https://ultratextgen.com/discord/">Discord</a> supports Unicode text in both your "About Me" bio section and your server nickname. Gothic and bold fonts are especially popular in gaming and community servers. Just paste your styled text into the appropriate field in your Discord profile settings.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Can I use a styled font in my Tinder or dating profile?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer">
+    Yes. Tinder, Hinge and Bumble have no built-in font options, so Unicode fonts are the only way to style your name or bio. Style your display name or one key line so your profile stands out while staying easy to read. Pick Tinder in the platform picker to preview against its 500-character About me limit.
   </div>
 </div>
 
 <!-- Fonts & Symbols -->
-<h2 class="faq-category">Fonts &amp; Symbols</h2>
+<h2 class="faq-category">Fonts, Symbols &amp; Decorators</h2>
 
 <div class="faq-item">
   <button class="faq-question" type="button">
@@ -375,155 +582,6 @@
 
 <div class="faq-item">
   <button class="faq-question" type="button">
-    Which bio font style is most popular?
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-    </svg>
-  </button>
-  <div class="faq-answer">
-    The top styles for bios are:
-    <br><br>
-    <strong><a href="https://ultratextgen.com/category/cursive-fonts/">Ultra Script Bold</a></strong> — the most popular bio font overall, elegant cursive that looks curated<br>
-    <strong><a href="https://ultratextgen.com/category/bold-fonts/">Ultra Bold</a></strong> — clean and punchy, widely supported everywhere<br>
-    <strong><a href="https://ultratextgen.com/category/bubble-fonts/">Ultra Bubble</a></strong> — fun and friendly, universally loved in bios<br>
-    <strong><a href="https://ultratextgen.com/category/gothic-fonts/">Ultra Gothic</a></strong> — distinctive Fraktur style, trending in alt and music communities
-  </div>
-</div>
-
-<!-- Instagram Bios -->
-<h2 class="faq-category">Instagram Bios</h2>
-
-<div class="faq-item">
-  <button class="faq-question" type="button">
-    How do I change my Instagram bio font?
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-    </svg>
-  </button>
-  <div class="faq-answer">
-    <a href="https://ultratextgen.com/instagram/">Instagram</a> doesn't offer native font options in bios. The only way to get styled text is by using Unicode fancy fonts — which is exactly what this generator creates. Type your bio text, pick a style, copy, and paste it directly into your Instagram bio edit field.
-  </div>
-</div>
-
-<div class="faq-item">
-  <button class="faq-question" type="button">
-    Which bio font styles work best on Instagram?
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-    </svg>
-  </button>
-  <div class="faq-answer">
-    For <a href="https://ultratextgen.com/instagram/">Instagram</a> bios, the styles that pop the most are:
-    <br><br>
-    <strong><a href="https://ultratextgen.com/category/cursive-fonts/">Script / Cursive</a></strong> (𝒹𝓇𝑒𝒶𝓂𝑒𝓇 · 𝒸𝓇𝑒𝒶𝓉𝑜𝓇) — feels personal and polished, the #1 choice for Instagram bios<br>
-    <strong><a href="https://ultratextgen.com/category/bold-fonts/">Bold</a></strong> (𝗙𝗶𝘁𝗻𝗲𝘀𝘀 · 𝗠𝗶𝗻𝗱𝘀𝗲𝘁) — clean emphasis that stands out against default text<br>
-    <strong><a href="https://ultratextgen.com/category/bubble-fonts/">Bubble text</a></strong> (Ⓛⓘⓥⓘⓝⓖ ⓜⓨ ⓑⓔⓢⓣ ⓛⓘⓕⓔ) — playful and lighthearted
-    <br><br>
-    <strong>Tip:</strong> Instagram bios have a 150-character limit. Unicode characters count the same as regular letters, so your styled bio won't eat extra characters.
-  </div>
-</div>
-
-<div class="faq-item">
-  <button class="faq-question" type="button">
-    Does Instagram allow Unicode text in bios?
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-    </svg>
-  </button>
-  <div class="faq-answer">
-    Yes. <a href="https://ultratextgen.com/instagram/">Instagram</a> has supported Unicode text in bios for years. It's completely safe, widely used by creators and influencers every day, and the styles available on this page are curated for maximum compatibility.
-  </div>
-</div>
-
-<!-- TikTok Bios -->
-<h2 class="faq-category">TikTok Bios</h2>
-
-<div class="faq-item">
-  <button class="faq-question" type="button">
-    Will fancy text work in TikTok bios?
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-    </svg>
-  </button>
-  <div class="faq-answer">
-    Yes — <a href="https://ultratextgen.com/tiktok/">TikTok</a> is one of the best platforms for fancy bio fonts. Unicode-styled text renders perfectly in TikTok bios and helps your profile stand out in a sea of plain-text accounts. TikTok bios have an 80-character limit, so keep your styled text concise.
-  </div>
-</div>
-
-<div class="faq-item">
-  <button class="faq-question" type="button">
-    What bio font style works best on TikTok?
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-    </svg>
-  </button>
-  <div class="faq-answer">
-    The most popular <a href="https://ultratextgen.com/tiktok/">TikTok</a> bio styles are:
-    <br><br>
-    <strong><a href="https://ultratextgen.com/category/cursive-fonts/">Cursive / Script</a></strong> — elegant and polished, the go-to for creator bios<br>
-    <strong><a href="https://ultratextgen.com/category/bold-fonts/">Bold</a></strong> (𝗟𝗶𝗸𝗲 𝘁𝗵𝗶𝘀) — punchy and direct, great for personal brands<br>
-    <strong><a href="https://ultratextgen.com/category/gothic-fonts/">Gothic</a></strong> (𝔏𝔦𝔨𝔢 𝔱𝔥𝔦𝔰) — trending in alt, music, and gaming communities
-    <br><br>
-    <strong>Tip:</strong> Combine a styled bio line with emoji decorators for maximum profile impact.
-  </div>
-</div>
-
-<!-- Discord & Other Platforms -->
-<h2 class="faq-category">Discord, X, &amp; Other Platforms</h2>
-
-<div class="faq-item">
-  <button class="faq-question" type="button">
-    Which platforms support bio fonts from this generator?
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-    </svg>
-  </button>
-  <div class="faq-answer">
-    Unicode-styled text works across virtually every major platform:
-    <a href="https://ultratextgen.com/instagram/">Instagram</a>,
-    <a href="https://ultratextgen.com/tiktok/">TikTok</a>,
-    <a href="https://ultratextgen.com/discord/">Discord</a>,
-    <a href="https://ultratextgen.com/x/">X (Twitter)</a>,
-    <a href="https://ultratextgen.com/youtube/">YouTube</a>,
-    <a href="https://ultratextgen.com/facebook/">Facebook</a>,
-    <a href="https://ultratextgen.com/linkedin/">LinkedIn</a>,
-    <a href="https://ultratextgen.com/whatsapp/">WhatsApp</a>,
-    <a href="https://ultratextgen.com/telegram/">Telegram</a>,
-    <a href="https://ultratextgen.com/snapchat/">Snapchat</a>,
-    <a href="https://ultratextgen.com/pinterest/">Pinterest</a>,
-    Twitch, Reddit, and most gaming platforms.
-  </div>
-</div>
-
-<div class="faq-item">
-  <button class="faq-question" type="button">
-    Does fancy text work in Discord bios and nicknames?
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-    </svg>
-  </button>
-  <div class="faq-answer">
-    Yes — <a href="https://ultratextgen.com/discord/">Discord</a> supports Unicode text in both your "About Me" bio section and your server nickname. Gothic and bold fonts are especially popular in gaming and community servers. Just paste your styled text into the appropriate field in your Discord profile settings.
-  </div>
-</div>
-
-<div class="faq-item">
-  <button class="faq-question" type="button">
-    Can I use bio fonts on X (Twitter)?
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-    </svg>
-  </button>
-  <div class="faq-answer">
-    Yes. <a href="https://ultratextgen.com/x/">X (Twitter)</a> supports Unicode characters in both your display name and bio. Bold or script fonts in your bio help your profile stand out, especially if you're building a personal brand or growing an audience.
-  </div>
-</div>
-
-<!-- Bio Decorators -->
-<h2 class="faq-category">Bio Decorators</h2>
-
-<div class="faq-item">
-  <button class="faq-question" type="button">
     What are bio decorators and when should I use them?
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
@@ -534,88 +592,8 @@
   </div>
 </div>
 
-<div class="faq-item">
-  <button class="faq-question" type="button">
-    What decorator categories are available for bios?
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-    </svg>
-  </button>
-  <div class="faq-answer">
-    The generator offers ten vibe-based decorator categories:
-    <br><br>
-    ⚔️ <strong>Gaming</strong> — sharp, aggressive, built for leaderboards and lobbies<br>
-    ✨ <strong>Aesthetic</strong> — dreamy, soft, ethereal, for profiles that feel like poetry<br>
-    💀 <strong>Edgy / Dark</strong> — gothic, raw, rebellious<br>
-    👑 <strong>Royal / Elite</strong> — prestige, power, authority<br>
-    🌸 <strong>Cute / Kawaii</strong> — sweet, playful, adorable<br>
-    🔥 <strong>Bold / Hype</strong> — loud, explosive, unstoppable<br>
-    🎯 <strong>Clean / Minimal</strong> — understated, elegant, precise<br>
-    🌀 <strong>Mystical</strong> — arcane, celestial, otherworldly<br>
-    📟 <strong>Retro / Pixel</strong> — nostalgic, 8-bit, arcade<br>
-    🌿 <strong>Nature / Organic</strong> — earthy, flowing, alive
-  </div>
-</div>
-
-<div class="faq-item">
-  <button class="faq-question" type="button">
-    Can I combine multiple decorators?
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-    </svg>
-  </button>
-  <div class="faq-answer">
-    Yes! Select a main theme (e.g., Gaming), then mix in individual symbols or emoji from other categories. You can also layer a font style with decorators — for example, cursive text wrapped in aesthetic symbols. Experiment in the preview to find your perfect combination.
-  </div>
-</div>
-
-<!-- How to Use -->
-<h2 class="faq-category">How to Use the Bio Font Generator</h2>
-
-<div class="faq-item">
-  <button class="faq-question" type="button">
-    How do I use the bio font generator?
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-    </svg>
-  </button>
-  <div class="faq-answer">
-    It takes about 5 seconds:
-    <br><br>
-    1. Type your bio text in the text box<br>
-    2. Pick a style — fonts are grouped by style: Cursive &amp; Script, Bold &amp; Italic, Gothic, or Bubble<br>
-    3. Optionally add a decorator to wrap your text with symbols<br>
-    4. Click "Copy" on the style you like<br>
-    5. Paste directly into your bio field (Instagram, TikTok, Discord, etc.)
-  </div>
-</div>
-
-<div class="faq-item">
-  <button class="faq-question" type="button">
-    Does the bio font generator work on mobile?
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-    </svg>
-  </button>
-  <div class="faq-answer">
-    100%. The tool is fully responsive — open it in your phone's browser, type your bio, copy, switch to your app, and paste. No app download needed. Works on both iOS and Android.
-  </div>
-</div>
-
-<div class="faq-item">
-  <button class="faq-question" type="button">
-    How do I copy the result?
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-    </svg>
-  </button>
-  <div class="faq-answer">
-    Click the "Copy" button next to any preview (or long-press on mobile). It copies the exact styled text to your clipboard — ready to paste into any bio, profile, or text field.
-  </div>
-</div>
-
-<!-- Safety & Limits -->
-<h2 class="faq-category">Safety, Limits &amp; Troubleshooting</h2>
+<!-- Safety, Privacy & Cost -->
+<h2 class="faq-category">Safety, Privacy &amp; Cost</h2>
 
 <div class="faq-item">
   <button class="faq-question" type="button">
@@ -626,63 +604,6 @@
   </button>
   <div class="faq-answer">
     No — using Unicode symbols and emojis is allowed on most platforms as long as the bio follows their general rules (no impersonation, hate speech, etc.). It's a common way people customize profiles. These are standard characters in the Unicode specification, not hacks or exploits.
-  </div>
-</div>
-
-<div class="faq-item">
-  <button class="faq-question" type="button">
-    Why can't I use certain characters or very long decorations?
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-    </svg>
-  </button>
-  <div class="faq-answer">
-    Platforms enforce character limits:
-    <br><br>
-    <strong>Instagram:</strong> 150 characters for bio, 30 characters for username (only letters, numbers, periods, underscores)<br>
-    <strong>TikTok:</strong> 80 characters for bio<br>
-    <strong>Discord:</strong> 190 characters for "About Me"<br>
-    <strong>X (Twitter):</strong> 160 characters for bio<br><br>
-    Our previews show realistic results, but trim if the final bio exceeds the platform's limit.
-  </div>
-</div>
-
-<div class="faq-item">
-  <button class="faq-question" type="button">
-    Do the decorations work in bios, posts, or just usernames?
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-    </svg>
-  </button>
-  <div class="faq-answer">
-    Almost all generated styles work everywhere Unicode is supported — bios, usernames, captions, comments, Discord nicknames, channel names, video descriptions, and more. Emojis and fancy text are especially popular in bios and display names.
-  </div>
-</div>
-
-<!-- Privacy & Cost -->
-<h2 class="faq-category">Privacy &amp; Cost</h2>
-
-<div class="faq-item">
-  <button class="faq-question" type="button">
-    Are these bio fonts free to use?
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-    </svg>
-  </button>
-  <div class="faq-answer">
-    Completely free. No sign-up, no limits, no watermarks. Generate and copy as many styled bios as you want.
-  </div>
-</div>
-
-<div class="faq-item">
-  <button class="faq-question" type="button">
-    Is the text I generate stored or tracked?
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-    </svg>
-  </button>
-  <div class="faq-answer">
-    No. The conversion happens entirely in your browser. UltraTextGen does not store your text and does not add any hidden or tracking characters to the output. What you copy is clean Unicode — nothing extra.
   </div>
 </div>
 
@@ -702,13 +623,13 @@
 
 <div class="faq-item">
   <button class="faq-question" type="button">
-    Can I suggest new themes or symbols?
+    Are these bio fonts free to use?
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
     </svg>
   </button>
   <div class="faq-answer">
-    Absolutely! We love feedback. Drop ideas via the feedback button or contact form — seasonal themes (e.g., Halloween, Christmas) and niche vibes (e.g., Cyberpunk, Cottagecore) often come from user requests.
+    Completely free. No sign-up, no limits, no watermarks. Generate and copy as many styled bios as you want.
   </div>
 </div>
 
@@ -720,8 +641,8 @@
     // Set default active decoration tab
     window.UTG_DEFAULT_DECO_TAB = "gaming";
 
-    // Style-to-font-slug mappings (bio-specific fonts)
-    const STYLE_MAP = {
+    // Style-to-font-slug mappings (bio-specific fonts) — read by bio-font.js mood tabs
+    window.STYLE_MAP = {
       "all": [
         "ultra-script", "ultra-script-bold",
         "ultra-bold", "ultra-bold-italic", "ultra-bold-italic-serif", "ultra-italic-serif", "ultra-alternating-bold",
@@ -735,7 +656,7 @@
     };
 
     // Start with all fonts visible
-    window.UTG_FONT_SLUGS = STYLE_MAP["all"];
+    window.UTG_FONT_SLUGS = window.STYLE_MAP["all"];
 
     // Custom bio-specific decorators
     window.UTG_DECORATIONS = {
@@ -848,34 +769,12 @@
         { text: "❦ name ❦", prefix: "❦ ", suffix: " ❦" }
       ]
     };
-
-    // Bind style tab behavior after DOM loads
-    document.addEventListener("DOMContentLoaded", function() {
-      const styleTabs = document.querySelectorAll("#moodTabs [data-mood]");
-      const mainInput = document.getElementById("mainInput");
-      
-      styleTabs.forEach(tab => {
-        tab.addEventListener("click", () => {
-          // Update active state
-          styleTabs.forEach(t => t.classList.remove("active"));
-          tab.classList.add("active");
-          
-          // Update the font slug filter
-          const style = tab.dataset.mood;
-          window.UTG_FONT_SLUGS = STYLE_MAP[style];
-          
-          // Trigger re-render by simulating input change
-          if (mainInput) {
-            mainInput.dispatchEvent(new Event("input", { bubbles: true }));
-          }
-        });
-      });
-    });
   </script>
 
   <script src="/styles.js"></script>
   <script src="/renderer.js"></script>
   <script src="/script.js" defer=""></script>
+  <script src="/usecase/bio-font/bio-font.js" defer=""></script>
 
 
 


### PR DESCRIPTION
…data

Rework /usecase/bio-font/ to serve the jobs the search data shows it actually attracts:

- Platform selector (Instagram/TikTok/Discord/X/Tinder) driving a platform-aware character counter, live profile preview, and compatibility note — targets the large Discord "what's allowed / char limit" query cluster (25% of the page's GSC impressions) and the desktop 0%-CTR gap.
- "How it works" 3-step strip — targets the dominant "how to find fonts for bio" query (57% of GSC impressions).
- New click-to-copy Symbols & Dividers and ready-made Bio Templates sections — match the aesthetic/symbol/template intent competitors win on.
- Intent-matched title/meta + HowTo JSON-LD; expanded FAQ (Discord allowed-characters, Tinder/dating, per-platform limits).

New page module: bio-font.css + bio-font.js (IIFE, no deps), reusing the shared generator engine (UTG_FONT_SLUGS / UTG_DECORATIONS / .copy-btn).

https://claude.ai/code/session_012X44HSE8VLKzniSMamZ4vp