### PR TITLE
fix(seo): backfill Article image in JSON-LD on 248 library pages

### DIFF
--- a/library/accent-marks-diacritics/index.html
+++ b/library/accent-marks-diacritics/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-accent-marks-diacritics.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/accent-marks-diacritics/",
   "datePublished": "2026-04-12",
   "dateModified": "2026-04-12"

--- a/library/achievement-symbols/index.html
+++ b/library/achievement-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-achievement-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/achievement-symbols/",
   "datePublished": "2026-03-31",
   "dateModified": "2026-04-01"

--- a/library/aesthetic-borders-frames/index.html
+++ b/library/aesthetic-borders-frames/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-aesthetic-borders-frames.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/aesthetic-borders-frames/",
   "datePublished": "2026-04-26",
   "dateModified": "2026-04-26"

--- a/library/aesthetic-symbols/index.html
+++ b/library/aesthetic-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-aesthetic-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/aesthetic-symbols/",
   "datePublished": "2026-03-31",
   "dateModified": "2026-03-31"

--- a/library/algeria-emoji-combos/index.html
+++ b/library/algeria-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-algeria-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/algeria-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/alt-codes/index.html
+++ b/library/alt-codes/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-alt-codes.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/alt-codes/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/angry-emoji/index.html
+++ b/library/angry-emoji/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-angry-emoji.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/angry-emoji/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/animal-emojis/index.html
+++ b/library/animal-emojis/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-animal-emojis.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/animal-emojis/",
   "datePublished": "2026-03-31",
   "dateModified": "2026-03-31"

--- a/library/argentina-emoji-combos/index.html
+++ b/library/argentina-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-argentina-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/argentina-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/arrow-symbols/index.html
+++ b/library/arrow-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-arrow-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/arrow-symbols/",
   "datePublished": "2026-03-31",
   "dateModified": "2026-03-31"

--- a/library/art-stationery-emojis/index.html
+++ b/library/art-stationery-emojis/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-art-stationery-emojis.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/art-stationery-emojis/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/ascii-table/index.html
+++ b/library/ascii-table/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-ascii-table.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/ascii-table/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/australia-emoji-combos/index.html
+++ b/library/australia-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-australia-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/australia-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/austria-emoji-combos/index.html
+++ b/library/austria-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-austria-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/austria-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/awareness-ribbons/index.html
+++ b/library/awareness-ribbons/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-awareness-ribbons.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/awareness-ribbons/",
   "datePublished": "2026-03-29",
   "dateModified": "2026-03-30"

--- a/library/beauty-nails-emojis/index.html
+++ b/library/beauty-nails-emojis/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-beauty-nails-emojis.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/beauty-nails-emojis/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/belgium-emoji-combos/index.html
+++ b/library/belgium-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-belgium-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/belgium-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/bellingham-emoji-combos/index.html
+++ b/library/bellingham-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-bellingham-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/bellingham-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/benzema-emoji-combos/index.html
+++ b/library/benzema-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-benzema-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/benzema-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/body-language-emojis/index.html
+++ b/library/body-language-emojis/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-body-language-emojis.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/body-language-emojis/",
   "datePublished": "2026-03-31",
   "dateModified": "2026-04-01"

--- a/library/bow-ribbon-symbols/index.html
+++ b/library/bow-ribbon-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-bow-ribbon-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/bow-ribbon-symbols/",
   "datePublished": "2026-04-26",
   "dateModified": "2026-04-26"

--- a/library/box-drawing-symbols/index.html
+++ b/library/box-drawing-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-box-drawing-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/box-drawing-symbols/",
   "datePublished": "2026-06-07",
   "dateModified": "2026-06-07"

--- a/library/bracket-symbols/index.html
+++ b/library/bracket-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-bracket-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/bracket-symbols/",
   "datePublished": "2026-03-31",
   "dateModified": "2026-03-31"

--- a/library/braille-pattern-symbols/index.html
+++ b/library/braille-pattern-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-braille-pattern-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/braille-pattern-symbols/",
   "datePublished": "2026-06-07",
   "dateModified": "2026-06-07"

--- a/library/brainrot-slang-emojis/index.html
+++ b/library/brainrot-slang-emojis/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-brainrot-slang-emojis.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/brainrot-slang-emojis/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/brazil-emoji-combos/index.html
+++ b/library/brazil-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-brazil-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/brazil-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/bullet-point-symbols/index.html
+++ b/library/bullet-point-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-bullet-point-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/bullet-point-symbols/",
   "datePublished": "2026-03-31",
   "dateModified": "2026-03-31"

--- a/library/cameroon-emoji-combos/index.html
+++ b/library/cameroon-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-cameroon-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/cameroon-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/canada-emoji-combos/index.html
+++ b/library/canada-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-canada-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/canada-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/card-emoji-soccer/index.html
+++ b/library/card-emoji-soccer/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-card-emoji-soccer.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/card-emoji-soccer/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/card-suit-symbols/index.html
+++ b/library/card-suit-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-card-suit-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/card-suit-symbols/",
   "datePublished": "2026-03-29",
   "dateModified": "2026-03-30"

--- a/library/checkmark-symbols/index.html
+++ b/library/checkmark-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-checkmark-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/checkmark-symbols/",
   "datePublished": "2026-03-31",
   "dateModified": "2026-03-31"

--- a/library/chess-symbols/index.html
+++ b/library/chess-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-chess-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/chess-symbols/",
   "datePublished": "2026-03-29",
   "dateModified": "2026-03-30"

--- a/library/chile-emoji-combos/index.html
+++ b/library/chile-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-chile-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/chile-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/china-emoji-combos/index.html
+++ b/library/china-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-china-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/china-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/chinese-symbols/index.html
+++ b/library/chinese-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-chinese-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/chinese-symbols/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/christmas-symbols/index.html
+++ b/library/christmas-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-christmas-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/christmas-symbols/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/clock-time-symbols/index.html
+++ b/library/clock-time-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-clock-time-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/clock-time-symbols/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/clothing-fashion-emojis/index.html
+++ b/library/clothing-fashion-emojis/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-clothing-fashion-emojis.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/clothing-fashion-emojis/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/colombia-emoji-combos/index.html
+++ b/library/colombia-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-colombia-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/colombia-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/color-emoji-combos/index.html
+++ b/library/color-emoji-combos/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-color-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/color-emoji-combos/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/copyright-trademark-symbols/index.html
+++ b/library/copyright-trademark-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-copyright-trademark-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/copyright-trademark-symbols/",
   "datePublished": "2026-06-07",
   "dateModified": "2026-06-07"

--- a/library/coquette-symbols/index.html
+++ b/library/coquette-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-coquette-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/coquette-symbols/",
   "datePublished": "2026-04-26",
   "dateModified": "2026-04-26"

--- a/library/costa-rica-emoji-combos/index.html
+++ b/library/costa-rica-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-costa-rica-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/costa-rica-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/cottagecore-symbols/index.html
+++ b/library/cottagecore-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-cottagecore-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/cottagecore-symbols/",
   "datePublished": "2026-04-26",
   "dateModified": "2026-04-26"

--- a/library/croatia-emoji-combos/index.html
+++ b/library/croatia-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-croatia-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/croatia-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/cross-x-symbols/index.html
+++ b/library/cross-x-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-cross-x-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/cross-x-symbols/",
   "datePublished": "2026-04-12",
   "dateModified": "2026-04-12"

--- a/library/crown-royalty-symbols/index.html
+++ b/library/crown-royalty-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-crown-royalty-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/crown-royalty-symbols/",
   "datePublished": "2026-04-26",
   "dateModified": "2026-04-26"

--- a/library/crying-emoji/index.html
+++ b/library/crying-emoji/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-crying-emoji.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/crying-emoji/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/currency-symbols/index.html
+++ b/library/currency-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-currency-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/currency-symbols/",
   "datePublished": "2026-03-29",
   "dateModified": "2026-03-30"

--- a/library/dash-hyphen-symbols/index.html
+++ b/library/dash-hyphen-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-dash-hyphen-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/dash-hyphen-symbols/",
   "datePublished": "2026-04-12",
   "dateModified": "2026-04-12"

--- a/library/de-bruyne-emoji-combos/index.html
+++ b/library/de-bruyne-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-de-bruyne-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/de-bruyne-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/degree-symbol/index.html
+++ b/library/degree-symbol/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-degree-symbol.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/degree-symbol/",
   "datePublished": "2026-06-07",
   "dateModified": "2026-06-07"

--- a/library/denmark-emoji-combos/index.html
+++ b/library/denmark-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-denmark-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/denmark-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/di-maria-emoji-combos/index.html
+++ b/library/di-maria-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-di-maria-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/di-maria-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/dice-domino-symbols/index.html
+++ b/library/dice-domino-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-dice-domino-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/dice-domino-symbols/",
   "datePublished": "2026-06-07",
   "dateModified": "2026-06-07"

--- a/library/discord-symbols/index.html
+++ b/library/discord-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-discord-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/discord-symbols/",
   "datePublished": "2026-04-26",
   "dateModified": "2026-04-26"

--- a/library/diwali-symbols/index.html
+++ b/library/diwali-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-diwali-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/diwali-symbols/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/dreamcore-weirdcore-symbols/index.html
+++ b/library/dreamcore-weirdcore-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-dreamcore-weirdcore-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/dreamcore-weirdcore-symbols/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/easter-symbols/index.html
+++ b/library/easter-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-easter-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/easter-symbols/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/ecuador-emoji-combos/index.html
+++ b/library/ecuador-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-ecuador-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/ecuador-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/egypt-emoji-combos/index.html
+++ b/library/egypt-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-egypt-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/egypt-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/egyptian-hieroglyphs/index.html
+++ b/library/egyptian-hieroglyphs/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-egyptian-hieroglyphs.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/egyptian-hieroglyphs/",
   "datePublished": "2026-04-12",
   "dateModified": "2026-04-12"

--- a/library/electrical-circuit-symbols/index.html
+++ b/library/electrical-circuit-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-electrical-circuit-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/electrical-circuit-symbols/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/email-symbols/index.html
+++ b/library/email-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-email-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/email-symbols/",
   "datePublished": "2026-03-31",
   "dateModified": "2026-03-31"

--- a/library/emoji-combos/index.html
+++ b/library/emoji-combos/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/emoji-combos/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-27"

--- a/library/emoji-flags/index.html
+++ b/library/emoji-flags/index.html
@@ -57,6 +57,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-emoji-flags.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/emoji-flags/",
   "datePublished": "2026-03-04",
   "dateModified": "2026-03-04"

--- a/library/emoji-meanings-guide/index.html
+++ b/library/emoji-meanings-guide/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-emoji-meanings-guide.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/emoji-meanings-guide/",
   "datePublished": "2026-03-31",
   "dateModified": "2026-03-31"

--- a/library/england-emoji-combos/index.html
+++ b/library/england-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-england-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/england-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/evil-eye-hamsa-symbols/index.html
+++ b/library/evil-eye-hamsa-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-evil-eye-hamsa-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/evil-eye-hamsa-symbols/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/face-emojis/index.html
+++ b/library/face-emojis/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-face-emojis.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/face-emojis/",
   "datePublished": "2026-03-31",
   "dateModified": "2026-03-31"

--- a/library/fairycore-symbols/index.html
+++ b/library/fairycore-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-fairycore-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/fairycore-symbols/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/fantasy-mythical-emojis/index.html
+++ b/library/fantasy-mythical-emojis/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-fantasy-mythical-emojis.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/fantasy-mythical-emojis/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/flower-symbols/index.html
+++ b/library/flower-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-flower-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/flower-symbols/",
   "datePublished": "2026-03-31",
   "dateModified": "2026-03-31"

--- a/library/foden-emoji-combos/index.html
+++ b/library/foden-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-foden-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/foden-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/food-drink-emojis/index.html
+++ b/library/food-drink-emojis/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-food-drink-emojis.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/food-drink-emojis/",
   "datePublished": "2026-03-31",
   "dateModified": "2026-03-31"

--- a/library/football-ascii-art/index.html
+++ b/library/football-ascii-art/index.html
@@ -50,6 +50,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-football-ascii-art.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/football-ascii-art/",
   "datePublished": "2026-06-16",
   "dateModified": "2026-06-16"

--- a/library/football-emoji-copy-paste/index.html
+++ b/library/football-emoji-copy-paste/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-football-emoji-copy-paste.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/football-emoji-copy-paste/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/football-kaomoji/index.html
+++ b/library/football-kaomoji/index.html
@@ -50,6 +50,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-football-kaomoji.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/football-kaomoji/",
   "datePublished": "2026-06-16",
   "dateModified": "2026-06-16"

--- a/library/football-reaction-emojis/index.html
+++ b/library/football-reaction-emojis/index.html
@@ -50,6 +50,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-football-reaction-emojis.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/football-reaction-emojis/",
   "datePublished": "2026-06-16",
   "dateModified": "2026-06-16"

--- a/library/football-symbols/index.html
+++ b/library/football-symbols/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-football-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/football-symbols/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-16"

--- a/library/football-trophy-emoji/index.html
+++ b/library/football-trophy-emoji/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-football-trophy-emoji.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/football-trophy-emoji/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/football-username-ideas/index.html
+++ b/library/football-username-ideas/index.html
@@ -50,6 +50,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-football-username-ideas.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/football-username-ideas/",
   "datePublished": "2026-06-16",
   "dateModified": "2026-06-16"

--- a/library/fortnite-symbols/index.html
+++ b/library/fortnite-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-fortnite-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/fortnite-symbols/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/fourth-of-july-symbols/index.html
+++ b/library/fourth-of-july-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-fourth-of-july-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/fourth-of-july-symbols/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/fraction-symbols/index.html
+++ b/library/fraction-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-fraction-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/fraction-symbols/",
   "datePublished": "2026-06-07",
   "dateModified": "2026-06-07"

--- a/library/france-emoji-combos/index.html
+++ b/library/france-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-france-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/france-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/free-fire-name-symbols/index.html
+++ b/library/free-fire-name-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-free-fire-name-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/free-fire-name-symbols/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/friendship-emojis/index.html
+++ b/library/friendship-emojis/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-friendship-emojis.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/friendship-emojis/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/funny-emoji-combos/index.html
+++ b/library/funny-emoji-combos/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-funny-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/funny-emoji-combos/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/gavi-emoji-combos/index.html
+++ b/library/gavi-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-gavi-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/gavi-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/gender-symbols/index.html
+++ b/library/gender-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-gender-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/gender-symbols/",
   "datePublished": "2026-06-07",
   "dateModified": "2026-06-07"

--- a/library/geometric-symbols/index.html
+++ b/library/geometric-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-geometric-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/geometric-symbols/",
   "datePublished": "2026-03-31",
   "dateModified": "2026-03-31"

--- a/library/germany-emoji-combos/index.html
+++ b/library/germany-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-germany-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/germany-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/ghana-emoji-combos/index.html
+++ b/library/ghana-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-ghana-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/ghana-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/goal-emoji-combos/index.html
+++ b/library/goal-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-goal-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/goal-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/goat-emoji-combos/index.html
+++ b/library/goat-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-goat-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/goat-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/goth-grunge-symbols/index.html
+++ b/library/goth-grunge-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-goth-grunge-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/goth-grunge-symbols/",
   "datePublished": "2026-04-26",
   "dateModified": "2026-04-26"

--- a/library/greece-emoji-combos/index.html
+++ b/library/greece-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-greece-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/greece-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/greek-letter-symbols/index.html
+++ b/library/greek-letter-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-greek-letter-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/greek-letter-symbols/",
   "datePublished": "2026-06-07",
   "dateModified": "2026-06-07"

--- a/library/greeting-message-emojis/index.html
+++ b/library/greeting-message-emojis/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-greeting-message-emojis.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/greeting-message-emojis/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/griezmann-emoji-combos/index.html
+++ b/library/griezmann-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-griezmann-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/griezmann-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/guess-soccer-player-by-emoji/index.html
+++ b/library/guess-soccer-player-by-emoji/index.html
@@ -50,6 +50,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-guess-soccer-player-by-emoji.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/guess-soccer-player-by-emoji/",
   "datePublished": "2026-06-16",
   "dateModified": "2026-06-16"

--- a/library/guess-soccer-team-by-emoji/index.html
+++ b/library/guess-soccer-team-by-emoji/index.html
@@ -50,6 +50,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-guess-soccer-team-by-emoji.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/guess-soccer-team-by-emoji/",
   "datePublished": "2026-06-16",
   "dateModified": "2026-06-16"

--- a/library/haaland-emoji-combos/index.html
+++ b/library/haaland-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-haaland-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/haaland-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/halloween-symbols/index.html
+++ b/library/halloween-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-halloween-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/halloween-symbols/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/hand-symbols/index.html
+++ b/library/hand-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-hand-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/hand-symbols/",
   "datePublished": "2026-03-29",
   "dateModified": "2026-03-30"

--- a/library/happy-emoji/index.html
+++ b/library/happy-emoji/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-happy-emoji.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/happy-emoji/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/hazard-warning-symbols/index.html
+++ b/library/hazard-warning-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-hazard-warning-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/hazard-warning-symbols/",
   "datePublished": "2026-06-07",
   "dateModified": "2026-06-07"

--- a/library/heart-symbols/index.html
+++ b/library/heart-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-heart-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/heart-symbols/",
   "datePublished": "2026-03-29",
   "dateModified": "2026-03-30"

--- a/library/hindi-symbols/index.html
+++ b/library/hindi-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-hindi-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/hindi-symbols/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/honduras-emoji-combos/index.html
+++ b/library/honduras-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-honduras-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/honduras-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/html-entities/index.html
+++ b/library/html-entities/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-html-entities.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/html-entities/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/india-emoji-combos/index.html
+++ b/library/india-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-india-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/india-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/instagram-symbols/index.html
+++ b/library/instagram-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-instagram-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/instagram-symbols/",
   "datePublished": "2026-03-31",
   "dateModified": "2026-03-31"

--- a/library/invisible-character/index.html
+++ b/library/invisible-character/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-invisible-character.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/invisible-character/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/ipa-phonetic-symbols/index.html
+++ b/library/ipa-phonetic-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-ipa-phonetic-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/ipa-phonetic-symbols/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/iran-emoji-combos/index.html
+++ b/library/iran-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-iran-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/iran-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/ireland-emoji-combos/index.html
+++ b/library/ireland-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-ireland-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/ireland-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/islamic-symbols/index.html
+++ b/library/islamic-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-islamic-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/islamic-symbols/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/italy-emoji-combos/index.html
+++ b/library/italy-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-italy-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/italy-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/ivory-coast-emoji-combos/index.html
+++ b/library/ivory-coast-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-ivory-coast-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/ivory-coast-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/jamaica-emoji-combos/index.html
+++ b/library/jamaica-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-jamaica-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/jamaica-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/japan-emoji-combos/index.html
+++ b/library/japan-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-japan-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/japan-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/japanese-symbols/index.html
+++ b/library/japanese-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-japanese-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/japanese-symbols/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/jewelry-gem-emojis/index.html
+++ b/library/jewelry-gem-emojis/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-jewelry-gem-emojis.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/jewelry-gem-emojis/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/kane-emoji-combos/index.html
+++ b/library/kane-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-kane-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/kane-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/kawaii-cute-symbols/index.html
+++ b/library/kawaii-cute-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-kawaii-cute-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/kawaii-cute-symbols/",
   "datePublished": "2026-04-26",
   "dateModified": "2026-04-26"

--- a/library/keyboard-symbols/index.html
+++ b/library/keyboard-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-keyboard-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/keyboard-symbols/",
   "datePublished": "2026-06-07",
   "dateModified": "2026-06-07"

--- a/library/korean-symbols/index.html
+++ b/library/korean-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-korean-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/korean-symbols/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/kvaratskhelia-emoji-combos/index.html
+++ b/library/kvaratskhelia-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-kvaratskhelia-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/kvaratskhelia-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/latex-symbols/index.html
+++ b/library/latex-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-latex-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/latex-symbols/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/laughing-emoji/index.html
+++ b/library/laughing-emoji/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-laughing-emoji.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/laughing-emoji/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/laundry-care-symbols/index.html
+++ b/library/laundry-care-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-laundry-care-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/laundry-care-symbols/",
   "datePublished": "2026-06-08",
   "dateModified": "2026-06-08"

--- a/library/lautaro-martinez-emoji-combos/index.html
+++ b/library/lautaro-martinez-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-lautaro-martinez-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/lautaro-martinez-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/lewandowski-emoji-combos/index.html
+++ b/library/lewandowski-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-lewandowski-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/lewandowski-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/line-divider-symbols/index.html
+++ b/library/line-divider-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-line-divider-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/line-divider-symbols/",
   "datePublished": "2026-03-31",
   "dateModified": "2026-03-31"

--- a/library/linkedin-comment-styling/index.html
+++ b/library/linkedin-comment-styling/index.html
@@ -54,6 +54,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-linkedin-comment-styling.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/linkedin-comment-styling/",
   "datePublished": "2026-03-02",
   "dateModified": "2026-03-02"

--- a/library/linkedin-symbol-library/index.html
+++ b/library/linkedin-symbol-library/index.html
@@ -53,6 +53,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-linkedin-symbol-library.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/linkedin-symbol-library/",
   "datePublished": "2026-03-02",
   "dateModified": "2026-03-31"

--- a/library/loading-text-symbols/index.html
+++ b/library/loading-text-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-loading-text-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/loading-text-symbols/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/math-symbols/index.html
+++ b/library/math-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-math-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/math-symbols/",
   "datePublished": "2026-03-31",
   "dateModified": "2026-03-31"

--- a/library/mbappe-emoji-combos/index.html
+++ b/library/mbappe-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-mbappe-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/mbappe-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/media-control-symbols/index.html
+++ b/library/media-control-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-media-control-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/media-control-symbols/",
   "datePublished": "2026-06-07",
   "dateModified": "2026-06-07"

--- a/library/medical-symbols/index.html
+++ b/library/medical-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-medical-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/medical-symbols/",
   "datePublished": "2026-06-07",
   "dateModified": "2026-06-07"

--- a/library/meme-text-art/index.html
+++ b/library/meme-text-art/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-meme-text-art.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/meme-text-art/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/messi-emoji-combos/index.html
+++ b/library/messi-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-messi-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/messi-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/mexico-emoji-combos/index.html
+++ b/library/mexico-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-mexico-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/mexico-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/minecraft-symbols/index.html
+++ b/library/minecraft-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-minecraft-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/minecraft-symbols/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/ml-name-symbols/index.html
+++ b/library/ml-name-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-ml-name-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/ml-name-symbols/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/moai-emoji/index.html
+++ b/library/moai-emoji/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-moai-emoji.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/moai-emoji/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/modric-emoji-combos/index.html
+++ b/library/modric-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-modric-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/modric-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/money-emojis/index.html
+++ b/library/money-emojis/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-money-emojis.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/money-emojis/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/moon-celestial-symbols/index.html
+++ b/library/moon-celestial-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-moon-celestial-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/moon-celestial-symbols/",
   "datePublished": "2026-04-26",
   "dateModified": "2026-04-26"

--- a/library/morocco-emoji-combos/index.html
+++ b/library/morocco-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-morocco-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/morocco-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/movie-night-emojis/index.html
+++ b/library/movie-night-emojis/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-movie-night-emojis.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/movie-night-emojis/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/musiala-emoji-combos/index.html
+++ b/library/musiala-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-musiala-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/musiala-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/music-symbols/index.html
+++ b/library/music-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-music-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/music-symbols/",
   "datePublished": "2026-03-29",
   "dateModified": "2026-03-30"

--- a/library/nature-emojis/index.html
+++ b/library/nature-emojis/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-nature-emojis.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/nature-emojis/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/nerd-emoji/index.html
+++ b/library/nerd-emoji/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-nerd-emoji.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/nerd-emoji/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/netherlands-emoji-combos/index.html
+++ b/library/netherlands-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-netherlands-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/netherlands-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/new-zealand-emoji-combos/index.html
+++ b/library/new-zealand-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-new-zealand-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/new-zealand-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/neymar-emoji-combos/index.html
+++ b/library/neymar-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-neymar-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/neymar-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/nickname-symbols/index.html
+++ b/library/nickname-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-nickname-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/nickname-symbols/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/nigeria-emoji-combos/index.html
+++ b/library/nigeria-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-nigeria-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/nigeria-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/nkunku-emoji-combos/index.html
+++ b/library/nkunku-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-nkunku-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/nkunku-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/norse-viking-runes/index.html
+++ b/library/norse-viking-runes/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-norse-viking-runes.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/norse-viking-runes/",
   "datePublished": "2026-04-12",
   "dateModified": "2026-04-12"

--- a/library/norway-emoji-combos/index.html
+++ b/library/norway-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-norway-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/norway-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/number-symbols/index.html
+++ b/library/number-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-number-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/number-symbols/",
   "datePublished": "2026-03-31",
   "dateModified": "2026-03-31"

--- a/library/object-emojis/index.html
+++ b/library/object-emojis/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-object-emojis.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/object-emojis/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/osimhen-emoji-combos/index.html
+++ b/library/osimhen-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-osimhen-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/osimhen-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/panama-emoji-combos/index.html
+++ b/library/panama-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-panama-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/panama-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/paraguay-emoji-combos/index.html
+++ b/library/paraguay-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-paraguay-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/paraguay-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/party-celebration-emojis/index.html
+++ b/library/party-celebration-emojis/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-party-celebration-emojis.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/party-celebration-emojis/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/peace-symbol/index.html
+++ b/library/peace-symbol/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-peace-symbol.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/peace-symbol/",
   "datePublished": "2026-06-07",
   "dateModified": "2026-06-07"

--- a/library/pedri-emoji-combos/index.html
+++ b/library/pedri-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-pedri-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/pedri-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/people-profession-emojis/index.html
+++ b/library/people-profession-emojis/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-people-profession-emojis.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/people-profession-emojis/",
   "datePublished": "2026-03-31",
   "dateModified": "2026-03-31"

--- a/library/peru-emoji-combos/index.html
+++ b/library/peru-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-peru-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/peru-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/poland-emoji-combos/index.html
+++ b/library/poland-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-poland-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/poland-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/poop-emoji/index.html
+++ b/library/poop-emoji/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-poop-emoji.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/poop-emoji/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/portugal-emoji-combos/index.html
+++ b/library/portugal-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-portugal-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/portugal-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/preppy-emoji-combos/index.html
+++ b/library/preppy-emoji-combos/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-preppy-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/preppy-emoji-combos/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/punctuation-symbols/index.html
+++ b/library/punctuation-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-punctuation-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/punctuation-symbols/",
   "datePublished": "2026-06-07",
   "dateModified": "2026-06-07"

--- a/library/qatar-emoji-combos/index.html
+++ b/library/qatar-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-qatar-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/qatar-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/rashford-emoji-combos/index.html
+++ b/library/rashford-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-rashford-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/rashford-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/recycle-environment-symbols/index.html
+++ b/library/recycle-environment-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-recycle-environment-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/recycle-environment-symbols/",
   "datePublished": "2026-06-07",
   "dateModified": "2026-06-07"

--- a/library/religious-symbols/index.html
+++ b/library/religious-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-religious-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/religious-symbols/",
   "datePublished": "2026-03-29",
   "dateModified": "2026-03-30"

--- a/library/roblox-symbols/index.html
+++ b/library/roblox-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-roblox-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/roblox-symbols/",
   "datePublished": "2026-04-26",
   "dateModified": "2026-04-26"

--- a/library/roblox-text-art/index.html
+++ b/library/roblox-text-art/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-roblox-text-art.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/roblox-text-art/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/rodri-emoji-combos/index.html
+++ b/library/rodri-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-rodri-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/rodri-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/rodrygo-emoji-combos/index.html
+++ b/library/rodrygo-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-rodrygo-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/rodrygo-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/ronaldo-emoji-combos/index.html
+++ b/library/ronaldo-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-ronaldo-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/ronaldo-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/sad-emoji/index.html
+++ b/library/sad-emoji/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-sad-emoji.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/sad-emoji/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/saka-emoji-combos/index.html
+++ b/library/saka-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-saka-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/saka-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/salah-emoji-combos/index.html
+++ b/library/salah-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-salah-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/salah-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/saudi-arabia-emoji-combos/index.html
+++ b/library/saudi-arabia-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-saudi-arabia-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/saudi-arabia-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/school-education-emojis/index.html
+++ b/library/school-education-emojis/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-school-education-emojis.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/school-education-emojis/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/scotland-emoji-combos/index.html
+++ b/library/scotland-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-scotland-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/scotland-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/seasonal-emoji-combos/index.html
+++ b/library/seasonal-emoji-combos/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-seasonal-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/seasonal-emoji-combos/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/senegal-emoji-combos/index.html
+++ b/library/senegal-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-senegal-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/senegal-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/serbia-emoji-combos/index.html
+++ b/library/serbia-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-serbia-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/serbia-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/shocked-emoji/index.html
+++ b/library/shocked-emoji/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-shocked-emoji.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/shocked-emoji/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/side-eye-emoji/index.html
+++ b/library/side-eye-emoji/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-side-eye-emoji.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/side-eye-emoji/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/slash-backslash-symbols/index.html
+++ b/library/slash-backslash-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-slash-backslash-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/slash-backslash-symbols/",
   "datePublished": "2026-04-12",
   "dateModified": "2026-04-12"

--- a/library/smiley-face-guide/index.html
+++ b/library/smiley-face-guide/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-smiley-face-guide.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/smiley-face-guide/",
   "datePublished": "2026-03-31",
   "dateModified": "2026-03-31"

--- a/library/soccer-emoji-copy-paste/index.html
+++ b/library/soccer-emoji-copy-paste/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-soccer-emoji-copy-paste.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/soccer-emoji-copy-paste/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/son-emoji-combos/index.html
+++ b/library/son-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-son-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/son-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/south-africa-emoji-combos/index.html
+++ b/library/south-africa-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-south-africa-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/south-africa-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/south-korea-emoji-combos/index.html
+++ b/library/south-korea-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-south-korea-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/south-korea-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/spain-emoji-combos/index.html
+++ b/library/spain-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-spain-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/spain-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/sparkle-symbols/index.html
+++ b/library/sparkle-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-sparkle-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/sparkle-symbols/",
   "datePublished": "2026-03-31",
   "dateModified": "2026-03-31"

--- a/library/special-characters/index.html
+++ b/library/special-characters/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-special-characters.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/special-characters/",
   "datePublished": "2026-03-31",
   "dateModified": "2026-06-08"

--- a/library/sports-emojis/index.html
+++ b/library/sports-emojis/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-sports-emojis.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/sports-emojis/",
   "datePublished": "2026-03-31",
   "dateModified": "2026-03-31"

--- a/library/star-symbols/index.html
+++ b/library/star-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-star-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/star-symbols/",
   "datePublished": "2026-03-29",
   "dateModified": "2026-03-29"

--- a/library/suarez-emoji-combos/index.html
+++ b/library/suarez-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-suarez-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/suarez-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/sweden-emoji-combos/index.html
+++ b/library/sweden-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-sweden-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/sweden-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/switzerland-emoji-combos/index.html
+++ b/library/switzerland-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-switzerland-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/switzerland-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/tech-status-symbols/index.html
+++ b/library/tech-status-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-tech-status-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/tech-status-symbols/",
   "datePublished": "2026-06-07",
   "dateModified": "2026-06-07"

--- a/library/text-art/index.html
+++ b/library/text-art/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-text-art.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/text-art/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/text-faces-kaomoji/index.html
+++ b/library/text-faces-kaomoji/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-text-faces-kaomoji.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/text-faces-kaomoji/",
   "datePublished": "2026-03-31",
   "dateModified": "2026-06-08"

--- a/library/thanksgiving-symbols/index.html
+++ b/library/thanksgiving-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-thanksgiving-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/thanksgiving-symbols/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/therian-symbols/index.html
+++ b/library/therian-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-therian-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/therian-symbols/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/thumbs-up-emoji/index.html
+++ b/library/thumbs-up-emoji/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-thumbs-up-emoji.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/thumbs-up-emoji/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/tiktok-symbols/index.html
+++ b/library/tiktok-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-tiktok-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/tiktok-symbols/",
   "datePublished": "2026-03-31",
   "dateModified": "2026-03-31"

--- a/library/traffic-road-sign-symbols/index.html
+++ b/library/traffic-road-sign-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-traffic-road-sign-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/traffic-road-sign-symbols/",
   "datePublished": "2026-04-12",
   "dateModified": "2026-04-12"

--- a/library/transport-symbols/index.html
+++ b/library/transport-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-transport-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/transport-symbols/",
   "datePublished": "2026-03-29",
   "dateModified": "2026-03-30"

--- a/library/travel-vacation-emojis/index.html
+++ b/library/travel-vacation-emojis/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-travel-vacation-emojis.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/travel-vacation-emojis/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/tunisia-emoji-combos/index.html
+++ b/library/tunisia-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-tunisia-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/tunisia-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/turkey-emoji-combos/index.html
+++ b/library/turkey-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-turkey-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/turkey-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/ukraine-emoji-combos/index.html
+++ b/library/ukraine-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-ukraine-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/ukraine-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/unit-measurement-symbols/index.html
+++ b/library/unit-measurement-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-unit-measurement-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/unit-measurement-symbols/",
   "datePublished": "2026-06-07",
   "dateModified": "2026-06-07"

--- a/library/uruguay-emoji-combos/index.html
+++ b/library/uruguay-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-uruguay-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/uruguay-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/usa-emoji-combos/index.html
+++ b/library/usa-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-usa-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/usa-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/venezuela-emoji-combos/index.html
+++ b/library/venezuela-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-venezuela-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/venezuela-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/vertical-line-symbols/index.html
+++ b/library/vertical-line-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-vertical-line-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/vertical-line-symbols/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/vinicius-emoji-combos/index.html
+++ b/library/vinicius-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-vinicius-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/vinicius-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/wales-emoji-combos/index.html
+++ b/library/wales-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-wales-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/wales-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/weapon-tool-emojis/index.html
+++ b/library/weapon-tool-emojis/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-weapon-tool-emojis.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/weapon-tool-emojis/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/weather-symbols/index.html
+++ b/library/weather-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-weather-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/weather-symbols/",
   "datePublished": "2026-03-29",
   "dateModified": "2026-03-29"

--- a/library/wedding-anniversary-emojis/index.html
+++ b/library/wedding-anniversary-emojis/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-wedding-anniversary-emojis.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/wedding-anniversary-emojis/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/whatsapp-symbols/index.html
+++ b/library/whatsapp-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-whatsapp-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/whatsapp-symbols/",
   "datePublished": "2026-06-12",
   "dateModified": "2026-06-12"

--- a/library/wirtz-emoji-combos/index.html
+++ b/library/wirtz-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-wirtz-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/wirtz-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/witchy-occult-symbols/index.html
+++ b/library/witchy-occult-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-witchy-occult-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/witchy-occult-symbols/",
   "datePublished": "2026-04-12",
   "dateModified": "2026-04-12"

--- a/library/world-cup-emoji-combos/index.html
+++ b/library/world-cup-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-world-cup-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/world-cup-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-16"

--- a/library/x-twitter-symbols/index.html
+++ b/library/x-twitter-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-x-twitter-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/x-twitter-symbols/",
   "datePublished": "2026-03-31",
   "dateModified": "2026-03-31"

--- a/library/y2k-symbols/index.html
+++ b/library/y2k-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-y2k-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/y2k-symbols/",
   "datePublished": "2026-04-26",
   "dateModified": "2026-06-27"

--- a/library/yamal-emoji-combos/index.html
+++ b/library/yamal-emoji-combos/index.html
@@ -51,6 +51,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-yamal-emoji-combos.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/yamal-emoji-combos/",
   "datePublished": "2026-06-14",
   "dateModified": "2026-06-14"

--- a/library/yin-yang-symbol/index.html
+++ b/library/yin-yang-symbol/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-yin-yang-symbol.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/yin-yang-symbol/",
   "datePublished": "2026-06-07",
   "dateModified": "2026-06-07"

--- a/library/zodiac-symbols/index.html
+++ b/library/zodiac-symbols/index.html
@@ -54,6 +54,7 @@
     "name": "UltraTextGen",
     "url": "https://ultratextgen.com/"
   },
+  "image": "https://ultratextgen.com/assets/og/library-zodiac-symbols.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/zodiac-symbols/",
   "datePublished": "2026-03-29",
   "dateModified": "2026-03-30"


### PR DESCRIPTION
Every library Article block was missing the recommended schema.org 'image' property. Backfill it from each page's existing per-page og:image asset (/assets/og/library-<slug>.png), all of which exist on disk. No other JSON-LD gaps found: BreadcrumbList, Article core fields, and the 11 FAQPage blocks all validate with correct URLs.


Claude-Session: https://claude.ai/code/session_011JtXDLDNT6zAz4HtkEwGY4