### PR TITLE
feat(es): reinforce letras/símbolos copy-paste intent on /es/

### DIFF
--- a/es/index.html
+++ b/es/index.html
@@ -14,7 +14,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
 <title data-i18n="meta.title">Letras bonitas para copiar y pegar · Cursivas, aesthetic y símbolos para Instagram, TikTok y WhatsApp</title>
-<meta name="description" data-i18n-content="meta.description" content="Generador de letras bonitas, cursivas, aesthetic, góticas y kawaii para copiar y pegar. Pásalas a tu bio de Instagram, tu estado de WhatsApp, tu nick de TikTok o Free Fire, y a Discord. Sin descargas y sin cuenta.">
+<meta name="description" data-i18n-content="meta.description" content="Letras bonitas y símbolos para copiar y pegar: cursivas, aesthetic, góticas, kawaii y letras en otros idiomas y alfabetos. Pásalas a tu bio de Instagram, estado de WhatsApp, nick de TikTok o Free Fire, y Discord. Sin descargas ni cuenta.">
 
 <link rel="canonical" href="https://ultratextgen.com/es/">
 
@@ -181,6 +181,22 @@
     },
     {
       "@type": "Question",
+      "name": "¿Puedo copiar letras en otros idiomas o de otros alfabetos?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Sí, y es una de las búsquedas más típicas: «letras en otros idiomas para copiar y pegar». Hay dos caminos. Letras que parecen de otro alfabeto: la gótica (𝔤𝔬𝔱𝔦𝔠𝔞) recuerda al alemán antiguo, la cursiva (𝒸𝓊𝓇𝓈𝒾𝓋𝒶) a la caligrafía, y además tienes runas (ᚱᚢᚾᚨᛋ) y ancho completo tipo japonés (ａｎｃｈｏ). Escribe tu palabra arriba y elige el estilo, o cópialas de la sección «Letras en otros idiomas para copiar y pegar». Letras de otros alfabetos de verdad: tienes el griego (αβγδ) y el cirílico (абвг) listos para copiar fila a fila, y los idiomas con alfabeto latino se transforman igual que el español. Lo único que no se estiliza son los alfabetos como árabe, chino, japonés, coreano o ruso cuando escribes en ellos: Unicode no tiene versión decorativa de esos caracteres, así que se quedan tal cual."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Cómo copio símbolos para pegar junto a mis letras?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Tienes los símbolos para copiar y pegar al alcance de un toque. Arriba del todo hay una tira de símbolos sueltos (corazones ♡, estrellas ★, destellos ✧, flores ❀, lunas ☾, flechas ➳): toca cualquiera y se copia solo. Si quieres que los símbolos rodeen tu texto automáticamente, escribe tu frase y usa las pestañas Símbolos, Marcos, Separadores y Flechas del generador: se aplican a todas las versiones a la vez. Así consigues letras y símbolos para copiar y pegar juntos, sin ir pegándolos uno a uno."
+      }
+    },
+    {
+      "@type": "Question",
       "name": "¿Cómo pongo letras bonitas en mi bio de Instagram?",
       "acceptedAnswer": {
         "@type": "Answer",
@@ -340,6 +356,42 @@
 
   <!-- Main Content -->
   <main class="container">
+
+    <!-- Quick copy: símbolos y letras para copiar y pegar (above the fold, sin escribir) -->
+    <section class="quick-copy" aria-label="Símbolos y letras para copiar y pegar">
+      <div class="quick-copy-block">
+        <span class="quick-copy-label">Símbolos para copiar y pegar</span>
+        <div class="glyph-grid">
+          <button type="button" class="glyph-copy" aria-label="Copiar corazón ♡">♡</button>
+          <button type="button" class="glyph-copy" aria-label="Copiar corazón ♥">♥</button>
+          <button type="button" class="glyph-copy" aria-label="Copiar corazón ❤">❤</button>
+          <button type="button" class="glyph-copy" aria-label="Copiar estrella ★">★</button>
+          <button type="button" class="glyph-copy" aria-label="Copiar estrella ☆">☆</button>
+          <button type="button" class="glyph-copy" aria-label="Copiar destello ✦">✦</button>
+          <button type="button" class="glyph-copy" aria-label="Copiar destello ✧">✧</button>
+          <button type="button" class="glyph-copy" aria-label="Copiar destello ⋆">⋆</button>
+          <button type="button" class="glyph-copy" aria-label="Copiar flor ❀">❀</button>
+          <button type="button" class="glyph-copy" aria-label="Copiar flor ✿">✿</button>
+          <button type="button" class="glyph-copy" aria-label="Copiar luna ☾">☾</button>
+          <button type="button" class="glyph-copy" aria-label="Copiar adorno ࿐">࿐</button>
+          <button type="button" class="glyph-copy" aria-label="Copiar flecha ➳">➳</button>
+          <button type="button" class="glyph-copy" aria-label="Copiar flecha ⤷">⤷</button>
+          <button type="button" class="glyph-copy" aria-label="Copiar chispa ✨">✨</button>
+        </div>
+      </div>
+      <div class="quick-copy-block">
+        <span class="quick-copy-label">Letras en otros idiomas para copiar y pegar</span>
+        <div class="glyph-grid">
+          <button type="button" class="glyph-copy glyph-word" aria-label="Copiar letras góticas">𝔤𝔬𝔱𝔦𝔠𝔞</button>
+          <button type="button" class="glyph-copy glyph-word" aria-label="Copiar letras cursivas">𝒸𝓊𝓇𝓈𝒾𝓋𝒶</button>
+          <button type="button" class="glyph-copy glyph-word" aria-label="Copiar letras de ancho completo">ａｎｃｈｏ</button>
+          <button type="button" class="glyph-copy glyph-word" aria-label="Copiar runas">ᚱᚢᚾᚨᛋ</button>
+          <button type="button" class="glyph-copy glyph-word" aria-label="Copiar letras griegas">αβγδε</button>
+          <button type="button" class="glyph-copy glyph-word" aria-label="Copiar letras cirílicas">абвгд</button>
+        </div>
+      </div>
+    </section>
+
     <!-- Category Tabs -->
     <div class="category-section">
       <div class="category-tabs" id="categoryTabs">
@@ -413,32 +465,97 @@
     <h2>Letras bonitas y símbolos para copiar y pegar</h2>
     <p>Combina tus letras con símbolos para que destaquen aún más. Aquí tienes los más usados, listos para copiar y pegar. Para añadirlos automáticamente a tu texto, usa las pestañas <strong>Símbolos</strong>, <strong>Marcos</strong> y <strong>Separadores</strong> del generador de arriba.</p>
 
+    <p class="symbols-hint">Toca cualquier símbolo y se copia solo, listo para pegar junto a tus letras.</p>
+
     <div class="symbol-groups">
       <div class="symbol-group">
         <h3>Corazones</h3>
-        <p class="symbol-set">♡ ♥ ❤ 💕 💖 💗 ❥ ღ ❣ ꒰♡꒱ ⟡</p>
+        <div class="glyph-grid">
+          <button type="button" class="glyph-copy">♡</button><button type="button" class="glyph-copy">♥</button><button type="button" class="glyph-copy">❤</button><button type="button" class="glyph-copy">💕</button><button type="button" class="glyph-copy">💖</button><button type="button" class="glyph-copy">💗</button><button type="button" class="glyph-copy">❥</button><button type="button" class="glyph-copy">ღ</button><button type="button" class="glyph-copy">❣</button><button type="button" class="glyph-copy">꒰♡꒱</button><button type="button" class="glyph-copy">⟡</button>
+        </div>
       </div>
       <div class="symbol-group">
         <h3>Estrellas y destellos</h3>
-        <p class="symbol-set">★ ☆ ✦ ✧ ⋆ ⭒ ✩ ✯ ✰ ࿐ ｡ﾟ</p>
+        <div class="glyph-grid">
+          <button type="button" class="glyph-copy">★</button><button type="button" class="glyph-copy">☆</button><button type="button" class="glyph-copy">✦</button><button type="button" class="glyph-copy">✧</button><button type="button" class="glyph-copy">⋆</button><button type="button" class="glyph-copy">⭒</button><button type="button" class="glyph-copy">✩</button><button type="button" class="glyph-copy">✯</button><button type="button" class="glyph-copy">✰</button><button type="button" class="glyph-copy">࿐</button><button type="button" class="glyph-copy">｡ﾟ</button>
+        </div>
       </div>
       <div class="symbol-group">
         <h3>Flores y naturaleza</h3>
-        <p class="symbol-set">✿ ❀ ❁ ✾ ♧ ☘ ⚘ ꕥ ❃ ✤</p>
+        <div class="glyph-grid">
+          <button type="button" class="glyph-copy">✿</button><button type="button" class="glyph-copy">❀</button><button type="button" class="glyph-copy">❁</button><button type="button" class="glyph-copy">✾</button><button type="button" class="glyph-copy">♧</button><button type="button" class="glyph-copy">☘</button><button type="button" class="glyph-copy">⚘</button><button type="button" class="glyph-copy">ꕥ</button><button type="button" class="glyph-copy">❃</button><button type="button" class="glyph-copy">✤</button>
+        </div>
       </div>
       <div class="symbol-group">
         <h3>Lunas y noche</h3>
-        <p class="symbol-set">☾ ☽ ⊹ ✬ ☄ ✫ ⋆｡˚ ☁ ❄ ❆</p>
+        <div class="glyph-grid">
+          <button type="button" class="glyph-copy">☾</button><button type="button" class="glyph-copy">☽</button><button type="button" class="glyph-copy">⊹</button><button type="button" class="glyph-copy">✬</button><button type="button" class="glyph-copy">☄</button><button type="button" class="glyph-copy">✫</button><button type="button" class="glyph-copy">⋆｡˚</button><button type="button" class="glyph-copy">☁</button><button type="button" class="glyph-copy">❄</button><button type="button" class="glyph-copy">❆</button>
+        </div>
       </div>
       <div class="symbol-group">
         <h3>Flechas</h3>
-        <p class="symbol-set">→ ← ↬ ↫ ➳ ➢ ➤ ⇢ ⇠ ↳ ⤷</p>
+        <div class="glyph-grid">
+          <button type="button" class="glyph-copy">→</button><button type="button" class="glyph-copy">←</button><button type="button" class="glyph-copy">↬</button><button type="button" class="glyph-copy">↫</button><button type="button" class="glyph-copy">➳</button><button type="button" class="glyph-copy">➢</button><button type="button" class="glyph-copy">➤</button><button type="button" class="glyph-copy">⇢</button><button type="button" class="glyph-copy">⇠</button><button type="button" class="glyph-copy">↳</button><button type="button" class="glyph-copy">⤷</button>
+        </div>
       </div>
       <div class="symbol-group">
         <h3>Kawaii y caritas (kaomoji)</h3>
-        <p class="symbol-set">(◍•ᴗ•◍) (｡♥‿♥｡) ʕ•ᴥ•ʔ (＾▽＾) (づ｡◕‿‿◕｡)づ ٩(◕‿◕)۶</p>
+        <div class="glyph-grid">
+          <button type="button" class="glyph-copy">(◍•ᴗ•◍)</button><button type="button" class="glyph-copy">(｡♥‿♥｡)</button><button type="button" class="glyph-copy">ʕ•ᴥ•ʔ</button><button type="button" class="glyph-copy">(＾▽＾)</button><button type="button" class="glyph-copy">(づ｡◕‿‿◕｡)づ</button><button type="button" class="glyph-copy">٩(◕‿◕)۶</button>
+        </div>
       </div>
     </div>
+  </section>
+
+  <!-- Letras en otros idiomas para copiar y pegar -->
+  <section class="editorial-section idiomas-section" aria-label="Letras en otros idiomas para copiar y pegar">
+    <h2>Letras en otros idiomas para copiar y pegar</h2>
+    <p>¿Buscas letras en otros idiomas para copiar y pegar? Aquí tienes dos opciones. Primero, letras que <strong>parecen de otro alfabeto</strong>: la gótica recuerda al alemán antiguo, la cursiva a la caligrafía, y también hay runas y letras de ancho completo tipo japonés. Segundo, <strong>letras de otros alfabetos de verdad</strong>: griego y cirílico (ruso). Toca cualquier fila para copiar el abecedario completo, o escribe tu palabra arriba y elige el estilo.</p>
+
+    <div class="abc-list">
+      <div class="abc-row">
+        <span class="abc-name">Gótica (alemán antiguo)</span>
+        <div class="abc-lines">
+          <button type="button" class="abc-line glyph-copy">𝔄𝔅ℭ𝔇𝔈𝔉𝔊ℌℑ𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔ℜ𝔖𝔗𝔘𝔙𝔚𝔛𝔜ℨ</button>
+          <button type="button" class="abc-line glyph-copy">𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷</button>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Cursiva (caligrafía)</span>
+        <div class="abc-lines">
+          <button type="button" class="abc-line glyph-copy">𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵</button>
+          <button type="button" class="abc-line glyph-copy">𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏</button>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Ancho completo (japonés)</span>
+        <div class="abc-lines">
+          <button type="button" class="abc-line glyph-copy">ＡＢＣＤＥＦＧＨＩＪＫＬＭＮＯＰＱＲＳＴＵＶＷＸＹＺ</button>
+          <button type="button" class="abc-line glyph-copy">ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ</button>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Runas (futhark)</span>
+        <div class="abc-lines">
+          <button type="button" class="abc-line glyph-copy">ᚠ ᚢ ᚦ ᚨ ᚱ ᚲ ᚷ ᚹ ᚺ ᚾ ᛁ ᛃ ᛇ ᛈ ᛉ ᛊ ᛏ ᛒ ᛖ ᛗ ᛚ ᛜ ᛞ ᛟ</button>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Griego</span>
+        <div class="abc-lines">
+          <button type="button" class="abc-line glyph-copy">Α Β Γ Δ Ε Ζ Η Θ Ι Κ Λ Μ Ν Ξ Ο Π Ρ Σ Τ Υ Φ Χ Ψ Ω</button>
+          <button type="button" class="abc-line glyph-copy">α β γ δ ε ζ η θ ι κ λ μ ν ξ ο π ρ σ τ υ φ χ ψ ω</button>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Cirílico (ruso)</span>
+        <div class="abc-lines">
+          <button type="button" class="abc-line glyph-copy">А Б В Г Д Е Ж З И Й К Л М Н О П Р С Т У Ф Х Ц Ч Ш Щ Ъ Ы Ь Э Ю Я</button>
+        </div>
+      </div>
+    </div>
+
+    <p class="idiomas-note">Ojo: los alfabetos de verdad (árabe, chino, japonés, coreano, ruso) solo se copian tal cual; Unicode no tiene una versión decorativa de esos caracteres. Las partes en alfabeto latino sí se transforman en todos los estilos.</p>
   </section>
 
   <!-- Popular Use Cases -->
@@ -630,6 +747,38 @@
   <div class="faq-answer" data-i18n-html="faq.categories.1.items.4.answer">El Zalgo es ese texto que se ve corrupto, como si la pantalla estuviera fallando: h̵̢͍o̸̩͊l̶̲̾a̷̹̾. Se hace apilando símbolos invisibles encima y debajo de cada letra.
     <br><br>
     Se usa mucho para bios oscuras, contenido de terror, memes raros, bromas en grupos de WhatsApp o nicks que llamen la atención. Aquí lo generas con un clic, sin tener que armarlo a mano.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.1.items.5.question">¿Puedo copiar letras en otros idiomas o de otros alfabetos?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.1.items.5.answer">Sí, y es una de las búsquedas más típicas: «letras en otros idiomas para copiar y pegar». Hay dos caminos:
+    <br><br>
+    — <strong>Letras que parecen de otro alfabeto</strong>: la gótica (𝔤𝔬𝔱𝔦𝔠𝔞) recuerda al alemán antiguo, la cursiva (𝒸𝓊𝓇𝓈𝒾𝓋𝒶) a la caligrafía, y además tienes runas (ᚱᚢᚾᚨᛋ) y ancho completo tipo japonés (ａｎｃｈｏ). Escribe tu palabra arriba y elige el estilo, o cópialas de la sección «Letras en otros idiomas para copiar y pegar».
+    <br><br>
+    — <strong>Letras de otros alfabetos de verdad</strong>: tienes el griego (αβγδ) y el cirílico (абвг) listos para copiar fila a fila. Y los idiomas con alfabeto latino (inglés, francés, portugués, italiano...) se transforman igual que el español.
+    <br><br>
+    Lo único que no se estiliza son los alfabetos como árabe, chino, japonés, coreano o ruso cuando escribes en ellos: Unicode no tiene versión decorativa de esos caracteres, así que se quedan tal cual.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.1.items.6.question">¿Cómo copio símbolos para pegar junto a mis letras?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.1.items.6.answer">Tienes los símbolos para copiar y pegar al alcance de un toque:
+    <br><br>
+    — Arriba del todo hay una tira de <strong>símbolos sueltos</strong> (corazones ♡, estrellas ★, destellos ✧, flores ❀, lunas ☾, flechas ➳): toca cualquiera y se copia solo.
+    <br><br>
+    — Si quieres que los símbolos <strong>rodeen tu texto automáticamente</strong>, escribe tu frase y usa las pestañas Símbolos, Marcos, Separadores y Flechas del generador: se aplican a todas las versiones a la vez.
+    <br><br>
+    Así consigues letras y símbolos para copiar y pegar juntos, sin ir pegándolos uno a uno.</div>
 </div>
 
 

--- a/locales/es.json
+++ b/locales/es.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "title": "Letras bonitas para copiar y pegar · Cursivas, aesthetic y símbolos para Instagram, TikTok y WhatsApp",
-    "description": "Generador de letras bonitas, cursivas, aesthetic, góticas y kawaii para copiar y pegar. Pásalas a tu bio de Instagram, tu estado de WhatsApp, tu nick de TikTok o Free Fire, y a Discord. Sin descargas y sin cuenta."
+    "description": "Letras bonitas y símbolos para copiar y pegar: cursivas, aesthetic, góticas, kawaii y letras en otros idiomas y alfabetos. Pásalas a tu bio de Instagram, estado de WhatsApp, nick de TikTok o Free Fire, y Discord. Sin descargas ni cuenta."
   },
   "hero": {
     "title": "Letras bonitas para copiar y pegar",
@@ -100,6 +100,14 @@
           {
             "question": "¿Qué es el texto Zalgo o glitch?",
             "answer": "El Zalgo es ese texto que se ve corrupto, como si la pantalla estuviera fallando: h̵̢͍o̸̩͊l̶̲̾a̷̹̾. Se hace apilando símbolos invisibles encima y debajo de cada letra.\n    <br><br>\n    Se usa mucho para bios oscuras, contenido de terror, memes raros, bromas en grupos de WhatsApp o nicks que llamen la atención. Aquí lo generas con un clic, sin tener que armarlo a mano."
+          },
+          {
+            "question": "¿Puedo copiar letras en otros idiomas o de otros alfabetos?",
+            "answer": "Sí, y es una de las búsquedas más típicas: «letras en otros idiomas para copiar y pegar». Hay dos caminos:\n    <br><br>\n    — <strong>Letras que parecen de otro alfabeto</strong>: la gótica (𝔤𝔬𝔱𝔦𝔠𝔞) recuerda al alemán antiguo, la cursiva (𝒸𝓊𝓇𝓈𝒾𝓋𝒶) a la caligrafía, y además tienes runas (ᚱᚢᚾᚨᛋ) y ancho completo tipo japonés (ａｎｃｈｏ). Escribe tu palabra arriba y elige el estilo, o cópialas de la sección «Letras en otros idiomas para copiar y pegar».\n    <br><br>\n    — <strong>Letras de otros alfabetos de verdad</strong>: tienes el griego (αβγδ) y el cirílico (абвг) listos para copiar fila a fila. Y los idiomas con alfabeto latino (inglés, francés, portugués, italiano...) se transforman igual que el español.\n    <br><br>\n    Lo único que no se estiliza son los alfabetos como árabe, chino, japonés, coreano o ruso cuando escribes en ellos: Unicode no tiene versión decorativa de esos caracteres, así que se quedan tal cual."
+          },
+          {
+            "question": "¿Cómo copio símbolos para pegar junto a mis letras?",
+            "answer": "Tienes los símbolos para copiar y pegar al alcance de un toque:\n    <br><br>\n    — Arriba del todo hay una tira de <strong>símbolos sueltos</strong> (corazones ♡, estrellas ★, destellos ✧, flores ❀, lunas ☾, flechas ➳): toca cualquiera y se copia solo.\n    <br><br>\n    — Si quieres que los símbolos <strong>rodeen tu texto automáticamente</strong>, escribe tu frase y usa las pestañas Símbolos, Marcos, Separadores y Flechas del generador: se aplican a todas las versiones a la vez.\n    <br><br>\n    Así consigues letras y símbolos para copiar y pegar juntos, sin ir pegándolos uno a uno."
           }
         ]
       },

--- a/style.css
+++ b/style.css
@@ -2866,6 +2866,54 @@ body.dark-mode .vertical-chip {
   word-break: break-word;
 }
 
+.symbols-hint {
+  margin: 0.5rem 0 0;
+  font-size: 0.92rem;
+  color: var(--text-secondary);
+}
+
+/* ==========================================================================
+   Quick copy strip (ES) — símbolos y letras para copiar y pegar, above the fold
+   ========================================================================== */
+.quick-copy {
+  display: grid;
+  gap: 1rem;
+  margin: 1.25rem 0 0.5rem;
+}
+
+.quick-copy-block {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.quick-copy-label {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+/* Word-length chips (other-alphabet samples) sit alongside single glyphs */
+.glyph-copy.glyph-word {
+  font-size: 1.05rem;
+}
+
+/* ==========================================================================
+   Letras en otros idiomas (ES) — copyable alphabet rows reuse .abc-* layout
+   ========================================================================== */
+.abc-line.glyph-copy {
+  display: block;
+  width: 100%;
+  text-align: left;
+}
+
+.idiomas-note {
+  margin-top: 1.25rem;
+  font-size: 0.92rem;
+  color: var(--text-secondary);
+}
+
 /* ── Ready-made name chips (gaming-name JTBD pages) ──────────────────────────
    Click-to-copy decorated nicknames. Tiles are auto-wired by symbol-explorer.js
    via the .symbol-tile class; styling here uses theme tokens so it follows dark


### PR DESCRIPTION
## Summary

Reinforcement pass on `/es/` around the proven, high-CTR Spanish query set from GSC (Mexico + Spain). The page already ranks for these intents with strong impressions but weak clicks — this pass makes the **letters + symbols, copy-and-paste** experience faster and more obviously above the fold, and adds a dedicated **"letras en otros idiomas"** (other-alphabet) section, which is a distinct high-CTR intent.

Target queries (impressions / clicks):
- `letras en otros idiomas para copiar y pegar` — 84 / 9
- `símbolos para copiar y pegar letras` — 81 / 4
- `letras bonitas y símbolos` — 80 / 8
- `letras y símbolos para copiar y pegar` — 67 / 5
- `símbolos y letras para copiar y pegar` — 41 / 5
- `símbolos y letras bonitas` — 33 / 1

## Changes

- **Above-the-fold quick-copy strip** (símbolos + letras en otros idiomas) inserted at the top of `<main>`. No typing required — chips copy on tap via the existing `.glyph-copy` handler, with the standard "Copiado" toast.
- **New `Letras en otros idiomas para copiar y pegar` section** with tap-to-copy alphabet rows: gótica (alemán antiguo), cursiva (caligrafía), ancho completo (japonés), runas, **griego** and **cirílico** — the latter two being real other-alphabet letters. Reuses the existing `.abc-*` layout.
- **Existing símbolos sets made click-to-copy** (converted plain text into `.glyph-copy` chips so "símbolos para copiar y pegar letras" works on tap).
- **FAQ expanded** with two real ES queries — *"¿Puedo copiar letras en otros idiomas o de otros alfabetos?"* and *"¿Cómo copio símbolos para pegar junto a mis letras?"* — added to the visible FAQ, to `locales/es.json`, and to the static `FAQPage` JSON-LD. (`i18n.js` rebuilds the schema from `es.json` at runtime, so all three stay in sync — verified 25 visible items == 25 JSON-LD questions.)
- **Meta description enriched** with letras/símbolos/otros-idiomas phrasing (HTML + `es.json`, kept in sync).
- **CSS** for the new strip/section uses existing theme tokens only — dark mode and the no-framework constraint are preserved.

## Constraints respected

- Existing `/es/` structure kept; GTM, canonical, hreflang, and JSON-LD intact.
- No new framework, no bundler, IIFE/global pattern untouched (reused the existing `.glyph-copy` click handler — no new JS).
- Token-based CSS only, no inline styles.

## Verification

Rendered `/es/` in headless Chromium (412px mobile viewport):
- Quick-copy chips toggle the `copied` state and fire the toast on click.
- Visible FAQ count (25) matches the runtime-rebuilt JSON-LD (25).
- "Letras en otros idiomas" section renders as tap-to-copy alphabet cards.
- No page/script errors from site code (only sandbox-blocked external resources like GTM/ads/fonts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ba1e11WCCaN39jDBSx6r1t

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ba1e11WCCaN39jDBSx6r1t)_