### PR TITLE
docs: add Pinterest "Vertical Text" pin board plan + on-brand pin tem…

### DIFF
--- a/docs/pinterest-vertical-text/README.md
+++ b/docs/pinterest-vertical-text/README.md
@@ -1,0 +1,221 @@
+# Pinterest Board: "Vertical Text Ideas That Stop the Scroll"
+
+A data-grounded Pinterest pin board designed to drive traffic to the vertical text
+pages on ultratextgen.com.
+
+- **Generator (primary destination / money page):** https://ultratextgen.com/usecase/vertical-text/
+- **Guide (authority / "why it works"):** https://ultratextgen.com/guide/vertical-text-guide/
+
+Ready-to-use pin graphics live in this folder as `pin-*.svg` (1000×1500, Pinterest 2:3).
+Export each to PNG before uploading (see "Producing the images" below).
+
+---
+
+## Why Pinterest, and what the data says
+
+**Search Console (last ~4 months):** `/usecase/vertical-text/` already earns
+**753 clicks / 14,918 impressions** at avg position **6.4** and **5.05% CTR** — it is
+the conversion engine, so most pins point there and use the guide as the supporting link.
+
+Demand splits into three intents we design pins around:
+
+1. **The tool** — `vertical font generator` (260/mo), `vertical text generator` (170),
+   `stacked text generator` (170), `stacked text` (170), `text stacker`.
+2. **Copy-paste / aesthetic** — `stacked text copy and paste`, `vertical text copy and paste`,
+   `letters on top of each other`, `top to bottom text`, `double stack font generator`.
+3. **Placement** — `how to stack words in instagram bio`, `stacked lines twitter bio unicode`
+   (we already rank ~#1.6), Discord statuses, TikTok comments.
+
+**Validated by Semrush (US):**
+
+| Keyword | Volume/mo | CPC | Competition |
+|---|---|---|---|
+| vertical font generator | 260 | $0.00 | 0.00 |
+| vertical text generator | 170 | $0.00 | 0.00 |
+| stacked text generator | 170 | $0.00 | 0.00 |
+| stacked text | 170 | $0.00 | 0.00 |
+| **stacked letters tattoo generator** | **140** | **$0.85** | **0.06** |
+| vertical tattoo font generator | 40 | $0.73 | 0.05 |
+| text stacker | 20 | $0.00 | 0.33 |
+| top to bottom text | 20 | $0.00 | 0.33 |
+| how to stack words in instagram bio | 20 | $0.00 | 0.33 |
+
+> **Insight:** the **tattoo** angle is the only cluster with real commercial CPC and
+> almost no competition — and Pinterest is *the* tattoo-idea platform. Weight it heavily.
+
+---
+
+## Board setup
+
+**Board name:** `Vertical Text Ideas That Stop the Scroll`
+
+**Board description (paste into Pinterest):**
+
+> Vertical text and stacked text ideas to make your bio, comments, and captions stand
+> out. Learn how a vertical font generator stacks letters top-to-bottom so a word reads
+> down a column instead of across the line — the easiest way to break the scroll on
+> Instagram, TikTok, X, and Discord. Copy-and-paste stacked text, bio formatting tricks,
+> aesthetic username ideas, tattoo lettering previews, and the psychology of why vertical
+> text grabs attention. Free vertical text generator, no app needed.
+
+**UTM tagging** — append to every destination link so Pinterest traffic is isolated in GA/GTM:
+`?utm_source=pinterest&utm_medium=social&utm_campaign=vertical_text_board`
+
+---
+
+## The 6 stand-out angles → 18 pins
+
+Provided SVG templates are marked `[SVG: pin-N.svg]`.
+
+### Angle 1 — Bios that get a second look
+*Targets: how to stack words in instagram bio · stacked lines twitter bio unicode (rank ~#1.6) · vertical name generator*
+
+**Pin 1 — Instagram bio glow-up** `[SVG: pin-1-bio.svg]`
+- Overlay: `Make your bio stop the scroll`
+- Title: `How to Stack Words in Your Instagram Bio (Free Vertical Text)`
+- Description: `Add one vertical word to your Instagram bio and watch it break the horizontal feed. This free vertical text generator stacks letters top-to-bottom — just type, copy, paste. No app, works in IG, TikTok & X bios. #instagrambio #aestheticbio #verticaltext`
+- → `/usecase/vertical-text/`
+
+**Pin 2 — X / Twitter bio unicode**
+- Overlay: `The bio trick that ranks #1 on Google`
+- Title: `Stacked Text for Your X / Twitter Bio (Copy & Paste)`
+- → `/usecase/vertical-text/`
+
+**Pin 3 — Aesthetic username / name ideas**
+- Overlay: `One word. Stacked. Instantly aesthetic.`
+- Title: `Vertical Name & Username Ideas to Stand Out`
+- → `/usecase/vertical-text/`
+
+### Angle 2 — Comments people actually notice
+*Targets: text stacker · letters on top of each other generator · stacked text brawl stars*
+
+**Pin 4 — The comment hack** `[SVG: pin-4-comment.svg]`
+- Overlay: `The comment everyone scrolls back to`
+- Title: `Make Your Comments Stand Out with Stacked Text`
+- Description: `Comment sections are horizontal noise. Lead a reply with a vertically stacked word like THIS, WAIT, or REAL and it stops the scroll instantly. Free text stacker — copy and paste anywhere. #commenthacks #verticaltext #socialmediatips`
+- → `/usecase/vertical-text/`
+
+**Pin 5 — Discord status / game chat**
+- Overlay: `Discord status that isn't boring`
+- Title: `Vertical Text for Discord Statuses & Game Chat`
+- → `/usecase/vertical-text/`
+
+**Pin 6 — Reaction word pack**
+- Overlay: `WAIT · THIS · REAL · STOP — stacked & ready`
+- Title: `Stacked Reaction Words to Copy & Paste`
+- → `/usecase/vertical-text/`
+
+### Angle 3 — Hooks that stop the scroll
+*Targets: top to bottom text · text above text · guide content*
+
+**Pin 7 — The caption hook** `[SVG: pin-7-hook.svg]`
+- Overlay: `STOP scrolling if you've felt this`
+- Title: `The Vertical Text Hook That Stops the Scroll`
+- Description: `The first line decides if people expand or scroll past. Start a caption with a stacked vertical word and you force a pause. Backed by reading-speed research. Free vertical text generator. #contentcreator #hooks #captionideas`
+- → `/guide/vertical-text-guide/`
+
+**Pin 8 — Hybrid layout technique**
+- Overlay: `1 vertical word + 1 line = perfect hook`
+- Title: `The Hybrid Layout: Vertical Word, Horizontal Message`
+- → `/guide/vertical-text-guide/`
+
+**Pin 9 — Before / after engagement**
+- Overlay: `Same post. One stops the scroll.`
+- Title: `Why Vertical Text Beats a Flat Caption`
+- → `/guide/vertical-text-guide/`
+
+### Angle 4 — The psychology (authority / save-bait)
+*Repurposes the research-backed guide — Pinterest loves "the science of" infographics*
+
+**Pin 10 — The science infographic** `[SVG: pin-10-science.svg]`
+- Overlay: `Why your eye CAN'T ignore vertical text`
+- Title: `The Science of Why Vertical Text Grabs Attention`
+- Description: `Vertical text isn't decoration — it's a pattern interrupt. Research shows we read horizontal text up to 70% faster, so stacked vertical text forces the eye to slow down and reset attention. Here's how to use it on purpose. #psychology #marketingtips #attention`
+- → `/guide/vertical-text-guide/`
+
+**Pin 11 — Do's and don'ts**
+- Overlay: `Vertical text: 1–2 words ✅  paragraphs ❌`
+- Title: `Vertical Text Best Practices (What Works & What Fails)`
+- → `/guide/vertical-text-guide/`
+
+**Pin 12 — "Use it like a speed bump"**
+- Overlay: `Use vertical text like a speed bump`
+- Title: `When to Use Vertical Text (And When Not To)`
+- → `/guide/vertical-text-guide/`
+
+### Angle 5 — Tattoo & lettering (highest commercial value)
+*Targets: stacked letters tattoo generator (140/mo, $0.85 CPC) · vertical tattoo fonts · vertical font generator for tattoos*
+
+**Pin 13 — Vertical tattoo lettering** `[SVG: pin-13-tattoo.svg]`
+- Overlay: `Preview your tattoo before you ink it`
+- Title: `Vertical Tattoo Font Ideas (Free Stacked Lettering Generator)`
+- Description: `Planning a vertical spine or arm tattoo? Preview your word stacked top-to-bottom before you commit. Free vertical text generator with clean, readable lettering. Type any name or word, copy, save your design. #tattooideas #tattoofont #verticaltattoo`
+- → `/usecase/vertical-text/`
+
+**Pin 14 — Name tattoo preview**
+- Overlay: `See your name vertically before you ink it`
+- Title: `Stacked Letter Tattoo Generator for Names`
+- → `/usecase/vertical-text/`
+
+### Angle 6 — Copy-paste & how-to tutorials
+*Targets: stacked text copy and paste · vertical text copy and paste · vertical font generator copy and paste*
+
+**Pin 15 — 3-step tutorial** `[SVG: pin-15-howto.svg]`
+- Overlay: `Type → Copy → Paste. That's it.`
+- Title: `How to Make Vertical Text in 3 Steps (Free)`
+- Description: `Make stacked vertical text in seconds: type your word, copy the result, paste it anywhere. Each letter sits on its own line so the word reads down a column. Works on Instagram, TikTok, X & Discord. Free, no app. #howto #verticaltext #copyandpaste`
+- → `/usecase/vertical-text/`
+
+**Pin 16 — Copy-paste pack**
+- Overlay: `Stacked text you can copy right now`
+- Title: `Vertical / Stacked Text to Copy and Paste`
+- → `/usecase/vertical-text/`
+
+**Pin 17 — Platform checklist**
+- Overlay: `Works on IG · TikTok · X · Discord`
+- Title: `Where Vertical Text Works (Every App)`
+- → `/usecase/vertical-text/`
+
+**Pin 18 — "No app needed"**
+- Overlay: `Free vertical font generator. No download.`
+- Title: `Free Vertical Font Generator (Works in Your Browser)`
+- → `/usecase/vertical-text/`
+
+---
+
+## Producing the images
+
+The `pin-*.svg` files are 1000×1500 (Pinterest's recommended 2:3). Pinterest needs raster
+uploads, so convert to PNG/JPG. Any of these works:
+
+```bash
+# ImageMagick
+magick -density 144 pin-1-bio.svg pin-1-bio.png
+
+# rsvg-convert (librsvg)
+rsvg-convert -w 1000 -h 1500 pin-1-bio.svg -o pin-1-bio.png
+
+# Inkscape
+inkscape pin-1-bio.svg --export-type=png -w 1000 -h 1500
+```
+
+Or open the SVG in a browser and screenshot, or import into Canva/Figma to restyle with
+photos. The 6 provided templates cover one pin per angle — duplicate and swap the headline
++ stacked word to produce the remaining 12 (and 3–5 color/photo variants each).
+
+## Publishing tips
+
+- **Format:** 1000×1500 (2:3). The pin itself should *demonstrate* stacked text so the
+  thumbnail self-explains.
+- **Cadence:** 1–3 fresh pins/day beats a single bulk dump. Make 3–5 variants per concept
+  (different colors/photos, same link) — Pinterest treats each as fresh.
+- **SEO:** put the keyword in the pin **title, description, AND image text** — Pinterest
+  reads all three.
+- **Brand:** matches the site palette (purple `#8b5cf6` → blue `#3b82f6`, ink `#1a1a2e`).
+- **Track:** use the UTM string above to measure Pinterest traffic separately.
+
+## Note on Semrush data
+
+The single-keyword volumes above were pulled live from Semrush (US database). A broader
+related-keyword expansion was attempted but stopped short on available Semrush API units —
+top up at https://www.semrush.com/mcp-access to refresh/expand the list.

--- a/docs/pinterest-vertical-text/pin-1-bio.svg
+++ b/docs/pinterest-vertical-text/pin-1-bio.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1500" width="1000" height="1500" role="img" font-family="Liberation Sans, DejaVu Sans, Arial, sans-serif">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#8b5cf6"/><stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+    <linearGradient id="gh" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#8b5cf6"/><stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#8b5cf6" stop-opacity="0.16"/><stop offset="1" stop-color="#8b5cf6" stop-opacity="0"/>
+    </radialGradient>
+    <pattern id="dots" width="26" height="26" patternUnits="userSpaceOnUse">
+      <circle cx="2" cy="2" r="1.6" fill="#1a1a2e" opacity="0.05"/>
+    </pattern>
+    <filter id="sh" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="10" stdDeviation="22" flood-color="#1a1a2e" flood-opacity="0.10"/>
+    </filter>
+  </defs>
+
+  <rect width="1000" height="1500" fill="#FBFBFE"/>
+  <rect width="1000" height="1500" fill="url(#dots)"/>
+  <circle cx="850" cy="180" r="360" fill="url(#glow)"/>
+  <rect width="1000" height="14" fill="url(#gh)"/>
+
+  <text x="500" y="92" text-anchor="middle" font-size="28" font-weight="700" letter-spacing="6" fill="#64748b">ULTRATEXTGEN.COM</text>
+
+  <rect x="305" y="128" width="390" height="50" rx="25" fill="#ffffff" stroke="#e2e8f0"/>
+  <text x="500" y="161" text-anchor="middle" font-size="22" font-weight="700" letter-spacing="2" fill="#8b5cf6">INSTAGRAM · TIKTOK · X BIOS</text>
+
+  <text x="500" y="300" text-anchor="middle" font-size="78" font-weight="700" fill="#1a1a2e">Make your bio</text>
+  <text x="500" y="392" text-anchor="middle" font-size="78" font-weight="700" fill="url(#g)">stop the scroll</text>
+
+  <!-- demo card -->
+  <rect x="140" y="500" width="720" height="540" rx="30" fill="#ffffff" stroke="#e2e8f0" filter="url(#sh)"/>
+  <!-- faux feed lines -->
+  <g stroke="#64748b" stroke-width="11" stroke-linecap="round" opacity="0.16">
+    <line x1="520" y1="600" x2="800" y2="600"/>
+    <line x1="520" y1="668" x2="780" y2="668"/>
+    <line x1="520" y1="872" x2="800" y2="872"/>
+    <line x1="520" y1="940" x2="760" y2="940"/>
+  </g>
+  <!-- stacked accent word -->
+  <g text-anchor="middle" font-size="118" font-weight="700" fill="url(#g)">
+    <text x="340" y="650">N</text><text x="340" y="775">O</text><text x="340" y="900">W</text>
+  </g>
+  <text x="500" y="1010" text-anchor="middle" font-size="26" fill="#64748b">one vertical word breaks the horizontal feed</text>
+
+  <!-- CTA -->
+  <rect x="230" y="1230" width="540" height="96" rx="48" fill="url(#gh)" filter="url(#sh)"/>
+  <text x="500" y="1291" text-anchor="middle" font-size="38" font-weight="700" fill="#ffffff">Try the free generator →</text>
+
+  <text x="500" y="1430" text-anchor="middle" font-size="27" fill="#94a3b8">ultratextgen.com/usecase/vertical-text</text>
+</svg>

--- a/docs/pinterest-vertical-text/pin-10-science.svg
+++ b/docs/pinterest-vertical-text/pin-10-science.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1500" width="1000" height="1500" role="img" font-family="Liberation Sans, DejaVu Sans, Arial, sans-serif">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#8b5cf6"/><stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+    <linearGradient id="gh" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#8b5cf6"/><stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#8b5cf6" stop-opacity="0.16"/><stop offset="1" stop-color="#8b5cf6" stop-opacity="0"/>
+    </radialGradient>
+    <pattern id="dots" width="26" height="26" patternUnits="userSpaceOnUse">
+      <circle cx="2" cy="2" r="1.6" fill="#1a1a2e" opacity="0.05"/>
+    </pattern>
+    <filter id="sh" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="10" stdDeviation="22" flood-color="#1a1a2e" flood-opacity="0.10"/>
+    </filter>
+  </defs>
+
+  <rect width="1000" height="1500" fill="#FBFBFE"/>
+  <rect width="1000" height="1500" fill="url(#dots)"/>
+  <circle cx="850" cy="180" r="360" fill="url(#glow)"/>
+  <rect width="1000" height="14" fill="url(#gh)"/>
+
+  <text x="500" y="92" text-anchor="middle" font-size="28" font-weight="700" letter-spacing="6" fill="#64748b">ULTRATEXTGEN.COM</text>
+
+  <rect x="350" y="128" width="300" height="50" rx="25" fill="#ffffff" stroke="#e2e8f0"/>
+  <text x="500" y="161" text-anchor="middle" font-size="22" font-weight="700" letter-spacing="2" fill="#8b5cf6">THE PSYCHOLOGY</text>
+
+  <text x="500" y="300" text-anchor="middle" font-size="74" font-weight="700" fill="#1a1a2e">Why your eye can't</text>
+  <text x="500" y="388" text-anchor="middle" font-size="74" font-weight="700" fill="url(#g)">ignore vertical text</text>
+
+  <!-- stat card -->
+  <rect x="140" y="490" width="720" height="560" rx="30" fill="#ffffff" stroke="#e2e8f0" filter="url(#sh)"/>
+
+  <text x="500" y="610" text-anchor="middle" font-size="120" font-weight="700" fill="url(#g)">70%</text>
+  <text x="500" y="660" text-anchor="middle" font-size="28" fill="#64748b">faster to read horizontal than vertical*</text>
+
+  <line x1="220" y1="710" x2="780" y2="710" stroke="#e2e8f0" stroke-width="2"/>
+
+  <!-- 3 mini facts -->
+  <g font-size="29" fill="#1a1a2e">
+    <circle cx="245" cy="770" r="9" fill="#8b5cf6"/><text x="280" y="780">Orientation contrast is pre-attentive</text>
+    <circle cx="245" cy="845" r="9" fill="#8b5cf6"/><text x="280" y="855">Reading slows → attention resets</text>
+    <circle cx="245" cy="920" r="9" fill="#8b5cf6"/><text x="280" y="930">The scroll rhythm gets interrupted</text>
+  </g>
+  <text x="500" y="1010" text-anchor="middle" font-size="22" fill="#94a3b8">*Yu et al., 2010 · Porter &amp; Arblaster, 2020</text>
+
+  <!-- CTA -->
+  <rect x="270" y="1240" width="460" height="96" rx="48" fill="url(#gh)" filter="url(#sh)"/>
+  <text x="500" y="1301" text-anchor="middle" font-size="38" font-weight="700" fill="#ffffff">Read the science →</text>
+
+  <text x="500" y="1430" text-anchor="middle" font-size="27" fill="#94a3b8">ultratextgen.com/guide/vertical-text-guide</text>
+</svg>

--- a/docs/pinterest-vertical-text/pin-13-tattoo.svg
+++ b/docs/pinterest-vertical-text/pin-13-tattoo.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1500" width="1000" height="1500" role="img" font-family="Liberation Sans, DejaVu Sans, Arial, sans-serif">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#8b5cf6"/><stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+    <linearGradient id="gh" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#8b5cf6"/><stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#8b5cf6" stop-opacity="0.16"/><stop offset="1" stop-color="#8b5cf6" stop-opacity="0"/>
+    </radialGradient>
+    <pattern id="dots" width="26" height="26" patternUnits="userSpaceOnUse">
+      <circle cx="2" cy="2" r="1.6" fill="#1a1a2e" opacity="0.05"/>
+    </pattern>
+    <filter id="sh" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="10" stdDeviation="22" flood-color="#1a1a2e" flood-opacity="0.10"/>
+    </filter>
+  </defs>
+
+  <rect width="1000" height="1500" fill="#FBFBFE"/>
+  <rect width="1000" height="1500" fill="url(#dots)"/>
+  <circle cx="850" cy="180" r="360" fill="url(#glow)"/>
+  <rect width="1000" height="14" fill="url(#gh)"/>
+
+  <text x="500" y="92" text-anchor="middle" font-size="28" font-weight="700" letter-spacing="6" fill="#64748b">ULTRATEXTGEN.COM</text>
+
+  <rect x="350" y="128" width="300" height="50" rx="25" fill="#ffffff" stroke="#e2e8f0"/>
+  <text x="500" y="161" text-anchor="middle" font-size="22" font-weight="700" letter-spacing="2" fill="#8b5cf6">TATTOO LETTERING</text>
+
+  <text x="500" y="300" text-anchor="middle" font-size="76" font-weight="700" fill="#1a1a2e">Preview your tattoo</text>
+  <text x="500" y="390" text-anchor="middle" font-size="76" font-weight="700" fill="url(#g)">before you ink it</text>
+
+  <!-- demo card: forearm + stacked name -->
+  <rect x="140" y="500" width="720" height="540" rx="30" fill="#ffffff" stroke="#e2e8f0" filter="url(#sh)"/>
+  <!-- stylised arm -->
+  <rect x="600" y="540" width="150" height="460" rx="75" fill="#f1ece7" stroke="#e7ded4"/>
+  <!-- stacked name down the arm -->
+  <g text-anchor="middle" font-size="74" font-weight="600" fill="#1a1a2e" font-style="italic">
+    <text x="675" y="640">G</text><text x="675" y="712">R</text><text x="675" y="784">A</text><text x="675" y="856">C</text><text x="675" y="928">E</text>
+  </g>
+  <!-- generator echo on the left -->
+  <g text-anchor="middle" font-size="74" font-weight="600" fill="url(#g)">
+    <text x="290" y="640">G</text><text x="290" y="712">R</text><text x="290" y="784">A</text><text x="290" y="856">C</text><text x="290" y="928">E</text>
+  </g>
+  <text x="290" y="985" text-anchor="middle" font-size="24" fill="#64748b">type any word</text>
+  <text x="675" y="985" text-anchor="middle" font-size="24" fill="#64748b">see it on skin</text>
+
+  <!-- CTA -->
+  <rect x="230" y="1230" width="540" height="96" rx="48" fill="url(#gh)" filter="url(#sh)"/>
+  <text x="500" y="1291" text-anchor="middle" font-size="38" font-weight="700" fill="#ffffff">Try the free generator →</text>
+
+  <text x="500" y="1430" text-anchor="middle" font-size="27" fill="#94a3b8">ultratextgen.com/usecase/vertical-text</text>
+</svg>

--- a/docs/pinterest-vertical-text/pin-15-howto.svg
+++ b/docs/pinterest-vertical-text/pin-15-howto.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1500" width="1000" height="1500" role="img" font-family="Liberation Sans, DejaVu Sans, Arial, sans-serif">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#8b5cf6"/><stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+    <linearGradient id="gh" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#8b5cf6"/><stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#8b5cf6" stop-opacity="0.16"/><stop offset="1" stop-color="#8b5cf6" stop-opacity="0"/>
+    </radialGradient>
+    <pattern id="dots" width="26" height="26" patternUnits="userSpaceOnUse">
+      <circle cx="2" cy="2" r="1.6" fill="#1a1a2e" opacity="0.05"/>
+    </pattern>
+    <filter id="sh" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="10" stdDeviation="22" flood-color="#1a1a2e" flood-opacity="0.10"/>
+    </filter>
+  </defs>
+
+  <rect width="1000" height="1500" fill="#FBFBFE"/>
+  <rect width="1000" height="1500" fill="url(#dots)"/>
+  <circle cx="850" cy="180" r="360" fill="url(#glow)"/>
+  <rect width="1000" height="14" fill="url(#gh)"/>
+
+  <text x="500" y="92" text-anchor="middle" font-size="28" font-weight="700" letter-spacing="6" fill="#64748b">ULTRATEXTGEN.COM</text>
+
+  <rect x="420" y="128" width="160" height="50" rx="25" fill="#ffffff" stroke="#e2e8f0"/>
+  <text x="500" y="161" text-anchor="middle" font-size="22" font-weight="700" letter-spacing="2" fill="#8b5cf6">HOW-TO</text>
+
+  <text x="500" y="300" text-anchor="middle" font-size="78" font-weight="700" fill="#1a1a2e">Vertical text in</text>
+  <text x="500" y="392" text-anchor="middle" font-size="78" font-weight="700" fill="url(#g)">3 simple steps</text>
+
+  <!-- step 1 -->
+  <rect x="140" y="490" width="720" height="160" rx="24" fill="#ffffff" stroke="#e2e8f0" filter="url(#sh)"/>
+  <circle cx="230" cy="570" r="44" fill="url(#g)"/>
+  <text x="230" y="586" text-anchor="middle" font-size="46" font-weight="700" fill="#ffffff">1</text>
+  <text x="310" y="555" font-size="40" font-weight="700" fill="#1a1a2e">Type your word</text>
+  <text x="310" y="600" font-size="27" fill="#64748b">any name, word, or short phrase</text>
+
+  <!-- step 2 -->
+  <rect x="140" y="680" width="720" height="160" rx="24" fill="#ffffff" stroke="#e2e8f0" filter="url(#sh)"/>
+  <circle cx="230" cy="760" r="44" fill="url(#g)"/>
+  <text x="230" y="776" text-anchor="middle" font-size="46" font-weight="700" fill="#ffffff">2</text>
+  <text x="310" y="745" font-size="40" font-weight="700" fill="#1a1a2e">Copy the result</text>
+  <text x="310" y="790" font-size="27" fill="#64748b">letters stacked top-to-bottom</text>
+
+  <!-- step 3 -->
+  <rect x="140" y="870" width="720" height="160" rx="24" fill="#ffffff" stroke="#e2e8f0" filter="url(#sh)"/>
+  <circle cx="230" cy="950" r="44" fill="url(#g)"/>
+  <text x="230" y="966" text-anchor="middle" font-size="46" font-weight="700" fill="#ffffff">3</text>
+  <text x="310" y="935" font-size="40" font-weight="700" fill="#1a1a2e">Paste anywhere</text>
+  <text x="310" y="980" font-size="27" fill="#64748b">IG · TikTok · X · Discord</text>
+
+  <!-- CTA -->
+  <rect x="280" y="1230" width="440" height="96" rx="48" fill="url(#gh)" filter="url(#sh)"/>
+  <text x="500" y="1291" text-anchor="middle" font-size="38" font-weight="700" fill="#ffffff">Make yours free →</text>
+
+  <text x="500" y="1430" text-anchor="middle" font-size="27" fill="#94a3b8">ultratextgen.com/usecase/vertical-text</text>
+</svg>

--- a/docs/pinterest-vertical-text/pin-4-comment.svg
+++ b/docs/pinterest-vertical-text/pin-4-comment.svg
@@ -1,0 +1,58 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1500" width="1000" height="1500" role="img" font-family="Liberation Sans, DejaVu Sans, Arial, sans-serif">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#8b5cf6"/><stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+    <linearGradient id="gh" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#8b5cf6"/><stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#8b5cf6" stop-opacity="0.16"/><stop offset="1" stop-color="#8b5cf6" stop-opacity="0"/>
+    </radialGradient>
+    <pattern id="dots" width="26" height="26" patternUnits="userSpaceOnUse">
+      <circle cx="2" cy="2" r="1.6" fill="#1a1a2e" opacity="0.05"/>
+    </pattern>
+    <filter id="sh" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="10" stdDeviation="22" flood-color="#1a1a2e" flood-opacity="0.10"/>
+    </filter>
+  </defs>
+
+  <rect width="1000" height="1500" fill="#FBFBFE"/>
+  <rect width="1000" height="1500" fill="url(#dots)"/>
+  <circle cx="850" cy="180" r="360" fill="url(#glow)"/>
+  <rect width="1000" height="14" fill="url(#gh)"/>
+
+  <text x="500" y="92" text-anchor="middle" font-size="28" font-weight="700" letter-spacing="6" fill="#64748b">ULTRATEXTGEN.COM</text>
+
+  <rect x="345" y="128" width="310" height="50" rx="25" fill="#ffffff" stroke="#e2e8f0"/>
+  <text x="500" y="161" text-anchor="middle" font-size="22" font-weight="700" letter-spacing="2" fill="#8b5cf6">COMMENTS &amp; REPLIES</text>
+
+  <text x="500" y="300" text-anchor="middle" font-size="78" font-weight="700" fill="#1a1a2e">The comment they</text>
+  <text x="500" y="392" text-anchor="middle" font-size="78" font-weight="700" fill="url(#g)">scroll back to</text>
+
+  <!-- demo card: comment thread -->
+  <rect x="140" y="500" width="720" height="540" rx="30" fill="#ffffff" stroke="#e2e8f0" filter="url(#sh)"/>
+  <!-- two muted comments -->
+  <g>
+    <circle cx="210" cy="585" r="26" fill="#e2e8f0"/>
+    <rect x="252" y="565" width="140" height="16" rx="8" fill="#cbd5e1"/>
+    <rect x="252" y="595" width="430" height="14" rx="7" fill="#eef2f7"/>
+    <circle cx="210" cy="690" r="26" fill="#e2e8f0"/>
+    <rect x="252" y="670" width="120" height="16" rx="8" fill="#cbd5e1"/>
+    <rect x="252" y="700" width="380" height="14" rx="7" fill="#eef2f7"/>
+  </g>
+  <!-- highlighted reply with stacked word -->
+  <rect x="170" y="752" width="660" height="240" rx="20" fill="#f5f3ff" stroke="#8b5cf6" stroke-opacity="0.35"/>
+  <g text-anchor="middle" font-size="58" font-weight="700" fill="url(#g)">
+    <text x="250" y="812">T</text><text x="250" y="868">H</text><text x="250" y="924">I</text><text x="250" y="980">S</text>
+  </g>
+  <text x="360" y="885" font-size="30" font-weight="600" fill="#1a1a2e">exactly what I</text>
+  <text x="360" y="925" font-size="30" font-weight="600" fill="#1a1a2e">was thinking</text>
+  <text x="500" y="1010" text-anchor="middle" font-size="26" fill="#64748b">lead your reply with one stacked word</text>
+
+  <!-- CTA -->
+  <rect x="210" y="1230" width="580" height="96" rx="48" fill="url(#gh)" filter="url(#sh)"/>
+  <text x="500" y="1291" text-anchor="middle" font-size="38" font-weight="700" fill="#ffffff">Try the free text stacker →</text>
+
+  <text x="500" y="1430" text-anchor="middle" font-size="27" fill="#94a3b8">ultratextgen.com/usecase/vertical-text</text>
+</svg>

--- a/docs/pinterest-vertical-text/pin-7-hook.svg
+++ b/docs/pinterest-vertical-text/pin-7-hook.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1500" width="1000" height="1500" role="img" font-family="Liberation Sans, DejaVu Sans, Arial, sans-serif">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#8b5cf6"/><stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+    <linearGradient id="gh" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#8b5cf6"/><stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#8b5cf6" stop-opacity="0.16"/><stop offset="1" stop-color="#8b5cf6" stop-opacity="0"/>
+    </radialGradient>
+    <pattern id="dots" width="26" height="26" patternUnits="userSpaceOnUse">
+      <circle cx="2" cy="2" r="1.6" fill="#1a1a2e" opacity="0.05"/>
+    </pattern>
+    <filter id="sh" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="10" stdDeviation="22" flood-color="#1a1a2e" flood-opacity="0.10"/>
+    </filter>
+  </defs>
+
+  <rect width="1000" height="1500" fill="#FBFBFE"/>
+  <rect width="1000" height="1500" fill="url(#dots)"/>
+  <circle cx="850" cy="180" r="360" fill="url(#glow)"/>
+  <rect width="1000" height="14" fill="url(#gh)"/>
+
+  <text x="500" y="92" text-anchor="middle" font-size="28" font-weight="700" letter-spacing="6" fill="#64748b">ULTRATEXTGEN.COM</text>
+
+  <rect x="360" y="128" width="280" height="50" rx="25" fill="#ffffff" stroke="#e2e8f0"/>
+  <text x="500" y="161" text-anchor="middle" font-size="22" font-weight="700" letter-spacing="2" fill="#8b5cf6">CAPTION HOOKS</text>
+
+  <text x="500" y="300" text-anchor="middle" font-size="78" font-weight="700" fill="#1a1a2e">Stop the scroll</text>
+  <text x="500" y="392" text-anchor="middle" font-size="78" font-weight="700" fill="url(#g)">in 4 letters</text>
+
+  <!-- demo card -->
+  <rect x="140" y="500" width="720" height="540" rx="30" fill="#ffffff" stroke="#e2e8f0" filter="url(#sh)"/>
+  <g stroke="#64748b" stroke-width="11" stroke-linecap="round" opacity="0.16">
+    <line x1="500" y1="560" x2="790" y2="560"/>
+    <line x1="500" y1="628" x2="760" y2="628"/>
+  </g>
+  <!-- stacked STOP -->
+  <g text-anchor="middle" font-size="104" font-weight="700" fill="url(#g)">
+    <text x="330" y="610">S</text><text x="330" y="720">T</text><text x="330" y="830">O</text><text x="330" y="940">P</text>
+  </g>
+  <text x="500" y="745" font-size="30" font-weight="600" fill="#1a1a2e">scrolling if</text>
+  <text x="500" y="788" font-size="30" font-weight="600" fill="#1a1a2e">you've ever</text>
+  <text x="500" y="831" font-size="30" font-weight="600" fill="#1a1a2e">felt this</text>
+  <text x="500" y="1010" text-anchor="middle" font-size="26" fill="#64748b">open your caption with a vertical hook</text>
+
+  <!-- CTA -->
+  <rect x="245" y="1230" width="510" height="96" rx="48" fill="url(#gh)" filter="url(#sh)"/>
+  <text x="500" y="1291" text-anchor="middle" font-size="38" font-weight="700" fill="#ffffff">See how it works →</text>
+
+  <text x="500" y="1430" text-anchor="middle" font-size="27" fill="#94a3b8">ultratextgen.com/guide/vertical-text-guide</text>
+</svg>


### PR DESCRIPTION
…plates

Add a data-grounded Pinterest content plan and six ready-to-use 1000x1500 pin graphics aimed at driving traffic to the vertical text pages.

- README.md: board setup, 18 pin concepts across 6 stand-out angles, each mapped to real keyword demand (GSC + Semrush US), link/UTM strategy, and publishing/export instructions.
- pin-*.svg: six on-brand pin templates (bio, comment, hook, science, tattoo, how-to) using the site palette and demonstrating stacked text.


Claude-Session: https://claude.ai/code/session_0142phUU5MSkKcN8ovBbTbK4