### PR TITLE
feat(es): add abecedario A–Z showcase and símbolos section to ES page

### DIFF
--- a/es/index.html
+++ b/es/index.html
@@ -351,6 +351,96 @@
     <div class="results-grid" id="resultsGrid"></div>
   </main>
 
+  <!-- Abecedario en letras bonitas -->
+  <section class="editorial-section abc-section" aria-label="Abecedario en letras bonitas para copiar y pegar">
+    <h2>Abecedario en letras bonitas</h2>
+    <p>Aquí tienes el abecedario completo —mayúsculas (A–Z), minúsculas (a–z) y números (0–9)— en los tipos de letras bonitas más usados. Escribe arriba y toca «Copiar» para llevarte cualquier palabra en estos estilos, o selecciona las letras de la tabla para copiarlas tú mismo.</p>
+
+    <div class="abc-list">
+      <div class="abc-row">
+        <span class="abc-name">Negrita</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝗔𝗕𝗖𝗗𝗘𝗙𝗚𝗛𝗜𝗝𝗞𝗟𝗠𝗡𝗢𝗣𝗤𝗥𝗦𝗧𝗨𝗩𝗪𝗫𝗬𝗭</span>
+          <span class="abc-line">𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇</span>
+          <span class="abc-line">𝟬𝟭𝟮𝟯𝟰𝟱𝟲𝟳𝟴𝟵</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Cursiva</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝘈𝘉𝘊𝘋𝘌𝘍𝘎𝘏𝘐𝘑𝘒𝘓𝘔𝘕𝘖𝘗𝘘𝘙𝘚𝘛𝘜𝘝𝘞𝘟𝘠𝘡</span>
+          <span class="abc-line">𝘢𝘣𝘤𝘥𝘦𝘧𝘨𝘩𝘪𝘫𝘬𝘭𝘮𝘯𝘰𝘱𝘲𝘳𝘴𝘵𝘶𝘷𝘸𝘹𝘺𝘻</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Cursiva elegante</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵</span>
+          <span class="abc-line">𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Cursiva gruesa</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩</span>
+          <span class="abc-line">𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Gótica</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝔄𝔅ℭ𝔇𝔈𝔉𝔊ℌℑ𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔ℜ𝔖𝔗𝔘𝔙𝔚𝔛𝔜ℨ</span>
+          <span class="abc-line">𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Burbuja</span>
+        <div class="abc-lines">
+          <span class="abc-line">ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ</span>
+          <span class="abc-line">ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ</span>
+          <span class="abc-line">⓪①②③④⑤⑥⑦⑧⑨</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Letras bonitas y símbolos -->
+  <section class="editorial-section symbols-section" aria-label="Letras bonitas y símbolos para copiar y pegar">
+    <h2>Letras bonitas y símbolos para copiar y pegar</h2>
+    <p>Combina tus letras con símbolos para que destaquen aún más. Aquí tienes los más usados, listos para copiar y pegar. Para añadirlos automáticamente a tu texto, usa las pestañas <strong>Símbolos</strong>, <strong>Marcos</strong> y <strong>Separadores</strong> del generador de arriba.</p>
+
+    <div class="symbol-groups">
+      <div class="symbol-group">
+        <h3>Corazones</h3>
+        <p class="symbol-set">♡ ♥ ❤ 💕 💖 💗 ❥ ღ ❣ ꒰♡꒱ ⟡</p>
+      </div>
+      <div class="symbol-group">
+        <h3>Estrellas y destellos</h3>
+        <p class="symbol-set">★ ☆ ✦ ✧ ⋆ ⭒ ✩ ✯ ✰ ࿐ ｡ﾟ</p>
+      </div>
+      <div class="symbol-group">
+        <h3>Flores y naturaleza</h3>
+        <p class="symbol-set">✿ ❀ ❁ ✾ ♧ ☘ ⚘ ꕥ ❃ ✤</p>
+      </div>
+      <div class="symbol-group">
+        <h3>Lunas y noche</h3>
+        <p class="symbol-set">☾ ☽ ⊹ ✬ ☄ ✫ ⋆｡˚ ☁ ❄ ❆</p>
+      </div>
+      <div class="symbol-group">
+        <h3>Flechas</h3>
+        <p class="symbol-set">→ ← ↬ ↫ ➳ ➢ ➤ ⇢ ⇠ ↳ ⤷</p>
+      </div>
+      <div class="symbol-group">
+        <h3>Kawaii y caritas (kaomoji)</h3>
+        <p class="symbol-set">(◍•ᴗ•◍) (｡♥‿♥｡) ʕ•ᴥ•ʔ (＾▽＾) (づ｡◕‿‿◕｡)づ ٩(◕‿◕)۶</p>
+      </div>
+    </div>
+  </section>
+
   <!-- Popular Use Cases -->
   <section class="editorial-section">
     <h2 data-i18n="useCases.title">Para qué se usan más</h2>

--- a/style.css
+++ b/style.css
@@ -2752,3 +2752,88 @@ body.dark-mode .vertical-chip {
   border-color: var(--accent-purple);
   color: #fff;
 }
+
+/* ==========================================================================
+   Abecedario showcase (ES) — letras bonitas A–Z
+   ========================================================================== */
+.abc-list {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.abc-row {
+  display: grid;
+  grid-template-columns: 140px 1fr;
+  gap: 1rem;
+  align-items: center;
+  padding: 0.9rem 1rem;
+  background: var(--bg-white);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius);
+}
+
+.abc-name {
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.abc-lines {
+  display: grid;
+  gap: 0.35rem;
+  min-width: 0;
+}
+
+.abc-line {
+  font-size: 1.15rem;
+  line-height: 1.4;
+  color: var(--text-primary);
+  overflow-x: auto;
+  white-space: nowrap;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: thin;
+}
+
+@media (max-width: 600px) {
+  .abc-row {
+    grid-template-columns: 1fr;
+    gap: 0.4rem;
+  }
+  .abc-line {
+    font-size: 1.05rem;
+  }
+}
+
+/* ==========================================================================
+   Símbolos para copiar y pegar (ES)
+   ========================================================================== */
+.symbol-groups {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.symbol-group {
+  padding: 1rem 1.1rem;
+  background: var(--bg-white);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius);
+}
+
+.symbol-group h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.symbol-set {
+  margin: 0;
+  font-size: 1.2rem;
+  line-height: 1.7;
+  letter-spacing: 0.12em;
+  color: var(--text-primary);
+  word-break: break-word;
+}


### PR DESCRIPTION
Targets the "abecedario letras bonitas" (KD 29) and "letras bonitas y símbolos" query clusters the /es/ page already ranks for, with crawlable on-page content. Adds the full alphabet (upper, lower, numbers) in the six most-used styles using the exact Unicode the generator produces, plus a categorized copy-and-paste symbols reference. Styling uses existing CSS tokens; no inline styles, no new JS.


Claude-Session: https://claude.ai/code/session_01BvxVmh52S4SnX7Tf1WcKCL