### PR TITLE
Improve line-height for multi-line kaomoji in symbol explorer

### DIFF
--- a/symbol-explorer.css
+++ b/symbol-explorer.css
@@ -43,7 +43,10 @@
                "Segoe UI Symbol", system-ui, -apple-system,
                "Plus Jakarta Sans", "Space Mono", sans-serif;
   font-size: 2rem;
-  line-height: 1;
+  /* 1.35 (not 1) so multi-line text faces / kaomoji like (ノಠ益ಠ)ノ keep
+     breathing room when they wrap to a second line; single emoji never wrap,
+     so they are visually unaffected. */
+  line-height: 1.35;
   background: none;
   border: none;
   cursor: pointer;


### PR DESCRIPTION
## Summary
Adjusted the line-height of the symbol explorer button from `1` to `1.35` to provide better visual spacing when multi-line text faces and kaomoji wrap to multiple lines.

## Changes
- **symbol-explorer.css**: Changed `line-height` from `1` to `1.35` on the button element
  - Added explanatory comment documenting the rationale: multi-line kaomoji like `(ノಠ益ಠ)ノ` now have breathing room when wrapping, while single emoji remain visually unaffected since they don't wrap

## Details
The increased line-height prevents multi-line kaomoji and text faces from appearing cramped when they wrap to a second line, improving readability and visual presentation. Single emoji are unaffected since they never wrap to multiple lines.

https://claude.ai/code/session_01JkeetbMP7W4HB6W6LRNUFq