### PR TITLE
Rewrite title + meta on 4 high-impression pages to lift CTR

### DIFF
--- a/library/emoji-combos/index.html
+++ b/library/emoji-combos/index.html
@@ -14,8 +14,8 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Emoji Combos: Copy &amp; Paste Aesthetic Emoji Combinations</title>
-<meta name="description" content="Browse aesthetic emoji combos for bios, captions, and usernames — soft girl, cottage garden, night sky, and Y2K sets. Click any combo to copy it instantly.">
+<title>Emoji Combos — Aesthetic Copy &amp; Paste Sets, No App</title>
+<meta name="description" content="Tap any aesthetic emoji combo to copy it instantly — soft girl, cottage garden, night sky &amp; Y2K sets for bios, captions and usernames. Free, no app or sign-up.">
 
 <link rel="canonical" href="https://ultratextgen.com/library/emoji-combos/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/library-emoji-combos.png">
@@ -23,11 +23,11 @@
 <meta property="og:image:height" content="630">
 <meta property="og:image:type" content="image/png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Emoji Combos: Copy &amp; Paste Aesthetic Emoji Combinations">
-<meta name="twitter:description" content="Browse aesthetic emoji combos for bios, captions, and usernames — soft girl, cottage garden, night sky, and Y2K sets. Click any combo to copy it instantly.">
+<meta name="twitter:title" content="Emoji Combos — Aesthetic Copy &amp; Paste Sets, No App">
+<meta name="twitter:description" content="Tap any aesthetic emoji combo to copy it instantly — soft girl, cottage garden, night sky &amp; Y2K sets for bios, captions and usernames. Free, no app or sign-up.">
 <meta name="twitter:image" content="https://ultratextgen.com/assets/og/library-emoji-combos.png">
-<meta property="og:title" content="Emoji Combos: Copy &amp; Paste Aesthetic Emoji Combinations">
-<meta property="og:description" content="Browse aesthetic emoji combos for bios, captions, and usernames — soft girl, cottage garden, night sky, and Y2K sets. Click any combo to copy it instantly.">
+<meta property="og:title" content="Emoji Combos — Aesthetic Copy &amp; Paste Sets, No App">
+<meta property="og:description" content="Tap any aesthetic emoji combo to copy it instantly — soft girl, cottage garden, night sky &amp; Y2K sets for bios, captions and usernames. Free, no app or sign-up.">
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://ultratextgen.com/library/emoji-combos/">
 
@@ -41,7 +41,7 @@
 {
   "@context": "https://schema.org",
   "@type": "Article",
-  "headline": "Emoji Combos: Copy & Paste Aesthetic Emoji Combinations",
+  "headline": "Emoji Combos — Aesthetic Copy & Paste Sets, No App",
   "alternateName": ["Emoji Combos Copy and Paste", "Aesthetic Emoji Combos", "Cute Emoji Combinations", "Emoji Combo Ideas", "Emoji Sets Copy Paste", "Bio Emoji Combos", "Aesthetic Emoji Copy and Paste"],
   "description": "Browse aesthetic emoji combos for bios, captions, and usernames — soft girl, cottage garden, night sky, and Y2K sets. Click any combo to copy it instantly.",
   "author": {

--- a/linkedin/index.html
+++ b/linkedin/index.html
@@ -13,11 +13,11 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-  <title>LinkedIn Font Generator — Free Bold &amp; Italic Text for Posts | UltraTextGen</title>
-  <meta name="description" content="Free LinkedIn font generator — create bold, italic, cursive &amp; fancy Unicode text for LinkedIn posts, headlines, and profiles. Copy and paste instantly. No signup required.">
+  <title>LinkedIn Font Generator — 60+ Bold &amp; Italic Fonts</title>
+  <meta name="description" content="Format LinkedIn posts, headlines &amp; profiles with 60+ bold, italic, cursive &amp; fancy Unicode fonts. Copy &amp; paste instantly — free, no app or sign-up.">
   <link rel="canonical" href="https://ultratextgen.com/linkedin/">
-  <meta property="og:title" content="LinkedIn Font Generator — Free Bold &amp; Italic Text for Posts | UltraTextGen">
-  <meta property="og:description" content="Free LinkedIn font generator — create bold, italic, cursive &amp; fancy Unicode text for LinkedIn posts, headlines, and profiles. Copy and paste instantly. No signup required.">
+  <meta property="og:title" content="LinkedIn Font Generator — 60+ Bold &amp; Italic Fonts">
+  <meta property="og:description" content="Format LinkedIn posts, headlines &amp; profiles with 60+ bold, italic, cursive &amp; fancy Unicode fonts. Copy &amp; paste instantly — free, no app or sign-up.">
   <meta property="og:url" content="https://ultratextgen.com/linkedin/">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://ultratextgen.com/assets/og/linkedin.png">
@@ -25,8 +25,8 @@
   <meta property="og:image:height" content="630">
   <meta property="og:image:type" content="image/png">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="LinkedIn Font Generator — Free Bold &amp; Italic Text for Posts | UltraTextGen">
-  <meta name="twitter:description" content="Free LinkedIn font generator — create bold, italic, cursive &amp; fancy Unicode text for LinkedIn posts, headlines, and profiles. Copy and paste instantly. No signup required.">
+  <meta name="twitter:title" content="LinkedIn Font Generator — 60+ Bold &amp; Italic Fonts">
+  <meta name="twitter:description" content="Format LinkedIn posts, headlines &amp; profiles with 60+ bold, italic, cursive &amp; fancy Unicode fonts. Copy &amp; paste instantly — free, no app or sign-up.">
   <meta name="twitter:image" content="https://ultratextgen.com/assets/og/linkedin.png">
 
   <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">

--- a/usecase/bio-font/index.html
+++ b/usecase/bio-font/index.html
@@ -12,11 +12,11 @@
 
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Bio Font Generator — Fonts, Symbols &amp; Dividers for Instagram, TikTok, Discord &amp; Tinder Bios | UltraTextGen</title>
-  <meta name="description" content="Free bio font generator: turn your text into stylish Unicode fonts, then add symbols, dividers and ready-made templates. Platform-aware previews and character limits for Instagram, TikTok, Discord, X and Tinder — copy and paste in seconds.">
+  <title>Bio Font Generator — 60+ Copy &amp; Paste Fonts</title>
+  <meta name="description" content="Style your bio with 60+ copy-paste Unicode fonts, symbols &amp; dividers. Live previews and character limits for Instagram, TikTok, Discord, X &amp; Tinder — no app or sign-up.">
   <link rel="canonical" href="https://ultratextgen.com/usecase/bio-font/">
-  <meta property="og:title" content="Bio Font Generator — Fonts, Symbols &amp; Dividers for Social Media Bios | UltraTextGen">
-  <meta property="og:description" content="Turn your text into stylish Unicode fonts, then add symbols, dividers and ready-made templates. Platform-aware previews and limits for Instagram, TikTok, Discord, X and Tinder.">
+  <meta property="og:title" content="Bio Font Generator — 60+ Copy &amp; Paste Fonts">
+  <meta property="og:description" content="Style your bio with 60+ copy-paste Unicode fonts, symbols &amp; dividers. Live previews and character limits for Instagram, TikTok, Discord, X &amp; Tinder — no app or sign-up.">
   <meta property="og:url" content="https://ultratextgen.com/usecase/bio-font/">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://ultratextgen.com/assets/og/usecase-bio-font.png">
@@ -24,8 +24,8 @@
   <meta property="og:image:height" content="630">
   <meta property="og:image:type" content="image/png">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Bio Font Generator — Fonts, Symbols &amp; Dividers for Social Media Bios | UltraTextGen">
-  <meta name="twitter:description" content="Turn your text into stylish Unicode fonts, then add symbols, dividers and ready-made templates. Platform-aware previews and limits for Instagram, TikTok, Discord, X and Tinder.">
+  <meta name="twitter:title" content="Bio Font Generator — 60+ Copy &amp; Paste Fonts">
+  <meta name="twitter:description" content="Style your bio with 60+ copy-paste Unicode fonts, symbols &amp; dividers. Live previews and character limits for Instagram, TikTok, Discord, X &amp; Tinder — no app or sign-up.">
   <meta name="twitter:image" content="https://ultratextgen.com/assets/og/usecase-bio-font.png">
 
   <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">

--- a/usecase/zalgo-text/index.html
+++ b/usecase/zalgo-text/index.html
@@ -14,8 +14,8 @@
 
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Zalgo Text Generator — Creepy Glitch &amp; Cursed Unicode Text | UltraTextGen</title>
-  <meta name="description" content="Generate creepy glitch Zalgo text using Unicode combining marks. Full control over characters, position, shape, frequency, and amplitude. Copy and paste anywhere.">
+  <title>Zalgo Text Generator — Copy &amp; Paste Glitch Text</title>
+  <meta name="description" content="Turn any text into creepy glitch Zalgo instantly. Adjust the intensity, then copy &amp; paste cursed text anywhere — free, no app or sign-up required.">
   <link rel="canonical" href="https://ultratextgen.com/usecase/zalgo-text/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/usecase/zalgo-text/">
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/usecase/zalgo-text/">
@@ -36,16 +36,16 @@
   <meta name="twitter:image" content="https://ultratextgen.com/assets/og/usecase-zalgo-text.png">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Zalgo Text Generator — Creepy Glitch &amp; Cursed Unicode Text">
-  <meta property="og:description" content="Generate creepy glitch Zalgo text using Unicode combining marks. Full control over characters, position, shape, frequency, and amplitude.">
+  <meta property="og:title" content="Zalgo Text Generator — Copy &amp; Paste Glitch Text">
+  <meta property="og:description" content="Turn any text into creepy glitch Zalgo instantly. Adjust the intensity, then copy &amp; paste cursed text anywhere — free, no app or sign-up required.">
   <meta property="og:url" content="https://ultratextgen.com/usecase/zalgo-text/">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="UltraTextGen">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Zalgo Text Generator — Creepy Glitch &amp; Cursed Unicode Text">
-  <meta name="twitter:description" content="Generate creepy glitch Zalgo text using Unicode combining marks. Full control over characters, position, shape, frequency, and amplitude.">
+  <meta name="twitter:title" content="Zalgo Text Generator — Copy &amp; Paste Glitch Text">
+  <meta name="twitter:description" content="Turn any text into creepy glitch Zalgo instantly. Adjust the intensity, then copy &amp; paste cursed text anywhere — free, no app or sign-up required.">
 
   <link rel="stylesheet" href="/style.css">
   <link rel="stylesheet" href="zalgo-text.css">


### PR DESCRIPTION
## What & why

Four pages already rank in position 6–8 and earn solid impressions (GSC ~Mar 27–Jun 25 2026) but bleed clicks through weak snippets, sitting well below the 5–7% CTR peers hit at the same positions:

| Page | Impressions | CTR | Top query targeted |
|---|---|---|---|
| `/library/emoji-combos/` | 6,245 | 0.77% | emoji combos |
| `/usecase/zalgo-text/` | 4,066 | 0.93% | zalgo text generator |
| `/usecase/bio-font/` | 6,538 | 2.10% | bio fonts |
| `/linkedin/` | 6,015 | 2.04% | linkedin font generator |

This is a **snippet-only** change to convert impressions we already have into clicks: each `<title>` and `<meta name="description">` is rewritten to front-load the page's actual top query, lead with the value, and add a concrete hook (style count, "copy & paste", "no app / no sign-up"). Titles kept ≤ ~60 chars.

## Changes

For each page I updated the `<title>`, `<meta name="description">`, and the mirrored `og:title` / `og:description` / `twitter:title` / `twitter:description` so social snippets stay consistent. The JSON-LD `headline` on the emoji-combos page was updated to match its new title.

New titles:

- **emoji-combos** — `Emoji Combos — Aesthetic Copy & Paste Sets, No App` (52)
- **zalgo-text** — `Zalgo Text Generator — Copy & Paste Glitch Text` (49)
- **bio-font** — `Bio Font Generator — 60+ Copy & Paste Fonts` (45)
- **linkedin** — `LinkedIn Font Generator — 60+ Bold & Italic Fonts` (51)

## Constraints honored

- No body content, layout, or JSON-LD changes beyond the one headline.
- GTM, canonical, and OpenGraph/Twitter tags verified intact on all four pages.
- "60+ fonts" hook matches the count the site already advertises elsewhere.

No merge requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NJunorQmdbda31RnpAPF3b

---
_Generated by [Claude Code](https://claude.ai/code/session_01NJunorQmdbda31RnpAPF3b)_