### PR TITLE
ID page: tulisan estetik + angka 0–9 sections; Pinterest domain verification

### DIFF
--- a/_root.html
+++ b/_root.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html><html lang="en"><head>
   <meta name="yandex-verification" content="aa326290e0338f4f">
+  <meta name="p:domain_verify" content="b2362cbc0f13ddea3e632da9bc7df05"/>
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
   new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],

--- a/id/index.html
+++ b/id/index.html
@@ -463,6 +463,16 @@
     <p class="u-mt-15 u-text-center">Cara ini jalan buat <strong>cara membuat tulisan aesthetic di WA</strong>, Instagram, buku catatan, sampai bio TikTok — sama persis langkahnya.</p>
   </section>
 
+  <!-- Tulisan Estetik (ejaan Indonesia) -->
+  <section class="editorial-section">
+    <h2>Tulisan Estetik: Cara Nulis yang Benar</h2>
+    <p>"Tulisan estetik" dan "tulisan aesthetic" itu sebenernya sama aja — cuma beda ejaan. "Aesthetic" versi Inggris, "estetik" versi Indonesia yang udah baku di KBBI. Dua-duanya ngarah ke hal yang sama: huruf bergaya yang bisa langsung copy paste ke bio, caption, atau nickname.</p>
+    <p>Jadi kalau kamu nyari <strong>tulisan estetik yang benar</strong> buat Instagram, WhatsApp, atau TikTok, gak perlu pusing soal ejaan — tinggal ketik kata atau kalimatmu di generator paling atas, dan semua gaya estetik langsung muncul, dari yang simpel sampai yang penuh ornamen. Mau buat caption, penulisan nama, atau status, langkahnya sama: ketik, pilih gaya, salin.</p>
+    <div class="block-example">
+      <strong>Contoh:</strong> "senja" → 𝓼𝓮𝓷𝓳𝓪 (kursif), 𝔰𝔢𝔫𝔧𝔞 (gotik), ⓢⓔⓝⓙⓐ (bubble), ꜱᴇɴᴊᴀ (small caps)
+    </div>
+  </section>
+
   <!-- Huruf Aesthetic A–Z -->
   <section class="editorial-section glyph-section">
     <h2>Huruf Aesthetic A–Z</h2>
@@ -489,7 +499,30 @@
         <button class="glyph-copy alpha-glyphs" type="button" data-text="ᴀʙᴄᴅᴇꜰɢʜɪᴊᴋʟᴍɴᴏᴘqʀsᴛᴜᴠᴡxʏᴢ" aria-label="Salin huruf aesthetic gaya Small Caps">ᴀ ʙ ᴄ ᴅ ᴇ ꜰ ɢ ʜ ɪ ᴊ ᴋ ʟ ᴍ ɴ ᴏ ᴘ q ʀ s ᴛ ᴜ ᴠ ᴡ x ʏ ᴢ</button>
       </div>
     </div>
-    <p class="u-mt-15">Mau huruf abjad aesthetic buat satu inisial nama doang? Tinggal ketik huruf itu di generator atas — semua gaya langsung muncul.</p>
+    <h3>Angka Aesthetic 0–9</h3>
+    <div class="alpha-list">
+      <div class="alpha-row">
+        <span class="alpha-label">Bold</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝟬𝟭𝟮𝟯𝟰𝟱𝟲𝟳𝟴𝟵" aria-label="Salin angka aesthetic gaya Bold">𝟬 𝟭 𝟮 𝟯 𝟰 𝟱 𝟲 𝟳 𝟴 𝟵</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Double-Struck</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝟘𝟙𝟚𝟛𝟜𝟝𝟞𝟟𝟠𝟡" aria-label="Salin angka aesthetic gaya Double-Struck">𝟘 𝟙 𝟚 𝟛 𝟜 𝟝 𝟞 𝟟 𝟠 𝟡</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Bubble</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="⓪①②③④⑤⑥⑦⑧⑨" aria-label="Salin angka aesthetic gaya Bubble">⓪ ① ② ③ ④ ⑤ ⑥ ⑦ ⑧ ⑨</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Fullwidth</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="０１２３４５６７８９" aria-label="Salin angka aesthetic gaya Fullwidth">０ １ ２ ３ ４ ５ ６ ７ ８ ９</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Mono</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝟶𝟷𝟸𝟹𝟺𝟻𝟼𝟽𝟾𝟿" aria-label="Salin angka aesthetic gaya Mono">𝟶 𝟷 𝟸 𝟹 𝟺 𝟻 𝟼 𝟽 𝟾 𝟿</button>
+      </div>
+    </div>
+    <p class="u-mt-15">Mau huruf abjad aesthetic buat satu inisial nama doang, atau angka buat tanggal lahir di bio? Tinggal ketik di generator atas — semua gaya langsung muncul.</p>
   </section>
 
   <!-- Simbol Aesthetic -->

--- a/index.html
+++ b/index.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html><html lang="en"><head>
   <meta name="yandex-verification" content="aa326290e0338f4f">
+  <meta name="p:domain_verify" content="b2362cbc0f13ddea3e632da9bc7df05"/>
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
   new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],


### PR DESCRIPTION
## Summary
Follow-up to #299 (which is already merged). Two changes:

### 1. `/id/` content — target the winnable low-KD cluster
- **"Tulisan Estetik" section** — bridges the Indonesian "estetik" spelling (KD ~25, "Easy" in Semrush; already ranking ~pos 3) into the page. Targets *tulisan estetik*, *tulisan estetik yang benar*, *penulisan nama estetik*.
- **"Angka Aesthetic 0–9"** — copyable digit showcase (Bold, Double-Struck, Bubble, Fullwidth, Mono) completing the existing A–Z set. Targets *angka aesthetic*, *huruf dan angka aesthetic*.

Both reuse the existing `.glyph-copy` / `.alpha-row` patterns from #299 — no new CSS or JS.

### 2. Pinterest domain verification (homepage)
- Add `<meta name="p:domain_verify">` to `index.html` (and synced `_root.html` build-copy) so `ultratextgen.com` can be claimed on Pinterest → unlocks Rich Pins + link attribution. The tag must live on the homepage, not a locale subpage.

## Notes
- ⚠️ Verification code was transcribed from a screenshot — please confirm the `content` value matches the Pinterest claim dialog exactly before claiming.
- After merge + deploy, click **Continue** in Pinterest's claim dialog to complete verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gjm8i1ndCDGWrRp62EeB3r)_