### PR TITLE
feat(seo): static library links, fix linkedin 404, expand thin pages

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -55,5 +55,9 @@ https://www.ultratextgen.com/*  https://ultratextgen.com/:splat  301!
 /?lang=pl                                   /pl/    301
 /?lang=vi                                   /vi/    301
 
+# Library: renamed/removed slug → live equivalent
+/library/linkedin-post-formatting-symbols/            /library/linkedin-symbol-library/ 301
+/library/linkedin-post-formatting-symbols/index.html  /library/linkedin-symbol-library/ 301
+
 /404  /404.html  200
 /*    /404.html  404

--- a/index.html
+++ b/index.html
@@ -414,6 +414,34 @@
     <p class="u-mt-15 u-text-center"><a class="cat-cta" href="/category/">Browse all font categories →</a></p>
   </section>
 
+  <!-- Popular Library References -->
+  <section class="editorial-section">
+    <h2>Popular symbol &amp; emoji libraries</h2>
+    <div class="tips-grid">
+      <a class="tip-card" href="/library/text-faces-kaomoji/" aria-label="Text faces and kaomoji library">
+        <div class="tip-icon">(•‿•)</div>
+        <h3>Text faces &amp; kaomoji</h3>
+        <p>Japanese emoticons and ASCII text faces — shrug, happy, table-flip and more — that copy and paste cleanly into any bio, comment, or chat without breaking.</p>
+      </a>
+      <a class="tip-card" href="/library/math-symbols/" aria-label="Math symbols library">
+        <div class="tip-icon">∑</div>
+        <h3>Math symbols</h3>
+        <p>Operators, Greek letters, set theory, calculus and superscripts as plain Unicode — write equations in emails, posts and docs with no LaTeX needed.</p>
+      </a>
+      <a class="tip-card" href="/library/aesthetic-symbols/" aria-label="Aesthetic symbols library">
+        <div class="tip-icon">✦</div>
+        <h3>Aesthetic symbols</h3>
+        <p>Coquette, Y2K, kawaii and soft decorative characters for usernames, bios and captions. Tap any symbol to copy it instantly.</p>
+      </a>
+      <a class="tip-card" href="/library/special-characters/" aria-label="Special characters library">
+        <div class="tip-icon">✧</div>
+        <h3>Special characters</h3>
+        <p>Unusual Unicode symbols, fancy punctuation and rare glyphs for names, design and formatting — a quick reference you can copy from in one tap.</p>
+      </a>
+    </div>
+    <p class="u-mt-15 u-text-center"><a class="cat-cta" href="/library/">Browse the full symbol &amp; emoji library →</a></p>
+  </section>
+
   <!-- FAQ Section -->
   <section class="faq-section-wrapper" aria-label="Frequently asked questions">
     <div class="faq-inner">

--- a/library/index.html
+++ b/library/index.html
@@ -564,6 +564,93 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   </div>
 </div>
 
+<!-- STATIC INDEX (crawlable links to every collection) -->
+<nav class="lib-index" aria-label="All library collections">
+  <div class="lib-index-inner">
+    <h2 class="lib-index-title">All Collections A–Z</h2>
+    <p class="lib-index-note">Every reference collection in the UltraTextGen Library. Browse the full directory above, or jump straight to a page below.</p>
+    <ul class="lib-index-list">
+      <li><a href="/library/accent-marks-diacritics/">Accent Marks &amp; Diacritics</a></li>
+      <li><a href="/library/achievement-symbols/">Achievement Symbols</a></li>
+      <li><a href="/library/aesthetic-symbols/">Aesthetic Symbols</a></li>
+      <li><a href="/library/aesthetic-borders-frames/">Aesthetic Borders &amp; Frames</a></li>
+      <li><a href="/library/animal-emojis/">Animal Emojis</a></li>
+      <li><a href="/library/arrow-symbols/">Arrow Symbols</a></li>
+      <li><a href="/library/awareness-ribbons/">Awareness Ribbons</a></li>
+      <li><a href="/library/body-language-emojis/">Body Language Emojis</a></li>
+      <li><a href="/library/bow-ribbon-symbols/">Bow &amp; Ribbon Symbols</a></li>
+      <li><a href="/library/box-drawing-symbols/">Box Drawing &amp; Block Symbols</a></li>
+      <li><a href="/library/bracket-symbols/">Bracket Symbols</a></li>
+      <li><a href="/library/braille-pattern-symbols/">Braille Pattern Symbols</a></li>
+      <li><a href="/library/bullet-point-symbols/">Bullet Point Symbols</a></li>
+      <li><a href="/library/card-suit-symbols/">Card Suit Symbols</a></li>
+      <li><a href="/library/checkmark-symbols/">Checkmark Symbols</a></li>
+      <li><a href="/library/chess-symbols/">Chess Symbols</a></li>
+      <li><a href="/library/coquette-symbols/">Coquette Symbols</a></li>
+      <li><a href="/library/cottagecore-symbols/">Cottagecore Symbols</a></li>
+      <li><a href="/library/cross-x-symbols/">Cross &amp; X Symbols</a></li>
+      <li><a href="/library/crown-royalty-symbols/">Crown &amp; Royalty Symbols</a></li>
+      <li><a href="/library/currency-symbols/">Currency Symbols</a></li>
+      <li><a href="/library/dash-hyphen-symbols/">Dash &amp; Hyphen Symbols</a></li>
+      <li><a href="/library/dice-domino-symbols/">Dice &amp; Domino Symbols</a></li>
+      <li><a href="/library/discord-symbols/">Discord Symbols</a></li>
+      <li><a href="/library/egyptian-hieroglyphs/">Egyptian Hieroglyphs</a></li>
+      <li><a href="/library/email-symbols/">Email Symbols</a></li>
+      <li><a href="/library/emoji-flags/">Emoji Flag Explorer</a></li>
+      <li><a href="/library/emoji-meanings-guide/">Emoji Meanings Guide</a></li>
+      <li><a href="/library/face-emojis/">Face Emojis</a></li>
+      <li><a href="/library/flower-symbols/">Flower Symbols</a></li>
+      <li><a href="/library/food-drink-emojis/">Food &amp; Drink Emojis</a></li>
+      <li><a href="/library/gender-symbols/">Gender Symbols</a></li>
+      <li><a href="/library/geometric-symbols/">Geometric Symbols</a></li>
+      <li><a href="/library/goth-grunge-symbols/">Goth &amp; Grunge Symbols</a></li>
+      <li><a href="/library/greek-letter-symbols/">Greek Letter Symbols</a></li>
+      <li><a href="/library/hand-symbols/">Hand Symbols &amp; Gestures</a></li>
+      <li><a href="/library/hazard-warning-symbols/">Hazard &amp; Warning Symbols</a></li>
+      <li><a href="/library/heart-symbols/">Heart Symbols</a></li>
+      <li><a href="/library/instagram-symbols/">Instagram Symbols</a></li>
+      <li><a href="/library/kawaii-cute-symbols/">Kawaii &amp; Cute Symbols</a></li>
+      <li><a href="/library/keyboard-symbols/">Keyboard Symbols</a></li>
+      <li><a href="/library/laundry-care-symbols/">Laundry Care Symbols</a></li>
+      <li><a href="/library/line-divider-symbols/">Line Divider Symbols</a></li>
+      <li><a href="/library/linkedin-comment-styling/">LinkedIn Comment Styling</a></li>
+      <li><a href="/library/linkedin-symbol-library/">LinkedIn Symbol Library</a></li>
+      <li><a href="/library/math-symbols/">Math Symbols</a></li>
+      <li><a href="/library/media-control-symbols/">Media Control Symbols</a></li>
+      <li><a href="/library/medical-symbols/">Medical Symbols</a></li>
+      <li><a href="/library/moon-celestial-symbols/">Moon &amp; Celestial Symbols</a></li>
+      <li><a href="/library/music-symbols/">Music Note Symbols</a></li>
+      <li><a href="/library/norse-viking-runes/">Norse / Viking Runes</a></li>
+      <li><a href="/library/number-symbols/">Number Symbols</a></li>
+      <li><a href="/library/peace-symbol/">Peace Symbol</a></li>
+      <li><a href="/library/people-profession-emojis/">People &amp; Profession Emojis</a></li>
+      <li><a href="/library/punctuation-symbols/">Punctuation Symbols</a></li>
+      <li><a href="/library/recycle-environment-symbols/">Recycle &amp; Environment Symbols</a></li>
+      <li><a href="/library/religious-symbols/">Religious &amp; Spiritual Symbols</a></li>
+      <li><a href="/library/roblox-symbols/">Roblox Symbols</a></li>
+      <li><a href="/library/slash-backslash-symbols/">Slash &amp; Backslash Symbols</a></li>
+      <li><a href="/library/smiley-face-guide/">Smiley Face Guide</a></li>
+      <li><a href="/library/sparkle-symbols/">Sparkle Symbols</a></li>
+      <li><a href="/library/special-characters/">Special Characters</a></li>
+      <li><a href="/library/sports-emojis/">Sports Emojis</a></li>
+      <li><a href="/library/star-symbols/">Star Symbol Collection</a></li>
+      <li><a href="/library/tech-status-symbols/">Tech &amp; Status Symbols</a></li>
+      <li><a href="/library/text-faces-kaomoji/">Text Faces &amp; Kaomoji</a></li>
+      <li><a href="/library/tiktok-symbols/">TikTok Symbols</a></li>
+      <li><a href="/library/traffic-road-sign-symbols/">Traffic &amp; Road Sign Symbols</a></li>
+      <li><a href="/library/transport-symbols/">Transport &amp; Map Symbols</a></li>
+      <li><a href="/library/unit-measurement-symbols/">Unit &amp; Measurement Symbols</a></li>
+      <li><a href="/library/weather-symbols/">Weather Symbols</a></li>
+      <li><a href="/library/whisper-subliminal-symbols/">Whisper &amp; Subliminal Symbols</a></li>
+      <li><a href="/library/witchy-occult-symbols/">Witchy &amp; Occult Symbols</a></li>
+      <li><a href="/library/x-twitter-symbols/">X / Twitter Symbols</a></li>
+      <li><a href="/library/y2k-symbols/">Y2K Symbols</a></li>
+      <li><a href="/library/yin-yang-symbol/">Yin Yang Symbol</a></li>
+      <li><a href="/library/zodiac-symbols/">Zodiac Symbols</a></li>
+    </ul>
+  </div>
+</nav>
+
 <!-- FOOTER -->
 <footer class="footer">
   <div class="footer-inner"></div>

--- a/library/special-characters/index.html
+++ b/library/special-characters/index.html
@@ -55,7 +55,7 @@
   },
   "mainEntityOfPage": "https://ultratextgen.com/library/special-characters/",
   "datePublished": "2026-03-31",
-  "dateModified": "2026-03-31"
+  "dateModified": "2026-06-08"
 }
 </script>
 
@@ -111,6 +111,8 @@
 <section class="editorial-section">
   <div class="editorial-block">
     <p>Browse and copy unique special characters organized by meaning — from infinity and eternity symbols to peace signs, scientific notation, legal marks, aesthetic decorators, and rare Unicode curiosities.</p>
+    <p>"Special characters" are any symbols that aren't standard letters or numbers — things like ∞, ©, ™, †, ★, and °. They live in the Unicode standard alongside ordinary text, which means you can copy them here and paste them into documents, social posts, code, usernames, and form fields without needing a special keyboard, ALT codes, or character-map software. Every symbol below is a single click to copy.</p>
+    <p>Use the categories to jump to what you need, or scan the page for that one glyph you can never remember how to type. Each character is plain Unicode, so it stays the same when you paste it into Google Docs, Word, Notion, Gmail, Instagram, or a chat window.</p>
   </div>
 </section>
 
@@ -433,6 +435,42 @@
       <button class="flag-emoji symbol-tile" data-symbol="⚚" aria-label="Copy ⚚">⚚</button>
       <span class="flag-label">Staff of Hermes</span>
     </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- HOW TO USE -->
+<section class="editorial-section" id="how-to-use">
+  <span class="article-section-label">How to use</span>
+  <h2>How to type special characters anywhere</h2>
+  <div class="editorial-block">
+    <p>There are several ways to insert a special character — but copy and paste is the fastest and the most reliable across devices:</p>
+    <ul>
+      <li><strong>Copy and paste (easiest):</strong> click any symbol on this page to copy it, then paste it (<code>Ctrl/Cmd + V</code>) wherever you need it. No codes to memorize.</li>
+      <li><strong>Windows ALT codes:</strong> hold <code>Alt</code> and type a number on the numeric keypad (for example <code>Alt + 0169</code> for ©). This only works on keyboards with a real number pad.</li>
+      <li><strong>Mac Character Viewer:</strong> press <code>Ctrl + Cmd + Space</code> to open the emoji and symbol picker.</li>
+      <li><strong>Unicode entry:</strong> on Windows, type the hex code and press <code>Alt + X</code> in some apps (for example <code>221E</code> then <code>Alt + X</code> gives ∞).</li>
+    </ul>
+    <p>Because these characters are part of Unicode, they display consistently on iPhone, Android, Windows, and Mac. A handful of the rarer mathematical and decorative glyphs can fall back to a missing-character box on older systems; if that happens, choose a more common alternative from the same category.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- FAQ -->
+<section class="editorial-section" id="faq">
+  <span class="article-section-label">FAQ</span>
+  <h2>Special characters frequently asked questions</h2>
+  <div class="editorial-block">
+    <h3>What counts as a special character?</h3>
+    <p>A special character is any symbol outside the basic letters (A–Z, a–z) and digits (0–9). That includes punctuation like &amp; and @, currency marks like € and £, math signs like ∞ and ±, and decorative glyphs like ★ and ✧. All of them are part of Unicode.</p>
+    <h3>How do I copy a special character without an ALT code?</h3>
+    <p>Just click the symbol you want on this page — it copies to your clipboard instantly, then paste it with <code>Ctrl + V</code> (Windows) or <code>Cmd + V</code> (Mac). You never need to remember a numeric code.</p>
+    <h3>Why does a special character show as a box or question mark?</h3>
+    <p>That happens when the app or device doesn't have a font glyph for that specific character. It's a display issue, not a copy error — the character is still correct underneath. Switching to a more widely supported symbol from the same category usually fixes it.</p>
+    <h3>Are special characters safe to use in passwords and usernames?</h3>
+    <p>Special punctuation (! @ # $ % &amp; *) strengthens passwords and is widely accepted. Rarer Unicode symbols, however, are often rejected by username and password fields, so stick to common ASCII punctuation there and save the decorative glyphs for posts and bios.</p>
   </div>
 </section>
 

--- a/library/text-faces-kaomoji/index.html
+++ b/library/text-faces-kaomoji/index.html
@@ -55,7 +55,7 @@
   },
   "mainEntityOfPage": "https://ultratextgen.com/library/text-faces-kaomoji/",
   "datePublished": "2026-03-31",
-  "dateModified": "2026-03-31"
+  "dateModified": "2026-06-08"
 }
 </script>
 
@@ -111,6 +111,8 @@
 <section class="editorial-section">
   <div class="editorial-block">
     <p>Kaomoji (顔文字) are emoticons that originated in Japan, built from standard keyboard characters and Unicode symbols. Unlike emoji, kaomoji are read horizontally and often capture nuanced expressions that emoji can't fully convey. They work in any text field and add personality to messages, bios, and captions.</p>
+    <p>The word <em>kaomoji</em> literally means "face characters" (顔 <em>kao</em>, "face" + 文字 <em>moji</em>, "character"). Where Western emoticons like <code>:-)</code> are read sideways, kaomoji such as <code>(◕‿◕)</code> are read upright, which makes the eyes, mouth, and even arms much easier to recognize at a glance. Because every kaomoji on this page is pure Unicode text — not an image or emoji font — it pastes cleanly into Instagram bios, TikTok captions, Discord messages, YouTube comments, usernames, and almost any other text field without turning into a broken box.</p>
+    <p>Browse the categories below and click any face to copy it instantly. Each one is grouped by mood — happy, sad, shrug, love, cute, angry, sleepy, and more — so you can find the right expression in seconds.</p>
   </div>
 </section>
 
@@ -329,6 +331,216 @@
       <button class="flag-emoji symbol-tile" data-symbol="(ˆ_ˆ)/" aria-label="Copy (ˆ_ˆ)/">(ˆ_ˆ)/</button>
       <span class="flag-label">Waving Hello</span>
     </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- LENNY & MISCHIEF -->
+<section class="mood-explainers" id="lenny-mischief">
+  <span class="article-section-label">Lenny &amp; Mischief</span>
+  <h2>Lenny Face &amp; Mischief Kaomoji</h2>
+  <p class="u-secondary-tight">The classic Lenny face and other smug, sly, and mischievous text faces.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="( ͡° ͜ʖ ͡°)" aria-label="Copy ( ͡° ͜ʖ ͡°)">( ͡° ͜ʖ ͡°)</button>
+      <span class="flag-label">Lenny Face</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="( ͡~ ͜ʖ ͡°)" aria-label="Copy ( ͡~ ͜ʖ ͡°)">( ͡~ ͜ʖ ͡°)</button>
+      <span class="flag-label">Winking Lenny</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(¬‿¬)" aria-label="Copy (¬‿¬)">(¬‿¬)</button>
+      <span class="flag-label">Smug Smirk</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="( ͡ʘ ͜ʖ ͡ʘ)" aria-label="Copy ( ͡ʘ ͜ʖ ͡ʘ)">( ͡ʘ ͜ʖ ͡ʘ)</button>
+      <span class="flag-label">Wide Lenny</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(◑‿◐)" aria-label="Copy (◑‿◐)">(◑‿◐)</button>
+      <span class="flag-label">Sly Grin</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="( ﾟ∀ﾟ)" aria-label="Copy ( ﾟ∀ﾟ)">( ﾟ∀ﾟ)</button>
+      <span class="flag-label">Cheeky</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- CUTE & KAWAII -->
+<section class="mood-explainers" id="cute-kawaii">
+  <span class="article-section-label">Cute &amp; Kawaii</span>
+  <h2>Cute &amp; Kawaii Kaomoji</h2>
+  <p class="u-secondary-tight">Soft, sweet, and kawaii text faces for wholesome and aesthetic messages.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(｡♥‿♥｡)" aria-label="Copy (｡♥‿♥｡)">(｡♥‿♥｡)</button>
+      <span class="flag-label">In Love</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(◍•ᴗ•◍)" aria-label="Copy (◍•ᴗ•◍)">(◍•ᴗ•◍)</button>
+      <span class="flag-label">Soft Smile</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(✿◡‿◡)" aria-label="Copy (✿◡‿◡)">(✿◡‿◡)</button>
+      <span class="flag-label">Flower Smile</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ʕ•ᴥ•ʔ♡" aria-label="Copy ʕ•ᴥ•ʔ♡">ʕ•ᴥ•ʔ♡</button>
+      <span class="flag-label">Bear Love</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(*ˊᗜˋ*)" aria-label="Copy (*ˊᗜˋ*)">(*ˊᗜˋ*)</button>
+      <span class="flag-label">Proud Cutie</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(づ￣ ³￣)づ" aria-label="Copy (づ￣ ³￣)づ">(づ￣ ³￣)づ</button>
+      <span class="flag-label">Kiss Hug</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- ANGRY & ANNOYED -->
+<section class="mood-explainers" id="angry-annoyed">
+  <span class="article-section-label">Angry &amp; Annoyed</span>
+  <h2>Angry &amp; Annoyed Kaomoji</h2>
+  <p class="u-secondary-tight">Mad, irritated, and fed-up text faces for venting and dramatic reactions.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(╬ Ò﹏Ó)" aria-label="Copy (╬ Ò﹏Ó)">(╬ Ò﹏Ó)</button>
+      <span class="flag-label">Furious</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ヽ(`Д´)ﾉ" aria-label="Copy ヽ(`Д´)ﾉ">ヽ(`Д´)ﾉ</button>
+      <span class="flag-label">Shouting</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(ﾉಥ益ಥ)ﾉ" aria-label="Copy (ﾉಥ益ಥ)ﾉ">(ﾉಥ益ಥ)ﾉ</button>
+      <span class="flag-label">Raging</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(¬､¬)" aria-label="Copy (¬､¬)">(¬､¬)</button>
+      <span class="flag-label">Unimpressed</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(눈_눈)" aria-label="Copy (눈_눈)">(눈_눈)</button>
+      <span class="flag-label">Done With It</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ヽ(ﾟДﾟ)ﾉ" aria-label="Copy ヽ(ﾟДﾟ)ﾉ">ヽ(ﾟДﾟ)ﾉ</button>
+      <span class="flag-label">Freaking Out</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SLEEPY & TIRED -->
+<section class="mood-explainers" id="sleepy-tired">
+  <span class="article-section-label">Sleepy &amp; Tired</span>
+  <h2>Sleepy &amp; Tired Kaomoji</h2>
+  <p class="u-secondary-tight">Drowsy, exhausted, and dozing text faces for low-energy moods.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(￣o￣) zzZ" aria-label="Copy (￣o￣) zzZ">(￣o￣) zzZ</button>
+      <span class="flag-label">Sleeping</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(－_－) zzz" aria-label="Copy (－_－) zzz">(－_－) zzz</button>
+      <span class="flag-label">Dozing Off</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(ᵕ̣̣̣̣̣̣﹏ᵕ̣̣̣̣̣̣)" aria-label="Copy (ᵕ̣̣̣̣̣̣﹏ᵕ̣̣̣̣̣̣)">(ᵕ̣̣̣̣̣̣﹏ᵕ̣̣̣̣̣̣)</button>
+      <span class="flag-label">Worn Out</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(´〜｀*) zzz" aria-label="Copy (´〜｀*) zzz">(´〜｀*) zzz</button>
+      <span class="flag-label">Cozy Nap</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="( -.-)旦" aria-label="Copy ( -.-)旦">( -.-)旦</button>
+      <span class="flag-label">Tired Tea</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(¦3[▓▓]" aria-label="Copy (¦3[▓▓]">(¦3[▓▓]</button>
+      <span class="flag-label">Tucked In</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- GREETING & WAVING -->
+<section class="mood-explainers" id="greeting-waving">
+  <span class="article-section-label">Greeting &amp; Waving</span>
+  <h2>Greeting &amp; Waving Kaomoji</h2>
+  <p class="u-secondary-tight">Hello, goodbye, and waving text faces for openers and sign-offs.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(/^▽^)/" aria-label="Copy (/^▽^)/">(/^▽^)/</button>
+      <span class="flag-label">Cheerful Wave</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="( ´ ▽ ` )ﾉ" aria-label="Copy ( ´ ▽ ` )ﾉ">( ´ ▽ ` )ﾉ</button>
+      <span class="flag-label">Friendly Hi</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ヾ(＾∇＾)" aria-label="Copy ヾ(＾∇＾)">ヾ(＾∇＾)</button>
+      <span class="flag-label">Waving Hello</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(｡･ω･)ﾉﾞ" aria-label="Copy (｡･ω･)ﾉﾞ">(｡･ω･)ﾉﾞ</button>
+      <span class="flag-label">Shy Wave</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(ﾉ´ヮ`)ﾉ*: ･ﾟ" aria-label="Copy (ﾉ´ヮ`)ﾉ*: ･ﾟ">(ﾉ´ヮ`)ﾉ*: ･ﾟ</button>
+      <span class="flag-label">Sparkle Greeting</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ε(´｡•᎑•`)っ" aria-label="Copy ε(´｡•᎑•`)っ">ε(´｡•᎑•`)っ</button>
+      <span class="flag-label">Reaching Out</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- HOW TO USE -->
+<section class="editorial-section" id="how-to-use">
+  <span class="article-section-label">How to use</span>
+  <h2>How to copy and paste kaomoji</h2>
+  <div class="editorial-block">
+    <p>Using kaomoji from this page takes one tap. Click (or tap) any face and it copies straight to your clipboard — a small confirmation appears so you know it worked. From there you can paste it anywhere text is allowed:</p>
+    <ul>
+      <li><strong>Social bios &amp; captions:</strong> drop a kaomoji into your Instagram, TikTok, or X bio to add personality. <code>(◕‿◕)</code> or <code>ʕ•ᴥ•ʔ</code> read well at small sizes.</li>
+      <li><strong>Chat &amp; comments:</strong> react in Discord, WhatsApp, or YouTube comments with <code>¯\_(ツ)_/¯</code> for a shrug or <code>(╯°□°）╯︵ ┻━┻</code> for mock rage.</li>
+      <li><strong>Usernames &amp; display names:</strong> short faces like <code>(¬‿¬)</code> work in most username fields, though some platforms strip non-Latin characters — test before saving.</li>
+    </ul>
+    <p>Because kaomoji are plain Unicode text, they don't rely on an emoji font, so they look almost identical across iPhone, Android, Windows, and Mac. A few of the more elaborate faces use rare combining marks that can render slightly differently on older devices; if a face looks off, pick a simpler one from the same category.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- FAQ -->
+<section class="editorial-section" id="faq">
+  <span class="article-section-label">FAQ</span>
+  <h2>Kaomoji frequently asked questions</h2>
+  <div class="editorial-block">
+    <h3>What is the difference between kaomoji and emoji?</h3>
+    <p>Emoji are single picture characters rendered by a font (🙂), while kaomoji are faces built from several text characters read upright, like <code>(◠‿◠)</code>. Kaomoji are more flexible and expressive, and because they're plain text they paste reliably even where emoji support is limited.</p>
+    <h3>How do you type the shrug kaomoji?</h3>
+    <p>The shrug — <code>¯\_(ツ)_/¯</code> — is awkward to type by hand because of the backslash and the Japanese katakana "tsu" (ツ). The easiest way is to click it in the <a href="#shrug-confusion">Shrug &amp; Confusion</a> section above to copy it instantly.</p>
+    <h3>Will kaomoji work on Instagram, TikTok, and Discord?</h3>
+    <p>Yes. Kaomoji are standard Unicode, so they work in posts, comments, captions, and most bios across Instagram, TikTok, Discord, X, WhatsApp, and YouTube. Some username fields restrict non-Latin characters, so simpler faces are safer there.</p>
+    <h3>Are these text faces free to use?</h3>
+    <p>Completely free. Copy any kaomoji on this page and use it wherever you like — there's no sign-up, no limit, and nothing to install.</p>
   </div>
 </section>
 

--- a/style.css
+++ b/style.css
@@ -2633,3 +2633,43 @@ body.dark-mode .vertical-chip {
     padding: 1.25rem 1.25rem;
   }
 }
+
+/* ── Library static index (crawlable A–Z collection links) ───────── */
+.lib-index {
+  max-width: 1100px;
+  margin: 3rem auto 0;
+  padding: 0 1.25rem;
+}
+.lib-index-inner {
+  border-top: 1px solid var(--border-light);
+  padding-top: 2rem;
+}
+.lib-index-title {
+  font-size: 1.25rem;
+  margin: 0 0 0.35rem;
+  color: var(--text-primary);
+}
+.lib-index-note {
+  margin: 0 0 1.25rem;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+}
+.lib-index-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 0.35rem 1.5rem;
+}
+.lib-index-list a {
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-size: 0.92rem;
+  line-height: 1.7;
+  border-bottom: 1px solid transparent;
+}
+.lib-index-list a:hover {
+  color: var(--accent-purple);
+  border-bottom-color: var(--accent-purple);
+}


### PR DESCRIPTION
On-page SEO improvements for under-performing library pages:

- library/index.html: add a static, crawlable "All Collections A–Z" link list (77 pages). Previously all child links were JS-generated, leaving the hub with no static internal links for crawlers.
- index.html: add a "Popular symbol & emoji libraries" card section linking to high-volume pages (kaomoji, math, aesthetic, special characters) plus the library hub — the homepage had no static path into /library/.
- _redirects: 301 the removed /library/linkedin-post-formatting-symbols/ slug to /library/linkedin-symbol-library/ (was a 404).
- text-faces-kaomoji: expand from ~510 to ~1,160 words — richer intro, 5 new kaomoji categories, a how-to-use section, and an FAQ.
- special-characters: expand from ~630 to ~1,130 words — richer intro, how-to-use, and FAQ sections.
- Refresh dateModified on the two expanded pages.
- style.css: styles for the new .lib-index static link list.