### PR TITLE
docs: add presentation_class axis (symbol/emoji/emoticon/kaomoji) to taxonomy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,9 @@ ultratextgen/
 ├── category/               # Category landing pages (bold, cursive, etc.)
 ├── usecase/                # Use case pages (bio, comment, etc.)
 ├── guide/                  # Educational article pages
-├── library/                # Symbol/emoji reference libraries
+├── library/                # Symbol/emoji/emoticon/kaomoji reference libraries
+│                           #   (classify each page by presentation_class +
+│                           #    copy_patterns — see docs/emoji-combination-taxonomy.md)
 ├── js/vertical/            # Vertical text feature module
 │
 └── Platform pages:

--- a/docs/emoji-combination-taxonomy.md
+++ b/docs/emoji-combination-taxonomy.md
@@ -8,6 +8,20 @@ and sits beside [`page-vs-section-decisions.md`](./page-vs-section-decisions.md)
 (when a thing earns a page) and [`jtbd-principles.md`](./jtbd-principles.md)
 (why).
 
+> **Two independent axes.** Every library item is classified on **two** axes that
+> must not be collapsed into each other:
+>
+> 1. **`copy_patterns` — structure / count** (§§1–7): is the artifact one glyph,
+>    a fused string, or a set of peers? This decides the *runtime* (single tile,
+>    whole-string tile, or `buildGrids` set-copy).
+> 2. **`presentation_class` — what the glyph *is*** (§§8–10): `symbol` · `emoji` ·
+>    `emoticon` · `kaomoji`. This decides **whether two intents share one page**
+>    (§9) and **which `alternateName` synonyms are on-intent** (§10).
+>
+> They correlate but are orthogonal: a `single` can be a `symbol` (`★`) *or* an
+> `emoji` (`🔥`); a `combo` can be a `kaomoji` (`◕‿◕`) *or* an emoji string
+> (`🗣️🔥💯`). Tag **both**, every time.
+
 > **Why this doc exists.** The workflow only ever defined two copy patterns
 > (`single` / `collection`), but the backlog has quietly grown **five** in
 > active use — `single` (229), `combo` (134), `collection` (111),
@@ -175,12 +189,145 @@ research: a whole competitor — emojicombos.com — plus TikTok Discover hubs, 
 
 ---
 
-## 8. Recommended follow-ups (not yet done)
+## 8. The second axis: `presentation_class` (symbol · emoji · emoticon · kaomoji)
+
+§§1–7 classify by **structure** (count / copy unit). This axis classifies by
+**what the glyph actually is** — its character class and how it renders. Users
+say these four words loosely and often interchangeably, but they are four
+**technically distinct** things, and the distinction is what drives the
+page-merge call (§9) and `alternateName` selection (§10).
+
+| `presentation_class` | What it is, technically | Renders as | Read | Code-point shape | Examples |
+|---|---|---|---|---|---|
+| **`symbol`** | A text code point with no `Emoji_Presentation` — a monochrome glyph styled by the **surrounding font** (inherits color, size, weight) | text glyph | upright | almost always **one** code point | `★ ♥ ☂ ✓ ∑ € ☮ ☯ ♈ ♪` |
+| **`emoji`** | A code point (or **sequence**) carrying `Emoji_Presentation`, drawn as **vendor color art** from an emoji font | color picture | upright | often **multi**-codepoint: `FE0F` selector, ZWJ families, skin-tone, regional-indicator flags | `❤️ 🔥 😂 🇯🇵 👨‍👩‍👧 🫶🏽` |
+| **`emoticon`** | A **typed** Western face built from ASCII/Latin punctuation, read rotated 90° | plain text | **sideways** | a short typed string (a `combo`) | `:-) :( ;) <3 :')` |
+| **`kaomoji`** | A **typed** Japanese-style face built from symbols/CJK, read head-on, no rotation | text glyphs | **upright** | a typed string of real symbols (a `combo`) | `◕‿◕ (╯°□°)╯ ʕ•ᴥ•ʔ ¯\_(ツ)_/¯` |
+
+The three distinctions that actually trip people up:
+
+- **`symbol` vs `emoji` — the `FE0F` overlap.** Some code points are **both**,
+  switched by a variation selector. `U+2764` is `❤` (a text **symbol**) but
+  `❤️` = `U+2764 U+FE0F` forces **emoji** presentation. Treat `❤` and `❤️` as
+  **two different items** (different class, different render, different intent
+  word). Most symbols never gain an emoji form; most picture-emoji were never
+  plain symbols. Overlapping, *not* identical.
+- **`emoticon` vs `kaomoji` — orientation + origin.** Both are *typed strings*
+  (so both are `combo` on the structure axis), but emoticons are Western and
+  read **sideways** (`:-)`), kaomoji are Japanese and read **upright**
+  (`(╯°□°)╯`). Don't lump them: they're searched by different names.
+- **`kaomoji`/`emoticon` vs `emoji` — built vs drawn.** A kaomoji is *assembled
+  from real symbols* and stays monochrome text; an emoji is a *single drawn
+  picture*. `(╯°□°)╯` is **not** `😠`. They are never the same item and rarely
+  the same page (§9).
+
+> **Colloquial drift (important for §10).** In everyday search, **"emoticon"**
+> is frequently used to mean **"emoji"** for a concrete concept ("heart
+> emoticon" ≈ "heart emoji"). So `emoticon` is **both** a real class (the `:-)`
+> family) **and** a loose synonym word people type for symbols/emoji. We exploit
+> that as an `alternateName` synonym (§10) without letting it blur the class.
+
+---
+
+## 9. One page or many — merging intent **across** classes
+
+The user-facing question: *when someone searches "heart symbol," "heart emoji,"
+and "heart emoticon," do they want the same page?* Often **yes** — and
+`heart-symbols` already answers all three (its `<title>` is literally *"Heart
+Symbol Collection: Copy & Paste Heart **Emojis** & Characters"* and it ships both
+text hearts `❤ ❣` and emoji hearts `💕 💖 ❤️‍🔥`). But it is **not** universal.
+The rule:
+
+**MERGE onto one concept page** when the classes are interchangeable expressions
+of **one concrete concept**, and the searcher neither knows nor cares about the
+class:
+
+- Concept nouns that exist as **both** a `symbol` and an `emoji`: `heart`,
+  `star` (`★`/`⭐`), `arrow`, `check` (`✓`/`✅`), `crown`, `sun`, `music note`
+  (`♪`/`🎵`), `flower`.
+- → **One page.** Show both presentations, **grouped and labelled** ("text
+  symbols" vs "emoji"), cover the `FE0F` variants, and capture *symbol / emoji /
+  emoticon* as synonym queries in `alternateName` (§10).
+
+**KEEP SEPARATE** when any of these is true:
+
+1. **The concept exists in only one class.** Math (`∑ ∫ ≠`), Greek
+   (`α β γ`), IPA, box-drawing, currency signs (`€ £ ¥`) have **no emoji
+   counterpart**. Symbol-only page → **do not** bolt on emoji, **do not** add
+   "emoji" synonyms. (`currency-symbols` is `symbol`-only.)
+2. **The two forms are different jobs.** `currency-symbols` (`€ £ $`, the typist
+   needs the sign) ≠ `money-emojis` (`💰 💵 🤑`, the poster wants the picture).
+   Same topic, **opposite intent** — two pages, no synonym crossover.
+3. **It's a kaomoji / emoticon destination.** People search *"kaomoji,"* *"text
+   faces,"* *"Japanese emoticons,"* *"`:-)` emoticons"* as their **own** intent.
+   These are `combo` library pages (`text-faces-kaomoji`) and **stay separate**
+   from any concept page, even when a face emoji exists — `(╯°□°)╯` ≠ `😠`.
+
+Decision flow:
+
+```
+   is the query a concrete concept that exists in >1 class?
+                         │
+              ┌──────────┴──────────┐
+             yes                     no
+              │                       │
+   same JTBD across classes?     ONE class → its own page;
+        ┌─────┴─────┐            alternateName stays in-class (§10)
+       yes           no
+        │             │
+   MERGE: one     SEPARATE: the
+   concept page,  forms are different
+   both classes,  jobs (currency vs
+   labelled       money-emoji) → 2 pages
+```
+
+---
+
+## 10. Picking `alternateName` from the classification
+
+This is where the two axes pay off. The Schema.org `alternateName` machinery
+([`scripts/alternatename-seo-report.md`](../scripts/alternatename-seo-report.md),
+validated by `scripts/validate-alternatenames.py`: **≤ 8 items, ≤ 60 chars,
+no dupes**) is how a page captures the *class-synonym* queries. The
+`presentation_class`(es) a page **actually serves** decide which synonym words
+are **on-intent** (include) vs **off-intent** (exclude):
+
+> **The one rule:** a class-synonym word may appear in `alternateName` **only if
+> the page actually ships that class's artifact.** Don't claim *"emoji"* with no
+> emoji on the page; don't claim *"symbol"* on an emoji-only page. Wrong synonyms
+> import mismatched intent (bounce) and waste the 8-slot budget.
+
+| Page (class served) | **Include** in `alternateName` | **Exclude** (off-intent) |
+|---|---|---|
+| **Merged concept** — `heart` (`symbol` + `emoji`) | "Heart Symbols", "Heart Emoji", "Heart Emoticon", "Copy Paste Heart", "Heart Text Symbol" | — (all four words are legitimate here) |
+| **Symbol-only** — `currency-symbols` (`symbol`) | "Currency Symbols", "Currency Signs", "Money Symbols" | ✗ "Currency Emoji", ✗ "Money Emoji" (→ that's `money-emojis`) |
+| **Emoji-only** — `face-emojis` (`emoji`) | "Face Emojis", "Smiley Emoji", "Emoticons" (colloquial), "Emoji Faces" | ✗ "Face Symbols" (no text-symbol set on the page) |
+| **Kaomoji** — `text-faces-kaomoji` (`kaomoji`) | "Kaomoji", "Japanese Emoticons", "Text Faces", "Emoticons" | ✗ "Face Emoji" (≠ the `😀` set), ✗ "Face Symbols" |
+
+Practical order of operations when writing a page's `alternateName`:
+
+1. Determine `presentation_class`(es) the page **serves** (§8).
+2. For **each** served class, add its head-noun synonym(s): `symbol` → "…
+   Symbols/Signs/Characters"; `emoji` → "… Emoji/Emojis"; `kaomoji` → "Kaomoji /
+   Text Faces / Japanese Emoticons"; `emoticon` (typed) → "Emoticons".
+3. Add the **colloquial** cross-words **only** where §9 says the intent merges
+   (e.g. "… Emoticon" on a concept page that serves symbol+emoji).
+4. Stop at 8, keep each ≤ 60 chars, no duplicates (the validator enforces this).
+
+---
+
+## 11. Recommended follow-ups (not yet done)
 
 1. **Document the field properly.** Update `unicode-library-workflow.md` §5 to
    reference this doc and list all five `copy_patterns` values (it currently
-   names only two).
-2. ~~**Let the auditor know `combo` is volume-exempt.**~~ **Done.**
+   names only two), **and** the four `presentation_class` values (§8).
+2. **Audit `presentation_class` + `alternateName` across the library** (separate
+   PR). Add the `presentation_class` column to `data/library_opportunities.csv`,
+   classify every live page per §8, flag pages that should **merge/split** per
+   §9, and reconcile each page's `alternateName` set against §10 (off-intent
+   synonyms to remove, missing class-synonyms to add). Wire the §10 rule into
+   `scripts/validate-alternatenames.py` where checkable.
+3. ~~**Let the auditor know `combo` is volume-exempt.**~~ **Done.**
    `scripts/audit_library_opportunities.py` now waives
    `flag_missing_search_volume` / `flag_low_demand_confidence` (and the
    resulting `needs-research` verdict) for `copy_patterns = combo` rows with
@@ -188,6 +335,6 @@ research: a whole competitor — emojicombos.com — plus TikTok Discover hubs, 
    Waivers are surfaced as `combo_volume_waived` in the run summary and noted
    per row in `audit_notes`. Unproven combos (`none`/`weak` evidence) stay
    gated.
-3. **Re-theme, don't multiply, the combos.** Treat the 96 `*-emoji-combos` as a
+4. **Re-theme, don't multiply, the combos.** Treat the 96 `*-emoji-combos` as a
    `combo` family to re-point at vibe/context/fandom over time (per the
    2026-06-17 audit); keep them live for now.


### PR DESCRIPTION
## What & why

We kept treating **symbol / emoji / emoticon / kaomoji** as the same thing, which muddies two decisions: **when two intents share one page**, and **which `alternateName` synonyms belong on a page**. The taxonomy doc previously only classified by *structure* (`copy_patterns`). This PR adds the missing **second, orthogonal axis** — `presentation_class` (what the glyph *is*) — and makes the classification strong enough to drive page-merge and `alternateName` calls.

Docs-only, additive. No page content or code behavior changes.

## Changes (`docs/emoji-combination-taxonomy.md`)

- **Intro** — frames the two independent axes (`copy_patterns` = structure, `presentation_class` = character class) and stresses they must both be tagged.
- **§8 The four classes** — `symbol` · `emoji` · `emoticon` · `kaomoji` with technical definitions and the three traps people hit:
  - `symbol` vs `emoji`: the `FE0F` overlap (`❤` ≠ `❤️` — two items).
  - `emoticon` vs `kaomoji`: Western/sideways vs Japanese/upright.
  - `kaomoji`/`emoticon` vs `emoji`: built-from-symbols vs drawn picture (`(╯°□°)╯` ≠ `😠`).
- **§9 One page or many** — the merge/split rule. Merge when one concrete concept exists across classes (heart symbol + emoji + emoticon → one page, which `heart-symbols` already does). Keep separate when a concept is one-class (`currency-symbols`), when the forms are different jobs (`currency-symbols` ≠ `money-emojis`), or when it's a kaomoji/emoticon destination. Includes a decision flow.
- **§10 Picking `alternateName`** — `presentation_class` served decides on-intent vs off-intent synonyms, with a per-page-type table and a step-by-step, tied to `validate-alternatenames.py` constraints (≤ 8 items, ≤ 60 chars, no dupes).
- **§11 Follow-ups** — adds an item to **audit `presentation_class` + `alternateName` across the library in a separate PR** (add the CSV column, classify every page, flag merges/splits, reconcile synonyms).

Also: `CLAUDE.md` library line now names all four classes and points at the doc.

## Follow-up (separate PR)

The library-wide audit (classify every live page, flag merge/split candidates, reconcile `alternateName` sets) will land as its own PR per §11.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xUzKqrddFDuDj9Wy88CT3

---
_Generated by [Claude Code](https://claude.ai/code/session_011xUzKqrddFDuDj9Wy88CT3)_