### PR TITLE
feat: deepen /fr/ around écriture aesthetic + French zalgo intent

### DIFF
--- a/fr/index.html
+++ b/fr/index.html
@@ -111,6 +111,38 @@
   "mainEntity": [
     {
       "@type": "Question",
+      "name": "Comment faire une écriture aesthetic à copier-coller ?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Tape ton texte dans le générateur tout en haut : il se transforme aussitôt en dizaines d'écritures aesthetic — cursive, gothique, bubble, large, small caps. Clique sur «Copier» à côté du style qui te plaît, puis colle-le dans ta bio Instagram, ton pseudo TikTok, une story ou Discord. Comme ce sont de vrais caractères Unicode, le style reste intact partout. Aucune appli, aucun compte."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "C'est quoi une écriture aesthetic ?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Une écriture aesthetic, c'est ce style de lettres propre, espacé et un peu minimal qu'on voit partout dans les bios Instagram, sur Pinterest et les couvertures TikTok. Ce qui la rend aesthetic, ce n'est pas une police au sens classique, mais des lettres espacées (𝔞 𝔢 𝔰 𝔱 𝔥), des petites majuscules ou du texte large (ａｅｓｔｈｅｔｉｃ), des ornements discrets (✧, ✿, ⋆, ࿐, ❀) et des écritures cursives ou gothiques douces. Tape ton mot dans le générateur du haut pour avoir toutes ces variantes d'un coup."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "C'est quoi les écritures stylées ?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "«Écritures stylées», «écriture stylée», «police d'écriture aesthetic» ou «lettres spéciales» désignent toutes la même chose : des lettres qui sortent du clavier normal et qui restent stylées une fois collées. Techniquement ce sont des caractères Unicode déjà dessinés en gras, cursive, gothique, etc. Tu n'installes rien : tu tapes, tu copies, tu colles. Le rendu suit ton texte sur Instagram, TikTok, Snap, WhatsApp ou Discord."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Comment écrire en zalgo (texte glitch / bugué) ?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Le zalgo, c'est l'écriture glitchée : on empile des signes au-dessus et en dessous de chaque lettre pour un rendu corrompu, façon bug d'écran. Pour en faire : tape ton mot dans la barre du haut, choisis le style Zalgo (catégorie glitch), puis copie-colle — l'empilement se fait tout seul. Exemple «zalgo» → z̷̢a̴l̶̨g̵o̶̧. Discord, les forums et les bios l'affichent sans souci ; sur des champs très stricts (parfois Instagram ou TikTok), garde un zalgo léger si le rendu saute."
+      }
+    },
+    {
+      "@type": "Question",
       "name": "C'est quoi UltraTextGen, concrètement ?",
       "acceptedAnswer": {
         "@type": "Answer",
@@ -337,6 +369,180 @@
     <div class="results-grid" id="resultsGrid"></div>
   </main>
 
+  <!-- Comment faire une écriture aesthetic -->
+  <section class="editorial-section">
+    <h2>Comment faire une écriture aesthetic</h2>
+    <p class="editorial-intro">Créer une écriture aesthetic ou une police d'écriture stylée prend trois secondes — aucune appli à installer, aucun compte à créer.</p>
+    <div class="steps-grid">
+      <div class="step-card">
+        <div class="step-number">1</div>
+        <h3>Tape ton texte</h3>
+        <p>Écris ton prénom, un mot ou une phrase dans la barre tout en haut. Tu peux aussi coller un texte déjà copié.</p>
+      </div>
+      <div class="step-card">
+        <div class="step-number">2</div>
+        <h3>Choisis une écriture stylée</h3>
+        <p>Les versions aesthetic s'affichent direct — gras, cursive, gothique, bubble, glitch. Filtre par catégorie pour aller plus vite.</p>
+      </div>
+      <div class="step-card">
+        <div class="step-number">3</div>
+        <h3>Copie &amp; colle</h3>
+        <p>Clique sur «Copier», puis colle dans ta bio Insta, ta légende TikTok, ton statut WhatsApp ou ton pseudo Discord. Le style reste intact.</p>
+      </div>
+    </div>
+    <p class="u-mt-15 u-text-center">Même méthode pour une <strong>écriture aesthetic sur Instagram</strong>, TikTok, Snap ou Discord — les étapes ne changent pas.</p>
+  </section>
+
+  <!-- Écriture aesthetic & écritures stylées -->
+  <section class="editorial-section">
+    <h2>Écriture aesthetic &amp; écritures stylées à copier-coller</h2>
+    <p class="editorial-intro">Tu cherches une <strong>écriture aesthetic à copier-coller</strong> pour ta bio Insta, ton pseudo TikTok ou une story ? Tape ton texte dans le générateur tout en haut : il se transforme aussitôt en dizaines d'<strong>écritures stylées</strong> prêtes à coller, sans appli ni inscription.</p>
+    <p>«Écriture aesthetic», «écriture stylée», «police d'écriture aesthetic» ou «lettres aesthetic» : tout le monde cherche la même chose — des lettres qui sortent de l'ordinaire et qui gardent leur look une fois collées. Ce ne sont pas des polices installées sur ton appareil, mais de vrais caractères Unicode. Du coup, le style voyage avec le texte, même là où Instagram ou TikTok effacent toute mise en forme.</p>
+    <div class="block-example">
+      <strong>Exemple :</strong> «aesthetic» → 𝒶𝑒𝓈𝓉𝒽𝑒𝓉𝒾𝒸 (cursive), 𝔞𝔢𝔰𝔱𝔥𝔢𝔱𝔦𝔠 (gothique), ⓐⓔⓢⓣⓗⓔⓣⓘⓒ (bubble), ａｅｓｔｈｅｔｉｃ (large), ᴀᴇsᴛʜᴇᴛɪᴄ (small caps)
+    </div>
+    <p>Tu veux te concentrer sur un seul style ? File sur les pages dédiées : <a href="/category/aesthetic-fonts/">écriture aesthetic</a>, <a href="/category/cursive-fonts/">écriture cursive</a>, <a href="/category/gothic-fonts/">écriture gothique</a> ou <a href="/category/bold-fonts/">écriture en gras</a>. Sinon, laisse le générateur du haut tout afficher d'un coup et choisis ce qui colle à ton vibe.</p>
+  </section>
+
+  <!-- Alphabet aesthetic A–Z -->
+  <section class="editorial-section glyph-section">
+    <h2>Alphabet aesthetic A–Z</h2>
+    <p class="editorial-intro">Voici l'alphabet complet dans les écritures aesthetic les plus utilisées. Clique sur une ligne pour copier tout l'alphabet d'un coup, ou tape un mot en haut pour l'obtenir directement dans ces styles.</p>
+    <div class="alpha-list">
+      <div class="alpha-row">
+        <span class="alpha-label">Gras</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇" aria-label="Copier l'alphabet aesthetic en Gras">𝗮 𝗯 𝗰 𝗱 𝗲 𝗳 𝗴 𝗵 𝗶 𝗷 𝗸 𝗹 𝗺 𝗻 𝗼 𝗽 𝗾 𝗿 𝘀 𝘁 𝘂 𝘃 𝘄 𝘅 𝘆 𝘇</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Cursive</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃" aria-label="Copier l'alphabet aesthetic en Cursive">𝓪 𝓫 𝓬 𝓭 𝓮 𝓯 𝓰 𝓱 𝓲 𝓳 𝓴 𝓵 𝓶 𝓷 𝓸 𝓹 𝓺 𝓻 𝓼 𝓽 𝓾 𝓿 𝔀 𝔁 𝔂 𝔃</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Gothique</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷" aria-label="Copier l'alphabet aesthetic en Gothique">𝔞 𝔟 𝔠 𝔡 𝔢 𝔣 𝔤 𝔥 𝔦 𝔧 𝔨 𝔩 𝔪 𝔫 𝔬 𝔭 𝔮 𝔯 𝔰 𝔱 𝔲 𝔳 𝔴 𝔵 𝔶 𝔷</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Bubble</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ" aria-label="Copier l'alphabet aesthetic en Bubble">ⓐ ⓑ ⓒ ⓓ ⓔ ⓕ ⓖ ⓗ ⓘ ⓙ ⓚ ⓛ ⓜ ⓝ ⓞ ⓟ ⓠ ⓡ ⓢ ⓣ ⓤ ⓥ ⓦ ⓧ ⓨ ⓩ</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Small Caps</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="ᴀʙᴄᴅᴇꜰɢʜɪᴊᴋʟᴍɴᴏᴘqʀsᴛᴜᴠᴡxʏᴢ" aria-label="Copier l'alphabet aesthetic en Small Caps">ᴀ ʙ ᴄ ᴅ ᴇ ꜰ ɢ ʜ ɪ ᴊ ᴋ ʟ ᴍ ɴ ᴏ ᴘ q ʀ s ᴛ ᴜ ᴠ ᴡ x ʏ ᴢ</button>
+      </div>
+    </div>
+    <h3>Chiffres aesthetic 0–9</h3>
+    <div class="alpha-list">
+      <div class="alpha-row">
+        <span class="alpha-label">Gras</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝟬𝟭𝟮𝟯𝟰𝟱𝟲𝟳𝟴𝟵" aria-label="Copier les chiffres aesthetic en Gras">𝟬 𝟭 𝟮 𝟯 𝟰 𝟱 𝟲 𝟳 𝟴 𝟵</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Ajourés</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝟘𝟙𝟚𝟛𝟜𝟝𝟞𝟟𝟠𝟡" aria-label="Copier les chiffres aesthetic ajourés">𝟘 𝟙 𝟚 𝟛 𝟜 𝟝 𝟞 𝟟 𝟠 𝟡</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Bubble</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="⓪①②③④⑤⑥⑦⑧⑨" aria-label="Copier les chiffres aesthetic en Bubble">⓪ ① ② ③ ④ ⑤ ⑥ ⑦ ⑧ ⑨</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Large</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="０１２３４５６７８９" aria-label="Copier les chiffres aesthetic larges">０ １ ２ ３ ４ ５ ６ ７ ８ ９</button>
+      </div>
+    </div>
+    <p class="u-mt-15">Besoin d'une seule initiale stylée ou de chiffres aesthetic pour une date dans ta bio ? Tape-les dans le générateur du haut — tous les styles apparaissent.</p>
+  </section>
+
+  <!-- Symboles aesthetic -->
+  <section class="editorial-section glyph-section">
+    <h2>Symboles aesthetic &amp; caractères spéciaux</h2>
+    <p class="editorial-intro">Une collection de symboles aesthetic et de caractères spéciaux pour séparer les lignes d'une bio Insta, décorer un pseudo ou ajouter du vibe à une légende. Clique sur un symbole pour le copier direct.</p>
+    <div class="glyph-group">
+      <h3>Étoiles &amp; sparkles</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="✦">✦</button>
+        <button class="glyph-copy" type="button" data-text="✧">✧</button>
+        <button class="glyph-copy" type="button" data-text="⋆">⋆</button>
+        <button class="glyph-copy" type="button" data-text="✩">✩</button>
+        <button class="glyph-copy" type="button" data-text="★">★</button>
+        <button class="glyph-copy" type="button" data-text="☆">☆</button>
+        <button class="glyph-copy" type="button" data-text="✰">✰</button>
+        <button class="glyph-copy" type="button" data-text="⊹">⊹</button>
+        <button class="glyph-copy" type="button" data-text="࿐">࿐</button>
+        <button class="glyph-copy" type="button" data-text="˚">˚</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Cœurs</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="♡">♡</button>
+        <button class="glyph-copy" type="button" data-text="♥">♥</button>
+        <button class="glyph-copy" type="button" data-text="❤">❤</button>
+        <button class="glyph-copy" type="button" data-text="❥">❥</button>
+        <button class="glyph-copy" type="button" data-text="❣">❣</button>
+        <button class="glyph-copy" type="button" data-text="ღ">ღ</button>
+        <button class="glyph-copy" type="button" data-text="ꨄ">ꨄ</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Lune &amp; ciel</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="☾">☾</button>
+        <button class="glyph-copy" type="button" data-text="☽">☽</button>
+        <button class="glyph-copy" type="button" data-text="☁">☁</button>
+        <button class="glyph-copy" type="button" data-text="✶">✶</button>
+        <button class="glyph-copy" type="button" data-text="❄">❄</button>
+        <button class="glyph-copy" type="button" data-text="ꕥ">ꕥ</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Cadres &amp; ornements</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="꧁">꧁</button>
+        <button class="glyph-copy" type="button" data-text="꧂">꧂</button>
+        <button class="glyph-copy" type="button" data-text="༺">༺</button>
+        <button class="glyph-copy" type="button" data-text="༻">༻</button>
+        <button class="glyph-copy" type="button" data-text="⟡">⟡</button>
+        <button class="glyph-copy" type="button" data-text="❪">❪</button>
+        <button class="glyph-copy" type="button" data-text="❫">❫</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Fleurs</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="❀">❀</button>
+        <button class="glyph-copy" type="button" data-text="✿">✿</button>
+        <button class="glyph-copy" type="button" data-text="⚘">⚘</button>
+        <button class="glyph-copy" type="button" data-text="✾">✾</button>
+        <button class="glyph-copy" type="button" data-text="❁">❁</button>
+        <button class="glyph-copy" type="button" data-text="ꕤ">ꕤ</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Séparateurs</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="·">·</button>
+        <button class="glyph-copy" type="button" data-text="•">•</button>
+        <button class="glyph-copy" type="button" data-text="◦">◦</button>
+        <button class="glyph-copy" type="button" data-text="➛">➛</button>
+        <button class="glyph-copy" type="button" data-text="⟢">⟢</button>
+        <button class="glyph-copy" type="button" data-text="—">—</button>
+        <button class="glyph-copy" type="button" data-text="☰">☰</button>
+      </div>
+    </div>
+  </section>
+
+  <!-- Texte Zalgo / glitch -->
+  <section class="editorial-section glyph-section">
+    <h2>Texte Zalgo : écriture glitch &amp; buguée</h2>
+    <p class="editorial-intro">Le <strong>zalgo</strong> (aussi appelé <strong>texte glitch</strong> ou <strong>texte bugué</strong>) empile des signes au-dessus et en dessous de chaque lettre pour donner un effet corrompu, façon écran qui plante. Parfait pour un pseudo dark, un mème Halloween ou un post qui dérange.</p>
+    <div class="block-example">
+      <strong>Exemple :</strong> «zalgo» → z̷̢a̴l̶̨g̵o̶̧ &nbsp;·&nbsp; «glitch» → g̷l̴i̶t̷c̸h̵ &nbsp;·&nbsp; «hello» → h̸̛e̷l̴l̶o̵̚
+    </div>
+    <p>Pour générer ton <strong>zalgo text</strong> : tape ton mot dans la barre du haut, choisis le style <strong>Zalgo</strong> (catégorie glitch), puis copie-colle. L'empilement des diacritiques se fait tout seul, et tu passes d'un glitch léger à une corruption totale selon le style choisi.</p>
+    <p>À savoir : certains champs très stricts (parfois Instagram ou TikTok) nettoient les signes empilés. Discord, les forums, les bios et les mèmes l'affichent sans souci. Si le rendu saute, garde un zalgo léger ou teste un autre champ.</p>
+    <p class="u-mt-15 u-text-center"><a class="cat-cta" href="/fr/usecase/zalgo-text/">Ouvrir le générateur de texte Zalgo →</a></p>
+  </section>
+
   <!-- Popular Use Cases -->
   <section class="editorial-section">
     <h2 data-i18n="useCases.title">Là où l'écriture stylée fait la différence</h2>
@@ -391,6 +597,70 @@
   <!-- FAQ Section -->
   <section class="faq-section-wrapper" aria-label="Questions fréquentes">
     <div class="faq-inner">
+
+<!-- Écriture aesthetic & texte Zalgo -->
+<h2 class="faq-category">Écriture aesthetic &amp; texte Zalgo</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span>Comment faire une écriture aesthetic à copier-coller ?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer">Tape ton texte dans le générateur tout en haut : il se transforme aussitôt en dizaines d'écritures aesthetic — cursive, gothique, bubble, large, small caps.
+    <br><br>
+    Clique sur «Copier» à côté du style qui te plaît, puis colle-le dans ta bio Insta, ton pseudo TikTok, une story ou Discord. Comme ce sont de vrais caractères Unicode, le style reste intact partout. Aucune appli, aucun compte.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span>C'est quoi une écriture aesthetic ?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer">Une «écriture aesthetic», c'est ce style de lettres propre, espacé et un peu minimal qu'on voit partout dans les bios Instagram, sur les tableaux Pinterest et les couvertures TikTok.
+    <br><br>
+    Ce qui rend une écriture «aesthetic», ce n'est pas une police au sens classique, mais :
+    <br><br>
+    — des lettres espacées (𝔞 𝔢 𝔰 𝔱 𝔥);<br>
+    — des petites majuscules ou du texte large (ａｅｓｔｈｅｔｉｃ);<br>
+    — des ornements discrets (✧, ✿, ⋆, ࿐, ❀);<br>
+    — des écritures cursives ou gothiques douces.
+    <br><br>
+    Tape ton mot dans le générateur du haut et tu auras toutes ces variantes d'un coup.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span>C'est quoi les écritures stylées ?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer">«Écritures stylées», «écriture stylée», «police d'écriture aesthetic», «lettres spéciales» : ce sont toutes des façons de dire la même chose — des lettres qui sortent du clavier normal et qui restent stylées une fois collées.
+    <br><br>
+    Techniquement, ce sont des caractères Unicode déjà dessinés en gras, cursive, gothique, etc. Tu n'installes rien : tu tapes, tu copies, tu colles. Le rendu suit ton texte sur Insta, TikTok, Snap, WhatsApp ou Discord.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span>Comment écrire en zalgo (texte glitch / bugué) ?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer">Le zalgo, c'est l'écriture glitchée : on empile des signes au-dessus et en dessous de chaque lettre pour un rendu corrompu, façon bug d'écran.
+    <br><br>
+    Pour en faire : tape ton mot dans la barre du haut, choisis le style <strong>Zalgo</strong> (catégorie glitch), puis copie-colle. L'empilement se fait tout seul.
+    <br><br>
+    <strong>Exemple</strong><br>
+    «zalgo» → z̷̢a̴l̶̨g̵o̶̧
+    <br><br>
+    Discord, les forums et les bios l'affichent sans souci. Sur certains champs très stricts (parfois Insta ou TikTok), garde un zalgo léger si le rendu saute.</div>
+</div>
+
 
 <!-- Getting Started -->
 <h2 class="faq-category" data-i18n="faq.categories.0.title">Démarrer en 30 secondes</h2>


### PR DESCRIPTION
## Why

GSC (query × country) shows France has real volume but weak conversion. The top FR queries weren't being served in depth on `/fr/`:

| Query | Impr / Clk |
|---|---|
| écriture aesthetic à copier-coller | 179 / 11 |
| écritures stylées | 86 / 0 |
| écriture aesthetic copier coller | 68 / 3 |
| ecriture aesthetic | 66 / 1 |
| zalgo / zalgo text | 167 / 2 · 102 / 0 |

This PR deepens `/fr/` to mirror the depth already present on `/es/` and `/id/`, focused on the **écriture aesthetic / écritures stylées** and **zalgo (texte glitch / bugué)** intent.

> "stacked text" (France's biggest single query) is intentionally **not** duplicated here — it belongs to the separate Stacked Text initiative.

## What changed (`fr/index.html` only)

- **How-to section** — "Comment faire une écriture aesthetic" (3-step `steps-grid`).
- **Editorial block** — "Écriture aesthetic & écritures stylées à copier-coller" targeting the head queries, with internal links to `/category/aesthetic-fonts/`, `/cursive-fonts/`, `/gothic-fonts/`, `/bold-fonts/`.
- **Alphabet aesthetic A–Z + chiffres 0–9** — interactive click-to-copy glyph grid (Gras, Cursive, Gothique, Bubble, Small Caps).
- **Symboles aesthetic & caractères spéciaux** — click-to-copy symbol grid (étoiles, cœurs, lune, cadres, fleurs, séparateurs).
- **French Zalgo section** — "Texte Zalgo : écriture glitch & buguée" for the zalgo / zalgo text queries, linking to `/fr/usecase/zalgo-text/`.
- **FAQ** — new "Écriture aesthetic & texte Zalgo" category (4 Q&As) plus matching **FAQPage JSON-LD** entries using real FR query phrasings.

## Constraints respected

- No new framework, bundler, or dependency — reuses existing CSS classes (`steps-grid`, `glyph-section`, `alpha-list`, `glyph-group`) and the `.glyph-copy` handler in `script.js`.
- GTM, canonical, `hreflang` set, and the `header → styles → renderer → script` load order left intact.
- Fully localized French copy (not machine-translated), mirroring `/es/` depth.
- Both JSON-LD blocks validate; visible FAQ accordion (25 items) matches FAQPage schema (25 entries); `<section>`/`<div>` tags balanced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XFJdLbwAGgdzFLYRWoaY3w)_