### PR TITLE
feat: deepen /it/ for scritte/scritta stilizzata aesthetic + simboli copia e incolla

### DIFF
--- a/it/index.html
+++ b/it/index.html
@@ -13,7 +13,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title data-i18n="meta.title">Testo Stilizzato Copia e Incolla — Font, Caratteri Belli e Simboli Aesthetic</title>
+<title data-i18n="meta.title">Scritte Aesthetic e Testo Stilizzato Copia e Incolla — Font Belli e Simboli</title>
 <meta name="description" data-i18n-content="meta.description" content="Genera testo stilizzato, font per Instagram, caratteri belli, scritte aesthetic e simboli da copiare e incollare. Pronti per bio, nickname stilosi, caption TikTok e stato WhatsApp.">
 
 <link rel="canonical" href="https://ultratextgen.com/it/">
@@ -34,7 +34,7 @@
 <meta name="robots" content="index, follow">
 
 <meta property="og:site_name" content="UltraTextGen">
-<meta property="og:title" content="Testo Stilizzato Copia e Incolla — Font, Caratteri Belli e Simboli Aesthetic">
+<meta property="og:title" content="Scritte Aesthetic e Testo Stilizzato Copia e Incolla — Font Belli e Simboli">
 <meta property="og:description" content="Genera testo stilizzato, font per Instagram, caratteri belli, scritte aesthetic e simboli da copiare e incollare. Pronti per bio, nickname stilosi, caption TikTok e stato WhatsApp.">
 <meta property="og:url" content="https://ultratextgen.com/it/">
 <meta property="og:type" content="website">
@@ -42,9 +42,10 @@
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta property="og:image:type" content="image/png">
+<meta property="og:locale" content="it_IT">
 
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Testo Stilizzato Copia e Incolla — Font, Caratteri Belli e Simboli Aesthetic">
+<meta name="twitter:title" content="Scritte Aesthetic e Testo Stilizzato Copia e Incolla — Font Belli e Simboli">
 <meta name="twitter:description" content="Genera testo stilizzato, font per Instagram, caratteri belli, scritte aesthetic e simboli da copiare e incollare. Pronti per bio, nickname stilosi, caption TikTok e stato WhatsApp.">
 <meta name="twitter:image" content="https://ultratextgen.com/assets/og/generatore-di-testo-stilizzato-preview.png">
 
@@ -110,7 +111,32 @@
 {
   "@context": "https://schema.org",
   "@type": "FAQPage",
+  "inLanguage": "it",
   "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Cosa sono le scritte aesthetic e come si copiano e incollano?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Le scritte aesthetic sono lettere con un look curato e stilizzato — corsivo elegante, gotico, bubble, maiuscoletto, lettere distanziate — che si usano tanto nelle bio Instagram, su Pinterest e nelle copertine TikTok. Per copiarle e incollarle: 1. Scrivi la frase nel riquadro in alto. 2. Scegli lo stile che ti piace. 3. Tocca \"Copia\" e incolla dove vuoi. Sono caratteri Unicode veri, quindi nel copia e incolla lo stile resta intatto su Instagram, WhatsApp, TikTok e ovunque ci sia un campo di testo."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Dove trovo le scritte stilizzate e le scritte aesthetic da copiare?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Proprio qui. Scrivi la tua parola o frase nel generatore in alto e ottieni decine di scritte stilizzate e scritte aesthetic da copiare con un tocco. Se ti serve solo l'alfabeto, nella sezione \"Alfabeto in scritte aesthetic (A–Z)\" trovi A–Z e i numeri 0–9 nei vari stili, già pronti da copiare riga per riga. \"Scritta stilizzata\" e \"scritte aesthetic\" sono lo stesso risultato: cambia solo il nome che usi tu."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Dove trovo i simboli aesthetic da copiare e incollare?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Nella sezione \"Simboli aesthetic copia e incolla\": stelle, cuori, lune, fiori, cornici e separatori, ognuno con un tocco per copiarlo. Sono perfetti per separare le righe della bio Instagram, decorare un nickname o aggiungere un dettaglio nelle caption. Esempi: ⋆˙⟡ frase ⟡˙⋆ oppure ꒰♡꒱ frase. Per avvolgere automaticamente la frase tra cornici e simboli, usa le schede Simboli, Cornici e Divisori del generatore in alto."
+      }
+    },
     {
       "@type": "Question",
       "name": "Cos'è il testo stilizzato e perché funziona ovunque?",
@@ -295,7 +321,7 @@
   <section class="hero">
     <div class="hero-inner">
       <div class="hero-card">
-        <h1 class="hero-headline" data-i18n="hero.title">Testo Stilizzato Copia e Incolla</h1>
+        <h1 class="hero-headline" data-i18n="hero.title">Scritte aesthetic e testo stilizzato da copiare</h1>
         <p class="hero-tagline" data-i18n="hero.subtitle">Font belli, scritte aesthetic, caratteri particolari e simboli pronti da incollare nella bio Instagram, nei nickname, nelle caption TikTok o nello stato WhatsApp.</p>
         <div class="input-wrapper">
           <textarea class="main-input" id="mainInput" placeholder="Scrivi qui la tua frase…" data-i18n-placeholder="ui.placeholder" maxlength="500" autofocus=""></textarea>
@@ -338,6 +364,172 @@
     <!-- Results -->
     <div class="results-grid" id="resultsGrid"></div>
   </main>
+
+  <!-- Come fare scritte aesthetic da copiare -->
+  <section class="editorial-section">
+    <h2>Come fare scritte aesthetic da copiare</h2>
+    <p class="editorial-intro">Creare scritte aesthetic, font particolari e scritte stilizzate da copiare richiede pochi secondi — niente app da scaricare, niente registrazione.</p>
+    <div class="steps-grid">
+      <div class="step-card">
+        <div class="step-number">1</div>
+        <h3>Scrivi la tua frase</h3>
+        <p>Digita un nome, una parola o una frase nel riquadro in alto. Puoi anche incollare un testo che hai già copiato.</p>
+      </div>
+      <div class="step-card">
+        <div class="step-number">2</div>
+        <h3>Scegli lo stile</h3>
+        <p>Le scritte aesthetic compaiono subito — grassetto, corsivo elegante, gotico, bubble, fino al glitch. Apri le categorie per filtrare più nel dettaglio.</p>
+      </div>
+      <div class="step-card">
+        <div class="step-number">3</div>
+        <h3>Copia e incolla</h3>
+        <p>Tocca "Copia" e incolla nella bio Instagram, nella caption TikTok, nello stato WhatsApp o nel nickname di un gioco. Lo stile non si perde.</p>
+      </div>
+    </div>
+    <p class="u-mt-15 u-text-center">Lo stesso procedimento vale per <strong>scritte aesthetic copia e incolla</strong> su Instagram, WhatsApp, negli appunti o nella bio TikTok — i passaggi sono identici.</p>
+  </section>
+
+  <!-- Scritta stilizzata vs scritte aesthetic -->
+  <section class="editorial-section">
+    <h2>Scritta stilizzata e scritte aesthetic: come funzionano</h2>
+    <p>"Scritta stilizzata" e "scritte aesthetic" indicano quasi sempre la stessa cosa: lettere con un look diverso da quello della tastiera, pronte da copiare e incollare in bio, caption, nickname o stato. La differenza è solo nel nome che usi tu — il risultato è identico.</p>
+    <p>Funziona perché ogni lettera non viene messa in "grassetto" come in Word, ma sostituita con un carattere Unicode che ha già quella forma. Per questo quando fai <strong>copia e incolla</strong> su Instagram, TikTok o WhatsApp lo stile non sparisce: non è formattazione, sono proprio caratteri diversi. Ti basta scrivere la parola o la frase nel generatore qui sopra e tutte le versioni stilizzate compaiono subito.</p>
+    <div class="block-example">
+      <strong>Esempio:</strong> "sogno" → 𝓼𝓸𝓰𝓷𝓸 (corsivo), 𝔰𝔬𝔤𝔫𝔬 (gotico), ⓢⓞⓖⓝⓞ (bubble), ꜱᴏɢɴᴏ (maiuscoletto)
+    </div>
+  </section>
+
+  <!-- Alfabeto in scritte aesthetic A–Z -->
+  <section class="editorial-section glyph-section">
+    <h2>Alfabeto in scritte aesthetic (A–Z)</h2>
+    <p class="editorial-intro">Vuoi l'alfabeto aesthetic dalla A alla Z? Ecco l'abbecedario completo negli stili più usati. Tocca una riga per copiare tutte le lettere in un colpo solo.</p>
+    <div class="alpha-list">
+      <div class="alpha-row">
+        <span class="alpha-label">Grassetto</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇" aria-label="Copia l'alfabeto aesthetic stile Grassetto">𝗮 𝗯 𝗰 𝗱 𝗲 𝗳 𝗴 𝗵 𝗶 𝗷 𝗸 𝗹 𝗺 𝗻 𝗼 𝗽 𝗾 𝗿 𝘀 𝘁 𝘂 𝘃 𝘄 𝘅 𝘆 𝘇</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Corsivo</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃" aria-label="Copia l'alfabeto aesthetic stile Corsivo">𝓪 𝓫 𝓬 𝓭 𝓮 𝓯 𝓰 𝓱 𝓲 𝓳 𝓴 𝓵 𝓶 𝓷 𝓸 𝓹 𝓺 𝓻 𝓼 𝓽 𝓾 𝓿 𝔀 𝔁 𝔂 𝔃</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Gotico</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷" aria-label="Copia l'alfabeto aesthetic stile Gotico">𝔞 𝔟 𝔠 𝔡 𝔢 𝔣 𝔤 𝔥 𝔦 𝔧 𝔨 𝔩 𝔪 𝔫 𝔬 𝔭 𝔮 𝔯 𝔰 𝔱 𝔲 𝔳 𝔴 𝔵 𝔶 𝔷</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Bubble</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ" aria-label="Copia l'alfabeto aesthetic stile Bubble">ⓐ ⓑ ⓒ ⓓ ⓔ ⓕ ⓖ ⓗ ⓘ ⓙ ⓚ ⓛ ⓜ ⓝ ⓞ ⓟ ⓠ ⓡ ⓢ ⓣ ⓤ ⓥ ⓦ ⓧ ⓨ ⓩ</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Maiuscoletto</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="ᴀʙᴄᴅᴇꜰɢʜɪᴊᴋʟᴍɴᴏᴘqʀsᴛᴜᴠᴡxʏᴢ" aria-label="Copia l'alfabeto aesthetic stile Maiuscoletto">ᴀ ʙ ᴄ ᴅ ᴇ ꜰ ɢ ʜ ɪ ᴊ ᴋ ʟ ᴍ ɴ ᴏ ᴘ q ʀ s ᴛ ᴜ ᴠ ᴡ x ʏ ᴢ</button>
+      </div>
+    </div>
+    <h3>Numeri aesthetic 0–9</h3>
+    <div class="alpha-list">
+      <div class="alpha-row">
+        <span class="alpha-label">Grassetto</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝟬𝟭𝟮𝟯𝟰𝟱𝟲𝟳𝟴𝟵" aria-label="Copia i numeri aesthetic stile Grassetto">𝟬 𝟭 𝟮 𝟯 𝟰 𝟱 𝟲 𝟳 𝟴 𝟵</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Double-struck</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝟘𝟙𝟚𝟛𝟜𝟝𝟞𝟟𝟠𝟡" aria-label="Copia i numeri aesthetic stile Double-struck">𝟘 𝟙 𝟚 𝟛 𝟜 𝟝 𝟞 𝟟 𝟠 𝟡</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Bubble</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="⓪①②③④⑤⑥⑦⑧⑨" aria-label="Copia i numeri aesthetic stile Bubble">⓪ ① ② ③ ④ ⑤ ⑥ ⑦ ⑧ ⑨</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Fullwidth</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="０１２３４５６７８９" aria-label="Copia i numeri aesthetic stile Fullwidth">０ １ ２ ３ ４ ５ ６ ７ ８ ９</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Mono</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝟶𝟷𝟸𝟹𝟺𝟻𝟼𝟽𝟾𝟿" aria-label="Copia i numeri aesthetic stile Mono">𝟶 𝟷 𝟸 𝟹 𝟺 𝟻 𝟼 𝟽 𝟾 𝟿</button>
+      </div>
+    </div>
+    <p class="u-mt-15">Ti serve solo l'iniziale aesthetic del nome, o i numeri per la data di nascita in bio? Scrivi nel generatore in alto — tutti gli stili compaiono all'istante.</p>
+  </section>
+
+  <!-- Simboli aesthetic copia e incolla -->
+  <section class="editorial-section glyph-section">
+    <h2>Simboli aesthetic copia e incolla</h2>
+    <p class="editorial-intro">Raccolta di simboli aesthetic e caratteri particolari per separare le righe della bio Instagram, decorare un nickname o dare un tocco in più alle caption. Tocca un simbolo per copiarlo subito.</p>
+    <div class="glyph-group">
+      <h3>Stelle e scintillii</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="✦">✦</button>
+        <button class="glyph-copy" type="button" data-text="✧">✧</button>
+        <button class="glyph-copy" type="button" data-text="⋆">⋆</button>
+        <button class="glyph-copy" type="button" data-text="✩">✩</button>
+        <button class="glyph-copy" type="button" data-text="★">★</button>
+        <button class="glyph-copy" type="button" data-text="☆">☆</button>
+        <button class="glyph-copy" type="button" data-text="✰">✰</button>
+        <button class="glyph-copy" type="button" data-text="⊹">⊹</button>
+        <button class="glyph-copy" type="button" data-text="࿐">࿐</button>
+        <button class="glyph-copy" type="button" data-text="˚">˚</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Cuori</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="♡">♡</button>
+        <button class="glyph-copy" type="button" data-text="♥">♥</button>
+        <button class="glyph-copy" type="button" data-text="❤">❤</button>
+        <button class="glyph-copy" type="button" data-text="❥">❥</button>
+        <button class="glyph-copy" type="button" data-text="❣">❣</button>
+        <button class="glyph-copy" type="button" data-text="ღ">ღ</button>
+        <button class="glyph-copy" type="button" data-text="ꨄ">ꨄ</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Luna e cielo</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="☾">☾</button>
+        <button class="glyph-copy" type="button" data-text="☽">☽</button>
+        <button class="glyph-copy" type="button" data-text="☁">☁</button>
+        <button class="glyph-copy" type="button" data-text="✶">✶</button>
+        <button class="glyph-copy" type="button" data-text="⍣">⍣</button>
+        <button class="glyph-copy" type="button" data-text="ꕥ">ꕥ</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Cornici e ornamenti</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="꧁">꧁</button>
+        <button class="glyph-copy" type="button" data-text="꧂">꧂</button>
+        <button class="glyph-copy" type="button" data-text="༺">༺</button>
+        <button class="glyph-copy" type="button" data-text="༻">༻</button>
+        <button class="glyph-copy" type="button" data-text="⟡">⟡</button>
+        <button class="glyph-copy" type="button" data-text="❪">❪</button>
+        <button class="glyph-copy" type="button" data-text="❫">❫</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Fiori</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="❀">❀</button>
+        <button class="glyph-copy" type="button" data-text="✿">✿</button>
+        <button class="glyph-copy" type="button" data-text="⚘">⚘</button>
+        <button class="glyph-copy" type="button" data-text="✾">✾</button>
+        <button class="glyph-copy" type="button" data-text="❁">❁</button>
+        <button class="glyph-copy" type="button" data-text="ꕤ">ꕤ</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Frecce e separatori</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="➳">➳</button>
+        <button class="glyph-copy" type="button" data-text="➤">➤</button>
+        <button class="glyph-copy" type="button" data-text="↳">↳</button>
+        <button class="glyph-copy" type="button" data-text="•">•</button>
+        <button class="glyph-copy" type="button" data-text="◦">◦</button>
+        <button class="glyph-copy" type="button" data-text="⟢">⟢</button>
+        <button class="glyph-copy" type="button" data-text="—">—</button>
+      </div>
+    </div>
+    <p class="u-mt-15">Per avvolgere automaticamente la frase tra cornici e simboli aesthetic, usa le schede <strong>Simboli</strong>, <strong>Cornici</strong> e <strong>Divisori</strong> del generatore in alto.</p>
+  </section>
 
   <!-- Popular Use Cases -->
   <section class="editorial-section">
@@ -762,6 +954,55 @@
     <br><br>
     <strong>Per uso</strong><br>
     La sezione "casi d'uso" porta direttamente a strumenti per bio, nickname, caption, commenti, titolo LinkedIn e altro.</div>
+</div>
+
+
+<!-- Scritte aesthetic, scritte stilizzate e simboli -->
+<h2 class="faq-category" data-i18n="faq.categories.8.title">Scritte aesthetic, scritte stilizzate e simboli</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.8.items.0.question">Cosa sono le scritte aesthetic e come si copiano e incollano?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.8.items.0.answer">Le scritte aesthetic sono lettere con un look curato e stilizzato — corsivo elegante, gotico, bubble, maiuscoletto, lettere distanziate — che si usano tanto nelle bio Instagram, su Pinterest e nelle copertine TikTok.
+    <br><br>
+    <strong>Per copiarle e incollarle</strong><br>
+    1. Scrivi la frase nel riquadro in alto.<br>
+    2. Scegli lo stile che ti piace tra quelli che compaiono.<br>
+    3. Tocca "Copia" e incolla dove vuoi.
+    <br><br>
+    Sono caratteri Unicode veri, quindi nel <strong>copia e incolla</strong> lo stile resta intatto su Instagram, WhatsApp, TikTok e ovunque ci sia un campo di testo.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.8.items.1.question">Dove trovo le scritte stilizzate e le scritte aesthetic da copiare?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.8.items.1.answer">Proprio qui. Scrivi la tua parola o frase nel generatore in alto e ottieni decine di scritte stilizzate e scritte aesthetic da copiare con un tocco.
+    <br><br>
+    Se ti serve solo l'alfabeto, nella sezione "Alfabeto in scritte aesthetic (A–Z)" trovi A–Z e i numeri 0–9 nei vari stili, già pronti da copiare riga per riga.
+    <br><br>
+    "Scritta stilizzata" e "scritte aesthetic" sono lo stesso risultato: cambia solo il nome che usi tu.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.8.items.2.question">Dove trovo i simboli aesthetic da copiare e incollare?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.8.items.2.answer">Nella sezione "Simboli aesthetic copia e incolla" qui sopra: stelle, cuori, lune, fiori, cornici e separatori, ognuno con un tocco per copiarlo.
+    <br><br>
+    Sono perfetti per separare le righe della bio Instagram, decorare un nickname o aggiungere un dettaglio nelle caption. Esempi: ⋆˙⟡ frase ⟡˙⋆ oppure ꒰♡꒱ frase.
+    <br><br>
+    Per avvolgere automaticamente la frase tra cornici e simboli, usa le schede <strong>Simboli</strong>, <strong>Cornici</strong> e <strong>Divisori</strong> del generatore in alto.</div>
 </div>
 
     </div>

--- a/locales/it.json
+++ b/locales/it.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "title": "Testo Stilizzato Copia e Incolla — Font, Caratteri Belli e Simboli Aesthetic",
+    "title": "Scritte Aesthetic e Testo Stilizzato Copia e Incolla — Font Belli e Simboli",
     "description": "Genera testo stilizzato, font per Instagram, caratteri belli, scritte aesthetic e simboli da copiare e incollare. Pronti per bio, nickname stilosi, caption TikTok e stato WhatsApp."
   },
   "hero": {
-    "title": "Testo Stilizzato Copia e Incolla",
+    "title": "Scritte aesthetic e testo stilizzato da copiare",
     "subtitle": "Font belli, scritte aesthetic, caratteri particolari e simboli pronti da incollare nella bio Instagram, nei nickname, nelle caption TikTok o nello stato WhatsApp."
   },
   "decorations": {
@@ -182,6 +182,23 @@
           {
             "question": "Come trovo velocemente lo stile giusto?",
             "answer": "Tre strade.\n    <br><br>\n    <strong>Per stile di font</strong><br>\n    Apri le categorie (bold, corsivo, gothic, bubble, capovolto, glitch…). Ogni categoria ha la propria pagina con tutti gli stili di quel gruppo.\n    <br><br>\n    <strong>Per piattaforma</strong><br>\n    Vai sulle pagine Instagram, TikTok, Discord, WhatsApp e simili: gli stili sono già filtrati per compatibilità.\n    <br><br>\n    <strong>Per uso</strong><br>\n    La sezione \"casi d'uso\" porta direttamente a strumenti per bio, nickname, caption, commenti, titolo LinkedIn e altro."
+          }
+        ]
+      },
+      {
+        "title": "Scritte aesthetic, scritte stilizzate e simboli",
+        "items": [
+          {
+            "question": "Cosa sono le scritte aesthetic e come si copiano e incollano?",
+            "answer": "Le scritte aesthetic sono lettere con un look curato e stilizzato — corsivo elegante, gotico, bubble, maiuscoletto, lettere distanziate — che si usano tanto nelle bio Instagram, su Pinterest e nelle copertine TikTok.<br><br><strong>Per copiarle e incollarle</strong><br>1. Scrivi la frase nel riquadro in alto.<br>2. Scegli lo stile che ti piace tra quelli che compaiono.<br>3. Tocca \"Copia\" e incolla dove vuoi.<br><br>Sono caratteri Unicode veri, quindi nel <strong>copia e incolla</strong> lo stile resta intatto su Instagram, WhatsApp, TikTok e ovunque ci sia un campo di testo."
+          },
+          {
+            "question": "Dove trovo le scritte stilizzate e le scritte aesthetic da copiare?",
+            "answer": "Proprio qui. Scrivi la tua parola o frase nel generatore in alto e ottieni decine di scritte stilizzate e scritte aesthetic da copiare con un tocco.<br><br>Se ti serve solo l'alfabeto, nella sezione \"Alfabeto in scritte aesthetic (A–Z)\" trovi A–Z e i numeri 0–9 nei vari stili, già pronti da copiare riga per riga.<br><br>\"Scritta stilizzata\" e \"scritte aesthetic\" sono lo stesso risultato: cambia solo il nome che usi tu."
+          },
+          {
+            "question": "Dove trovo i simboli aesthetic da copiare e incollare?",
+            "answer": "Nella sezione \"Simboli aesthetic copia e incolla\" qui sopra: stelle, cuori, lune, fiori, cornici e separatori, ognuno con un tocco per copiarlo.<br><br>Sono perfetti per separare le righe della bio Instagram, decorare un nickname o aggiungere un dettaglio nelle caption. Esempi: ⋆˙⟡ frase ⟡˙⋆ oppure ꒰♡꒱ frase.<br><br>Per avvolgere automaticamente la frase tra cornici e simboli, usa le schede <strong>Simboli</strong>, <strong>Cornici</strong> e <strong>Divisori</strong> del generatore in alto."
           }
         ]
       }


### PR DESCRIPTION
## Why

Italy shows impressions but near-zero conversion on its top native queries (GSC, query×country):

| Query | Impr / Clk |
|---|---|
| scritta stilizzata | 83 / 2 |
| scritte aesthetic | 78 / 2 |
| scritte aesthetic copia e incolla | 64 / 1 |
| scritte aesthetic da copiare | 47 / 0 |
| simboli aesthetic copia e incolla | 75 / 0 |

The `/it/` homepage had the generator + FAQ but lacked the deeper, query-matching content that `/es/` and `/id/` carry (A–Z table, símboli grid, how-to). This PR closes that gap, fully in Italian. (English "stacked text" is out of scope — handled by the Stacked Text initiative.)

## What changed

**`it/index.html`**
- Four new localized editorial sections after the generator, mirroring `/id/` depth:
  - **Come fare scritte aesthetic da copiare** — 3-step how-to (`steps-grid`).
  - **Scritta stilizzata e scritte aesthetic: come funzionano** — terminology explainer (the two terms = same result).
  - **Alfabeto in scritte aesthetic (A–Z)** — clickable `glyph-copy` rows for A–Z + numbers 0–9 across Grassetto / Corsivo / Gotico / Bubble / Maiuscoletto.
  - **Simboli aesthetic copia e incolla** — tap-to-copy grid (stelle, cuori, luna, cornici, fiori, frecce/separatori).
- New FAQ category **"Scritte aesthetic, scritte stilizzate e simboli"** (3 items phrased on the real IT queries), wired with `data-i18n` and added to the static FAQPage JSON-LD.
- Title / H1 / OG / Twitter now lead with "scritte aesthetic"; added `og:locale` `it_IT` and `inLanguage: "it"` on the FAQPage schema.

**`locales/it.json`**
- Added the matching FAQ category (index 8) so the runtime-rebuilt FAQPage schema and visible FAQ text stay in sync.
- Updated `meta.title` and `hero.title` to match the HTML.

## Constraints honored
- No new framework / bundler; reuses existing CSS (`glyph-section`, `alpha-list`, `steps-grid`) and the delegated `glyph-copy` handler in `script.js`.
- Script load order, GTM, canonical, and the full hreflang cluster unchanged.
- SITE_PAGES untracked for language pages (consistent with `/es/` and `/id/`), so no change needed there.
- Both JSON-LD blocks validated; `it.json` validated (9 FAQ categories); section tags balanced.

## Done when
`/it/` covers the scritte/scritta stilizzata aesthetic + simboli aesthetic copia e incolla queries in Italian, with matching FAQPage schema. ✅

No merge requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KkkUMSDzJcdVaWVcxgp47o)_