### PR TITLE
feat: rebuild gothic hub + add Old English page (Phase 1)

### DIFF
--- a/category/gothic-fonts/index.html
+++ b/category/gothic-fonts/index.html
@@ -115,6 +115,22 @@
         "@type": "Answer",
         "text": "Simply type or paste your text into UltraTextGen, select a Gothic style such as bold, symbolic, or tattoo-inspired, and click generate. Your styled text appears instantly. <br><br> <strong>Example</strong><br> Typing \"Dark Vibes\" might produce 𝔇𝔞𝔯𝔨 𝔙𝔦𝔟𝔢𝔰 — ready to copy and paste anywhere."
       }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the difference between Gothic and Old English fonts?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "They overlap. \"Gothic\" is the broad family of medieval blackletter scripts (Textura, Fraktur, Schwabacher). \"Old English\" usually means the heavy, high-contrast blackletter weight used on tattoos, sports jerseys, and newspaper mastheads — the bold 𝕺𝖑𝖉 𝕰𝖓𝖌𝖑𝖎𝖘𝖍 look. In Unicode they share the same glyph blocks, so this generator produces both. For the chunky tattoo/jersey style specifically, use the dedicated Old English font generator."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I make gothic numbers?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes, with one caveat: true blackletter digits do not exist in Unicode — the Fraktur block only covers letters. When you type numbers here they are paired with bold digits (𝟎𝟏𝟐𝟑𝟒𝟓𝟔𝟕𝟖𝟗), the closest heavy match, so they don't fall back to plain text. Genuine ornate blackletter numerals only exist as drawn lettering or image fonts, which copy-paste Unicode cannot reproduce."
+      }
     }
   ]
 }
@@ -205,13 +221,11 @@
             Add decoration to results
        </div>
     <div class="decoration-tabs">
-    <button class="decoration-tab active" data-deco-tab="symbols">Symbols</button>
+    <button class="decoration-tab active" data-deco-tab="crosses">Crosses</button>
+    <button class="decoration-tab" data-deco-tab="occult">Occult</button>
+    <button class="decoration-tab" data-deco-tab="runes">Runes</button>
     <button class="decoration-tab" data-deco-tab="frames">Frames</button>
     <button class="decoration-tab" data-deco-tab="dividers">Dividers</button>
-    <button class="decoration-tab" data-deco-tab="arrows">Arrows</button>
-    <button class="decoration-tab" data-deco-tab="minimal">Minimal</button>
-    <button class="decoration-tab" data-deco-tab="emojis">Emojis</button>
-    <button class="decoration-tab" data-deco-tab="flags">Flags</button>
       </div>
           <div class="decoration-grid" id="decorationGrid"></div>
         </div>
@@ -240,6 +254,101 @@
     
     <!-- Results -->
     <div class="results-grid" id="resultsGrid"></div>
+
+    <!-- ============================================================
+         UNIQUE EDITORIAL CONTENT (indexing + JTBD coverage)
+         ============================================================ -->
+    <section class="editorial-section">
+      <h2>Gothic, Fraktur &amp; Blackletter — what you're copying</h2>
+      <p>
+        Type anything above and this generator rewrites it in <strong>blackletter</strong> —
+        the dense, angular medieval script people mean by "gothic font." It isn't a
+        downloaded typeface; it's real <strong>Unicode</strong>, so the styled text pastes
+        straight into Instagram, TikTok, Discord, X, a gaming username, or a YouTube title
+        and keeps its look with nothing to install.
+      </p>
+      <p>
+        There are two base blackletter alphabets in Unicode and four decorated variants built
+        from them, so you get six distinct gothic looks in one place — from a light scholarly
+        <span lang="und">𝔉𝔯𝔞𝔨𝔱𝔲𝔯</span> to a heavy <span lang="und">𝕺𝖑𝖉 𝕰𝖓𝖌𝖑𝖎𝖘𝖍</span> tattoo
+        weight. Looking specifically for the chunky Old English / Olde English style used on
+        jerseys, name tattoos and varsity lettering? See the dedicated
+        <a href="/category/old-english-fonts/">Old English font generator</a>.
+      </p>
+    </section>
+
+    <section class="editorial-section">
+      <h2>Every gothic letter, A to Z</h2>
+      <p class="glyph-sub">
+        The full blackletter alphabet for the two base styles — copy a single letter, or type
+        a word above to style the whole thing.
+      </p>
+      <div class="gothic-charts">
+        <div class="glyph-chart">
+          <h3>Fraktur — 𝔊𝔬𝔱𝔥𝔦𝔠</h3>
+          <p class="glyph-sub">The classic medieval blackletter. Lighter, scholarly, German-manuscript feel.</p>
+          <div class="glyph-row">𝔄 𝔅 ℭ 𝔇 𝔈 𝔉 𝔊 ℌ ℑ 𝔍 𝔎 𝔏 𝔐 𝔑 𝔒 𝔓 𝔔 ℜ 𝔖 𝔗 𝔘 𝔙 𝔚 𝔛 𝔜 ℨ</div>
+          <div class="glyph-row">𝔞 𝔟 𝔠 𝔡 𝔢 𝔣 𝔤 𝔥 𝔦 𝔧 𝔨 𝔩 𝔪 𝔫 𝔬 𝔭 𝔮 𝔯 𝔰 𝔱 𝔲 𝔳 𝔴 𝔵 𝔶 𝔷</div>
+          <div class="glyph-row">𝟎 𝟏 𝟐 𝟑 𝟒 𝟓 𝟔 𝟕 𝟖 𝟗</div>
+        </div>
+        <div class="glyph-chart">
+          <h3>Bold Fraktur / Old English — 𝕲𝖔𝖙𝖍𝖎𝖈</h3>
+          <p class="glyph-sub">The heavy, high-contrast weight — the "Old English" look used for tattoos and jerseys.</p>
+          <div class="glyph-row">𝕬 𝕭 𝕮 𝕯 𝕰 𝕱 𝕲 𝕳 𝕴 𝕵 𝕶 𝕷 𝕸 𝕹 𝕺 𝕻 𝕼 𝕽 𝕾 𝕿 𝖀 𝖁 𝖂 𝖃 𝖄 𝖅</div>
+          <div class="glyph-row">𝖆 𝖇 𝖈 𝖉 𝖊 𝖋 𝖌 𝖍 𝖎 𝖏 𝖐 𝖑 𝖒 𝖓 𝖔 𝖕 𝖖 𝖗 𝖘 𝖙 𝖚 𝖛 𝖜 𝖝 𝖞 𝖟</div>
+          <div class="glyph-row">𝟎 𝟏 𝟐 𝟑 𝟒 𝟓 𝟔 𝟕 𝟖 𝟗</div>
+        </div>
+      </div>
+    </section>
+
+    <section class="editorial-section">
+      <h2>Six gothic styles in one generator</h2>
+      <div class="editorial-grid">
+        <div class="style-card"><p class="style-preview">𝔊𝔬𝔱𝔥𝔦𝔠</p><p>Fraktur — the classic blackletter</p></div>
+        <div class="style-card"><p class="style-preview">𝕲𝖔𝖙𝖍𝖎𝖈</p><p>Bold Fraktur / Old English weight</p></div>
+        <div class="style-card"><p class="style-preview">𝔊̲𝔬̲𝔱̲𝔥̲𝔦̲𝔠̲</p><p>Gothic Underline</p></div>
+        <div class="style-card"><p class="style-preview">✝ 𝕲𝖔𝖙𝖍𝖎𝖈 ✝</p><p>Gothic + Cross (bible-verse / memorial)</p></div>
+        <div class="style-card"><p class="style-preview">⛧ 𝔊𝔬𝔱𝔥𝔦𝔠 ⛧</p><p>Gothic Occult (goth / metal)</p></div>
+        <div class="style-card"><p class="style-preview">𝔊̶𝔬̶𝔱̶𝔥̶𝔦̶𝔠̶</p><p>Gothic Strikethrough (grunge)</p></div>
+      </div>
+    </section>
+
+    <section class="editorial-section">
+      <h2>Gothic numbers (0–9)</h2>
+      <p>
+        A heads-up most generators skip: <strong>true blackletter digits don't exist in
+        Unicode</strong> — the Fraktur block only covers A–Z and a–z. So when you type
+        numbers here, we pair them with the closest heavy match — bold digits — instead of
+        dropping back to plain text:
+      </p>
+      <div class="glyph-row">𝟎 𝟏 𝟐 𝟑 𝟒 𝟓 𝟔 𝟕 𝟖 𝟗</div>
+      <p>
+        Great for dates, jersey numbers, and "<span lang="und">𝟒𝟒𝟒</span>"-style bios. If you
+        need genuine ornate blackletter numerals (for a tattoo stencil, say), those only exist
+        as drawn lettering or image fonts — copy-paste Unicode can't reproduce them.
+      </p>
+    </section>
+
+    <section class="editorial-section">
+      <h2>Will gothic text show up on your device?</h2>
+      <p>
+        The #1 gothic complaint is boxes or squares (□□□) — that happens when a device is
+        missing the blackletter glyphs. This checks, live on your current device, which styles
+        render cleanly before you paste them somewhere public:
+      </p>
+      <div class="gothic-compat" id="gothicCompat"></div>
+    </section>
+
+    <section class="editorial-section">
+      <h2>Types of gothic lettering</h2>
+      <p>"Gothic" covers a family of medieval blackletter scripts. The main ones:</p>
+      <div class="editorial-grid">
+        <div class="style-card"><h3>Textura</h3><p>The earliest, tightest form — narrow, uniform vertical strokes. The "spiky" cathedral look.</p></div>
+        <div class="style-card"><h3>Fraktur</h3><p>German blackletter with "broken" curves. The classic <span lang="und">𝔊𝔬𝔱𝔥𝔦𝔠</span> alphabet on this page.</p></div>
+        <div class="style-card"><h3>Schwabacher</h3><p>Rounder, bolder cousin of Fraktur — heavy and decorative.</p></div>
+        <div class="style-card"><h3>Old English</h3><p>The chunky tattoo / jersey / newspaper-masthead style. <a href="/category/old-english-fonts/">Old English generator →</a></p></div>
+      </div>
+    </section>
   </main>
 
   <!-- Footer -->
@@ -297,6 +406,39 @@
     Textura — the earliest form, known for its tight, uniform vertical strokes.
     <br><br>
     UltraTextGen offers variations like bold Gothic (𝕲𝖔𝖙𝖍𝖎𝖈), symbolic styles, and tattoo-inspired scripts to match your vibe.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    What is the difference between Gothic and Old English fonts?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer">
+    They overlap. "Gothic" is the broad family of medieval blackletter scripts (Textura, Fraktur, Schwabacher).
+    "Old English" usually means the heavy, high-contrast blackletter weight used on tattoos, sports jerseys, and
+    newspaper mastheads — the bold 𝕺𝖑𝖉 𝕰𝖓𝖌𝖑𝖎𝖘𝖍 look.
+    In Unicode they share the same glyph blocks, so this generator produces both.
+    <br><br>
+    For the chunky tattoo/jersey style specifically, use the dedicated <a href="/category/old-english-fonts/">Old English font generator</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Can I make gothic numbers?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer">
+    Yes, with one caveat: true blackletter digits do not exist in Unicode — the Fraktur block only covers letters.
+    When you type numbers here they are paired with bold digits (𝟎𝟏𝟐𝟑𝟒𝟓𝟔𝟕𝟖𝟗), the closest heavy match,
+    so they don't fall back to plain text.
+    <br><br>
+    Genuine ornate blackletter numerals only exist as drawn lettering or image fonts, which copy-paste Unicode cannot reproduce.
   </div>
 </div>
 
@@ -427,14 +569,70 @@
     </div>
   </footer>
 
-  <!-- Category filter -->
+  <!-- Category filter + gothic-themed decorations -->
   <script>
     window.UTG_FAMILY = "gothic";
+    window.UTG_DEFAULT_DECO_TAB = "crosses";
+    window.UTG_DECORATIONS = {
+      crosses: [
+        { text: "✝ text ✝", prefix: "✝ ", suffix: " ✝" },
+        { text: "✟ text ✟", prefix: "✟ ", suffix: " ✟" },
+        { text: "☩ text ☩", prefix: "☩ ", suffix: " ☩" },
+        { text: "☦ text ☦", prefix: "☦ ", suffix: " ☦" },
+        { text: "✠ text ✠", prefix: "✠ ", suffix: " ✠" },
+        { text: "✚ text ✚", prefix: "✚ ", suffix: " ✚" },
+        { text: "♰ text ♰", prefix: "♰ ", suffix: " ♰" },
+        { text: "♱ text ♱", prefix: "♱ ", suffix: " ♱" },
+        { text: "† text †", prefix: "† ", suffix: " †" },
+        { text: "‡ text ‡", prefix: "‡ ", suffix: " ‡" }
+      ],
+      occult: [
+        { text: "⛧ text ⛧", prefix: "⛧ ", suffix: " ⛧" },
+        { text: "𖤐 text 𖤐", prefix: "𖤐 ", suffix: " 𖤐" },
+        { text: "☠ text ☠", prefix: "☠ ", suffix: " ☠" },
+        { text: "⚰ text ⚰", prefix: "⚰ ", suffix: " ⚰" },
+        { text: "☽ text ☾", prefix: "☽ ", suffix: " ☾" },
+        { text: "⛤ text ⛤", prefix: "⛤ ", suffix: " ⛤" },
+        { text: "☥ text ☥", prefix: "☥ ", suffix: " ☥" },
+        { text: "⚱ text ⚱", prefix: "⚱ ", suffix: " ⚱" },
+        { text: "𓆩 text 𓆪", prefix: "𓆩 ", suffix: " 𓆪" },
+        { text: "♆ text ♆", prefix: "♆ ", suffix: " ♆" }
+      ],
+      runes: [
+        { text: "ᚱ text ᚱ", prefix: "ᚱ ", suffix: " ᚱ" },
+        { text: "ᚢ text ᚢ", prefix: "ᚢ ", suffix: " ᚢ" },
+        { text: "ᚾ text ᚾ", prefix: "ᚾ ", suffix: " ᚾ" },
+        { text: "ᚦ text ᚦ", prefix: "ᚦ ", suffix: " ᚦ" },
+        { text: "ᛟ text ᛟ", prefix: "ᛟ ", suffix: " ᛟ" },
+        { text: "ᛉ text ᛉ", prefix: "ᛉ ", suffix: " ᛉ" },
+        { text: "ᚨ text ᚨ", prefix: "ᚨ ", suffix: " ᚨ" },
+        { text: "ᛊ text ᛊ", prefix: "ᛊ ", suffix: " ᛊ" }
+      ],
+      frames: [
+        { text: "꧁ text ꧂", prefix: "꧁ ", suffix: " ꧂" },
+        { text: "༺ text ༻", prefix: "༺ ", suffix: " ༻" },
+        { text: "【 text 】", prefix: "【 ", suffix: " 】" },
+        { text: "❰ text ❱", prefix: "❰ ", suffix: " ❱" },
+        { text: "⟬ text ⟭", prefix: "⟬ ", suffix: " ⟭" },
+        { text: "☩ text ☩", prefix: "☩ ", suffix: " ☩" },
+        { text: "「 text 」", prefix: "「 ", suffix: " 」" },
+        { text: "⸉ text ⸊", prefix: "⸉ ", suffix: " ⸊" }
+      ],
+      dividers: [
+        { text: "✝═══ text ═══✝", prefix: "✝═══ ", suffix: " ═══✝" },
+        { text: "⛧─── text ───⛧", prefix: "⛧─── ", suffix: " ───⛧" },
+        { text: "†•••• text ••••†", prefix: "†•••• ", suffix: " ••••†" },
+        { text: "═══ text ═══", prefix: "═══ ", suffix: " ═══" },
+        { text: "⸸━━ text ━━⸸", prefix: "⸸━━ ", suffix: " ━━⸸" },
+        { text: "♰ ═══ text ═══ ♰", prefix: "♰ ═══ ", suffix: " ═══ ♰" }
+      ]
+    };
   </script>
 
   <script src="/styles.js"></script>
 <script src="/renderer.js"></script>
 <script src="/script.js" defer=""></script>
+<script src="/gothic-tools.js" defer=""></script>
 
 
 

--- a/category/index.html
+++ b/category/index.html
@@ -344,6 +344,31 @@
       <a class="cat-cta" href="/category/gothic-fonts/">Open Gothic Fonts Generator →</a>
     </div>
 
+    <!-- Old English Fonts -->
+    <div class="style-card cat-anchor" id="cat-old-english" style="flex-direction:column;align-items:stretch;gap:12px;">
+      <div class="style-name">
+        <span class="style-tag">𝕺</span>
+        Old English Fonts
+      </div>
+      <div class="style-preview">
+        The heavy blackletter weight used for name tattoos, sports jerseys, and the famous "Old English D." Ornate, established, and built to be read at scale.
+      </div>
+      <p style="font-size:0.875rem;color:var(--text-secondary);line-height:1.6;margin:0;">
+        <strong>Signals:</strong> heritage, permanence, craft.
+        Best for tattoo previews, jersey lettering, chicano/streetwear graphics, logos, and monograms.
+      </p>
+      <div class="platform-pills">
+        <span class="platform-pill">Name tattoos</span>
+        <span class="platform-pill">Jerseys</span>
+        <span class="platform-pill">Monograms</span>
+        <span class="platform-pill">Logos</span>
+      </div>
+      <div class="block-example">
+        <strong>Example:</strong> "hello" → 𝖍𝖊𝖑𝖑𝖔 (Old English) — chunky and heritage.
+      </div>
+      <a class="cat-cta" href="/category/old-english-fonts/">Open Old English Fonts Generator →</a>
+    </div>
+
     <!-- Bubble Fonts -->
     <div class="style-card cat-anchor" id="cat-bubble" style="flex-direction:column;align-items:stretch;gap:12px;">
       <div class="style-name">

--- a/category/old-english-fonts/index.html
+++ b/category/old-english-fonts/index.html
@@ -1,0 +1,414 @@
+<!DOCTYPE html><html lang="en"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8242324164413945"
+       crossorigin="anonymous"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Old English Font Generator — Blackletter Text for Tattoos &amp; Names | UltraTextGen</title>
+  <meta name="description" content="Old English font generator. Copy and paste blackletter text for name tattoos, sports jerseys, the Old English D, chicano lettering, and band logos. Free, no download.">
+  <link rel="canonical" href="https://ultratextgen.com/category/old-english-fonts/">
+  <meta property="og:title" content="Old English Font Generator — Blackletter Text for Tattoos &amp; Names | UltraTextGen">
+  <meta property="og:description" content="Copy and paste Old English blackletter text for name tattoos, jerseys, the Old English D, and chicano lettering. Free, no download.">
+  <meta property="og:url" content="https://ultratextgen.com/category/old-english-fonts/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category-gothic-fonts.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Old English Font Generator — Blackletter Text for Tattoos &amp; Names | UltraTextGen">
+  <meta name="twitter:description" content="Copy and paste Old English blackletter text for name tattoos, jerseys, the Old English D, and chicano lettering.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category-gothic-fonts.png">
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Is Old English the same as a gothic font?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "They are closely related. \"Gothic\" is the broad family of medieval blackletter scripts (Textura, Fraktur, Schwabacher). \"Old English\" usually refers to the heavy, high-contrast blackletter weight — the look used on tattoos, sports jerseys, certificates, and newspaper mastheads. In Unicode they share the same character blocks, so this generator produces the bold 𝕺𝖑𝖉 𝕰𝖓𝖌𝖑𝖎𝖘𝖍 style as well as a lighter Fraktur. For the wider family of dark/medieval styles, see the Gothic font generator."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the Old English D?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The \"Old English D\" is the single blackletter capital D (𝕯) made famous by the Detroit Tigers cap and widely used in tattoos and streetwear. You can copy it — and any other single Old English initial — from the letter monogram chart on this page. Type one letter in the box and copy the styled result for a clean name initial."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I use Old English text for a tattoo?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "You can use it to mock up and preview a name, word, or phrase in Old English lettering before taking it to an artist. Because this is copy-paste Unicode (not an image), it is perfect for planning, captions, and digital use. For the actual stencil, your tattoo artist will redraw the lettering at high resolution — Unicode text is for the preview and the idea, not the final line art."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the difference between Old English and Olde English?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Visually, nothing — \"Olde English\" is just a stylized spelling of the same heavy blackletter look (popularized by brands and labels). Both describe the chunky, ornate medieval lettering this generator produces. Note it is unrelated to Old English the language (Anglo-Saxon); here it only means the lettering style."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I make Old English numbers?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes, with a caveat: true blackletter digits do not exist in Unicode. When you type numbers they are paired with bold digits (𝟎𝟏𝟐𝟑𝟒𝟓𝟔𝟕𝟖𝟗), the closest heavy match, so jersey numbers and dates stay styled instead of dropping to plain text. Genuine drawn Old English numerals only exist as image lettering."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Why does my Old English text show as boxes or squares?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Boxes (□□□) appear when a device or app is missing the blackletter glyphs. Most modern phones and platforms render them fine, but some older Android builds or custom system fonts do not. Use the live compatibility checker on this page to see which styles render on your current device before you paste them somewhere public."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ultratextgen.com/" },
+    { "@type": "ListItem", "position": 2, "name": "Categories", "item": "https://ultratextgen.com/category/" },
+    { "@type": "ListItem", "position": 3, "name": "Old English Fonts", "item": "https://ultratextgen.com/category/old-english-fonts/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Old English Font Generator",
+  "alternateName": ["Old English Text Generator", "Olde English Generator", "Blackletter Tattoo Font Generator", "Copy and Paste Old English"],
+  "url": "https://ultratextgen.com/category/old-english-fonts/",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+  "description": "Old English blackletter font generator for name tattoos, sports jerseys, the Old English D, and chicano lettering. Copy and paste anywhere.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
+</head>
+<body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<script src="/header.js"></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/">Home</a>
+  <span class="breadcrumb-separator">›</span>
+  <a href="/category/">Categories</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Old English Fonts</span>
+</nav>
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/category-gothic-fonts.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+  <!-- Hero Section -->
+  <section class="hero">
+    <div class="hero-inner">
+      <div class="hero-card">
+        <h1 class="hero-headline">Old English Font Generator</h1>
+        <div class="input-wrapper">
+          <textarea class="main-input" id="mainInput" placeholder="Type a name or word…" maxlength="500"></textarea>
+          <span class="char-count"><span id="charCount">0</span>/500</span>
+        </div>
+
+        <!-- Decoration Selector -->
+        <div class="decoration-section">
+          <div class="decoration-label">
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"></path>
+            </svg>
+            Add decoration to results
+       </div>
+    <div class="decoration-tabs">
+    <button class="decoration-tab active" data-deco-tab="crosses">Crosses</button>
+    <button class="decoration-tab" data-deco-tab="chicano">Chicano</button>
+    <button class="decoration-tab" data-deco-tab="varsity">Varsity</button>
+    <button class="decoration-tab" data-deco-tab="frames">Frames</button>
+    <button class="decoration-tab" data-deco-tab="dividers">Dividers</button>
+      </div>
+          <div class="decoration-grid" id="decorationGrid"></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Main Content -->
+  <main class="container">
+    <!-- Category Tabs -->
+    <div class="category-section">
+      <div class="category-tabs" id="categoryTabs">
+        <button class="category-tab active" data-category="all">All</button>
+        <button class="category-tab" data-category="cool">✦ Cool</button>
+        <button class="category-tab" data-category="bold">𝗕 Bold</button>
+        <button class="category-tab" data-category="gothic">𝔊 Gothic</button>
+        <button class="category-tab" data-category="special">⚡ Special</button>
+      </div>
+    </div>
+
+    <!-- Results -->
+    <div class="results-grid" id="resultsGrid"></div>
+
+    <!-- ============================================================
+         UNIQUE EDITORIAL CONTENT
+         ============================================================ -->
+    <section class="editorial-section">
+      <h2>Old English lettering, ready to copy</h2>
+      <p>
+        Type a name or word above and this generator rewrites it in <strong>Old English</strong> —
+        the heavy, ornate blackletter used on <strong>name tattoos</strong>, <strong>sports
+        jerseys</strong>, certificates, band logos, and chicano-style lettering. It's real
+        <strong>Unicode</strong>, not a downloaded font, so you can paste
+        <span lang="und">𝕺𝖑𝖉 𝕰𝖓𝖌𝖑𝖎𝖘𝖍</span> straight into Instagram, TikTok, a jersey-design
+        tool, or a tattoo-idea board with nothing to install.
+      </p>
+      <p>
+        Old English is one weight in the wider blackletter family. If you want lighter Fraktur,
+        occult/goth accents, or the full range of dark medieval styles, use the
+        <a href="/category/gothic-fonts/">Gothic font generator</a>.
+      </p>
+    </section>
+
+    <section class="editorial-section">
+      <h2>The Old English alphabet, A to Z</h2>
+      <p class="glyph-sub">The full blackletter alphabet. Copy a single letter, or type a word above to style it all.</p>
+      <div class="gothic-charts">
+        <div class="glyph-chart">
+          <h3>Old English — 𝕺𝖑𝖉 𝕰𝖓𝖌𝖑𝖎𝖘𝖍</h3>
+          <p class="glyph-sub">The heavy, high-contrast weight used for tattoos and jerseys.</p>
+          <div class="glyph-row">𝕬 𝕭 𝕮 𝕯 𝕰 𝕱 𝕲 𝕳 𝕴 𝕵 𝕶 𝕷 𝕸 𝕹 𝕺 𝕻 𝕼 𝕽 𝕾 𝕿 𝖀 𝖁 𝖂 𝖃 𝖄 𝖅</div>
+          <div class="glyph-row">𝖆 𝖇 𝖈 𝖉 𝖊 𝖋 𝖌 𝖍 𝖎 𝖏 𝖐 𝖑 𝖒 𝖓 𝖔 𝖕 𝖖 𝖗 𝖘 𝖙 𝖚 𝖛 𝖜 𝖝 𝖞 𝖟</div>
+          <div class="glyph-row">𝟎 𝟏 𝟐 𝟑 𝟒 𝟓 𝟔 𝟕 𝟖 𝟗</div>
+        </div>
+        <div class="glyph-chart">
+          <h3>Lighter Fraktur — 𝔒𝔩𝔡 𝔈𝔫𝔤𝔩𝔦𝔰𝔥</h3>
+          <p class="glyph-sub">A thinner blackletter if the bold weight feels too heavy.</p>
+          <div class="glyph-row">𝔄 𝔅 ℭ 𝔇 𝔈 𝔉 𝔊 ℌ ℑ 𝔍 𝔎 𝔏 𝔐 𝔑 𝔒 𝔓 𝔔 ℜ 𝔖 𝔗 𝔘 𝔙 𝔚 𝔛 𝔜 ℨ</div>
+          <div class="glyph-row">𝔞 𝔟 𝔠 𝔡 𝔢 𝔣 𝔤 𝔥 𝔦 𝔧 𝔨 𝔩 𝔪 𝔫 𝔬 𝔭 𝔮 𝔯 𝔰 𝔱 𝔲 𝔳 𝔴 𝔵 𝔶 𝔷</div>
+          <div class="glyph-row">𝟎 𝟏 𝟐 𝟑 𝟒 𝟓 𝟔 𝟕 𝟖 𝟗</div>
+        </div>
+      </div>
+    </section>
+
+    <section class="editorial-section">
+      <h2>Old English letter monograms (the "Old English D")</h2>
+      <p>
+        Want just one initial — for a name tattoo, a logo, or the famous Detroit-style
+        <span lang="und">𝕯</span>? Copy any single Old English capital below:
+      </p>
+      <div class="glyph-row">𝕬 𝕭 𝕮 𝕯 𝕰 𝕱 𝕲 𝕳 𝕴 𝕵 𝕶 𝕷 𝕸 𝕹 𝕺 𝕻 𝕼 𝕽 𝕾 𝕿 𝖀 𝖁 𝖂 𝖃 𝖄 𝖅</div>
+    </section>
+
+    <section class="editorial-section">
+      <h2>Old English numbers &amp; jersey digits</h2>
+      <p>
+        True blackletter digits don't exist in Unicode, so we pair numbers with the closest
+        heavy match — bold digits — instead of dropping to plain text. Good for jersey numbers,
+        years, and dates:
+      </p>
+      <div class="glyph-row">𝟎 𝟏 𝟐 𝟑 𝟒 𝟓 𝟔 𝟕 𝟖 𝟗</div>
+    </section>
+
+    <section class="editorial-section">
+      <h2>Will Old English text show up on your device?</h2>
+      <p>
+        Blackletter sometimes shows as boxes (□□□) on older devices. This checks, live on your
+        current device, which styles render cleanly before you post a name or paste it into a bio:
+      </p>
+      <div class="gothic-compat" id="gothicCompat"></div>
+    </section>
+
+    <section class="editorial-section">
+      <h2>Where Old English lettering is used</h2>
+      <div class="editorial-grid">
+        <div class="style-card"><h3>Name tattoos</h3><p>The go-to script for names, dates, and memorial pieces — bold, ornate, and legible at scale.</p></div>
+        <div class="style-card"><h3>Sports jerseys &amp; the Old English D</h3><p>Team wordmarks and the Detroit-Tigers-style 𝕯 made the heavy blackletter capital iconic.</p></div>
+        <div class="style-card"><h3>Chicano / streetwear lettering</h3><p>A cornerstone of West-Coast chicano script and streetwear graphics.</p></div>
+        <div class="style-card"><h3>Logos &amp; mastheads</h3><p>Newspapers, breweries, and bands lean on Old English for a heritage, established feel.</p></div>
+      </div>
+    </section>
+  </main>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-inner">
+<h2 class="faq-category">About Old English Fonts</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Is Old English the same as a gothic font?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer">
+    They are closely related. "Gothic" is the broad family of medieval blackletter scripts (Textura, Fraktur, Schwabacher).
+    "Old English" usually refers to the heavy, high-contrast blackletter weight — the look used on tattoos, sports jerseys,
+    certificates, and newspaper mastheads. In Unicode they share the same character blocks, so this generator produces the
+    bold 𝕺𝖑𝖉 𝕰𝖓𝖌𝖑𝖎𝖘𝖍 style as well as a lighter Fraktur.
+    <br><br>
+    For the wider family of dark/medieval styles, see the <a href="/category/gothic-fonts/">Gothic font generator</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    What is the Old English D?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer">
+    The "Old English D" is the single blackletter capital D (𝕯) made famous by the Detroit Tigers cap and widely used
+    in tattoos and streetwear. You can copy it — and any other single Old English initial — from the letter monogram
+    chart above. Type one letter in the box and copy the styled result for a clean name initial.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Can I use Old English text for a tattoo?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer">
+    You can use it to mock up and preview a name, word, or phrase in Old English lettering before taking it to an artist.
+    Because this is copy-paste Unicode (not an image), it is perfect for planning, captions, and digital use.
+    <br><br>
+    For the actual stencil, your tattoo artist will redraw the lettering at high resolution — Unicode text is for the
+    preview and the idea, not the final line art.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    What is the difference between Old English and Olde English?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer">
+    Visually, nothing — "Olde English" is just a stylized spelling of the same heavy blackletter look (popularized by
+    brands and labels). Both describe the chunky, ornate medieval lettering this generator produces. Note it is unrelated
+    to Old English the language (Anglo-Saxon); here it only means the lettering style.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Can I make Old English numbers?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer">
+    Yes, with a caveat: true blackletter digits do not exist in Unicode. When you type numbers they are paired with bold
+    digits (𝟎𝟏𝟐𝟑𝟒𝟓𝟔𝟕𝟖𝟗), the closest heavy match, so jersey numbers and dates stay styled instead of dropping to
+    plain text. Genuine drawn Old English numerals only exist as image lettering.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Why does my Old English text show as boxes or squares?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer">
+    Boxes (□□□) appear when a device or app is missing the blackletter glyphs. Most modern phones and platforms render
+    them fine, but some older Android builds or custom system fonts do not. Use the live compatibility checker above to
+    see which styles render on your current device before you paste them somewhere public.
+  </div>
+</div>
+    </div>
+  </footer>
+
+  <!-- Category filter + Old English decorations -->
+  <script>
+    window.UTG_FAMILY = "old-english";
+    window.UTG_DEFAULT_DECO_TAB = "crosses";
+    window.UTG_DECORATIONS = {
+      crosses: [
+        { text: "✝ text ✝", prefix: "✝ ", suffix: " ✝" },
+        { text: "✟ text ✟", prefix: "✟ ", suffix: " ✟" },
+        { text: "☩ text ☩", prefix: "☩ ", suffix: " ☩" },
+        { text: "☦ text ☦", prefix: "☦ ", suffix: " ☦" },
+        { text: "✠ text ✠", prefix: "✠ ", suffix: " ✠" },
+        { text: "♰ text ♰", prefix: "♰ ", suffix: " ♰" },
+        { text: "† text †", prefix: "† ", suffix: " †" },
+        { text: "‡ text ‡", prefix: "‡ ", suffix: " ‡" }
+      ],
+      chicano: [
+        { text: "꧁ text ꧂", prefix: "꧁ ", suffix: " ꧂" },
+        { text: "༺ text ༻", prefix: "༺ ", suffix: " ༻" },
+        { text: "꧁༺ text ༻꧂", prefix: "꧁༺ ", suffix: " ༻꧂" },
+        { text: "☩ text ☩", prefix: "☩ ", suffix: " ☩" },
+        { text: "⟬ text ⟭", prefix: "⟬ ", suffix: " ⟭" },
+        { text: "❰ text ❱", prefix: "❰ ", suffix: " ❱" }
+      ],
+      varsity: [
+        { text: "★ text ★", prefix: "★ ", suffix: " ★" },
+        { text: "✪ text ✪", prefix: "✪ ", suffix: " ✪" },
+        { text: "✦ text ✦", prefix: "✦ ", suffix: " ✦" },
+        { text: "⚜ text ⚜", prefix: "⚜ ", suffix: " ⚜" },
+        { text: "❖ text ❖", prefix: "❖ ", suffix: " ❖" },
+        { text: "✥ text ✥", prefix: "✥ ", suffix: " ✥" }
+      ],
+      frames: [
+        { text: "【 text 】", prefix: "【 ", suffix: " 】" },
+        { text: "「 text 」", prefix: "「 ", suffix: " 」" },
+        { text: "❰ text ❱", prefix: "❰ ", suffix: " ❱" },
+        { text: "⟬ text ⟭", prefix: "⟬ ", suffix: " ⟭" },
+        { text: "༺ text ༻", prefix: "༺ ", suffix: " ༻" },
+        { text: "⸉ text ⸊", prefix: "⸉ ", suffix: " ⸊" }
+      ],
+      dividers: [
+        { text: "✝═══ text ═══✝", prefix: "✝═══ ", suffix: " ═══✝" },
+        { text: "★─── text ───★", prefix: "★─── ", suffix: " ───★" },
+        { text: "†•••• text ••••†", prefix: "†•••• ", suffix: " ••••†" },
+        { text: "═══ text ═══", prefix: "═══ ", suffix: " ═══" },
+        { text: "♰ ═══ text ═══ ♰", prefix: "♰ ═══ ", suffix: " ═══ ♰" }
+      ]
+    };
+  </script>
+
+  <script src="/styles.js"></script>
+<script src="/renderer.js"></script>
+<script src="/script.js" defer=""></script>
+<script src="/gothic-tools.js" defer=""></script>
+
+<script src="/footer.js"></script>
+</body></html>

--- a/gothic-tools.js
+++ b/gothic-tools.js
@@ -1,0 +1,152 @@
+/* ==========================================================================
+   UltraTextGen — gothic-tools.js
+   Live "will it render on your device?" compatibility tester for gothic /
+   blackletter styles. Self-contained IIFE. Loads AFTER styles.js + renderer.js.
+
+   It mounts into #gothicCompat (if present) and answers the single biggest
+   gothic complaint: "why do I see boxes/squares?" — by detecting, on THIS
+   device, whether each blackletter style actually has glyphs.
+   ========================================================================== */
+(function () {
+  "use strict";
+
+  const mount = document.getElementById("gothicCompat");
+  if (!mount) return;
+
+  const Render = window.UltraTextGenRender;
+  const styles = window.textStyles || {};
+  if (!Render || typeof Render.renderAny !== "function") return;
+
+  // Styles surfaced in the tester, in display order. Each maps to a registry key.
+  const TESTS = [
+    { label: "Fraktur — 𝔤𝔬𝔱𝔥𝔦𝔠", key: "Ultra Gothic" },
+    { label: "Bold Fraktur / Old English — 𝖌𝖔𝖙𝖍𝖎𝖈", key: "Ultra Gothic Bold" },
+    { label: "Gothic Underline", key: "Ultra Gothic Underline" },
+    { label: "Gothic + Cross", key: "Ultra Gothic Cross" },
+    { label: "Gothic Occult", key: "Ultra Gothic Occult" },
+    { label: "Gothic Strikethrough", key: "Ultra Gothic Strikethrough" }
+  ].filter(t => styles[t.key]);
+
+  // --- Canvas glyph-support detector -------------------------------------
+  // Compares the drawn width of a glyph against the width of a code point no
+  // font has (every browser falls back to the same .notdef "tofu" box, so an
+  // unsupported glyph measures identical to the reference).
+  function makeDetector() {
+    let ctx;
+    try {
+      ctx = document.createElement("canvas").getContext("2d");
+    } catch (e) {
+      return null;
+    }
+    if (!ctx) return null;
+    const family = (getComputedStyle(mount).fontFamily || "sans-serif");
+    ctx.font = "36px " + family;
+    const refWidth = ctx.measureText(String.fromCodePoint(0x10fffd)).width;
+    return function supported(ch) {
+      if (!ch) return true;
+      return ctx.measureText(ch).width !== refWidth;
+    };
+  }
+
+  const detect = makeDetector();
+
+  // Representative base glyph for a style: render lowercase "a" and grab the
+  // first Mathematical-Alphanumeric code point (skips wrapper symbols like ✝/⛧).
+  function baseGlyph(key) {
+    const out = Render.renderAny("a", styles[key]);
+    for (const c of out) {
+      if (c.codePointAt(0) >= 0x1d400) return c;
+    }
+    return null;
+  }
+
+  const supportMap = {};
+  TESTS.forEach(t => {
+    supportMap[t.key] = detect ? detect(baseGlyph(t.key)) : true;
+  });
+
+  // --- Build the widget ---------------------------------------------------
+  const input = document.createElement("input");
+  input.type = "text";
+  input.className = "compat-input";
+  input.maxLength = 60;
+  input.setAttribute("aria-label", "Text to test for gothic compatibility");
+  input.placeholder = "Type a name to test…";
+
+  // Seed from the main generator input if it already has text.
+  const mainInput = document.getElementById("mainInput");
+  input.value = (mainInput && mainInput.value.trim()) || "Your Name";
+
+  const list = document.createElement("div");
+  list.className = "compat-rows";
+
+  const note = document.createElement("p");
+  note.className = "compat-note";
+  note.innerHTML = detect
+    ? 'Checked live on <strong>this device</strong>. A ⚠ flag means your current device is missing those glyphs — they may show as boxes for some viewers too. Tap a sample to copy it.'
+    : "Showing how each style renders. Tap a sample to copy it.";
+
+  function badge(ok) {
+    const b = document.createElement("span");
+    b.className = "compat-badge " + (ok ? "is-ok" : "is-warn");
+    b.textContent = ok ? "✓ Renders" : "⚠ May break";
+    return b;
+  }
+
+  function rowFor(t) {
+    const row = document.createElement("button");
+    row.type = "button";
+    row.className = "compat-row";
+    row.dataset.ok = String(supportMap[t.key]);
+
+    const name = document.createElement("span");
+    name.className = "compat-name";
+    name.textContent = t.label;
+
+    const sample = document.createElement("span");
+    sample.className = "compat-sample";
+
+    row.appendChild(badge(supportMap[t.key]));
+    row.appendChild(name);
+    row.appendChild(sample);
+    row.addEventListener("click", () => copyRow(t, sample.textContent, row));
+    return { row, sample, key: t.key };
+  }
+
+  const built = TESTS.map(rowFor);
+  built.forEach(b => list.appendChild(b.row));
+
+  function render() {
+    const text = input.value.trim() || "Your Name";
+    built.forEach(b => {
+      b.sample.textContent = Render.renderAny(text, styles[b.key]);
+    });
+  }
+
+  function copyRow(t, text, row) {
+    if (!text) return;
+    const done = () => {
+      row.classList.add("is-copied");
+      setTimeout(() => row.classList.remove("is-copied"), 1100);
+    };
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).then(done).catch(() => {});
+    }
+  }
+
+  input.addEventListener("input", render);
+  if (mainInput) {
+    mainInput.addEventListener("input", () => {
+      const v = mainInput.value.trim();
+      if (v) {
+        input.value = v.slice(0, 60);
+        render();
+      }
+    });
+  }
+
+  mount.appendChild(input);
+  mount.appendChild(list);
+  mount.appendChild(note);
+  render();
+})();

--- a/renderer.js
+++ b/renderer.js
@@ -420,6 +420,36 @@ function renderMap(text, style) {
     'ultra_cursive_sparkle': text =>
       text.trim()
         ? `⋆˚꒰ ${renderMap(text, textStyles['Ultra Script'])} ꒱˚⋆`
+        : text,
+
+    // === GOTHIC PROCEDURES ===
+    // Keyed by style.slug (see renderProcedure). Each builds on the Fraktur /
+    // Bold Fraktur maps and adds a combining mark or symbol wrapper.
+
+    // Fraktur + combining underline — the "gothic underline" intent.
+    'ultra-gothic-underline': text =>
+      text.trim()
+        ? [...renderMap(text, textStyles['Ultra Gothic'])]
+            .map(c => (c === ' ' || c === '\n') ? c : c + '̲').join('')
+        : text,
+
+    // Bold Fraktur bookended with crosses — religious / bible-verse intent.
+    'ultra-gothic-cross': text =>
+      text.trim()
+        ? `✝ ${renderMap(text, textStyles['Ultra Gothic Bold'])} ✝`
+        : text,
+
+    // Fraktur wrapped in occult accents — goth / metal / dark-aesthetic intent.
+    'ultra-gothic-occult': text =>
+      text.trim()
+        ? `⛧ ${renderMap(text, textStyles['Ultra Gothic'])} ⛧`
+        : text,
+
+    // Fraktur struck through — grunge / edgy intent.
+    'ultra-gothic-strike': text =>
+      text.trim()
+        ? [...renderMap(text, textStyles['Ultra Gothic'])]
+            .map(c => (c === ' ' || c === '\n') ? c : c + '̶').join('')
         : text
   };
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -17,7 +17,7 @@
 
   <url>
     <loc>https://ultratextgen.com/answers/</loc>
-    <lastmod>2026-06-17</lastmod>
+    <lastmod>2026-06-29</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -58,8 +58,15 @@
   </url>
 
   <url>
+    <loc>https://ultratextgen.com/answers/how-to-uncover-redacted-text/</loc>
+    <lastmod>2026-06-29</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
     <loc>https://ultratextgen.com/answers/is-linkedin-bold-text-safe/</loc>
-    <lastmod>2026-06-17</lastmod>
+    <lastmod>2026-06-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -80,14 +87,14 @@
 
   <url>
     <loc>https://ultratextgen.com/answers/what-font-does-linkedin-use/</loc>
-    <lastmod>2026-06-17</lastmod>
+    <lastmod>2026-06-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/answers/what-font-does-snapchat-use/</loc>
-    <lastmod>2026-06-27</lastmod>
+    <lastmod>2026-06-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -121,22 +128,8 @@
   </url>
 
   <url>
-    <loc>https://ultratextgen.com/category/bold-fonts/alternating/</loc>
-    <lastmod>2026-06-17</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-
-  <url>
     <loc>https://ultratextgen.com/category/bold-fonts/bold-italic/</loc>
-    <lastmod>2026-06-17</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-
-  <url>
-    <loc>https://ultratextgen.com/category/bold-fonts/bold/</loc>
-    <lastmod>2026-06-17</lastmod>
+    <lastmod>2026-06-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -157,7 +150,7 @@
 
   <url>
     <loc>https://ultratextgen.com/category/classified/</loc>
-    <lastmod>2026-06-17</lastmod>
+    <lastmod>2026-06-29</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -170,13 +163,6 @@
   </url>
 
   <url>
-    <loc>https://ultratextgen.com/category/cursive-fonts/script/</loc>
-    <lastmod>2026-06-17</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-
-  <url>
     <loc>https://ultratextgen.com/category/cute-fonts/</loc>
     <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
@@ -185,21 +171,21 @@
 
   <url>
     <loc>https://ultratextgen.com/category/gothic-fonts/</loc>
+    <lastmod>2026-06-29</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/category/italic-fonts/</loc>
     <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://ultratextgen.com/category/gothic-fonts/fraktur/</loc>
-    <lastmod>2026-06-17</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-
-  <url>
-    <loc>https://ultratextgen.com/category/italic-fonts/</loc>
-    <lastmod>2026-06-17</lastmod>
+    <loc>https://ultratextgen.com/category/old-english-fonts/</loc>
+    <lastmod>2026-06-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -318,7 +304,7 @@
 
   <url>
     <loc>https://ultratextgen.com/guide/branding-with-fonts-for-social-media/</loc>
-    <lastmod>2026-06-17</lastmod>
+    <lastmod>2026-06-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -353,35 +339,35 @@
 
   <url>
     <loc>https://ultratextgen.com/guide/linkedin-comments-guide/</loc>
-    <lastmod>2026-06-17</lastmod>
+    <lastmod>2026-06-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/guide/personal-branding-through-typography/</loc>
-    <lastmod>2026-06-17</lastmod>
+    <lastmod>2026-06-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/guide/stop-the-scroll-with-font-variation/</loc>
-    <lastmod>2026-06-17</lastmod>
+    <lastmod>2026-06-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/guide/style-linkedin-hooks-to-stand-out/</loc>
-    <lastmod>2026-06-17</lastmod>
+    <lastmod>2026-06-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/guide/the-rhetoric-of-fonts/</loc>
-    <lastmod>2026-06-17</lastmod>
+    <lastmod>2026-06-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -500,7 +486,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/aesthetic-symbols/</loc>
-    <lastmod>2026-06-28</lastmod>
+    <lastmod>2026-06-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -2334,7 +2320,7 @@
 
   <url>
     <loc>https://ultratextgen.com/tr/</loc>
-    <lastmod>2026-06-17</lastmod>
+    <lastmod>2026-06-29</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -2397,7 +2383,7 @@
 
   <url>
     <loc>https://ultratextgen.com/usecase/linkedin-headline/</loc>
-    <lastmod>2026-06-17</lastmod>
+    <lastmod>2026-06-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>

--- a/style.css
+++ b/style.css
@@ -3548,3 +3548,139 @@ body.dark-mode .vertical-chip {
   margin: 0;
   font-size: 0.9rem;
 }
+
+/* ==========================================================================
+   Gothic compatibility tester (gothic-tools.js) + per-style alphabet charts
+   ========================================================================== */
+.gothic-compat {
+  margin-top: 14px;
+}
+
+.compat-input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 12px 14px;
+  font-size: 1rem;
+  color: var(--text-primary);
+  background: var(--bg-white);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius);
+  margin-bottom: 14px;
+}
+
+.compat-input:focus {
+  outline: none;
+  border-color: var(--accent-purple);
+}
+
+.compat-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.compat-row {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-areas: "badge name" "badge sample";
+  align-items: center;
+  gap: 2px 14px;
+  width: 100%;
+  text-align: left;
+  padding: 12px 16px;
+  background: var(--bg-white);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-soft);
+  cursor: pointer;
+  transition: box-shadow 0.15s ease, transform 0.05s ease;
+}
+
+.compat-row:hover {
+  box-shadow: var(--shadow-hover);
+}
+
+.compat-row.is-copied {
+  border-color: var(--ts-safe);
+}
+
+.compat-badge {
+  grid-area: badge;
+  font-size: 0.78rem;
+  font-weight: 600;
+  white-space: nowrap;
+  padding: 4px 10px;
+  border-radius: 999px;
+}
+
+.compat-badge.is-ok {
+  color: var(--ts-safe);
+  background: color-mix(in srgb, var(--ts-safe) 12%, transparent);
+}
+
+.compat-badge.is-warn {
+  color: var(--ts-risk);
+  background: color-mix(in srgb, var(--ts-risk) 14%, transparent);
+}
+
+.compat-name {
+  grid-area: name;
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+}
+
+.compat-sample {
+  grid-area: sample;
+  font-size: 1.25rem;
+  color: var(--text-primary);
+  word-break: break-word;
+}
+
+.compat-note {
+  margin-top: 12px;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+/* Per-style alphabet / number reference charts (static, crawlable) */
+.gothic-charts {
+  display: grid;
+  gap: 16px;
+  margin-top: 12px;
+}
+
+.glyph-chart {
+  background: var(--bg-white);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius);
+  padding: 16px 18px;
+  box-shadow: var(--shadow-soft);
+}
+
+.glyph-chart h3 {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0 0 4px;
+}
+
+.glyph-chart .glyph-sub {
+  margin: 0 0 12px;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.glyph-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 10px;
+  font-size: 1.15rem;
+  color: var(--text-primary);
+  line-height: 1.6;
+}
+
+.glyph-row + .glyph-row {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border-light);
+}

--- a/styles.js
+++ b/styles.js
@@ -33,6 +33,11 @@ const CATEGORY_PAGES = {
     title: 'Gothic Fonts',
     description: 'Dark gothic and fraktur Unicode fonts.'
   },
+  'old-english': {
+    slug: 'old-english-fonts',
+    title: 'Old English Fonts',
+    description: 'Old English blackletter fonts for names, tattoos, and varsity lettering.'
+  },
   'bubble': {
     slug: 'bubble-fonts',
     title: 'Bubble Fonts',
@@ -337,10 +342,12 @@ const textStyles = {
   'Ultra Gothic': {
     upper: '𝔄𝔅ℭ𝔇𝔈𝔉𝔊ℌℑ𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔ℜ𝔖𝔗𝔘𝔙𝔚𝔛𝔜ℨ',
     lower: '𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷',
-    nums: '0123456789',
+    // Mathematical Fraktur has no digits — pair with Mathematical Bold digits
+    // (the closest heavy match) so numbers stop falling back to plain ASCII.
+    nums: '𝟎𝟏𝟐𝟑𝟒𝟓𝟔𝟕𝟖𝟗',
     type: 'map',
     category: 'gothic',
-    familySlug: 'gothic',
+    familySlug: ['gothic', 'old-english'],
     groupSlug: 'fraktur',
     slug: 'ultra-gothic',
     platforms: ['all', 'instagram', 'x', 'discord']
@@ -349,13 +356,59 @@ const textStyles = {
   'Ultra Gothic Bold': {
     upper: '𝕬𝕭𝕮𝕯𝕰𝕱𝕲𝕳𝕴𝕵𝕶𝕷𝕸𝕹𝕺𝕻𝕼𝕽𝕾𝕿𝖀𝖁𝖂𝖃𝖄𝖅',
     lower: '𝖆𝖇𝖈𝖉𝖊𝖋𝖌𝖍𝖎𝖏𝖐𝖑𝖒𝖓𝖔𝖕𝖖𝖗𝖘𝖙𝖚𝖛𝖜𝖝𝖞𝖟',
-    nums: '0123456789',
+    nums: '𝟎𝟏𝟐𝟑𝟒𝟓𝟔𝟕𝟖𝟗',
     type: 'map',
     category: 'gothic',
-    // Cross-listed onto the bold page: it is a bold-weight blackletter.
-    familySlug: ['gothic', 'bold'],
+    // Bold Fraktur is the heavy "Old English" newspaper/tattoo look — cross-list
+    // it onto the bold page and the Old English page.
+    familySlug: ['gothic', 'bold', 'old-english'],
     groupSlug: 'fraktur',
     slug: 'ultra-gothic-bold',
+    platforms: ['all', 'instagram', 'x', 'discord']
+  },
+
+  // Fraktur with a combining underline — serves the "gothic underline" intent
+  // (seen directly in Search Console impressions for this page).
+  'Ultra Gothic Underline': {
+    type: 'procedure',
+    procedureId: 'ultra_gothic_underline',
+    category: 'gothic',
+    familySlug: ['gothic', 'old-english'],
+    groupSlug: 'fraktur',
+    slug: 'ultra-gothic-underline',
+    platforms: ['all', 'instagram', 'x', 'discord']
+  },
+
+  // Blackletter bookended with crosses — religious / "gothic bible verse" intent.
+  'Ultra Gothic Cross': {
+    type: 'procedure',
+    procedureId: 'ultra_gothic_cross',
+    category: 'gothic',
+    familySlug: ['gothic', 'old-english'],
+    groupSlug: 'fraktur',
+    slug: 'ultra-gothic-cross',
+    platforms: ['all', 'instagram', 'x', 'discord']
+  },
+
+  // Fraktur wrapped in occult accents — goth / metal / dark-aesthetic intent.
+  'Ultra Gothic Occult': {
+    type: 'procedure',
+    procedureId: 'ultra_gothic_occult',
+    category: 'gothic',
+    familySlug: 'gothic',
+    groupSlug: 'fraktur',
+    slug: 'ultra-gothic-occult',
+    platforms: ['all', 'instagram', 'x', 'discord']
+  },
+
+  // Fraktur struck through — grunge / edgy intent.
+  'Ultra Gothic Strikethrough': {
+    type: 'procedure',
+    procedureId: 'ultra_gothic_strike',
+    category: 'gothic',
+    familySlug: 'gothic',
+    groupSlug: 'fraktur',
+    slug: 'ultra-gothic-strike',
     platforms: ['all', 'instagram', 'x', 'discord']
   },
 


### PR DESCRIPTION
Gothic JTBD relaunch — fixes the "homepage replica / not indexed" problem and broadens coverage of the addressable blackletter market.

styles.js / renderer.js
- Fix gothic numbers: pair digits with Mathematical Bold digits instead of plain ASCII fallback (Fraktur has no Unicode digits).
- Add 4 distinct gothic variants (underline, cross, occult, strikethrough) via render procedures, taking gothic from 2 to ~7 styles.
- Register 'old-english' family + cross-list the blackletter styles.

category/gothic-fonts/index.html
- Add unique, crawlable content: per-style A–Z/a–z/0–9 charts, a numbers section, a "types of gothic" strip, and two new FAQ entries (kept in sync with FAQPage JSON-LD).
- Gothic-themed decorations (crosses / occult / runes / frames / dividers) via UTG_DECORATIONS override.
- Mount the live compatibility tester; cross-link the Old English page.

category/old-english-fonts/index.html (new)
- Intent-distinct page: name tattoos, jerseys, the "Old English D", chicano/varsity lettering — own alphabet + monogram + numbers charts, OE-specific FAQ + schema, decorations, and compatibility tester.

gothic-tools.js (new)
- Self-contained canvas glyph-support detector: flags whether each gothic style renders on the current device (the "boxes/squares" complaint).

style.css / category/index.html / sitemap.xml
- Tester + chart styles (existing tokens); Old English card on the category hub; regenerated sitemap.


Claude-Session: https://claude.ai/code/session_01KJi817Du87hTT5dmhd4Kwo