### PR TITLE
feat: deepen /vi/ around "chữ kiểu" queries with có dấu support

### DIFF
--- a/locales/vi.json
+++ b/locales/vi.json
@@ -75,6 +75,10 @@
           {
             "question": "Trang này có miễn phí thật không, hay xài một lúc lại bắt trả tiền?",
             "answer": "Free 100%, không bắt đăng ký, không giới hạn lượt copy, không gắn watermark vào chữ. Copy paste bao nhiêu lần cũng được, lúc nào cũng được. Mở web lên là dùng, đóng tab là xong - không cần tạo tài khoản gì cả."
+          },
+          {
+            "question": "Chữ kiểu có dấu là gì? Tạo chữ kiểu có giữ được dấu tiếng Việt không?",
+            "answer": "Chữ kiểu có dấu là chữ kiểu vẫn giữ nguyên dấu thanh và dấu mũ của tiếng Việt (á, à, ả, ã, ạ, ă, â, ê, ô, ơ, ư, đ). UltraTextGen đổi từng chữ cái Latin sang kí tự Unicode có sẵn kiểu dáng, còn các nguyên âm có dấu được giữ nguyên nên bạn đọc vẫn đúng chính tả - không bị mất dấu, không ra ô vuông.\n    <br><br>\n    <strong>Ví dụ</strong><br>\n    Gõ \"chữ kiểu đẹp\" → ra 𝗰𝗵ữ 𝗸𝗶ể𝘂 đẹ𝗽 (đậm), 𝘤𝘩ữ 𝘬𝘪ể𝘶 đẹ𝘱 (nghiêng), ᴄʜữ ᴋɪểᴜ đẹᴘ (small caps).\n    <br><br>\n    <strong>Mẹo</strong><br>\n    Với caption tiếng Việt có dấu, ba kiểu Đậm, Nghiêng và Small Caps cho ra dấu đều và đẹp nhất. Kiểu cong nghệ thuật như Script hay Gothic đôi khi không có biến thể cho nguyên âm có dấu - khi đó công cụ giữ nguyên chữ gốc để bạn vẫn đọc được, thay vì hiển thị lỗi."
           }
         ]
       },

--- a/vi/index.html
+++ b/vi/index.html
@@ -59,7 +59,8 @@
     "@type": "WebSite",
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/",
-    "description": "Fast, clean Unicode text generator for social bios, captions, and usernames.",
+    "inLanguage": "vi",
+    "description": "Trình tạo chữ kiểu đẹp và kí tự đặc biệt, gõ một dòng ra hàng trăm font chữ copy paste cho tên game, bio Facebook, Instagram, Zalo và caption TikTok.",
     "potentialAction": {
       "@type": "SearchAction",
       "target": {
@@ -86,8 +87,9 @@
     "@context": "https://schema.org",
     "@type": "WebApplication",
     "name": "UltraTextGen",
-    "alternateName": ["Trình tạo phông chữ Unicode", "Trình tạo chữ kiểu", "Trình đổi phông chữ", "Phông chữ sao chép và dán"],
-    "url": "https://ultratextgen.com/",
+    "alternateName": ["Trình tạo phông chữ Unicode", "Tạo chữ kiểu", "Trình đổi phông chữ", "Chữ kiểu đẹp copy paste"],
+    "url": "https://ultratextgen.com/vi/",
+    "inLanguage": "vi",
     "applicationCategory": "UtilitiesApplication",
     "operatingSystem": "All",
     "browserRequirements": "Requires JavaScript",
@@ -96,7 +98,7 @@
       "price": "0",
       "priceCurrency": "USD"
     },
-    "description": "Generate stylish Unicode text instantly for Instagram, TikTok, X, WhatsApp, and Discord. Copy and paste text styles for social bios, usernames, and posts."
+    "description": "Tạo chữ kiểu đẹp, font chữ aesthetic và kí tự đặc biệt để copy paste vào tên Free Fire, Liên Quân, bio Facebook, Instagram, Zalo và caption TikTok. Giữ nguyên tiếng Việt có dấu, miễn phí, không cần tải app."
   }
 ]
 </script>
@@ -108,7 +110,16 @@
 {
   "@context": "https://schema.org",
   "@type": "FAQPage",
+  "inLanguage": "vi",
   "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Chữ kiểu có dấu là gì? Tạo chữ kiểu có giữ được dấu tiếng Việt không?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Chữ kiểu có dấu là chữ kiểu vẫn giữ nguyên dấu thanh và dấu mũ của tiếng Việt (á, à, ả, ã, ạ, ă, â, ê, ô, ơ, ư, đ). UltraTextGen đổi từng chữ cái Latin sang kí tự Unicode có sẵn kiểu dáng, còn các nguyên âm có dấu được giữ nguyên nên bạn đọc vẫn đúng chính tả - không bị mất dấu, không ra ô vuông. Ví dụ gõ \"chữ kiểu đẹp\" ra 𝗰𝗵ữ 𝗸𝗶ể𝘂 đẹ𝗽 (đậm), 𝘤𝘩ữ 𝘬𝘪ể𝘶 đẹ𝘱 (nghiêng), ᴄʜữ ᴋɪểᴜ đẹᴘ (small caps). Mẹo: với caption tiếng Việt có dấu, ba kiểu Đậm, Nghiêng và Small Caps cho ra dấu đều và đẹp nhất."
+      }
+    },
     {
       "@type": "Question",
       "name": "Chữ kiểu là gì? Tạo chữ kiểu trên đây như thế nào?",
@@ -280,8 +291,39 @@
   ]
 }
 </script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "inLanguage": "vi",
+  "name": "Cách tạo chữ kiểu đẹp để copy paste",
+  "description": "Hướng dẫn tạo chữ kiểu đẹp và kí tự đặc biệt bằng UltraTextGen, copy paste vào tên game, bio Facebook, Instagram, Zalo và caption TikTok.",
+  "totalTime": "PT1M",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "Gõ chữ vào ô",
+      "text": "Nhập hoặc dán đoạn chữ bạn muốn đổi font. Gõ tiếng Việt có dấu thoải mái, công cụ giữ nguyên dấu thanh và dấu mũ."
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Chọn kiểu chữ",
+      "text": "Cuộn xuống xem cả loạt chữ kiểu - đậm, nghiêng, script, gothic, bong bóng, small caps - và thêm khung viền, kí tự đặc biệt nếu muốn."
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "Copy và paste",
+      "text": "Bấm Sao chép cạnh kiểu bạn thích rồi dán vào bất kỳ ô nhập chữ nào. Vì là kí tự Unicode thật, chữ kiểu giữ nguyên dù paste ở đâu."
+    }
+  ]
+}
+</script>
 </head>
-  
+
 <body>
   <!-- Google Tag Manager (noscript) -->
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
@@ -337,6 +379,142 @@
     <div class="results-grid" id="resultsGrid"></div>
   </main>
 
+  <!-- Cách tạo chữ kiểu -->
+  <section class="editorial-section" aria-label="Cách tạo chữ kiểu đẹp">
+    <h2>Cách tạo chữ kiểu đẹp trong 3 bước</h2>
+    <p>Tạo chữ kiểu trên UltraTextGen nhanh gần như tức thì - gõ là ra, không cần cài app hay đăng ký. Làm theo 3 bước dưới đây để có font chữ copy paste cho tên game, bio và caption.</p>
+    <div class="tips-grid">
+      <div class="tip-card">
+        <div class="tip-icon">⌨️</div>
+        <h3>1. Gõ chữ vào ô</h3>
+        <p>Nhập hoặc dán đoạn chữ bạn muốn - tên Free Fire, bio Facebook, caption TikTok. Gõ tiếng Việt có dấu thoải mái, công cụ giữ nguyên dấu thanh.</p>
+      </div>
+      <div class="tip-card">
+        <div class="tip-icon">🎨</div>
+        <h3>2. Chọn kiểu chữ</h3>
+        <p>Cuộn xuống xem cả loạt chữ kiểu đẹp - đậm, nghiêng, script, gothic, bong bóng, small caps. Muốn xịn hơn thì thêm khung viền và kí tự đặc biệt chỉ với một cú nhấp.</p>
+      </div>
+      <div class="tip-card">
+        <div class="tip-icon">📋</div>
+        <h3>3. Copy &amp; paste</h3>
+        <p>Bấm Sao chép cạnh kiểu bạn thích, rồi dán vào bất kỳ ô nhập chữ nào. Vì là kí tự Unicode thật, chữ kiểu giữ nguyên dù paste ở đâu.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Bảng chữ cái A–Z -->
+  <section class="editorial-section abc-section" aria-label="Bảng chữ cái chữ kiểu A–Z để copy paste">
+    <h2>Bảng chữ cái chữ kiểu A–Z</h2>
+    <p>Đây là bảng chữ cái đầy đủ - chữ hoa (A–Z), chữ thường (a–z) và số (0–9) - ở các kiểu chữ đẹp hay dùng nhất. Gõ chữ ở ô trên rồi bấm «Sao chép» để lấy cả từ theo kiểu, hoặc bôi đen từng kí tự trong bảng để copy thủ công.</p>
+
+    <div class="abc-list">
+      <div class="abc-row">
+        <span class="abc-name">Đậm</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝗔𝗕𝗖𝗗𝗘𝗙𝗚𝗛𝗜𝗝𝗞𝗟𝗠𝗡𝗢𝗣𝗤𝗥𝗦𝗧𝗨𝗩𝗪𝗫𝗬𝗭</span>
+          <span class="abc-line">𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇</span>
+          <span class="abc-line">𝟬𝟭𝟮𝟯𝟰𝟱𝟲𝟳𝟴𝟵</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Nghiêng</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝘈𝘉𝘊𝘋𝘌𝘍𝘎𝘏𝘐𝘑𝘒𝘓𝘔𝘕𝘖𝘗𝘘𝘙𝘚𝘛𝘜𝘝𝘞𝘟𝘠𝘡</span>
+          <span class="abc-line">𝘢𝘣𝘤𝘥𝘦𝘧𝘨𝘩𝘪𝘫𝘬𝘭𝘮𝘯𝘰𝘱𝘲𝘳𝘴𝘵𝘶𝘷𝘸𝘹𝘺𝘻</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Thư pháp (script)</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵</span>
+          <span class="abc-line">𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏</span>
+          <span class="abc-line">𝟢𝟣𝟤𝟥𝟦𝟧𝟨𝟩𝟪𝟫</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Gothic</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝔄𝔅ℭ𝔇𝔈𝔉𝔊ℌℑ𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔ℜ𝔖𝔗𝔘𝔙𝔚𝔛𝔜ℨ</span>
+          <span class="abc-line">𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Small Caps</span>
+        <div class="abc-lines">
+          <span class="abc-line">ᴀʙᴄᴅᴇꜰɢʜɪᴊᴋʟᴍɴᴏᴘQʀsᴛᴜᴠᴡxʏᴢ</span>
+          <span class="abc-line">ᴀʙᴄᴅᴇꜰɢʜɪᴊᴋʟᴍɴᴏᴘqʀsᴛᴜᴠᴡxʏᴢ</span>
+          <span class="abc-line">⁰¹²³⁴⁵⁶⁷⁸⁹</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Bong bóng</span>
+        <div class="abc-lines">
+          <span class="abc-line">ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ</span>
+          <span class="abc-line">ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ</span>
+          <span class="abc-line">⓪①②③④⑤⑥⑦⑧⑨</span>
+        </div>
+      </div>
+    </div>
+
+    <h3 class="u-mt-15">Chữ kiểu tiếng Việt có dấu</h3>
+    <p>Tiếng Việt dựa trên bảng chữ Latin nên chữ kiểu áp dụng được luôn. Dấu thanh và dấu mũ (á, ằ, ể, ữ, ợ, đ…) được giữ nguyên để đọc đúng chính tả. Đậm, Nghiêng và Small Caps là ba kiểu cho ra dấu đều và đẹp nhất:</p>
+    <div class="abc-list">
+      <div class="abc-row">
+        <span class="abc-name">Đậm</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝗰𝗵ữ 𝗸𝗶ể𝘂 đẹ𝗽 · 𝗧𝗶ế𝗻𝗴 𝗩𝗶ệ𝘁 · 𝗛à 𝗡ộ𝗶 · 𝗖ả𝗺 ơ𝗻</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Nghiêng</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝘤𝘩ữ 𝘬𝘪ể𝘶 đẹ𝘱 · 𝘛𝘪ế𝘯𝘨 𝘝𝘪ệ𝘵 · 𝘏à 𝘕ộ𝘪 · 𝘊ả𝘮 ơ𝘯</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Small Caps</span>
+        <div class="abc-lines">
+          <span class="abc-line">ᴄʜữ ᴋɪểᴜ đẹᴘ · ᴛɪếɴɢ ᴠɪệᴛ · ʜà ɴộɪ · ᴄảᴍ ơɴ</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Chữ kiểu & kí tự đặc biệt -->
+  <section class="editorial-section symbols-section" aria-label="Kí tự đặc biệt để copy paste">
+    <h2>Chữ kiểu &amp; kí tự đặc biệt để copy paste</h2>
+    <p>Ghép thêm kí tự đặc biệt để tên game và bio nổi bật hơn. Dưới đây là những kí hiệu hay dùng nhất, bấm chọn là copy. Muốn tự động bọc quanh chữ, dùng các tab <strong>Kí hiệu</strong>, <strong>Khung viền</strong> và <strong>Đường kẻ</strong> ở ô tạo phía trên.</p>
+
+    <div class="symbol-groups">
+      <div class="symbol-group">
+        <h3>Trái tim</h3>
+        <p class="symbol-set">♡ ♥ ❤ 💕 💖 💗 ❥ ღ ❣ ꒰♡꒱ ⟡</p>
+      </div>
+      <div class="symbol-group">
+        <h3>Sao &amp; lấp lánh</h3>
+        <p class="symbol-set">★ ☆ ✦ ✧ ⋆ ⭒ ✩ ✯ ✰ ࿐ ｡ﾟ</p>
+      </div>
+      <div class="symbol-group">
+        <h3>Hoa &amp; thiên nhiên</h3>
+        <p class="symbol-set">✿ ❀ ❁ ✾ ♧ ☘ ⚘ ꕥ ❃ ✤</p>
+      </div>
+      <div class="symbol-group">
+        <h3>Trăng &amp; đêm</h3>
+        <p class="symbol-set">☾ ☽ ⊹ ✬ ☄ ✫ ⋆｡˚ ☁ ❄ ❆</p>
+      </div>
+      <div class="symbol-group">
+        <h3>Kí tự game (bo viền tên)</h3>
+        <p class="symbol-set">☬ ✦ ➤ ೋ ໒ ๑ ⚝ ✯ ꧁ ꧂ ★彡 彡★</p>
+      </div>
+      <div class="symbol-group">
+        <h3>Mặt cười (kaomoji)</h3>
+        <p class="symbol-set">(◍•ᴗ•◍) (｡♥‿♥｡) ʕ•ᴥ•ʔ (＾▽＾) (づ｡◕‿‿◕｡)づ ٩(◕‿◕)۶</p>
+      </div>
+    </div>
+  </section>
+
   <!-- Popular Use Cases -->
   <section class="editorial-section">
     <h2 data-i18n="useCases.title">Người Việt thường dùng để làm gì?</h2>
@@ -389,6 +567,22 @@
 
 <!-- Mở đầu cho người mới -->
 <h2 class="faq-category" data-i18n="faq.categories.0.title">Mở đầu cho người mới</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.0.items.3.question">Chữ kiểu có dấu là gì? Tạo chữ kiểu có giữ được dấu tiếng Việt không?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.0.items.3.answer">Chữ kiểu có dấu là chữ kiểu vẫn giữ nguyên dấu thanh và dấu mũ của tiếng Việt (á, à, ả, ã, ạ, ă, â, ê, ô, ơ, ư, đ). UltraTextGen đổi từng chữ cái Latin sang kí tự Unicode có sẵn kiểu dáng, còn các nguyên âm có dấu được giữ nguyên nên bạn đọc vẫn đúng chính tả - không bị mất dấu, không ra ô vuông.
+    <br><br>
+    <strong>Ví dụ</strong><br>
+    Gõ "chữ kiểu đẹp" → ra 𝗰𝗵ữ 𝗸𝗶ể𝘂 đẹ𝗽 (đậm), 𝘤𝘩ữ 𝘬𝘪ể𝘶 đẹ𝘱 (nghiêng), ᴄʜữ ᴋɪểᴜ đẹᴘ (small caps).
+    <br><br>
+    <strong>Mẹo</strong><br>
+    Với caption tiếng Việt có dấu, ba kiểu Đậm, Nghiêng và Small Caps cho ra dấu đều và đẹp nhất. Kiểu cong nghệ thuật như Script hay Gothic đôi khi không có biến thể cho nguyên âm có dấu - khi đó công cụ giữ nguyên chữ gốc để bạn vẫn đọc được, thay vì hiển thị lỗi.</div>
+</div>
 
 <div class="faq-item">
   <button class="faq-question" type="button">


### PR DESCRIPTION
## What & why

The Vietnam GSC query×country data shows a small, clean native cluster around styled-text intent (early, ~0 clicks but real):

| Query | Impr / Clicks |
|---|---|
| chữ kiểu có dấu | 45 / 0 |
| chữ kiểu đẹp | 33 / 2 |
| chữ kiểu | 31 / 0 |
| font chữ copy | 19 / 3 |
| text kiểu | 10 / 0 |
| tạo chữ kiểu | 8 / 0 |

This PR deepens the existing `/vi/` homepage to mirror `/es/` editorial depth (bảng chữ cái A–Z, ký hiệu, how-to, FAQ) and explicitly targets the **"có dấu"** (Vietnamese diacritics) angle, which is the strongest query.

## Changes

- **How-to section** — "Cách tạo chữ kiểu đẹp trong 3 bước" (targets *tạo chữ kiểu* / *cách tạo chữ kiểu*), backed by a new **HowTo** JSON-LD block.
- **Alphabet section** — "Bảng chữ cái chữ kiểu A–Z" with copy-paste tables for Đậm, Nghiêng, Thư pháp/script, Gothic, Small Caps, Bong bóng (A–Z, a–z, 0–9), plus a dedicated **"Tiếng Việt có dấu"** demo row showing tone marks rendered intact.
- **Symbols section** — "Chữ kiểu & kí tự đặc biệt" with localized groups (trái tim, sao, hoa, trăng, kí tự game, kaomoji).
- **FAQ** — added a "chữ kiểu có dấu" Q&A as a visible item, in `locales/vi.json`, and in the FAQPage schema.
- **JSON-LD localization** — `inLanguage: "vi"` on WebSite / WebApplication / FAQPage, fixed the WebApplication `url` to `/vi/`, and translated the English descriptions to Vietnamese.

All new editorial sections are hardcoded Vietnamese (same pattern as `/es/`); FAQ content stays driven by `locales/vi.json` (i18n rebuilds the FAQ schema at runtime).

## Constraints respected

- No new framework / bundler; IIFE + GTM + canonical preserved.
- hreflang block intact (already lists `vi` + all locales); SITE_PAGES untouched (routing is not language-specific).
- All 3 JSON-LD blocks parse as valid JSON; all 81 `data-i18n` keys resolve in `vi.json`; HTML tag balance verified.

## Diacritic verification (DONE-WHEN)

Ran the actual `renderer.js` against Vietnamese input — combining marks are **identical in/out** across Bold, Italic, Script, and Small Caps. Base ASCII letters get styled; precomposed Vietnamese vowels (ữ, ể, ấ, ệ, ợ, đ…) pass through unchanged, so output keeps correct spelling and never drops a tone mark.

```
chữ kiểu có dấu  →  𝗰𝗵ữ 𝗸𝗶ể𝘂 𝗰ó 𝗱ấ𝘂   (Ultra Bold)
Khuyến mãi 50%   →  𝗞𝗵𝘂𝘆ế𝗻 𝗺ã𝗶 𝟱𝟬%   (Ultra Bold)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EzMuryKW64gfzfVvVvsUER)_