### PR TITLE
Add collection-copy suitability audit for all 79 library pages

### DIFF
--- a/data/build_collection_copy_audit.py
+++ b/data/build_collection_copy_audit.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Build / refresh the collection-copy suitability ledger for every library page.
+
+Idempotent: if data/collection_copy_audit.csv exists, rows are updated in place
+(refreshing checked_date + fields) and new library pages are appended. The CSV
+always contains exactly one row per current library/*/index.html page, sorted by
+slug. Run from the repo root: python3 data/build_collection_copy_audit.py
+"""
+import csv
+import datetime
+import glob
+import os
+import re
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CSV_PATH = os.path.join(REPO, "data", "collection_copy_audit.csv")
+TODAY = datetime.date.today().isoformat()
+
+FIELDS = [
+    "slug", "page_path", "symbol_category", "has_collection_now",
+    "collection_opportunity", "verdict", "rationale", "checked_date",
+]
+
+# Audit verdicts. Tuple: (symbol_category, collection_opportunity, verdict, rationale)
+# has_collection_now is detected from the page source (buildGrids / copy-collection-btn).
+AUDIT = {
+    "accent-marks-diacritics": ("Combining diacritics", "no", "N/A",
+        "Combining marks attach to individual letters; users copy one mark at a time, not a set."),
+    "achievement-symbols": ("Achievement emojis", "no", "N/A",
+        "Trophies, medals and award emojis are copied individually for a specific accolade, not pasted as a group."),
+    "aesthetic-borders-frames": ("Decorative borders/frames", "yes", "ADD",
+        "Entire page is multi-symbol borders, frames and dividers (Floral/Star/Heart Borders, Corner Frames, Minimalist Dividers) meant to be pasted as a unit."),
+    "aesthetic-symbols": ("Aesthetic decoration", "yes", "ADD",
+        "Aesthetic bio strings and divider/border sets (Sparkle/Heart/Nature aesthetic sets, Arrow & Divider sets) are typically pasted whole."),
+    "animal-emojis": ("Animal emojis", "no", "N/A",
+        "Users pick one animal emoji for context; there is no natural set pasted together."),
+    "arrow-symbols": ("Directional arrows", "no", "N/A",
+        "Arrows are functional single glyphs chosen for direction, not strung together as a collection."),
+    "awareness-ribbons": ("Awareness ribbons", "no", "N/A",
+        "A single cause ribbon is copied for a specific cause, not a set."),
+    "body-language-emojis": ("Gesture/body emojis", "no", "N/A",
+        "Expressive body and gesture emojis are used singly in context."),
+    "bow-ribbon-symbols": ("Coquette bows/ribbons", "yes", "ADD",
+        "Coquette/preppy bio decoration; bow+heart combos and ribbon strings are pasted together (page has a Bow & Heart Combos section)."),
+    "box-drawing-symbols": ("Box-drawing / blocks", "yes", "ADD",
+        "Box-drawing runs (lines, corners, junctions, shading) are assembled into multi-character borders and boxes - a textbook collection use."),
+    "bracket-symbols": ("Brackets/braces", "no", "N/A",
+        "A bracket pair is copied individually to wrap text, not as a symbol set."),
+    "braille-pattern-symbols": ("Braille patterns", "no", "N/A",
+        "Braille glyphs are looked up and copied individually (blank or solid fill), not as a curated set."),
+    "bullet-point-symbols": ("Bullet markers", "no", "N/A",
+        "Users copy one bullet to mark list items; the set is not pasted together."),
+    "card-suit-symbols": ("Card suits", "no", "N/A",
+        "Card suits are copied individually; the four-suit set is small and rarely pasted as a unit."),
+    "checkmark-symbols": ("Checkmarks/status", "no", "N/A",
+        "Checkmarks and crosses are status glyphs chosen one at a time (explicit single-glyph case)."),
+    "chess-symbols": ("Chess pieces", "yes", "KEEP",
+        "Has a Chess Piece Sets grouping; full white/black piece sets form a coherent unit, though intent is borderline single-glyph."),
+    "copyright-trademark-symbols": ("Legal marks", "no", "N/A",
+        "Copyright/registered/trademark marks are inserted individually next to a name; no set use."),
+    "coquette-symbols": ("Coquette aesthetic", "yes", "ADD",
+        "Soft feminine bio decoration; bows, hearts and dust strings are pasted together as aesthetic units."),
+    "cottagecore-symbols": ("Cottagecore aesthetic", "yes", "ADD",
+        "Cottagecore bio decoration including a Soft Cottagecore Borders set pasted as a unit."),
+    "cross-x-symbols": ("Crosses / X marks", "no", "N/A",
+        "Crosses and X marks are copied individually for a specific glyph."),
+    "crown-royalty-symbols": ("Crowns/royalty", "no", "N/A",
+        "A single crown or tiara is copied for a username; it is not pasted as a set."),
+    "currency-symbols": ("Currency signs", "no", "N/A",
+        "Currency signs are copied one at a time for a price (explicit single-glyph case)."),
+    "dash-hyphen-symbols": ("Dashes/hyphens", "no", "N/A",
+        "A specific dash or hyphen is copied for typography, not as a collection."),
+    "degree-symbol": ("Degree/angle signs", "no", "N/A",
+        "The degree sign and related marks are single-glyph inserts (explicit single-glyph case)."),
+    "dice-domino-symbols": ("Dice/dominoes", "no", "N/A",
+        "A single die or domino face is copied; the full face run is a minor sequence, not a typical paste unit."),
+    "discord-symbols": ("Discord decoration", "yes", "ADD",
+        "Explicit Symbol Combo Templates and Dividers sections are built to be pasted whole into Discord bios and channels."),
+    "egyptian-hieroglyphs": ("Hieroglyphs", "no", "N/A",
+        "A reference of 1,072 glyphs browsed to copy one specific hieroglyph."),
+    "email-symbols": ("Email utility symbols", "no", "N/A",
+        "Subject grabbers, bullets and status icons are inserted individually; dividers are single-character."),
+    "emoji-flags": ("Country flags", "yes", "KEEP",
+        "Regional flag grids are pasted as sets - already implemented and a genuine fit."),
+    "emoji-meanings-guide": ("Editorial guide", "no", "N/A",
+        "Editorial guide explaining emoji meanings, not a copy-grid page."),
+    "face-emojis": ("Face emojis", "no", "N/A",
+        "One expressive face emoji is chosen per context."),
+    "flower-symbols": ("Flowers/nature", "yes", "ADD",
+        "Has a Floral Dividers & Aesthetic Bio Sets section; floral strings are pasted whole as decoration."),
+    "food-drink-emojis": ("Food/drink emojis", "no", "N/A",
+        "Food and drink emojis are picked individually."),
+    "fraction-symbols": ("Fractions", "no", "N/A",
+        "A specific fraction glyph is copied; there is no set use."),
+    "gender-symbols": ("Gender signs", "no", "N/A",
+        "A single gender or orientation sign is copied for identity."),
+    "geometric-symbols": ("Geometric shapes", "no", "N/A",
+        "Geometric shapes are functional single glyphs used for formatting."),
+    "goth-grunge-symbols": ("Goth/grunge aesthetic", "yes", "ADD",
+        "Dark-aesthetic bio decoration; crosses, daggers and dark florals are strung together as units."),
+    "greek-letter-symbols": ("Greek letters", "no", "N/A",
+        "Primary intent is one Greek letter (alpha, pi); full-alphabet copy is already covered as a math sequence."),
+    "hand-symbols": ("Hand emojis", "no", "N/A",
+        "Hand gestures are copied singly."),
+    "hazard-warning-symbols": ("Hazard/warning signs", "no", "N/A",
+        "A specific warning sign is copied for labeling."),
+    "heart-symbols": ("Hearts", "yes", "ADD",
+        "Colored-heart sets and decorative heart strings are commonly pasted whole into bios (weaker fit than dedicated decoration pages)."),
+    "instagram-symbols": ("Instagram decoration", "yes", "ADD",
+        "Explicit Instagram Symbol Combos are built to paste as bio and caption units."),
+    "kawaii-cute-symbols": ("Kawaii aesthetic", "yes", "ADD",
+        "Cute decorative marks and pastel motifs are pasted together as aesthetic strings."),
+    "keyboard-symbols": ("Keyboard glyphs", "no", "N/A",
+        "Modifier and key glyphs are inserted individually into shortcuts."),
+    "laundry-care-symbols": ("Care symbols", "no", "N/A",
+        "Care symbols are referenced and copied one at a time."),
+    "line-divider-symbols": ("Line dividers", "yes", "ADD",
+        "Built around Decorative Divider Combos and Ornamental Separator Combos - multi-symbol dividers pasted as a unit."),
+    "linkedin-comment-styling": ("Editorial guide", "no", "N/A",
+        "Editorial how-to guide, not a copy-grid page."),
+    "linkedin-symbol-library": ("LinkedIn utility", "no", "N/A",
+        "Professional arrows, bullets and numbers are copied individually with no formatting loss."),
+    "math-symbols": ("Math operators", "no", "REMOVE",
+        "Math operators, comparison and set symbols are looked up one at a time (explicit single-glyph case); collection copy is a poor fit despite current use."),
+    "media-control-symbols": ("Media controls", "no", "N/A",
+        "Play/pause/stop glyphs are inserted individually."),
+    "medical-symbols": ("Medical signs", "no", "N/A",
+        "A specific medical sign (Rx, caduceus) is copied alone."),
+    "moon-celestial-symbols": ("Moon/celestial", "yes", "KEEP",
+        "Moon-phase sequences and night-sky sets are pasted as decorative units - already implemented and a genuine fit."),
+    "music-symbols": ("Music notes", "yes", "ADD",
+        "Has a Music Note Bio Decorations section; note strings are pasted as decoration (weaker fit; page is mostly single-note lookup)."),
+    "norse-viking-runes": ("Runes", "yes", "KEEP",
+        "Full futhark alphabets are copied as runic sets - already implemented and a genuine fit."),
+    "number-symbols": ("Numerals", "no", "REMOVE",
+        "Circled, superscript and Roman numerals are chosen individually (explicit individual-numerals case); collection copy is a poor fit despite current use."),
+    "peace-symbol": ("Peace symbols", "no", "N/A",
+        "A single peace sign or dove is copied."),
+    "people-profession-emojis": ("Profession emojis", "no", "N/A",
+        "One profession emoji is picked per context."),
+    "punctuation-symbols": ("Punctuation marks", "no", "N/A",
+        "Special punctuation marks are inserted individually."),
+    "recycle-environment-symbols": ("Recycling/eco signs", "no", "N/A",
+        "A specific recycling or eco sign is copied alone."),
+    "religious-symbols": ("Faith symbols", "no", "N/A",
+        "A single faith symbol is copied per tradition."),
+    "roblox-symbols": ("Roblox decoration", "yes", "ADD",
+        "Cute/Y2K decoration strings for Roblox display names are pasted as units within the content filter (weaker, platform-driven fit)."),
+    "slash-backslash-symbols": ("Slashes", "no", "N/A",
+        "A specific slash or backslash glyph is copied alone."),
+    "smiley-face-guide": ("Editorial guide", "no", "N/A",
+        "Editorial guide on smiley meanings, not a copy-grid page."),
+    "sparkle-symbols": ("Sparkles", "yes", "ADD",
+        "Sparkle/glitter strings, aesthetic decorators and divider/border characters are pasted whole (explicit sparkle-string case)."),
+    "special-characters": ("Standalone specials", "no", "N/A",
+        "Meaningful standalone symbols are copied individually by definition."),
+    "sports-emojis": ("Sports emojis", "no", "N/A",
+        "One sport or activity emoji is picked per post."),
+    "star-symbols": ("Stars", "yes", "ADD",
+        "Has Aesthetic Star Bio Decorations; star strings are pasted whole as decoration."),
+    "tech-status-symbols": ("Status glyphs", "no", "N/A",
+        "Wi-Fi, battery and power glyphs are inserted individually."),
+    "text-faces-kaomoji": ("Kaomoji", "yes", "ADD",
+        "Themed kaomoji combos can be offered as sets, though each kaomoji is already a self-contained unit (task-listed case; weaker fit)."),
+    "tiktok-symbols": ("TikTok decoration", "yes", "ADD",
+        "Has TikTok Bio Separators & Dividers built to paste as multi-symbol units."),
+    "traffic-road-sign-symbols": ("Traffic/road signs", "no", "N/A",
+        "A specific traffic or road sign is copied; the stoplight trio is a minor sequence."),
+    "transport-symbols": ("Transport emojis", "no", "N/A",
+        "One vehicle or transport emoji is picked per context."),
+    "unit-measurement-symbols": ("Units/measures", "no", "N/A",
+        "Scientific unit symbols are inserted individually."),
+    "weather-symbols": ("Weather", "no", "N/A",
+        "A single weather glyph is copied per condition."),
+    "witchy-occult-symbols": ("Occult aesthetic", "yes", "ADD",
+        "Witchy bio decoration; pentagram, moon and planetary strings are pasted as aesthetic units, though it doubles as an alchemical reference (weaker fit)."),
+    "x-twitter-symbols": ("X/Twitter formatting", "no", "N/A",
+        "Thread-formatting, quote markers and verification glyphs are functional single inserts."),
+    "y2k-symbols": ("Y2K aesthetic", "yes", "ADD",
+        "Explicit Y2K Combo Templates; cyber, star and butterfly strings are pasted as decorative units."),
+    "yin-yang-symbol": ("Yin yang", "no", "N/A",
+        "The yin-yang glyph and related balance characters are copied individually."),
+    "zodiac-symbols": ("Zodiac/astrology", "yes", "KEEP",
+        "Has a Zodiac & Astrology Sets grouping; the 12-sign set and astrology strings are pasted as units - already implemented."),
+}
+
+
+def detect_has_collection(page_path):
+    try:
+        html = open(os.path.join(REPO, page_path), encoding="utf-8").read()
+    except OSError:
+        return "no"
+    return "yes" if re.search(r"buildGrids|copy-collection-btn", html) else "no"
+
+
+def main():
+    pages = sorted(glob.glob(os.path.join(REPO, "library", "*", "index.html")))
+    slugs = [os.path.basename(os.path.dirname(p)) for p in pages]
+
+    missing = [s for s in slugs if s not in AUDIT]
+    if missing:
+        sys.exit("ERROR: no audit entry for: " + ", ".join(missing))
+
+    # Load existing ledger (idempotent merge).
+    existing = {}
+    if os.path.exists(CSV_PATH):
+        with open(CSV_PATH, newline="", encoding="utf-8") as f:
+            for row in csv.DictReader(f):
+                existing[row["slug"]] = row
+
+    rows = []
+    for slug in slugs:
+        page_path = "library/%s/index.html" % slug
+        category, opportunity, verdict, rationale = AUDIT[slug]
+        row = existing.get(slug, {})
+        row.update({
+            "slug": slug,
+            "page_path": page_path,
+            "symbol_category": category,
+            "has_collection_now": detect_has_collection(page_path),
+            "collection_opportunity": opportunity,
+            "verdict": verdict,
+            "rationale": rationale,
+            "checked_date": TODAY,
+        })
+        rows.append(row)
+
+    rows.sort(key=lambda r: r["slug"])
+    with open(CSV_PATH, "w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=FIELDS, quoting=csv.QUOTE_MINIMAL)
+        w.writeheader()
+        w.writerows(rows)
+
+    print("Wrote %d rows to %s (pages found: %d)" % (len(rows), CSV_PATH, len(pages)))
+    assert len(rows) == len(pages), "row count != page count"
+
+
+if __name__ == "__main__":
+    main()

--- a/data/collection_copy_audit.csv
+++ b/data/collection_copy_audit.csv
@@ -1,0 +1,80 @@
+slug,page_path,symbol_category,has_collection_now,collection_opportunity,verdict,rationale,checked_date
+accent-marks-diacritics,library/accent-marks-diacritics/index.html,Combining diacritics,no,no,N/A,"Combining marks attach to individual letters; users copy one mark at a time, not a set.",2026-06-09
+achievement-symbols,library/achievement-symbols/index.html,Achievement emojis,no,no,N/A,"Trophies, medals and award emojis are copied individually for a specific accolade, not pasted as a group.",2026-06-09
+aesthetic-borders-frames,library/aesthetic-borders-frames/index.html,Decorative borders/frames,no,yes,ADD,"Entire page is multi-symbol borders, frames and dividers (Floral/Star/Heart Borders, Corner Frames, Minimalist Dividers) meant to be pasted as a unit.",2026-06-09
+aesthetic-symbols,library/aesthetic-symbols/index.html,Aesthetic decoration,no,yes,ADD,"Aesthetic bio strings and divider/border sets (Sparkle/Heart/Nature aesthetic sets, Arrow & Divider sets) are typically pasted whole.",2026-06-09
+animal-emojis,library/animal-emojis/index.html,Animal emojis,no,no,N/A,Users pick one animal emoji for context; there is no natural set pasted together.,2026-06-09
+arrow-symbols,library/arrow-symbols/index.html,Directional arrows,no,no,N/A,"Arrows are functional single glyphs chosen for direction, not strung together as a collection.",2026-06-09
+awareness-ribbons,library/awareness-ribbons/index.html,Awareness ribbons,no,no,N/A,"A single cause ribbon is copied for a specific cause, not a set.",2026-06-09
+body-language-emojis,library/body-language-emojis/index.html,Gesture/body emojis,no,no,N/A,Expressive body and gesture emojis are used singly in context.,2026-06-09
+bow-ribbon-symbols,library/bow-ribbon-symbols/index.html,Coquette bows/ribbons,no,yes,ADD,Coquette/preppy bio decoration; bow+heart combos and ribbon strings are pasted together (page has a Bow & Heart Combos section).,2026-06-09
+box-drawing-symbols,library/box-drawing-symbols/index.html,Box-drawing / blocks,no,yes,ADD,"Box-drawing runs (lines, corners, junctions, shading) are assembled into multi-character borders and boxes - a textbook collection use.",2026-06-09
+bracket-symbols,library/bracket-symbols/index.html,Brackets/braces,no,no,N/A,"A bracket pair is copied individually to wrap text, not as a symbol set.",2026-06-09
+braille-pattern-symbols,library/braille-pattern-symbols/index.html,Braille patterns,no,no,N/A,"Braille glyphs are looked up and copied individually (blank or solid fill), not as a curated set.",2026-06-09
+bullet-point-symbols,library/bullet-point-symbols/index.html,Bullet markers,no,no,N/A,Users copy one bullet to mark list items; the set is not pasted together.,2026-06-09
+card-suit-symbols,library/card-suit-symbols/index.html,Card suits,no,no,N/A,Card suits are copied individually; the four-suit set is small and rarely pasted as a unit.,2026-06-09
+checkmark-symbols,library/checkmark-symbols/index.html,Checkmarks/status,no,no,N/A,Checkmarks and crosses are status glyphs chosen one at a time (explicit single-glyph case).,2026-06-09
+chess-symbols,library/chess-symbols/index.html,Chess pieces,yes,yes,KEEP,"Has a Chess Piece Sets grouping; full white/black piece sets form a coherent unit, though intent is borderline single-glyph.",2026-06-09
+copyright-trademark-symbols,library/copyright-trademark-symbols/index.html,Legal marks,no,no,N/A,Copyright/registered/trademark marks are inserted individually next to a name; no set use.,2026-06-09
+coquette-symbols,library/coquette-symbols/index.html,Coquette aesthetic,no,yes,ADD,"Soft feminine bio decoration; bows, hearts and dust strings are pasted together as aesthetic units.",2026-06-09
+cottagecore-symbols,library/cottagecore-symbols/index.html,Cottagecore aesthetic,no,yes,ADD,Cottagecore bio decoration including a Soft Cottagecore Borders set pasted as a unit.,2026-06-09
+cross-x-symbols,library/cross-x-symbols/index.html,Crosses / X marks,no,no,N/A,Crosses and X marks are copied individually for a specific glyph.,2026-06-09
+crown-royalty-symbols,library/crown-royalty-symbols/index.html,Crowns/royalty,no,no,N/A,A single crown or tiara is copied for a username; it is not pasted as a set.,2026-06-09
+currency-symbols,library/currency-symbols/index.html,Currency signs,no,no,N/A,Currency signs are copied one at a time for a price (explicit single-glyph case).,2026-06-09
+dash-hyphen-symbols,library/dash-hyphen-symbols/index.html,Dashes/hyphens,no,no,N/A,"A specific dash or hyphen is copied for typography, not as a collection.",2026-06-09
+degree-symbol,library/degree-symbol/index.html,Degree/angle signs,no,no,N/A,The degree sign and related marks are single-glyph inserts (explicit single-glyph case).,2026-06-09
+dice-domino-symbols,library/dice-domino-symbols/index.html,Dice/dominoes,no,no,N/A,"A single die or domino face is copied; the full face run is a minor sequence, not a typical paste unit.",2026-06-09
+discord-symbols,library/discord-symbols/index.html,Discord decoration,no,yes,ADD,Explicit Symbol Combo Templates and Dividers sections are built to be pasted whole into Discord bios and channels.,2026-06-09
+egyptian-hieroglyphs,library/egyptian-hieroglyphs/index.html,Hieroglyphs,no,no,N/A,"A reference of 1,072 glyphs browsed to copy one specific hieroglyph.",2026-06-09
+email-symbols,library/email-symbols/index.html,Email utility symbols,no,no,N/A,"Subject grabbers, bullets and status icons are inserted individually; dividers are single-character.",2026-06-09
+emoji-flags,library/emoji-flags/index.html,Country flags,yes,yes,KEEP,Regional flag grids are pasted as sets - already implemented and a genuine fit.,2026-06-09
+emoji-meanings-guide,library/emoji-meanings-guide/index.html,Editorial guide,no,no,N/A,"Editorial guide explaining emoji meanings, not a copy-grid page.",2026-06-09
+face-emojis,library/face-emojis/index.html,Face emojis,no,no,N/A,One expressive face emoji is chosen per context.,2026-06-09
+flower-symbols,library/flower-symbols/index.html,Flowers/nature,no,yes,ADD,Has a Floral Dividers & Aesthetic Bio Sets section; floral strings are pasted whole as decoration.,2026-06-09
+food-drink-emojis,library/food-drink-emojis/index.html,Food/drink emojis,no,no,N/A,Food and drink emojis are picked individually.,2026-06-09
+fraction-symbols,library/fraction-symbols/index.html,Fractions,no,no,N/A,A specific fraction glyph is copied; there is no set use.,2026-06-09
+gender-symbols,library/gender-symbols/index.html,Gender signs,no,no,N/A,A single gender or orientation sign is copied for identity.,2026-06-09
+geometric-symbols,library/geometric-symbols/index.html,Geometric shapes,no,no,N/A,Geometric shapes are functional single glyphs used for formatting.,2026-06-09
+goth-grunge-symbols,library/goth-grunge-symbols/index.html,Goth/grunge aesthetic,no,yes,ADD,"Dark-aesthetic bio decoration; crosses, daggers and dark florals are strung together as units.",2026-06-09
+greek-letter-symbols,library/greek-letter-symbols/index.html,Greek letters,no,no,N/A,"Primary intent is one Greek letter (alpha, pi); full-alphabet copy is already covered as a math sequence.",2026-06-09
+hand-symbols,library/hand-symbols/index.html,Hand emojis,no,no,N/A,Hand gestures are copied singly.,2026-06-09
+hazard-warning-symbols,library/hazard-warning-symbols/index.html,Hazard/warning signs,no,no,N/A,A specific warning sign is copied for labeling.,2026-06-09
+heart-symbols,library/heart-symbols/index.html,Hearts,no,yes,ADD,Colored-heart sets and decorative heart strings are commonly pasted whole into bios (weaker fit than dedicated decoration pages).,2026-06-09
+instagram-symbols,library/instagram-symbols/index.html,Instagram decoration,no,yes,ADD,Explicit Instagram Symbol Combos are built to paste as bio and caption units.,2026-06-09
+kawaii-cute-symbols,library/kawaii-cute-symbols/index.html,Kawaii aesthetic,no,yes,ADD,Cute decorative marks and pastel motifs are pasted together as aesthetic strings.,2026-06-09
+keyboard-symbols,library/keyboard-symbols/index.html,Keyboard glyphs,no,no,N/A,Modifier and key glyphs are inserted individually into shortcuts.,2026-06-09
+laundry-care-symbols,library/laundry-care-symbols/index.html,Care symbols,no,no,N/A,Care symbols are referenced and copied one at a time.,2026-06-09
+line-divider-symbols,library/line-divider-symbols/index.html,Line dividers,no,yes,ADD,Built around Decorative Divider Combos and Ornamental Separator Combos - multi-symbol dividers pasted as a unit.,2026-06-09
+linkedin-comment-styling,library/linkedin-comment-styling/index.html,Editorial guide,no,no,N/A,"Editorial how-to guide, not a copy-grid page.",2026-06-09
+linkedin-symbol-library,library/linkedin-symbol-library/index.html,LinkedIn utility,no,no,N/A,"Professional arrows, bullets and numbers are copied individually with no formatting loss.",2026-06-09
+math-symbols,library/math-symbols/index.html,Math operators,yes,no,REMOVE,"Math operators, comparison and set symbols are looked up one at a time (explicit single-glyph case); collection copy is a poor fit despite current use.",2026-06-09
+media-control-symbols,library/media-control-symbols/index.html,Media controls,no,no,N/A,Play/pause/stop glyphs are inserted individually.,2026-06-09
+medical-symbols,library/medical-symbols/index.html,Medical signs,no,no,N/A,"A specific medical sign (Rx, caduceus) is copied alone.",2026-06-09
+moon-celestial-symbols,library/moon-celestial-symbols/index.html,Moon/celestial,yes,yes,KEEP,Moon-phase sequences and night-sky sets are pasted as decorative units - already implemented and a genuine fit.,2026-06-09
+music-symbols,library/music-symbols/index.html,Music notes,no,yes,ADD,Has a Music Note Bio Decorations section; note strings are pasted as decoration (weaker fit; page is mostly single-note lookup).,2026-06-09
+norse-viking-runes,library/norse-viking-runes/index.html,Runes,yes,yes,KEEP,Full futhark alphabets are copied as runic sets - already implemented and a genuine fit.,2026-06-09
+number-symbols,library/number-symbols/index.html,Numerals,yes,no,REMOVE,"Circled, superscript and Roman numerals are chosen individually (explicit individual-numerals case); collection copy is a poor fit despite current use.",2026-06-09
+peace-symbol,library/peace-symbol/index.html,Peace symbols,no,no,N/A,A single peace sign or dove is copied.,2026-06-09
+people-profession-emojis,library/people-profession-emojis/index.html,Profession emojis,no,no,N/A,One profession emoji is picked per context.,2026-06-09
+punctuation-symbols,library/punctuation-symbols/index.html,Punctuation marks,no,no,N/A,Special punctuation marks are inserted individually.,2026-06-09
+recycle-environment-symbols,library/recycle-environment-symbols/index.html,Recycling/eco signs,no,no,N/A,A specific recycling or eco sign is copied alone.,2026-06-09
+religious-symbols,library/religious-symbols/index.html,Faith symbols,no,no,N/A,A single faith symbol is copied per tradition.,2026-06-09
+roblox-symbols,library/roblox-symbols/index.html,Roblox decoration,no,yes,ADD,"Cute/Y2K decoration strings for Roblox display names are pasted as units within the content filter (weaker, platform-driven fit).",2026-06-09
+slash-backslash-symbols,library/slash-backslash-symbols/index.html,Slashes,no,no,N/A,A specific slash or backslash glyph is copied alone.,2026-06-09
+smiley-face-guide,library/smiley-face-guide/index.html,Editorial guide,no,no,N/A,"Editorial guide on smiley meanings, not a copy-grid page.",2026-06-09
+sparkle-symbols,library/sparkle-symbols/index.html,Sparkles,no,yes,ADD,"Sparkle/glitter strings, aesthetic decorators and divider/border characters are pasted whole (explicit sparkle-string case).",2026-06-09
+special-characters,library/special-characters/index.html,Standalone specials,no,no,N/A,Meaningful standalone symbols are copied individually by definition.,2026-06-09
+sports-emojis,library/sports-emojis/index.html,Sports emojis,no,no,N/A,One sport or activity emoji is picked per post.,2026-06-09
+star-symbols,library/star-symbols/index.html,Stars,no,yes,ADD,Has Aesthetic Star Bio Decorations; star strings are pasted whole as decoration.,2026-06-09
+tech-status-symbols,library/tech-status-symbols/index.html,Status glyphs,no,no,N/A,"Wi-Fi, battery and power glyphs are inserted individually.",2026-06-09
+text-faces-kaomoji,library/text-faces-kaomoji/index.html,Kaomoji,no,yes,ADD,"Themed kaomoji combos can be offered as sets, though each kaomoji is already a self-contained unit (task-listed case; weaker fit).",2026-06-09
+tiktok-symbols,library/tiktok-symbols/index.html,TikTok decoration,no,yes,ADD,Has TikTok Bio Separators & Dividers built to paste as multi-symbol units.,2026-06-09
+traffic-road-sign-symbols,library/traffic-road-sign-symbols/index.html,Traffic/road signs,no,no,N/A,A specific traffic or road sign is copied; the stoplight trio is a minor sequence.,2026-06-09
+transport-symbols,library/transport-symbols/index.html,Transport emojis,no,no,N/A,One vehicle or transport emoji is picked per context.,2026-06-09
+unit-measurement-symbols,library/unit-measurement-symbols/index.html,Units/measures,no,no,N/A,Scientific unit symbols are inserted individually.,2026-06-09
+weather-symbols,library/weather-symbols/index.html,Weather,no,no,N/A,A single weather glyph is copied per condition.,2026-06-09
+witchy-occult-symbols,library/witchy-occult-symbols/index.html,Occult aesthetic,no,yes,ADD,"Witchy bio decoration; pentagram, moon and planetary strings are pasted as aesthetic units, though it doubles as an alchemical reference (weaker fit).",2026-06-09
+x-twitter-symbols,library/x-twitter-symbols/index.html,X/Twitter formatting,no,no,N/A,"Thread-formatting, quote markers and verification glyphs are functional single inserts.",2026-06-09
+y2k-symbols,library/y2k-symbols/index.html,Y2K aesthetic,no,yes,ADD,"Explicit Y2K Combo Templates; cyber, star and butterfly strings are pasted as decorative units.",2026-06-09
+yin-yang-symbol,library/yin-yang-symbol/index.html,Yin yang,no,no,N/A,The yin-yang glyph and related balance characters are copied individually.,2026-06-09
+zodiac-symbols,library/zodiac-symbols/index.html,Zodiac/astrology,yes,yes,KEEP,Has a Zodiac & Astrology Sets grouping; the 12-sign set and astrology strings are pasted as units - already implemented.,2026-06-09

--- a/data/collection_copy_audit_2026-06-09.md
+++ b/data/collection_copy_audit_2026-06-09.md
@@ -1,0 +1,95 @@
+# Collection-Copy Suitability Audit — 2026-06-09
+
+Audited **all 79 `library/*/index.html` pages** for "collection copy" suitability
+(the `UltraTextGen.buildGrids` / `.copy-collection-btn` "Copy Collection" block
+with Inline/Vertical/Comma/Space/Bullet format tabs).
+
+Ledger: [`data/collection_copy_audit.csv`](./collection_copy_audit.csv) — one row
+per page, idempotent, sorted by slug. This audit is **discovery only**; no pages
+or `symbol-explorer.js` were modified.
+
+> Note on scope: the task referenced "80 pages". The glob `library/*/index.html`
+> resolves to **79** symbol pages; the 80th `index.html` under `library/` is the
+> library hub (`library/index.html`), which is a navigation page, not a symbol
+> grid, so it is out of scope.
+
+## Verdict counts
+
+| Verdict | Count | Meaning |
+|---|---|---|
+| KEEP   | 5  | Has collection copy + opportunity is real |
+| ADD    | 21 | No collection copy now, but opportunity is real (candidate to add) |
+| REMOVE | 2  | Has collection copy now, but no real opportunity (candidate to remove) |
+| N/A    | 51 | No collection copy + no opportunity (correct as-is) |
+| **Total** | **79** | |
+
+The 7 pages that currently use `buildGrids` resolve to **5 KEEP + 2 REMOVE**.
+
+## KEEP (5) — has it, opportunity is real
+
+| Slug | Why it stays |
+|---|---|
+| emoji-flags | Regional flag grids pasted as sets. |
+| moon-celestial-symbols | Moon-phase sequences + night-sky sets pasted as decorative units. |
+| norse-viking-runes | Full futhark alphabets copied as runic sets. |
+| zodiac-symbols | 12-sign set + astrology strings pasted as units. |
+| chess-symbols | "Chess Piece Sets" form a coherent unit — **borderline** (intent leans single-glyph; flag for a second look). |
+
+## ADD shortlist (21) — collection copy should be added
+
+Tiered by strength of fit. The "Collection groups" column notes which existing
+sections would feed the `buildGrids` collections.
+
+### Strong fit (decorative borders / dividers / combos / aesthetic strings)
+
+| Slug | Rationale | Collection groups to build from |
+|---|---|---|
+| aesthetic-borders-frames | Whole page is multi-symbol borders/frames/dividers. | Floral Borders, Star Borders, Heart Borders, Soft & Corner Frames, Minimalist Dividers |
+| line-divider-symbols | Built around prebuilt divider/separator combos. | Decorative Divider Combos, Ornamental Separator Combos, Box-Drawing Border Characters |
+| box-drawing-symbols | Box-drawing runs assemble into multi-char borders/boxes. | Lines/Corners/Junctions, Double & Heavy Borders, Block Elements & Shading |
+| sparkle-symbols | Sparkle strings + divider/border characters pasted whole. | Aesthetic Decorator Symbols, Divider & Border Characters, Star & Point Symbols |
+| aesthetic-symbols | Aesthetic bio strings + divider/border sets. | Sparkle/Heart/Nature Aesthetic sets, Arrow & Divider, Bracket & Border |
+| discord-symbols | Explicit combo templates + dividers for Discord. | Symbol Combo Templates, Dividers, Stars & Sparkles, Frames & Brackets |
+| instagram-symbols | Explicit IG combos for bios/captions. | Instagram Symbol Combos, Bio-Ready Symbols, Story & Highlight Cover Symbols |
+| y2k-symbols | Explicit Y2K combo templates. | Y2K Combo Templates, Crosses & Stars, Decorative Dust & Sparkle |
+| tiktok-symbols | Bio separators/dividers pasted as units. | TikTok Bio Separators & Dividers, Trending Aesthetic Characters |
+| flower-symbols | Dedicated floral-divider/bio-set section. | Floral Dividers & Aesthetic Bio Sets, Unicode Floral Characters |
+| star-symbols | Dedicated aesthetic star decoration section. | Aesthetic Star Bio Decorations, Asterisks & Sparkle Symbols |
+
+### Medium fit (named-aesthetic bio decoration)
+
+| Slug | Rationale | Collection groups to build from |
+|---|---|---|
+| coquette-symbols | Bows/hearts/dust strings pasted as aesthetic units. | Bows & Ribbons, Soft Hearts, Dots & Dust, Flowers |
+| cottagecore-symbols | Includes a soft-borders set. | Soft Cottagecore Borders, Mushrooms & Plants, Moon & Sky Motifs |
+| kawaii-cute-symbols | Cute marks/pastel motifs pasted as strings. | Decorative Marks, Pastel Motifs, Cute Hearts |
+| goth-grunge-symbols | Dark-aesthetic decoration strung together. | Crosses & Daggers, Dark Florals, Skulls & Death Motifs |
+| bow-ribbon-symbols | Bow+heart combos already grouped. | Bow & Heart Combos, Bow Emojis & Symbols |
+| heart-symbols | Color sets + decorative heart strings for bios. | Colored Heart Emojis, Decorated Heart Emojis, Unicode Heart Characters |
+
+### Weaker / optional fit (single-glyph intent partly competes — confirm before adding)
+
+| Slug | Rationale | Collection groups to build from |
+|---|---|---|
+| witchy-occult-symbols | Occult/aesthetic strings, but also an alchemical reference. | Pentagrams, Moon Phase Symbols, Planetary & Astrological |
+| roblox-symbols | Platform-driven decoration strings for display names. | Cute Decorations, Y2K Style Symbols, Roblox-Friendly Symbols |
+| music-symbols | Has a note-decoration section; mostly single-note lookup. | Music Note Bio Decorations, Musical Notes |
+| text-faces-kaomoji | Task-listed kaomoji combos, but each kaomoji is already a unit. | Happy/Sad/Love/Animal Kaomoji groups |
+
+## REMOVE shortlist (2) — has it, but no real opportunity
+
+| Slug | Rationale |
+|---|---|
+| math-symbols | Math operators / comparison / set symbols are looked up one at a time — the task's explicit single-glyph case. The current "Greek Alphabet Sequences" collection is the only set-like use; the rest of the page does not warrant collection copy. |
+| number-symbols | Circled / superscript / Roman numerals are chosen individually — the task's explicit "individual numerals" case. "Number Sequences" is the lone set-like grouping; collection copy is otherwise a poor fit. |
+
+## Method notes
+- `has_collection_now` was detected by grepping each page for `buildGrids` /
+  `copy-collection-btn`; exactly 7 pages matched (chess, emoji-flags, math, moon-celestial,
+  norse-viking-runes, number, zodiac).
+- `collection_opportunity` is a judgement on whether users plausibly paste a SET
+  of the page's symbols together, grounded in each page's section headings
+  (e.g. "…Combos", "…Templates", "…Borders", "…Sets", "…Sequences").
+- Semrush was not required: page intent was unambiguous from titles, descriptions,
+  and section structure.
+- Re-running `data/build_collection_copy_audit.py` refreshes the ledger in place.


### PR DESCRIPTION
## Summary

This PR introduces a comprehensive audit of all 79 symbol library pages to assess their suitability for the "collection copy" feature (`buildGrids` / `.copy-collection-btn`). The audit is discovery-only and includes an idempotent Python script to generate and maintain an audit ledger.

## Changes

- **`data/build_collection_copy_audit.py`** (new): Idempotent Python script that:
  - Scans all `library/*/index.html` pages and detects current `buildGrids` usage via regex
  - Evaluates each page against a hardcoded audit dictionary with verdicts (KEEP, ADD, REMOVE, N/A)
  - Generates/updates `data/collection_copy_audit.csv` with one row per page, sorted by slug
  - Refreshes `checked_date` on each run while preserving existing rows
  - Validates that all discovered slugs have audit entries

- **`data/collection_copy_audit.csv`** (new): Ledger with 80 rows (79 symbol pages + header):
  - Columns: `slug`, `page_path`, `symbol_category`, `has_collection_now`, `collection_opportunity`, `verdict`, `rationale`, `checked_date`
  - Detects 7 pages currently using `buildGrids` (chess, emoji-flags, math, moon-celestial, norse-viking-runes, number, zodiac)
  - Verdict breakdown: 5 KEEP, 21 ADD, 2 REMOVE, 51 N/A

- **`data/collection_copy_audit_2026-06-09.md`** (new): Human-readable audit report with:
  - Executive summary and verdict counts
  - Detailed KEEP section (5 pages with real collection-copy opportunity)
  - ADD shortlist (21 candidates, tiered by fit strength: strong/medium/weaker)
  - REMOVE shortlist (2 pages where collection copy is a poor fit despite current use)
  - Method notes explaining detection and judgment criteria

## Implementation Details

- The audit dictionary in `build_collection_copy_audit.py` maps all 79 slug keys to tuples of `(symbol_category, collection_opportunity, verdict, rationale)`
- Detection of current `buildGrids` usage is regex-based (`buildGrids|copy-collection-btn`) to handle both the feature name and CSS class
- The script is idempotent: existing CSV rows are updated in place (preserving history if needed) and new pages are appended
- No pages or `symbol-explorer.js` were modified; this is discovery/audit only
- The audit is grounded in page structure (section headings like "…Combos", "…Templates", "…Sets") rather than external tools

## Notes

- The glob `library/*/index.html` resolves to 79 pages; the 80th `index.html` under `library/` is the hub navigation page, which is out of scope
- The script can be re-run to refresh the ledger (e.g., after adding new pages or modifying existing ones)

https://claude.ai/code/session_01WoHGmVzfiGEuVns1KUuPjW