### PR TITLE
refactor: make Tag Studio the sole generator on tag-studio pages

### DIFF
--- a/id/usecase/nama-guild-ff-keren/index.html
+++ b/id/usecase/nama-guild-ff-keren/index.html
@@ -153,14 +153,8 @@
 
 <!-- GENERATOR -->
 <section class="hero"><div class="hero-inner"><div class="hero-card">
-  <div class="input-wrapper"><textarea class="main-input" id="mainInput" placeholder="Ketik nama guild atau squad kamu…" maxlength="100">SQUAD</textarea><span class="char-count"><span id="charCount">0</span>/100</span></div>
-  <div class="decoration-section"><div class="decoration-label">Tambah hiasan ke hasil</div><div class="decoration-tabs"><button class="decoration-tab active" data-deco-tab="symbols">Simbol</button><button class="decoration-tab" data-deco-tab="minimal">Minimal</button><button class="decoration-tab" data-deco-tab="emojis">Emoji</button></div><div class="decoration-grid" id="decorationGrid"></div></div>
+  <div class="input-wrapper"><textarea class="main-input" id="mainInput" placeholder="Ketik nama guild atau squad kamu…" maxlength="100">SQUAD</textarea></div>
 </div></div></section>
-
-<main class="container">
-  <div class="category-section"><div class="category-tabs" id="categoryTabs"></div></div>
-  <div class="results-grid" id="resultsGrid"></div>
-</main>
 
 <!-- INTRO -->
 <section class="editorial-section">
@@ -319,10 +313,9 @@
 <!-- TOAST -->
 <div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
 
-<!-- Generator scripts -->
+<!-- Generator scripts (Tag Studio is the engine — no generic generator UI) -->
 <script src="/styles.js"></script>
 <script src="/renderer.js"></script>
-<script src="/script.js" defer></script>
 
 <!-- Symbol explorer + live tag studio -->
 <script src="/symbol-explorer.js"></script>

--- a/id/usecase/nama-squad-ml-keren/index.html
+++ b/id/usecase/nama-squad-ml-keren/index.html
@@ -145,14 +145,8 @@
 
 <!-- GENERATOR -->
 <section class="hero"><div class="hero-inner"><div class="hero-card">
-  <div class="input-wrapper"><textarea class="main-input" id="mainInput" placeholder="Ketik nama atau singkatan squad kamu…" maxlength="100">SQUAD</textarea><span class="char-count"><span id="charCount">0</span>/100</span></div>
-  <div class="decoration-section"><div class="decoration-label">Tambah hiasan ke hasil</div><div class="decoration-tabs"><button class="decoration-tab active" data-deco-tab="symbols">Simbol</button><button class="decoration-tab" data-deco-tab="minimal">Minimal</button><button class="decoration-tab" data-deco-tab="emojis">Emoji</button></div><div class="decoration-grid" id="decorationGrid"></div></div>
+  <div class="input-wrapper"><textarea class="main-input" id="mainInput" placeholder="Ketik nama atau singkatan squad kamu…" maxlength="100">SQUAD</textarea></div>
 </div></div></section>
-
-<main class="container">
-  <div class="category-section"><div class="category-tabs" id="categoryTabs"></div></div>
-  <div class="results-grid" id="resultsGrid"></div>
-</main>
 
 <!-- INTRO -->
 <section class="editorial-section">
@@ -311,10 +305,9 @@
 <!-- TOAST -->
 <div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
 
-<!-- Generator scripts -->
+<!-- Generator scripts (Tag Studio is the engine — no generic generator UI) -->
 <script src="/styles.js"></script>
 <script src="/renderer.js"></script>
-<script src="/script.js" defer></script>
 
 <!-- Symbol explorer + live tag studio -->
 <script src="/symbol-explorer.js"></script>

--- a/usecase/clan-tag-generator/index.html
+++ b/usecase/clan-tag-generator/index.html
@@ -148,14 +148,8 @@
 
 <!-- GENERATOR -->
 <section class="hero"><div class="hero-inner"><div class="hero-card">
-  <div class="input-wrapper"><textarea class="main-input" id="mainInput" placeholder="Type your clan tag (2–5 letters)…" maxlength="100">CLAN</textarea><span class="char-count"><span id="charCount">0</span>/100</span></div>
-  <div class="decoration-section"><div class="decoration-label">Add decoration to results</div><div class="decoration-tabs"><button class="decoration-tab active" data-deco-tab="symbols">Symbols</button><button class="decoration-tab" data-deco-tab="minimal">Minimal</button><button class="decoration-tab" data-deco-tab="emojis">Emojis</button></div><div class="decoration-grid" id="decorationGrid"></div></div>
+  <div class="input-wrapper"><textarea class="main-input" id="mainInput" placeholder="Type your clan tag (2–5 letters)…" maxlength="100">CLAN</textarea></div>
 </div></div></section>
-
-<main class="container">
-  <div class="category-section"><div class="category-tabs" id="categoryTabs"></div></div>
-  <div class="results-grid" id="resultsGrid"></div>
-</main>
 
 <!-- INTRO -->
 <section class="editorial-section">
@@ -279,10 +273,9 @@
 <!-- TOAST -->
 <div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
 
-<!-- Generator scripts -->
+<!-- Generator scripts (Tag Studio is the engine — no generic generator UI) -->
 <script src="/styles.js"></script>
 <script src="/renderer.js"></script>
-<script src="/script.js" defer></script>
 
 <!-- Symbol explorer + live tag studio -->
 <script src="/symbol-explorer.js"></script>


### PR DESCRIPTION
The clan-tag, FF-guild, and ML-squad pages each loaded the full normal generator (script.js + generic 100+ font results grid, category tabs, and decoration tabs) on top of the purpose-built Tag Studio engine (js/tag-studio.js), wired to the same #mainInput. The generic layer was redundant for a clan/guild/squad-tag use case — its category and decoration tabs had no effect on bracketed tags — so the page ran two input-driven generators stacked on one textarea.

Remove the generic generator UI and script.js from the three full-studio pages (tagStudio.init), leaving Tag Studio as the only generator — mirroring the self-contained vertical-text / zalgo-text approach. The engine keeps its real dependencies (styles.js, renderer.js, symbol-explorer.js). Also drop the dead #charCount span the removed script used to update.

The nickname-generator page is intentionally left unchanged: it uses the liveChips garnish only and its results grid is a load-bearing feature.


Claude-Session: https://claude.ai/code/session_01GBg2gQjvpye3xeKz71RTGE