### PR TITLE
feat: deepen /pt/ page to win Brazilian "fontes" search intent

### DIFF
--- a/locales/pt.json
+++ b/locales/pt.json
@@ -1,7 +1,7 @@
 {
   "meta": {
-    "title": "Letras Diferentes para Copiar e Colar — Fontes Bonitas e Símbolos",
-    "description": "Gerador de letras diferentes para copiar e colar: fontes bonitas, texto estiloso, símbolos aesthetic e letras cursivas para bio do Instagram, nick de Free Fire, status do WhatsApp, Discord e TikTok."
+    "title": "Gerador de Fontes para Copiar e Colar — Letras Diferentes e Símbolos",
+    "description": "Gerador de fontes online: letras diferentes, fontes bonitas e símbolos aesthetic para copiar e colar na bio do Instagram, nick de Free Fire, status do WhatsApp, Discord e TikTok. Tem zalgo, sublinhado e símbolos y2k."
   },
   "hero": {
     "title": "Letras diferentes para copiar e colar",
@@ -96,6 +96,14 @@
           {
             "question": "Posso misturar fontes com símbolos e molduras na mesma frase?",
             "answer": "Pode, e é onde a coisa fica divertida. Embaixo da caixa de texto tem abas de Símbolos, Molduras, Divisores, Setas, Minimalista, Emojis e Bandeiras. Clica e elas embrulham seu texto com decoração de um lado e do outro.\n    <br><br>\n    <strong>Exemplo</strong><br>\n    «marina» em cursiva com moldura de estrelas vira ⋆˚࿔ 𝓂𝒶𝓇𝒾𝓃𝒶 𝜗𝜚˚⋆.\n    <br><br>\n    Dá pra combinar dois ou três pra um nome bem único."
+          },
+          {
+            "question": "O que é um gerador de fontes e como uso pra copiar e colar?",
+            "answer": "Um gerador de fontes pega o texto comum que você digita e mostra ele em várias fontes diferentes — fontes bonitas, cursivas, góticas, bubble — usando caracteres Unicode. Não são fontes instaladas no aparelho: são caracteres reais, então funcionam como fontes para copiar e colar em qualquer lugar (bio do Insta, nick, status do Zap).\n    <br><br>\n    <strong>Exemplo</strong><br>\n    «fonte» → 𝗳𝗼𝗻𝘁𝗲, 𝓯𝓸𝓷𝓽𝓮, 𝔣𝔬𝔫𝔱𝔢, ⓕⓞⓝⓣⓔ, ꜰᴏɴᴛᴇ\n    <br><br>\n    Clica em «Copiar» e cola onde quiser. É de graça e sem cadastro."
+          },
+          {
+            "question": "Como fazer letra sublinhada (underline) e riscada pra copiar?",
+            "answer": "Dá pra deixar qualquer texto sublinhado ou riscado usando caracteres de combinação do Unicode.\n    <br><br>\n    <strong>Sublinhado (underline)</strong><br>\n    «sublinhado» → s̲u̲b̲l̲i̲n̲h̲a̲d̲o̲\n    <br><br>\n    <strong>Riscado (tachado)</strong><br>\n    «riscado» → r̶i̶s̶c̶a̶d̶o̶\n    <br><br>\n    Como é Unicode puro, o sublinhado e o riscado colam direto na bio, no nick e no status — diferente do sublinhado do Word, que some quando você cola. Escreve o texto, escolhe o estilo sublinhado ou riscado nos resultados e clica em «Copiar»."
           }
         ]
       },
@@ -130,6 +138,10 @@
           {
             "question": "Como deixar um nome com coração, estrela e setas?",
             "answer": "Digita o nome, escolhe a fonte que você gostou (cursiva costuma combinar com coração e estrela), depois abre a aba <strong>Símbolos</strong> ou <strong>Molduras</strong> e clica em um. O nome sai pronto com o símbolo dos dois lados.\n    <br><br>\n    <strong>Exemplos</strong><br>\n    «sofia» → ♡ 𝓈𝑜𝒻𝒾𝒶 ♡<br>\n    «sofia» → ✧･ﾟ: 𝓈𝑜𝒻𝒾𝒶 :･ﾟ✧<br>\n    «sofia» → ➳ 𝓈𝑜𝒻𝒾𝒶 ☆\n    <br><br>\n    Pra setas, abre a aba Setas. Pra raios e brilho, vai em Símbolos."
+          },
+          {
+            "question": "Onde acho símbolos y2k e aesthetic pra copiar?",
+            "answer": "Na seção «Símbolos para copiar e colar» aqui da página e na aba <strong>Símbolos</strong> do gerador.\n    <br><br>\n    <strong>Look y2k</strong><br>\n    Aquele clima dos anos 2000, com estrela de 4 pontas, brilho e florzinha: ✦ ✧ ★ ☆ ⋆ ✩ ✰ ⊹ ✮ ❀\n    <br><br>\n    <strong>Aesthetic clean</strong><br>\n    Só pontinho e estrelinha: · ✦ ⋆ ⌗\n    <br><br>\n    <strong>Dark</strong><br>\n    Cruz, lua e ornamento: ✝ ☽ ♱ ⛧ ༒\n    <br><br>\n    Clica no símbolo que ele já entra envolvendo seu texto, ou copia avulso da lista de símbolos."
           }
         ]
       },

--- a/pt/index.html
+++ b/pt/index.html
@@ -13,8 +13,8 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title data-i18n="meta.title">Letras Diferentes para Copiar e Colar — Fontes Bonitas e Símbolos</title>
-<meta name="description" data-i18n-content="meta.description" content="Gerador de letras diferentes para copiar e colar: fontes bonitas, texto estiloso, símbolos aesthetic e letras cursivas para bio do Instagram, nick de Free Fire, status do WhatsApp, Discord e TikTok.">
+<title data-i18n="meta.title">Gerador de Fontes para Copiar e Colar — Letras Diferentes e Símbolos</title>
+<meta name="description" data-i18n-content="meta.description" content="Gerador de fontes online: letras diferentes, fontes bonitas e símbolos aesthetic para copiar e colar na bio do Instagram, nick de Free Fire, status do WhatsApp, Discord e TikTok. Tem zalgo, sublinhado e símbolos y2k.">
 
 <link rel="canonical" href="https://ultratextgen.com/pt/">
 
@@ -34,7 +34,7 @@
 <meta name="robots" content="index, follow">
 
 <meta property="og:site_name" content="UltraTextGen">
-<meta property="og:title" content="Letras Diferentes para Copiar e Colar — Fontes Bonitas e Símbolos">
+<meta property="og:title" content="Gerador de Fontes para Copiar e Colar — Letras Diferentes e Símbolos">
 <meta property="og:description" content="Fontes bonitas, letras estilosas e símbolos aesthetic para bio do Instagram, nick de Free Fire, status do WhatsApp e nome no Discord. Copia e cola na hora, sem cadastro.">
 <meta property="og:url" content="https://ultratextgen.com/pt/">
 <meta property="og:type" content="website">
@@ -44,7 +44,7 @@
 <meta property="og:image:type" content="image/png">
 
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Letras Diferentes para Copiar e Colar — Fontes Bonitas e Símbolos">
+<meta name="twitter:title" content="Gerador de Fontes para Copiar e Colar — Letras Diferentes e Símbolos">
 <meta name="twitter:description" content="Fontes bonitas, letras estilosas e símbolos aesthetic para bio do Instagram, nick de Free Fire, status do WhatsApp e nome no Discord. Copia e cola na hora, sem cadastro.">
 <meta name="twitter:image" content="https://ultratextgen.com/assets/og/gerador-de-letras-diferentes-preview.png">
 
@@ -252,6 +252,30 @@
         "@type": "Answer",
         "text": "Sim. O que sai daqui é texto Unicode comum, igual qualquer letra que você digita no teclado. Não tem script, não tem link escondido, não tem nada estranho. Pode colar em bio, em currículo, em e-mail, em qualquer lugar."
       }
+    },
+    {
+      "@type": "Question",
+      "name": "O que é um gerador de fontes e como uso pra copiar e colar?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Um gerador de fontes pega o texto comum que você digita e mostra ele em várias fontes diferentes — fontes bonitas, cursivas, góticas, bubble — usando caracteres Unicode. Não são fontes instaladas no aparelho: são caracteres reais, então funcionam como fontes para copiar e colar em qualquer lugar (bio do Insta, nick, status do Zap). Exemplo: «fonte» → 𝗳𝗼𝗻𝘁𝗲, 𝓯𝓸𝓷𝓽𝓮, 𝔣𝔬𝔫𝔱𝔢, ⓕⓞⓝⓣⓔ, ꜰᴏɴᴛᴇ. Clica em Copiar e cola onde quiser. É de graça e sem cadastro."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Como fazer letra sublinhada (underline) e riscada pra copiar?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Dá pra deixar qualquer texto sublinhado ou riscado usando caracteres de combinação do Unicode. Sublinhado: «sublinhado» → s̲u̲b̲l̲i̲n̲h̲a̲d̲o̲. Riscado (tachado): «riscado» → r̶i̶s̶c̶a̶d̶o̶. Como é Unicode puro, o sublinhado e o riscado colam direto na bio, no nick e no status — diferente do sublinhado do Word, que some quando você cola. Escreve o texto, escolhe o estilo sublinhado ou riscado nos resultados e clica em Copiar."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Onde acho símbolos y2k e aesthetic pra copiar?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Na seção de símbolos da página e na aba Símbolos do gerador. Pro look y2k (anos 2000, com estrela de 4 pontas, brilho e florzinha): ✦ ✧ ★ ☆ ⋆ ✩ ✰ ⊹ ✮ ❀. Pra aesthetic clean, só pontinho e estrelinha: · ✦ ⋆ ⌗. Pra dark, cruz e lua: ✝ ☽ ♱ ⛧ ༒. Clica no símbolo que ele já entra envolvendo seu texto, ou copia avulso da lista de símbolos."
+      }
     }
   ]
 }
@@ -312,6 +336,169 @@
     <!-- Results -->
     <div class="results-grid" id="resultsGrid"></div>
   </main>
+
+  <!-- Gerador de fontes (head term: fontes) -->
+  <section class="editorial-section" aria-label="Gerador de fontes para copiar e colar">
+    <h2>Gerador de fontes para copiar e colar</h2>
+    <p class="editorial-intro">Este é um <strong>gerador de fontes</strong> grátis e online: você digita uma palavra e ela vira dezenas de <strong>fontes diferentes</strong> na hora — fontes bonitas, fontes cursivas, fontes góticas, bubble e fontes com símbolos aesthetic. Tudo em <strong>fontes para copiar e colar</strong>, sem instalar nada, sem cadastro e sem perder o estilo na hora de colar.</p>
+    <div class="block-example">
+      <strong>Exemplo:</strong> «fonte» → 𝗳𝗼𝗻𝘁𝗲 (negrito), 𝓯𝓸𝓷𝓽𝓮 (cursiva), 𝔣𝔬𝔫𝔱𝔢 (gótica), ⓕⓞⓝⓣⓔ (bubble), ꜰᴏɴᴛᴇ (small caps)
+    </div>
+    <p>Diferente da fonte do Word ou do Canva, o que sai daqui não é formatação — é caractere Unicode de verdade. Por isso essas <strong>fontes para Instagram</strong>, TikTok, WhatsApp e Discord coladas na bio, no nick ou no status continuam com o desenho da letra. Quer focar num tipo só? Veja as páginas de <a href="/category/bold-fonts/">fontes em negrito</a>, <a href="/category/cursive-fonts/">fontes cursivas</a>, <a href="/category/gothic-fonts/">fontes góticas</a> e <a href="/category/aesthetic-fonts/">fontes aesthetic</a>.</p>
+  </section>
+
+  <!-- Abecedário A–Z em fontes diferentes -->
+  <section class="editorial-section glyph-section" aria-label="Abecedário A–Z em fontes diferentes para copiar">
+    <h2>Abecedário A–Z em fontes diferentes</h2>
+    <p class="editorial-intro">O alfabeto completo — maiúsculas (A–Z), minúsculas (a–z) e números (0–9) — nas fontes mais usadas para copiar e colar. Clica numa linha pra copiar o abecedário inteiro daquele estilo, ou escreve lá em cima e leva a sua própria palavra.</p>
+    <div class="alpha-list">
+      <div class="alpha-row">
+        <span class="alpha-label">Negrito</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝗔𝗕𝗖𝗗𝗘𝗙𝗚𝗛𝗜𝗝𝗞𝗟𝗠𝗡𝗢𝗣𝗤𝗥𝗦𝗧𝗨𝗩𝗪𝗫𝗬𝗭 𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇" aria-label="Copiar abecedário em negrito">𝗔𝗕𝗖𝗗𝗘𝗙𝗚𝗛𝗜𝗝𝗞𝗟𝗠𝗡𝗢𝗣𝗤𝗥𝗦𝗧𝗨𝗩𝗪𝗫𝗬𝗭 · 𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Cursiva</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩 𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃" aria-label="Copiar abecedário em cursiva">𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩 · 𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Gótica (dark)</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝔄𝔅ℭ𝔇𝔈𝔉𝔊ℌℑ𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔ℜ𝔖𝔗𝔘𝔙𝔚𝔛𝔜ℨ 𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷" aria-label="Copiar abecedário gótico dark">𝔄𝔅ℭ𝔇𝔈𝔉𝔊ℌℑ𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔ℜ𝔖𝔗𝔘𝔙𝔚𝔛𝔜ℨ · 𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Bubble</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ" aria-label="Copiar abecedário bubble">ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ · ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Small Caps</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="ᴀʙᴄᴅᴇꜰɢʜɪᴊᴋʟᴍɴᴏᴘqʀsᴛᴜᴠᴡxʏᴢ" aria-label="Copiar abecedário em small caps">ᴀ ʙ ᴄ ᴅ ᴇ ꜰ ɢ ʜ ɪ ᴊ ᴋ ʟ ᴍ ɴ ᴏ ᴘ q ʀ s ᴛ ᴜ ᴠ ᴡ x ʏ ᴢ</button>
+      </div>
+    </div>
+    <h3>Números 0–9 em fontes diferentes</h3>
+    <div class="alpha-list">
+      <div class="alpha-row">
+        <span class="alpha-label">Negrito</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝟬𝟭𝟮𝟯𝟰𝟱𝟲𝟳𝟴𝟵" aria-label="Copiar números em negrito">𝟬 𝟭 𝟮 𝟯 𝟰 𝟱 𝟲 𝟳 𝟴 𝟵</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Vazado</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝟘𝟙𝟚𝟛𝟜𝟝𝟞𝟟𝟠𝟡" aria-label="Copiar números vazados">𝟘 𝟙 𝟚 𝟛 𝟜 𝟝 𝟞 𝟟 𝟠 𝟡</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Bubble</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="⓪①②③④⑤⑥⑦⑧⑨" aria-label="Copiar números bubble">⓪ ① ② ③ ④ ⑤ ⑥ ⑦ ⑧ ⑨</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Largo</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="０１２３４５６７８９" aria-label="Copiar números largos">０ １ ２ ３ ４ ５ ６ ７ ８ ９</button>
+      </div>
+    </div>
+    <p class="u-mt-15">Quer só a inicial do nome numa fonte aesthetic, ou a data de aniversário pra bio? Digita no gerador lá em cima que todas as fontes aparecem na hora.</p>
+  </section>
+
+  <!-- Símbolos para copiar (aesthetic, y2k, dark) -->
+  <section class="editorial-section glyph-section" aria-label="Símbolos aesthetic e y2k para copiar e colar">
+    <h2>Símbolos para copiar e colar — aesthetic, y2k e dark</h2>
+    <p class="editorial-intro">Coleção de <strong>símbolos aesthetic</strong>, símbolos y2k e caracteres especiais pra separar linha de bio, enfeitar nick e dar vibe na legenda. Clica no símbolo que ele já é copiado. Pra envolver seu texto automaticamente, use as abas <strong>Símbolos</strong>, <strong>Molduras</strong> e <strong>Divisores</strong> do gerador.</p>
+    <div class="glyph-group">
+      <h3>Estrelas &amp; brilhos</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="✦">✦</button>
+        <button class="glyph-copy" type="button" data-text="✧">✧</button>
+        <button class="glyph-copy" type="button" data-text="⋆">⋆</button>
+        <button class="glyph-copy" type="button" data-text="✩">✩</button>
+        <button class="glyph-copy" type="button" data-text="★">★</button>
+        <button class="glyph-copy" type="button" data-text="☆">☆</button>
+        <button class="glyph-copy" type="button" data-text="✰">✰</button>
+        <button class="glyph-copy" type="button" data-text="⊹">⊹</button>
+        <button class="glyph-copy" type="button" data-text="࿐">࿐</button>
+        <button class="glyph-copy" type="button" data-text="˚">˚</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Símbolos y2k</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="✮">✮</button>
+        <button class="glyph-copy" type="button" data-text="✯">✯</button>
+        <button class="glyph-copy" type="button" data-text="⟡">⟡</button>
+        <button class="glyph-copy" type="button" data-text="☆">☆</button>
+        <button class="glyph-copy" type="button" data-text="✦">✦</button>
+        <button class="glyph-copy" type="button" data-text="❀">❀</button>
+        <button class="glyph-copy" type="button" data-text="✿">✿</button>
+        <button class="glyph-copy" type="button" data-text="౨ৎ">౨ৎ</button>
+        <button class="glyph-copy" type="button" data-text="⫷">⫷</button>
+        <button class="glyph-copy" type="button" data-text="⫸">⫸</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Corações</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="♡">♡</button>
+        <button class="glyph-copy" type="button" data-text="♥">♥</button>
+        <button class="glyph-copy" type="button" data-text="❤">❤</button>
+        <button class="glyph-copy" type="button" data-text="❥">❥</button>
+        <button class="glyph-copy" type="button" data-text="❣">❣</button>
+        <button class="glyph-copy" type="button" data-text="ღ">ღ</button>
+        <button class="glyph-copy" type="button" data-text="ꨄ">ꨄ</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Lua &amp; céu</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="☾">☾</button>
+        <button class="glyph-copy" type="button" data-text="☽">☽</button>
+        <button class="glyph-copy" type="button" data-text="☁">☁</button>
+        <button class="glyph-copy" type="button" data-text="✶">✶</button>
+        <button class="glyph-copy" type="button" data-text="❄">❄</button>
+        <button class="glyph-copy" type="button" data-text="ꕥ">ꕥ</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Dark &amp; góticos</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="✝">✝</button>
+        <button class="glyph-copy" type="button" data-text="♱">♱</button>
+        <button class="glyph-copy" type="button" data-text="⛧">⛧</button>
+        <button class="glyph-copy" type="button" data-text="☠">☠</button>
+        <button class="glyph-copy" type="button" data-text="༒">༒</button>
+        <button class="glyph-copy" type="button" data-text="꧁">꧁</button>
+        <button class="glyph-copy" type="button" data-text="꧂">꧂</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Setas &amp; divisores</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="➳">➳</button>
+        <button class="glyph-copy" type="button" data-text="↳">↳</button>
+        <button class="glyph-copy" type="button" data-text="·">·</button>
+        <button class="glyph-copy" type="button" data-text="•">•</button>
+        <button class="glyph-copy" type="button" data-text="⌗">⌗</button>
+        <button class="glyph-copy" type="button" data-text="—">—</button>
+        <button class="glyph-copy" type="button" data-text="❪">❪</button>
+        <button class="glyph-copy" type="button" data-text="❫">❫</button>
+      </div>
+    </div>
+  </section>
+
+  <!-- Sublinhado, riscado e zalgo -->
+  <section class="editorial-section glyph-section" aria-label="Letra sublinhada, riscada e zalgo para copiar">
+    <h2>Sublinhado, riscado e zalgo pra copiar</h2>
+    <p class="editorial-intro">Além das fontes, dá pra deixar o texto <strong>sublinhado</strong>, <strong>riscado</strong> (tachado) ou no estilo <strong>zalgo</strong> (texto bugado / glitch). Como é Unicode puro, o efeito cola direto na bio e no nick — diferente do sublinhado do Word, que some quando você cola. Clica num exemplo pra copiar.</p>
+    <div class="glyph-group">
+      <h3>Sublinhado (underline) pra copiar</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="s̲u̲b̲l̲i̲n̲h̲a̲d̲o̲" aria-label="Copiar texto sublinhado">s̲u̲b̲l̲i̲n̲h̲a̲d̲o̲</button>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="u̲n̲d̲e̲r̲l̲i̲n̲e̲" aria-label="Copiar underline">u̲n̲d̲e̲r̲l̲i̲n̲e̲</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Riscado (tachado) pra copiar</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="r̶i̶s̶c̶a̶d̶o̶" aria-label="Copiar texto riscado">r̶i̶s̶c̶a̶d̶o̶</button>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="t̶e̶x̶t̶o̶" aria-label="Copiar texto tachado">t̶e̶x̶t̶o̶</button>
+      </div>
+    </div>
+    <p>Pra aplicar em qualquer palavra, escreve no gerador lá em cima e escolhe o estilo nos resultados, ou veja as páginas de <a href="/category/underline-text/">letra sublinhada</a> e <a href="/category/strikethrough-text/">letra riscada</a>. Quer aquela letra toda bugada e amaldiçoada? Veja o <a href="/pt/usecase/zalgo-text/">texto zalgo (glitch)</a> — exemplo: «oi» → ó̷i̴̅.</p>
+  </section>
 
   <!-- Popular Use Cases -->
   <section class="editorial-section">
@@ -489,6 +676,39 @@
     Dá pra combinar dois ou três pra um nome bem único.</div>
 </div>
 
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.1.items.4.question">O que é um gerador de fontes e como uso pra copiar e colar?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.1.items.4.answer">Um gerador de fontes pega o texto comum que você digita e mostra ele em várias fontes diferentes — fontes bonitas, cursivas, góticas, bubble — usando caracteres Unicode. Não são fontes instaladas no aparelho: são caracteres reais, então funcionam como fontes para copiar e colar em qualquer lugar (bio do Insta, nick, status do Zap).
+    <br><br>
+    <strong>Exemplo</strong><br>
+    «fonte» → 𝗳𝗼𝗻𝘁𝗲, 𝓯𝓸𝓷𝓽𝓮, 𝔣𝔬𝔫𝔱𝔢, ⓕⓞⓝⓣⓔ, ꜰᴏɴᴛᴇ
+    <br><br>
+    Clica em «Copiar» e cola onde quiser. É de graça e sem cadastro.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.1.items.5.question">Como fazer letra sublinhada (underline) e riscada pra copiar?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.1.items.5.answer">Dá pra deixar qualquer texto sublinhado ou riscado usando caracteres de combinação do Unicode.
+    <br><br>
+    <strong>Sublinhado (underline)</strong><br>
+    «sublinhado» → s̲u̲b̲l̲i̲n̲h̲a̲d̲o̲
+    <br><br>
+    <strong>Riscado (tachado)</strong><br>
+    «riscado» → r̶i̶s̶c̶a̶d̶o̶
+    <br><br>
+    Como é Unicode puro, o sublinhado e o riscado colam direto na bio, no nick e no status — diferente do sublinhado do Word, que some quando você cola. Escreve o texto, escolhe o estilo sublinhado ou riscado nos resultados e clica em «Copiar».</div>
+</div>
+
 
 <!-- Onde funciona -->
 <h2 class="faq-category" data-i18n="faq.categories.2.title">Onde funciona — Insta, TikTok, WhatsApp, Free Fire</h2>
@@ -591,6 +811,27 @@
     «sofia» → ➳ 𝓈𝑜𝒻𝒾𝒶 ☆
     <br><br>
     Pra setas, abre a aba Setas. Pra raios e brilho, vai em Símbolos.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.3.items.2.question">Onde acho símbolos y2k e aesthetic pra copiar?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.3.items.2.answer">Na seção «Símbolos para copiar e colar» aqui da página e na aba <strong>Símbolos</strong> do gerador.
+    <br><br>
+    <strong>Look y2k</strong><br>
+    Aquele clima dos anos 2000, com estrela de 4 pontas, brilho e florzinha: ✦ ✧ ★ ☆ ⋆ ✩ ✰ ⊹ ✮ ❀
+    <br><br>
+    <strong>Aesthetic clean</strong><br>
+    Só pontinho e estrelinha: · ✦ ⋆ ⌗
+    <br><br>
+    <strong>Dark</strong><br>
+    Cruz, lua e ornamento: ✝ ☽ ♱ ⛧ ༒
+    <br><br>
+    Clica no símbolo que ele já entra envolvendo seu texto, ou copia avulso da lista de símbolos.</div>
 </div>
 
 


### PR DESCRIPTION
## Why

GSC (query×country, ~Mar–Jun 2026) shows Brazil drives strong impressions on `/pt/` but converts almost nothing — the page is leaving clicks on the table. Top BR queries:

| query | impr / clicks |
|---|---|
| fontes | 447 / 1 |
| fontes aesthetic symbols | 65 / 0 |
| underline copiar | 126 / 0 |
| letras dark para copiar | 45 / 3 |
| zalgo | 71 / 1 |
| y2k symbols | 43 / 1 |

This deepens the existing `/pt/` page to mirror `/es/` depth and `/id/`'s clickable "aesthetic text" layout, targeting the Portuguese intent behind those queries. Copy is fully pt-BR.

## What changed

**`pt/index.html`**
- New **"Gerador de fontes para copiar e colar"** section targeting the head term *fontes* (gerador de fontes / fontes para copiar), with internal links to the bold/cursive/gothic/aesthetic category pages.
- New **Abecedário A–Z** showcase (`glyph-section`): clickable copy rows for negrito, cursiva, **gótica (dark)**, bubble, small caps + números — mirrors the `/id/` winning layout.
- New **"Símbolos para copiar"** section: aesthetic, **y2k**, corações, lua/céu, **dark/góticos**, setas/divisores glyph groups (covers *fontes aesthetic symbols*, *y2k symbols*, *letras dark*).
- New **"Sublinhado, riscado e zalgo"** section: copyable underline/strikethrough examples (covers *underline / sublinhado copiar*) + links to `/category/underline-text/`, `/category/strikethrough-text/`, and `/pt/usecase/zalgo-text/`.
- Sharpened `<title>`/description (+ OG/Twitter) toward *gerador de fontes*.
- 3 new pt-BR FAQ items (gerador de fontes, sublinhado/underline, símbolos y2k) wired into the static **FAQPage** JSON-LD.

**`locales/pt.json`**
- Updated `meta` (title/description).
- Added the 3 FAQ items to `faq.categories`. Because `i18n.js` rebuilds the FAQ schema and visible copy from this file at runtime, the locale bundle and the static HTML stay in sync.

## Constraints honored
- **No new framework/layout** — reuses the existing `.glyph-copy` click handler and existing CSS classes (`glyph-section`, `alpha-row`, `glyph-group`, `block-example`).
- **GTM**, **canonical**, **hreflang**, and **WebApplication** JSON-LD all preserved.
- **FAQPage** JSON-LD includes real pt queries.
- Locale/hreflang wiring already complete for `/pt/` (`pt` in `i18n.js` supported list + hreflang tags + lang-switcher). `SITE_PAGES` holds only home/category/font roots, not locale pages, so no change there.

## Validation
- `pt.json` parses; FAQ category item counts and `data-i18n` indices are contiguous and consistent.
- Both JSON-LD blocks parse; static FAQ now has 21 entities (18 + 3).
- `<section>` tags balanced; 61 copy buttons; 4 new H2 sections.

Manual/browser-tested feature; no automated test framework in repo (per CLAUDE.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V6B8msPgk2Be2y4kLU7AJy)_