### PR TITLE
feat: add Indonesian "simbol aesthetic" symbol library page

### DIFF
--- a/id/library/simbol-aesthetic/index.html
+++ b/id/library/simbol-aesthetic/index.html
@@ -1,0 +1,552 @@
+<!DOCTYPE html>
+<html lang="id">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8242324164413945"
+       crossorigin="anonymous"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Simbol Aesthetic — Salin &amp; Tempel Simbol Keren &amp; Estetik</title>
+<meta name="description" content="Salin &amp; tempel simbol aesthetic untuk bio, nama, dan caption. Koleksi simbol huruf aesthetic, simbol keren, kilau, hati, bunga, dan pembatas — klik untuk menyalin.">
+
+<link rel="canonical" href="https://ultratextgen.com/id/library/simbol-aesthetic/">
+<link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/aesthetic-symbols/">
+<link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/aesthetic-symbols/">
+<link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-aesthetic/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/library-aesthetic-symbols.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Simbol Aesthetic — Salin &amp; Tempel Simbol Keren &amp; Estetik">
+<meta name="twitter:description" content="Salin &amp; tempel simbol aesthetic untuk bio, nama, dan caption. Simbol huruf aesthetic, simbol keren, kilau, hati, bunga, dan pembatas.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/library-aesthetic-symbols.png">
+<meta property="og:title" content="Simbol Aesthetic — Salin &amp; Tempel Simbol Keren &amp; Estetik">
+<meta property="og:description" content="Salin &amp; tempel simbol aesthetic untuk bio, nama, dan caption. Simbol huruf aesthetic, simbol keren, kilau, hati, bunga, dan pembatas.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/id/library/simbol-aesthetic/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Simbol Aesthetic — Salin & Tempel Simbol Keren & Estetik",
+  "alternateName": ["Simbol Aesthetic", "Simbol Huruf Aesthetic", "Simbol Keren Aesthetic", "Simbol Estetik", "Simbol Font Keren", "Simbol Aesthetic Copy Paste"],
+  "description": "Salin & tempel simbol aesthetic untuk bio, nama, dan caption. Koleksi simbol huruf aesthetic, simbol keren, kilau, hati, bunga, dan pembatas.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/library-aesthetic-symbols.png",
+  "mainEntityOfPage": "https://ultratextgen.com/id/library/simbol-aesthetic/",
+  "inLanguage": "id",
+  "datePublished": "2026-06-29",
+  "dateModified": "2026-06-29"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Beranda",
+      "item": "https://ultratextgen.com/id/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Simbol Aesthetic",
+      "item": "https://ultratextgen.com/id/library/simbol-aesthetic/"
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "name": "Simbol Aesthetic — Salin & Tempel Simbol Keren & Estetik",
+  "description": "Halaman koleksi simbol Unicode aesthetic. Berisi grid salin-tempel simbol kilau, hati, bunga, pembatas, dan kurung untuk bio, nama, dan caption.",
+  "url": "https://ultratextgen.com/id/library/simbol-aesthetic/",
+  "inLanguage": "id",
+  "isPartOf": {
+    "@type": "WebSite",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  }
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Apa itu simbol aesthetic?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Simbol aesthetic adalah karakter Unicode dekoratif — seperti kilau (✧ ⊹), hati (♡), bunga (❀), dan pembatas (✦──✦) — yang dipakai untuk mempercantik bio, nama, dan caption di Instagram, TikTok, WhatsApp, Discord, dan Twitter/X. Karakter ini bukan emoji biasa, melainkan simbol Unicode yang bisa langsung disalin dan ditempel."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Bagaimana cara memakai simbol huruf aesthetic?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Klik simbol mana pun di halaman ini untuk menyalinnya, lalu tempel di bio atau nama Anda. Untuk mengubah huruf biasa menjadi font aesthetic (huruf tebal, miring, atau gaya unik), gunakan generator tulisan aesthetic UltraTextGen, lalu tambahkan simbol dari halaman ini di depan atau belakang teks."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Di mana simbol aesthetic bisa ditempel?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Simbol aesthetic berfungsi di hampir semua platform yang mendukung Unicode: bio dan nama Instagram, TikTok, WhatsApp, Telegram, Discord, Facebook, dan Twitter/X. Karena ini karakter Unicode standar, simbol tampil sama untuk semua orang tanpa perlu aplikasi tambahan."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Apakah simbol aesthetic aman dan gratis?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ya. Simbol aesthetic hanyalah teks Unicode — tidak mengandung kode atau aplikasi, sepenuhnya aman, dan gratis untuk disalin dan ditempel sebanyak yang Anda mau. Beberapa simbol kombinasi (tanda kecil) mungkin tampil sedikit berbeda tergantung perangkat."
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<div id="shared-header"></div>
+<script src="/header.js"></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/id/">Beranda</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Simbol Aesthetic</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Simbol Aesthetic</h1>
+    <p class="hero-tagline">Koleksi simbol Unicode aesthetic untuk bio, nama, dan caption di Instagram, TikTok, WhatsApp, dan Discord. Klik simbol mana pun untuk langsung menyalinnya.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/library-aesthetic-symbols.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Simbol aesthetic adalah karakter Unicode yang dipakai untuk mempercantik <strong>bio, nama, dan caption</strong> di Instagram, TikTok, WhatsApp, Discord, dan Twitter/X. Di bawah ini ada kumpulan simbol keren siap salin-tempel — mulai dari kilau, hati, bunga, pembatas, sampai kurung. Ingin mengubah huruf biasa menjadi <a href="/id/">font huruf aesthetic</a> sekaligus? Padukan simbol di sini dengan generator tulisan aesthetic.</p>
+  </div>
+</section>
+
+<!-- QUICK PICK — paling sering disalin -->
+<section class="mood-explainers" id="quick-pick">
+  <span class="article-section-label">Pilihan cepat</span>
+  <h2>Simbol aesthetic paling sering dipakai</h2>
+  <p class="section-lead is-spaced">Kalau cuma butuh beberapa simbol cepat, mulai dari sini. Klik untuk menyalin.</p>
+  <div class="flag-rows symbol-pick-grid">
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="⋆" aria-label="Salin ⋆">⋆</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="✦" aria-label="Salin ✦">✦</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="✧" aria-label="Salin ✧">✧</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="⊹" aria-label="Salin ⊹">⊹</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="˚" aria-label="Salin ˚">˚</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="₊" aria-label="Salin ₊">₊</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="❀" aria-label="Salin ❀">❀</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="♡" aria-label="Salin ♡">♡</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="♥" aria-label="Salin ♥">♥</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="✿" aria-label="Salin ✿">✿</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="❁" aria-label="Salin ❁">❁</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="୨୧" aria-label="Salin ୨୧">୨୧</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="ʚɞ" aria-label="Salin ʚɞ">ʚɞ</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="𐙚" aria-label="Salin 𐙚">𐙚</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="⋆˚࿔" aria-label="Salin ⋆˚࿔">⋆˚࿔</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="✮" aria-label="Salin ✮">✮</button></div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- KILAU & BINTANG -->
+<section class="mood-explainers" id="simbol-kilau">
+  <span class="article-section-label">Kilau &amp; Bintang</span>
+  <h2>Simbol Kilau &amp; Bintang Aesthetic</h2>
+  <p class="u-secondary-tight">Simbol kilau dan bintang lembut yang populer di bio aesthetic dan gaya teks kawaii.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✧" aria-label="Salin ✧">✧</button>
+      <span class="flag-label">Bintang Empat Sudut Putih</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✦" aria-label="Salin ✦">✦</button>
+      <span class="flag-label">Bintang Empat Sudut Hitam</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊹" aria-label="Salin ⊹">⊹</button>
+      <span class="flag-label">Silang Ortogonal</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="₊" aria-label="Salin ₊">₊</button>
+      <span class="flag-label">Tanda Plus Kecil</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="˚" aria-label="Salin ˚">˚</button>
+      <span class="flag-label">Cincin di Atas</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✮" aria-label="Salin ✮">✮</button>
+      <span class="flag-label">Bintang Lingkaran Terbuka</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⋆" aria-label="Salin ⋆">⋆</button>
+      <span class="flag-label">Operator Bintang</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✯" aria-label="Salin ✯">✯</button>
+      <span class="flag-label">Bintang Pinwheel</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- HATI -->
+<section class="mood-explainers" id="simbol-hati">
+  <span class="article-section-label">Hati</span>
+  <h2>Simbol Hati Aesthetic</h2>
+  <p class="u-secondary-tight">Karakter hati lembut dan dekoratif yang populer di gaya aesthetic dan kawaii.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♡" aria-label="Salin ♡">♡</button>
+      <span class="flag-label">Hati Putih</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♥" aria-label="Salin ♥">♥</button>
+      <span class="flag-label">Hati Hitam</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❥" aria-label="Salin ❥">❥</button>
+      <span class="flag-label">Bulir Hati</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ʚɞ" aria-label="Salin ʚɞ">ʚɞ</button>
+      <span class="flag-label">Hati Sayap Mini</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="୨୧" aria-label="Salin ୨୧">୨୧</button>
+      <span class="flag-label">Hati Cermin Oriya</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𐙚" aria-label="Salin 𐙚">𐙚</button>
+      <span class="flag-label">Bintang Hati Coquette</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ෆ" aria-label="Salin ෆ">ෆ</button>
+      <span class="flag-label">Hati Sinhala</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- BUNGA & ALAM -->
+<section class="mood-explainers" id="simbol-bunga">
+  <span class="article-section-label">Bunga &amp; Alam</span>
+  <h2>Simbol Bunga &amp; Alam Aesthetic</h2>
+  <p class="u-secondary-tight">Simbol bunga dan alam untuk bio dan caption aesthetic yang lembut.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❀" aria-label="Salin ❀">❀</button>
+      <span class="flag-label">Florette Putih</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✿" aria-label="Salin ✿">✿</button>
+      <span class="flag-label">Florette Hitam</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❁" aria-label="Salin ❁">❁</button>
+      <span class="flag-label">Florette Bertitik</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✾" aria-label="Salin ✾">✾</button>
+      <span class="flag-label">Florette Enam Kelopak</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚘" aria-label="Salin ⚘">⚘</button>
+      <span class="flag-label">Bunga</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☘" aria-label="Salin ☘">☘</button>
+      <span class="flag-label">Semanggi</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓆸" aria-label="Salin 𓆸">𓆸</button>
+      <span class="flag-label">Teratai Mesir</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- GARIS & PEMBATAS -->
+<section class="mood-explainers" id="simbol-pembatas">
+  <span class="article-section-label">Garis &amp; Pembatas</span>
+  <h2>Simbol Garis &amp; Pembatas Aesthetic</h2>
+  <p class="u-secondary-tight">Garis pemisah dan pola pembatas untuk menyusun bio aesthetic yang rapi.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="──" aria-label="Salin ──">──</button>
+      <span class="flag-label">Garis Ganda</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✦──✦" aria-label="Salin ✦──✦">✦──✦</button>
+      <span class="flag-label">Bintang Garis Bintang</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="╌╌╌" aria-label="Salin ╌╌╌">╌╌╌</button>
+      <span class="flag-label">Garis Putus Tipis</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="∘∘∘" aria-label="Salin ∘∘∘">∘∘∘</button>
+      <span class="flag-label">Titik Cincin</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊱" aria-label="Salin ⊱">⊱</button>
+      <span class="flag-label">Ornamen Kanan</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊰" aria-label="Salin ⊰">⊰</button>
+      <span class="flag-label">Ornamen Kiri</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⋆˚࿔" aria-label="Salin ⋆˚࿔">⋆˚࿔</button>
+      <span class="flag-label">Pembatas Langit Mini</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- KURUNG & BINGKAI -->
+<section class="mood-explainers" id="simbol-kurung">
+  <span class="article-section-label">Kurung &amp; Bingkai</span>
+  <h2>Simbol Kurung &amp; Bingkai Aesthetic</h2>
+  <p class="u-secondary-tight">Kurung gaya Jepang dan CJK untuk membingkai bio dan nama aesthetic.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="【" aria-label="Salin 【">【</button>
+      <span class="flag-label">Kurung Lenticular Hitam Kiri</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="】" aria-label="Salin 】">】</button>
+      <span class="flag-label">Kurung Lenticular Hitam Kanan</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="「" aria-label="Salin 「">「</button>
+      <span class="flag-label">Kurung Sudut Kiri</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="」" aria-label="Salin 」">」</button>
+      <span class="flag-label">Kurung Sudut Kanan</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="『" aria-label="Salin 『">『</button>
+      <span class="flag-label">Kurung Sudut Putih Kiri</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="』" aria-label="Salin 』">』</button>
+      <span class="flag-label">Kurung Sudut Putih Kanan</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="꒰" aria-label="Salin ꒰">꒰</button>
+      <span class="flag-label">Kurung Ornamen Kiri</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="꒱" aria-label="Salin ꒱">꒱</button>
+      <span class="flag-label">Kurung Ornamen Kanan</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SIMBOL HALUS / MINIMAL -->
+<section class="mood-explainers" id="simbol-minimal">
+  <span class="article-section-label">Minimal &amp; Halus</span>
+  <h2>Simbol Minimal &amp; Aksen Halus</h2>
+  <p class="u-secondary-tight">Aksen titik kecil dan tanda halus bergaya Pinterest minimal. Sebagian adalah tanda kombinasi yang menempel pada karakter di depannya — coba dulu di aplikasi catatan untuk melihat hasilnya.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="࣪" aria-label="Salin ࣪">◌࣪</button>
+      <span class="flag-label">Titik Halus Arab</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="݁" aria-label="Salin ݁">◌݁</button>
+      <span class="flag-label">Titik di Atas Suryani</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊹" aria-label="Salin ⊹">⊹</button>
+      <span class="flag-label">Silang Halus</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="๑" aria-label="Salin ๑">๑</button>
+      <span class="flag-label">Karakter Thai Ko Kai</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⌒" aria-label="Salin ⌒">⌒</button>
+      <span class="flag-label">Busur</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="╭" aria-label="Salin ╭">╭</button>
+      <span class="flag-label">Busur Bawah-Kanan</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="╮" aria-label="Salin ╮">╮</button>
+      <span class="flag-label">Busur Atas-Kiri</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="◎" aria-label="Salin ◎">◎</button>
+      <span class="flag-label">Lingkaran Bidik</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- HURUF AESTHETIC CROSS-LINK -->
+<section class="editorial-section" id="huruf-aesthetic">
+  <span class="article-section-label">Simbol huruf aesthetic</span>
+  <h2>Mau huruf aesthetic juga, bukan cuma simbol?</h2>
+  <p class="section-lead">Simbol di atas untuk dekorasi. Untuk mengubah huruf biasa menjadi <strong>font huruf aesthetic</strong> — tebal, miring, kecil, atau gaya unik — ketik teks Anda di generator, lalu bingkai dengan simbol dari halaman ini.</p>
+  <div class="cta-card">
+    <h3>Buat tulisan &amp; font aesthetic</h3>
+    <p>Ubah teks biasa menjadi 100+ gaya font Unicode keren — gratis dan langsung jadi. Padukan dengan simbol aesthetic untuk bio yang menonjol.</p>
+    <a href="/id/" class="cta-btn">Buka Generator Tulisan Aesthetic →</a>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- FAQ -->
+<section class="editorial-section" id="faq">
+  <span class="article-section-label">FAQ</span>
+  <h2>Simbol aesthetic, dijawab</h2>
+  <details class="faq-item">
+    <summary class="faq-question">Apa itu simbol aesthetic?</summary>
+    <p class="faq-answer">Simbol aesthetic adalah karakter Unicode dekoratif — seperti kilau (✧ ⊹), hati (♡), bunga (❀), dan pembatas (✦──✦) — yang dipakai untuk mempercantik bio, nama, dan caption di Instagram, TikTok, WhatsApp, Discord, dan Twitter/X. Karakter ini bukan emoji biasa, melainkan simbol Unicode yang bisa langsung disalin dan ditempel.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">Bagaimana cara memakai simbol huruf aesthetic?</summary>
+    <p class="faq-answer">Klik simbol mana pun di halaman ini untuk menyalinnya, lalu tempel di bio atau nama Anda. Untuk mengubah huruf biasa menjadi font aesthetic (huruf tebal, miring, atau gaya unik), gunakan <a href="/id/">generator tulisan aesthetic</a> UltraTextGen, lalu tambahkan simbol dari halaman ini di depan atau belakang teks.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">Di mana simbol aesthetic bisa ditempel?</summary>
+    <p class="faq-answer">Simbol aesthetic berfungsi di hampir semua platform yang mendukung Unicode: bio dan nama Instagram, TikTok, WhatsApp, Telegram, Discord, Facebook, dan Twitter/X. Karena ini karakter Unicode standar, simbol tampil sama untuk semua orang tanpa perlu aplikasi tambahan.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">Apakah simbol aesthetic aman dan gratis?</summary>
+    <p class="faq-answer">Ya. Simbol aesthetic hanyalah teks Unicode — tidak mengandung kode atau aplikasi, sepenuhnya aman, dan gratis untuk disalin dan ditempel sebanyak yang Anda mau. Beberapa simbol kombinasi (tanda kecil) mungkin tampil sedikit berbeda tergantung perangkat.</p>
+  </details>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- COLLECTIONS -->
+<section class="mood-explainers" id="simbol-aesthetic-collections">
+  <span class="article-section-label">Set Aesthetic</span>
+  <h2>Set Simbol untuk Bio &amp; Nama</h2>
+  <p class="u-secondary-block">Rangkaian simbol aesthetic siap tempel ke bio, nama, atau caption — salin satu kombo sekaligus dengan satu klik.</p>
+  <div id="aestheticCollectionsContainer"></div>
+</section>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Halaman Terkait</span>
+  <div class="compare-grid">
+    <a href="/id/" class="compare-card variant-muted u-no-underline">
+      <h4>Generator Tulisan Aesthetic</h4>
+      <p>Ubah teks biasa menjadi font huruf aesthetic, keren, dan unik — gratis dan langsung jadi.</p>
+    </a>
+    <a href="/id/usecase/zalgo-text/" class="compare-card variant-muted u-no-underline">
+      <h4>Generator Teks Zalgo</h4>
+      <p>Buat teks glitch dan menyeramkan dengan tanda Unicode kombinasi.</p>
+    </a>
+    <a href="/id/usecase/nama-ml-keren/" class="compare-card variant-muted u-no-underline">
+      <h4>Nama ML Keren</h4>
+      <p>Generator nama Mobile Legends keren dengan font dan simbol unik.</p>
+    </a>
+    <a href="/id/usecase/nama-ff-keren/" class="compare-card variant-muted u-no-underline">
+      <h4>Nama FF Keren</h4>
+      <p>Generator nama Free Fire keren dengan huruf dan simbol estetik.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js"></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    { name: "Bio Kilau Lembut", flags: ["⊹","˚","₊","✧","₊","˚","⊹"], defaultFormat: "inline" },
+    { name: "Kombo Hati Coquette", flags: ["୨୧","♡","ʚɞ","♡","୨୧"], defaultFormat: "inline" },
+    { name: "Set Bunga Florette", flags: ["❀","✿","❁","✾","❀"], defaultFormat: "inline" },
+    { name: "Pembatas Bintang", flags: ["✦──✦"], defaultFormat: "inline" },
+    { name: "Aksen Titik Minimal", flags: ["⊰","∘","⋆","✦","⋆","∘","⊱"], defaultFormat: "inline" },
+    { name: "Tag Nama Langit", flags: ["⋆˚࿔","✧","˚","⋆"], defaultFormat: "inline" }
+  ];
+
+  ns.buildGrids("aestheticCollectionsContainer", GROUPS);
+  ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js"></script>
+</body>
+</html>

--- a/library/aesthetic-symbols/index.html
+++ b/library/aesthetic-symbols/index.html
@@ -18,6 +18,9 @@
 <meta name="description" content="Copy &amp; paste aesthetic symbols for bios, usernames, and captions. Browse by aesthetic — coquette, cottagecore, kawaii, y2k, goth, whisper, and more.">
 
 <link rel="canonical" href="https://ultratextgen.com/library/aesthetic-symbols/">
+<link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/aesthetic-symbols/">
+<link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/aesthetic-symbols/">
+<link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-aesthetic/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/library-aesthetic-symbols.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -10,21 +10,21 @@
 
   <url>
     <loc>https://ultratextgen.com/about/</loc>
-    <lastmod>2026-06-13</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/answers/</loc>
-    <lastmod>2026-06-13</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/answers/change-font-size-on-facebook/</loc>
-    <lastmod>2026-06-13</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -45,42 +45,42 @@
 
   <url>
     <loc>https://ultratextgen.com/answers/how-to-change-roblox-username/</loc>
-    <lastmod>2026-06-13</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/answers/how-to-change-tiktok-username/</loc>
-    <lastmod>2026-06-13</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/answers/is-linkedin-bold-text-safe/</loc>
-    <lastmod>2026-06-13</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/answers/what-font-does-discord-use/</loc>
-    <lastmod>2026-06-13</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/answers/what-font-does-facebook-use/</loc>
-    <lastmod>2026-06-13</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/answers/what-font-does-linkedin-use/</loc>
-    <lastmod>2026-06-13</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -94,49 +94,49 @@
 
   <url>
     <loc>https://ultratextgen.com/answers/what-is-a-tiktok-handle/</loc>
-    <lastmod>2026-06-13</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/category/</loc>
-    <lastmod>2026-06-13</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/category/aesthetic-fonts/</loc>
-    <lastmod>2026-06-14</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/category/bold-fonts/</loc>
-    <lastmod>2026-06-14</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/category/bold-fonts/alternating/</loc>
-    <lastmod>2026-06-14</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/category/bold-fonts/bold-italic/</loc>
-    <lastmod>2026-06-14</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/category/bold-fonts/bold/</loc>
-    <lastmod>2026-06-14</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -150,14 +150,14 @@
 
   <url>
     <loc>https://ultratextgen.com/category/bubble-fonts/circle/</loc>
-    <lastmod>2026-06-14</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/category/classified/</loc>
-    <lastmod>2026-06-14</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -171,77 +171,77 @@
 
   <url>
     <loc>https://ultratextgen.com/category/cursive-fonts/script/</loc>
-    <lastmod>2026-06-14</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/category/cute-fonts/</loc>
-    <lastmod>2026-06-14</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/category/gothic-fonts/</loc>
-    <lastmod>2026-06-14</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/category/gothic-fonts/fraktur/</loc>
-    <lastmod>2026-06-14</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/category/italic-fonts/</loc>
-    <lastmod>2026-06-14</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/category/small-text/</loc>
-    <lastmod>2026-06-14</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/category/strikethrough-text/</loc>
-    <lastmod>2026-06-14</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/category/underline-text/</loc>
-    <lastmod>2026-06-14</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/category/upside-down-text/</loc>
-    <lastmod>2026-06-14</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/category/word-wrappers/</loc>
-    <lastmod>2026-06-14</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/contact/</loc>
-    <lastmod>2026-06-13</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -255,7 +255,7 @@
 
   <url>
     <loc>https://ultratextgen.com/de/usecase/zalgo-text/</loc>
-    <lastmod>2026-06-13</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -269,7 +269,7 @@
 
   <url>
     <loc>https://ultratextgen.com/embed/linkedin-headline-generator/</loc>
-    <lastmod>2026-06-13</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -283,14 +283,14 @@
 
   <url>
     <loc>https://ultratextgen.com/es/usecase/zalgo-text/</loc>
-    <lastmod>2026-06-13</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/facebook/</loc>
-    <lastmod>2026-06-14</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -304,7 +304,7 @@
 
   <url>
     <loc>https://ultratextgen.com/fr/usecase/zalgo-text/</loc>
-    <lastmod>2026-06-13</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -318,14 +318,14 @@
 
   <url>
     <loc>https://ultratextgen.com/guide/branding-with-fonts-for-social-media/</loc>
-    <lastmod>2026-06-07</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/guide/comments-that-stand-out/</loc>
-    <lastmod>2026-06-07</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -353,42 +353,42 @@
 
   <url>
     <loc>https://ultratextgen.com/guide/linkedin-comments-guide/</loc>
-    <lastmod>2026-06-07</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/guide/personal-branding-through-typography/</loc>
-    <lastmod>2026-06-07</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/guide/stop-the-scroll-with-font-variation/</loc>
-    <lastmod>2026-06-07</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/guide/style-linkedin-hooks-to-stand-out/</loc>
-    <lastmod>2026-06-07</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/guide/the-rhetoric-of-fonts/</loc>
-    <lastmod>2026-06-07</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/guide/vertical-text-guide/</loc>
-    <lastmod>2026-06-07</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -405,6 +405,13 @@
     <lastmod>2026-06-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/id/library/simbol-aesthetic/</loc>
+    <lastmod>2026-06-29</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
   </url>
 
   <url>
@@ -437,7 +444,7 @@
 
   <url>
     <loc>https://ultratextgen.com/id/usecase/zalgo-text/</loc>
-    <lastmod>2026-06-13</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -458,14 +465,14 @@
 
   <url>
     <loc>https://ultratextgen.com/it/usecase/zalgo-text/</loc>
-    <lastmod>2026-06-13</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/library/</loc>
-    <lastmod>2026-06-16</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -2215,21 +2222,21 @@
 
   <url>
     <loc>https://ultratextgen.com/nl/</loc>
-    <lastmod>2026-06-13</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/nl/usecase/zalgo-text/</loc>
-    <lastmod>2026-06-13</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/pinterest/</loc>
-    <lastmod>2026-06-14</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -2243,14 +2250,14 @@
 
   <url>
     <loc>https://ultratextgen.com/pl/usecase/zalgo-text/</loc>
-    <lastmod>2026-06-13</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/privacy/</loc>
-    <lastmod>2026-06-13</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -2264,21 +2271,21 @@
 
   <url>
     <loc>https://ultratextgen.com/pt/usecase/zalgo-text/</loc>
-    <lastmod>2026-06-13</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/roblox/</loc>
-    <lastmod>2026-06-14</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/roblox/name-generator/</loc>
-    <lastmod>2026-06-14</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -2292,49 +2299,49 @@
 
   <url>
     <loc>https://ultratextgen.com/telegram/</loc>
-    <lastmod>2026-06-14</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/terms/</loc>
-    <lastmod>2026-06-13</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/tiktok/</loc>
-    <lastmod>2026-06-14</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/tiktok/name-generator/</loc>
-    <lastmod>2026-06-14</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/tiktok/what-font-does-tiktok-use/</loc>
-    <lastmod>2026-06-13</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/tr/</loc>
-    <lastmod>2026-06-13</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/tr/usecase/zalgo-text/</loc>
-    <lastmod>2026-06-13</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -2348,7 +2355,7 @@
 
   <url>
     <loc>https://ultratextgen.com/usecase/before-after-emoji/</loc>
-    <lastmod>2026-06-14</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -2369,14 +2376,14 @@
 
   <url>
     <loc>https://ultratextgen.com/usecase/comment-font/</loc>
-    <lastmod>2026-06-13</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/usecase/emoji-combinations/</loc>
-    <lastmod>2026-06-14</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -2390,14 +2397,14 @@
 
   <url>
     <loc>https://ultratextgen.com/usecase/linkedin-headline/</loc>
-    <lastmod>2026-06-14</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/usecase/linkedin-headline/embed/</loc>
-    <lastmod>2026-05-31</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -2411,7 +2418,7 @@
 
   <url>
     <loc>https://ultratextgen.com/usecase/text-to-emoji/</loc>
-    <lastmod>2026-06-14</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -2439,14 +2446,14 @@
 
   <url>
     <loc>https://ultratextgen.com/vi/usecase/zalgo-text/</loc>
-    <lastmod>2026-06-13</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/whatsapp/</loc>
-    <lastmod>2026-06-14</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -2460,21 +2467,21 @@
 
   <url>
     <loc>https://ultratextgen.com/youtube/</loc>
-    <lastmod>2026-06-14</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/youtube/name-generator/</loc>
-    <lastmod>2026-06-14</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/youtube/what-font-does-youtube-use/</loc>
-    <lastmod>2026-06-13</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>


### PR DESCRIPTION
Adds /id/library/simbol-aesthetic/ targeting ~3,000 monthly impressions of uncovered Indonesian demand (simbol aesthetic, simbol huruf aesthetic, simbol keren aesthetic) that currently only ranks via the /id/ homepage.

- New ID copy-paste symbol library mirroring library/aesthetic-symbols: kilau, hati, bunga, pembatas, kurung, and minimal sections
- Full ID localization with Article/Breadcrumb/WebPage/FAQ JSON-LD
- Reciprocal hreflang pair between EN and new ID page
- Cross-links to /id/ generator for "simbol huruf aesthetic" font intent
- Sitemap regenerated via npm run prebuild


Claude-Session: https://claude.ai/code/session_013qkuWD2d5oFY9w7SxdtVDP