### PR TITLE
feat(audit): waive search-volume gate for socially-discovered combos + library audit & combo taxonomy

### DIFF
--- a/docs/emoji-combination-taxonomy.md
+++ b/docs/emoji-combination-taxonomy.md
@@ -180,11 +180,14 @@ research: a whole competitor — emojicombos.com — plus TikTok Discover hubs, 
 1. **Document the field properly.** Update `unicode-library-workflow.md` §5 to
    reference this doc and list all five `copy_patterns` values (it currently
    names only two).
-2. **Let the auditor know `combo` is volume-exempt.** Teach
-   `scripts/audit_library_opportunities.py` not to raise
-   `flag_missing_search_volume` / `flag_low_demand_confidence` for
-   `copy_patterns = combo` when `forum_evidence` is `medium`+ (§7), so social
-   demand isn't gated out.
+2. ~~**Let the auditor know `combo` is volume-exempt.**~~ **Done.**
+   `scripts/audit_library_opportunities.py` now waives
+   `flag_missing_search_volume` / `flag_low_demand_confidence` (and the
+   resulting `needs-research` verdict) for `copy_patterns = combo` rows with
+   `forum_evidence` `medium`+ (§7), via the `is_volume_exempt(...)` helper.
+   Waivers are surfaced as `combo_volume_waived` in the run summary and noted
+   per row in `audit_notes`. Unproven combos (`none`/`weak` evidence) stay
+   gated.
 3. **Re-theme, don't multiply, the combos.** Treat the 96 `*-emoji-combos` as a
    `combo` family to re-point at vibe/context/fandom over time (per the
    2026-06-17 audit); keep them live for now.

--- a/docs/emoji-combination-taxonomy.md
+++ b/docs/emoji-combination-taxonomy.md
@@ -1,0 +1,190 @@
+# Emoji & Symbol Combination Taxonomy
+
+The canonical reference for the **different kinds of multi-glyph content** the
+library ships, so we stop conflating them when we plan pages. It formalizes the
+`copy_patterns` field used in `data/library_opportunities.csv` and the copy
+mechanics in [`unicode-library-workflow.md`](./unicode-library-workflow.md) §5,
+and sits beside [`page-vs-section-decisions.md`](./page-vs-section-decisions.md)
+(when a thing earns a page) and [`jtbd-principles.md`](./jtbd-principles.md)
+(why).
+
+> **Why this doc exists.** The workflow only ever defined two copy patterns
+> (`single` / `collection`), but the backlog has quietly grown **five** in
+> active use — `single` (229), `combo` (134), `collection` (111),
+> `section` (267), `transform` (24). Three of those describe *multi-glyph*
+> content and were never told apart. This is the standing definition so future
+> pages get tagged the same way every time.
+
+---
+
+## 1. The core idea: glyph **count** is not the discriminator
+
+The instinct is to split on "one symbol vs. many." That's wrong and it's the
+source of the confusion. **Many-glyph content splits into two completely
+different things:**
+
+- A **combination** is *one atomic, ordered artifact* — many glyphs fused into a
+  single meaning (`◕‿◕`, `🗣️🔥💯`, `⋆｡°✩`). Splitting it destroys it. The user
+  wants **the whole string, as one paste.**
+- A **collection** is *a set of independent peers* — distinct glyphs that share
+  a family (ASEAN flags, zodiac signs, chess pieces). Each stands alone. The
+  user wants **one of them, or the whole set.**
+
+So the two real questions for any multi-glyph idea are:
+
+1. **Atomic or set?** Is it one fused artifact (→ combination) or a group of
+   peers (→ collection)?
+2. **What is the copy unit?** The whole arrangement, one member, or the entire
+   family?
+
+Everything below follows from those two questions.
+
+---
+
+## 2. The five types (the full `copy_patterns` vocabulary)
+
+| `copy_patterns` | What it is | Copy unit | How it renders | Primary JTBD | Demand / discovery channel |
+|---|---|---|---|---|---|
+| **`single`** | One standalone glyph (the atom) | one character | `.symbol-tile` whose `data-symbol` is **one char** (`★`) | "give me *this one* character" | **Keyword head-noun**, high volume (`heart symbol copy paste` 22k) |
+| **`combo`** | A crafted, ordered multi-glyph **string** (atomic) | the **whole string** | `.symbol-tile` whose `data-symbol` is the **entire sequence** (`◕‿◕`, `🗣️🔥💯`) — one click = whole artifact | "give me this whole little artwork/expression as one paste" | **Social discovery** (TikTok), organized by *vibe / context / fandom*; largely keyword-invisible |
+| **`collection`** | A **set of distinct peers** in one family | **one member *or* the whole set** | `.symbol-tile` per member **plus** `UltraTextGen.buildGrids(...)` to copy the set in a chosen format (inline/vertical/…) | dual: "copy one of these" **and** "copy the whole matching set" | **Keyword head-noun for the *set*** (`zodiac symbols`, `ASEAN flags`) and/or members; rarely searched "by combination" |
+| **`section`** | Not a standalone page — folds into a parent hub | n/a (inherits parent) | a block inside another page | enrichment of an existing intent | n/a — gated out as a page by [`page-vs-section-decisions.md`](./page-vs-section-decisions.md) |
+| **`transform`** | Algorithmically generated text, not a curated glyph set | the transformed output | the renderer's `transform` types (backwards, smallCaps, mirror, zalgo, upside-down) | "restyle *my* text" | keyword, but it's a **generator**, not a library of fixed items — the odd one out here |
+
+The first three are the multi-glyph types people confuse. `section` and
+`transform` are included only so the vocabulary is complete; they're a
+page-vs-section call and a generator mechanism respectively, not "combo" types.
+
+---
+
+## 3. `combo` vs `collection` — the distinction in full
+
+This is the pair the brief was about (kaomoji/emoji-combo **combination** vs
+ASEAN-flags **collection**). They look alike (both are "more than one glyph")
+and behave oppositely:
+
+| | **`combo`** (combination) | **`collection`** (set of peers) |
+|---|---|---|
+| Structure | **ordered, fused** — meaning is the arrangement | **unordered membership** — meaning is the family |
+| Split it and… | it's destroyed (`◕‿◕` → `◕` `‿` `◕` is nonsense) | each piece still stands (`🇮🇩` is fine alone) |
+| Copy unit | always **the whole string** | **one member or all members** |
+| Render | one tile, `data-symbol` = full string | tiles per member **+** `buildGrids` set-copy |
+| Multiple formats matter? | No — it's already one fixed string | **Yes** — inline/vertical/spaced is the differentiator |
+| Searched "by combination"? | **Yes** (as a vibe: "funny emoji combos") but mostly **social**, not Google | **No** — searched as the *family head-noun* ("ASEAN flags"), almost never "by combination" |
+| Authority comes from | breadth of *vibes/contexts* | completeness of the *set* |
+
+**The ASEAN-flags point, precisely:** it's a `collection`, not a `combo`. Nobody
+searches "the combination of ASEAN flags," so framing/slugging it as a "combo"
+would chase a query that doesn't exist. It earns a page (if at all) on the
+**set's own head-noun + utility** ("ASEAN flag emojis"), and its value is the
+*copy-the-whole-set* job — which is the `collection` runtime (`buildGrids`),
+i.e. the retention play, not a keyword play.
+
+---
+
+## 4. Where they overlap (and how to break the tie)
+
+```
+        glyph count > 1 ?
+                │
+        ┌───────┴───────┐
+       no               yes
+        │                │
+     SINGLE      atomic & ordered?
+                  ┌──────┴──────┐
+                 yes            no
+                  │              │
+                COMBO       set of peers?
+                              ┌───┴───┐
+                             yes      (no → it was really a SINGLE or a COMBO)
+                              │
+                          COLLECTION
+                              │
+                   does the set/combo clear the
+                   page-vs-section demand+supply gate?
+                              │
+                        no → SECTION
+```
+
+Genuine overlaps and the rule that settles them:
+
+- **`single` ⟷ `collection`.** A `collection` page is *built from* singles, and a
+  single-glyph page is a degenerate one-family collection. **Tie-break by the
+  foregrounded job:** if the page exists so users grab *one* glyph → `single`
+  (heart-symbols). If it exists so they grab the *matching set* (and offers
+  set-copy via `buildGrids`) → `collection` (zodiac-symbols). A page can do
+  **both** (single tiles + a `buildGrids` block) — tag it by its *primary*
+  intent and the presence of `buildGrids` makes the validator treat it as a
+  collection.
+- **`combo` ⟷ `collection`.** A page can present *a collection of combos*
+  (e.g. 30 funny emoji combos). Each tile is a `combo` (whole-string copy); the
+  page-level pattern is still `combo` because there is **no peer-set to copy as
+  one unit** — you don't paste all 30 combos at once. Use `collection` only when
+  "copy the entire set together" is a real job.
+- **`combo` ⟷ `single`.** A kaomoji tile *renders* like a single tile, so they're
+  mechanically similar — but tag `combo`, because the demand channel and page
+  organization differ entirely (vibe/social vs. keyword head-noun). Mislabeling
+  combos as singles is what hides their social-discovery nature.
+
+---
+
+## 5. How the current site maps onto this
+
+| Page(s) | Correct type | Notes |
+|---|---|---|
+| `heart-symbols`, `arrow-symbols`, `currency-symbols` | `single` (+ optional `collection`) | head-noun keyword pages; some already add `buildGrids` |
+| `text-faces-kaomoji` | `combo` | tiles carry whole strings (`◕‿◕`) — confirmed |
+| `zodiac-symbols`, `chess-symbols`, `card-suit-symbols`, `emoji-flags` | `collection` | call `buildGrids`; copy-the-set is the job |
+| `aesthetic-borders-frames`, `line-divider-symbols` | `combo` | decorative arrangements, copied whole |
+| **the 96 `*-emoji-combos`** (players/countries) | **mis-built `combo`** | right *pattern*, **wrong axis** — built on *subject* (player/country), but `combo` demand clusters on **vibe/context/fandom** (funny, cute, tiktok-comment, Sonic). See the 2026-06-17 GSC/forum findings: 0 impressions, demand is social. Re-theme, don't multiply. |
+
+---
+
+## 6. Tagging rules for the backlog (do this every time)
+
+When you add an opportunity row, set `copy_patterns` by this checklist:
+
+1. One glyph, grabbed alone → **`single`**.
+2. Many glyphs fused into one string people paste whole → **`combo`**.
+   - Then theme it by **vibe / context / fandom**, never by an arbitrary subject
+     axis, and expect **social** discovery (note it in `notes`; search volume
+     may legitimately be near-zero without killing the row — see §7).
+3. A family of peers where "copy the whole set" is a real job → **`collection`**;
+   it must render `buildGrids`. Justify it on the **set's head-noun**.
+4. Clears neither the demand nor supply gate as a standalone page →
+   **`section`** (fold into the hub).
+5. It's a text *generator*, not a fixed set → **`transform`**.
+
+---
+
+## 7. The acquisition-vs-retention caveat (don't let the demand gate misfire)
+
+The library workflow's demand gate assumes **keyword** demand. That's right for
+`single` and `collection` (head-noun searchable) but it **misfires on `combo`**,
+whose demand is social and keyword-invisible by nature (see the 2026-06-17
+research: a whole competitor — emojicombos.com — plus TikTok Discover hubs, with
+~nothing in Google/Semrush). So:
+
+- For `combo` rows, **don't auto-reject on low `search_volume`.** Record the
+  social evidence (TikTok/forum) as `forum_evidence`, mark the channel in
+  `notes`, and judge on the **copy-a-whole-string JTBD + retention**, not
+  acquisition. This is the "hidden JTBD" the brief identified: people want to
+  copy a *group/arrangement*, and offering it well (incl. multiple copy formats
+  for `collection`) is a **retention/UX** lever, not a search lever.
+- For `single`/`collection`, the existing keyword demand gate stands.
+
+---
+
+## 8. Recommended follow-ups (not yet done)
+
+1. **Document the field properly.** Update `unicode-library-workflow.md` §5 to
+   reference this doc and list all five `copy_patterns` values (it currently
+   names only two).
+2. **Let the auditor know `combo` is volume-exempt.** Teach
+   `scripts/audit_library_opportunities.py` not to raise
+   `flag_missing_search_volume` / `flag_low_demand_confidence` for
+   `copy_patterns = combo` when `forum_evidence` is `medium`+ (§7), so social
+   demand isn't gated out.
+3. **Re-theme, don't multiply, the combos.** Treat the 96 `*-emoji-combos` as a
+   `combo` family to re-point at vibe/context/fandom over time (per the
+   2026-06-17 audit); keep them live for now.

--- a/docs/unicode-library-workflow.md
+++ b/docs/unicode-library-workflow.md
@@ -215,6 +215,15 @@ region.
 
 ## 5. Copy patterns
 
+> **Full vocabulary lives in
+> [`emoji-combination-taxonomy.md`](./emoji-combination-taxonomy.md).** The two
+> interaction models below are the page-rendering mechanics, but the
+> `copy_patterns` backlog field actually carries **five** values —
+> `single`, `combo`, `collection`, `section`, `transform`. In particular,
+> `combo` (a crafted multi-glyph *string* copied whole, e.g. kaomoji) is **not**
+> the same as `collection` (a *set of peers* copied together, e.g. zodiac
+> signs); conflating them is the classic mistake. Tag rows by that taxonomy.
+
 Two interaction models, chosen per page via `copy_pattern`:
 
 ### `single` — browse-and-copy

--- a/scripts/audit_library_opportunities.py
+++ b/scripts/audit_library_opportunities.py
@@ -67,6 +67,14 @@ FORUM_EVIDENCE_SCORE = {
     "strong": 25,
 }
 
+# Copy patterns whose demand is socially discovered (TikTok, forums) rather than
+# keyword search — see docs/emoji-combination-taxonomy.md §7. For these, the
+# search-volume / demand-confidence gate misfires, so we waive it *provided*
+# there is real social proof (forum_evidence at least 'medium'). Unproven combos
+# (none/weak evidence) are still gated like anything else.
+VOLUME_EXEMPT_PATTERNS = {"combo"}
+VOLUME_EXEMPT_MIN_EVIDENCE = FORUM_EVIDENCE_SCORE["medium"]  # 15
+
 # Intent-overlap similarity at/above this threshold is treated as a strong
 # duplicate-risk signal, even without an exact slug/title match.
 STRONG_OVERLAP_THRESHOLD = 0.6
@@ -75,6 +83,19 @@ STRONG_OVERLAP_THRESHOLD = 0.6
 def forum_evidence_score(value):
     """Map a forum_evidence label to its numeric score (unknown -> 0)."""
     return FORUM_EVIDENCE_SCORE.get((value or "").strip().lower(), 0)
+
+
+def is_volume_exempt(copy_patterns, ev_score):
+    """
+    True when an opportunity's demand is socially discovered (a `combo` whose
+    JTBD is "copy this whole arrangement") and it has at least 'medium' forum
+    evidence. Such rows are waived from the keyword search-volume /
+    demand-confidence gate, which only models acquisition search intent and
+    misfires on socially-distributed combos. See
+    docs/emoji-combination-taxonomy.md §7.
+    """
+    pattern = (copy_patterns or "").strip().lower()
+    return pattern in VOLUME_EXEMPT_PATTERNS and ev_score >= VOLUME_EXEMPT_MIN_EVIDENCE
 
 
 def is_blank(value):
@@ -253,6 +274,7 @@ def main():
         "missing_search_volume": 0,
         "low_demand_confidence": 0,
         "strong_duplicate_risk": 0,
+        "volume_exempt_waived": 0,
     }
 
     for opp in opportunities:
@@ -318,6 +340,10 @@ def main():
             notes.append("no forum evidence captured")
             counts["missing_forum_evidence"] += 1
 
+        # Socially-discovered combos with real forum proof are waived from the
+        # keyword search-volume / demand-confidence gate (see helper docstring).
+        volume_exempt = is_volume_exempt(opp.get("copy_patterns"), ev_score)
+
         # 6. Missing search volume (blank or non-numeric)
         sv_raw = (opp.get("search_volume") or "").strip().replace(",", "")
         missing_sv = "no"
@@ -328,14 +354,23 @@ def main():
                 float(sv_raw)
             except ValueError:
                 missing_sv = "yes"
-        if missing_sv == "yes":
+        if missing_sv == "yes" and volume_exempt:
+            missing_sv = "no"
+            notes.append("combo: search-volume gate waived "
+                         "(socially-discovered, forum_evidence>=medium)")
+            counts["volume_exempt_waived"] += 1
+        elif missing_sv == "yes":
             notes.append("search volume missing or non-numeric")
             counts["missing_search_volume"] += 1
 
         # 7. Low demand confidence
         confidence = (opp.get("demand_confidence") or "").strip().lower()
         low_conf = "yes" if confidence == "low" else "no"
-        if low_conf == "yes":
+        if low_conf == "yes" and volume_exempt:
+            low_conf = "no"
+            notes.append("combo: demand-confidence gate waived "
+                         "(socially-discovered)")
+        elif low_conf == "yes":
             notes.append("demand confidence is low")
             counts["low_demand_confidence"] += 1
 
@@ -390,7 +425,8 @@ def main():
     print("Research flags: "
           f"missing_forum_evidence={counts['missing_forum_evidence']}, "
           f"missing_search_volume={counts['missing_search_volume']}, "
-          f"low_demand_confidence={counts['low_demand_confidence']}")
+          f"low_demand_confidence={counts['low_demand_confidence']}, "
+          f"combo_volume_waived={counts['volume_exempt_waived']}")
     print(f"Wrote {AUDIT_OUT.relative_to(REPO)}")
     return 0
 


### PR DESCRIPTION
## Summary

Teaches the opportunity auditor that **`combo` demand is socially discovered, not keyword-searched**, so the keyword demand gate stops misfiring on it — plus the library audit and the combo/collection taxonomy that motivated the change.

The headline change is in `scripts/audit_library_opportunities.py`; the docs are the evidence trail and the standing definitions behind it.

## The code change

The library workflow's demand gate assumes **keyword/acquisition** intent. That's correct for `single` and `collection` pages (head-noun searchable) but wrong for **`combo`** pages (kaomoji, emoji combos), whose demand lives on TikTok/forums and is largely keyword-invisible. Today such rows get hit with `flag_missing_search_volume` / `flag_low_demand_confidence` → a spurious `needs-research` verdict, gating out legitimate combo ideas.

New `is_volume_exempt(copy_patterns, ev_score)` helper waives the **search-volume** and **demand-confidence** gates (and the resulting `needs-research` verdict) **only** for:
- `copy_patterns = combo`, **and**
- `forum_evidence` at least `medium` (real social proof).

Unproven combos (`none`/`weak` evidence) and all other patterns stay fully gated. Waivers surface as `combo_volume_waived` in the run summary and per-row in `audit_notes`.

### No regression — forward-looking by design
Running against the current backlog is **identical to baseline** (`missing_search_volume=0`, `low_demand_confidence=137`, `combo_volume_waived=0`) — no row qualifies today. The change matters for the **vibe/context/fandom combo rows** surfaced in the 2026-06-17 research, which will carry social evidence but little search volume.

### Tests
Added a focused unit + integration check (run locally, all pass):
- `is_volume_exempt` across medium/strong (waive), weak/none (gate), non-combo patterns (gate), and case/space tolerance;
- a synthetic future vibe-combo row (medium evidence, blank volume, low confidence) now clears, while the same row with weak evidence stays gated.

## Supporting docs in this branch

- **`docs/library-pages-audit-2026-06-17.md`** — full audit of all 248 live `/library` pages (spec coverage / "inline", SEO gaps incl. FAQ JSON-LD missing on 246, thin 96-page emoji-combos cohort, two broken LinkedIn pages, data asks).
- **`data/library_opportunities_audit_2026-06-17.md`** — reconciliation of the backlog against disk (untracked pages, specless pages, the missing `stage` column).
- **`docs/emoji-combination-taxonomy.md`** — the canonical definition of the five `copy_patterns` values (`single`/`combo`/`collection`/`section`/`transform`). Pins down **combination (atomic, copied whole — kaomoji) vs. collection (set of peers — e.g. ASEAN flags, copy-the-set)**, with overlap rules, a decision flow, backlog tagging rules, and the acquisition-vs-retention caveat the code change implements. `unicode-library-workflow.md` §5 now cross-links it.

### Evidence behind the combo policy (2026-06-17)
- GSC: all 96 `*-emoji-combos` pages have **0 impressions**; Semrush shows the demand pattern is single-token (`heart emoji copy and paste` 18.1k), not "combos".
- Forum/social research: a whole competitor (emojicombos.com) + TikTok Discover hubs prove the "copy a whole combo" JTBD is real but **social/keyword-invisible** — exactly the case the gate was mishandling.

## Not included (left for follow-up, per discussion)
- Re-theming the 96 combo pages onto vibe/context/fandom (kept live for now).
- The two LinkedIn page fixes and FAQ JSON-LD generator change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BiNcp9haidJ3P4GweEF6Gy)_