### PR TITLE
feat: add emphasis scope control (whole text / first line only)

### DIFF
--- a/script.js
+++ b/script.js
@@ -225,6 +225,16 @@ const decorations = window.UTG_DECORATIONS || {
   const SAVED_KEY = "utg_saved_styles";
   let savedStyles = loadSavedStyles();
 
+  // Emphasis scope — how much of the input gets styled. Persisted per device.
+  //   'whole'      → style the entire input (default; best for bios/usernames)
+  //   'first-line' → style only the first line, leave the rest plain text.
+  //                  This is the accessibility-friendly pattern for social
+  //                  posts: the hook stands out while the body stays plain
+  //                  (readable by search and screen readers).
+  const SCOPE_KEY = "utg_scope_pref";
+  const SCOPE_VALUES = ["whole", "first-line"];
+  let currentScope = loadScopePref();
+
   /* ===================
      ELEMENTS
      =================== */
@@ -265,6 +275,23 @@ const decorations = window.UTG_DECORATIONS || {
     }
   }
 
+  function loadScopePref() {
+    try {
+      const saved = localStorage.getItem(SCOPE_KEY);
+      return SCOPE_VALUES.indexOf(saved) !== -1 ? saved : "whole";
+    } catch (err) {
+      return "whole";
+    }
+  }
+
+  function persistScopePref() {
+    try {
+      localStorage.setItem(SCOPE_KEY, currentScope);
+    } catch (err) {
+      // Storage may be unavailable — fail silently
+    }
+  }
+
   function isSaved(name) {
     return savedStyles.indexOf(name) !== -1;
   }
@@ -293,6 +320,23 @@ const decorations = window.UTG_DECORATIONS || {
   function applyDecoration(text) {
     if (!selectedDecoration || !text) return text;
     return selectedDecoration.prefix + text + selectedDecoration.suffix;
+  }
+
+  // Render input through a style, honoring the current emphasis scope.
+  // 'first-line' styles only the first line and leaves the remaining lines as
+  // plain text — the recommended pattern for social posts (the hook pops while
+  // the body stays searchable and screen-reader friendly). Single-line input
+  // falls back to styling the whole thing.
+  function applyScope(text, style) {
+    if (!text || !Render || typeof Render.renderAny !== "function") return "";
+    if (currentScope === "first-line") {
+      const nlIndex = text.indexOf("\n");
+      if (nlIndex === -1) return Render.renderAny(text, style);
+      const firstLine = text.slice(0, nlIndex);
+      const rest = text.slice(nlIndex); // original newline(s) + body, untouched
+      return Render.renderAny(firstLine, style) + rest;
+    }
+    return Render.renderAny(text, style);
   }
 
    function isStyleInFamily(style, familyKey) {
@@ -621,6 +665,54 @@ const decorations = window.UTG_DECORATIONS || {
   }
 
   /* ===================
+     RENDER: Scope control
+     =================== */
+  // Lazily inject the "Apply style to" control row directly above the results
+  // grid. Injected from JS so it appears on every generator page without
+  // editing each HTML file (skipped on the dedicated vertical/zalgo pages,
+  // which run their own controllers).
+  function ensureScopeControl() {
+    if (window.UTG_VERTICAL_MODE || window.UTG_ZALGO_MODE) return null;
+    if (!el.resultsGrid) return null;
+
+    let control = $("#scopeControl");
+    if (control) return control;
+
+    const host = el.resultsGrid.parentElement;
+    if (!host) return null;
+
+    control = document.createElement("div");
+    control.className = "scope-control";
+    control.id = "scopeControl";
+    control.innerHTML = `
+      <span class="scope-control-label">Apply style to</span>
+      <div class="scope-chips" role="group" aria-label="Choose how much text to style">
+        <button class="scope-chip${currentScope === "whole" ? " active" : ""}" type="button" data-scope="whole">Whole text</button>
+        <button class="scope-chip${currentScope === "first-line" ? " active" : ""}" type="button" data-scope="first-line">First line only <span class="scope-chip-tag">for posts</span></button>
+      </div>
+    `;
+    host.insertBefore(control, el.resultsGrid);
+
+    $$(".scope-chip", control).forEach((chip) => {
+      chip.addEventListener("click", () => {
+        const scope = chip.getAttribute("data-scope");
+        if (!scope || scope === currentScope || SCOPE_VALUES.indexOf(scope) === -1) return;
+        currentScope = scope;
+        persistScopePref();
+        $$(".scope-chip", control).forEach((c) => c.classList.toggle("active", c === chip));
+
+        window.dataLayer = window.dataLayer || [];
+        window.dataLayer.push({ event: "set_scope", scope: currentScope });
+
+        renderSavedStyles();
+        renderResults();
+      });
+    });
+
+    return control;
+  }
+
+  /* ===================
      RENDER: Saved styles
      =================== */
   // Lazily build the "Your saved styles" section above the results grid.
@@ -691,8 +783,8 @@ const decorations = window.UTG_DECORATIONS || {
     valid.forEach((name) => {
       const style = stylesRegistry[name];
       let converted = "";
-      if (inputText && Render && typeof Render.renderAny === "function") {
-        converted = Render.renderAny(inputText, style);
+      if (inputText) {
+        converted = applyScope(inputText, style);
       }
       const decorated = converted ? applyDecoration(converted) : "";
       grid.appendChild(createStyleCard(name, converted, selectedDecoration ? decorated : null, style));
@@ -751,8 +843,8 @@ const decorations = window.UTG_DECORATIONS || {
 
     filtered.forEach(([name, style]) => {
       let converted = "";
-      if (inputText && Render && typeof Render.renderAny === "function") {
-        converted = Render.renderAny(inputText, style);
+      if (inputText) {
+        converted = applyScope(inputText, style);
       }
 
       const decorated = converted ? applyDecoration(converted) : "";
@@ -947,6 +1039,7 @@ document.addEventListener("copy", () => {
     }
 
     renderDecorations();
+    ensureScopeControl();
     renderSavedStyles();
 
     // Show skeleton placeholders while fonts.json loads

--- a/style.css
+++ b/style.css
@@ -428,6 +428,70 @@
       color: white;
     }
 
+    /* Scope control — "Apply style to" (whole text / first line only) */
+    .scope-control {
+      display: flex;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 10px;
+      margin: 4px 0 16px;
+    }
+
+    .scope-control-label {
+      font-size: 0.8125rem;
+      font-weight: 600;
+      color: var(--text-muted);
+    }
+
+    .scope-chips {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    .scope-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 8px 14px;
+      border-radius: 50px;
+      border: 1px solid var(--border-light);
+      background: var(--bg-white);
+      color: var(--text-secondary);
+      font-size: 0.8125rem;
+      font-weight: 500;
+      cursor: pointer;
+      transition: all 0.2s;
+    }
+
+    .scope-chip:hover {
+      border-color: var(--accent-purple);
+      color: var(--accent-purple);
+      background: rgba(139, 92, 246, 0.05);
+    }
+
+    .scope-chip.active {
+      background: var(--accent-purple);
+      border-color: var(--accent-purple);
+      color: #fff;
+    }
+
+    .scope-chip-tag {
+      font-size: 0.625rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      padding: 2px 6px;
+      border-radius: 50px;
+      background: rgba(139, 92, 246, 0.12);
+      color: var(--accent-purple);
+    }
+
+    .scope-chip.active .scope-chip-tag {
+      background: rgba(255, 255, 255, 0.22);
+      color: #fff;
+    }
+
     /* Results Grid */
     .results-grid {
       display: flex;


### PR DESCRIPTION
Adds a global "Apply style to" control row above the results grid on every generator page, mirroring the selector pattern used by the Zalgo and Vertical text pages.

- "Whole text" (default) styles the entire input — best for bios/usernames.
- "First line only" styles just the first line and leaves the body as plain text — the accessibility-friendly pattern for social posts (the hook pops while the body stays searchable and screen-reader readable).

Implementation:
- applyScope() wraps renderAny() and is used by both renderResults() and renderSavedStyles(), so the scope applies to every style card.
- Control is injected from script.js (ensureScopeControl) so it appears site-wide without editing each HTML page; skipped on vertical/zalgo pages which run their own controllers.
- Preference persists per device in localStorage (utg_scope_pref) and emits a set_scope dataLayer event for GTM.

Applies globally across bold/italic/underline/strikethrough emphasis styles. Selected-phrase scope (marker-based) is a planned fast-follow.


Claude-Session: https://claude.ai/code/session_01JYCa9bk2yq8SpzQzDSxzQ2