### PR TITLE
feat: deepen /pl/ around "literki/litery do skopiowania" + ozdobniki

### DIFF
--- a/pl/index.html
+++ b/pl/index.html
@@ -111,6 +111,30 @@
   "mainEntity": [
     {
       "@type": "Question",
+      "name": "Gdzie znajdę ładne literki do skopiowania?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Na tej stronie. Wpisujesz tekst w polu na górze, a ładne literki — pogrubione, kursywa, gotyk, bubble i jeszcze parę dziesiątek innych — pojawiają się od razu pod spodem. Klikasz „Kopiuj\" i wklejasz, gdzie chcesz. Masz też gotowy alfabet A–Z do skopiowania w popularnych stylach — wielkie litery, małe litery i cyfry — który możesz wziąć nawet bez wpisywania czegokolwiek."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Czym są ozdobniki do skopiowania i gdzie ich szukać?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ozdobniki to małe symbole, którymi dekorujesz tekst — gwiazdki ✦, serca ♡, ramki ꧁꧂, strzałki → i separatory. W sekcji „Ozdobniki i symbole do skopiowania\" klikasz dowolny znak, żeby go skopiować osobno. Możesz też dodać ozdobniki tekstu automatycznie do całego napisu — w zakładkach Symbole, Ramki i Separatory nad polem wpisywania."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Macie ładne i aesthetic czcionki do skopiowania?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Tak — od minimalistycznych, rozstrzelonych aesthetic czcionek do skopiowania po ozdobne litery z symbolami. Wpisujesz tekst, a wszystkie style ładnych czcionek pojawiają się naraz. Całość jest darmowa i gotowa do skopiowania jednym kliknięciem, tak samo na telefonie i na komputerze."
+      }
+    },
+    {
+      "@type": "Question",
       "name": "Co to jest UltraTextGen i co tu w ogóle się dzieje?",
       "acceptedAnswer": {
         "@type": "Answer",
@@ -345,6 +369,201 @@
     <div class="results-grid" id="resultsGrid"></div>
   </main>
 
+  <!-- How To: Jak skopiować ładne literki -->
+  <section class="editorial-section">
+    <h2>Litery i literki do skopiowania — jak to działa</h2>
+    <p class="editorial-intro">Ładne <strong>litery do skopiowania</strong> zrobisz w kilka sekund — bez instalowania aplikacji i bez zakładania konta. Wpisujesz tekst, a generator zamienia go na dziesiątki stylów ładnych literek, gotowych do skopiowania i wklejenia.</p>
+    <div class="steps-grid">
+      <div class="step-card">
+        <div class="step-number">1</div>
+        <h3>Wpisz tekst</h3>
+        <p>Wpisz imię, słowo albo całe zdanie w polu na samej górze. Możesz też wkleić coś, co już masz skopiowane.</p>
+      </div>
+      <div class="step-card">
+        <div class="step-number">2</div>
+        <h3>Wybierz styl literek</h3>
+        <p>Ładne literki pojawiają się od razu — pogrubione, kursywa, kaligrafia, gotyk, bubble i small caps. Zawęź wybór kategorią u góry.</p>
+      </div>
+      <div class="step-card">
+        <div class="step-number">3</div>
+        <h3>Skopiuj i wklej</h3>
+        <p>Klikasz „Kopiuj", wklejasz w bio na insta, nick w grze, status WhatsAppa albo podpis na TikToku. Styl się nie gubi.</p>
+      </div>
+    </div>
+    <p class="u-mt-15 u-text-center">Te same kroki działają dla <strong>ładnych czcionek do skopiowania</strong>, ozdobnych liter i aesthetic literek — tak samo na komputerze i na telefonie.</p>
+  </section>
+
+  <!-- Alfabet ładnych literek A–Z -->
+  <section class="editorial-section abc-section" aria-label="Alfabet ładnych literek do skopiowania">
+    <h2>Ładne literki A–Z do skopiowania</h2>
+    <p>Cały alfabet — wielkie litery (A–Z), małe litery (a–z) i cyfry (0–9) — w najczęściej używanych stylach ładnych literek. Wpisz coś w generatorze na górze i kliknij „Kopiuj", żeby wziąć całe słowo w danym stylu, albo zaznacz litery z tabeli i skopiuj samodzielnie.</p>
+
+    <div class="abc-list">
+      <div class="abc-row">
+        <span class="abc-name">Pogrubione</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝗔𝗕𝗖𝗗𝗘𝗙𝗚𝗛𝗜𝗝𝗞𝗟𝗠𝗡𝗢𝗣𝗤𝗥𝗦𝗧𝗨𝗩𝗪𝗫𝗬𝗭</span>
+          <span class="abc-line">𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇</span>
+          <span class="abc-line">𝟬𝟭𝟮𝟯𝟰𝟱𝟲𝟳𝟴𝟵</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Kursywa</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝘈𝘉𝘊𝘋𝘌𝘍𝘎𝘏𝘐𝘑𝘒𝘓𝘔𝘕𝘖𝘗𝘘𝘙𝘚𝘛𝘜𝘝𝘞𝘟𝘠𝘡</span>
+          <span class="abc-line">𝘢𝘣𝘤𝘥𝘦𝘧𝘨𝘩𝘪𝘫𝘬𝘭𝘮𝘯𝘰𝘱𝘲𝘳𝘴𝘵𝘶𝘷𝘸𝘹𝘺𝘻</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Kaligrafia</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵</span>
+          <span class="abc-line">𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Kaligrafia gruba</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩</span>
+          <span class="abc-line">𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Gotyk</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝔄𝔅ℭ𝔇𝔈𝔉𝔊ℌℑ𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔ℜ𝔖𝔗𝔘𝔙𝔚𝔛𝔜ℨ</span>
+          <span class="abc-line">𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Bubble</span>
+        <div class="abc-lines">
+          <span class="abc-line">ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ</span>
+          <span class="abc-line">ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ</span>
+          <span class="abc-line">⓪①②③④⑤⑥⑦⑧⑨</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Small caps</span>
+        <div class="abc-lines">
+          <span class="abc-line">ᴀʙᴄᴅᴇꜰɢʜɪᴊᴋʟᴍɴᴏᴘqʀsᴛᴜᴠᴡxʏᴢ</span>
+          <span class="abc-line">ᴀʙᴄᴅᴇꜰɢʜɪᴊᴋʟᴍɴᴏᴘqʀsᴛᴜᴠᴡxʏᴢ</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+    </div>
+    <p class="u-mt-15">Szukasz konkretnego kroju? Zajrzyj do <a href="/category/bold-fonts/">pogrubionych liter</a>, <a href="/category/gothic-fonts/">liter gotyckich do skopiowania</a> albo <a href="/category/cursive-fonts/">liter pisanych i kursywy</a> — każda kategoria pokazuje tylko jeden styl, od dużych po małe litery.</p>
+  </section>
+
+  <!-- Ozdobniki i symbole do skopiowania -->
+  <section class="editorial-section glyph-section" aria-label="Ozdobniki i symbole do skopiowania">
+    <h2>Ozdobniki i symbole do skopiowania</h2>
+    <p class="editorial-intro">Gotowe <strong>ozdobniki tekstu do skopiowania</strong> — gwiazdki, serca, ramki, strzałki i separatory. Kliknij dowolny znak, żeby go skopiować, albo dodaj je automatycznie do tekstu przez zakładki <strong>Symbole</strong>, <strong>Ramki</strong> i <strong>Separatory</strong> w generatorze na górze.</p>
+    <div class="glyph-group">
+      <h3>Gwiazdki i błyski</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="✦">✦</button>
+        <button class="glyph-copy" type="button" data-text="✧">✧</button>
+        <button class="glyph-copy" type="button" data-text="⋆">⋆</button>
+        <button class="glyph-copy" type="button" data-text="✩">✩</button>
+        <button class="glyph-copy" type="button" data-text="★">★</button>
+        <button class="glyph-copy" type="button" data-text="☆">☆</button>
+        <button class="glyph-copy" type="button" data-text="✰">✰</button>
+        <button class="glyph-copy" type="button" data-text="⊹">⊹</button>
+        <button class="glyph-copy" type="button" data-text="࿐">࿐</button>
+        <button class="glyph-copy" type="button" data-text="˚">˚</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Serca</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="♡">♡</button>
+        <button class="glyph-copy" type="button" data-text="♥">♥</button>
+        <button class="glyph-copy" type="button" data-text="❤">❤</button>
+        <button class="glyph-copy" type="button" data-text="❥">❥</button>
+        <button class="glyph-copy" type="button" data-text="❣">❣</button>
+        <button class="glyph-copy" type="button" data-text="ღ">ღ</button>
+        <button class="glyph-copy" type="button" data-text="ꨄ">ꨄ</button>
+        <button class="glyph-copy" type="button" data-text="ஐ">ஐ</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Księżyc i niebo</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="☾">☾</button>
+        <button class="glyph-copy" type="button" data-text="☽">☽</button>
+        <button class="glyph-copy" type="button" data-text="☁">☁</button>
+        <button class="glyph-copy" type="button" data-text="✶">✶</button>
+        <button class="glyph-copy" type="button" data-text="⍣">⍣</button>
+        <button class="glyph-copy" type="button" data-text="ꕥ">ꕥ</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Kwiaty</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="❀">❀</button>
+        <button class="glyph-copy" type="button" data-text="✿">✿</button>
+        <button class="glyph-copy" type="button" data-text="⚘">⚘</button>
+        <button class="glyph-copy" type="button" data-text="✾">✾</button>
+        <button class="glyph-copy" type="button" data-text="❁">❁</button>
+        <button class="glyph-copy" type="button" data-text="ꕤ">ꕤ</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Ramki i ornamenty</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="꧁">꧁</button>
+        <button class="glyph-copy" type="button" data-text="꧂">꧂</button>
+        <button class="glyph-copy" type="button" data-text="༺">༺</button>
+        <button class="glyph-copy" type="button" data-text="༻">༻</button>
+        <button class="glyph-copy" type="button" data-text="⟡">⟡</button>
+        <button class="glyph-copy" type="button" data-text="❪">❪</button>
+        <button class="glyph-copy" type="button" data-text="❫">❫</button>
+        <button class="glyph-copy" type="button" data-text="★彡">★彡</button>
+        <button class="glyph-copy" type="button" data-text="彡★">彡★</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Strzałki</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="→">→</button>
+        <button class="glyph-copy" type="button" data-text="⇨">⇨</button>
+        <button class="glyph-copy" type="button" data-text="➤">➤</button>
+        <button class="glyph-copy" type="button" data-text="⟶">⟶</button>
+        <button class="glyph-copy" type="button" data-text="➳">➳</button>
+        <button class="glyph-copy" type="button" data-text="↬">↬</button>
+        <button class="glyph-copy" type="button" data-text="⇢">⇢</button>
+        <button class="glyph-copy" type="button" data-text="↳">↳</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Separatory</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="·">·</button>
+        <button class="glyph-copy" type="button" data-text="•">•</button>
+        <button class="glyph-copy" type="button" data-text="◦">◦</button>
+        <button class="glyph-copy" type="button" data-text="➛">➛</button>
+        <button class="glyph-copy" type="button" data-text="⟢">⟢</button>
+        <button class="glyph-copy" type="button" data-text="—">—</button>
+        <button class="glyph-copy" type="button" data-text="☰">☰</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Kaomoji (buźki)</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="(◍•ᴗ•◍)">(◍•ᴗ•◍)</button>
+        <button class="glyph-copy" type="button" data-text="(｡♥‿♥｡)">(｡♥‿♥｡)</button>
+        <button class="glyph-copy" type="button" data-text="ʕ•ᴥ•ʔ">ʕ•ᴥ•ʔ</button>
+        <button class="glyph-copy" type="button" data-text="(＾▽＾)">(＾▽＾)</button>
+        <button class="glyph-copy" type="button" data-text="٩(◕‿◕)۶">٩(◕‿◕)۶</button>
+      </div>
+    </div>
+  </section>
+
   <!-- Popular Use Cases -->
   <section class="editorial-section">
     <h2 data-i18n="useCases.title">Do czego ludzie tego najczęściej używają</h2>
@@ -399,6 +618,44 @@
   <!-- FAQ Section -->
   <section class="faq-section-wrapper" aria-label="Frequently asked questions">
     <div class="faq-inner">
+
+<!-- Literki i ozdobniki do skopiowania -->
+<h2 class="faq-category">Literki i ozdobniki do skopiowania</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span>Gdzie znajdę ładne literki do skopiowania?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer">Na tej stronie. Wpisujesz tekst w polu na górze, a ładne literki — <strong>pogrubione</strong>, <strong>kursywa</strong>, <strong>gotyk</strong>, <strong>bubble</strong> i jeszcze parę dziesiątek innych — pojawiają się od razu pod spodem. Klikasz „Kopiuj" i wklejasz, gdzie chcesz.
+    <br><br>
+    Masz też gotowy <strong>alfabet A–Z do skopiowania</strong> w popularnych stylach — wielkie litery, małe litery i cyfry — który możesz wziąć nawet bez wpisywania czegokolwiek.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span>Czym są ozdobniki do skopiowania i gdzie ich szukać?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer">Ozdobniki to małe symbole, którymi dekorujesz tekst — gwiazdki ✦, serca ♡, ramki ꧁꧂, strzałki → i separatory.
+    <br><br>
+    W sekcji <strong>„Ozdobniki i symbole do skopiowania"</strong> klikasz dowolny znak, żeby go skopiować osobno. Możesz też dodać <strong>ozdobniki tekstu</strong> automatycznie do całego napisu — w zakładkach <strong>Symbole</strong>, <strong>Ramki</strong> i <strong>Separatory</strong> nad polem wpisywania.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span>Macie ładne i aesthetic czcionki do skopiowania?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer">Tak — od minimalistycznych, rozstrzelonych <strong>aesthetic czcionek do skopiowania</strong> po ozdobne litery z symbolami. Wpisujesz tekst, a wszystkie style ładnych czcionek pojawiają się naraz. Całość jest darmowa i gotowa do skopiowania jednym kliknięciem, tak samo na telefonie i na komputerze.</div>
+</div>
+
 
 <!-- Pierwsze pytania -->
 <h2 class="faq-category" data-i18n="faq.categories.0.title">Pierwsze pytania</h2>


### PR DESCRIPTION
## What & why

Poland already converts a little on the PL homepage — this PR deepens `/pl/` to fully cover the converting query cluster from GSC (query×country) and Semrush volume:

| Query | Impr/Clk | Vol |
|---|---|---|
| literki / litery do skopiowania | 261/13, 203/5 | 880 |
| ozdobne litery do skopiowania | — | 590 |
| ładne literki (do skopiowania) | 93/2, 87/7 | 210 |
| ładne / aesthetic czcionki do skopiowania | 84/1, 34/1 | — |
| ozdobniki (tekstu) do skopiowania | 53/1, 34/2 | — |

The page previously stopped at the generator + use cases/guides/FAQ (753 lines). It now mirrors the depth of `/es/` (template) and `/id/` (reference) — 1010 lines — with the two sections that directly answer "letters to copy" and "decorations to copy".

## Changes (`pl/index.html` only)

- **How-to** — "Litery i literki do skopiowania — jak to działa": 3-step `steps-grid` with keyword-rich intro.
- **A–Z showcase** — "Ładne literki A–Z do skopiowania" (`abc-section`): uppercase (A–Z), lowercase (a–z) and digits (0–9) across 7 popular styles (pogrubione, kursywa, kaligrafia, kaligrafia gruba, gotyk, bubble, small caps). Covers "duże/małe litery do skopiowania" + links to bold/gothic/cursive category pages ("litery gotyckie do skopiowania").
- **Ozdobniki / symbols** — "Ozdobniki i symbole do skopiowania" (`glyph-section`): 8 click-to-copy glyph groups (gwiazdki, serca, księżyc i niebo, kwiaty, ramki, strzałki, separatory, kaomoji) using the existing `.glyph-copy` handler.
- **FAQ** — new category "Literki i ozdobniki do skopiowania" with 3 Q&As on the exact head queries, mirrored into the **FAQPage JSON-LD** (now 25 questions).

All copy is fully localized into Polish.

## Constraints honored

- GTM, canonical, hreflang (incl. `pl`), lang-switcher and i18n (`supported` includes `pl`) left intact — already wired.
- Both JSON-LD blocks validated as parseable; FAQPage uses real PL queries.
- No framework/bundler, no `var`, no `import/export`, no inline `<style>`, no new browser deps. Reuses existing CSS classes and the existing global `glyph-copy` click handler in `script.js`.

## Testing

Manual/static: JSON-LD parsed with a validator, section ordering verified (how-to → A–Z → ozdobniki → use cases → guides → FAQ → footer). No automated test framework in repo per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExPgYHRaNHrgfr1Jbi9bRZ)_