### PR TITLE
Vertical/stacked text: keyword-volume check + targeted depth pass

### DIFF
--- a/id/index.html
+++ b/id/index.html
@@ -512,6 +512,21 @@
     <p>Buat <strong>tulisan keren nama</strong> atau nickname game, gabungin gaya font sama simbol biar makin standout. Mau yang spesifik buat game? Cek <a href="/id/usecase/nama-ff-keren/">nama FF keren</a>, <a href="/id/usecase/nama-ml-keren/">nama ML keren</a>, <a href="/id/usecase/nama-squad-ml-keren/">nama squad ML keren</a>, atau <a href="/id/usecase/nama-guild-ff-keren/">nama guild FF keren</a> — lengkap sama simbol payung ꧁꧂ dan kumpulan nama siap pakai. Mau fokus ke satu gaya? Mampir ke <a href="/category/bold-fonts/">font bold</a>, <a href="/category/gothic-fonts/">font gotik</a>, atau <a href="/category/cursive-fonts/">font kursif</a>.</p>
   </section>
 
+  <!-- Tulisan Tumpuk Atas Bawah (Vertical / Stacked) -->
+  <section class="editorial-section">
+    <h2>Tulisan Tumpuk Atas Bawah (Vertikal)</h2>
+    <p class="editorial-intro">Pengen <strong>tulisan tumpuk atas bawah</strong> — huruf yang disusun vertikal dari atas ke bawah, bukan menyamping? Pakai generator khusus biar tiap huruf turun satu baris dan tetap rapi waktu di-paste.</p>
+    <p>"Tulisan atas bawah", "font tumpuk atas bawah", "tulisan tumpuk keren", dan "tulisan aesthetic atas bawah" intinya sama: teks yang membaca dari atas ke bawah. Beda sama tulisan aesthetic biasa yang menyamping, gaya ini bikin nama, hook caption, atau bio kelihatan beda karena mecah pola baca normal. Karena hasilnya cuma karakter Unicode plus baris baru, tulisannya tetap nempel di bio Instagram, caption TikTok, status WhatsApp, sampai nickname game.</p>
+    <div class="block-example">
+      <strong>Contoh — "HALO" ditumpuk atas bawah:</strong>
+<pre>H
+A
+L
+O</pre>
+    </div>
+    <p>Mau bikin <strong>generator teks bertumpuk</strong> sendiri? Buka <a href="/usecase/vertical-text/"><strong>Generator Tulisan Vertikal &amp; Tumpuk Atas Bawah</strong></a> — pilih layout (tumpuk, tangga, piramida, sampai bingkai kotak), tambahin pemisah antar huruf, terus salin-tempel ke mana aja.</p>
+  </section>
+
   <!-- Huruf Aesthetic A–Z -->
   <section class="editorial-section glyph-section">
     <h2>Huruf Aesthetic A–Z</h2>

--- a/usecase/vertical-text/index.html
+++ b/usecase/vertical-text/index.html
@@ -12,8 +12,8 @@
 
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Vertical &amp; Stacked Text Generator — Stack Text Top to Bottom | UltraTextGen</title>
-  <meta name="description" content="Free vertical & stacked text generator. Stack text top to bottom for Instagram, TikTok, Discord, WhatsApp and X bios and comments. Pick a layout, add separators, copy and paste instantly.">
+  <title>Vertical Font &amp; Stacked Text Generator — Stack Text Top to Bottom | UltraTextGen</title>
+  <meta name="description" content="Free vertical font & stacked text generator. A vertical text generator that stacks text top to bottom for Instagram, TikTok, Discord, WhatsApp and X bios and comments. Pick a layout, add separators, copy and paste instantly.">
   <link rel="canonical" href="https://ultratextgen.com/usecase/vertical-text/">
   <meta property="og:image" content="https://ultratextgen.com/assets/og/usecase-vertical-text.png">
   <meta property="og:image:width" content="1200">
@@ -22,16 +22,16 @@
   <meta name="twitter:image" content="https://ultratextgen.com/assets/og/usecase-vertical-text.png">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Vertical & Stacked Text Generator — Stack Text Top to Bottom">
-  <meta property="og:description" content="Free vertical & stacked text generator. Stack text top to bottom for Instagram, TikTok, Discord, WhatsApp and X bios and comments. Copy and paste instantly.">
+  <meta property="og:title" content="Vertical Font & Stacked Text Generator — Stack Text Top to Bottom">
+  <meta property="og:description" content="Free vertical font & stacked text generator. Stack text top to bottom for Instagram, TikTok, Discord, WhatsApp and X bios and comments. Copy and paste instantly.">
   <meta property="og:url" content="https://ultratextgen.com/usecase/vertical-text/">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="UltraTextGen">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Vertical & Stacked Text Generator — Stack Text Top to Bottom">
-  <meta name="twitter:description" content="Free tool to stack text vertically, top to bottom. Copy and paste stacked text into Instagram bios, TikTok, Discord, WhatsApp and more.">
+  <meta name="twitter:title" content="Vertical Font & Stacked Text Generator — Stack Text Top to Bottom">
+  <meta name="twitter:description" content="Free vertical font generator that stacks text vertically, top to bottom. Copy and paste stacked text into Instagram bios, TikTok, Discord, WhatsApp and more.">
 
   <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/style.css">
@@ -95,6 +95,14 @@
       "acceptedAnswer": {
         "@type": "Answer",
         "text": "A text stacker is any tool that turns a normal horizontal word into stacked, top-to-bottom text — that is exactly what this generator does, across every Unicode font style at once. A 'double stack font' is different: it layers one line of text on top of another on a single line using combining marks, so only certain letters render correctly and the result can break when pasted. For copy-and-paste reliability across Instagram, TikTok, Discord and more, the top-to-bottom stacker on this page is the safer choice."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is this a vertical font generator or a vertical text generator?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Both — they are the same tool under two names. A vertical text generator stacks your letters top to bottom; a vertical font generator first restyles each letter into a Unicode font (bold, cursive, gothic, bubble and more) and then stacks it. This page does both at once: type a word and every result is rendered in a vertical font and stacked into a column you can copy and paste. So whether you searched for a vertical font generator, a vertical text generator, or a stacked text generator, this is the tool — pick the vertical font you like, then copy the stacked result."
       }
     },
     {
@@ -299,6 +307,7 @@ o</pre></div>
         <div class="editorial-block">
           <h3>How this generator works</h3>
           <p>Type your text and choose from 12 layout styles — Stacked, Staircase, Pyramid, Box, and more. The generator applies your chosen layout across every Unicode font style (bold, italic, cursive, gothic, and more) at once, so you can compare all variations side by side and copy the one you want.</p>
+          <p>Because each character is restyled into a Unicode font <em>before</em> it is stacked, this page works as a vertical font generator as much as a vertical text generator: pick the vertical font that fits your vibe, then copy the stacked, top-to-bottom result.</p>
           <p>Two word modes control how multi-word input is handled:</p>
           <ul>
             <li><strong>Stack mode:</strong> Each word becomes its own vertical block, with optional dividers between words (None, Blank Line, or Divider Line).</li>
@@ -619,6 +628,21 @@ Feature launching tomorrow</pre></div>
     A text stacker is any tool that turns a normal horizontal word into stacked, top-to-bottom text — that is exactly what this generator does, across every Unicode font style at once.
     A "double stack font" is different: it layers one line of text on top of another on a single line using combining marks, so only certain letters render correctly and the result can break when pasted.
     For copy-and-paste reliability across Instagram, TikTok, Discord and more, the top-to-bottom stacker on this page is the safer choice.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Is this a vertical font generator or a vertical text generator?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer">
+    Both — they're the same tool under two names. A <strong>vertical text generator</strong> stacks your letters top to bottom; a <strong>vertical font generator</strong> first restyles each letter into a Unicode font (bold, cursive, gothic, bubble and more) and then stacks it.
+    This page does both at once: type a word and every result is rendered in a vertical font and stacked into a column you can copy and paste.
+    <br><br>
+    So whether you searched for a vertical font generator, a vertical text generator, or a stacked text generator, this is the tool — pick the vertical font you like, then copy the stacked result.
   </div>
 </div>
 


### PR DESCRIPTION
## Summary

Two parts, as requested: (1) a keyword-volume check, then (2) a depth pass made **only** for volume-confirmed terms.

> ⚠️ **Data-source note.** The Semrush MCP returned *"not enough API units"* on every call, so live Semrush pulls weren't possible. Search volume + difficulty below come from the **attached Semrush broad-match US exports** (`*_broadmatch_us_20260628.csv` — same Volume/KD/Intent schema as the MCP). GSC impressions/clicks come from the attached `usecase/vertical-text/` performance export and the query×country context in the task. **English/US volumes are real Semrush data; non-English (FR/ID/DE/IT/ES/PT) volumes could not be retrieved** and are marked `n/a (Semrush units)` — verdicts for those rely on GSC demand + rank as the proxy.

## Part 1 — Volume table

### English (US) — real Semrush volume
| Term | Country | Volume | KD | GSC impr | GSC clk | Verdict |
|---|---|---:|---:|---:|---:|---|
| vertical font generator | US | **260** | 10 | 659 | 135 | ✅ **Target** — best CTR on site (20.5%), highest gen. volume, low KD |
| stacked text | US | 170 | 9 | 2,988 | 48 | ✅ Target — head term, most impressions, low KD |
| stacked text generator | US | 170 | 17 | 1,492 | 57 | ✅ Target |
| vertical text generator | US | 170 | 11 | 604 | 32 | ✅ Target |
| stack text | US | 40 | — | 131 | 3 | ➖ Secondary (covered by above) |
| stacked text maker | US | 10 | — | — | — | ➖ Minor synonym |
| vertical text | US | 880 | 34 | (2) | 0 | ⚠️ Mostly CSS/Word intent — not our use case |

Note: the high-volume "vertical" terms (e.g. `vertical css text` 1,900; `how to vertically center text in word` 1,300) are CSS/word-processor intent and irrelevant to a Unicode generator — excluded.

### Non-English — GSC demand only (Semrush volume unavailable)
| Term | Country | Volume | GSC impr | GSC clk | Verdict |
|---|---|---|---:|---:|---|
| écriture aesthetic à copier-coller | FR | n/a (units) | 179 | 11 | ⚠️ Generic "aesthetic" intent, not stacked-specific |
| écritures stylées | FR | n/a (units) | 86 | 0 | ⚠️ Generic, served by /fr/ homepage |
| staked texte / stacked texte | FR | n/a (units) | 61 / 55 | 4 / 3 | ➖ Stacked-specific but small + misspellings |
| stacked text | FR | n/a (units) | 559 | 11 | ➖ English head term in FR — low CTR |
| font tumpuk atas bawah | ID | n/a (units) | 6 | 2 | ✅ **We already rank #1 (pos 1.17)** |
| font atas bawah / generator teks bertumpuk / font memanjang ke bawah | ID | n/a (units) | 3 / 2 / 2 | 0 | ✅ Native cluster, top pos 2.3–8.5; ID is the page's #1 market |
| tulisan tumpuk / atas bawah / aesthetic atas bawah | ID | n/a (units) | (context) | — | ✅ Targeted via new /id/ section |
| text übereinander / gestapelter text (DE) | DE | n/a (units) | — | — | ❓ Unconfirmed — defer |
| scritta/testo verticale (IT) | IT | n/a (units) | 123–559* | — | ❓ Unconfirmed volume — defer |
| texto/letras verticales (ES), texto vertical / fonte empilhada (PT) | ES/PT | n/a (units) | — | — | ❓ Unconfirmed — defer |

<sub>*IT figure is the task's `stacked text [Italy]` query×country impressions, not a Semrush volume.</sub>

## Part 2 — Depth pass (volume-confirmed only)

**1. `/usecase/vertical-text/` — added the under-used "vertical font" terminology.**
The page used `vertical text` 79× but `vertical font` only **1×**, even though `vertical font generator` is the single best-performing GSC term (135 clicks / 20.5% CTR / vol 260 / KD 10). Changes:
- `<title>`, OG/Twitter titles, and meta description now lead with **Vertical Font** while keeping *stacked text generator* / *vertical text generator*.
- New body paragraph framing the tool as a vertical font generator (it restyles each char into a Unicode font, then stacks).
- New FAQ *"Is this a vertical font generator or a vertical text generator?"* — added to both the visible FAQ and the **FAQPage JSON-LD** (now 17 items, validated).

**2. `/id/` — added an Indonesian stacked/vertical section + cross-link.**
New "Tulisan Tumpuk Atas Bawah (Vertikal)" section targeting the native cluster (`tulisan atas bawah`, `font tumpuk atas bawah`, `tulisan tumpuk keren`, `tulisan aesthetic atas bawah`, `generator teks bertumpuk`) and cross-linking to `/usecase/vertical-text/`. Justified by GSC: we already rank **#1** for `font tumpuk atas bawah` and Indonesia is the page's top market. (Hardcoded section, matching the page's other non-i18n editorial blocks.)

**3. French — recommendation: defer (no change made).**
French stacked demand does **not** justify a localized stacked block yet:
- Semrush FR volume couldn't be confirmed (units), and the GSC clicks are low (`staked texte` 4, `stacked texte` 3).
- The dominant FR demand is **generic** "écriture aesthetic / écritures stylées" — already the focus of the `/fr/` homepage title — not stacked-specific.
- The stacked-specific FR terms are small misspellings.

**Recommendation:** hold the FR localized block / hreflang section until Semrush units are restored and `texte vertical` / `texte empilé` volume can be validated. If we want a cheap interim capture of the existing FR clicks, a single cross-link from `/fr/` → `/usecase/vertical-text/` is low-risk — but per "changes only for volume-confirmed terms," it's left out of this PR.

## Constraints
- GTM snippets intact; all JSON-LD blocks validated (parse-checked).
- No framework/bundler added; reuses the existing `js/vertical/` module.
- Do **not** merge to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0151CARkq34wA4D4xf8Dnh9h)_