### PR TITLE
feat(de): deepen /de/ around "schriftarten und symbole" + German Discord section

### DIFF
--- a/de/index.html
+++ b/de/index.html
@@ -326,6 +326,42 @@
 
   <!-- Main Content -->
   <main class="container">
+
+    <!-- Quick copy: Schriftarten und Symbole zum Kopieren (ohne zu tippen) -->
+    <section class="quick-copy" aria-label="Schriftarten und Symbole zum Kopieren">
+      <div class="quick-copy-block">
+        <span class="quick-copy-label">Symbole zum Kopieren</span>
+        <div class="glyph-grid">
+          <button type="button" class="glyph-copy" aria-label="Herz ♡ kopieren">♡</button>
+          <button type="button" class="glyph-copy" aria-label="Herz ♥ kopieren">♥</button>
+          <button type="button" class="glyph-copy" aria-label="Herz ❤ kopieren">❤</button>
+          <button type="button" class="glyph-copy" aria-label="Stern ★ kopieren">★</button>
+          <button type="button" class="glyph-copy" aria-label="Stern ☆ kopieren">☆</button>
+          <button type="button" class="glyph-copy" aria-label="Funkeln ✦ kopieren">✦</button>
+          <button type="button" class="glyph-copy" aria-label="Funkeln ✧ kopieren">✧</button>
+          <button type="button" class="glyph-copy" aria-label="Funkeln ⋆ kopieren">⋆</button>
+          <button type="button" class="glyph-copy" aria-label="Blume ❀ kopieren">❀</button>
+          <button type="button" class="glyph-copy" aria-label="Blume ✿ kopieren">✿</button>
+          <button type="button" class="glyph-copy" aria-label="Mond ☾ kopieren">☾</button>
+          <button type="button" class="glyph-copy" aria-label="Verzierung ࿐ kopieren">࿐</button>
+          <button type="button" class="glyph-copy" aria-label="Pfeil ➳ kopieren">➳</button>
+          <button type="button" class="glyph-copy" aria-label="Pfeil ⤷ kopieren">⤷</button>
+          <button type="button" class="glyph-copy" aria-label="Glitzer ✨ kopieren">✨</button>
+        </div>
+      </div>
+      <div class="quick-copy-block">
+        <span class="quick-copy-label">Schriftarten zum Kopieren</span>
+        <div class="glyph-grid">
+          <button type="button" class="glyph-copy glyph-word" aria-label="Fette Schrift kopieren">𝗳𝗲𝘁𝘁</button>
+          <button type="button" class="glyph-copy glyph-word" aria-label="Kursive Schrift kopieren">𝘬𝘶𝘳𝘴𝘪𝘷</button>
+          <button type="button" class="glyph-copy glyph-word" aria-label="Schreibschrift kopieren">𝓼𝓬𝓱𝓸𝓮𝓷</button>
+          <button type="button" class="glyph-copy glyph-word" aria-label="Gotische Schrift kopieren">𝔤𝔬𝔱𝔦𝔰𝔠𝔥</button>
+          <button type="button" class="glyph-copy glyph-word" aria-label="Bubble-Schrift kopieren">ⓑⓤⓑⓑⓛⓔ</button>
+          <button type="button" class="glyph-copy glyph-word" aria-label="Breite Schrift kopieren">ｂｒｅｉｔ</button>
+        </div>
+      </div>
+    </section>
+
     <!-- Category Tabs -->
     <div class="category-section">
       <div class="category-tabs" id="categoryTabs">
@@ -336,6 +372,204 @@
     <!-- Results -->
     <div class="results-grid" id="resultsGrid"></div>
   </main>
+
+  <!-- Schriftarten-Alphabet zum Kopieren -->
+  <section class="editorial-section abc-section" aria-label="Schriftarten-Alphabet zum Kopieren">
+    <h2>Schriftarten-Alphabet zum Kopieren</h2>
+    <p>Hier ist das komplette Alphabet — Großbuchstaben (A–Z), Kleinbuchstaben (a–z) und Zahlen (0–9) — in den beliebtesten Schriftarten. Tipp oben dein Wort ein und klick auf «Kopieren», um es in diesen Stilen mitzunehmen, oder markier die Buchstaben aus der Tabelle und kopier sie selbst.</p>
+
+    <div class="abc-list">
+      <div class="abc-row">
+        <span class="abc-name">Fett</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝗔𝗕𝗖𝗗𝗘𝗙𝗚𝗛𝗜𝗝𝗞𝗟𝗠𝗡𝗢𝗣𝗤𝗥𝗦𝗧𝗨𝗩𝗪𝗫𝗬𝗭</span>
+          <span class="abc-line">𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇</span>
+          <span class="abc-line">𝟬𝟭𝟮𝟯𝟰𝟱𝟲𝟳𝟴𝟵</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Kursiv</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝘈𝘉𝘊𝘋𝘌𝘍𝘎𝘏𝘐𝘑𝘒𝘓𝘔𝘕𝘖𝘗𝘘𝘙𝘚𝘛𝘜𝘝𝘞𝘟𝘠𝘡</span>
+          <span class="abc-line">𝘢𝘣𝘤𝘥𝘦𝘧𝘨𝘩𝘪𝘫𝘬𝘭𝘮𝘯𝘰𝘱𝘲𝘳𝘴𝘵𝘶𝘷𝘸𝘹𝘺𝘻</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Schreibschrift</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵</span>
+          <span class="abc-line">𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Schreibschrift fett</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩</span>
+          <span class="abc-line">𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Gotisch / Fraktur</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝔄𝔅ℭ𝔇𝔈𝔉𝔊ℌℑ𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔ℜ𝔖𝔗𝔘𝔙𝔚𝔛𝔜ℨ</span>
+          <span class="abc-line">𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Bubble</span>
+        <div class="abc-lines">
+          <span class="abc-line">ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ</span>
+          <span class="abc-line">ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ</span>
+          <span class="abc-line">⓪①②③④⑤⑥⑦⑧⑨</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Schriftarten und Symbole zum Kopieren -->
+  <section class="editorial-section symbols-section" aria-label="Schriftarten und Symbole zum Kopieren">
+    <h2>Schriftarten und Symbole zum Kopieren</h2>
+    <p>Kombinier deine Schrift mit Symbolen, damit sie noch mehr auffällt. Hier sind die beliebtesten, fertig zum Kopieren und Einfügen. Um sie automatisch um deinen Text zu legen, nimm die Reiter <strong>Symbole</strong>, <strong>Rahmen</strong> und <strong>Trennlinien</strong> im Generator oben.</p>
+
+    <p class="symbols-hint">Tipp auf ein beliebiges Symbol — es wird sofort kopiert, fertig zum Einfügen neben deinen Buchstaben.</p>
+
+    <div class="symbol-groups">
+      <div class="symbol-group">
+        <h3>Herzen</h3>
+        <div class="glyph-grid">
+          <button type="button" class="glyph-copy">♡</button><button type="button" class="glyph-copy">♥</button><button type="button" class="glyph-copy">❤</button><button type="button" class="glyph-copy">💕</button><button type="button" class="glyph-copy">💖</button><button type="button" class="glyph-copy">💗</button><button type="button" class="glyph-copy">❥</button><button type="button" class="glyph-copy">ღ</button><button type="button" class="glyph-copy">❣</button><button type="button" class="glyph-copy">꒰♡꒱</button><button type="button" class="glyph-copy">⟡</button>
+        </div>
+      </div>
+      <div class="symbol-group">
+        <h3>Sterne &amp; Funkeln</h3>
+        <div class="glyph-grid">
+          <button type="button" class="glyph-copy">★</button><button type="button" class="glyph-copy">☆</button><button type="button" class="glyph-copy">✦</button><button type="button" class="glyph-copy">✧</button><button type="button" class="glyph-copy">⋆</button><button type="button" class="glyph-copy">⭒</button><button type="button" class="glyph-copy">✩</button><button type="button" class="glyph-copy">✯</button><button type="button" class="glyph-copy">✰</button><button type="button" class="glyph-copy">࿐</button><button type="button" class="glyph-copy">｡ﾟ</button>
+        </div>
+      </div>
+      <div class="symbol-group">
+        <h3>Blumen &amp; Natur</h3>
+        <div class="glyph-grid">
+          <button type="button" class="glyph-copy">✿</button><button type="button" class="glyph-copy">❀</button><button type="button" class="glyph-copy">❁</button><button type="button" class="glyph-copy">✾</button><button type="button" class="glyph-copy">♧</button><button type="button" class="glyph-copy">☘</button><button type="button" class="glyph-copy">⚘</button><button type="button" class="glyph-copy">ꕥ</button><button type="button" class="glyph-copy">❃</button><button type="button" class="glyph-copy">✤</button>
+        </div>
+      </div>
+      <div class="symbol-group">
+        <h3>Mond &amp; Nacht</h3>
+        <div class="glyph-grid">
+          <button type="button" class="glyph-copy">☾</button><button type="button" class="glyph-copy">☽</button><button type="button" class="glyph-copy">⊹</button><button type="button" class="glyph-copy">✬</button><button type="button" class="glyph-copy">☄</button><button type="button" class="glyph-copy">✫</button><button type="button" class="glyph-copy">⋆｡˚</button><button type="button" class="glyph-copy">☁</button><button type="button" class="glyph-copy">❄</button><button type="button" class="glyph-copy">❆</button>
+        </div>
+      </div>
+      <div class="symbol-group">
+        <h3>Pfeile</h3>
+        <div class="glyph-grid">
+          <button type="button" class="glyph-copy">→</button><button type="button" class="glyph-copy">←</button><button type="button" class="glyph-copy">↬</button><button type="button" class="glyph-copy">↫</button><button type="button" class="glyph-copy">➳</button><button type="button" class="glyph-copy">➢</button><button type="button" class="glyph-copy">➤</button><button type="button" class="glyph-copy">⇢</button><button type="button" class="glyph-copy">⇠</button><button type="button" class="glyph-copy">↳</button><button type="button" class="glyph-copy">⤷</button>
+        </div>
+      </div>
+      <div class="symbol-group">
+        <h3>Kaomoji &amp; Gesichter</h3>
+        <div class="glyph-grid">
+          <button type="button" class="glyph-copy">(◍•ᴗ•◍)</button><button type="button" class="glyph-copy">(｡♥‿♥｡)</button><button type="button" class="glyph-copy">ʕ•ᴥ•ʔ</button><button type="button" class="glyph-copy">(＾▽＾)</button><button type="button" class="glyph-copy">(づ｡◕‿‿◕｡)づ</button><button type="button" class="glyph-copy">٩(◕‿◕)۶</button>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Schriften aus anderen Sprachen zum Kopieren -->
+  <section class="editorial-section idiomas-section" aria-label="Schriften aus anderen Sprachen zum Kopieren">
+    <h2>Schriften aus anderen Sprachen zum Kopieren</h2>
+    <p>Du suchst Buchstaben aus anderen Schriften zum Kopieren? Hier hast du zwei Optionen. Erstens Schriften, die <strong>wie ein anderes Alphabet aussehen</strong>: Gotisch erinnert an altdeutsche Schrift, die Schreibschrift an Kalligrafie, dazu Runen und Buchstaben in voller Breite im Japan-Look. Zweitens <strong>echte andere Alphabete</strong>: Griechisch und Kyrillisch (Russisch). Tipp auf eine Zeile, um das komplette Alphabet zu kopieren, oder schreib oben dein Wort und wähl den Stil.</p>
+
+    <div class="abc-list">
+      <div class="abc-row">
+        <span class="abc-name">Gotisch (altdeutsch)</span>
+        <div class="abc-lines">
+          <button type="button" class="abc-line glyph-copy">𝔄𝔅ℭ𝔇𝔈𝔉𝔊ℌℑ𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔ℜ𝔖𝔗𝔘𝔙𝔚𝔛𝔜ℨ</button>
+          <button type="button" class="abc-line glyph-copy">𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷</button>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Schreibschrift (Kalligrafie)</span>
+        <div class="abc-lines">
+          <button type="button" class="abc-line glyph-copy">𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵</button>
+          <button type="button" class="abc-line glyph-copy">𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏</button>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Volle Breite (Japan-Look)</span>
+        <div class="abc-lines">
+          <button type="button" class="abc-line glyph-copy">ＡＢＣＤＥＦＧＨＩＪＫＬＭＮＯＰＱＲＳＴＵＶＷＸＹＺ</button>
+          <button type="button" class="abc-line glyph-copy">ａｂｃｄｅｆｇｈｉｊｋｌｍｎｏｐｑｒｓｔｕｖｗｘｙｚ</button>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Runen (Futhark)</span>
+        <div class="abc-lines">
+          <button type="button" class="abc-line glyph-copy">ᚠ ᚢ ᚦ ᚨ ᚱ ᚲ ᚷ ᚹ ᚺ ᚾ ᛁ ᛃ ᛇ ᛈ ᛉ ᛊ ᛏ ᛒ ᛖ ᛗ ᛚ ᛜ ᛞ ᛟ</button>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Griechisch</span>
+        <div class="abc-lines">
+          <button type="button" class="abc-line glyph-copy">Α Β Γ Δ Ε Ζ Η Θ Ι Κ Λ Μ Ν Ξ Ο Π Ρ Σ Τ Υ Φ Χ Ψ Ω</button>
+          <button type="button" class="abc-line glyph-copy">α β γ δ ε ζ η θ ι κ λ μ ν ξ ο π ρ σ τ υ φ χ ψ ω</button>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Kyrillisch (Russisch)</span>
+        <div class="abc-lines">
+          <button type="button" class="abc-line glyph-copy">А Б В Г Д Е Ж З И Й К Л М Н О П Р С Т У Ф Х Ц Ч Ш Щ Ъ Ы Ь Э Ю Я</button>
+        </div>
+      </div>
+    </div>
+
+    <p class="idiomas-note">Achtung: Echte Alphabete (Arabisch, Chinesisch, Japanisch, Koreanisch, Russisch) werden nur 1:1 kopiert — Unicode hat für diese Zeichen keine schicke Variante. Die lateinischen Teile werden dagegen in allen Stilen umgewandelt.</p>
+  </section>
+
+  <!-- Discord-Schriftart -->
+  <section class="editorial-section discord-section" aria-label="Discord-Schriftart und Symbole zum Kopieren">
+    <h2>Discord-Schriftart: stylischer Text für Namen, Bio &amp; Channels</h2>
+    <p>Discord hat keinen Knopf für andere Schriftarten — die stilisierten Buchstaben hier sind echtes Unicode und halten deshalb überall: im Server-Namen, im Profil («Über mich»), in Channel-Namen, Rollen und mitten im Chat. Schreib oben dein Wort, wähl einen Stil und füg ihn in Discord ein.</p>
+
+    <div class="abc-list">
+      <div class="abc-row">
+        <span class="abc-name">Fett</span>
+        <div class="abc-lines">
+          <button type="button" class="abc-line glyph-copy">𝗗𝗶𝘀𝗰𝗼𝗿𝗱</button>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Gotisch / Fraktur</span>
+        <div class="abc-lines">
+          <button type="button" class="abc-line glyph-copy">𝔇𝔦𝔰𝔠𝔬𝔯𝔡</button>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Schreibschrift</span>
+        <div class="abc-lines">
+          <button type="button" class="abc-line glyph-copy">𝒟𝒾𝓈𝒸ℴ𝓇𝒹</button>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Bubble</span>
+        <div class="abc-lines">
+          <button type="button" class="abc-line glyph-copy">Ⓓⓘⓢⓒⓞⓡⓓ</button>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Volle Breite</span>
+        <div class="abc-lines">
+          <button type="button" class="abc-line glyph-copy">Ｄｉｓｃｏｒｄ</button>
+        </div>
+      </div>
+    </div>
+
+    <p class="symbols-hint">Tipp: Discord rendert die meisten Unicode-Stile sauber — fett, kursiv, gotisch und Bubble laufen praktisch immer. Zalgo bzw. Glitch-Schrift wird in manchen Feldern gekürzt; falls ein Name zickt, nimm einen Klassiker wie Fett oder Bubble.</p>
+
+    <p class="u-mt-15 u-text-center"><a class="cat-cta" href="/discord/">Schriftarten für Discord ansehen →</a></p>
+  </section>
 
   <!-- Popular Use Cases -->
   <section class="editorial-section">


### PR DESCRIPTION
## What

A light localization pass on `/de/` to cover Germany's thin native-German search signal, mirroring the `/es/` deepening structure but in German.

GSC (query×country) shows Germany is mostly English queries ("discord fonts", "stacked text" — handled elsewhere) with a thin native signal: **"schriftarten und symbole"** and **"discord schriftart"**. This deepens `/de/` around exactly those, without over-investing.

## Changes (all in `de/index.html`)

- **Above-the-fold quick-copy block** — "Schriftarten und Symbole zum Kopieren" with copy-on-click symbols and font-word samples.
- **Schriftarten-Alphabet table** — full A–Z / a–z / 0–9 across 6 styles (Fett, Kursiv, Schreibschrift, Schreibschrift fett, Gotisch/Fraktur, Bubble).
- **"Schriftarten und Symbole zum Kopieren" section** — symbol groups (Herzen, Sterne & Funkeln, Blumen, Mond, Pfeile, Kaomoji) — the primary native query.
- **"Schriften aus anderen Sprachen" section** — Gotisch/altdeutsch, Schreibschrift, volle Breite, Runen, Griechisch, Kyrillisch, with the altdeutsche-Schrift tie-in.
- **German Discord section** — copy-ready word samples (Fett, Gotisch, Schreibschrift, Bubble, volle Breite), usage note, and a link to `/discord/`, targeting "discord schriftart".

## Constraints honored

- Template reused from `/es/` structure; copy fully localized into German. Symbol glyphs reused as language-neutral.
- GTM, canonical, hreflang, and JSON-LD (WebSite / Organization / WebApplication / FAQPage) left intact.
- No new framework, no bundler, no new CSS — reuses existing classes (`quick-copy`, `abc-section`, `symbols-section`, `idiomas-section`, `editorial-section`, `glyph-copy`). Copy-on-click is handled by the existing global `.glyph-copy` listener in `script.js`.
- `SITE_PAGES` unchanged (it holds only `home`/`categoryRoot`/`fontRoot`, not per-language entries).

## Validation

- Tag balance verified (sections 9/9, `<main>` 1/1, `<div>` 119/119).
- No merge requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KLjWSWww6fu8cA6tb21SdU)_