### PR TITLE
Add "How to Write Comments That Stand Out" guide

### DIFF
--- a/guide/comments-that-stand-out/index.html
+++ b/guide/comments-that-stand-out/index.html
@@ -1,0 +1,536 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+<!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8242324164413945"
+       crossorigin="anonymous"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>How to Write Comments That Stand Out — A Field Guide to Styled Replies | UltraTextGen</title>
+<meta name="description" content="A field guide to styled comments: decide what the comment is trying to do, then reach for the technique. Bold, strikethrough, script, emoji, and vertical text — what each signals, where it works, and when not to use it.">
+
+<link rel="canonical" href="https://ultratextgen.com/guide/comments-that-stand-out/">
+<meta property="og:image" content="https://ultratextgen.com/logo.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="How to Write Comments That Stand Out — A Field Guide to Styled Replies">
+<meta name="twitter:description" content="Decide what your comment is trying to do, then reach for the technique. What each style signals, where it works, and when not to use it.">
+<meta name="twitter:image" content="https://ultratextgen.com/logo.png">
+<meta property="og:title" content="How to Write Comments That Stand Out — A Field Guide to Styled Replies">
+<meta property="og:description" content="Decide what your comment is trying to do, then reach for the technique. What each style signals, where it works, and when not to use it.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/guide/comments-that-stand-out/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "How to Write Comments That Stand Out — A Field Guide to Styled Replies",
+  "description": "A field guide to styled comments: decide what the comment is trying to do, then reach for the technique. What each style signals, where it works, and when not to use it.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "mainEntityOfPage": "https://ultratextgen.com/guide/comments-that-stand-out/",
+  "datePublished": "2026-06-07",
+  "dateModified": "2026-06-07"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://ultratextgen.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Guides",
+      "item": "https://ultratextgen.com/guide/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "How to Write Comments That Stand Out",
+      "item": "https://ultratextgen.com/guide/comments-that-stand-out/"
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Can I make text bold or italic in a YouTube comment?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes — but the reliable way is Unicode, not YouTube's native formatting. YouTube's *bold* and _italic_ markdown exists yet breaks across app updates and devices. Styled Unicode characters render the same everywhere because the styling is built into the characters themselves. Type your comment, pick a style in the Comment Style Generator, copy, and paste."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Why did my asterisks stop working on YouTube?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "YouTube's native markdown is inconsistent and changes with updates, so the asterisk trick works one month and not the next. Unicode styled text doesn't rely on the platform offering a formatting feature, so it doesn't break the same way. Use a generated style instead of asterisks."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does styled comment text work on mobile?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. The generator is browser-based and fully responsive — style your comment on your phone, copy, switch to the app, paste. No download. Note that on some platforms (TikTok especially) appearance can vary slightly between iPhone and Android, so favor widely-supported styles like bold, italic, and script."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Will styled text hurt my reach or get me flagged?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Used sparingly, no — a single styled phrase is fine. Used heavily, it can read as spam, break screen readers, and become invisible to search. The safe rule: style one phrase, keep the rest plain, and never style a keyword, link, or call to action you want found."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is using these fonts in comments allowed?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. They're standard Unicode characters, not a hack or a mod — the same standard that powers emoji. Platforms render them as ordinary text. The only judgment call is taste: style for emphasis, not for the sake of it."
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+<script src="/header.js"></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/">Home</a>
+  <span class="breadcrumb-separator">&rsaquo;</span>
+  <a href="/guide/">Guides</a>
+  <span class="breadcrumb-separator">&rsaquo;</span>
+  <span class="breadcrumb-current">How to Write Comments That Stand Out</span>
+</nav>
+
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">How to Write Comments That Stand Out</h1>
+    <p class="hero-tagline">A field guide to styled replies — what each comment is trying to do, the technique that does it, and where it works.</p>
+  </div>
+</section>
+
+<!-- ═══════════════════════════════════════════ -->
+<!-- SECTION: Signal, not decoration             -->
+<!-- ═══════════════════════════════════════════ -->
+
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Most comment sections are a wall of identical plain text. The reply that breaks the visual pattern is the one that gets read — by the creator deciding who to answer, and by everyone else scrolling past. That is the entire mechanic behind a styled comment: in a column of sameness, difference earns the eye.</p>
+    <p>But styling is a <strong>signal, not decoration</strong>. A bold phrase says <em>pay attention to this</em>. A strikethrough says <em>I'm being ironic</em>. A cursive thank-you says <em>I mean this warmly</em>. Used with intent, the style adds a layer your words alone can't carry. Used as noise — the whole comment in fancy font, every reply dressed up the same way — it does the opposite of standing out, and on some platforms it actively works against you.</p>
+  </div>
+  <div class="mood-example">This guide is organized the way you should actually think about it: not "which font looks cool," but <strong>"what is this comment trying to do?"</strong> Decide the job first, then reach for the technique.</div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- ═══════════════════════════════════════════ -->
+<!-- SECTION: First principle                     -->
+<!-- ═══════════════════════════════════════════ -->
+
+<section class="mood-explainers">
+  <span class="article-section-label">The First Principle</span>
+  <h2>Style the Phrase, Not the Comment</h2>
+  <div class="mood-explainer">
+    <p>The single most common mistake is styling everything. When every word is bold or every line is cursive, the contrast that made it stand out disappears — you're back to a wall, just a fancier one. Worse, fully-styled text is harder to read and reads as spam.</p>
+    <p>The fix is restraint. Pick the <strong>one phrase</strong> that carries the point and style only that. The plain text around it becomes the frame; the styled phrase becomes the thing the eye lands on.</p>
+  </div>
+  <div class="compare-grid">
+    <div class="compare-card variant-muted">
+      <span class="compare-badge">Before</span>
+      <ul><li>this whole update is a huge improvement honestly</li></ul>
+    </div>
+    <div class="compare-card variant-positive">
+      <span class="compare-badge">After</span>
+      <ul><li>this whole update is a 𝗵𝘂𝗴𝗲 𝗶𝗺𝗽𝗿𝗼𝘃𝗲𝗺𝗲𝗻𝘁 honestly</li></ul>
+    </div>
+  </div>
+  <div class="mood-example u-mt-15">Same words. One anchor. That's the rule that governs everything below.</div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- ═══════════════════════════════════════════ -->
+<!-- SECTION: The comment types                   -->
+<!-- ═══════════════════════════════════════════ -->
+
+<section class="mood-explainers">
+  <span class="article-section-label">The Framework</span>
+  <h2>The Comment Types</h2>
+  <div class="mood-explainer">
+    <p>Each "type" is a job. Find the one you're doing, use the technique, reach for the tool.</p>
+  </div>
+</section>
+
+<!-- Type 1: The Emphasis -->
+<section class="mood-explainers">
+  <span class="article-section-label">Comment Type 1</span>
+  <h2>&#x1F4A5; The Emphasis — Make One Point Land</h2>
+  <div class="mood-explainer">
+    <p>The workhorse. You're making a statement, answering a question, or correcting a misconception, and you want the key idea to register before someone scrolls. <strong>Bold</strong> (or bold-italic for maximum weight) does this. It mimics the native formatting most comment fields don't offer, so it stands out without shouting.</p>
+    <div class="mood-example">
+      <div class="example-pair">
+        <span class="ex-label">Plain</span>
+        <span class="ex-plain">the real problem isn't the price, it's the wait time</span>
+        <span class="ex-arrow">&rarr;</span>
+        <span class="ex-label">With <a href="/usecase/comment-font/">Comment Style</a></span>
+        <span class="ex-styled">the real problem isn't the price — it's 𝗧𝗵𝗲 𝘄𝗮𝗶𝘁 𝘁𝗶𝗺𝗲</span>
+      </div>
+    </div>
+    <p><strong>Style it with:</strong> the <a href="/usecase/comment-font/">Comment Style Generator</a> (bold / bold italic).</p>
+  </div>
+</section>
+
+<!-- Type 2: The Correction -->
+<section class="mood-explainers">
+  <span class="article-section-label">Comment Type 2</span>
+  <h2>&#x270F;&#xFE0F; The Correction — Disagree Without Being Harsh</h2>
+  <div class="mood-explainer">
+    <p>You want to push back, retract, or flag irony, and tone matters. <strong>Strikethrough</strong> crosses out a word and replaces it, communicating disagreement or sarcasm without confrontation. It's one of the most underrated tools in any comment section because it carries tone that plain text loses.</p>
+    <div class="mood-example">
+      <div class="example-pair">
+        <span class="ex-label">Example</span>
+        <span class="ex-styled">Their support is t&#x0336;o&#x0336;t&#x0336;a&#x0336;l&#x0336;l&#x0336;y&#x0336; &#x0336;g&#x0336;r&#x0336;e&#x0336;a&#x0336;t&#x0336; non-existent<br><br>Oh sure, that's d&#x0336;e&#x0336;f&#x0336;i&#x0336;n&#x0336;i&#x0336;t&#x0336;e&#x0336;l&#x0336;y&#x0336; how it works</span>
+      </div>
+    </div>
+    <p><strong>Style it with:</strong> the <a href="/usecase/comment-font/">Comment Style Generator</a> (strikethrough). For the deeper logic of matching tone to technique, see <a href="/guide/the-rhetoric-of-fonts/">The Rhetoric of Fonts</a>.</p>
+  </div>
+</section>
+
+<!-- Type 3: The Aside -->
+<section class="mood-explainers">
+  <span class="article-section-label">Comment Type 3</span>
+  <h2>&#x1F4DD; The Aside — Quiet, Deliberate Emphasis</h2>
+  <div class="mood-explainer">
+    <p>When bold is too loud, <strong>underline</strong> adds emphasis that feels intentional rather than emphatic — a softer way to say <em>notice this</em>. Good for tone-sensitive replies where you want weight without volume.</p>
+    <div class="mood-example">
+      <div class="example-pair">
+        <span class="ex-label">Example</span>
+        <span class="ex-styled">The fix is s&#x0332;i&#x0332;m&#x0332;p&#x0332;l&#x0332;e&#x0332;, people just don't like hearing it</span>
+      </div>
+    </div>
+    <p><strong>Style it with:</strong> the <a href="/usecase/comment-font/">Comment Style Generator</a> (underline).</p>
+  </div>
+</section>
+
+<!-- Type 4: The Warmth -->
+<section class="mood-explainers">
+  <span class="article-section-label">Comment Type 4</span>
+  <h2>&#x2764;&#xFE0F; The Warmth — Compliments and Thank-Yous</h2>
+  <div class="mood-explainer">
+    <p>A compliment in plain text reads as polite. The same words in <strong>script or cursive</strong> read as personal. When the job is appreciation — a friend's photo, a creator you admire, a thank-you — warmth styling makes the words feel human instead of reflexive. This is where Instagram and Facebook replies shine.</p>
+    <div class="mood-example">
+      <div class="example-pair">
+        <span class="ex-label">Plain</span>
+        <span class="ex-plain">you are amazing, this made my day</span>
+        <span class="ex-arrow">&rarr;</span>
+        <span class="ex-label">With <a href="/usecase/comment-font/">Comment Style</a></span>
+        <span class="ex-styled">&#x1D4B4;&#x1D45C;&#x1D4CA; &#x1D44E;&#x1D45F;&#x1D452; &#x1D4B6;&#x1D45A;&#x1D44E;&#x1D4CF;&#x1D456;&#x1D45B;&#x1D454; &#x2764;&#xFE0F; this made my day</span>
+      </div>
+    </div>
+    <p><strong>Style it with:</strong> the <a href="/usecase/comment-font/">Comment Style Generator</a> (script / cursive).</p>
+  </div>
+</section>
+
+<!-- Type 5: The Reaction -->
+<section class="mood-explainers">
+  <span class="article-section-label">Comment Type 5</span>
+  <h2>&#x1F389; The Reaction — Emoji as Punctuation</h2>
+  <div class="mood-explainer">
+    <p>Sometimes the comment <em>is</em> the reaction. Emoji used deliberately — as punctuation around a phrase, or as a compact emotional stamp — lands faster than words. The trick is the same as with fonts: a placed emoji beats a pile of them.</p>
+    <p><strong>Build it with:</strong> <a href="/usecase/emoji-combinations/">Emoji Combinations</a>, or turn a word into its emoji form with the <a href="/usecase/text-to-emoji/">Text to Emoji Generator</a>.</p>
+  </div>
+</section>
+
+<!-- Type 6: The Transformation -->
+<section class="mood-explainers">
+  <span class="article-section-label">Comment Type 6</span>
+  <h2>&#x1F504; The Transformation — Show a Before and After</h2>
+  <div class="mood-explainer">
+    <p>Some comments are arguments about change: this got better, this got worse, here's the journey. Framing the reply as a visible <strong>before &rarr; after</strong> makes the transformation legible at a glance, which is far more persuasive than describing it.</p>
+    <div class="mood-example">
+      <div class="example-pair">
+        <span class="ex-label">Example</span>
+        <span class="ex-styled">&#x1F534; Before: clunky, three taps to do anything<br>&#x1F7E2; After: one tap, done</span>
+      </div>
+    </div>
+    <p><strong>Frame it with:</strong> <a href="/usecase/before-after-emoji/">Before &amp; After Emoji</a> — once the core comment is clean, not as a substitute for it.</p>
+  </div>
+</section>
+
+<!-- Type 7: The Scroll-Stopper -->
+<section class="mood-explainers">
+  <span class="article-section-label">Comment Type 7</span>
+  <h2>&#x1F441;&#xFE0F; The Scroll-Stopper — Break the Reading Axis</h2>
+  <div class="mood-explainer">
+    <p>Horizontal text is invisible because it's expected. A single <strong>vertical / stacked word</strong> breaks the axis the eye is trained to follow, forcing a half-second pause — and a half-second is all you need to be read. Use it as an anchor, not a replacement: one vertical word, then continue horizontally.</p>
+    <div class="mood-example">
+      <div class="example-pair">
+        <span class="ex-label">Example</span>
+        <span class="ex-styled">W<br>A<br>I<br>T<br>— before you scroll past this</span>
+      </div>
+    </div>
+    <p><strong>Stack it with:</strong> the <a href="/usecase/vertical-text/">Vertical Text Generator</a>. For why this works (and where it fails), see <a href="/guide/stop-the-scroll-with-font-variation/">Stop the Scroll with Font Variation</a>.</p>
+  </div>
+</section>
+
+<!-- Type 8: The Edgy -->
+<section class="mood-explainers">
+  <span class="article-section-label">Comment Type 8</span>
+  <h2>&#x1F480; The Edgy — Chaotic or Glitchy by Design</h2>
+  <div class="mood-explainer">
+    <p>Occasionally the vibe <em>is</em> the message — a horror community, a chaotic in-joke, an intentionally unhinged reply. Glitch / corrupted text carries that energy. This is the one to use most sparingly: it's illegible by nature, so it works as a visual gesture, never as the words that have to be read.</p>
+    <p><strong>Style it with:</strong> the <a href="/usecase/zalgo-text/">Zalgo Text Generator</a>.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- ═══════════════════════════════════════════ -->
+<!-- SECTION: Platform field notes                -->
+<!-- ═══════════════════════════════════════════ -->
+
+<section class="mood-explainers">
+  <span class="article-section-label">Platform Field Notes</span>
+  <h2>The Same Text Behaves Differently Per Platform</h2>
+  <div class="mood-explainer">
+    <p>A styled comment doesn't render identically everywhere you paste it. A quick reality check per platform:</p>
+  </div>
+
+  <div class="brand-card">
+    <h3>&#x25B6;&#xFE0F; YouTube</h3>
+    <p>YouTube's native markdown (<code>*bold*</code>, <code>_italic_</code>, <code>-strike-</code>) exists but is unreliable — it breaks on app updates and behaves inconsistently across devices. Unicode styled text doesn't depend on the platform supporting a feature, because the characters <em>are</em> the style, so it renders the same everywhere and doesn't suddenly stop working.</p>
+  </div>
+
+  <div class="brand-card">
+    <h3>&#x1F4F8; Instagram &amp; Facebook</h3>
+    <p>Both render Unicode in comments. The effect is subtler than on YouTube because their default type is already clean — but script, bold, and bubble styles still break the pattern, and the warmth styles land especially well on personal posts.</p>
+  </div>
+
+  <div class="brand-card">
+    <h3>&#x1F3B5; TikTok</h3>
+    <p>Styled text works in comments and replies. Because TikTok is mobile-first and renders characters using each device's system fonts, appearance can vary slightly between iPhone and Android — test a style before leaning on it, and favor the widest-support styles (bold, italic, script).</p>
+  </div>
+
+  <div class="brand-card">
+    <h3>&#x1F4BC; LinkedIn</h3>
+    <p>A category of its own, with its own playbook. If you're commenting on LinkedIn, start with the <a href="/guide/linkedin-comments-guide/">LinkedIn Comment Archetypes</a> and <a href="/library/linkedin-comment-styling/">LinkedIn Comment Styling</a> — the rules there reward structure and restraint more than flourish.</p>
+  </div>
+
+  <div class="brand-card">
+    <h3>&#x1F6D1; Reddit — the exception</h3>
+    <p>Reddit is the one place to <em>not</em> reach for styled fonts. It supports native markdown for comments (bold, italic, strikethrough, spoilers, quotes), so you don't need Unicode to format. More importantly, Reddit's culture treats fancy Unicode in comments as spammy, and it draws downvotes. On Reddit, a comment stands out through substance, timing, and clean markdown — not typography. Skip the generator here.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- ═══════════════════════════════════════════ -->
+<!-- SECTION: When not to style                   -->
+<!-- ═══════════════════════════════════════════ -->
+
+<section class="mood-explainers">
+  <span class="article-section-label">The Honest Part</span>
+  <h2>When <em>Not</em> to Style</h2>
+  <div class="mood-explainer">
+    <p>This is what separates a comment that lands from one that backfires. Styled Unicode has real costs, and knowing them is what lets you use it well.</p>
+  </div>
+  <div class="steps-grid">
+    <div class="step-card">
+      <div class="step-number">&#x267F;</div>
+      <h3>It breaks screen readers</h3>
+      <p>Styled characters aren't fonts — they're separate Unicode symbols that happen to look styled. A screen reader reads out "mathematical bold m," one character at a time. Style a phrase for emphasis; never style an entire message.</p>
+    </div>
+    <div class="step-card">
+      <div class="step-number">&#x1F6AB;</div>
+      <h3>It can read as spam</h3>
+      <p>Because spammers use Unicode swaps to dodge keyword filters, these characters carry a spam association, and some platforms' filters treat them with suspicion. A lightly-styled phrase is fine; a comment drowning in fancy characters can trip exactly the filters built to catch it.</p>
+    </div>
+    <div class="step-card">
+      <div class="step-number">&#x1F50D;</div>
+      <h3>It's invisible to search</h3>
+      <p>Styled characters aren't indexed as the words they resemble. If a phrase is something you want found — a brand name, a keyword, a link's anchor, a call to action — leave it plain.</p>
+    </div>
+    <div class="step-card">
+      <div class="step-number">&#x1F4D6;</div>
+      <h3>It hurts readability if overused</h3>
+      <p>The through-line of the whole guide: the styled phrase only stands out because the plain text around it doesn't. Style everything and you've styled nothing.</p>
+    </div>
+  </div>
+  <div class="mood-example u-mt-15"><strong>The rule of one.</strong> One styled element per comment. One bold phrase, <em>or</em> one strikethrough, <em>or</em> one emoji stamp — not all three. Restraint is the entire skill.</div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- ═══════════════════════════════════════════ -->
+<!-- SECTION: Quick reference                     -->
+<!-- ═══════════════════════════════════════════ -->
+
+<section class="editorial-section">
+  <span class="article-section-label">Quick Reference</span>
+  <h2>Match the Job to the Technique</h2>
+  <div class="editorial-block"><p>Decide what the comment is trying to do, then reach for the tool that does it.</p></div>
+  <div class="data-table-wrap">
+    <table class="data-table">
+      <thead><tr><th>What you're doing</th><th>Technique</th><th>Tool</th></tr></thead>
+      <tbody>
+        <tr><td>Make a point land</td><td>Bold / bold italic</td><td><a href="/usecase/comment-font/">Comment Style Generator</a></td></tr>
+        <tr><td>Disagree or be ironic</td><td>Strikethrough</td><td><a href="/usecase/comment-font/">Comment Style Generator</a></td></tr>
+        <tr><td>Quiet, deliberate emphasis</td><td>Underline</td><td><a href="/usecase/comment-font/">Comment Style Generator</a></td></tr>
+        <tr><td>Compliment / thank</td><td>Script / cursive</td><td><a href="/usecase/comment-font/">Comment Style Generator</a></td></tr>
+        <tr><td>React</td><td>Emoji as punctuation</td><td><a href="/usecase/emoji-combinations/">Emoji Combinations</a> &middot; <a href="/usecase/text-to-emoji/">Text to Emoji</a></td></tr>
+        <tr><td>Show change</td><td>Before &rarr; after</td><td><a href="/usecase/before-after-emoji/">Before &amp; After Emoji</a></td></tr>
+        <tr><td>Stop the scroll</td><td>Vertical / stacked anchor</td><td><a href="/usecase/vertical-text/">Vertical Text</a></td></tr>
+        <tr><td>Edgy / chaotic vibe</td><td>Glitch text (sparingly)</td><td><a href="/usecase/zalgo-text/">Zalgo Text</a></td></tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<div class="pull-quote">In a column of sameness, difference earns the eye.<br><br>Style the phrase, not the comment. One anchor per reply. Keep the rest plain.</div>
+
+<div class="cta-card">
+  <h3>Ready to write one?</h3>
+  <p>Open the Comment Style Generator, type your comment, style the one phrase that carries it, and paste it where it'll get noticed — free, instant, no sign-up.</p>
+  <a href="/usecase/comment-font/" class="cta-btn">Open Comment Style Generator &rarr;</a>
+</div>
+
+<!-- RELATED GUIDES -->
+<section class="editorial-section">
+  <span class="article-section-label">Related Guides</span>
+  <h2 style="font-size:1.35rem;">Continue Reading</h2>
+  <div class="compare-grid">
+    <a href="/guide/linkedin-comments-guide/" class="compare-card variant-muted" style="text-decoration:none;">
+      <span class="compare-badge">Guide</span>
+      <h4>LinkedIn Comment Archetypes</h4>
+      <ul><li>The 14 comment archetypes, power combos, and formatting strategies that build authority in the comments section.</li></ul>
+    </a>
+    <a href="/guide/the-rhetoric-of-fonts/" class="compare-card variant-muted" style="text-decoration:none;">
+      <span class="compare-badge">Guide</span>
+      <h4>The Rhetoric of Fonts</h4>
+      <ul><li>How each Unicode font maps to a specific mode of persuasion — from sarcasm to gravitas.</li></ul>
+    </a>
+    <a href="/guide/stop-the-scroll-with-font-variation/" class="compare-card variant-muted" style="text-decoration:none;">
+      <span class="compare-badge">Guide</span>
+      <h4>Stop the Scroll with Font Variation</h4>
+      <ul><li>Use font contrast as visual navigation so people read your post instead of skipping it.</li></ul>
+    </a>
+    <a href="/library/linkedin-comment-styling/" class="compare-card variant-muted" style="text-decoration:none;">
+      <span class="compare-badge">Library</span>
+      <h4>LinkedIn Comment Styling Techniques</h4>
+      <ul><li>Ready-to-use Unicode formatting for LinkedIn comments — emphasis, tone, and readability.</li></ul>
+    </a>
+  </div>
+</section>
+
+<!-- PLATFORM PILLS -->
+<section class="editorial-section" style="text-align:center;">
+  <div class="platform-pills">
+    <a href="/usecase/comment-font/" class="platform-pill">Comment Style</a>
+    <a href="/usecase/emoji-combinations/" class="platform-pill">Emoji Combos</a>
+    <a href="/usecase/text-to-emoji/" class="platform-pill">Text to Emoji</a>
+    <a href="/usecase/before-after-emoji/" class="platform-pill">Before-After Emoji</a>
+    <a href="/usecase/vertical-text/" class="platform-pill">Vertical Text</a>
+    <a href="/usecase/zalgo-text/" class="platform-pill">Zalgo Text</a>
+    <a href="/usecase/" class="platform-pill">All Use Cases</a>
+  </div>
+</section>
+
+<!-- FAQ Section -->
+<section class="editorial-section">
+  <h2>Frequently Asked Questions</h2>
+
+  <div class="faq-item">
+    <button class="faq-question">Can I make text bold or italic in a YouTube comment?</button>
+    <div class="faq-answer">
+      <p>Yes — but the reliable way is Unicode, not YouTube's native formatting. YouTube's <code>*bold*</code> and <code>_italic_</code> markdown exists yet breaks across app updates and devices. Styled Unicode characters render the same everywhere because the styling is built into the characters themselves. Type your comment, pick a style in the <a href="/usecase/comment-font/">Comment Style Generator</a>, copy, and paste.</p>
+    </div>
+  </div>
+
+  <div class="faq-item">
+    <button class="faq-question">Why did my asterisks stop working on YouTube?</button>
+    <div class="faq-answer">
+      <p>YouTube's native markdown is inconsistent and changes with updates, so the asterisk trick works one month and not the next. Unicode styled text doesn't rely on the platform offering a formatting feature, so it doesn't break the same way. Use a generated style instead of asterisks.</p>
+    </div>
+  </div>
+
+  <div class="faq-item">
+    <button class="faq-question">Does this work on mobile?</button>
+    <div class="faq-answer">
+      <p>Yes. The generator is browser-based and fully responsive — style your comment on your phone, copy, switch to the app, paste. No download. Note that on some platforms (TikTok especially) appearance can vary slightly between iPhone and Android, so favor widely-supported styles like bold, italic, and script.</p>
+    </div>
+  </div>
+
+  <div class="faq-item">
+    <button class="faq-question">Will styled text hurt my reach or get me flagged?</button>
+    <div class="faq-answer">
+      <p>Used sparingly, no — a single styled phrase is fine. Used heavily, it can read as spam, break screen readers, and become invisible to search. The safe rule: style one phrase, keep the rest plain, and never style a keyword, link, or call to action you want found.</p>
+    </div>
+  </div>
+
+  <div class="faq-item">
+    <button class="faq-question">Is using these fonts allowed?</button>
+    <div class="faq-answer">
+      <p>Yes. They're standard Unicode characters, not a hack or a mod — the same standard that powers emoji. Platforms render them as ordinary text. The only judgment call is taste: style for emphasis, not for the sake of it.</p>
+    </div>
+  </div>
+</section>
+
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<script>
+  document.querySelectorAll('.faq-question').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      this.closest('.faq-item').classList.toggle('open');
+    });
+  });
+</script>
+<script src="/footer.js"></script>
+</body>
+</html>

--- a/guide/index.html
+++ b/guide/index.html
@@ -98,6 +98,20 @@ Reaction → Contribution.</div>
       <a class="usecase-cta" href="/guide/linkedin-comments-guide/">LinkedIn Comment Archetypes →</a>
     </div>
 
+    <!-- Guide: How to Write Comments That Stand Out -->
+    <div class="style-card usecase-cards" style="flex-direction:column;align-items:stretch;gap:8px;">
+      <div class="style-name">
+        <span class="style-tag">💬</span>
+        How to Write Comments That Stand Out
+      </div>
+      <p class="usecase-outcome">Decide what your comment is trying to do, then reach for the technique that does it.</p>
+      <p class="usecase-diff">A field guide to styled replies across every platform — eight comment types mapped to bold, strikethrough, script, emoji, and vertical text, with platform field notes and a clear rule for when not to style.</p>
+      <div class="usecase-example">Before: this whole update is a huge improvement honestly
+After: this whole update is a 𝗵𝘂𝗴𝗲 𝗶𝗺𝗽𝗿𝗼𝘃𝗲𝗺𝗲𝗻𝘁 honestly
+Style the phrase, not the comment.</div>
+      <a class="usecase-cta" href="/guide/comments-that-stand-out/">How to Write Comments That Stand Out →</a>
+    </div>
+
     <!-- Guide: Style Your LinkedIn Hooks to Stand Out -->
     <div class="style-card usecase-cards" style="flex-direction:column;align-items:stretch;gap:8px;">
       <div class="style-name">


### PR DESCRIPTION
## Summary
Added a comprehensive guide page teaching users how to write styled comments that stand out across social platforms. The guide maps eight comment types (emphasis, correction, aside, warmth, reaction, transformation, scroll-stopper, edgy) to specific styling techniques, with platform-specific field notes and clear rules for when not to style.

## Changes Made

- **New guide page**: `guide/comments-that-stand-out/index.html` (536 lines)
  - Eight comment type sections with examples and tool recommendations
  - Platform field notes for YouTube, Instagram/Facebook, TikTok, LinkedIn, and Reddit
  - "When Not to Style" section covering accessibility, spam filters, search visibility, and readability
  - Quick reference table mapping comment jobs to techniques
  - FAQ section with 5 common questions (structured as JSON-LD FAQPage)
  - Related guides and platform pill navigation
  - Full SEO metadata (canonical, OG tags, Twitter Card, structured data)

- **Updated guide index**: `guide/index.html`
  - Added new guide card in the "Platform & Posting" section
  - Includes preview text, example before/after, and link to full guide

## Implementation Details

- Follows all project conventions: GTM tracking, JSON-LD structured data (Article, BreadcrumbList, FAQPage), dark mode support via CSS variables
- Uses existing design system classes and patterns from other guide pages
- Emphasizes the core principle: "Style the phrase, not the comment" — one anchor per reply
- Includes practical warnings about screen readers, spam filters, search indexing, and readability
- All internal links point to existing tools (Comment Style Generator, Emoji Combinations, Vertical Text, etc.)
- Mobile-responsive with semantic HTML and accessibility considerations

https://claude.ai/code/session_015h1FFk4d4SJFZg4it92wcm