### PR TITLE
feat: optimize Y2K symbols library page for "y2k symbols" / "y2k aest…

### DIFF
--- a/index.html
+++ b/index.html
@@ -439,6 +439,11 @@
         <h3>Emoji combos</h3>
         <p>100+ aesthetic emoji combos — soft girl, cottagecore, night sky, Y2K and more. Tap any combo to copy the whole set for your bio, caption or username.</p>
       </a>
+      <a class="tip-card" href="/library/y2k-symbols/" aria-label="Y2K symbols library">
+        <div class="tip-icon">✦♱🦋</div>
+        <h3>Y2K symbols</h3>
+        <p>80+ Y2K aesthetic symbols — sparkle stars, gothic crosses, butterflies, CDs and cyber glyphs. Tap any symbol or combo to copy it straight into a bio or caption.</p>
+      </a>
       <a class="tip-card" href="/library/special-characters/" aria-label="Special characters library">
         <div class="tip-icon">✧</div>
         <h3>Special characters</h3>

--- a/library/y2k-symbols/index.html
+++ b/library/y2k-symbols/index.html
@@ -14,8 +14,8 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Y2K Symbols Copy &amp; Paste — Aesthetic 2000s Cyber Bio Decorations</title>
-<meta name="description" content="Y2K aesthetic symbols for bios, usernames, and captions. Stars, crosses, butterflies, CDs, and cyber decorations from the 2000s revival aesthetic.">
+<title>Y2K Symbols ✦ 80+ Aesthetic Copy &amp; Paste Cyber Decorations</title>
+<meta name="description" content="Y2K aesthetic symbols to copy and paste — stars ✦, butterflies 🦋, crosses ♱, sparkles and CDs 💿 for your bio, username, and captions. One-tap copy.">
 
 <link rel="canonical" href="https://ultratextgen.com/library/y2k-symbols/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/library-y2k-symbols.png">
@@ -23,11 +23,11 @@
 <meta property="og:image:height" content="630">
 <meta property="og:image:type" content="image/png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Y2K Symbols Copy &amp; Paste — Aesthetic 2000s Cyber Bio Decorations">
-<meta name="twitter:description" content="Y2K aesthetic symbols for bios, usernames, and captions. Stars, crosses, butterflies, CDs, and cyber decorations from the 2000s revival aesthetic.">
+<meta name="twitter:title" content="Y2K Symbols ✦ 80+ Aesthetic Copy &amp; Paste Cyber Decorations">
+<meta name="twitter:description" content="Y2K aesthetic symbols to copy and paste — stars ✦, butterflies 🦋, crosses ♱, sparkles and CDs 💿 for your bio, username, and captions. One-tap copy.">
 <meta name="twitter:image" content="https://ultratextgen.com/assets/og/library-y2k-symbols.png">
-<meta property="og:title" content="Y2K Symbols Copy &amp; Paste — Aesthetic 2000s Cyber Bio Decorations">
-<meta property="og:description" content="Y2K aesthetic symbols for bios, usernames, and captions. Stars, crosses, butterflies, CDs, and cyber decorations from the 2000s revival aesthetic.">
+<meta property="og:title" content="Y2K Symbols ✦ 80+ Aesthetic Copy &amp; Paste Cyber Decorations">
+<meta property="og:description" content="Y2K aesthetic symbols to copy and paste — stars ✦, butterflies 🦋, crosses ♱, sparkles and CDs 💿 for your bio, username, and captions. One-tap copy.">
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://ultratextgen.com/library/y2k-symbols/">
 
@@ -41,9 +41,9 @@
 {
   "@context": "https://schema.org",
   "@type": "Article",
-  "headline": "Y2K Symbols Copy & Paste — Aesthetic 2000s Cyber Bio Decorations",
+  "headline": "Y2K Symbols ✦ 80+ Aesthetic Copy & Paste Cyber Decorations",
   "alternateName": ["Y2K Aesthetic Symbols", "Y2K Symbols Copy Paste", "2000s Aesthetic Symbols", "Cyber Y2K Characters", "Y2K Bio Decorations", "Y2K Text Symbols", "2000s Aesthetic Copy Paste"],
-  "description": "Y2K aesthetic symbols for bios, usernames, and captions. Stars, crosses, butterflies, CDs, and cyber decorations from the 2000s revival aesthetic.",
+  "description": "Y2K aesthetic symbols to copy and paste — stars ✦, butterflies 🦋, crosses ♱, sparkles and CDs 💿 for your bio, username, and captions. One-tap copy.",
   "author": {
     "@type": "Organization",
     "name": "UltraTextGen",
@@ -56,7 +56,7 @@
   },
   "mainEntityOfPage": "https://ultratextgen.com/library/y2k-symbols/",
   "datePublished": "2026-04-26",
-  "dateModified": "2026-04-26"
+  "dateModified": "2026-06-27"
 }
 </script>
 
@@ -87,6 +87,39 @@
 }
 </script>
 
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What are Y2K symbols?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Y2K symbols are Unicode characters that capture the early-2000s cyber aesthetic — sparkle stars (✦ ✮ ⋆), gothic crosses (♱ ✟ †), butterflies (🦋), CDs and pagers (💿 📟), and frosted dust marks. Because they are plain Unicode rather than images, you can copy and paste them straight into any bio, username, or caption without uploading a file."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How do I use Y2K symbols in an Instagram bio?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Tap any symbol or combo on this page to copy it, then open Instagram, go to Edit Profile, and paste it into your name or bio field. Frame your text with matching symbols — for example ♱ your text ♱ or 𓆩♡𓆪 — and add a sparkle (✦) or star (✮) between words. Keep it to two or three symbols so the bio stays readable."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Do Y2K symbols work on TikTok and Discord?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Every symbol here is standard Unicode, so it renders in TikTok usernames, captions, and comments, and in Discord display names, channel names, and messages. A few rare glyphs may show as a box on older devices that lack the font, so preview on your phone before posting. Plain stars, hearts, and crosses have the widest support."
+      }
+    }
+  ]
+}
+</script>
+
 </head>
 <body>
   <!-- Google Tag Manager (noscript) -->
@@ -99,7 +132,7 @@
 <section class="hero">
   <div class="hero-inner">
     <h1 class="hero-headline">Y2K Symbols</h1>
-    <p class="hero-tagline">Aesthetic symbols from the Y2K and 2000s cyber revival — crosses, Egyptian frames, sparkle dust, and pre-built combos. Click any to copy instantly.</p>
+    <p class="hero-tagline">The Y2K aesthetic is early-2000s cyber nostalgia — sparkle stars, gothic crosses, butterflies, and CD shine. Tap any symbol below to copy it instantly.</p>
   </div>
 </section>
 <figure class="page-hero-figure" data-uthero aria-hidden="true">
@@ -109,52 +142,95 @@
 
 
 
-<!-- INTRO -->
-<section class="editorial-section">
-  <div class="editorial-block">
-    <p>Y2K aesthetic draws from early-internet nostalgia: butterfly clips, flip phones, glitter, gothic crosses, and holographic everything. These Unicode symbols capture that energy — crosses and stars for edge, Egyptian frames for drama, and sparkle dust for that frosted shimmer. Works on Instagram, TikTok, Pinterest, and any platform that supports Unicode text.</p>
-  </div>
-</section>
-
-<div class="section-divider"></div>
-
-<!-- SECTION 1 -->
-<section class="mood-explainers" id="crosses-stars">
-  <span class="article-section-label">Crosses &amp; Stars</span>
-  <h2>Crosses &amp; Stars</h2>
-  <p>Gothic crosses, dark stars, and edgy Y2K symbols for bios and usernames.</p>
+<!-- QUICK COPY (above the fold) -->
+<section class="mood-explainers" id="quick-copy">
+  <span class="article-section-label">Most-Copied Y2K Symbols</span>
+  <h2>Tap to copy</h2>
+  <p>The Y2K aesthetic symbols people grab most — stars, crosses, butterflies, sparkles, and CDs. One tap copies the glyph.</p>
   <div class="flag-rows">
     <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✦" aria-label="Copy ✦">✦</button>
+      <span class="flag-label">Sparkle Star</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✮" aria-label="Copy ✮">✮</button>
+      <span class="flag-label">Y2K Star</span>
+    </div>
+    <div class="flag-row">
       <button class="flag-emoji symbol-tile" data-symbol="♱" aria-label="Copy ♱">♱</button>
-      <span class="flag-label">East Syriac Cross</span>
+      <span class="flag-label">Cross</span>
     </div>
     <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="✟" aria-label="Copy ✟">✟</button>
-      <span class="flag-label">Outlined Latin Cross</span>
+      <button class="flag-emoji symbol-tile" data-symbol="🦋" aria-label="Copy 🦋">🦋</button>
+      <span class="flag-label">Butterfly</span>
     </div>
     <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="†" aria-label="Copy †">†</button>
-      <span class="flag-label">Dagger</span>
+      <button class="flag-emoji symbol-tile" data-symbol="✨" aria-label="Copy ✨">✨</button>
+      <span class="flag-label">Sparkles</span>
     </div>
     <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="⛧" aria-label="Copy ⛧">⛧</button>
-      <span class="flag-label">Inverted Pentagram</span>
+      <button class="flag-emoji symbol-tile" data-symbol="💿" aria-label="Copy 💿">💿</button>
+      <span class="flag-label">CD</span>
     </div>
     <div class="flag-row">
       <button class="flag-emoji symbol-tile" data-symbol="𖤐" aria-label="Copy 𖤐">𖤐</button>
       <span class="flag-label">Black Sun</span>
     </div>
     <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓆩♡𓆪" aria-label="Copy 𓆩♡𓆪">𓆩♡𓆪</button>
+      <span class="flag-label">Heart Frame</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Y2K aesthetic symbols draw from early-2000s internet nostalgia: butterfly clips, flip phones, glitter, gothic crosses, and holographic CD shine. These Unicode characters capture that energy — sparkle stars for shine, crosses for edge, butterflies and bows for the soft side, cyber glyphs for the tech era, and arrow brackets to frame your text. Everything below is copy and paste: tap a symbol to grab it, then drop it into an Instagram bio, TikTok caption, Discord name, or anywhere that supports Unicode text.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 1 -->
+<section class="mood-explainers" id="stars-sparkles">
+  <span class="article-section-label">Stars &amp; Sparkles</span>
+  <h2>Stars &amp; Sparkles</h2>
+  <p>The core of the Y2K aesthetic — sparkle stars and glitter marks for usernames, bios, and captions. Tap any to copy.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✦" aria-label="Copy ✦">✦</button>
+      <span class="flag-label">Black Four-Pointed Star</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✧" aria-label="Copy ✧">✧</button>
+      <span class="flag-label">White Four-Pointed Star</span>
+    </div>
+    <div class="flag-row">
       <button class="flag-emoji symbol-tile" data-symbol="★" aria-label="Copy ★">★</button>
       <span class="flag-label">Black Star</span>
     </div>
     <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☆" aria-label="Copy ☆">☆</button>
+      <span class="flag-label">White Star</span>
+    </div>
+    <div class="flag-row">
       <button class="flag-emoji symbol-tile" data-symbol="✮" aria-label="Copy ✮">✮</button>
-      <span class="flag-label">Circled White Star</span>
+      <span class="flag-label">Heavy Outlined Star</span>
     </div>
     <div class="flag-row">
       <button class="flag-emoji symbol-tile" data-symbol="✯" aria-label="Copy ✯">✯</button>
       <span class="flag-label">Pinwheel Star</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✩" aria-label="Copy ✩">✩</button>
+      <span class="flag-label">Stress Outlined Star</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✪" aria-label="Copy ✪">✪</button>
+      <span class="flag-label">Circled White Star</span>
     </div>
     <div class="flag-row">
       <button class="flag-emoji symbol-tile" data-symbol="✫" aria-label="Copy ✫">✫</button>
@@ -165,55 +241,194 @@
       <span class="flag-label">Black Centre White Star</span>
     </div>
     <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="⭒" aria-label="Copy ⭒">⭒</button>
-      <span class="flag-label">Outlined Star</span>
-    </div>
-      <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="✦" aria-label="Copy ✦">✦</button>
-      <span class="flag-label">Black Four-Pointed Star</span>
+      <button class="flag-emoji symbol-tile" data-symbol="✭" aria-label="Copy ✭">✭</button>
+      <span class="flag-label">Outlined Black Star</span>
     </div>
     <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="✧" aria-label="Copy ✧">✧</button>
-      <span class="flag-label">White Four-Pointed Star</span>
+      <button class="flag-emoji symbol-tile" data-symbol="✰" aria-label="Copy ✰">✰</button>
+      <span class="flag-label">Shadowed White Star</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⭑" aria-label="Copy ⭑">⭑</button>
+      <span class="flag-label">Black Small Star</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⭒" aria-label="Copy ⭒">⭒</button>
+      <span class="flag-label">White Small Star</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⋆" aria-label="Copy ⋆">⋆</button>
+      <span class="flag-label">Star Operator</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⍟" aria-label="Copy ⍟">⍟</button>
+      <span class="flag-label">Squared Star</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚝" aria-label="Copy ⚝">⚝</button>
+      <span class="flag-label">Outlined White Star</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✨" aria-label="Copy ✨">✨</button>
+      <span class="flag-label">Sparkles Emoji</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌟" aria-label="Copy 🌟">🌟</button>
+      <span class="flag-label">Glowing Star</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💫" aria-label="Copy 💫">💫</button>
+      <span class="flag-label">Dizzy Star</span>
     </div>
     <div class="flag-row">
       <button class="flag-emoji symbol-tile" data-symbol="⭐" aria-label="Copy ⭐">⭐</button>
       <span class="flag-label">Star Emoji</span>
     </div>
     <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="☆" aria-label="Copy ☆">☆</button>
-      <span class="flag-label">White Star</span>
+      <button class="flag-emoji symbol-tile" data-symbol="˚" aria-label="Copy ˚">˚</button>
+      <span class="flag-label">Ring Above (dust)</span>
     </div>
-</div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 1B -->
+<section class="mood-explainers" id="hearts-crosses">
+  <span class="article-section-label">Hearts &amp; Crosses</span>
+  <h2>Hearts &amp; Crosses</h2>
+  <p>Gothic crosses and Y2K hearts — the edgy-meets-soft pairing at the heart of the 2000s revival.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♡" aria-label="Copy ♡">♡</button>
+      <span class="flag-label">White Heart</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♥" aria-label="Copy ♥">♥</button>
+      <span class="flag-label">Black Heart</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❤" aria-label="Copy ❤">❤</button>
+      <span class="flag-label">Red Heart Emoji</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🖤" aria-label="Copy 🖤">🖤</button>
+      <span class="flag-label">Black Heart Emoji</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🤍" aria-label="Copy 🤍">🤍</button>
+      <span class="flag-label">White Heart Emoji</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ᥫ᭡" aria-label="Copy ᥫ᭡">ᥫ᭡</button>
+      <span class="flag-label">Lazy Heart</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ʚ♡ɞ" aria-label="Copy ʚ♡ɞ">ʚ♡ɞ</button>
+      <span class="flag-label">Winged Heart (combo)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❦" aria-label="Copy ❦">❦</button>
+      <span class="flag-label">Floral Heart</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❧" aria-label="Copy ❧">❧</button>
+      <span class="flag-label">Rotated Floral Heart</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♱" aria-label="Copy ♱">♱</button>
+      <span class="flag-label">East Syriac Cross</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♰" aria-label="Copy ♰">♰</button>
+      <span class="flag-label">West Syriac Cross</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✟" aria-label="Copy ✟">✟</button>
+      <span class="flag-label">Outlined Latin Cross</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✝" aria-label="Copy ✝">✝</button>
+      <span class="flag-label">Latin Cross</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="†" aria-label="Copy †">†</button>
+      <span class="flag-label">Dagger</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☦" aria-label="Copy ☦">☦</button>
+      <span class="flag-label">Orthodox Cross</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛧" aria-label="Copy ⛧">⛧</button>
+      <span class="flag-label">Inverted Pentagram</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𖤐" aria-label="Copy 𖤐">𖤐</button>
+      <span class="flag-label">Black Sun</span>
+    </div>
+  </div>
 </section>
 
 <div class="section-divider"></div>
 
 <!-- SECTION 2 -->
-<section class="mood-explainers" id="cyber-web">
-  <span class="article-section-label">Cyber &amp; Web</span>
-  <h2>Cyber &amp; Web Symbols</h2>
-  <p>Tech and internet motifs from the early-2000s digital era.</p>
+<section class="mood-explainers" id="tech-cyber">
+  <span class="article-section-label">Tech &amp; Cyber</span>
+  <h2>Tech &amp; Cyber Symbols</h2>
+  <p>CDs, pagers, and cyber motifs from the early-2000s digital era — peak Y2K tech aesthetic.</p>
   <div class="flag-rows">
     <div class="flag-row">
       <button class="flag-emoji symbol-tile" data-symbol="💿" aria-label="Copy 💿">💿</button>
       <span class="flag-label">CD Emoji</span>
     </div>
     <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="📀" aria-label="Copy 📀">📀</button>
+      <span class="flag-label">DVD Emoji</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💾" aria-label="Copy 💾">💾</button>
+      <span class="flag-label">Floppy Disk Emoji</span>
+    </div>
+    <div class="flag-row">
       <button class="flag-emoji symbol-tile" data-symbol="📟" aria-label="Copy 📟">📟</button>
       <span class="flag-label">Pager Emoji</span>
     </div>
     <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="🛸" aria-label="Copy 🛸">🛸</button>
-      <span class="flag-label">Flying Saucer Emoji</span>
+      <button class="flag-emoji symbol-tile" data-symbol="📱" aria-label="Copy 📱">📱</button>
+      <span class="flag-label">Mobile Phone Emoji</span>
     </div>
     <div class="flag-row">
       <button class="flag-emoji symbol-tile" data-symbol="💻" aria-label="Copy 💻">💻</button>
       <span class="flag-label">Laptop Emoji</span>
     </div>
     <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🖥" aria-label="Copy 🖥">🖥</button>
+      <span class="flag-label">Desktop Computer</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕹" aria-label="Copy 🕹">🕹</button>
+      <span class="flag-label">Joystick Emoji</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🎮" aria-label="Copy 🎮">🎮</button>
+      <span class="flag-label">Video Game Controller</span>
+    </div>
+    <div class="flag-row">
       <button class="flag-emoji symbol-tile" data-symbol="🌐" aria-label="Copy 🌐">🌐</button>
       <span class="flag-label">Globe with Meridians</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🛸" aria-label="Copy 🛸">🛸</button>
+      <span class="flag-label">Flying Saucer Emoji</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="📡" aria-label="Copy 📡">📡</button>
+      <span class="flag-label">Satellite Antenna</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🔋" aria-label="Copy 🔋">🔋</button>
+      <span class="flag-label">Battery Emoji</span>
     </div>
     <div class="flag-row">
       <button class="flag-emoji symbol-tile" data-symbol="🕸" aria-label="Copy 🕸">🕸</button>
@@ -228,10 +443,6 @@
       <span class="flag-label">Gear</span>
     </div>
     <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="🎮" aria-label="Copy 🎮">🎮</button>
-      <span class="flag-label">Video Game Controller</span>
-    </div>
-    <div class="flag-row">
       <button class="flag-emoji symbol-tile" data-symbol="⌨" aria-label="Copy ⌨">⌨</button>
       <span class="flag-label">Keyboard</span>
     </div>
@@ -241,15 +452,11 @@
 <div class="section-divider"></div>
 
 <!-- SECTION 3 -->
-<section class="mood-explainers" id="bubbles-butterflies">
-  <span class="article-section-label">Bubbles, Butterflies &amp; Motifs</span>
-  <h2>Bubbles, Butterflies &amp; Motifs</h2>
-  <p>Soft Y2K motifs including butterflies, bows, and bubble accents.</p>
+<section class="mood-explainers" id="butterflies-bows">
+  <span class="article-section-label">Butterflies, Bows &amp; Bubbles</span>
+  <h2>Butterflies, Bows &amp; Bubbles</h2>
+  <p>The soft side of Y2K — butterfly clips, ribbon bows, and frosted bubble accents.</p>
   <div class="flag-rows">
-    <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="🫧" aria-label="Copy 🫧">🫧</button>
-      <span class="flag-label">Bubbles Emoji</span>
-    </div>
     <div class="flag-row">
       <button class="flag-emoji symbol-tile" data-symbol="🦋" aria-label="Copy 🦋">🦋</button>
       <span class="flag-label">Butterfly Emoji</span>
@@ -263,12 +470,95 @@
       <span class="flag-label">Ballet Shoes Emoji</span>
     </div>
     <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="🌐" aria-label="Copy 🌐">🌐</button>
-      <span class="flag-label">Globe with Meridians</span>
+      <button class="flag-emoji symbol-tile" data-symbol="🫧" aria-label="Copy 🫧">🫧</button>
+      <span class="flag-label">Bubbles Emoji</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌸" aria-label="Copy 🌸">🌸</button>
+      <span class="flag-label">Cherry Blossom</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🍓" aria-label="Copy 🍓">🍓</button>
+      <span class="flag-label">Strawberry</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ꨄ" aria-label="Copy ꨄ">ꨄ</button>
+      <span class="flag-label">Curled Heart</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ᡣ𐭩" aria-label="Copy ᡣ𐭩">ᡣ𐭩</button>
+      <span class="flag-label">Kitty Face (combo)</span>
     </div>
     <div class="flag-row">
       <button class="flag-emoji symbol-tile" data-symbol="✨" aria-label="Copy ✨">✨</button>
       <span class="flag-label">Sparkles Emoji</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 3B -->
+<section class="mood-explainers" id="arrows-brackets">
+  <span class="article-section-label">Arrows &amp; Brackets</span>
+  <h2>Arrows &amp; Brackets</h2>
+  <p>Frame your text Y2K-style — corner brackets, curved braces, and arrows to point and box your bio.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="「" aria-label="Copy 「">「</button>
+      <span class="flag-label">Corner Bracket Left</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="」" aria-label="Copy 」">」</button>
+      <span class="flag-label">Corner Bracket Right</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="『" aria-label="Copy 『">『</button>
+      <span class="flag-label">White Corner Bracket Left</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="』" aria-label="Copy 』">』</button>
+      <span class="flag-label">White Corner Bracket Right</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="꒰" aria-label="Copy ꒰">꒰</button>
+      <span class="flag-label">Curved Bracket Left</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="꒱" aria-label="Copy ꒱">꒱</button>
+      <span class="flag-label">Curved Bracket Right</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⫷" aria-label="Copy ⫷">⫷</button>
+      <span class="flag-label">Left Triangle Bracket</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⫸" aria-label="Copy ⫸">⫸</button>
+      <span class="flag-label">Right Triangle Bracket</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="➶" aria-label="Copy ➶">➶</button>
+      <span class="flag-label">Heavy Upward Arrow</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="➴" aria-label="Copy ➴">➴</button>
+      <span class="flag-label">Heavy Downward Arrow</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="↳" aria-label="Copy ↳">↳</button>
+      <span class="flag-label">Arrow with Hook</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="➤" aria-label="Copy ➤">➤</button>
+      <span class="flag-label">Black Arrowhead</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☆彡" aria-label="Copy ☆彡">☆彡</button>
+      <span class="flag-label">Shooting Star (combo)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⌗" aria-label="Copy ⌗">⌗</button>
+      <span class="flag-label">Viewdata Square</span>
     </div>
   </div>
 </section>
@@ -389,6 +679,26 @@
 <div class="section-divider"></div>
 
 
+<!-- FAQ -->
+<section class="editorial-section" id="faq">
+  <span class="article-section-label">FAQ</span>
+  <h2>Y2K symbols, answered</h2>
+  <details class="faq-item">
+    <summary class="faq-question">What are Y2K symbols?</summary>
+    <p class="faq-answer">Y2K symbols are Unicode characters that capture the early-2000s cyber aesthetic — sparkle stars (✦ ✮ ⋆), gothic crosses (♱ ✟ †), butterflies (🦋), CDs and pagers (💿 📟), and frosted dust marks. Because they are plain Unicode rather than images, you can copy and paste them straight into any bio, username, or caption without uploading a file.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">How do I use Y2K symbols in an Instagram bio?</summary>
+    <p class="faq-answer">Tap any symbol or combo on this page to copy it, then open Instagram, go to Edit Profile, and paste it into your name or bio field. Frame your text with matching symbols — for example ♱ your text ♱ or 𓆩♡𓆪 — and add a sparkle (✦) or star (✮) between words. Keep it to two or three symbols so the bio stays readable.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">Do Y2K symbols work on TikTok and Discord?</summary>
+    <p class="faq-answer">Yes. Every symbol here is standard Unicode, so it renders in TikTok usernames, captions, and comments, and in Discord display names, channel names, and messages. A few rare glyphs may show as a box on older devices that lack the font, so preview on your phone before posting. Plain stars, hearts, and crosses have the widest support.</p>
+  </details>
+</section>
+
+<div class="section-divider"></div>
+
 <!-- COLLECTIONS -->
 <section class="mood-explainers" id="y2k-collections">
   <span class="article-section-label">Y2K Collections</span>
@@ -416,21 +726,21 @@
       <h4>Aesthetic Symbols</h4>
       <p>Curated aesthetic Unicode characters for bios.</p>
     </a>
-    <a href="/library/egyptian-hieroglyphs/" class="compare-card variant-muted u-no-underline">
-      <h4>Egyptian Hieroglyphs</h4>
-      <p>All 1,072 Unicode hieroglyph characters.</p>
+    <a href="/library/coquette-symbols/" class="compare-card variant-muted u-no-underline">
+      <h4>Coquette Symbols</h4>
+      <p>Bows, ribbons, and soft-feminine characters for bios.</p>
+    </a>
+    <a href="/library/sparkle-symbols/" class="compare-card variant-muted u-no-underline">
+      <h4>Sparkle Symbols</h4>
+      <p>Glitter and sparkle decoration characters.</p>
     </a>
     <a href="/library/star-symbols/" class="compare-card variant-muted u-no-underline">
       <h4>Star Symbol Collection</h4>
       <p>Stars and sparkle characters in various styles.</p>
     </a>
-    <a href="/library/witchy-occult-symbols/" class="compare-card variant-muted u-no-underline">
-      <h4>Witchy &amp; Occult Symbols</h4>
-      <p>Esoteric symbols including pentagrams and moon phases.</p>
-    </a>
-    <a href="/library/sparkle-symbols/" class="compare-card variant-muted u-no-underline">
-      <h4>Sparkle Symbols</h4>
-      <p>Glitter and sparkle decoration characters.</p>
+    <a href="/library/egyptian-hieroglyphs/" class="compare-card variant-muted u-no-underline">
+      <h4>Egyptian Hieroglyphs</h4>
+      <p>All 1,072 Unicode hieroglyph characters.</p>
     </a>
   </div>
 </section>


### PR DESCRIPTION
…hetic symbols"

- Rewrite title (count + Copy & Paste) and meta description (leads with "y2k aesthetic symbols", names glyphs + use cases)
- Define the aesthetic in the H1 intro; add above-the-fold tap-to-copy strip
- Expand and regroup symbol set (107 one-tap tiles): Stars & Sparkles, Hearts & Crosses, Tech & Cyber, Butterflies/Bows/Bubbles, new Arrows & Brackets
- Add FAQ section + FAQPage JSON-LD; sync OG/Twitter/Article JSON-LD, bump dateModified
- Link to coquette/sparkle/star/aesthetic; add Y2K card to homepage library grid


Claude-Session: https://claude.ai/code/session_01XjAQN6WWvyTMZyBRrkw87Z