### PR TITLE
docs: codify Pinterest board conventions to stop off-system reworks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,8 +52,16 @@ ultratextgen/
 │   ├── update-sitemap.js   # Sitemap generator (Node.js)
 │   ├── inject-faq-jsonld.js# FAQ structured data injector
 │   ├── tweet_queue.py      # Git-to-tweet automation (Python)
+│   ├── generate-site-art.py# SINGLE source of truth for the brand pin/art skin
+│   ├── generate-pinterest.py     # Per-page pin generator (imports generate-site-art)
+│   ├── generate-id-pins.py       # /id/ board generator (mirror this for new boards)
+│   ├── generate-vertical-text-pins.py # vertical-text board generator
 │   ├── pinterest_csv.py    # SINGLE source of truth for the Pinterest upload schema
 │   └── build_pinterest_upload.py # inventory CSV -> *_upload.csv (importer-ready)
+│
+├── assets/pinterest/<board>/ # Pin images (1000×1500 PNG, 2:3) — the ONLY place pins go
+├── data/*_pinterest_pins.csv      # internal inventory CSVs (never uploaded)
+├── data/*_pinterest_pins_upload.csv # importer-ready CSVs (upload these only)
 │
 ├── category/               # Category landing pages (bold, cursive, etc.)
 ├── usecase/                # Use case pages (bio, comment, etc.)
@@ -298,3 +306,11 @@ Do not add a test framework unless explicitly requested.
   The internal inventory CSVs (`data/*_pins.csv`) are NOT importable. Only the
   `data/*_upload.csv` files are — generated solely via `scripts/pinterest_csv.py`
   / `scripts/build_pinterest_upload.py`. See `docs/pinterest-csv-format.md`.
+- Do not create a new Pinterest board off-system. Read
+  `docs/pinterest-pin-generation.md` ("Adding a new pin board") FIRST, every time.
+  Specifically: do not put pins in a new top-level folder (e.g. `pinterest-kit/`)
+  or under `docs/` — they go in `assets/pinterest/<board>/`; do not write a
+  bespoke generator or visual template — mirror `scripts/generate-id-pins.py` and
+  import the brand skin from `scripts/generate-site-art.py`; do not bundle `.ttf`
+  font files; do not invent a pin look (no Poppins/pills/saturated colors/green
+  CTA — use the off-white panel + dot grid + purple→blue brand skin).

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,7 +50,7 @@ These run across page types rather than producing a type.
 | Track | Scripts | Doc | Cadence |
 |---|---|---|---|
 | Image SEO (hero art, OG cards) | `make-hero-decorative.py`, `add-og-dimensions.py`, `build-image-seo-status.py` | [`image-seo-fixes.md`](./image-seo-fixes.md) | per batch |
-| Pinterest pins | `generate-pinterest.py` | [`pinterest-pin-generation.md`](./pinterest-pin-generation.md) | per batch |
+| Pinterest pins (+ new boards) | `generate-pinterest.py`, `generate-id-pins.py`, `generate-vertical-text-pins.py` (skin: `generate-site-art.py`); CSV: `pinterest_csv.py` + `build_pinterest_upload.py` | [`pinterest-pin-generation.md`](./pinterest-pin-generation.md) (board conventions) + [`pinterest-csv-format.md`](./pinterest-csv-format.md) | per batch |
 | Schema / alternateName SEO | `validate-alternatenames.py`, `inject-faq-jsonld.js`, `alternatename-seo-report.md` | ⚠️ none | per batch |
 | Collection-copy audit | `audit_library_opportunities.py` (+ explorer, see workflow §5) | ⚠️ workflow §5; [`emoji-combination-taxonomy.md`](./emoji-combination-taxonomy.md) for combo taxonomy | per batch |
 | i18n / localization | `prerender-i18n.js` (+ `es/`, `locales/`, `README.*.md`) | ❌ none | as needed |
@@ -102,6 +102,10 @@ here so they aren't lost. Update as they're closed or new ones appear.
    pages (`/discord/`, `/instagram/`, `/x/`, …) receive SEO and FAQ updates but
    have no governing workflow, backlog, or generator. The classifier also has no
    rules for them, so PRs that touch those paths are flagged Unclassified.
+6. **One Pinterest board is off-system.** The Spanish `/es/` board lives in an
+   orphaned top-level `pinterest-kit/` (own generator, bundled fonts, hand-named
+   CSV) instead of the `assets/pinterest/` + `data/*_upload.csv` pipeline every
+   other board uses. Migrate it per `docs/pinterest-pin-generation.md`.
 
 ---
 

--- a/docs/pinterest-pin-generation.md
+++ b/docs/pinterest-pin-generation.md
@@ -17,6 +17,71 @@ Run `python3 scripts/generate-pinterest.py` to regenerate everything
 
 ---
 
+## Adding a new pin board — the system (read this BEFORE generating)
+
+Every new Pinterest batch (a language board, a use-case board, a campaign set)
+**must reuse this system**. Three boards in a row drifted off it and each one had
+to be reworked — don't be the fourth. The rules below are non-negotiable.
+
+### 1. Put files in the canonical locations (never invent new folders)
+
+| What | Where it goes | Example |
+|---|---|---|
+| Generator script | `scripts/generate-<board>-pins.py` | `scripts/generate-id-pins.py` |
+| Pin images (1000×1500 PNG, 2:3) | `assets/pinterest/<board>/<slug>.png` | `assets/pinterest/vertical-text/copy-paste.png` |
+| Internal inventory CSV | `data/<board>_pinterest_pins.csv` | `data/id_pinterest_pins.csv` |
+| Importer-ready upload CSV | `data/<board>_pinterest_pins_upload.csv` | `data/id_pinterest_pins_upload.csv` |
+| Board doc | `docs/<board>-pinterest-board.md` | `docs/vertical-text-pinterest-board.md` |
+
+**Do NOT** create a top-level `pinterest-kit/`-style folder, put pins or SVGs under
+`docs/`, bundle your own font files, or hand-name a CSV. Those are the exact
+mistakes that caused PRs #303–#306 to be redone. The `/id/` and `/vertical-text/`
+boards are the reference implementations — mirror them.
+
+### 2. Reuse the generator and the brand skin — don't write a new template
+
+Mirror `scripts/generate-id-pins.py` / `scripts/generate-vertical-text-pins.py`.
+Each imports the shared tokens and helpers from `scripts/generate-site-art.py`
+(the single source of truth for the brand look) so every pin renders identically
+to `assets/pinterest/`:
+
+- soft off-white panel + faint dot grid + brand **purple→blue** gradient
+- left accent bar, kicker, large keyword title + underline
+- one focal motif/hero card per pin
+- the `UltraTextGen.com` wordmark at the bottom
+
+**Never** introduce a bespoke look: no Poppins/Baloo/Pacifico, no centered pills,
+no rotating saturated background colors, no green CTA button. That was the
+"didn't match UltraTextGen" rebuild (`28d610d`). Use the system fonts the brand
+helpers already use (system Liberation/DejaVu/Symbola stack) — **do not commit
+`.ttf` files into the repo.**
+
+### 3. Wire the upload CSV through the converter (not by hand)
+
+Register the board in `SOURCES` in `scripts/build_pinterest_upload.py`, then call
+`convert("<board>")` at the end of your generator's `main()`. The `*_upload.csv`
+is produced **only** by `scripts/pinterest_csv.py`. Read
+[`pinterest-csv-format.md`](./pinterest-csv-format.md) — uploading any other
+schema fails Pinterest's importer.
+
+### Checklist before you commit a new board
+
+- [ ] Generator at `scripts/generate-<board>-pins.py`, mirrors an existing one
+- [ ] Imports brand tokens from `generate-site-art.py` (no new visual template)
+- [ ] Images at `assets/pinterest/<board>/`, all exactly 1000×1500
+- [ ] No bundled fonts, no new top-level folder, no SVGs under `docs/`
+- [ ] Inventory + `_upload.csv` in `data/`, board registered in `build_pinterest_upload.py`
+- [ ] Board doc at `docs/<board>-pinterest-board.md` (mirror the vertical-text one)
+
+> **Known cleanup:** the Spanish `/es/` board still lives in the orphaned
+> top-level `pinterest-kit/` directory with its own generator and a hand-named
+> `pinterest-bulk-upload.csv`. It is the one board not yet on this system and
+> should be migrated to the layout above (`scripts/generate-es-pins.py`,
+> `assets/pinterest/es/`, `data/es_pinterest_pins[_upload].csv`) — do **not**
+> copy it as a pattern.
+
+---
+
 ## How the pins are built
 
 The generator **extends the existing brand system** rather than inventing a


### PR DESCRIPTION
Three Pinterest boards in a row drifted off the established system and each had to be reworked (PRs #303-#306): pins dumped in a new top-level pinterest-kit/ and under docs/, a bespoke generator with bundled .ttf fonts, an off-brand look (Poppins/pills/saturated colors/green CTA), and a hand-named upload CSV. The board-creation rules existed only implicitly in a task report, so each new board reinvented them.

- docs/pinterest-pin-generation.md: add a prescriptive "Adding a new pin board" section up front — canonical file locations, reuse generate-id-pins.py + the generate-site-art.py brand skin, no bundled fonts, the upload-CSV converter, a pre-commit checklist, and the pinterest-kit/ orphan flagged.
- CLAUDE.md: list assets/pinterest/, the data CSVs and the pin generators in the repo map; broaden the Pinterest "What NOT to Do" beyond CSVs to cover locations, generator/brand reuse and bundled fonts.
- docs/README.md: point the Pinterest track at both governing docs + the full generator set; record the off-system /es/ board as a known gap.


Claude-Session: https://claude.ai/code/session_01X4gwgTYk1wxee35zGkmiLJ