### PR TITLE
SEO: front-load keren/unik intent on /id/ snippet + style section (Ph…

### DIFF
--- a/id/index.html
+++ b/id/index.html
@@ -14,7 +14,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
 <title data-i18n="meta.title">Tulisan Aesthetic &amp; Font Keren — Generator Tulisan Unik (Copy Paste)</title>
-<meta name="description" data-i18n-content="meta.description" content="Bikin tulisan aesthetic, font keren, huruf estetik, dan simbol unik buat bio IG, caption TikTok, status WA, sampai nickname ML & Free Fire. Tinggal ketik, salin, tempel — gratis, tanpa daftar.">
+<meta name="description" data-i18n-content="meta.description" content="Tulisan aesthetic, tulisan keren, huruf estetik & font unik buat bio IG, caption TikTok, status WA & nickname game. Salin-tempel — gratis, tanpa daftar.">
 
 <link rel="canonical" href="https://ultratextgen.com/id/">
 
@@ -35,7 +35,7 @@
 
 <meta property="og:site_name" content="UltraTextGen">
 <meta property="og:title" content="Tulisan Aesthetic &amp; Font Keren — Generator Tulisan Unik (Copy Paste)">
-<meta property="og:description" content="Bikin tulisan aesthetic, font keren, huruf estetik, dan simbol unik buat bio IG, caption TikTok, status WA, sampai nickname ML & Free Fire. Tinggal ketik, salin, tempel — gratis, tanpa daftar.">
+<meta property="og:description" content="Tulisan aesthetic, tulisan keren, huruf estetik & font unik buat bio IG, caption TikTok, status WA & nickname game. Salin-tempel — gratis, tanpa daftar.">
 <meta property="og:url" content="https://ultratextgen.com/id/">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/generator-font-aesthetic-preview.png">
@@ -45,7 +45,7 @@
 
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Tulisan Aesthetic &amp; Font Keren — Generator Tulisan Unik (Copy Paste)">
-<meta name="twitter:description" content="Bikin tulisan aesthetic, font keren, huruf estetik, dan simbol unik buat bio IG, caption TikTok, status WA, sampai nickname ML & Free Fire. Tinggal ketik, salin, tempel — gratis, tanpa daftar.">
+<meta name="twitter:description" content="Tulisan aesthetic, tulisan keren, huruf estetik & font unik buat bio IG, caption TikTok, status WA & nickname game. Salin-tempel — gratis, tanpa daftar.">
 <meta name="twitter:image" content="https://ultratextgen.com/assets/og/generator-font-aesthetic-preview.png">
 
 <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
@@ -414,6 +414,34 @@
       </a>
     </div>
     <p class="u-mt-15 u-text-center"><a class="cat-cta" href="/usecase/" data-i18n="useCases.viewAll">Lihat semua ide pemakaian →</a></p>
+  </section>
+
+  <!-- Gaya Tulisan: Keren, Unik, Lucu -->
+  <section class="editorial-section">
+    <h2>Tulisan Keren, Unik &amp; Lucu — Nggak Cuma Aesthetic</h2>
+    <p class="editorial-intro">Selain tulisan aesthetic, generator ini juga bikin tulisan keren, font unik, sampai simbol lucu — semua tinggal ketik, salin, tempel. Pilih gaya yang paling cocok sama vibe kamu:</p>
+    <div class="tips-grid">
+      <div class="tip-card">
+        <div class="tip-icon">🔥</div>
+        <h3>Tulisan Keren</h3>
+        <p>Font tebal, gotik, dan gaya tegas yang bikin nama atau caption langsung stand out — favorit buat judul postingan dan tulisan keren copy paste.</p>
+      </div>
+      <div class="tip-card">
+        <div class="tip-icon">✨</div>
+        <h3>Tulisan Unik</h3>
+        <p>Huruf langka dan kombinasi simbol yang jarang dipakai orang, biar bio dan username kamu beda dari yang lain.</p>
+      </div>
+      <div class="tip-card">
+        <div class="tip-icon">🧸</div>
+        <h3>Font Lucu &amp; Simbol</h3>
+        <p>Gaya bubble, huruf imut, dan simbol aesthetic mungil buat tampilan yang playful dan gemoy di IG, TikTok, atau WhatsApp.</p>
+      </div>
+      <div class="tip-card">
+        <div class="tip-icon">🎮</div>
+        <h3>Font Nama Game</h3>
+        <p>Bikin nickname keren buat ML, Free Fire, dan PUBG pakai font dan simbol yang didukung di kolom nama — tinggal salin-tempel.</p>
+      </div>
+    </div>
   </section>
 
   <!-- Popular Guides -->

--- a/locales/id.json
+++ b/locales/id.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "title": "Tulisan Aesthetic & Font Keren — Generator Tulisan Unik (Copy Paste)",
-    "description": "Bikin tulisan aesthetic, font keren, huruf estetik, dan simbol unik buat bio IG, caption TikTok, status WA, sampai nickname ML & Free Fire. Tinggal ketik, salin, tempel — gratis, tanpa daftar."
+    "description": "Tulisan aesthetic, tulisan keren, huruf estetik & font unik buat bio IG, caption TikTok, status WA & nickname game. Salin-tempel — gratis, tanpa daftar."
   },
   "hero": {
     "title": "Tulisan Aesthetic & Font Keren",


### PR DESCRIPTION
…ase 1)

/id/ already ranks well for the "aesthetic" intent (tulisan aesthetic pos ~4, 5.7% CTR) but bleeds clicks on the adjacent "keren / unik / lucu" intent it also ranks for (tulisan keren 5.2k impr @ 1.3% CTR @ pos ~7; font text keren 0.3% CTR). This is a Phase 1, low-risk snippet + on-page change only:

- Rebalance the Indonesian meta description (locales/id.json source of truth + prerendered /id/ description, og, twitter) to front-load "tulisan keren" and "font unik" without displacing "aesthetic".
- Add a hardcoded "Tulisan Keren, Unik & Lucu" section reusing existing editorial-section / tips-grid classes (no new CSS, no inline styles), giving Google snippet-able copy for the keren/unik/lucu/game-nickname queries the page already surfaces for.

Title left untouched to protect the existing aesthetic rankings. Ranking work to lift keren queries from pos ~7 toward pos ~4 is deferred to a later phase pending a few weeks of GSC measurement.


Claude-Session: https://claude.ai/code/session_01TPtEDje3jo4zeYmxpYBdqk