### PR TITLE
feat: capture Discord zero-click demand (CTR title + answer-shaped FAQ pages)

### DIFF
--- a/answers/discord-allowed-characters/index.html
+++ b/answers/discord-allowed-characters/index.html
@@ -47,6 +47,71 @@
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Does Discord allow Unicode characters in a display name?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Discord display names fully support Unicode characters, including bold, italic, cursive, and gothic styled letters, plus emoji and non-Latin scripts. The display name is the main field for styled text, with a limit of about 32 characters. Generate copy-ready styles with the <a href=\"https://ultratextgen.com/discord/\">Discord font generator</a>."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does a Discord server name allow Unicode characters?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Server names accept Unicode letters and symbols, up to roughly 100 characters. Around 30 characters is the practical target so the name stays readable in the server list. Styled text and symbol prefixes both render fine."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Are Unicode characters allowed in Discord nicknames?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Server nicknames accept Unicode characters just like display names, so styled fonts work. The only limit is moderation — some servers block decorative or hard-to-read names through their own rules."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can Discord channel names use Unicode characters like blackletter?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Partly. Text channel slugs are forced to lowercase with hyphens and no spaces, so heavy styling is limited there. Category names, role names, and the channel topic accept Unicode, including blackletter (fraktur) and other decorative styles."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What characters are allowed in a Discord username?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Usernames are strict: lowercase Latin letters (a–z), numbers (0–9), underscores, and periods only. No consecutive periods, no spaces, no emoji, and no Unicode font characters. For styled text, use your display name instead."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Are Unicode characters allowed in Discord display names without Nitro?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Unicode characters are standard text, not a paid feature, so they work in display names, nicknames, bios, and messages on free accounts. Nitro is not required. See <a href=\"https://ultratextgen.com/answers/do-you-need-nitro-for-discord-fonts/\">Do you need Nitro for Discord fonts</a> for the full breakdown."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What characters are allowed in a Discord username in 2026?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The username rules are unchanged in 2026: lowercase a–z, 0–9, underscore, and period, between 2 and 32 characters, with no two periods in a row. Display names and other fields remain the place for Unicode and styled fonts."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
   "@type": "BreadcrumbList",
   "itemListElement": [
     { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ultratextgen.com/" },
@@ -180,6 +245,78 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
+  <span class="article-section-label">Frequently asked</span>
+  <h2>Discord Unicode character rules by field</h2>
+  <div class="faq-section">
+    <div class="faq-item">
+      <button class="faq-question" type="button">
+        Does Discord allow Unicode characters in a display name?
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+      </button>
+      <div class="faq-answer">
+        Yes. Discord display names fully support Unicode characters, including bold, italic, cursive, and gothic styled letters, plus emoji and non-Latin scripts. The display name is the main field for styled text, with a limit of about 32 characters. Generate copy-ready styles with the <a href="/discord/">Discord font generator</a>.
+      </div>
+    </div>
+    <div class="faq-item">
+      <button class="faq-question" type="button">
+        Does a Discord server name allow Unicode characters?
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+      </button>
+      <div class="faq-answer">
+        Yes. Server names accept Unicode letters and symbols, up to roughly 100 characters. Around 30 characters is the practical target so the name stays readable in the server list. Styled text and symbol prefixes both render fine.
+      </div>
+    </div>
+    <div class="faq-item">
+      <button class="faq-question" type="button">
+        Are Unicode characters allowed in Discord nicknames?
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+      </button>
+      <div class="faq-answer">
+        Yes. Server nicknames accept Unicode characters just like display names, so styled fonts work. The only limit is moderation — some servers block decorative or hard-to-read names through their own rules.
+      </div>
+    </div>
+    <div class="faq-item">
+      <button class="faq-question" type="button">
+        Can Discord channel names use Unicode characters like blackletter?
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+      </button>
+      <div class="faq-answer">
+        Partly. Text channel slugs are forced to lowercase with hyphens and no spaces, so heavy styling is limited there. Category names, role names, and the channel topic accept Unicode, including blackletter (fraktur) and other decorative styles.
+      </div>
+    </div>
+    <div class="faq-item">
+      <button class="faq-question" type="button">
+        What characters are allowed in a Discord username?
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+      </button>
+      <div class="faq-answer">
+        Usernames are strict: lowercase Latin letters (a–z), numbers (0–9), underscores, and periods only. No consecutive periods, no spaces, no emoji, and no Unicode font characters. For styled text, use your display name instead.
+      </div>
+    </div>
+    <div class="faq-item">
+      <button class="faq-question" type="button">
+        Are Unicode characters allowed in Discord display names without Nitro?
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+      </button>
+      <div class="faq-answer">
+        Yes. Unicode characters are standard text, not a paid feature, so they work in display names, nicknames, bios, and messages on free accounts. Nitro is not required. See <a href="/answers/do-you-need-nitro-for-discord-fonts/">Do you need Nitro for Discord fonts</a> for the full breakdown.
+      </div>
+    </div>
+    <div class="faq-item">
+      <button class="faq-question" type="button">
+        What characters are allowed in a Discord username in 2026?
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+      </button>
+      <div class="faq-answer">
+        The username rules are unchanged in 2026: lowercase a–z, 0–9, underscore, and period, between 2 and 32 characters, with no two periods in a row. Display names and other fields remain the place for Unicode and styled fonts.
+      </div>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="editorial-section">
   <span class="article-section-label">Next step</span>
   <h2>Generate Discord-safe styled text</h2>
   <div class="cta-card">
@@ -203,5 +340,12 @@
 </section>
 
 <footer class="footer"><div class="footer-inner"></div></footer>
+<script>
+  document.querySelectorAll('.faq-question').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      this.closest('.faq-item').classList.toggle('open');
+    });
+  });
+</script>
 <script src="/footer.js"></script>
 </body></html>

--- a/answers/do-you-need-nitro-for-discord-fonts/index.html
+++ b/answers/do-you-need-nitro-for-discord-fonts/index.html
@@ -47,6 +47,71 @@
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Does Discord support Unicode characters in messages without Nitro?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Discord renders Unicode characters in messages for every account, free or Nitro. Styled text from a font generator is made of standard Unicode letters, so it posts in chat, DMs, and group messages without any subscription."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Nitro required to use Unicode characters in messages?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. Nitro is not required to send Unicode characters in messages. The characters are normal text that Discord displays the same way it displays ordinary letters, so free accounts can paste bold, italic, cursive, and other styles into any message."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Nitro required for custom fonts or Unicode text on Discord?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. So-called custom fonts are Unicode text, not a Nitro feature. Bold, italic, script, fraktur, and bubble styles all work on free accounts because the styled letters already exist in the Unicode standard. Generate them with the <a href=\"https://ultratextgen.com/discord/\">Discord font generator</a>."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can you use Unicode characters in Discord without Nitro?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. You can use Unicode characters anywhere Discord accepts normal text without Nitro — messages, display names, server nicknames, bios, server names, and role names. The one exception is the username handle, which has stricter rules."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Are Unicode characters allowed in Discord nicknames without Nitro?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Server nicknames accept Unicode characters on free accounts, so you can paste a styled nickname without Nitro. Nitro does not change which characters a nickname allows."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Do you need Nitro to change your name font on Discord?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. Changing your display name font is just pasting Unicode text into the display-name field, which any account can do for free. Nitro's Display Name Styles are a separate, paid feature for proprietary fonts and colours."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What does Nitro actually add for text styling?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Nitro adds Display Name Styles: proprietary fonts, colour gradients, and animated effects that Discord renders on your display name only. That is the paid text feature. Plain Unicode styling, which works everywhere and on free accounts, is different and needs no subscription."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
   "@type": "BreadcrumbList",
   "itemListElement": [
     { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ultratextgen.com/" },
@@ -144,6 +209,78 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
+  <span class="article-section-label">Frequently asked</span>
+  <h2>Nitro and Unicode text: the common questions</h2>
+  <div class="faq-section">
+    <div class="faq-item">
+      <button class="faq-question" type="button">
+        Does Discord support Unicode characters in messages without Nitro?
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+      </button>
+      <div class="faq-answer">
+        Yes. Discord renders Unicode characters in messages for every account, free or Nitro. Styled text from a font generator is made of standard Unicode letters, so it posts in chat, DMs, and group messages without any subscription.
+      </div>
+    </div>
+    <div class="faq-item">
+      <button class="faq-question" type="button">
+        Is Nitro required to use Unicode characters in messages?
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+      </button>
+      <div class="faq-answer">
+        No. Nitro is not required to send Unicode characters in messages. The characters are normal text that Discord displays the same way it displays ordinary letters, so free accounts can paste bold, italic, cursive, and other styles into any message.
+      </div>
+    </div>
+    <div class="faq-item">
+      <button class="faq-question" type="button">
+        Is Nitro required for custom fonts or Unicode text on Discord?
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+      </button>
+      <div class="faq-answer">
+        No. So-called custom fonts are Unicode text, not a Nitro feature. Bold, italic, script, fraktur, and bubble styles all work on free accounts because the styled letters already exist in the Unicode standard. Generate them with the <a href="/discord/">Discord font generator</a>.
+      </div>
+    </div>
+    <div class="faq-item">
+      <button class="faq-question" type="button">
+        Can you use Unicode characters in Discord without Nitro?
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+      </button>
+      <div class="faq-answer">
+        Yes. You can use Unicode characters anywhere Discord accepts normal text without Nitro — messages, display names, server nicknames, bios, server names, and role names. The one exception is the username handle, which has stricter rules.
+      </div>
+    </div>
+    <div class="faq-item">
+      <button class="faq-question" type="button">
+        Are Unicode characters allowed in Discord nicknames without Nitro?
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+      </button>
+      <div class="faq-answer">
+        Yes. Server nicknames accept Unicode characters on free accounts, so you can paste a styled nickname without Nitro. Nitro does not change which characters a nickname allows.
+      </div>
+    </div>
+    <div class="faq-item">
+      <button class="faq-question" type="button">
+        Do you need Nitro to change your name font on Discord?
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+      </button>
+      <div class="faq-answer">
+        No. Changing your display name font is just pasting Unicode text into the display-name field, which any account can do for free. Nitro's Display Name Styles are a separate, paid feature for proprietary fonts and colours.
+      </div>
+    </div>
+    <div class="faq-item">
+      <button class="faq-question" type="button">
+        What does Nitro actually add for text styling?
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+      </button>
+      <div class="faq-answer">
+        Nitro adds Display Name Styles: proprietary fonts, colour gradients, and animated effects that Discord renders on your display name only. That is the paid text feature. Plain Unicode styling, which works everywhere and on free accounts, is different and needs no subscription.
+      </div>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="editorial-section">
   <span class="article-section-label">Next step</span>
   <h2>Generate Discord-ready styled text</h2>
   <div class="cta-card">
@@ -167,5 +304,12 @@
 </section>
 
 <footer class="footer"><div class="footer-inner"></div></footer>
+<script>
+  document.querySelectorAll('.faq-question').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      this.closest('.faq-item').classList.toggle('open');
+    });
+  });
+</script>
 <script src="/footer.js"></script>
 </body></html>

--- a/discord/index.html
+++ b/discord/index.html
@@ -13,11 +13,11 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-  <title>Discord Font Generator — Copy and Paste, No Nitro | UltraTextGen</title>
-  <meta name="description" content="Free Discord font generator. Style your display name, server nickname, bio, and chat with 100+ Unicode fonts — bold, italic, cursive, gothic, bubble. Copy and paste. No Nitro required.">
+  <title>Discord Fonts — Change Your Name Font, Copy &amp; Paste, No Nitro | UltraTextGen</title>
+  <meta name="description" content="Turn your name into 𝗯𝗼𝗹𝗱, 𝘪𝘵𝘢𝘭𝘪𝘤, or 𝒸𝓊𝓇𝓈𝒾𝓋𝑒 text in seconds. Free Discord font generator — 100+ copy-and-paste Unicode fonts for display names, server nicknames, bios, and chat. No Nitro required.">
   <link rel="canonical" href="https://ultratextgen.com/discord/">
-  <meta property="og:title" content="Discord Font Generator — Copy and Paste, No Nitro | UltraTextGen">
-  <meta property="og:description" content="Free Discord font generator. Style your display name, server nickname, bio, and chat with 100+ Unicode fonts — no Nitro required. Copy and paste.">
+  <meta property="og:title" content="Discord Fonts — Change Your Name Font, Copy &amp; Paste, No Nitro">
+  <meta property="og:description" content="Free Discord font generator with 100+ copy-and-paste Unicode fonts. Style your display name, server nickname, bio, and chat — bold, italic, cursive, gothic, bubble. No Nitro required.">
   <meta property="og:url" content="https://ultratextgen.com/discord/">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://ultratextgen.com/assets/og/discord.png">
@@ -25,8 +25,8 @@
   <meta property="og:image:height" content="630">
   <meta property="og:image:type" content="image/png">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Discord Font Generator — Copy and Paste, No Nitro | UltraTextGen">
-  <meta name="twitter:description" content="Free Discord font generator. Style your display name, server nickname, bio, and chat with 100+ Unicode fonts — no Nitro required. Copy and paste.">
+  <meta name="twitter:title" content="Discord Fonts — Change Your Name Font, Copy &amp; Paste, No Nitro">
+  <meta name="twitter:description" content="Free Discord font generator with 100+ copy-and-paste Unicode fonts. Style your display name, server nickname, bio, and chat — no Nitro required.">
   <meta name="twitter:image" content="https://ultratextgen.com/assets/og/discord.png">
 
   <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">


### PR DESCRIPTION
## Why

Per Google Search Console (~Mar 27–Jun 25 2026), `/discord/` is the #2 page by demand (88,111 impressions) but converts at only **2.82% CTR** while peers run 5%+. Worse, a wall of high-impression Discord **informational** queries return **zero clicks** — the two `/answers/` Discord pages rank pos 3–6 but convert 0%.

This PR captures that demand in two workstreams.

## (a) `/discord/` CTR rewrite

Rewrote the `<title>` + meta description (and aligned OG/Twitter) to front-load the **converting** intents instead of a generic label:

| | Before | After |
|---|---|---|
| Title | Discord Font Generator — Copy and Paste, No Nitro | **Discord Fonts — Change Your Name Font, Copy & Paste, No Nitro** |

The description now leads with an action + a styled-glyph hook (`𝗯𝗼𝗹𝗱, 𝘪𝘵𝘢𝘭𝘪𝘤, 𝒸𝓊𝓇𝓈𝒾𝓋𝑒`) — a proven CTR lever in this niche — targeting `discord fonts` (4,912 impr / 0.43%), `discord font generator` (819 / 3.05%), `discord name font`, and `how to change discord name font`.

## (b) Answer pages restructured to win the zero-click queries

Each page now carries a visible FAQ accordion + matching **FAQPage JSON-LD** whose questions mirror the **real query phrasing** from GSC. Answers lead with the direct yes/no, then link back to `/discord/`. Structure matches the existing `/answers/` pages exactly (no new components, accordion toggle script reused).

**`/answers/discord-allowed-characters/`** — per-field "`<field>` allowed characters unicode" cluster:
- display name (620 impr), server name (625), server nickname (584), nickname (244/185), channel name + blackletter (183), username, username 2025/2026 (118), and a "without Nitro" bridge.

**`/answers/do-you-need-nitro-for-discord-fonts/`** — "unicode without nitro" cluster:
- **discord supports unicode characters in messages without nitro (1,400 impr)**, nitro required for custom fonts/unicode text (557/142/113…), can you use unicode without nitro (319/166/136…), nicknames without nitro (318), and a Nitro Display Name Styles disambiguation.

## Query → page mapping

| Query cluster (zero-click) | Home page |
|---|---|
| `<field> allowed characters unicode` (display name / server name / nickname / channel / username) | `/answers/discord-allowed-characters/` |
| `nitro required for unicode/custom fonts`, `unicode in messages without nitro`, `can you use unicode without nitro` | `/answers/do-you-need-nitro-for-discord-fonts/` |
| `discord fonts`, `discord font generator`, `how to change discord name font`, `discord display name styles` | `/discord/` (title/meta) |

No new page was created: both zero-click clusters already have a strong home, and the two pages cleanly split the "which characters/fields" angle from the "is Nitro required" angle. Adding a thin third page would risk cannibalization.

## Constraints respected

- No framework / bundler, no inline `<style>`, no `var`/ES modules.
- GTM snippets and all existing JSON-LD (QAPage, BreadcrumbList, WebApplication) intact.
- All 9 JSON-LD blocks across the 3 files validated as parseable; visible FAQ text matches the structured data.
- All internal links point back to `/discord/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LNWH1ErJJPxB9YJHv9f1vh

---
_Generated by [Claude Code](https://claude.ai/code/session_01LNWH1ErJJPxB9YJHv9f1vh)_