### PR TITLE
feat: add high-intent Schema.org alternateName across SEO landing pages

### DIFF
--- a/category/aesthetic-fonts/index.html
+++ b/category/aesthetic-fonts/index.html
@@ -33,6 +33,7 @@
   "@context": "https://schema.org",
   "@type": "WebApplication",
   "name": "Aesthetic Font Generator",
+  "alternateName": ["Aesthetic Text Generator", "Aesthetic Font Maker", "Vaporwave Text Generator", "Aesthetic Letters", "Copy and Paste Aesthetic Fonts"],
   "url": "https://ultratextgen.com/category/aesthetic-fonts/",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Any",

--- a/category/bold-fonts/alternating/index.html
+++ b/category/bold-fonts/alternating/index.html
@@ -58,6 +58,25 @@
   ]
 }
      </script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Alternating Caps Generator",
+  "alternateName": ["Alternating Bold Text Generator", "Mixed Case Bold Generator", "Bold Alternating Font Maker", "Copy and Paste Alternating Caps", "Spongebob Text Generator"],
+  "url": "https://ultratextgen.com/category/bold-fonts/alternating/",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "description": "Generate alternating bold Unicode font styles for eye-catching social media posts and bios. Copy and paste instantly.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
 </head>
 <body>
   <!-- Google Tag Manager (noscript) -->

--- a/category/bold-fonts/bold-italic/index.html
+++ b/category/bold-fonts/bold-italic/index.html
@@ -104,6 +104,25 @@
   ]
 }
   </script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Bold Italic Text Generator",
+  "alternateName": ["Bold Italic Font Generator", "Bold Italic Converter", "Bold Italic Unicode Generator", "Copy and Paste Bold Italic Text", "Bold Italic Letter Maker"],
+  "url": "https://ultratextgen.com/category/bold-fonts/bold-italic/",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "description": "Double the impact with bold italic fonts. Perfect for attention-grabbing Instagram captions, TikTok bios, and standout messages.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
 </head>
 <body>
   <!-- Google Tag Manager (noscript) -->

--- a/category/bold-fonts/bold/index.html
+++ b/category/bold-fonts/bold/index.html
@@ -104,6 +104,25 @@
   ]
 }
   </script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Bold Text Generator",
+  "alternateName": ["Unicode Bold Generator", "Bold Font Converter", "Bold Letter Maker", "Copy and Paste Bold Letters", "Bold Unicode Text"],
+  "url": "https://ultratextgen.com/category/bold-fonts/bold/",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "description": "Make your text impossible to ignore. Bold Unicode fonts perfect for Instagram bios, X posts, and Discord usernames. One-click copy.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
 </head>
 <body>
   <!-- Google Tag Manager (noscript) -->

--- a/category/bold-fonts/index.html
+++ b/category/bold-fonts/index.html
@@ -138,6 +138,25 @@
   ]
 }
   </script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Bold Fonts Generator",
+  "alternateName": ["Bold Text Generator", "Bold Letters Generator", "Bold Font Maker", "Copy and Paste Bold Text", "Bold Unicode Generator"],
+  "url": "https://ultratextgen.com/category/bold-fonts/",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "description": "Create bold Unicode fonts for strong emphasis and high visibility. Ideal for Instagram bios, headings, usernames, and callouts. Copy and paste instantly.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
 </head>
 <body>
   <!-- Google Tag Manager (noscript) -->

--- a/category/bubble-fonts/circle/index.html
+++ b/category/bubble-fonts/circle/index.html
@@ -104,6 +104,25 @@
   ]
 }
   </script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Circle Text Generator",
+  "alternateName": ["Circled Letters Generator", "Bubble Circle Font Generator", "Circle Letter Maker", "Enclosed Circle Text", "Copy and Paste Circle Letters"],
+  "url": "https://ultratextgen.com/category/bubble-fonts/circle/",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "description": "Enclosed circle letter fonts for unique profile names, creative bullet points, and distinctive social posts. Copy and paste ready.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
 </head>
 <body>
   <!-- Google Tag Manager (noscript) -->

--- a/category/bubble-fonts/index.html
+++ b/category/bubble-fonts/index.html
@@ -146,6 +146,25 @@
   ]
 }
   </script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Bubble Fonts Generator",
+  "alternateName": ["Bubble Text Generator", "Circle Letters Generator", "Bubble Letter Font", "Circled Text Generator", "Copy and Paste Bubble Letters"],
+  "url": "https://ultratextgen.com/category/bubble-fonts/",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "description": "Fun bubble fonts for playful bios, cute captions, and friendly messages. Perfect for kid-friendly content and cheerful vibes.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
 </head>
 <body>
   <!-- Google Tag Manager (noscript) -->

--- a/category/classified/index.html
+++ b/category/classified/index.html
@@ -98,6 +98,25 @@
   ]
 }
   </script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Classified Text Generator",
+  "alternateName": ["Redacted Text Generator", "Censored Text Generator", "Blacked Out Text Generator", "Redacted Font Generator", "Copy and Paste Classified Text"],
+  "url": "https://ultratextgen.com/category/classified/",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "description": "Generate classified and redacted Unicode symbols like ███, ⬛⬛⬛, ▓▓▓, and more. Perfect for censored text effects, mystery posts, and dramatic reveals. Copy and paste instantly.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
 </head>
 <body>
   <!-- Google Tag Manager (noscript) -->

--- a/category/cursive-fonts/index.html
+++ b/category/cursive-fonts/index.html
@@ -146,6 +146,25 @@
   ]
 }
   </script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Cursive Fonts Generator",
+  "alternateName": ["Cursive Text Generator", "Script Font Generator", "Handwriting Font Generator", "Calligraphy Font Generator", "Copy and Paste Cursive"],
+  "url": "https://ultratextgen.com/category/cursive-fonts/",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "description": "Elegant cursive fonts for aesthetic Instagram bios, wedding announcements, love notes, and beautiful social captions. Copy instantly.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
 </head>
 <body>
   <!-- Google Tag Manager (noscript) -->

--- a/category/cursive-fonts/script/index.html
+++ b/category/cursive-fonts/script/index.html
@@ -104,6 +104,25 @@
   ]
 }
   </script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Script Font Generator",
+  "alternateName": ["Cursive Script Generator", "Handwriting Text Generator", "Script Letter Maker", "Calligraphy Script Generator", "Copy and Paste Script Text"],
+  "url": "https://ultratextgen.com/category/cursive-fonts/script/",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "description": "Flowing script fonts that add sophistication to your profiles, invitations, and romantic messages. Works everywhere, copy and paste.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
 </head>
 <body>
   <!-- Google Tag Manager (noscript) -->

--- a/category/cute-fonts/index.html
+++ b/category/cute-fonts/index.html
@@ -33,6 +33,7 @@
   "@context": "https://schema.org",
   "@type": "WebApplication",
   "name": "Cute Font Generator",
+  "alternateName": ["Cute Text Generator", "Cute Letters Generator", "Kawaii Font Generator", "Cutesy Font Generator", "Copy and Paste Cute Fonts"],
   "url": "https://ultratextgen.com/category/cute-fonts/",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Any",

--- a/category/gothic-fonts/fraktur/index.html
+++ b/category/gothic-fonts/fraktur/index.html
@@ -104,6 +104,25 @@
   ]
 }
   </script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Fraktur Fonts Generator",
+  "alternateName": ["Fraktur Text Generator", "Blackletter Font Generator", "Gothic Fraktur Maker", "Old German Font Generator", "Copy and Paste Fraktur Text"],
+  "url": "https://ultratextgen.com/category/gothic-fonts/fraktur/",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "description": "Classic fraktur blackletter fonts for vintage aesthetics, tattoo-style text, and old-world charm. One-click copy for any platform.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
 </head>
 <body>
   <!-- Google Tag Manager (noscript) -->

--- a/category/gothic-fonts/index.html
+++ b/category/gothic-fonts/index.html
@@ -146,6 +146,25 @@
   ]
 }
   </script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Gothic Fonts Generator",
+  "alternateName": ["Gothic Text Generator", "Fraktur Font Generator", "Blackletter Generator", "Old English Font Generator", "Copy and Paste Gothic Text"],
+  "url": "https://ultratextgen.com/category/gothic-fonts/",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "description": "Dark gothic fonts for edgy profiles, gaming usernames, metal band aesthetics, and mysterious vibes. Copy and paste anywhere.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
 </head>
 <body>
   <!-- Google Tag Manager (noscript) -->

--- a/category/italic-fonts/index.html
+++ b/category/italic-fonts/index.html
@@ -146,6 +146,25 @@
   ]
 }
   </script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Italic Fonts Generator",
+  "alternateName": ["Italic Text Generator", "Italic Font Maker", "Slanted Text Generator", "Copy and Paste Italic Text", "Oblique Font Generator"],
+  "url": "https://ultratextgen.com/category/italic-fonts/",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "description": "Generate italic Unicode fonts to add tone and nuance to your text. Perfect for Instagram bios, quotes, captions, and subtle emphasis. Copy and paste instantly.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
 </head>
 <body>
   <!-- Google Tag Manager (noscript) -->

--- a/category/small-text/index.html
+++ b/category/small-text/index.html
@@ -33,6 +33,7 @@
   "@context": "https://schema.org",
   "@type": "WebApplication",
   "name": "Small Text Generator",
+  "alternateName": ["Small Text Generator", "Tiny Text Generator", "Small Caps Generator", "Mini Text Generator", "Copy and Paste Small Text"],
   "url": "https://ultratextgen.com/category/small-text/",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Any",

--- a/category/strikethrough-text/index.html
+++ b/category/strikethrough-text/index.html
@@ -146,6 +146,25 @@
   ]
 }
   </script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Strikethrough Text Generator",
+  "alternateName": ["Crossed Out Text Generator", "Strikethrough Generator", "Cross Out Text", "Copy and Paste Strikethrough", "Strike Text Maker"],
+  "url": "https://ultratextgen.com/category/strikethrough-text/",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "description": "Strikethrough Text fonts to make your text unforgettable. Stand out on Instagram, TikTok, gaming profiles, and beyond.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
 </head>
 <body>
   <!-- Google Tag Manager (noscript) -->

--- a/category/underline-text/index.html
+++ b/category/underline-text/index.html
@@ -146,6 +146,24 @@
   ]
 }
   </script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Underline Text Generator",
+  "alternateName": ["Underlined Text Generator", "Underline Font Generator", "Copy and Paste Underline Text", "Unicode Underline Maker"],
+  "url": "https://ultratextgen.com/category/underline-text/",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "description": "Underline Text fonts and styles to emphasize your text. Make it stand out on Instagram, TikTok, gaming profiles, and more.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
 </head>
 <body>
   <!-- Google Tag Manager (noscript) -->

--- a/category/upside-down-text/index.html
+++ b/category/upside-down-text/index.html
@@ -146,6 +146,24 @@
   ]
 }
   </script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Upside Down Text Generator",
+  "alternateName": ["Flip Text Generator", "Reverse Text Generator", "Backwards Text Generator", "Copy and Paste Upside Down Text", "Flipped Text Maker"],
+  "url": "https://ultratextgen.com/category/upside-down-text/",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "description": "Flip your text upside down and copy paste instantly. Choose from multiple upside down styles, including full flip, reverse, and emoji based.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
 </head>
 <body>
   <!-- Google Tag Manager (noscript) -->

--- a/category/word-wrappers/index.html
+++ b/category/word-wrappers/index.html
@@ -146,6 +146,24 @@
   ]
 }
   </script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Word Wrappers Generator",
+  "alternateName": ["Text Decorator", "Symbol Text Wrapper", "Fancy Text Wrapper", "Name Decorator", "Copy and Paste Decorations"],
+  "url": "https://ultratextgen.com/category/word-wrappers/",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "description": "Automatically wrap words in decorative wrappers and separators. Create boxed, bracketed, and emoji-wrapped text for bios, captions, and usernames.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
 </head>
 <body>
   <!-- Google Tag Manager (noscript) -->

--- a/discord/index.html
+++ b/discord/index.html
@@ -280,6 +280,25 @@
   ]
 }
   </script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Discord Font Generator",
+  "alternateName": ["Discord Text Generator", "Discord Fonts Copy and Paste", "Discord Name Font Generator", "Discord Bio Font Generator", "Discord Username Font Generator", "Discord Nickname Font Generator"],
+  "url": "https://ultratextgen.com/discord/",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "description": "Free Discord font generator. Style your display name, server nickname, bio, and chat with 100+ Unicode fonts — bold, italic, cursive, gothic, bubble. Copy and paste. No Nitro required.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
 </head>
 
 <body>

--- a/facebook/index.html
+++ b/facebook/index.html
@@ -101,6 +101,25 @@
   ]
 }
   </script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Facebook Font Generator",
+  "alternateName": ["Facebook Text Generator", "Facebook Fonts Copy and Paste", "Facebook Bio Fonts", "Stylish Text for Facebook", "Facebook Name Font Generator", "Facebook Post Font Generator"],
+  "url": "https://ultratextgen.com/facebook/",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "description": "Generate Facebook fonts by job: post text, profile name, bio, or comment. Includes rejection-safe name mode, bold/cursive presets, and copy-paste Unicode styles.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
 </head>
 <body>
   <!-- Google Tag Manager (noscript) -->

--- a/instagram/index.html
+++ b/instagram/index.html
@@ -159,6 +159,25 @@
   ]
 }
   </script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Instagram Font Generator",
+  "alternateName": ["Instagram Bio Fonts", "IG Font Generator", "Instagram Fonts Copy and Paste", "Insta Font Generator", "Instagram Bio Font Generator", "Instagram Caption Font Generator"],
+  "url": "https://ultratextgen.com/instagram/",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "description": "Generate stylish fonts for Instagram bios, captions, and comments. Copy-paste ready.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
 </head>
 <body>
   <!-- Google Tag Manager (noscript) -->

--- a/library/accent-marks-diacritics/index.html
+++ b/library/accent-marks-diacritics/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Accent Marks &amp; Diacritics: Copy &amp; Paste Combining Characters",
+  "alternateName": ["Accent Marks Copy and Paste", "Diacritics Symbols", "Combining Characters Copy Paste", "Accent Characters List", "Diacritical Marks Symbols", "Special Accent Letters"],
   "description": "Browse and copy accent marks and diacritical characters — combining marks, spacing forms, and accented letter quick-copies. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/achievement-symbols/index.html
+++ b/library/achievement-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Trophy, Medal & Award Emojis 🏆 — Achievement Symbols Copy & Paste",
+  "alternateName": ["Trophy Emoji Copy and Paste", "Achievement Symbols Copy Paste", "Medal Emoji Copy and Paste", "Award Emojis", "Crown Emoji Copy Paste", "Trophy and Medal Symbols", "Win Emojis Copy and Paste"],
   "description": "Browse and copy achievement symbols — crowns, trophies, medals, celebration emojis, and status symbols for bios, posts, and profiles. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/aesthetic-borders-frames/index.html
+++ b/library/aesthetic-borders-frames/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Aesthetic Borders & Frames Copy & Paste — Pretty Decorative Dividers",
+  "alternateName": ["Aesthetic Borders Copy and Paste", "Decorative Frames Copy Paste", "Pretty Borders Symbols", "Aesthetic Dividers Copy and Paste", "Decorative Border Text", "Bio Borders Copy and Paste", "Frame Symbols Copy Paste"],
   "description": "Decorative borders, frames, and aesthetic dividers for bios and captions. Pretty multi-symbol patterns including flower, star, and heart frames.",
   "author": {
     "@type": "Organization",

--- a/library/aesthetic-symbols/index.html
+++ b/library/aesthetic-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Aesthetic Symbols Copy & Paste — Coquette, Y2K, Kawaii & More",
+  "alternateName": ["Aesthetic Symbols Copy and Paste", "Cute Aesthetic Symbols", "Kawaii Symbols Copy Paste", "Coquette Symbols", "Y2K Symbols Copy and Paste", "Aesthetic Text Symbols", "Bio Aesthetic Symbols"],
   "description": "Copy & paste aesthetic symbols for bios, usernames, and captions. Browse by aesthetic — coquette, cottagecore, kawaii, y2k, goth, whisper, and more.",
   "author": {
     "@type": "Organization",

--- a/library/algeria-emoji-combos/index.html
+++ b/library/algeria-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Algeria Emoji Combos 🇩🇿⚽ Copy & Paste",
+  "alternateName": ["Algeria Emoji Copy and Paste", "Algeria Flag Emoji Combos", "Algeria Emojis", "Algeria Emoji Combinations", "Algeria Football Emojis", "Algerian Emoji Copy Paste"],
   "description": "Algeria emoji combos 🇩🇿⚽ — Desert Foxes colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/alt-codes/index.html
+++ b/library/alt-codes/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Alt Codes: Full List of Keyboard Alt Key Symbol Codes",
+  "alternateName": ["Alt Codes List", "Alt Key Codes", "Alt Code Symbols", "Keyboard Alt Codes", "Alt Code Characters", "Windows Alt Codes", "Alt Number Codes"],
   "description": "Full list of keyboard Alt codes — Alt+0169 for ©, currency, math, accented letters, and classic DOS symbols with codes. Click any character to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/angry-emoji/index.html
+++ b/library/angry-emoji/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Angry Emoji & Kaomoji: Copy & Paste 😡 Rage Combos",
+  "alternateName": ["Angry Emoji Copy and Paste", "Angry Face Emoji", "Rage Emoji Copy Paste", "Mad Emoji Copy and Paste", "Angry Kaomoji", "Angry Emoji Combinations", "Frustrated Emoji Copy Paste"],
   "description": "Angry emoji 😡 🤬 😤, rage combo sets, and table-flip kaomoji like (╯°□°）╯︵ ┻━┻ for venting in chats and comments. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/animal-emojis/index.html
+++ b/library/animal-emojis/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Animal & Creature Emojis: Copy & Paste Animal Symbols",
+  "alternateName": ["Animal Emoji Copy and Paste", "Animal Emojis List", "Cute Animal Emojis", "Pet Emoji Copy Paste", "Wild Animal Emojis", "Animal Symbols Copy and Paste", "Creature Emojis"],
   "description": "Browse and copy animal emojis — pets, wildlife, sea creatures, birds, and mythical beings. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/argentina-emoji-combos/index.html
+++ b/library/argentina-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Argentina Emoji Combos 🇦🇷⚽ Copy & Paste",
+  "alternateName": ["Argentina Emoji Copy and Paste", "Argentina Flag Emoji Combos", "Argentina Emojis", "Argentina Emoji Combinations", "Argentina Football Emojis", "Albiceleste Emojis Copy Paste"],
   "description": "Argentina emoji combos 🇦🇷⚽ — Albiceleste, three stars, and champion sets for fan bios. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/arrow-symbols/index.html
+++ b/library/arrow-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Arrow Symbols: Copy & Paste Directional Arrow Characters",
+  "alternateName": ["Arrow Symbol Copy and Paste", "Arrow Emoji Copy Paste", "Arrow Text Symbols", "Copy and Paste Arrows", "Arrow Signs", "Directional Arrow Symbols", "Arrow Characters List"],
   "description": "Browse and copy arrow symbols — straight, curved, double, triangle, and emoji arrows for documents, posts, and formatting. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/art-stationery-emojis/index.html
+++ b/library/art-stationery-emojis/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Art & Stationery Emojis: Copy & Paste ✏ 🎨 Creative Combos",
+  "alternateName": ["Art Emoji Copy and Paste", "Stationery Emojis Copy Paste", "Pencil Emoji Copy and Paste", "Palette Emoji Copy Paste", "Creative Emojis", "Art Supply Emojis", "Drawing Emoji Copy and Paste"],
   "description": "Art and stationery emojis to copy and paste — pencils ✏️, palettes 🎨, paintbrushes, notebooks, paper, and creative combo sets. Click any emoji to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/ascii-table/index.html
+++ b/library/ascii-table/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "ASCII Table: Copy & Paste ASCII Codes & Characters",
+  "alternateName": ["ASCII Table Chart", "ASCII Character Codes", "ASCII Code List", "Full ASCII Table", "ASCII Codes Reference", "ASCII Characters Copy Paste", "ASCII Code Chart"],
   "description": "ASCII table with decimal and hex codes for punctuation, digits, letters, and symbols — a quick developer reference chart. Click any character to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/australia-emoji-combos/index.html
+++ b/library/australia-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Australia Emoji Combos 🇦🇺⚽ Copy & Paste",
+  "alternateName": ["Australia Emoji Copy and Paste", "Australia Flag Emoji Combos", "Australia Emojis", "Australia Emoji Combinations", "Australian Football Emojis", "Socceroos Emojis Copy Paste"],
   "description": "Australia emoji combos 🇦🇺⚽ — Socceroos colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/austria-emoji-combos/index.html
+++ b/library/austria-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Austria Emoji Combos 🇦🇹⚽ Copy & Paste",
+  "alternateName": ["Austria Emoji Copy and Paste", "Austria Flag Emoji Combos", "Austria Emojis", "Austria Emoji Combinations", "Austrian Football Emojis", "Austria Soccer Emojis Copy Paste"],
   "description": "Austria emoji combos 🇦🇹⚽ — Das Team colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/awareness-ribbons/index.html
+++ b/library/awareness-ribbons/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Awareness Ribbon Symbols: Copy & Paste Ribbon Emojis",
+  "alternateName": ["Awareness Ribbon Copy and Paste", "Ribbon Emoji Copy Paste", "Cancer Ribbon Symbols", "Pink Ribbon Symbol Copy Paste", "Awareness Ribbon Colors", "Cause Ribbon Symbols", "Ribbon Symbols List"],
   "description": "Browse and copy awareness ribbon symbols and emojis. Click any ribbon or symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/beauty-nails-emojis/index.html
+++ b/library/beauty-nails-emojis/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Beauty & Nails Emojis: Copy & Paste 💅 Makeup Combos",
+  "alternateName": ["Nails Emoji Copy and Paste", "Beauty Emojis Copy Paste", "Nail Polish Emoji Copy Paste", "Makeup Emoji Copy and Paste", "Glam Emojis", "Salon Emoji Copy Paste", "Beauty Emoji Combinations"],
   "description": "Copy and paste beauty and nails emojis — 💅 polish, 💄 lipstick, 🪞 mirror — plus girly glam combo sets for salon bios. Click any emoji to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/belgium-emoji-combos/index.html
+++ b/library/belgium-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Belgium Emoji Combos 🇧🇪⚽ Copy & Paste",
+  "alternateName": ["Belgium Emoji Copy and Paste", "Belgium Flag Emoji Combos", "Belgium Emojis", "Belgium Emoji Combinations", "Belgian Football Emojis", "Red Devils Emojis Copy Paste"],
   "description": "Belgium emoji combos 🇧🇪⚽ — Red Devils colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/bellingham-emoji-combos/index.html
+++ b/library/bellingham-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Bellingham Emoji Combos 🏴󠁧󠁢󠁥󠁮󠁧󠁿⚽🐐 Copy & Paste",
+  "alternateName": ["Bellingham Emojis Copy and Paste", "Jude Bellingham Emoji", "Bellingham Emoji Combinations", "Bellingham Emoji Copy Paste", "Bellingham Fan Emojis"],
   "description": "Bellingham emoji combos 🏴󠁧󠁢󠁥󠁮󠁧󠁿⚽ — fan emoji sets for bios, captions, and comments. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/benzema-emoji-combos/index.html
+++ b/library/benzema-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Benzema Emoji Combos 🇫🇷⚽🐐 Copy & Paste",
+  "alternateName": ["Benzema Emojis Copy and Paste", "Karim Benzema Emoji", "Benzema Emoji Combinations", "Benzema Emoji Copy Paste", "Benzema Fan Emojis"],
   "description": "Benzema emoji combos 🇫🇷⚽ — fan emoji sets for bios, captions, and comments. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/body-language-emojis/index.html
+++ b/library/body-language-emojis/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Body Language Emojis: Copy & Paste People & Gesture Symbols",
+  "alternateName": ["Body Language Emoji Copy and Paste", "Gesture Emojis Copy Paste", "People Emoji Copy and Paste", "Hand Gesture Emojis", "Body Emojis List", "Gesture Symbols Copy Paste", "Expression Emojis Copy and Paste"],
   "description": "Browse and copy body language emojis — eyes, mouths, running figures, bowing, and expressive person symbols. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/bow-ribbon-symbols/index.html
+++ b/library/bow-ribbon-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Bow & Ribbon Symbols Copy & Paste — Aesthetic Bow Emojis",
+  "alternateName": ["Bow Symbol Copy and Paste", "Ribbon Symbol Copy Paste", "Bow Emoji Copy and Paste", "Cute Bow Symbols", "Coquette Bow Symbols", "Aesthetic Bow Copy Paste", "Bow and Ribbon Emojis"],
   "description": "Bow and ribbon symbols for coquette, preppy, and feminine bios. Copy & paste bow emojis and ribbon decorations for usernames and captions.",
   "author": {
     "@type": "Organization",

--- a/library/box-drawing-symbols/index.html
+++ b/library/box-drawing-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Box Drawing & Block Symbols: Copy & Paste ─ │ ┌ █ ▓ ASCII Boxes",
+  "alternateName": ["Box Drawing Symbols Copy and Paste", "ASCII Box Characters", "Block Symbols Copy Paste", "Line Drawing Characters", "Box Drawing Characters List", "ASCII Border Characters", "Unicode Box Drawing"],
   "description": "Copy and paste box drawing and block element symbols — lines, corners, double borders, full blocks, and shading characters for ASCII boxes. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/bracket-symbols/index.html
+++ b/library/bracket-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Brackets, Braces & Parentheses: All Unicode Bracket Types",
+  "alternateName": ["Bracket Symbols Copy and Paste", "Curly Braces Copy Paste", "Parentheses Symbols", "Square Bracket Symbols", "Decorative Brackets Copy Paste", "Unicode Bracket Characters", "Bracket Signs List"],
   "description": "Browse and copy all Unicode bracket types — standard brackets, CJK brackets, mathematical brackets, decorative brackets, quotation marks, and full-width brackets. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/braille-pattern-symbols/index.html
+++ b/library/braille-pattern-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Braille Pattern Symbols: Copy & Paste ⠿ ⣿ Blank & Dot Characters",
+  "alternateName": ["Braille Symbols Copy and Paste", "Blank Braille Character Copy", "Braille Pattern Copy Paste", "Invisible Character Copy Paste", "Braille Unicode Symbols", "Braille Dot Symbols", "Empty Character Copy Paste"],
   "description": "Copy and paste braille pattern symbols — the blank braille character (⠀), solid fills (⣿), and every dot combination. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/brainrot-slang-emojis/index.html
+++ b/library/brainrot-slang-emojis/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Brainrot & Slang Emoji Combos: Copy & Paste Sigma Rizz 67",
+  "alternateName": ["Brainrot Emojis Copy and Paste", "Sigma Emoji Copy Paste", "Rizz Emoji Copy and Paste", "Gen Z Emoji Combos", "Skull Emoji Combo Copy Paste", "Meme Emojis Copy and Paste", "Slang Emoji Combinations"],
   "description": "Brainrot and slang emoji combos to copy: sigma 🗿, rizz 😏, skull 💀, aura ✨, 67, and other current Gen Z meme sets in one place. Click any emoji to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/brazil-emoji-combos/index.html
+++ b/library/brazil-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Brazil Emoji Combos 🇧🇷⚽ Copy & Paste",
+  "alternateName": ["Brazil Emoji Copy and Paste", "Brazil Flag Emoji Combos", "Brazil Emojis", "Brazil Emoji Combinations", "Brazilian Football Emojis", "Brazil Soccer Emojis Copy Paste"],
   "description": "Brazil emoji combos 🇧🇷⚽ — Selecao, samba, and yellow-green sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/bullet-point-symbols/index.html
+++ b/library/bullet-point-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Bullet Point Symbols: Copy & Paste List Markers",
+  "alternateName": ["Bullet Point Copy and Paste", "Bullet Symbol Copy Paste", "List Bullet Symbols", "Cool Bullet Points Copy Paste", "Bullet Point Text Symbols", "Bullet Points for Bios", "Dot Bullet Symbol Copy Paste"],
   "description": "Browse and copy bullet point symbols, list markers, arrow bullets, checkmark bullets, and decorative bullets for documents and social posts. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/cameroon-emoji-combos/index.html
+++ b/library/cameroon-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Cameroon Emoji Combos 🇨🇲⚽ Copy & Paste",
+  "alternateName": ["Cameroon Emoji Copy and Paste", "Cameroon Flag Emoji Combos", "Cameroon Emojis", "Cameroon Emoji Combinations", "Cameroon Football Emojis", "Indomitable Lions Emojis Copy Paste"],
   "description": "Cameroon emoji combos 🇨🇲⚽ — Indomitable Lions colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/canada-emoji-combos/index.html
+++ b/library/canada-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Canada Emoji Combos 🇨🇦⚽ Copy & Paste",
+  "alternateName": ["Canada Emoji Copy and Paste", "Canada Flag Emoji Combos", "Canada Emojis", "Canada Emoji Combinations", "Canadian Football Emojis", "Canada Soccer Emojis Copy Paste"],
   "description": "Canada emoji combos 🇨🇦⚽ — Canada Soccer colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/card-emoji-soccer/index.html
+++ b/library/card-emoji-soccer/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Yellow Card & Red Card Emoji 🟨🟥 Copy & Paste",
+  "alternateName": ["Yellow Card Emoji Copy and Paste", "Red Card Emoji Copy Paste", "Soccer Card Emoji", "Football Card Emoji Copy Paste", "Yellow Card Symbol", "Referee Card Emojis", "VAR Emoji Copy and Paste"],
   "description": "Copy and paste the yellow card 🟨 and red card 🟥 emoji for soccer, plus referee, VAR, and booking combos. Click any emoji to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/card-suit-symbols/index.html
+++ b/library/card-suit-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Card Suit Symbols ♠♥♦♣ — Playing Card Suits Copy & Paste",
+  "alternateName": ["Card Suit Symbols Copy and Paste", "Playing Card Symbols", "Spade Heart Diamond Club Symbols", "Card Suit Copy Paste", "Card Symbols Text", "Suit of Cards Symbols", "Card Suit Unicode"],
   "description": "Browse and copy playing card suit symbols, dice, dominoes, and game-related Unicode characters. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/checkmark-symbols/index.html
+++ b/library/checkmark-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Checkmark Symbols: Copy & Paste Check Marks & Status Icons",
+  "alternateName": ["Checkmark Symbol Copy and Paste", "Check Mark Copy Paste", "Tick Symbols Copy and Paste", "Check Symbols Text", "Tick Mark Symbols", "Checkmark Signs", "Check Mark Unicode"],
   "description": "Browse and copy checkmark symbols, cross marks, and status indicators for lists, comparisons, and professional formatting. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/chess-symbols/index.html
+++ b/library/chess-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Chess Symbols: Copy & Paste Chess Piece Unicode Characters",
+  "alternateName": ["Chess Symbols Copy and Paste", "Chess Piece Symbols", "Chess Emoji Copy Paste", "Chess Unicode Symbols", "Chess Characters Copy and Paste", "Chess Piece Unicode", "Chess Text Symbols"],
   "description": "Browse and copy Unicode chess piece symbols — white and black kings, queens, rooks, bishops, knights, and pawns. Click any piece to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/chile-emoji-combos/index.html
+++ b/library/chile-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Chile Emoji Combos 🇨🇱⚽ Copy & Paste",
+  "alternateName": ["Chile Emoji Copy and Paste", "Chile Flag Emoji Combos", "Chile Emojis", "Chile Emoji Combinations", "Chile Football Emojis", "La Roja Emoji Copy Paste"],
   "description": "Chile emoji combos 🇨🇱⚽ — La Roja colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/china-emoji-combos/index.html
+++ b/library/china-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "China Emoji Combos 🇨🇳⚽ Copy & Paste",
+  "alternateName": ["China Emoji Copy and Paste", "China Flag Emoji Combos", "China Emojis", "China Emoji Combinations", "China Football Emojis", "Chinese Flag Emoji Copy Paste"],
   "description": "China emoji combos 🇨🇳⚽ — Team Dragon colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/chinese-symbols/index.html
+++ b/library/chinese-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Chinese Symbols: Copy & Paste 福 龍 Chinese Characters",
+  "alternateName": ["Chinese Symbols Copy and Paste", "Chinese Characters Copy Paste", "Lucky Chinese Symbols", "Chinese Text Symbols", "Hanzi Symbols Copy and Paste", "Chinese Unicode Symbols", "Chinese Symbol Signs"],
   "description": "Copy and paste Chinese symbols with pinyin and meanings — lucky characters like 福 and 龍, love, nature, and strength hanzi. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/christmas-symbols/index.html
+++ b/library/christmas-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Christmas Symbols: Copy & Paste 🎄 ❄ ☃ Festive Characters",
+  "alternateName": ["Christmas Symbols Copy and Paste", "Christmas Emoji Copy Paste", "Festive Symbols Copy and Paste", "Holiday Symbols Copy Paste", "Christmas Text Symbols", "Xmas Symbols Copy and Paste", "Christmas Signs"],
   "description": "Festive Christmas symbols and emojis — trees, snowflakes, snowmen, gifts, and ready-made holiday greeting combos. Tap any character to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/clock-time-symbols/index.html
+++ b/library/clock-time-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Clock & Time Symbols: Copy & Paste 🕐 ⌛ ⏰ Time Characters",
+  "alternateName": ["Clock Symbols Copy and Paste", "Time Symbols Copy Paste", "Clock Emoji Copy and Paste", "Hourglass Emoji Copy Paste", "Clock Text Symbols", "Time Emoji Copy and Paste", "Clock Signs"],
   "description": "Copy clock and time symbols — all 24 Unicode clock faces 🕐, hourglasses ⌛, alarm clocks ⏰, watches, and AM/PM marks. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/clothing-fashion-emojis/index.html
+++ b/library/clothing-fashion-emojis/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Clothing & Fashion Emojis: Copy & Paste 👗 👟 Outfit Combos",
+  "alternateName": ["Clothing Emoji Copy and Paste", "Fashion Emojis Copy Paste", "Outfit Emojis Copy and Paste", "Clothes Emoji Copy Paste", "Fashion Emoji Combinations", "Dress Emoji Copy and Paste", "Style Emojis Copy Paste"],
   "description": "Clothing and fashion emojis to copy and paste — dresses 👗, sneakers 👟, hats 🎩, bags 👜, glasses, and outfit combo sets. Click any emoji to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/colombia-emoji-combos/index.html
+++ b/library/colombia-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Colombia Emoji Combos 🇨🇴⚽ Copy & Paste",
+  "alternateName": ["Colombia Emoji Copy and Paste", "Colombia Flag Emoji Combos", "Colombia Emojis", "Colombia Emoji Combinations", "Colombia Football Emojis", "Los Cafeteros Emoji Copy Paste"],
   "description": "Colombia emoji combos 🇨🇴⚽ — Los Cafeteros colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/color-emoji-combos/index.html
+++ b/library/color-emoji-combos/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Color Emoji Combos: Copy & Paste Blue Pink Purple Themes",
+  "alternateName": ["Color Emoji Copy and Paste", "Colour Emoji Combos Copy Paste", "Aesthetic Color Emoji Sets", "Pink Emoji Copy and Paste", "Blue Emoji Combos", "Purple Emoji Copy and Paste", "Color Theme Emojis"],
   "description": "Copy and paste color emoji combos sorted by theme — blue 💙🦋🌊, pink 🌸💗🎀, purple 💜🔮, plus red, green, and black sets. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/copyright-trademark-symbols/index.html
+++ b/library/copyright-trademark-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Copyright, Trademark & Legal Symbols: Copy & Paste © ® ™",
+  "alternateName": ["Copyright Symbol Copy and Paste", "Trademark Symbol Copy and Paste", "Copyright and Trademark Symbols", "Legal Symbols Copy Paste", "Copyright Sign Text Symbol", "Registered Trademark Symbol", "TM Symbol Copy and Paste"],
   "description": "Copy and paste copyright, registered, trademark, and other legal Unicode symbols — ©, ®, ™, ℠, ℗, §, ¶, and more. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/coquette-symbols/index.html
+++ b/library/coquette-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Coquette Symbols Copy & Paste — Pink Bow & Ribbon Aesthetic",
+  "alternateName": ["Coquette Aesthetic Symbols", "Pink Bow Symbols Copy and Paste", "Coquette Text Symbols", "Ribbon Symbols Copy Paste", "Dollette Aesthetic Symbols", "Coquette Bio Symbols", "Cute Bow Symbols Copy and Paste"],
   "description": "Coquette aesthetic symbols, bows, ribbons, and pink decorations for bios and usernames. Soft, feminine, dollette-style copy & paste characters.",
   "author": {
     "@type": "Organization",

--- a/library/costa-rica-emoji-combos/index.html
+++ b/library/costa-rica-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Costa Rica Emoji Combos 🇨🇷⚽ Copy & Paste",
+  "alternateName": ["Costa Rica Emoji Copy and Paste", "Costa Rica Flag Emoji Combos", "Costa Rica Emojis", "Costa Rica Emoji Combinations", "Costa Rica Football Emoji", "Costa Rica Flag Copy and Paste"],
   "description": "Costa Rica emoji combos 🇨🇷⚽ — Los Ticos colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/cottagecore-symbols/index.html
+++ b/library/cottagecore-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Cottagecore Symbols Copy & Paste — Mushroom, Flower & Nature Aesthetic",
+  "alternateName": ["Cottagecore Aesthetic Symbols", "Cottagecore Text Symbols", "Mushroom Symbols Copy and Paste", "Nature Aesthetic Symbols", "Cottagecore Bio Symbols", "Flower Symbols Copy Paste", "Cottage Aesthetic Symbols"],
   "description": "Cottagecore aesthetic symbols including mushrooms, flowers, bees, and rural motifs. Copy & paste cottage-life decorations for bios and captions.",
   "author": {
     "@type": "Organization",

--- a/library/croatia-emoji-combos/index.html
+++ b/library/croatia-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Croatia Emoji Combos 🇭🇷⚽ Copy & Paste",
+  "alternateName": ["Croatia Emoji Copy and Paste", "Croatia Flag Emoji Combos", "Croatia Emojis", "Croatia Emoji Combinations", "Croatia Football Emoji", "Croatia Flag Copy and Paste"],
   "description": "Croatia emoji combos 🇭🇷⚽ — Vatreni colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/cross-x-symbols/index.html
+++ b/library/cross-x-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Cross &amp; X Symbols: Copy &amp; Paste All Cross Characters",
+  "alternateName": ["Cross Symbol Copy and Paste", "X Symbol Copy and Paste", "Cross Text Symbols", "Cross Signs Copy Paste", "Multiplication Sign Symbol", "Religious Cross Symbols", "X Mark Symbols Copy and Paste"],
   "description": "Browse and copy every cross and X symbol — multiplication signs, ballot marks, religious crosses, decorative dagger symbols, and more. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/crown-royalty-symbols/index.html
+++ b/library/crown-royalty-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Crown & Royalty Symbols Copy & Paste — King, Queen & Tiara Symbols",
+  "alternateName": ["Crown Symbol Copy and Paste", "Crown Text Symbols", "Queen Symbol Copy and Paste", "King Symbol Copy and Paste", "Royalty Symbols Copy Paste", "Crown Emoji Symbols", "Tiara Symbol Copy and Paste"],
   "description": "Crown, tiara, and royalty symbols for usernames, ranking, and queen/king bios. Copy & paste chess king/queen and royal motif characters.",
   "author": {
     "@type": "Organization",

--- a/library/crying-emoji/index.html
+++ b/library/crying-emoji/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Crying Emoji & Kaomoji: Copy & Paste 😭 Tears Combos",
+  "alternateName": ["Crying Emoji Copy and Paste", "Sad Crying Emoji", "Crying Face Emoji", "Sobbing Emoji Copy Paste", "Tear Emoji", "Crying Kaomoji Copy and Paste", "Loudly Crying Emoji"],
   "description": "Copy and paste crying emoji like 😭 😢 🥹, sobbing kaomoji such as (T_T), and tearful combo sets for captions and replies. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/currency-symbols/index.html
+++ b/library/currency-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Currency Symbols: Copy & Paste Money Signs & Symbols",
+  "alternateName": ["Currency Symbol Copy and Paste", "Money Symbols Copy and Paste", "Currency Signs", "Money Sign Symbols", "Dollar Sign Copy and Paste", "Financial Symbols", "World Currency Symbols"],
   "description": "Browse and copy currency symbols from around the world — dollar, euro, pound, yen, rupee, bitcoin, and more. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/dash-hyphen-symbols/index.html
+++ b/library/dash-hyphen-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Dash &amp; Hyphen Symbols: Copy &amp; Paste All Dash Characters",
+  "alternateName": ["Dash Symbol Copy and Paste", "Hyphen Symbol Copy and Paste", "Em Dash Copy and Paste", "En Dash Copy and Paste", "Dash Text Symbols", "Horizontal Line Symbols", "Minus Sign Copy and Paste"],
   "description": "Browse and copy every dash and hyphen character — hyphens, en dashes, em dashes, minus signs, and decorative dashes. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/de-bruyne-emoji-combos/index.html
+++ b/library/de-bruyne-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "De Bruyne Emoji Combos 🇧🇪⚽🐐 Copy & Paste",
+  "alternateName": ["De Bruyne Emoji Copy and Paste", "Kevin De Bruyne Emoji", "De Bruyne Fan Emoji Combos", "De Bruyne Football Emoji", "De Bruyne Emoji Combinations", "KDB Emoji Copy and Paste"],
   "description": "De Bruyne emoji combos 🇧🇪⚽ — fan emoji sets for bios, captions, and comments. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/degree-symbol/index.html
+++ b/library/degree-symbol/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Degree Symbol: Copy & Paste ° Temperature & Angle Signs",
+  "alternateName": ["Degree Symbol Copy and Paste", "Degree Sign Copy and Paste", "Temperature Symbol Copy Paste", "Celsius Symbol Copy and Paste", "Fahrenheit Symbol Copy and Paste", "Degree Symbol Text", "How to Type Degree Symbol"],
   "description": "Copy and paste the degree symbol (°) plus Celsius, Fahrenheit, Kelvin, angle, prime, and geometry signs. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/denmark-emoji-combos/index.html
+++ b/library/denmark-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Denmark Emoji Combos 🇩🇰⚽ Copy & Paste",
+  "alternateName": ["Denmark Emoji Copy and Paste", "Denmark Flag Emoji Combos", "Denmark Emojis", "Denmark Emoji Combinations", "Denmark Football Emoji", "Denmark Flag Copy and Paste"],
   "description": "Denmark emoji combos 🇩🇰⚽ — Danish Dynamite colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/di-maria-emoji-combos/index.html
+++ b/library/di-maria-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Di Maria Emoji Combos 🇦🇷⚽🐐 Copy & Paste",
+  "alternateName": ["Di Maria Emoji Copy and Paste", "Angel Di Maria Emoji", "Di Maria Fan Emoji Combos", "Di Maria Football Emoji", "Di Maria Emoji Combinations", "Angel Di Maria Copy and Paste"],
   "description": "Di Maria emoji combos 🇦🇷⚽ — fan emoji sets for bios, captions, and comments. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/dice-domino-symbols/index.html
+++ b/library/dice-domino-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Dice, Domino & Mahjong Symbols: Copy & Paste ⚀ ⚁ 🀄 Game Tiles",
+  "alternateName": ["Dice Symbol Copy and Paste", "Dice Emoji Copy and Paste", "Domino Symbols Copy and Paste", "Mahjong Symbols Copy Paste", "Die Face Symbols", "Game Tile Symbols", "Dice Text Symbols"],
   "description": "Copy and paste dice, domino, and mahjong symbols — all six die faces, domino tiles, and mahjong tiles. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/discord-symbols/index.html
+++ b/library/discord-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Discord Symbols Copy & Paste — Aesthetic Bio & Username Symbols",
+  "alternateName": ["Discord Symbols Copy and Paste", "Discord Text Symbols", "Symbols for Discord", "Discord Symbol Copy Paste", "Discord Emoji Symbols", "Discord Bio Symbols", "Discord Username Symbols"],
   "description": "Copy & paste Discord symbols for usernames, server names, channels, and bios. Aesthetic decorations, dividers, hearts, and stars that render cleanly in Discord.",
   "author": {
     "@type": "Organization",

--- a/library/diwali-symbols/index.html
+++ b/library/diwali-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Diwali Symbols: Copy & Paste 🪔 ✨ Festival of Lights Characters",
+  "alternateName": ["Diwali Symbols Copy and Paste", "Diwali Emoji Copy and Paste", "Deepavali Symbols", "Festival of Lights Symbols", "Diwali Diya Emoji", "Diwali Text Symbols", "Happy Diwali Emoji"],
   "description": "Diwali symbols and emojis for the Festival of Lights — diyas, fireworks, rangoli flowers, and Shubh Deepavali greetings. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/dreamcore-weirdcore-symbols/index.html
+++ b/library/dreamcore-weirdcore-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Dreamcore & Weirdcore Symbols: Copy & Paste 👁 🌈 ⋆ Surreal Aesthetic",
+  "alternateName": ["Dreamcore Symbols Copy and Paste", "Weirdcore Symbols Copy and Paste", "Dreamcore Aesthetic Symbols", "Weirdcore Aesthetic Symbols", "Surreal Aesthetic Symbols", "Liminal Space Symbols", "Dreamcore Text Symbols"],
   "description": "Dreamcore and weirdcore symbols — surreal eyes 👁, rainbows 🌈, glitch blocks, doors, and sleepcore combos for liminal posts. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/easter-symbols/index.html
+++ b/library/easter-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Easter Symbols & Emojis: Copy & Paste 🐰 🥚 ✝ Spring Festive",
+  "alternateName": ["Easter Symbols Copy and Paste", "Easter Emoji Copy and Paste", "Easter Bunny Emoji Copy Paste", "Easter Egg Symbols", "Easter Text Symbols", "Happy Easter Emoji", "Spring Holiday Symbols"],
   "description": "Easter symbols and emojis — bunnies, eggs, chicks, crosses, and spring flowers for cards, captions, and bios. Click any Easter symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/ecuador-emoji-combos/index.html
+++ b/library/ecuador-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Ecuador Emoji Combos 🇪🇨⚽ Copy & Paste",
+  "alternateName": ["Ecuador Emoji Copy and Paste", "Ecuador Flag Emoji Combos", "Ecuador Emojis", "Ecuador Emoji Combinations", "Ecuador Football Emoji", "Ecuador Flag Copy and Paste"],
   "description": "Ecuador emoji combos 🇪🇨⚽ — La Tri colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/egypt-emoji-combos/index.html
+++ b/library/egypt-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Egypt Emoji Combos 🇪🇬⚽ Copy & Paste",
+  "alternateName": ["Egypt Emoji Copy and Paste", "Egypt Flag Emoji Combos", "Egypt Emojis", "Egypt Emoji Combinations", "Egyptian Emoji Copy Paste", "Egypt Football Emoji"],
   "description": "Egypt emoji combos 🇪🇬⚽ — Pharaohs colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/egyptian-hieroglyphs/index.html
+++ b/library/egyptian-hieroglyphs/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Egyptian Hieroglyphs: Copy &amp; Paste Unicode Hieroglyph Characters",
+  "alternateName": ["Egyptian Hieroglyphs Copy and Paste", "Hieroglyph Symbols", "Ancient Egyptian Symbols", "Unicode Hieroglyphs", "Egyptian Writing Symbols", "Hieroglyphic Characters Copy Paste"],
   "description": "Browse and copy all 1,072 Unicode Egyptian Hieroglyph characters (U+13000–U+1342F), organized by Gardiner category. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/electrical-circuit-symbols/index.html
+++ b/library/electrical-circuit-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Electrical & Circuit Symbols: Copy & Paste Ω ⏚ ⚡ Engineering Glyphs",
+  "alternateName": ["Electrical Symbols Copy and Paste", "Circuit Symbols Text", "Engineering Symbols Copy Paste", "Ohm Symbol Copy and Paste", "Electrical Signs", "Electronic Symbols Unicode"],
   "description": "Copy electrical and circuit symbols — ohm Ω, earth ground ⏚, AC current ⏦, logic gates, and unit glyphs for engineering text. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/email-symbols/index.html
+++ b/library/email-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Email Symbols: Copy & Paste Icons for Subject Lines & Signatures",
+  "alternateName": ["Email Symbols Copy and Paste", "Email Subject Line Symbols", "Email Signature Icons", "Email Icons Copy Paste", "Email Special Characters", "Newsletter Symbols"],
   "description": "Browse and copy symbols optimized for email — subject line grabbers, professional bullets, signature icons, and status indicators. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/emoji-combos/index.html
+++ b/library/emoji-combos/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Emoji Combos: Copy & Paste Aesthetic Emoji Combinations",
+  "alternateName": ["Emoji Combos Copy and Paste", "Aesthetic Emoji Combos", "Cute Emoji Combinations", "Emoji Combo Ideas", "Emoji Sets Copy Paste", "Bio Emoji Combos", "Aesthetic Emoji Copy and Paste"],
   "description": "Browse aesthetic emoji combos for bios, captions, and usernames — soft girl, cottage garden, night sky, and Y2K sets. Click any combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/emoji-flags/index.html
+++ b/library/emoji-flags/index.html
@@ -45,6 +45,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Flag Emoji Explorer: Copy & Paste Country Flag Emojis",
+  "alternateName": ["Flag Emoji Copy and Paste", "Country Flag Emojis", "Flag Emojis List", "All Country Flags Emoji", "Flag Emoji Copy Paste", "National Flag Emojis"],
   "description": "Browse and copy flag emojis for every country. Click any flag to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/emoji-meanings-guide/index.html
+++ b/library/emoji-meanings-guide/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Emoji Meanings Guide: What Every Popular Emoji Actually Means",
+  "alternateName": ["Emoji Meanings", "What Does This Emoji Mean", "Emoji Meaning List", "Emoji Dictionary", "All Emoji Meanings Explained", "Emoji Meanings Chart"],
   "description": "Discover what popular emojis actually mean — face expressions, hand gestures, heart colors, animal symbolism, and double-meaning emojis explained. Your complete emoji meanings reference.",
   "author": {
     "@type": "Organization",

--- a/library/england-emoji-combos/index.html
+++ b/library/england-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "England Emoji Combos 🏴󠁧󠁢󠁥󠁮󠁧󠁿⚽ Copy & Paste",
+  "alternateName": ["England Emoji Copy and Paste", "England Flag Emoji Combos", "England Emojis", "England Emoji Combinations", "Three Lions Emoji", "England Football Emoji"],
   "description": "England emoji combos 🏴󠁧󠁢󠁥󠁮󠁧󠁿⚽ — Three Lions, St George, and football sets for fan bios. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/evil-eye-hamsa-symbols/index.html
+++ b/library/evil-eye-hamsa-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Evil Eye & Hamsa Symbols: Copy & Paste 🧿 🪬 Nazar Characters",
+  "alternateName": ["Evil Eye Symbol Copy and Paste", "Hamsa Symbol Copy and Paste", "Nazar Emoji Copy and Paste", "Evil Eye Emoji", "Hamsa Hand Symbol", "Blue Eye Symbol Copy Paste", "Evil Eye Signs"],
   "description": "Copy and paste the evil eye 🧿 and hamsa 🪬 emoji plus nazar amulets, protective eyes, and blue bead symbols for your bio. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/face-emojis/index.html
+++ b/library/face-emojis/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Face & Emotion Emojis: Copy & Paste Smiley Faces & Expressions",
+  "alternateName": ["Face Emojis Copy and Paste", "Smiley Face Emoji Copy Paste", "Emotion Emojis", "Facial Expression Emojis", "Smiley Emojis List", "Copy and Paste Face Emojis"],
   "description": "Browse and copy face and emotion emojis — smileys, angry faces, shrug, confused, and expressive Unicode characters. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/fairycore-symbols/index.html
+++ b/library/fairycore-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Fairycore Symbols: Copy & Paste 🧚 🍄 ✨ Fairy Aesthetic",
+  "alternateName": ["Fairycore Symbols Copy and Paste", "Fairy Aesthetic Symbols", "Fairycore Emoji", "Fairy Symbols Copy Paste", "Cottagecore Fairy Symbols", "Whimsical Symbols Copy and Paste"],
   "description": "Fairycore symbols and emoji combos — fairies 🧚, mushrooms 🍄, sparkles ✨, and dainty flower characters for whimsical bios. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/fantasy-mythical-emojis/index.html
+++ b/library/fantasy-mythical-emojis/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Fantasy & Mythical Emojis: Copy & Paste 👽 🧚 🧙 Magic Combos",
+  "alternateName": ["Fantasy Emojis Copy and Paste", "Mythical Emojis", "Magic Emojis Copy Paste", "Fantasy Emoji Combinations", "Dragon Wizard Fairy Emoji", "Mythical Creature Emojis"],
   "description": "Copy and paste fantasy emojis — 👽 alien, 🧚 fairy, 🧙 wizard, 🐉 dragon — with mythical magic combos for usernames and bios. Click any emoji to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/flower-symbols/index.html
+++ b/library/flower-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Flower & Nature Symbols: Copy & Paste Plant Emojis & Characters",
+  "alternateName": ["Flower Symbols Copy and Paste", "Flower Emoji Copy Paste", "Nature Symbols", "Plant Emoji Copy and Paste", "Floral Symbols", "Flower Text Symbols", "Nature Emoji Copy Paste"],
   "description": "Browse and copy flower emojis, plant symbols, and nature-themed Unicode characters for bios, captions, and messages. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/foden-emoji-combos/index.html
+++ b/library/foden-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Foden Emoji Combos 🏴󠁧󠁢󠁥󠁮󠁧󠁿⚽🐐 Copy & Paste",
+  "alternateName": ["Foden Emoji Copy and Paste", "Phil Foden Emoji Combos", "Foden Fan Emojis", "Foden Emoji Combinations", "Foden Football Emoji"],
   "description": "Foden emoji combos 🏴󠁧󠁢󠁥󠁮󠁧󠁿⚽ — fan emoji sets for bios, captions, and comments. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/food-drink-emojis/index.html
+++ b/library/food-drink-emojis/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Food & Drink Emojis: Copy & Paste Food Symbols",
+  "alternateName": ["Food Emojis Copy and Paste", "Food and Drink Emoji List", "Food Emoji Copy Paste", "Drink Emojis", "Restaurant Emojis", "Food Symbols Copy and Paste", "Fruit and Vegetable Emojis"],
   "description": "Browse and copy food and drink emojis including fruits, vegetables, prepared foods, desserts, beverages, and kitchen tools. Click any emoji to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/football-emoji-copy-paste/index.html
+++ b/library/football-emoji-copy-paste/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Football Emoji Copy & Paste ⚽🏈",
+  "alternateName": ["Football Emoji Copy and Paste", "Soccer Emoji Copy and Paste", "Football Emojis", "Soccer Emoji", "Football Emoji Text", "American Football Emoji Copy Paste"],
   "description": "Copy and paste football emojis — soccer ⚽, American football 🏈, rugby 🏉, trophies 🏆, and match emojis. Click any emoji to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/football-symbols/index.html
+++ b/library/football-symbols/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Football Symbols & Combos ⚽🏆 Copy & Paste",
+  "alternateName": ["Football Symbols Copy and Paste", "Soccer Symbols", "Football Text Symbols", "Football Emoji Combos", "Soccer Text Symbols Copy Paste", "Football Signs"],
   "description": "Football and soccer symbols, trophies, goals, cards, and match combos — ⚽ 🥅 🏆 🟨 🟥 🥇 🐐. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/football-trophy-emoji/index.html
+++ b/library/football-trophy-emoji/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Football / World Cup Trophy Emoji 🏆 Copy & Paste",
+  "alternateName": ["Trophy Emoji Copy and Paste", "World Cup Trophy Emoji", "Football Trophy Emoji", "Champion Trophy Emoji", "Gold Trophy Copy Paste", "Winner Emoji Copy and Paste"],
   "description": "Copy and paste the football and World Cup trophy emoji 🏆 plus medals 🥇🥈🥉, crown 👑, and champion combos. Click any emoji to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/fortnite-symbols/index.html
+++ b/library/fortnite-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Fortnite Symbols: Copy & Paste ツ 亗 Sweaty Name Characters",
+  "alternateName": ["Fortnite Symbols Copy and Paste", "Sweaty Fortnite Symbols", "Fortnite Name Symbols", "Fortnite Text Symbols", "Fortnite Special Characters", "Cool Fortnite Symbols"],
   "description": "Sweaty Fortnite symbols — ツ 亗 乂 smiles, power kanji, clan-tag stars, and crosshair glyphs, plus ready-made sweaty name combos. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/fourth-of-july-symbols/index.html
+++ b/library/fourth-of-july-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "4th of July Symbols & Emojis: Copy & Paste 🇺🇸 🎆 Independence Day",
+  "alternateName": ["4th of July Symbols Copy and Paste", "Fourth of July Emojis", "Independence Day Symbols", "July 4th Emoji Copy Paste", "Patriotic Symbols Copy and Paste", "USA Independence Day Emojis"],
   "description": "4th of July symbols and emojis — US flags, fireworks, stars, and patriotic red-white-blue combos for Independence Day posts. Click any symbol to copy it.",
   "author": {
     "@type": "Organization",

--- a/library/fraction-symbols/index.html
+++ b/library/fraction-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Fraction Symbols: Copy & Paste ½ ⅓ ¼ Unicode Fractions",
+  "alternateName": ["Fraction Symbols Copy and Paste", "Unicode Fractions", "Half Symbol Copy Paste", "Math Fraction Signs", "Vulgar Fractions", "Fraction Characters"],
   "description": "Copy and paste Unicode fraction symbols — halves, thirds, quarters, eighths, fifths, and a build-your-own fraction set with superscript and subscript digits. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/france-emoji-combos/index.html
+++ b/library/france-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "France Emoji Combos 🇫🇷⚽ Copy & Paste",
+  "alternateName": ["France Emoji Copy and Paste", "France Flag Emoji Combos", "France Emojis", "France Emoji Combinations", "French Emoji Copy Paste", "Les Bleus Emojis"],
   "description": "France emoji combos 🇫🇷⚽ — Les Bleus colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/free-fire-name-symbols/index.html
+++ b/library/free-fire-name-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Free Fire Name Symbols: Copy & Paste ꧁꧂ ツ FF Nick Characters",
+  "alternateName": ["Free Fire Symbols Copy and Paste", "FF Name Symbols", "Free Fire Nick Symbols", "Garena Free Fire Name Characters", "FF Username Symbols", "Free Fire Special Characters", "Cool Symbols for Free Fire"],
   "description": "Free Fire name symbols — ornate ꧁꧂ frames, crowns, katakana flair, and ready-made FF nick wrappers for stylish nicknames. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/friendship-emojis/index.html
+++ b/library/friendship-emojis/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Friendship & Love Emojis: Copy & Paste 🫂 Bestie Combos",
+  "alternateName": ["Friendship Emojis Copy and Paste", "Best Friend Emojis", "BFF Emoji Copy Paste", "Bestie Emojis", "Friendship Emoji Combos", "Friend Emoji Copy and Paste"],
   "description": "Friendship emojis to copy and paste: 🫂 hugs, 👯 besties, yellow hearts, and bestie combo sets for bios, captions, and DMs. Click any emoji to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/funny-emoji-combos/index.html
+++ b/library/funny-emoji-combos/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Funny Emoji Combos: Copy & Paste Meme & Joke Emojis",
+  "alternateName": ["Funny Emoji Copy and Paste", "Meme Emoji Combos", "Joke Emoji Combinations", "Funny Emojis to Copy", "Hilarious Emoji Combos", "Comedy Emoji Copy Paste"],
   "description": "Funny emoji combos to copy and paste: clown moments 🤡, laughing faces 😂, monkey trios 🙈, and joke sets for any group chat. Click any emoji to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/gavi-emoji-combos/index.html
+++ b/library/gavi-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Gavi Emoji Combos 🇪🇸⚽🐐 Copy & Paste",
+  "alternateName": ["Gavi Emoji Copy and Paste", "Gavi Football Emojis", "Gavi Fan Emoji Combos", "Gavi Soccer Emojis", "Pedri Gavi Emoji"],
   "description": "Gavi emoji combos 🇪🇸⚽ — fan emoji sets for bios, captions, and comments. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/gender-symbols/index.html
+++ b/library/gender-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Gender Symbols: Copy & Paste ♂ ♀ ⚧ Male, Female & More",
+  "alternateName": ["Gender Symbols Copy and Paste", "Male Female Symbol Copy Paste", "Gender Signs", "Male Symbol Copy Paste", "Female Symbol Copy Paste", "Transgender Symbol", "Gender Text Symbols"],
   "description": "Copy and paste gender symbols — male, female, transgender, non-binary, neuter, and combined orientation signs. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/geometric-symbols/index.html
+++ b/library/geometric-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Geometric Symbols: Copy & Paste Circles, Diamonds & Shapes",
+  "alternateName": ["Geometric Symbols Copy and Paste", "Shape Symbols", "Geometric Shapes Copy Paste", "Circle Symbol Copy Paste", "Diamond Symbols", "Square Triangle Symbols", "Geometric Text Symbols"],
   "description": "Browse and copy geometric shape symbols — circles, diamonds, squares, triangles, and decorative shapes for formatting and design. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/germany-emoji-combos/index.html
+++ b/library/germany-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Germany Emoji Combos 🇩🇪⚽ Copy & Paste",
+  "alternateName": ["Germany Emoji Copy and Paste", "Germany Flag Emoji Combos", "Germany Emojis", "Germany Emoji Combinations", "German Emoji Copy Paste", "Deutschland Emojis"],
   "description": "Germany emoji combos 🇩🇪⚽ — Die Mannschaft colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/ghana-emoji-combos/index.html
+++ b/library/ghana-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Ghana Emoji Combos 🇬🇭⚽ Copy & Paste",
+  "alternateName": ["Ghana Emoji Copy and Paste", "Ghana Flag Emoji Combos", "Ghana Emojis", "Ghana Emoji Combinations", "Black Stars Emojis"],
   "description": "Ghana emoji combos 🇬🇭⚽ — Black Stars colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/goal-emoji-combos/index.html
+++ b/library/goal-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Goal Emoji ⚽🥅 Celebration Combos",
+  "alternateName": ["Goal Emoji Copy and Paste", "Football Goal Emojis", "Soccer Goal Emoji Combos", "Goal Celebration Emojis", "Goal Emoji Combinations"],
   "description": "Goal emoji combos ⚽🥅 — goal celebration sets for football captions and reactions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/goat-emoji-combos/index.html
+++ b/library/goat-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "GOAT Emoji Combos 🐐⚽🏆 Copy & Paste",
+  "alternateName": ["GOAT Emoji Copy and Paste", "Greatest of All Time Emojis", "GOAT Football Emojis", "GOAT Emoji Combinations", "Best Player Emoji Combos"],
   "description": "GOAT emoji combos 🐐⚽🏆 — greatest-of-all-time sets for football bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/goth-grunge-symbols/index.html
+++ b/library/goth-grunge-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Goth & Grunge Symbols Copy & Paste — Dark Aesthetic Bio Decorations",
+  "alternateName": ["Goth Symbols Copy and Paste", "Dark Aesthetic Symbols", "Grunge Symbols Copy Paste", "Dark Bio Symbols", "Gothic Symbols", "Emo Symbols Copy Paste", "Dark Aesthetic Text Symbols"],
   "description": "Dark aesthetic symbols for goth and grunge bios. Crosses, skulls, spiders, daggers, and alt fashion decorations for usernames and profiles.",
   "author": {
     "@type": "Organization",

--- a/library/greece-emoji-combos/index.html
+++ b/library/greece-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Greece Emoji Combos 🇬🇷⚽ Copy & Paste",
+  "alternateName": ["Greece Emoji Copy and Paste", "Greece Flag Emoji Combos", "Greece Emojis", "Greece Emoji Combinations", "Greek Emoji Copy Paste"],
   "description": "Greece emoji combos 🇬🇷⚽ — Galanolefki colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/greek-letter-symbols/index.html
+++ b/library/greek-letter-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Greek Letter Symbols: Copy & Paste α β Δ Σ Ω π Alphabet",
+  "alternateName": ["Greek Letters Copy and Paste", "Greek Alphabet Copy Paste", "Greek Symbols", "Greek Letter Copy Paste", "Alpha Beta Delta Symbols", "Greek Text Symbols", "Greek Characters Copy Paste"],
   "description": "Copy and paste every Greek letter — uppercase, lowercase, and math variant forms including alpha, beta, delta, sigma, omega, and pi. Click any letter to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/greeting-message-emojis/index.html
+++ b/library/greeting-message-emojis/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Greeting & Message Emojis: Copy & Paste Thank You Good Morning Combos",
+  "alternateName": ["Greeting Emojis Copy and Paste", "Good Morning Emojis", "Thank You Emojis Copy Paste", "Message Emoji Combos", "WhatsApp Greeting Emojis", "Congratulations Emojis Copy Paste"],
   "description": "Greeting emojis for good morning, thank you, sorry, and congratulations messages, with ready combo sets for WhatsApp chats. Click any emoji to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/griezmann-emoji-combos/index.html
+++ b/library/griezmann-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Griezmann Emoji Combos 🇫🇷⚽🐐 Copy & Paste",
+  "alternateName": ["Griezmann Emoji Copy and Paste", "Antoine Griezmann Emojis", "Griezmann Fan Emoji Combos", "Griezmann Football Emojis", "Griezmann Soccer Emojis"],
   "description": "Griezmann emoji combos 🇫🇷⚽ — fan emoji sets for bios, captions, and comments. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/haaland-emoji-combos/index.html
+++ b/library/haaland-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Haaland Emoji Combos 🇳🇴⚽🐐 Copy & Paste",
+  "alternateName": ["Haaland Emoji Copy and Paste", "Erling Haaland Emojis", "Haaland Fan Emoji Combos", "Haaland Football Emojis", "Haaland Soccer Emojis"],
   "description": "Haaland emoji combos 🇳🇴⚽ — fan emoji sets for bios, captions, and comments. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/halloween-symbols/index.html
+++ b/library/halloween-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Halloween Symbols: Copy & Paste 🎃 💀 🕸 Spooky Characters",
+  "alternateName": ["Halloween Symbols Copy and Paste", "Spooky Symbols Copy Paste", "Halloween Emojis", "Halloween Text Symbols", "Scary Symbols Copy Paste", "Spooky Emojis Copy and Paste"],
   "description": "Spooky Halloween symbols — pumpkins, ghosts, skulls, bats, spider webs, and trick-or-treat combo strings for October bios. Click any character to copy it.",
   "author": {
     "@type": "Organization",

--- a/library/hand-symbols/index.html
+++ b/library/hand-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Hand Symbols: Copy & Paste Hand Gesture Emojis",
+  "alternateName": ["Hand Symbols Copy and Paste", "Hand Gesture Emojis Copy Paste", "Hand Emojis", "Hand Signs Copy Paste", "Finger Symbols", "Pointing Hand Symbols"],
   "description": "Browse and copy hand gesture emojis — pointing, thumbs up, fist, open hand, and more. Click any hand symbol to copy it instantly for posts and messages.",
   "author": {
     "@type": "Organization",

--- a/library/happy-emoji/index.html
+++ b/library/happy-emoji/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Happy Emoji & Kaomoji: Copy & Paste 😊 Joy Combos",
+  "alternateName": ["Happy Emoji Copy and Paste", "Happy Face Emoji Copy Paste", "Joy Emojis", "Happy Kaomoji", "Smiling Emojis Copy Paste", "Happiness Emoji Combos"],
   "description": "Happy emoji 😊 😄 🥰, joyful kaomoji like ヽ(´▽`)/, and sunny combo sets to brighten bios, captions, and messages. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/hazard-warning-symbols/index.html
+++ b/library/hazard-warning-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Hazard & Warning Symbols: Copy & Paste ☢ ☣ ⚠ Danger Signs",
+  "alternateName": ["Warning Symbols Copy and Paste", "Hazard Symbols Copy Paste", "Danger Signs Copy Paste", "Warning Signs Symbols", "Radioactive Symbol Copy Paste", "Biohazard Symbol", "Warning Text Symbols"],
   "description": "Copy and paste hazard and warning symbols — radioactive, biohazard, warning triangle, high voltage, skull and crossbones, and alert marks. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/heart-symbols/index.html
+++ b/library/heart-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Heart Symbol Collection: Copy & Paste Heart Emojis & Characters",
+  "alternateName": ["Heart Symbol Copy and Paste", "Heart Emoji Copy Paste", "Love Symbols", "Heart Text Symbols", "Copy and Paste Hearts", "Heart Signs", "Heart Characters"],
   "description": "Browse and copy heart emojis and Unicode heart characters — red, colored, broken, and decorative hearts. Click any heart to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/hindi-symbols/index.html
+++ b/library/hindi-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Hindi Symbols: Copy & Paste ॐ Devanagari Characters",
+  "alternateName": ["Hindi Symbols Copy and Paste", "Devanagari Symbols Copy Paste", "Om Symbol Copy Paste", "Sanskrit Symbols", "Indian Symbols Copy Paste", "Hindi Characters Copy Paste"],
   "description": "Hindi symbols and Devanagari characters to copy and paste — ॐ, sacred words like शांति (peace), vowels, and digits. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/honduras-emoji-combos/index.html
+++ b/library/honduras-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Honduras Emoji Combos 🇭🇳⚽ Copy & Paste",
+  "alternateName": ["Honduras Emoji Copy and Paste", "Honduras Flag Emoji Combos", "Honduras Emojis", "Honduras Emoji Combinations", "Los Catrachos Emojis"],
   "description": "Honduras emoji combos 🇭🇳⚽ — Los Catrachos colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/html-entities/index.html
+++ b/library/html-entities/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "HTML Entities: Copy & Paste Symbol Codes for the Web",
+  "alternateName": ["HTML Entities Copy and Paste", "HTML Symbol Codes", "HTML Special Characters", "HTML Character Entities", "HTML Escape Codes", "HTML Symbols List", "Web Symbol Codes"],
   "description": "HTML entities reference — named codes like &, ©, and ♥ with the characters they produce, grouped by type. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/india-emoji-combos/index.html
+++ b/library/india-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "India Emoji Combos 🇮🇳⚽ Copy & Paste",
+  "alternateName": ["India Emoji Copy and Paste", "India Flag Emoji Combos", "India Emojis", "India Emoji Combinations", "Indian Emoji Copy Paste", "Indian Flag Emoji"],
   "description": "India emoji combos 🇮🇳⚽ — tricolour, lotus, and sport sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/instagram-symbols/index.html
+++ b/library/instagram-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Instagram Symbols: Copy & Paste Special Characters for IG",
+  "alternateName": ["Instagram Symbols Copy and Paste", "Symbols for Instagram Bio", "Instagram Bio Symbols", "Insta Symbols", "Instagram Text Symbols", "Instagram Special Characters", "IG Symbols"],
   "description": "Browse and copy Instagram symbols, bio characters, caption enhancers, and story decorators for IG. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/invisible-character/index.html
+++ b/library/invisible-character/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Invisible Character: Copy & Paste Blank Space & Invisible Text",
+  "alternateName": ["Invisible Text Copy Paste", "Blank Character", "Empty Character", "Invisible Letter", "Whitespace Character", "Blank Space Copy Paste", "Invisible Space"],
   "description": "Copy an invisible character or blank space — zero width space, Hangul filler, braille blank — for empty names and bios. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/ipa-phonetic-symbols/index.html
+++ b/library/ipa-phonetic-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "IPA Phonetic Symbols: Copy & Paste ə ʃ θ Pronunciation Characters",
+  "alternateName": ["IPA Symbols Copy and Paste", "Phonetic Alphabet Symbols", "IPA Characters", "International Phonetic Alphabet", "Phonetic Symbols Copy Paste", "IPA Letters"],
   "description": "Copy and paste IPA phonetic symbols — schwa ə, esh ʃ, theta θ, vowels, consonants, and stress marks with example sounds. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/iran-emoji-combos/index.html
+++ b/library/iran-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Iran Emoji Combos 🇮🇷⚽ Copy & Paste",
+  "alternateName": ["Iran Emoji Copy and Paste", "Iran Flag Emoji Combos", "Iran Emojis", "Iran Emoji Combinations", "Iranian Emoji Copy Paste", "Iran Flag Emoji"],
   "description": "Iran emoji combos 🇮🇷⚽ — Team Melli colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/ireland-emoji-combos/index.html
+++ b/library/ireland-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Ireland Emoji Combos 🇮🇪⚽ Copy & Paste",
+  "alternateName": ["Ireland Emoji Copy and Paste", "Ireland Flag Emoji Combos", "Ireland Emojis", "Ireland Emoji Combinations", "Irish Emoji Copy Paste", "Ireland Flag Emoji"],
   "description": "Ireland emoji combos 🇮🇪⚽ — Boys in Green colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/islamic-symbols/index.html
+++ b/library/islamic-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Islamic Symbols: Copy & Paste ☪ ﷲ ﷺ Muslim Faith Characters",
+  "alternateName": ["Islamic Symbols Copy and Paste", "Muslim Symbols", "Islam Symbols", "Arabic Religious Symbols", "Islamic Text Symbols", "Muslim Faith Symbols", "Crescent Moon Symbol"],
   "description": "Islamic symbols to copy and paste — the star and crescent, Allah and Bismillah ligatures, mosque and prayer emojis, and Eid greetings. Click any symbol to copy.",
   "author": {
     "@type": "Organization",

--- a/library/italy-emoji-combos/index.html
+++ b/library/italy-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Italy Emoji Combos 🇮🇹⚽ Copy & Paste",
+  "alternateName": ["Italy Emoji Copy and Paste", "Italy Flag Emoji Combos", "Italy Emojis", "Italy Emoji Combinations", "Italian Emoji Copy Paste", "Azzurri Emojis"],
   "description": "Italy emoji combos 🇮🇹⚽ — Azzurri colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/ivory-coast-emoji-combos/index.html
+++ b/library/ivory-coast-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Ivory Coast Emoji Combos 🇨🇮⚽ Copy & Paste",
+  "alternateName": ["Ivory Coast Emoji Copy and Paste", "Ivory Coast Flag Emoji Combos", "Ivory Coast Emojis", "Ivory Coast Emoji Combinations", "Cote d Ivoire Emoji", "Ivory Coast Flag Emoji"],
   "description": "Ivory Coast emoji combos 🇨🇮⚽ — Les Éléphants colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/jamaica-emoji-combos/index.html
+++ b/library/jamaica-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Jamaica Emoji Combos 🇯🇲⚽ Copy & Paste",
+  "alternateName": ["Jamaica Emoji Copy and Paste", "Jamaica Flag Emoji Combos", "Jamaica Emojis", "Jamaica Emoji Combinations", "Jamaican Emoji Copy Paste", "Jamaica Flag Emoji"],
   "description": "Jamaica emoji combos 🇯🇲⚽ — Reggae Boyz colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/japan-emoji-combos/index.html
+++ b/library/japan-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Japan Emoji Combos 🇯🇵⚽ Copy & Paste",
+  "alternateName": ["Japan Emoji Copy and Paste", "Japan Flag Emoji Combos", "Japan Emojis", "Japan Emoji Combinations", "Japanese Emoji Copy Paste", "Japan Flag Emoji"],
   "description": "Japan emoji combos 🇯🇵⚽ — Samurai Blue colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/japanese-symbols/index.html
+++ b/library/japanese-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Japanese Symbols: Copy & Paste 桜 愛 Kanji & Kana Characters",
+  "alternateName": ["Japanese Symbols Copy and Paste", "Kanji Symbols", "Japanese Text Symbols", "Japanese Characters Copy Paste", "Kanji Copy and Paste", "Japanese Letters", "Hiragana Katakana Symbols"],
   "description": "Japanese symbols to copy and paste — kanji like 桜 and 愛, hiragana, katakana, and punctuation with romaji meanings. Click any character to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/jewelry-gem-emojis/index.html
+++ b/library/jewelry-gem-emojis/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Jewelry & Gem Emojis: Copy & Paste 💎 💍 Bling Combos",
+  "alternateName": ["Jewelry Emoji Copy and Paste", "Gem Emoji Copy Paste", "Diamond Emoji Copy Paste", "Bling Emoji Combos", "Ring Emoji Copy Paste", "Jewel Emojis", "Luxury Emoji Copy Paste"],
   "description": "Copy and paste jewelry and gem emojis — diamonds 💎, rings 💍, crowns 👑, crystals 🔮, and sparkling bling combo sets for bios. Click any emoji to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/kane-emoji-combos/index.html
+++ b/library/kane-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Kane Emoji Combos 🏴󠁧󠁢󠁥󠁮󠁧󠁿⚽🐐 Copy & Paste",
+  "alternateName": ["Harry Kane Emoji Copy and Paste", "Kane Football Emojis", "Kane Fan Emoji Combos", "Harry Kane Soccer Emojis", "Kane Emoji Combinations", "Kane England Emojis"],
   "description": "Kane emoji combos 🏴󠁧󠁢󠁥󠁮󠁧󠁿⚽ — fan emoji sets for bios, captions, and comments. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/kawaii-cute-symbols/index.html
+++ b/library/kawaii-cute-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Kawaii Cute Symbols Copy & Paste — Soft Aesthetic Decorations",
+  "alternateName": ["Kawaii Symbols Copy and Paste", "Cute Symbols Copy Paste", "Kawaii Text Symbols", "Cute Aesthetic Symbols", "Soft Aesthetic Symbols", "Kawaii Decorations", "Cute Japanese Symbols"],
   "description": "Kawaii and cute symbols for bios, usernames, and messages. Soft hearts, tiny faces, sparkles, and pastel decorations from the kawaii aesthetic.",
   "author": {
     "@type": "Organization",

--- a/library/keyboard-symbols/index.html
+++ b/library/keyboard-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Keyboard Symbols: Copy & Paste ⌘ ⌥ ⇧ Mac & PC Key Glyphs",
+  "alternateName": ["Keyboard Symbols Copy and Paste", "Mac Keyboard Symbols", "PC Key Symbols", "Copy and Paste Keyboard Symbols", "Mac Modifier Key Symbols", "Keyboard Glyphs"],
   "description": "Copy and paste keyboard symbols — Mac modifier keys (⌘ ⌥ ⇧ ⌃), editing keys (⏎ ⌫ ⇥), and arrow and special key glyphs. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/korean-symbols/index.html
+++ b/library/korean-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Korean Symbols: Copy & Paste 사랑 Hangul Characters",
+  "alternateName": ["Korean Symbols Copy and Paste", "Hangul Characters", "Korean Text Symbols", "K-pop Symbols", "Korean Letters Copy Paste", "Korean Characters"],
   "description": "Korean symbols and Hangul to copy and paste — words like 사랑 (love), K-pop fan slang, jamo letters, and ㅋㅋㅋ text laughs. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/kvaratskhelia-emoji-combos/index.html
+++ b/library/kvaratskhelia-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Kvaratskhelia Emoji Combos 🇬🇪⚽🐐 Copy & Paste",
+  "alternateName": ["Kvaratskhelia Emojis Copy and Paste", "Khvicha Kvaratskhelia Emoji", "Kvaratskhelia Emoji Combinations", "Kvaratskhelia Emoji Copy Paste"],
   "description": "Kvaratskhelia emoji combos 🇬🇪⚽ — fan emoji sets for bios, captions, and comments. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/latex-symbols/index.html
+++ b/library/latex-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "LaTeX Symbols: Copy & Paste Math Notation & Commands",
+  "alternateName": ["LaTeX Symbols Copy and Paste", "LaTeX Math Symbols", "LaTeX Commands List", "LaTeX Greek Letters", "LaTeX Mathematical Notation", "Copy and Paste LaTeX Symbols"],
   "description": "Copy LaTeX math symbols with their commands — \\sum, \\alpha, \\infty, integrals, Greek letters, relations, and set notation. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/laughing-emoji/index.html
+++ b/library/laughing-emoji/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Laughing Emoji & Kaomoji: Copy & Paste 😂 LOL Combos",
+  "alternateName": ["Laughing Emoji Copy and Paste", "LOL Emoji", "Crying Laughing Emoji", "Funny Emoji Copy Paste", "Laughing Face Emoji", "LOL Kaomoji"],
   "description": "Grab laughing emoji 😂 🤣 💀, LOL kaomoji like (≧▽≦), and ready-made meme reaction combos for comments and group chats. Click any emoji to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/laundry-care-symbols/index.html
+++ b/library/laundry-care-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Laundry Care Symbols: Wash, Dry & Iron Symbol Meanings Chart",
+  "alternateName": ["Laundry Care Symbols Copy and Paste", "Washing Symbols Meaning", "Laundry Symbols Guide", "Clothing Care Symbols", "Wash and Care Symbols", "Laundry Icon Meanings"],
   "description": "Laundry care symbols and their meanings — wash, bleach, dry, and iron care icons in copy-paste Unicode. Click any symbol to copy it for labels, notes, and posts.",
   "author": {
     "@type": "Organization",

--- a/library/lautaro-martinez-emoji-combos/index.html
+++ b/library/lautaro-martinez-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Lautaro Martinez Emoji Combos 🇦🇷⚽🐐 Copy & Paste",
+  "alternateName": ["Lautaro Martinez Emojis Copy and Paste", "Lautaro Emoji", "Lautaro Martinez Emoji Combinations", "Lautaro Martinez Emoji Copy Paste"],
   "description": "Lautaro Martinez emoji combos 🇦🇷⚽ — fan emoji sets for bios, captions, and comments. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/lewandowski-emoji-combos/index.html
+++ b/library/lewandowski-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Lewandowski Emoji Combos 🇵🇱⚽🐐 Copy & Paste",
+  "alternateName": ["Lewandowski Emojis Copy and Paste", "Robert Lewandowski Emoji", "Lewandowski Emoji Combinations", "Lewandowski Emoji Copy Paste"],
   "description": "Lewandowski emoji combos 🇵🇱⚽ — fan emoji sets for bios, captions, and comments. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/line-divider-symbols/index.html
+++ b/library/line-divider-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Line Dividers & Separators: Copy & Paste Border Characters",
+  "alternateName": ["Line Dividers Copy and Paste", "Text Dividers Copy and Paste", "Separator Symbols", "Decorative Dividers", "Horizontal Line Symbols", "Line Separator Characters"],
   "description": "Browse and copy line divider and separator characters — horizontal lines, decorative dividers, ornamental separators, dashes, box-drawing characters, and pre-built divider combos. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/linkedin-comment-styling/index.html
+++ b/library/linkedin-comment-styling/index.html
@@ -42,6 +42,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "LinkedIn Comment Styling Techniques (With Examples)",
+  "alternateName": ["LinkedIn Comment Formatting", "How to Style LinkedIn Comments", "LinkedIn Bold Text Comments", "LinkedIn Comment Tips", "LinkedIn Unicode Formatting"],
   "description": "How to style any LinkedIn comment with professional Unicode formatting — authority comments, emphasis, line breaks, separators and structured blocks. Congratulations is just one use case.",
   "author": {
     "@type": "Organization",

--- a/library/linkedin-symbol-library/index.html
+++ b/library/linkedin-symbol-library/index.html
@@ -41,6 +41,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "LinkedIn Symbol Library: Copy & Paste Professional Arrows, Bullets, Numbers",
+  "alternateName": ["LinkedIn Symbols Copy and Paste", "LinkedIn Text Symbols", "LinkedIn Arrows and Bullets", "Symbols for LinkedIn Posts", "LinkedIn Unicode Symbols", "LinkedIn Special Characters"],
   "description": "A curated Unicode symbol library for LinkedIn. Click any arrow, bullet, number, or status indicator to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/loading-text-symbols/index.html
+++ b/library/loading-text-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Loading Text & Progress Bars: Copy & Paste ▓▒░ Blocks",
+  "alternateName": ["Loading Bar Copy and Paste", "Progress Bar Symbols", "Loading Text Aesthetic", "Loading Bar Emoji", "Loading Symbols Copy Paste", "Loading Bar Text Art"],
   "description": "Loading text and progress bars made of ▓▒░ blocks — fill sequences, buffering spinners, and Y2K loading captions for bios. Click any set to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/math-symbols/index.html
+++ b/library/math-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Math Symbols: Copy & Paste Mathematical Characters",
+  "alternateName": ["Math Symbols Copy and Paste", "Mathematical Symbols", "Math Signs", "Copy and Paste Math Symbols", "Mathematics Symbols", "Math Text Symbols"],
   "description": "Browse and copy math symbols including operators, Greek letters, set theory, calculus, and superscript characters. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/mbappe-emoji-combos/index.html
+++ b/library/mbappe-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Mbappe Emoji Combos 🇫🇷⚽🐐 Copy & Paste",
+  "alternateName": ["Mbappe Emojis Copy and Paste", "Kylian Mbappe Emoji", "Mbappe Emoji Combinations", "Mbappe Emoji Copy Paste"],
   "description": "Mbappe emoji combos 🇫🇷⚽⚡ — France, speed, and GOAT sets for fan bios. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/media-control-symbols/index.html
+++ b/library/media-control-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Media Control Symbols: Copy & Paste ▶ ⏸ ⏹ Play, Pause, Power",
+  "alternateName": ["Media Control Symbols Copy and Paste", "Play Pause Stop Symbols", "Media Button Symbols", "Player Control Icons", "Play Symbol Copy Paste", "Audio Control Symbols"],
   "description": "Copy and paste media control symbols — play, pause, stop, record, skip, fast-forward, eject, and power buttons. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/medical-symbols/index.html
+++ b/library/medical-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Medical Symbols: Copy & Paste ⚕ Caduceus, Rx & Health Signs",
+  "alternateName": ["Medical Symbols Copy and Paste", "Health Symbols", "Caduceus Symbol Copy Paste", "Pharmacy Symbols", "Medical Signs Text", "Healthcare Symbols"],
   "description": "Copy and paste medical symbols — the staff of Aesculapius, caduceus, prescription Rx mark, medical crosses, and health and emergency signs. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/meme-text-art/index.html
+++ b/library/meme-text-art/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Meme Text Art: Copy & Paste Dot Art & Copypasta Memes",
+  "alternateName": ["Meme Text Art Copy and Paste", "Text Memes", "Lenny Face Copy Paste", "Copypasta Memes", "Meme Faces Text Art", "ASCII Meme Art"],
   "description": "Meme text art to copy and paste — lenny face packs, table flips, disapproval looks, and original dot art reaction faces. Click any set to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/messi-emoji-combos/index.html
+++ b/library/messi-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Messi Emoji Combos 🇦🇷⚽🐐 Copy & Paste",
+  "alternateName": ["Messi Emojis Copy and Paste", "Lionel Messi Emoji", "Messi Emoji Combinations", "Messi Emoji Copy Paste"],
   "description": "Messi emoji combos 🇦🇷⚽🐐 — GOAT, Argentina, and Leo 10 sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/mexico-emoji-combos/index.html
+++ b/library/mexico-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Mexico Emoji Combos 🇲🇽⚽ Copy & Paste",
+  "alternateName": ["Mexico Emoji Copy and Paste", "Mexico Flag Emoji Combos", "Mexico Emojis", "Mexico Emoji Combinations"],
   "description": "Mexico emoji combos 🇲🇽⚽ — El Tri colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/minecraft-symbols/index.html
+++ b/library/minecraft-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Minecraft Symbols: Copy & Paste Chat & Server Name Characters",
+  "alternateName": ["Minecraft Symbols Copy and Paste", "Minecraft Text Symbols", "Minecraft Chat Symbols", "Minecraft Name Symbols", "Symbols for Minecraft", "Minecraft Special Characters"],
   "description": "Copy Minecraft symbols for chat, MOTDs, and server names — arrows, block shading ░▒▓, box-drawing lines, and game-style icons. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/ml-name-symbols/index.html
+++ b/library/ml-name-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Mobile Legends Name Symbols: Copy & Paste ꧁꧂ ML Nick Characters",
+  "alternateName": ["ML Name Symbols Copy and Paste", "Mobile Legends Symbols", "ML Nick Symbols", "Mobile Legends Name Decoration", "Symbols for ML Names", "ML Username Symbols"],
   "description": "Mobile Legends name symbols — rank letters for ᴳᵒᵈ tags, epic kanji, flourish dingbats, and one-click ML nick decorations. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/moai-emoji/index.html
+++ b/library/moai-emoji/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Moai Emoji: Copy & Paste 🗿 Rock Meme Combos",
+  "alternateName": ["Moai Emoji Copy and Paste", "Stone Emoji", "Rock Emoji Meme", "Moai Emoji Combos", "Deadpan Face Emoji", "Easter Island Emoji"],
   "description": "The moai emoji 🗿 plus deadpan faces, stone-faced kaomoji, and rock meme combos like 🗿 🍷 for dry replies and comments. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/modric-emoji-combos/index.html
+++ b/library/modric-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Modric Emoji Combos 🇭🇷⚽🐐 Copy & Paste",
+  "alternateName": ["Modric Emojis Copy and Paste", "Luka Modric Emoji", "Modric Emoji Combinations", "Modric Emoji Copy Paste"],
   "description": "Modric emoji combos 🇭🇷⚽ — fan emoji sets for bios, captions, and comments. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/money-emojis/index.html
+++ b/library/money-emojis/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Money Emojis: Copy & Paste 💰 💸 Cash & Rich Combos",
+  "alternateName": ["Money Emojis Copy and Paste", "Cash Emoji", "Rich Emoji Combos", "Money Bag Emoji Copy Paste", "Dollar Emoji", "Money Signs Emoji"],
   "description": "Copy and paste money emojis — 💰 money bag, 💸 flying cash, 🤑 money face — plus rich-aesthetic bio combos and hustle captions. Tap any emoji to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/moon-celestial-symbols/index.html
+++ b/library/moon-celestial-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Moon & Celestial Symbols Copy & Paste — Moon Phases, Stars & Suns",
+  "alternateName": ["Moon Symbols Copy and Paste", "Moon Phase Symbols", "Celestial Symbols", "Star and Moon Symbols", "Moon Emoji Copy Paste", "Night Sky Symbols"],
   "description": "Moon, sun, and celestial symbols for dreamy and cosmic aesthetic bios. Copy & paste moon phases, star symbols, and night-sky decorations.",
   "author": {
     "@type": "Organization",

--- a/library/morocco-emoji-combos/index.html
+++ b/library/morocco-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Morocco Emoji Combos 🇲🇦⚽ Copy & Paste",
+  "alternateName": ["Morocco Emoji Copy and Paste", "Morocco Flag Emoji Combos", "Morocco Emojis", "Morocco Emoji Combinations"],
   "description": "Morocco emoji combos 🇲🇦⚽ — Atlas Lions colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/movie-night-emojis/index.html
+++ b/library/movie-night-emojis/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Movie Night Emojis: Copy & Paste 🍿 🎬 Film Combos",
+  "alternateName": ["Movie Emojis Copy and Paste", "Film Emoji Combos", "Cinema Emojis", "Movie Night Emoji Copy Paste", "Popcorn Emoji Combos", "Movie Emoji"],
   "description": "Copy and paste movie night emojis — 🍿 popcorn, 🎬 clapper, 📺 TV — plus film combo sets for Letterboxd bios and watch parties. Click any emoji to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/musiala-emoji-combos/index.html
+++ b/library/musiala-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Musiala Emoji Combos 🇩🇪⚽🐐 Copy & Paste",
+  "alternateName": ["Musiala Emojis Copy and Paste", "Jamal Musiala Emoji", "Musiala Emoji Combinations", "Musiala Emoji Copy Paste"],
   "description": "Musiala emoji combos 🇩🇪⚽ — fan emoji sets for bios, captions, and comments. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/music-symbols/index.html
+++ b/library/music-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Music Note Symbols: Copy & Paste Musical Notes & Signs",
+  "alternateName": ["Music Note Symbols Copy and Paste", "Musical Notes Copy Paste", "Music Symbols Text", "Copy and Paste Music Notes", "Music Signs", "Music Emoji and Symbols"],
   "description": "Browse and copy music note symbols, clefs, accidentals, and instrument emojis. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/nature-emojis/index.html
+++ b/library/nature-emojis/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Nature Emojis: Copy & Paste 🌿 🍄 🌊 Forest & Outdoor Combos",
+  "alternateName": ["Nature Emojis Copy and Paste", "Nature Emoji Combos", "Plant Emojis", "Forest Emojis", "Outdoor Emoji Copy Paste", "Nature Aesthetic Emojis"],
   "description": "Copy and paste nature emojis — 🌳 trees, 🌿 leaves, 🍄 mushrooms, 🌊 waves — plus forest and outdoor combos for earthy bios. Click any emoji to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/nerd-emoji/index.html
+++ b/library/nerd-emoji/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Nerd Emoji: Copy & Paste 🤓 Nerd Face Meme Combos",
+  "alternateName": ["Nerd Emoji Copy and Paste", "Nerd Face Emoji", "Nerd Emoji Combos", "Glasses Emoji", "Nerd Meme Emoji", "Copy and Paste Nerd Emoji"],
   "description": "The 🤓 nerd emoji plus erm-actually ☝ meme combos, study and science emojis, and glasses kaomoji like (⌐■_■) for replies. Click any emoji to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/netherlands-emoji-combos/index.html
+++ b/library/netherlands-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Netherlands Emoji Combos 🇳🇱⚽ Copy & Paste",
+  "alternateName": ["Netherlands Emoji Copy and Paste", "Netherlands Flag Emoji Combos", "Netherlands Emojis", "Netherlands Emoji Combinations", "Holland Emoji Combos", "Dutch Emoji Copy Paste"],
   "description": "Netherlands emoji combos 🇳🇱⚽ — Oranje colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/new-zealand-emoji-combos/index.html
+++ b/library/new-zealand-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "New Zealand Emoji Combos 🇳🇿⚽ Copy & Paste",
+  "alternateName": ["New Zealand Emoji Copy and Paste", "New Zealand Flag Emoji Combos", "New Zealand Emojis", "New Zealand Emoji Combinations", "NZ Emoji Combos", "New Zealand Football Emojis"],
   "description": "New Zealand emoji combos 🇳🇿⚽ — All Whites colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/neymar-emoji-combos/index.html
+++ b/library/neymar-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Neymar Emoji Combos 🇧🇷⚽🐐 Copy & Paste",
+  "alternateName": ["Neymar Emojis Copy and Paste", "Neymar Jr Emoji", "Neymar Emoji Combinations", "Neymar Emoji Copy Paste", "Neymar Jr Emoji Combos"],
   "description": "Neymar emoji combos 🇧🇷⚽ — Brazil, Joga Bonito, and number 10 sets for fan bios. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/nickname-symbols/index.html
+++ b/library/nickname-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Nickname Symbols: Copy & Paste ꧁꧂ Stylish Nick Decorations",
+  "alternateName": ["Nickname Symbols Copy and Paste", "Name Symbols", "Symbols for Names", "Cool Nickname Symbols", "Username Symbols", "Stylish Nick Symbols"],
   "description": "Nickname symbols and ready-made nick decorations — ꧁꧂ wings, ツ smileys, ♛ crowns, and 亗 pro tags for any game or app. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/nigeria-emoji-combos/index.html
+++ b/library/nigeria-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Nigeria Emoji Combos 🇳🇬⚽ Copy & Paste",
+  "alternateName": ["Nigeria Emoji Copy and Paste", "Nigeria Flag Emoji Combos", "Nigeria Emojis", "Nigeria Emoji Combinations", "Super Eagles Emoji Combos"],
   "description": "Nigeria emoji combos 🇳🇬⚽ — Super Eagles colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/nkunku-emoji-combos/index.html
+++ b/library/nkunku-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Nkunku Emoji Combos 🇫🇷⚽🐐 Copy & Paste",
+  "alternateName": ["Nkunku Emojis Copy and Paste", "Christopher Nkunku Emoji", "Nkunku Emoji Combinations", "Nkunku Emoji Copy Paste", "Nkunku Football Emojis"],
   "description": "Nkunku emoji combos 🇫🇷⚽ — fan emoji sets for bios, captions, and comments. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/norse-viking-runes/index.html
+++ b/library/norse-viking-runes/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Norse &amp; Viking Runes: Copy &amp; Paste All Runic Characters",
+  "alternateName": ["Viking Runes Copy and Paste", "Norse Runes", "Elder Futhark Runes", "Runic Symbols Copy Paste", "Viking Symbols", "Norse Runic Alphabet"],
   "description": "Browse and copy all runic characters — Elder Futhark, Younger Futhark, Anglo-Saxon Futhorc, and medieval runes. Click any rune to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/norway-emoji-combos/index.html
+++ b/library/norway-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Norway Emoji Combos 🇳🇴⚽ Copy & Paste",
+  "alternateName": ["Norway Emoji Copy and Paste", "Norway Flag Emoji Combos", "Norway Emojis", "Norway Emoji Combinations", "Norwegian Emoji Combos"],
   "description": "Norway emoji combos 🇳🇴⚽ — Lions colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/number-symbols/index.html
+++ b/library/number-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Number & Numeral Symbols: Circled, Superscript & Roman Numerals",
+  "alternateName": ["Number Symbols Copy and Paste", "Numeral Symbols", "Circled Numbers Copy Paste", "Roman Numeral Symbols", "Superscript Numbers", "Number Text Symbols"],
   "description": "Browse and copy number symbols — circled numbers, negative circled, superscript, subscript, Roman numerals, and parenthesized numbers. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/object-emojis/index.html
+++ b/library/object-emojis/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Object Emojis: Copy & Paste 📌 📷 🔒 Everyday Item Emojis",
+  "alternateName": ["Object Emojis Copy and Paste", "Everyday Item Emojis", "Objects Emoji List", "Copy and Paste Object Emojis", "Household Emojis", "Object Emoji Symbols"],
   "description": "Browse object emojis for everyday items — pins 📌, cameras 📷, locks 🔒, keys, candles, trophies, and household things. Click any emoji to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/osimhen-emoji-combos/index.html
+++ b/library/osimhen-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Osimhen Emoji Combos 🇳🇬⚽🐐 Copy & Paste",
+  "alternateName": ["Osimhen Emojis Copy and Paste", "Victor Osimhen Emoji", "Osimhen Emoji Combinations", "Osimhen Fan Emojis", "Osimhen Nigeria Emoji"],
   "description": "Osimhen emoji combos 🇳🇬⚽ — fan emoji sets for bios, captions, and comments. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/panama-emoji-combos/index.html
+++ b/library/panama-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Panama Emoji Combos 🇵🇦⚽ Copy & Paste",
+  "alternateName": ["Panama Emoji Copy and Paste", "Panama Flag Emoji Combos", "Panama Emojis", "Panama Emoji Combinations", "Panama Football Emojis"],
   "description": "Panama emoji combos 🇵🇦⚽ — La Marea Roja colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/paraguay-emoji-combos/index.html
+++ b/library/paraguay-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Paraguay Emoji Combos 🇵🇾⚽ Copy & Paste",
+  "alternateName": ["Paraguay Emoji Copy and Paste", "Paraguay Flag Emoji Combos", "Paraguay Emojis", "Paraguay Emoji Combinations", "Paraguay Football Emojis"],
   "description": "Paraguay emoji combos 🇵🇾⚽ — La Albirroja colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/party-celebration-emojis/index.html
+++ b/library/party-celebration-emojis/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Party & Celebration Emojis: Copy & Paste 🎉 Confetti Combos",
+  "alternateName": ["Party Emojis Copy and Paste", "Celebration Emojis", "Confetti Emoji Copy Paste", "Party Emoji Combos", "Birthday Party Emojis", "Celebration Emoji Symbols"],
   "description": "Party emojis to copy and paste: 🎉 confetti, 🥳 partying face, balloons, fireworks, toasts, and celebration combo sets. Click any emoji to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/peace-symbol/index.html
+++ b/library/peace-symbol/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Peace Symbol: Copy & Paste ☮ Peace Sign & Dove Characters",
+  "alternateName": ["Peace Symbol Copy and Paste", "Peace Sign Symbol", "Peace Sign Text", "Peace Symbols", "Copy and Paste Peace Sign", "Peace Sign Copy Paste"],
   "description": "Copy and paste the peace symbol (☮) plus peace-sign gestures, doves, olive branches, and harmony characters. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/pedri-emoji-combos/index.html
+++ b/library/pedri-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Pedri Emoji Combos 🇪🇸⚽🐐 Copy & Paste",
+  "alternateName": ["Pedri Emojis Copy and Paste", "Pedri Gonzalez Emoji", "Pedri Emoji Combinations", "Pedri Fan Emojis", "Pedri Barcelona Emoji"],
   "description": "Pedri emoji combos 🇪🇸⚽ — fan emoji sets for bios, captions, and comments. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/people-profession-emojis/index.html
+++ b/library/people-profession-emojis/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "People & Profession Emojis: Copy & Paste Job & Person Symbols",
+  "alternateName": ["People Emojis Copy and Paste", "Profession Emojis", "Job Emojis Copy Paste", "Person Emoji Symbols", "Worker Emojis", "Occupation Emojis Copy and Paste"],
   "description": "Browse and copy people and profession emojis — healthcare, technology, education, business, creative arts, and science. Click any emoji to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/peru-emoji-combos/index.html
+++ b/library/peru-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Peru Emoji Combos 🇵🇪⚽ Copy & Paste",
+  "alternateName": ["Peru Emoji Copy and Paste", "Peru Flag Emoji Combos", "Peru Emojis", "Peru Emoji Combinations", "Peru Football Emojis"],
   "description": "Peru emoji combos 🇵🇪⚽ — La Blanquirroja colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/poland-emoji-combos/index.html
+++ b/library/poland-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Poland Emoji Combos 🇵🇱⚽ Copy & Paste",
+  "alternateName": ["Poland Emoji Copy and Paste", "Poland Flag Emoji Combos", "Poland Emojis", "Poland Emoji Combinations", "Poland Football Emojis"],
   "description": "Poland emoji combos 🇵🇱⚽ — Bialo-Czerwoni colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/poop-emoji/index.html
+++ b/library/poop-emoji/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Poop Emoji: Copy & Paste 💩 Funny Combos",
+  "alternateName": ["Poop Emoji Copy and Paste", "Pile of Poo Emoji", "Poo Emoji", "Smiling Poop Emoji", "Poop Emoji Copy Paste", "Funny Poop Emojis"],
   "description": "The poop emoji 💩 with toilets, stink clouds, gross-out faces, and funny meme combos for jokes, pranks, and silly group chats. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/portugal-emoji-combos/index.html
+++ b/library/portugal-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Portugal Emoji Combos 🇵🇹⚽ Copy & Paste",
+  "alternateName": ["Portugal Emoji Copy and Paste", "Portugal Flag Emoji Combos", "Portugal Emojis", "Portugal Emoji Combinations", "Portugal Football Emojis"],
   "description": "Portugal emoji combos 🇵🇹⚽ — Selecao colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/preppy-emoji-combos/index.html
+++ b/library/preppy-emoji-combos/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Preppy Emoji Combos: Copy & Paste Pink Bow Smiley Themes",
+  "alternateName": ["Preppy Emoji Copy and Paste", "Preppy Emoji Combinations", "Preppy Bio Emojis", "Pink Bow Emoji Combos", "Aesthetic Preppy Emojis", "Preppy Emoji Sets"],
   "description": "Preppy emoji combos with pink hearts 🩷, bows 🎀, lightning bolts ⚡, smileys, and beachy themes for bright bios. Click any combo or symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/punctuation-symbols/index.html
+++ b/library/punctuation-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Punctuation Symbols: Copy & Paste † ‡ ¶ ※ ‽ Special Marks",
+  "alternateName": ["Punctuation Symbols Copy and Paste", "Special Punctuation Marks", "Punctuation Signs Copy Paste", "Text Punctuation Symbols", "Dagger Symbol Copy and Paste", "Special Marks Symbols"],
   "description": "Copy and paste special punctuation symbols — dagger, double dagger, pilcrow, section sign, asterism, interrobang, and inverted marks. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/qatar-emoji-combos/index.html
+++ b/library/qatar-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Qatar Emoji Combos 🇶🇦⚽ Copy & Paste",
+  "alternateName": ["Qatar Emoji Copy and Paste", "Qatar Flag Emoji Combos", "Qatar Emojis", "Qatar Emoji Combinations", "Qatar Football Emojis"],
   "description": "Qatar emoji combos 🇶🇦⚽ — Al-Annabi colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/rashford-emoji-combos/index.html
+++ b/library/rashford-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Rashford Emoji Combos 🏴󠁧󠁢󠁥󠁮󠁧󠁿⚽🐐 Copy & Paste",
+  "alternateName": ["Rashford Emojis Copy and Paste", "Marcus Rashford Emoji", "Rashford Emoji Combinations", "Rashford Fan Emojis", "Rashford Manchester United Emoji"],
   "description": "Rashford emoji combos 🏴󠁧󠁢󠁥󠁮󠁧󠁿⚽ — fan emoji sets for bios, captions, and comments. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/recycle-environment-symbols/index.html
+++ b/library/recycle-environment-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Recycle Symbols: Copy & Paste ♻ ♲ Recycling & Eco Signs",
+  "alternateName": ["Recycle Symbol Copy and Paste", "Recycling Symbol Text", "Eco Symbols Copy Paste", "Recycle Sign Copy and Paste", "Environment Symbols", "Recycling Signs Copy Paste"],
   "description": "Copy and paste recycle symbols — the universal recycling sign (♻), plastic resin codes (♳–♹), and eco and environment glyphs. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/religious-symbols/index.html
+++ b/library/religious-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Religious Symbols: Copy & Paste Faith & Spiritual Symbols",
+  "alternateName": ["Religious Symbols Copy and Paste", "Faith Symbols Copy Paste", "Spiritual Symbols", "Religion Symbols Text", "Sacred Symbols Copy and Paste", "World Religion Symbols"],
   "description": "Browse and copy religious and spiritual symbols — crosses, crescents, stars of David, dharma wheels, and more. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/roblox-symbols/index.html
+++ b/library/roblox-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Roblox Symbols Copy & Paste — Display Name & Bio Decorations",
+  "alternateName": ["Roblox Symbols Copy and Paste", "Symbols for Roblox", "Roblox Name Symbols", "Roblox Text Symbols", "Roblox Username Symbols", "Roblox Bio Symbols"],
   "description": "Symbols for Roblox display names, bios, and groups. Aesthetic decorations that work with Roblox's name validator — copy & paste characters that don't get blocked.",
   "author": {
     "@type": "Organization",

--- a/library/roblox-text-art/index.html
+++ b/library/roblox-text-art/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Roblox Text Art: Copy & Paste Man Face & Character Dot Art",
+  "alternateName": ["Roblox Text Art Copy and Paste", "Roblox ASCII Art", "Roblox Man Face Text Art", "Roblox Chat Art", "Roblox Dot Art Copy Paste", "Roblox Text Characters"],
   "description": "Roblox text art for chat and bios — man face style dot art, blocky smiles, emote one-liners, and GG banners. Click any piece to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/rodri-emoji-combos/index.html
+++ b/library/rodri-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Rodri Emoji Combos 🇪🇸⚽🐐 Copy & Paste",
+  "alternateName": ["Rodri Emojis Copy and Paste", "Rodri Hernandez Emoji", "Rodri Emoji Combinations", "Rodri Fan Emojis", "Rodri Manchester City Emoji"],
   "description": "Rodri emoji combos 🇪🇸⚽ — fan emoji sets for bios, captions, and comments. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/rodrygo-emoji-combos/index.html
+++ b/library/rodrygo-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Rodrygo Emoji Combos 🇧🇷⚽🐐 Copy & Paste",
+  "alternateName": ["Rodrygo Emojis Copy and Paste", "Rodrygo Goes Emoji", "Rodrygo Emoji Combinations", "Rodrygo Fan Emojis", "Rodrygo Real Madrid Emoji"],
   "description": "Rodrygo emoji combos 🇧🇷⚽ — fan emoji sets for bios, captions, and comments. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/ronaldo-emoji-combos/index.html
+++ b/library/ronaldo-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Ronaldo Emoji Combos 🇵🇹⚽🐐 Copy & Paste",
+  "alternateName": ["Ronaldo Emojis Copy and Paste", "Cristiano Ronaldo Emoji", "CR7 Emoji Combos", "Ronaldo Emoji Combinations", "Ronaldo Fan Emojis", "CR7 Emoji Copy and Paste"],
   "description": "Ronaldo emoji combos 🇵🇹⚽🐐 — CR7, GOAT, and Siuuu sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/sad-emoji/index.html
+++ b/library/sad-emoji/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Sad Emoji & Kaomoji: Copy & Paste 😢 Sad Face Combos",
+  "alternateName": ["Sad Emoji Copy and Paste", "Sad Face Emoji", "Crying Emoji Copy Paste", "Sad Emojis List", "Sad Kaomoji Copy and Paste", "Depressed Emoji Combos"],
   "description": "Sad emoji 😢 😔 for melancholy bios and captions, heartbroken 💔 combo sets, and down-mood kaomoji like (μ_μ) in one library. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/saka-emoji-combos/index.html
+++ b/library/saka-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Saka Emoji Combos 🏴󠁧󠁢󠁥󠁮󠁧󠁿⚽🐐 Copy & Paste",
+  "alternateName": ["Saka Emojis Copy and Paste", "Bukayo Saka Emoji", "Saka Emoji Combinations", "Saka Fan Emojis", "Saka Arsenal Emoji"],
   "description": "Saka emoji combos 🏴󠁧󠁢󠁥󠁮󠁧󠁿⚽ — fan emoji sets for bios, captions, and comments. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/salah-emoji-combos/index.html
+++ b/library/salah-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Salah Emoji Combos 🇪🇬⚽🐐 Copy & Paste",
+  "alternateName": ["Salah Emojis Copy and Paste", "Mohamed Salah Emoji", "Salah Emoji Combinations", "Salah Fan Emojis", "Salah Liverpool Emoji"],
   "description": "Salah emoji combos 🇪🇬⚽ — fan emoji sets for bios, captions, and comments. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/saudi-arabia-emoji-combos/index.html
+++ b/library/saudi-arabia-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Saudi Arabia Emoji Combos 🇸🇦⚽ Copy & Paste",
+  "alternateName": ["Saudi Arabia Emoji Copy and Paste", "Saudi Arabia Flag Emoji Combos", "Saudi Arabia Emojis", "Saudi Arabia Emoji Combinations", "Saudi Football Emojis"],
   "description": "Saudi Arabia emoji combos 🇸🇦⚽ — Green Falcons colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/school-education-emojis/index.html
+++ b/library/school-education-emojis/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "School & Education Emojis: Copy & Paste 🎓 📚 Study Combos",
+  "alternateName": ["School Emojis Copy and Paste", "Education Emojis", "Study Emojis Copy Paste", "Back to School Emojis", "Graduation Emoji Copy and Paste", "School Emoji Combos"],
   "description": "Copy and paste school emojis — 🎓 graduation cap, 📚 books, ✏️ pencil — with study-bio combos for back-to-school posts. Click any emoji to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/scotland-emoji-combos/index.html
+++ b/library/scotland-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Scotland Emoji Combos 🏴󠁧󠁢󠁳󠁣󠁴󠁿⚽ Copy & Paste",
+  "alternateName": ["Scotland Emoji Copy and Paste", "Scotland Flag Emoji Combos", "Scotland Emojis", "Scotland Emoji Combinations", "Scotland Football Emojis"],
   "description": "Scotland emoji combos 🏴󠁧󠁢󠁳󠁣󠁴󠁿⚽ — Tartan Army colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/seasonal-emoji-combos/index.html
+++ b/library/seasonal-emoji-combos/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Seasonal Emoji Combos: Copy & Paste Summer Fall Spring Winter",
+  "alternateName": ["Seasonal Emoji Copy and Paste", "Season Emoji Combos", "Summer Emoji Combos", "Winter Emoji Combos", "Fall Autumn Emoji Combos", "Spring Emoji Combinations"],
   "description": "Seasonal emoji combos for every time of year — summer ☀️🌊, fall 🍂🎃, winter ❄️☃️, and spring 🌸🐝 aesthetic sets. Click any symbol or set to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/senegal-emoji-combos/index.html
+++ b/library/senegal-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Senegal Emoji Combos 🇸🇳⚽ Copy & Paste",
+  "alternateName": ["Senegal Emoji Copy and Paste", "Senegal Flag Emoji Combos", "Senegal Emojis", "Senegal Emoji Combinations", "Senegal Football Emojis"],
   "description": "Senegal emoji combos 🇸🇳⚽ — Lions of Teranga colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/serbia-emoji-combos/index.html
+++ b/library/serbia-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Serbia Emoji Combos 🇷🇸⚽ Copy & Paste",
+  "alternateName": ["Serbia Emoji Copy and Paste", "Serbia Flag Emoji Combos", "Serbia Emojis", "Serbia Emoji Combinations", "Serbia Football Emojis"],
   "description": "Serbia emoji combos 🇷🇸⚽ — Orlovi colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/shocked-emoji/index.html
+++ b/library/shocked-emoji/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Shocked Emoji & Kaomoji: Copy & Paste 😱 Surprise Combos",
+  "alternateName": ["Shocked Emoji Copy and Paste", "Surprised Emoji", "Shock Emoji", "Surprised Face Emoji", "Jaw Drop Emoji", "Shocked Emoji Combos"],
   "description": "Shocked emoji 😱 😲 🤯, surprised kaomoji like (⊙_⊙), and plot-twist combo sets for jaw-drop reactions and replies. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/side-eye-emoji/index.html
+++ b/library/side-eye-emoji/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Side Eye Emoji & Kaomoji: Copy & Paste 👀 Judging Combos",
+  "alternateName": ["Side Eye Emoji Copy and Paste", "Side-Eye Emoji", "Judging Emoji", "Suspicion Emoji", "Side Eye Emoji Combos", "Side Eye Kaomoji"],
   "description": "Copy and paste side eye emojis like 👀 😒 🤨, judging kaomoji such as ಠ_ಠ, and caught-in-4K combo sets for memes and replies. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/slash-backslash-symbols/index.html
+++ b/library/slash-backslash-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Slash &amp; Backslash Symbols: Copy &amp; Paste All Slash Characters",
+  "alternateName": ["Slash Symbol Copy and Paste", "Backslash Symbol", "Forward Slash Symbols", "Slash Characters", "Slash and Backslash Copy Paste", "Slash Text Symbols"],
   "description": "Browse and copy every slash and backslash character — forward slashes, backslash variants, fraction slashes, and division symbols. Click any to copy.",
   "author": {
     "@type": "Organization",

--- a/library/smiley-face-guide/index.html
+++ b/library/smiley-face-guide/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Smiley Face Guide: Emoji Meanings & When to Use Them",
+  "alternateName": ["Smiley Face Emoji Meanings", "Smiley Emoji Guide", "Smiley Face Emojis", "Happy Face Emoji Meanings", "Smiley Emoji List", "Smiley Face Emoji Copy and Paste"],
   "description": "Understand what each smiley face emoji means and when to use it. A practical reference for choosing the right face emoji for every situation.",
   "author": {
     "@type": "Organization",

--- a/library/soccer-emoji-copy-paste/index.html
+++ b/library/soccer-emoji-copy-paste/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Soccer Emoji ⚽ Copy & Paste List",
+  "alternateName": ["Soccer Emoji Copy and Paste", "Football Emoji Copy Paste", "Soccer Ball Emoji", "Soccer Emojis", "Football Emojis Copy and Paste", "Soccer Emoji List"],
   "description": "Copy and paste every soccer emoji — ⚽ ball, 🥅 goal, 🧤 gloves, 🏆 trophy, plus cards and celebration emojis. Click any emoji to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/son-emoji-combos/index.html
+++ b/library/son-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Son Emoji Combos 🇰🇷⚽🐐 Copy & Paste",
+  "alternateName": ["Son Emojis Copy and Paste", "Son Heung-min Emoji", "Son Emoji Combinations", "Sonny Emoji Combos", "Son Spurs Emoji"],
   "description": "Son emoji combos 🇰🇷⚽ — fan emoji sets for bios, captions, and comments. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/south-africa-emoji-combos/index.html
+++ b/library/south-africa-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "South Africa Emoji Combos 🇿🇦⚽ Copy & Paste",
+  "alternateName": ["South Africa Emoji Copy and Paste", "South Africa Flag Emoji Combos", "South Africa Emojis", "South Africa Emoji Combinations", "South Africa Football Emojis"],
   "description": "South Africa emoji combos 🇿🇦⚽ — Bafana Bafana colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/south-korea-emoji-combos/index.html
+++ b/library/south-korea-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "South Korea Emoji Combos 🇰🇷⚽ Copy & Paste",
+  "alternateName": ["South Korea Emoji Copy and Paste", "South Korea Flag Emoji Combos", "South Korea Emojis", "South Korea Emoji Combinations", "Korea Football Emojis"],
   "description": "South Korea emoji combos 🇰🇷⚽ — Taeguk Warriors colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/spain-emoji-combos/index.html
+++ b/library/spain-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Spain Emoji Combos 🇪🇸⚽ Copy & Paste",
+  "alternateName": ["Spain Emoji Copy and Paste", "Spain Flag Emoji Combos", "Spain Emojis", "Spain Emoji Combinations", "Spanish Football Emoji"],
   "description": "Spain emoji combos 🇪🇸⚽ — La Roja colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/sparkle-symbols/index.html
+++ b/library/sparkle-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Sparkle Symbols & Emoji ✨ — Sparkles Copy & Paste",
+  "alternateName": ["Sparkle Symbol Copy and Paste", "Sparkles Copy and Paste", "Glitter Symbols", "Aesthetic Sparkle Characters", "Sparkle Emoji Copy Paste", "Sparkle Text Symbols"],
   "description": "Browse and copy sparkle symbols, glitter characters, and aesthetic decorators for bios, captions, and text styling. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/special-characters/index.html
+++ b/library/special-characters/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Special Characters: Copy & Paste Unique Unicode Symbols",
+  "alternateName": ["Special Characters Copy and Paste", "Unicode Special Characters", "Copy and Paste Special Symbols", "Special Symbols List", "Unique Unicode Characters", "Special Text Characters"],
   "description": "Browse and copy unique special characters — infinity, peace, OK hand, and meaningful standalone Unicode symbols for bios and text. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/sports-emojis/index.html
+++ b/library/sports-emojis/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Sports & Activity Emojis: Copy & Paste Athletic Symbols",
+  "alternateName": ["Sports Emoji Copy and Paste", "Athletic Emojis", "Sports Symbols Copy Paste", "Activity Emojis", "Sports Emoji List", "Copy and Paste Sports Emojis"],
   "description": "Browse and copy sports and activity emojis — ball sports, racket sports, water and winter sports, fitness, outdoor adventure, and medals. Click any emoji to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/star-symbols/index.html
+++ b/library/star-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Star Symbol Collection: Copy & Paste Star Characters & Emojis",
+  "alternateName": ["Star Symbol Copy and Paste", "Star Emoji Copy Paste", "Star Text Symbols", "Copy and Paste Stars", "Star Signs", "Star Characters"],
   "description": "Browse and copy star symbols and emojis — basic stars, multi-pointed stars, asterisks, sparkles, and glitter. Click any star to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/suarez-emoji-combos/index.html
+++ b/library/suarez-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Suarez Emoji Combos 🇺🇾⚽🐐 Copy & Paste",
+  "alternateName": ["Suarez Emojis Copy and Paste", "Luis Suarez Emoji", "Suarez Emoji Combinations", "Suarez Football Emoji"],
   "description": "Suarez emoji combos 🇺🇾⚽ — fan emoji sets for bios, captions, and comments. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/sweden-emoji-combos/index.html
+++ b/library/sweden-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Sweden Emoji Combos 🇸🇪⚽ Copy & Paste",
+  "alternateName": ["Sweden Emoji Copy and Paste", "Sweden Flag Emoji Combos", "Sweden Emojis", "Sweden Emoji Combinations", "Swedish Football Emoji"],
   "description": "Sweden emoji combos 🇸🇪⚽ — Blagult colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/switzerland-emoji-combos/index.html
+++ b/library/switzerland-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Switzerland Emoji Combos 🇨🇭⚽ Copy & Paste",
+  "alternateName": ["Switzerland Emoji Copy and Paste", "Switzerland Flag Emoji Combos", "Switzerland Emojis", "Switzerland Emoji Combinations", "Swiss Football Emoji"],
   "description": "Switzerland emoji combos 🇨🇭⚽ — Nati colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/tech-status-symbols/index.html
+++ b/library/tech-status-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Tech & Status Symbols: Copy & Paste 📶 🔋 ⏻ Wi-Fi, Battery & Power",
+  "alternateName": ["Tech Symbols Copy and Paste", "Status Symbols Copy Paste", "Wi-Fi Symbol Copy Paste", "Battery Symbol Copy Paste", "Power Symbols Unicode", "Technology Icons Copy Paste"],
   "description": "Copy and paste tech status symbols — Wi-Fi and signal (📶), battery and power (🔋 ⏻), and sound and notification glyphs. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/text-art/index.html
+++ b/library/text-art/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Text Art: Copy & Paste ASCII & Unicode Art Collections",
+  "alternateName": ["ASCII Art Copy and Paste", "Text Art Copy Paste", "Unicode Art", "Copy and Paste Text Art", "ASCII Art Generator", "Cool Text Art"],
   "description": "Copy and paste text art — ASCII cats, braille hearts, star frames, and kaomoji classics, plus blocks to draw your own. Click any piece to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/text-faces-kaomoji/index.html
+++ b/library/text-faces-kaomoji/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Text Faces & Kaomoji: Copy & Paste Japanese Emoticons",
+  "alternateName": ["Kaomoji Copy and Paste", "Japanese Text Faces", "Text Emoticons", "Cute Text Faces", "Kaomoji Emoticons", "ASCII Faces Copy Paste"],
   "description": "Browse and copy text faces and kaomoji — Japanese emoticons using ASCII and Unicode characters. Happy, sad, shrug, love, animals, and action expressions. Click any to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/thanksgiving-symbols/index.html
+++ b/library/thanksgiving-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Thanksgiving Symbols & Emojis: Copy & Paste 🦃 🍂 Harvest Festive",
+  "alternateName": ["Thanksgiving Emoji Copy and Paste", "Thanksgiving Symbols Copy Paste", "Turkey Emoji Copy Paste", "Harvest Emojis", "Thanksgiving Emoji Combos", "Fall Thanksgiving Symbols"],
   "description": "Thanksgiving symbols and emojis — turkeys, autumn leaves, pies, and gratitude combos for November posts and bios. Click any harvest symbol to copy it fast.",
   "author": {
     "@type": "Organization",

--- a/library/therian-symbols/index.html
+++ b/library/therian-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Therian Symbols: Copy & Paste Δ Theta-Delta & Alterhuman Marks",
+  "alternateName": ["Therian Symbol Copy and Paste", "Theta Delta Symbol Copy Paste", "Alterhuman Symbols", "Therian Community Symbols", "Therian Signs", "Paw Print Symbols Copy Paste"],
   "description": "Browse theta-delta (θΔ) marks, paw prints, moon phases, and animal symbols used by the therian and alterhuman community. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/thumbs-up-emoji/index.html
+++ b/library/thumbs-up-emoji/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Thumbs Up Emoji: Copy & Paste 👍 👎 Approval Combos",
+  "alternateName": ["Thumbs Up Emoji Copy and Paste", "Copy and Paste Thumbs Up", "Thumbs Down Emoji Copy Paste", "Like Emoji Copy Paste", "Approval Emoji", "Thumbs Up Symbol"],
   "description": "Copy and paste the thumbs up emoji 👍 in every skin tone, plus thumbs down 👎, OK hands, and approval combo sets for chats. Click any emoji to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/tiktok-symbols/index.html
+++ b/library/tiktok-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "TikTok Symbols: Copy & Paste Special Characters for TikTok",
+  "alternateName": ["TikTok Symbols Copy and Paste", "Symbols for TikTok Bio", "TikTok Bio Symbols", "TikTok Special Characters", "TikTok Aesthetic Symbols", "TikTok Text Symbols"],
   "description": "Browse and copy TikTok symbols for bios, captions, comments, and aesthetic profiles. Trending characters, dividers, and fire symbols for TikTok. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/traffic-road-sign-symbols/index.html
+++ b/library/traffic-road-sign-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Traffic &amp; Road Sign Symbols: Copy &amp; Paste Traffic Sign Emojis",
+  "alternateName": ["Traffic Sign Symbols Copy and Paste", "Road Sign Emojis", "Traffic Light Symbol Copy Paste", "Road Sign Symbols", "Traffic Symbol Copy Paste", "Stop Sign Emoji Copy Paste"],
   "description": "Browse and copy traffic and road sign symbols — traffic lights, prohibition signs, pedestrian icons, and road facility emojis. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/transport-symbols/index.html
+++ b/library/transport-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Transportation Symbols 🚆 — Transport & Map Icons Copy & Paste",
+  "alternateName": ["Transport Symbols Copy and Paste", "Vehicle Emojis Copy Paste", "Transportation Emoji Copy Paste", "Travel Icons Copy Paste", "Transport Icons Unicode", "Map Symbols Copy Paste"],
   "description": "Browse and copy transport and travel symbols — cars, trains, planes, boats, and map symbols. Click any icon to copy it instantly for travel posts and captions.",
   "author": {
     "@type": "Organization",

--- a/library/travel-vacation-emojis/index.html
+++ b/library/travel-vacation-emojis/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Travel & Vacation Emojis: Copy & Paste ✈ 🏖 Trip Combos",
+  "alternateName": ["Travel Emoji Copy and Paste", "Vacation Emojis Copy Paste", "Travel Emoji Combos", "Beach Emoji Copy Paste", "Wanderlust Emojis", "Holiday Emojis Copy Paste"],
   "description": "Copy and paste travel and vacation emojis — ✈️ plane, 🏖️ beach, 🗺️ map — plus trip-countdown combos for wanderlust bios. Click any emoji to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/tunisia-emoji-combos/index.html
+++ b/library/tunisia-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Tunisia Emoji Combos 🇹🇳⚽ Copy & Paste",
+  "alternateName": ["Tunisia Emoji Copy and Paste", "Tunisia Flag Emoji Combos", "Tunisia Emojis", "Tunisia Emoji Combinations", "Tunisian Football Emoji"],
   "description": "Tunisia emoji combos 🇹🇳⚽ — Eagles of Carthage colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/turkey-emoji-combos/index.html
+++ b/library/turkey-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Turkey Emoji Combos 🇹🇷⚽ Copy & Paste",
+  "alternateName": ["Turkey Emoji Copy and Paste", "Turkey Flag Emoji Combos", "Turkey Emojis", "Turkey Emoji Combinations", "Turkish Football Emoji"],
   "description": "Turkey emoji combos 🇹🇷⚽ — Crescent-Stars colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/ukraine-emoji-combos/index.html
+++ b/library/ukraine-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Ukraine Emoji Combos 🇺🇦⚽ Copy & Paste",
+  "alternateName": ["Ukraine Emoji Copy and Paste", "Ukraine Flag Emoji Combos", "Ukraine Emojis", "Ukraine Emoji Combinations", "Ukrainian Football Emoji"],
   "description": "Ukraine emoji combos 🇺🇦⚽ — Zhovto-Blakytni colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/unit-measurement-symbols/index.html
+++ b/library/unit-measurement-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Unit & Measurement Symbols: Copy & Paste Ω µ Å ℧ Scientific Units",
+  "alternateName": ["Measurement Symbols Copy and Paste", "Scientific Unit Symbols", "Unit Symbols Copy Paste", "Ohm Symbol Copy Paste", "Scientific Symbols Unicode", "Metric Symbols Copy Paste"],
   "description": "Copy and paste scientific unit and measurement symbols — ohm (Ω), micro (µ), angstrom (Å), mho (℧), metric squares, and per-mille marks. Click to copy instantly.",
   "author": {
     "@type": "Organization",

--- a/library/uruguay-emoji-combos/index.html
+++ b/library/uruguay-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Uruguay Emoji Combos 🇺🇾⚽ Copy & Paste",
+  "alternateName": ["Uruguay Emoji Copy and Paste", "Uruguay Flag Emoji Combos", "Uruguay Emojis", "Uruguay Emoji Combinations", "Uruguayan Football Emoji"],
   "description": "Uruguay emoji combos 🇺🇾⚽ — La Celeste colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/usa-emoji-combos/index.html
+++ b/library/usa-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "USA Emoji Combos 🇺🇸⚽ Copy & Paste",
+  "alternateName": ["USA Emoji Copy and Paste", "US Flag Emoji Combos", "USA Emojis", "USA Emoji Combinations", "American Football Emoji"],
   "description": "USA emoji combos 🇺🇸⚽ — USMNT colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/venezuela-emoji-combos/index.html
+++ b/library/venezuela-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Venezuela Emoji Combos 🇻🇪⚽ Copy & Paste",
+  "alternateName": ["Venezuela Emoji Copy and Paste", "Venezuela Flag Emoji Combos", "Venezuela Emojis", "Venezuela Emoji Combinations", "Venezuelan Football Emoji"],
   "description": "Venezuela emoji combos 🇻🇪⚽ — La Vinotinto colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/vertical-line-symbols/index.html
+++ b/library/vertical-line-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Vertical Line Symbols: Copy & Paste | ‖ │ ┃ Pipe & Bar Characters",
+  "alternateName": ["Vertical Line Symbol Copy and Paste", "Pipe Character Copy Paste", "Vertical Bar Symbol", "Bar Line Symbol Copy Paste", "Pipe Symbol Unicode", "Vertical Line Character"],
   "description": "Copy the vertical line symbol in every Unicode form — pipe |, double bar ‖, box-drawing │ ┃, and heavy dingbat bars. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/vinicius-emoji-combos/index.html
+++ b/library/vinicius-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Vinicius Emoji Combos 🇧🇷⚽🐐 Copy & Paste",
+  "alternateName": ["Vinicius Emojis Copy and Paste", "Vinicius Jr Emoji", "Vinicius Emoji Combinations", "Vinicius Junior Football Emoji"],
   "description": "Vinicius emoji combos 🇧🇷⚽ — fan emoji sets for bios, captions, and comments. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/wales-emoji-combos/index.html
+++ b/library/wales-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Wales Emoji Combos 🏴󠁧󠁢󠁷󠁬󠁳󠁿⚽ Copy & Paste",
+  "alternateName": ["Wales Emoji Copy and Paste", "Wales Flag Emoji Combos", "Wales Emojis", "Wales Emoji Combinations", "Welsh Football Emoji"],
   "description": "Wales emoji combos 🏴󠁧󠁢󠁷󠁬󠁳󠁿⚽ — The Dragons colours and football sets for fan bios and captions. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/weapon-tool-emojis/index.html
+++ b/library/weapon-tool-emojis/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Weapon & Tool Emojis: Copy & Paste ⚔ 🔪 🔨 Battle Combos",
+  "alternateName": ["Weapon Emoji Copy and Paste", "Sword Emoji Copy Paste", "Tool Emojis Copy Paste", "Battle Emojis", "Weapon Symbols Emoji", "Gaming Battle Emoji"],
   "description": "Reference list of weapon and tool emojis — swords ⚔️, shields 🛡️, bows 🏹, hammers 🔨, plus gaming battle combo sets. Click any emoji to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/weather-symbols/index.html
+++ b/library/weather-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Weather Symbols: Copy & Paste Weather Icons & Emojis",
+  "alternateName": ["Weather Symbol Copy and Paste", "Weather Emoji Copy Paste", "Rain Symbol Copy Paste", "Sun Symbol Copy Paste", "Weather Signs Unicode", "Weather Icons Copy Paste"],
   "description": "Browse and copy weather symbols, sun and cloud emojis, snowflakes, and storm icons. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/wedding-anniversary-emojis/index.html
+++ b/library/wedding-anniversary-emojis/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Wedding & Anniversary Emojis: Copy & Paste 💍 Ring Combos",
+  "alternateName": ["Wedding Emoji Copy and Paste", "Anniversary Emoji Copy Paste", "Wedding Emoji Combos", "Ring Emoji Copy Paste", "Bridal Emojis", "Marriage Emojis Copy Paste"],
   "description": "Wedding and anniversary emojis to copy: 💍 rings, 👰 couples, doves, bells, and romantic combo sets for invitations and captions. Click any emoji to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/whatsapp-symbols/index.html
+++ b/library/whatsapp-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "WhatsApp Symbols: Copy & Paste Status & Bio Characters",
+  "alternateName": ["WhatsApp Symbols Copy and Paste", "WhatsApp Status Symbols", "WhatsApp Bio Symbols", "Symbols for WhatsApp", "WhatsApp Special Characters", "WhatsApp Text Symbols"],
   "description": "Copy and paste WhatsApp symbols for your status, bio, and group names — ticks, hearts, stars, and decorative characters. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/wirtz-emoji-combos/index.html
+++ b/library/wirtz-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Wirtz Emoji Combos 🇩🇪⚽🐐 Copy & Paste",
+  "alternateName": ["Wirtz Emojis Copy and Paste", "Florian Wirtz Emoji", "Wirtz Emoji Combinations", "Wirtz Football Emoji"],
   "description": "Wirtz emoji combos 🇩🇪⚽ — fan emoji sets for bios, captions, and comments. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/witchy-occult-symbols/index.html
+++ b/library/witchy-occult-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Witchy &amp; Occult Symbols: Copy &amp; Paste All Occult Characters",
+  "alternateName": ["Occult Symbols Copy and Paste", "Witchy Symbols Copy Paste", "Witch Symbols Unicode", "Magic Symbols Copy Paste", "Esoteric Symbols Copy Paste", "Pentagram Symbol Copy Paste"],
   "description": "Browse and copy witchy and occult symbols — pentagrams, moon phases, planetary signs, alchemical symbols, and other esoteric characters. Click any to copy.",
   "author": {
     "@type": "Organization",

--- a/library/world-cup-emoji-combos/index.html
+++ b/library/world-cup-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "World Cup Emoji & Combos ⚽🏆 2026",
+  "alternateName": ["World Cup Emoji Copy and Paste", "FIFA World Cup Emoji Combos", "World Cup 2026 Emoji", "Football World Cup Emoji", "Soccer World Cup Combos", "World Cup Fan Emoji"],
   "description": "World Cup emoji combos for 2026 — ⚽🏆🌎 fan sets for bios, captions, and usernames. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/x-twitter-symbols/index.html
+++ b/library/x-twitter-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "X (Twitter) Symbols: Copy & Paste Special Characters for Posts",
+  "alternateName": ["Twitter Symbols Copy and Paste", "Symbols for Twitter Bio", "X Symbols Copy Paste", "Twitter Bio Symbols", "Twitter Text Symbols", "X Twitter Special Characters"],
   "description": "Browse and copy X (Twitter) symbols for thread formatting, quote markers, hashtag enhancements, checkmarks, engagement emoji, and bio decoration. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/y2k-symbols/index.html
+++ b/library/y2k-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Y2K Symbols Copy & Paste — Aesthetic 2000s Cyber Bio Decorations",
+  "alternateName": ["Y2K Aesthetic Symbols", "Y2K Symbols Copy Paste", "2000s Aesthetic Symbols", "Cyber Y2K Characters", "Y2K Bio Decorations", "Y2K Text Symbols", "2000s Aesthetic Copy Paste"],
   "description": "Y2K aesthetic symbols for bios, usernames, and captions. Stars, crosses, butterflies, CDs, and cyber decorations from the 2000s revival aesthetic.",
   "author": {
     "@type": "Organization",

--- a/library/yamal-emoji-combos/index.html
+++ b/library/yamal-emoji-combos/index.html
@@ -39,6 +39,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Yamal Emoji Combos 🇪🇸⚽🐐 Copy & Paste",
+  "alternateName": ["Yamal Emojis Copy and Paste", "Lamine Yamal Emoji", "Yamal Emoji Combinations", "Yamal Football Emoji", "Lamine Yamal Emoji Combos"],
   "description": "Yamal emoji combos 🇪🇸⚽ — fan emoji sets for bios, captions, and comments. Click any emoji or combo to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/yin-yang-symbol/index.html
+++ b/library/yin-yang-symbol/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Yin Yang Symbol: Copy & Paste ☯ Taijitu Balance Character",
+  "alternateName": ["Yin Yang Symbol Copy and Paste", "Yin Yang Emoji Copy Paste", "Yin Yang Sign", "Peace Symbol Copy Paste", "Balance Symbol Copy Paste", "Taijitu Symbol Copy Paste"],
   "description": "Copy and paste the yin yang symbol (☯) plus the bagua trigrams, yin and yang line digrams, and balance characters from the I Ching. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/library/zodiac-symbols/index.html
+++ b/library/zodiac-symbols/index.html
@@ -42,6 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Zodiac Symbols: Copy & Paste Astrology Signs",
+  "alternateName": ["Zodiac Symbol Copy and Paste", "Astrology Signs Copy Paste", "Zodiac Signs Symbols", "Horoscope Symbols Copy Paste", "Zodiac Text Symbols", "Astrological Signs Unicode"],
   "description": "Browse and copy zodiac symbols, astrology signs, and celestial body symbols. Click any symbol to copy it instantly.",
   "author": {
     "@type": "Organization",

--- a/linkedin/index.html
+++ b/linkedin/index.html
@@ -182,6 +182,25 @@
   }
 }
 </script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "LinkedIn Font Generator",
+  "alternateName": ["LinkedIn Text Formatter", "LinkedIn Bold Text Generator", "LinkedIn Post Formatter", "Bold Text for LinkedIn", "LinkedIn Fonts Copy and Paste", "LinkedIn Profile Font Generator"],
+  "url": "https://ultratextgen.com/linkedin/",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "description": "Free LinkedIn font generator — create bold, italic, cursive & fancy Unicode text for LinkedIn posts, headlines, and profiles. Copy and paste instantly. No signup required.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
 </head>
 <body>
   <!-- Google Tag Manager (noscript) -->

--- a/pinterest/index.html
+++ b/pinterest/index.html
@@ -143,6 +143,25 @@
   ]
 }
   </script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Pinterest Font Generator",
+  "alternateName": ["Pinterest Fonts Copy and Paste", "Pinterest Bio Fonts", "Fonts for Pinterest", "Pinterest Text Generator", "Pinterest Pin Font Generator", "Pinterest Aesthetic Font Generator"],
+  "url": "https://ultratextgen.com/pinterest/",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "description": "Create eye-catching Pinterest text styles for pins, boards, and bios. Copy and paste stylish Unicode fonts instantly.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
 </head>
 <body>
   <!-- Google Tag Manager (noscript) -->

--- a/roblox/index.html
+++ b/roblox/index.html
@@ -42,6 +42,24 @@
   ]
 }
 </script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Roblox Username Tools",
+  "alternateName": ["Roblox Name Generator", "Roblox Username Generator", "Roblox Name Ideas", "Cool Roblox Names", "Roblox Display Name Generator"],
+  "url": "https://ultratextgen.com/roblox/",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "description": "Roblox username generator with live availability check, display-name symbols, and how-to-change guides. Generate available Roblox name ideas by vibe or length.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
 </head>
 <body>
   <!-- Google Tag Manager (noscript) -->

--- a/roblox/name-generator/index.html
+++ b/roblox/name-generator/index.html
@@ -38,6 +38,7 @@
   "@context": "https://schema.org",
   "@type": "WebApplication",
   "name": "Roblox Username Generator",
+  "alternateName": ["Roblox Name Generator", "Roblox Display Name Generator", "Roblox Name Ideas", "Roblox Usernames", "Cool Roblox Names", "Roblox Username Ideas"],
   "url": "https://ultratextgen.com/roblox/name-generator/",
   "description": "Generate Roblox username ideas by vibe or length and check availability instantly.",
   "applicationCategory": "UtilityApplication",

--- a/scripts/alternatename-seo-report.md
+++ b/scripts/alternatename-seo-report.md
@@ -1,0 +1,75 @@
+# Schema.org `alternateName` SEO Coverage Report
+
+**Goal:** Maximize organic search reach by adding high-intent `alternateName` values
+to JSON-LD structured data across all relevant SEO landing pages.
+
+## Summary
+
+| Metric | Before | After |
+|---|---:|---:|
+| Pages with `alternateName` | 24 | **305** |
+| `index.html` files scanned | 337 | 337 |
+| `alternateName` items total | ~110 | **~1,765** |
+
+- **Files modified:** 282 `index.html` pages
+- **alternateName values added across modified files:** 1,655 (4–8 per page)
+- **JSON-LD validation:** all 305 entities parse as valid JSON; 0 errors, 0 warnings
+- **Constraints verified:** every array has 4–8 items, no item > 60 chars, no duplicate
+  items within an array, and `alternateName` never placed on `BreadcrumbList`,
+  `FAQPage`, `Question`, `Answer`, `ListItem`, or `Organization`.
+
+Run validation any time with:
+
+```bash
+python3 scripts/validate-alternatenames.py
+```
+
+## Pages updated (282)
+
+| Section | Pages | Placement |
+|---|---:|---|
+| `library/*` (symbol & emoji reference) | 242 | `alternateName` added to existing `Article` entity (after `headline`) |
+| `category/*` (font generators) | 19 | added to existing `WebApplication`, or new minimal `WebApplication` block where only `FAQPage`/`BreadcrumbList` existed |
+| Social platform pages (`discord`, `instagram`, `linkedin`, `facebook`, `pinterest`, `snapchat`, `telegram`, `whatsapp`, `x`, `youtube`, `tiktok`) + `tiktok/name-generator`, `youtube/name-generator` | 13 | new minimal `WebApplication` block (pages previously had only `FAQPage`/`BreadcrumbList`) |
+| `usecase/*` | 6 | added to existing `WebApplication`, or new block; `usecase/vertical-text` expanded 3 → 6 items |
+| `roblox/*` (game) | 2 | `roblox/name-generator` added to existing `WebApplication`; `roblox/` hub got a new `WebApplication` block |
+
+### Placement strategy
+Following the requested priority order:
+1. `WebApplication` present → `alternateName` added there.
+2. `SoftwareApplication` → none exist in the repo.
+3. Otherwise, for **tool/generator** pages whose only schema was `FAQPage` /
+   `BreadcrumbList`, a minimal valid `WebApplication` block was inserted before
+   `</head>` (mirroring the existing site convention) to carry `alternateName`.
+4. For **library reference** pages (which use an `Article` entity describing the
+   page), `alternateName` was added directly to that `Article`. `alternateName`
+   is a valid `Thing`/`CreativeWork` property, so this avoids introducing a
+   second, redundant entity per page. No `alternateName` was added to
+   `BreadcrumbList` or `FAQPage`/`Question`.
+
+### International pages (left intact — already localized)
+The 10 translated index pages (`de`, `es`, `fr`, `id`, `it`, `nl`, `pl`, `pt`,
+`tr`, `vi`) and the 10 translated `usecase/zalgo-text` pages already carried
+**localized** `alternateName` values (e.g. `"Glitch-Textgenerator"`,
+`"Generador de fuentes Unicode"`). These were validated and left unchanged to
+avoid breaking multilingual targeting; canonical and hreflang were untouched.
+
+## Pages skipped (32) and why
+
+| Pages | Reason |
+|---|---|
+| `about`, `contact`, `privacy`, `terms` | Legal / utility pages — not search-variant landing pages. |
+| `answers/*` (11 pages) | `QAPage`/FAQ format; the main entity is a `Question`, where `alternateName` is disallowed and semantically wrong. |
+| `guide/*` (8 article pages) | Editorial long-form articles, not tool/keyword-variant landing pages. |
+| `category/index`, `usecase/index`, `library/index`, `guide/index`, `answers/index` | Navigational hub/listing pages, not single-topic tools. |
+| `embed/linkedin-headline-generator`, `usecase/linkedin-headline/embed` | Embeddable widget endpoints (not standalone SEO targets). |
+| `tiktok/what-font-does-tiktok-use`, `youtube/what-font-does-youtube-use` | Informational FAQ pages (question intent, not tool-variant intent). |
+
+## Pages needing manual review
+
+None blocking. Optional future enhancements (deliberately out of scope here):
+- `guide/*` and `answers/*` could gain a dedicated `WebPage`/`Article`
+  `alternateName` set if the strategy expands to informational query variants.
+- Hub pages (`category/`, `library/`, `usecase/`) could target head terms
+  (e.g. "Font Categories", "Symbol Library") via an `ItemList`/`CollectionPage`
+  `name`/`alternateName` if desired.

--- a/scripts/validate-alternatenames.py
+++ b/scripts/validate-alternatenames.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Validate JSON-LD blocks and alternateName coverage across all index.html pages.
+
+Checks:
+  - Every <script type="application/ld+json"> block parses as valid JSON.
+  - No alternateName array has more than 8 items.
+  - No alternateName item is longer than 60 characters (warning only).
+  - No alternateName array contains duplicate identical items.
+  - alternateName is never placed on BreadcrumbList or FAQPage Question entities.
+Reports coverage stats.
+"""
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+LD_RE = re.compile(
+    r'<script[^>]*type=["\']application/ld\+json["\'][^>]*>(.*?)</script>',
+    re.DOTALL | re.IGNORECASE,
+)
+
+errors = []
+warnings = []
+pages_with_alt = 0
+total_alt_blocks = 0
+files_scanned = 0
+
+
+def walk_alt(obj, path, file):
+    """Recursively find alternateName fields and validate them; flag bad placements."""
+    global total_alt_blocks
+    if isinstance(obj, dict):
+        atype = obj.get("@type")
+        if "alternateName" in obj:
+            total_alt_blocks += 1
+            if atype in ("BreadcrumbList", "Question", "Answer", "ListItem"):
+                errors.append(f"{file}: alternateName on disallowed @type '{atype}'")
+            alt = obj["alternateName"]
+            items = alt if isinstance(alt, list) else [alt]
+            if isinstance(alt, list):
+                if len(alt) > 8:
+                    errors.append(f"{file}: alternateName has {len(alt)} items (>8) on {atype}")
+                lowered = [str(i).strip().lower() for i in alt]
+                if len(lowered) != len(set(lowered)):
+                    errors.append(f"{file}: duplicate alternateName items on {atype}")
+            for it in items:
+                if len(str(it)) > 60:
+                    warnings.append(f"{file}: alternateName item >60 chars on {atype}: {it!r}")
+        for v in obj.values():
+            walk_alt(v, path, file)
+    elif isinstance(obj, list):
+        for v in obj:
+            walk_alt(v, path, file)
+
+
+for html in sorted(ROOT.rglob("index.html")):
+    if "node_modules" in html.parts:
+        continue
+    files_scanned += 1
+    text = html.read_text(encoding="utf-8")
+    rel = html.relative_to(ROOT)
+    had_alt = False
+    for block in LD_RE.findall(text):
+        raw = block.strip()
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as e:
+            errors.append(f"{rel}: JSON parse error: {e}")
+            continue
+        if "alternateName" in raw:
+            had_alt = True
+        walk_alt(data, rel, rel)
+    if had_alt:
+        pages_with_alt += 1
+
+print(f"Files scanned:           {files_scanned}")
+print(f"Pages with alternateName:{pages_with_alt}")
+print(f"alternateName entities:  {total_alt_blocks}")
+print(f"Warnings:                {len(warnings)}")
+print(f"Errors:                  {len(errors)}")
+if warnings:
+    print("\n--- WARNINGS ---")
+    for w in warnings:
+        print("  " + w)
+if errors:
+    print("\n--- ERRORS ---")
+    for e in errors:
+        print("  " + e)
+    sys.exit(1)
+print("\nAll JSON-LD blocks valid. No constraint violations.")

--- a/snapchat/index.html
+++ b/snapchat/index.html
@@ -143,6 +143,25 @@
   ]
 }
   </script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Snapchat Font Generator",
+  "alternateName": ["Snapchat Fonts Copy and Paste", "Snapchat Name Fonts", "Fonts for Snapchat", "Snapchat Text Generator", "Snapchat Bio Font Generator", "Snapchat Caption Font Generator"],
+  "url": "https://ultratextgen.com/snapchat/",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "description": "Generate stylish Snapchat text for captions, bios, and stories. Copy and paste bold, italic, and fancy Unicode fonts instantly.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
 </head>
 <body>
   <!-- Google Tag Manager (noscript) -->

--- a/telegram/index.html
+++ b/telegram/index.html
@@ -143,6 +143,25 @@
   ]
 }
   </script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Telegram Font Generator",
+  "alternateName": ["Telegram Fonts Copy and Paste", "Telegram Bio Fonts", "Fonts for Telegram", "Telegram Text Generator", "Telegram Channel Font Generator", "Telegram Name Font Generator"],
+  "url": "https://ultratextgen.com/telegram/",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "description": "Create bold, italic, and stylish Telegram text for channels and group messages. Copy and paste Unicode fonts instantly.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
 </head>
 <body>
   <!-- Google Tag Manager (noscript) -->

--- a/tiktok/index.html
+++ b/tiktok/index.html
@@ -102,6 +102,25 @@
   ]
 }
   </script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "TikTok Font Generator",
+  "alternateName": ["TikTok Fonts Copy and Paste", "TikTok Bio Fonts", "Fonts for TikTok", "TikTok Username Font Generator", "TikTok Display Name Font Generator", "TikTok Caption Fonts"],
+  "url": "https://ultratextgen.com/tiktok/",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "description": "Free TikTok font generator with a destination switcher for display name, bio, captions, comments, and username rules. Copy and paste 100+ Unicode styles.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
 </head>
 <body>
   <!-- Google Tag Manager (noscript) -->

--- a/tiktok/name-generator/index.html
+++ b/tiktok/name-generator/index.html
@@ -77,6 +77,24 @@
   ]
 }
 </script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "TikTok Name Generator",
+  "alternateName": ["TikTok Username Generator", "TikTok Name Ideas", "TikTok Username Ideas", "Cool TikTok Names", "TikTok Handle Generator"],
+  "url": "https://ultratextgen.com/tiktok/name-generator/",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "description": "Generate TikTok username ideas from your vibe, keyword, and initials. Get ASCII-safe @handle options plus matching display-name suggestions.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
 </head>
 <body>
   <!-- Google Tag Manager (noscript) -->

--- a/usecase/before-after-emoji/index.html
+++ b/usecase/before-after-emoji/index.html
@@ -132,6 +132,24 @@
   ]
 }
 </script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Emoji Transformation Caption Generator",
+  "alternateName": ["Before After Emoji Generator", "Emoji Around Text Generator", "Text Between Emojis", "Emoji Bracket Generator", "Wrap Text With Emojis", "Emoji Caption Maker"],
+  "url": "https://ultratextgen.com/usecase/before-after-emoji/",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "description": "Wrap a short message between two emojis — one for where you started, one for where you ended. 12 transformation pairs, inline and stacked formats. Copy and paste anywhere.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
 </head>
 <body>
   <!-- Google Tag Manager (noscript) -->

--- a/usecase/bio-font/index.html
+++ b/usecase/bio-font/index.html
@@ -161,6 +161,24 @@
   ]
 }
   </script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Bio Font Generator",
+  "alternateName": ["Bio Text Generator", "Fonts for Bio", "Instagram Bio Font Generator", "Copy and Paste Bio Fonts", "Social Media Bio Font Generator"],
+  "url": "https://ultratextgen.com/usecase/bio-font/",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "description": "Free bio font generator: turn your text into stylish Unicode fonts, then add symbols, dividers and ready-made templates. Platform-aware previews and character limits for Instagram, TikTok, Discord, X and Tinder — copy and paste in seconds.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
 </head>
 <body>
   <!-- Google Tag Manager (noscript) -->

--- a/usecase/emoji-combinations/index.html
+++ b/usecase/emoji-combinations/index.html
@@ -130,6 +130,24 @@
   ]
 }
   </script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Emoji Combinations",
+  "alternateName": ["Emoji Combos", "Emoji Combos Copy and Paste", "Emoji Combinations Generator", "Cute Emoji Combos", "Aesthetic Emoji Combos"],
+  "url": "https://ultratextgen.com/usecase/emoji-combinations/",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "description": "Find curated emoji combinations you can copy and paste for captions, posts, announcements, wins, motivation, confidence, and more — perfect for Instagram, TikTok, LinkedIn, and other social platforms.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
 </head>
 <body>
   <!-- Google Tag Manager (noscript) -->

--- a/usecase/linkedin-headline/index.html
+++ b/usecase/linkedin-headline/index.html
@@ -115,6 +115,24 @@
   ]
 }
   </script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "LinkedIn Headline Generator",
+  "alternateName": ["LinkedIn Headline Ideas", "LinkedIn Headline Examples", "LinkedIn Title Generator", "LinkedIn Headline Maker", "LinkedIn Profile Headline Generator"],
+  "url": "https://ultratextgen.com/usecase/linkedin-headline/",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "description": "Create a standout LinkedIn headline with structured separators and selective Unicode font styling. 4 LinkedIn-safe fonts, smart separator insertion, and instant copy. 220 characters max.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
 </head>
 <body>
   <!-- Google Tag Manager (noscript) -->

--- a/usecase/text-to-emoji/index.html
+++ b/usecase/text-to-emoji/index.html
@@ -292,6 +292,24 @@
   ]
 }
   </script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Text to Emoji Converter",
+  "alternateName": ["Emoji Text Generator", "Letters to Emoji", "Emoji Letter Generator", "Text to Emoji Translator", "Emoji Language Converter"],
+  "url": "https://ultratextgen.com/usecase/text-to-emoji/",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "description": "Convert text to emoji using a structured emoji language system. Copy and paste instantly.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
 </head>
 <body>
   <!-- Google Tag Manager (noscript) -->

--- a/usecase/vertical-text/index.html
+++ b/usecase/vertical-text/index.html
@@ -203,7 +203,7 @@
   "@context": "https://schema.org",
   "@type": "WebApplication",
   "name": "Vertical & Stacked Text Generator",
-  "alternateName": ["Stacked Text Generator", "Text Stacker", "Vertical Font Generator"],
+  "alternateName": ["Stacked Text Generator", "Vertical Font Generator", "Text Stacker", "Vertical Writing Generator", "Top to Bottom Text Generator", "Copy and Paste Vertical Text"],
   "url": "https://ultratextgen.com/usecase/vertical-text/",
   "applicationCategory": "UtilityApplication",
   "operatingSystem": "All",

--- a/whatsapp/index.html
+++ b/whatsapp/index.html
@@ -143,6 +143,25 @@
   ]
 }
   </script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "WhatsApp Font Generator",
+  "alternateName": ["WhatsApp Fonts Copy and Paste", "WhatsApp Bold Text", "Fonts for WhatsApp", "WhatsApp Text Generator", "WhatsApp Status Font Generator", "WhatsApp Message Font Generator"],
+  "url": "https://ultratextgen.com/whatsapp/",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "description": "Fancy text generator for WhatsApp messages and statuses. Safe to copy and paste with ease.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
 </head>
 <body>
   <!-- Google Tag Manager (noscript) -->

--- a/x/index.html
+++ b/x/index.html
@@ -143,6 +143,25 @@
   ]
 }
   </script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "X (Twitter) Font Generator",
+  "alternateName": ["Twitter Font Generator", "X Font Generator", "Twitter Fonts Copy and Paste", "Twitter Bio Fonts", "Fonts for Twitter", "X Text Generator", "Twitter Text Styles"],
+  "url": "https://ultratextgen.com/x/",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "description": "Stylish Unicode text for your X posts and bio. Bold, italic, fancy fonts.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
 </head>
 <body>
   <!-- Google Tag Manager (noscript) -->

--- a/youtube/index.html
+++ b/youtube/index.html
@@ -85,6 +85,25 @@
   ]
 }
   </script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "YouTube Font Generator",
+  "alternateName": ["YouTube Fonts Copy and Paste", "YouTube Channel Name Fonts", "Fonts for YouTube", "YouTube Comment Font Generator", "YouTube Description Font Generator", "YouTube Text Styles"],
+  "url": "https://ultratextgen.com/youtube/",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "description": "Style your YouTube channel name and profile text with copy-ready Unicode fonts. Switch destinations first to avoid handle and title formatting failures.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
 </head>
 <body>
   <!-- Google Tag Manager (noscript) -->

--- a/youtube/name-generator/index.html
+++ b/youtube/name-generator/index.html
@@ -68,6 +68,24 @@
   ]
 }
 </script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "YouTube Channel Name Generator",
+  "alternateName": ["YouTube Name Ideas", "YouTube Username Generator", "Channel Name Ideas", "Cool YouTube Names", "YouTube Channel Name Ideas"],
+  "url": "https://ultratextgen.com/youtube/name-generator/",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "description": "Generate YouTube channel name ideas from your vibe, keyword, and initials. Copy a name, style it in the YouTube Font Generator, and format-check handle candidates.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
 </head>
 <body>
   <!-- Google Tag Manager (noscript) -->


### PR DESCRIPTION
Add or improve alternateName JSON-LD values on 282 generator, category, library, social, game, and use-case pages to capture real search-query variants (copy-and-paste, generator/maker, synonyms, platform variants).

- library/*: alternateName added to existing Article entity
- category/* and social/game generator pages: added to existing WebApplication, or minimal WebApplication block inserted where only FAQPage/BreadcrumbList existed
- usecase/vertical-text expanded; translated pages left intact (localized)
- never added to BreadcrumbList or FAQPage Question entities

Adds scripts/validate-alternatenames.py (parses every ld+json block, enforces 4-8 items, <=60 chars, no dupes, valid placement) and a coverage report. Coverage: 24 -> 305 pages; all JSON-LD valid.