### PR TITLE
docs: weekly infrastructure review 2026-06-20

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -97,15 +97,23 @@ here so they aren't lost. Update as they're closed or new ones appear.
    library lane. These pages are hand-built.
 3. **Usecase and guide lanes are undocumented** — no workflow, no backlog.
 4. **Operational tracks without docs:** schema/alternateName SEO, i18n, CSS/GTM
-   CI checks. Scripts exist; the process is tribal knowledge.
+   CI checks. Scripts exist; the process is tribal knowledge. The
+   alternateName SEO track is now **actively in use** — PR #277 added
+   `alternateName` to 30+ category/library/platform pages and PR #291 updated
+   `validate-alternatenames.py` — making the missing governing doc the most
+   pressing gap here.
 5. **Platform pages lane is undocumented** — the eleven social-network generator
-   pages (`/discord/`, `/instagram/`, `/x/`, …) receive SEO and FAQ updates but
-   have no governing workflow, backlog, or generator. The classifier also has no
-   rules for them, so PRs that touch those paths are flagged Unclassified.
-6. **One Pinterest board is off-system.** The Spanish `/es/` board lives in an
-   orphaned top-level `pinterest-kit/` (own generator, bundled fonts, hand-named
-   CSV) instead of the `assets/pinterest/` + `data/*_upload.csv` pipeline every
-   other board uses. Migrate it per `docs/pinterest-pin-generation.md`.
+   pages (`/discord/`, `/instagram/`, `/x/`, …) receive active SEO updates
+   (`alternateName`: PR #277; FAQ structured data: PR #290) but have no
+   governing workflow, backlog, or generator. The classifier correctly routes
+   them to "Platform pages" via path rules in `LANE_RULES`.
+6. **Pinterest off-system patterns (two).** (a) The Spanish `/es/` board lives
+   in `pinterest-kit/` (own generator, bundled fonts, hand-named CSV) instead
+   of the `assets/pinterest/<board>/` + `data/*_upload.csv` pipeline. (b) ~334
+   pins for category, answers, and library pages are stored flat in
+   `assets/pinterest/` root rather than a named board subdirectory — these
+   should be moved to `assets/pinterest/<board>/` and wired into the upload
+   pipeline. Migrate both per `docs/pinterest-pin-generation.md`.
 
 ---
 

--- a/scripts/weekly_pr_digest.py
+++ b/scripts/weekly_pr_digest.py
@@ -51,6 +51,7 @@ LANE_RULES = [
     (".github/workflows/", "CI / automation"),
     ("scripts/", "Scripts / tooling"),
     ("docs/", "Docs"),
+    ("CLAUDE.md", "Docs"),
     ("style.css", "Styling"),
     ("symbol-explorer", "Symbol explorer"),
     ("renderer.js", "Core JS"),


### PR DESCRIPTION
## What changed and why

Weekly infrastructure review for the 2026-06-10 → 2026-06-17 digest (first live run of the routine — digest was produced manually since the `weekly-pr-digest.yml` Action had just landed in PR #289).

### Unclassified PRs resolved

All 4 unclassified PRs (#263, #265, #270, #277) were flagged only because the manually-produced digest lacked file lists from the GitHub search API — not because they represent new lanes. After retrieving their actual files:

| PR | Actual files | Correct lane |
|---|---|---|
| #263 | `data/library_opportunities.csv`, `data/semrush-exports/readme.md` | Opportunity backlog, Data / backlog |
| #265 | `assets/pinterest/*.png` (category/answers pins, 334 files) | Image SEO |
| #270 | `assets/pinterest/answers-*.png`, `assets/pinterest/category-*.png` | Image SEO |
| #277 | `category/*/index.html`, `library/*/index.html`, `discord/`, `facebook/`, `instagram/` | Category pages, Library pages, Platform pages |

No new lane is needed.

### docs/README.md — Known gaps updated

**Gap #4 (schema/alternateName SEO):** PR #277 added `alternateName` to 30+ pages; PR #291 updated `validate-alternatenames.py`. The track is now actively in use — flagged as the most pressing missing doc.

**Gap #5 (platform pages):** Fixed an incorrect statement — the classifier *does* have path rules for all eleven platform pages (`discord/`, `instagram/`, `x/`, …). Updated to reflect the active SEO work happening there (#277, #290) while the governance gap remains.

**Gap #6 (Pinterest off-system):** Extended from one pattern to two. In addition to the Spanish `/es/` board in `pinterest-kit/`, ~334 pins for category, answers, and library pages are stored flat in `assets/pinterest/` root rather than in a `<board>/` subdirectory — violating the convention in CLAUDE.md.

### scripts/weekly_pr_digest.py — classifier fix

Added `CLAUDE.md` → `"Docs"` to `LANE_RULES` so future PRs that touch the project instructions file aren't spuriously flagged Unclassified.

---

**Do not merge** — human review required per the weekly infrastructure review process.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FiGABs8NwKzd394xre86Ec)_