### PR TITLE
feat: add Indonesian kaomoji library page (/id/library/kaomoji/)

### DIFF
--- a/id/index.html
+++ b/id/index.html
@@ -412,6 +412,11 @@
         <h3>Tulisan Zalgo / Glitch</h3>
         <p>Bikin tulisan creepy, glitchy, dan rusak dengan diakritik bertumpuk — cocok buat konten horor TikTok, meme gelap, dan bio edgy.</p>
       </a>
+      <a class="tip-card" href="/id/library/kaomoji/" aria-label="Kaomoji Lucu Copy Paste">
+        <div class="tip-icon">(◕‿◕)</div>
+        <h3>Kaomoji Lucu</h3>
+        <p>Wajah teks ala Jepang siap salin-tempel — senang, sedih, cinta, hewan, sampai Lenny face — buat chat, bio, dan caption yang lebih hidup.</p>
+      </a>
     </div>
     <p class="u-mt-15 u-text-center"><a class="cat-cta" href="/usecase/" data-i18n="useCases.viewAll">Lihat semua ide pemakaian →</a></p>
   </section>

--- a/id/library/kaomoji/index.html
+++ b/id/library/kaomoji/index.html
@@ -1,0 +1,680 @@
+<!DOCTYPE html>
+<html lang="id">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8242324164413945"
+       crossorigin="anonymous"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Kaomoji — Wajah Teks Jepang untuk Disalin &amp; Ditempel</title>
+<meta name="description" content="Salin &amp; tempel kaomoji — wajah teks ala Jepang dari karakter Unicode. Kaomoji lucu, senang, sedih, menangis, cinta, hewan, dan Lenny face. Klik mana pun untuk langsung menyalin.">
+
+<link rel="canonical" href="https://ultratextgen.com/id/library/kaomoji/">
+<link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/text-faces-kaomoji/">
+<link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/text-faces-kaomoji/">
+<link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/kaomoji/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/library-text-faces-kaomoji.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Kaomoji — Wajah Teks Jepang untuk Disalin &amp; Ditempel">
+<meta name="twitter:description" content="Salin &amp; tempel kaomoji — wajah teks ala Jepang dari karakter Unicode. Kaomoji lucu, senang, sedih, cinta, hewan, dan Lenny face.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/library-text-faces-kaomoji.png">
+<meta property="og:title" content="Kaomoji — Wajah Teks Jepang untuk Disalin &amp; Ditempel">
+<meta property="og:description" content="Salin &amp; tempel kaomoji — wajah teks ala Jepang dari karakter Unicode. Kaomoji lucu, senang, sedih, cinta, hewan, dan Lenny face.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/id/library/kaomoji/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Kaomoji — Wajah Teks Jepang untuk Disalin & Ditempel",
+  "alternateName": ["Kaomoji", "Kaomoji Lucu", "Kaomoji Copy Paste", "Wajah Teks Jepang", "Emoticon Teks", "Kaomoji Cute"],
+  "description": "Salin & tempel kaomoji — wajah teks ala Jepang dari karakter Unicode. Kaomoji lucu, senang, sedih, menangis, cinta, hewan, dan Lenny face.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/library-text-faces-kaomoji.png",
+  "mainEntityOfPage": "https://ultratextgen.com/id/library/kaomoji/",
+  "inLanguage": "id",
+  "datePublished": "2026-06-30",
+  "dateModified": "2026-06-30"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Beranda",
+      "item": "https://ultratextgen.com/id/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Kaomoji",
+      "item": "https://ultratextgen.com/id/library/kaomoji/"
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "name": "Kaomoji — Wajah Teks Jepang untuk Disalin & Ditempel",
+  "description": "Halaman koleksi kaomoji Unicode. Berisi grid salin-tempel wajah teks Jepang — senang, sedih, cinta, hewan, Lenny face, dan pelukan — untuk chat, bio, dan caption.",
+  "url": "https://ultratextgen.com/id/library/kaomoji/",
+  "inLanguage": "id",
+  "isPartOf": {
+    "@type": "WebSite",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  }
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Apa itu kaomoji?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Kaomoji (顔文字) adalah emoticon yang berasal dari Jepang, dibuat dari karakter keyboard dan simbol Unicode. Berbeda dengan emoji yang dibaca menyamping, kaomoji dibaca tegak — misalnya (◕‿◕) — sehingga mata, mulut, bahkan tangannya langsung terlihat. Kata kaomoji berarti 'karakter wajah' (kao = wajah, moji = karakter)."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Bagaimana cara memakai kaomoji?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Klik kaomoji mana pun di halaman ini untuk menyalinnya, lalu tempel di chat, bio, atau caption Anda. Karena kaomoji hanyalah teks Unicode, ia langsung tertempel rapi tanpa berubah menjadi kotak kosong."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Di mana kaomoji bisa ditempel?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Kaomoji berfungsi di hampir semua kolom teks: WhatsApp, Instagram, TikTok, Discord, Telegram, Facebook, komentar YouTube, sampai nama pengguna game. Karena ini karakter Unicode standar, kaomoji tampil sama di semua perangkat tanpa aplikasi tambahan."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Apakah kaomoji aman dan gratis?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ya. Kaomoji hanyalah teks Unicode — tidak mengandung kode atau aplikasi, sepenuhnya aman, dan gratis untuk disalin sebanyak yang Anda mau. Sebagian kaomoji rumit mungkin tampil sedikit berbeda tergantung font perangkat."
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<div id="shared-header"></div>
+<script src="/header.js"></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/id/">Beranda</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Kaomoji</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Kaomoji</h1>
+    <p class="hero-tagline">Salin &amp; tempel kaomoji — wajah teks ala Jepang dari karakter Unicode. Wajah senang, sedih, angkat bahu, hewan lucu, sampai Lenny face. Klik mana pun untuk langsung menyalinnya.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/library-text-faces-kaomoji.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Kaomoji (顔文字) adalah emoticon yang berasal dari Jepang, dibuat dari karakter keyboard biasa dan simbol Unicode. Berbeda dengan emoji, kaomoji dibaca mendatar dan sering menangkap ekspresi yang lebih halus daripada yang bisa disampaikan emoji. Kaomoji berfungsi di kolom teks mana pun dan menambah karakter pada pesan, bio, serta caption.</p>
+    <p>Kata <em>kaomoji</em> secara harfiah berarti "karakter wajah" (顔 <em>kao</em>, "wajah" + 文字 <em>moji</em>, "karakter"). Jika emoticon Barat seperti <code>:-)</code> dibaca menyamping, kaomoji seperti <code>(◕‿◕)</code> dibaca tegak — sehingga mata, mulut, bahkan tangannya jauh lebih mudah dikenali. Karena setiap kaomoji di halaman ini murni teks Unicode — bukan gambar atau font emoji — ia tertempel rapi di bio Instagram, caption TikTok, pesan Discord, komentar YouTube, nama pengguna, dan hampir semua kolom teks tanpa berubah jadi kotak rusak.</p>
+    <p>Jelajahi kategori di bawah dan klik wajah mana pun untuk langsung menyalinnya. Semua dikelompokkan menurut suasana hati — senang, sedih, angkat bahu, cinta, lucu, marah, mengantuk, dan lainnya — supaya Anda menemukan ekspresi yang pas dalam hitungan detik.</p>
+  </div>
+</section>
+
+<!-- QUICK PICK — paling sering disalin -->
+<section class="mood-explainers" id="quick-pick">
+  <span class="article-section-label">Pilihan cepat</span>
+  <h2>Kaomoji paling sering dipakai</h2>
+  <p class="section-lead is-spaced">Kalau cuma butuh beberapa wajah cepat, mulai dari sini. Klik untuk menyalin.</p>
+  <div class="flag-rows symbol-pick-grid">
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="¯\_(ツ)_/¯" aria-label="Salin ¯\_(ツ)_/¯">¯\_(ツ)_/¯</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="( ͡° ͜ʖ ͡°)" aria-label="Salin ( ͡° ͜ʖ ͡°)">( ͡° ͜ʖ ͡°)</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="(◕‿◕)" aria-label="Salin (◕‿◕)">(◕‿◕)</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="(≧◡≦)" aria-label="Salin (≧◡≦)">(≧◡≦)</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="ʕ•ᴥ•ʔ" aria-label="Salin ʕ•ᴥ•ʔ">ʕ•ᴥ•ʔ</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="(=^・ω・^=)" aria-label="Salin (=^・ω・^=)">(=^・ω・^=)</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="(T_T)" aria-label="Salin (T_T)">(T_T)</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="╥﹏╥" aria-label="Salin ╥﹏╥">╥﹏╥</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="(♥ω♥)" aria-label="Salin (♥ω♥)">(♥ω♥)</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="(づ｡◕‿‿◕｡)づ" aria-label="Salin (づ｡◕‿‿◕｡)づ">(づ｡◕‿‿◕｡)づ</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="(^▽^)" aria-label="Salin (^▽^)">(^▽^)</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="(ノ°▽°)ノ" aria-label="Salin (ノ°▽°)ノ">(ノ°▽°)ノ</button></div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- HAPPY & POSITIVE -->
+<section class="mood-explainers" id="senang-positif">
+  <span class="article-section-label">Senang &amp; Positif</span>
+  <h2>Kaomoji Senang &amp; Positif</h2>
+  <p class="u-secondary-tight">Wajah teks ceria dan positif untuk pesan yang penuh semangat.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="◕‿◕" aria-label="Salin ◕‿◕">◕‿◕</button>
+      <span class="flag-label">Wajah Senang</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(◠‿◠)" aria-label="Salin (◠‿◠)">(◠‿◠)</button>
+      <span class="flag-label">Wajah Tersenyum</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="╰(▔∀▔)╯" aria-label="Salin ╰(▔∀▔)╯">╰(▔∀▔)╯</button>
+      <span class="flag-label">Joget Heboh</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(✿◠‿◠)" aria-label="Salin (✿◠‿◠)">(✿◠‿◠)</button>
+      <span class="flag-label">Senang Bunga</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ヽ(•‿•)ノ" aria-label="Salin ヽ(•‿•)ノ">ヽ(•‿•)ノ</button>
+      <span class="flag-label">Angkat Tangan Senang</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(^▽^)" aria-label="Salin (^▽^)">(^▽^)</button>
+      <span class="flag-label">Cengiran Lebar</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(≧◡≦)" aria-label="Salin (≧◡≦)">(≧◡≦)</button>
+      <span class="flag-label">Sangat Senang</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="٩(◕‿◕)۶" aria-label="Salin ٩(◕‿◕)۶">٩(◕‿◕)۶</button>
+      <span class="flag-label">Merayakan</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SAD & UPSET -->
+<section class="mood-explainers" id="sedih-kesal">
+  <span class="article-section-label">Sedih &amp; Kesal</span>
+  <h2>Kaomoji Sedih &amp; Kesal</h2>
+  <p class="u-secondary-tight">Wajah teks sedih, menangis, dan kesal.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="╥﹏╥" aria-label="Salin ╥﹏╥">╥﹏╥</button>
+      <span class="flag-label">Wajah Menangis</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(╯︵╰,)" aria-label="Salin (╯︵╰,)">(╯︵╰,)</button>
+      <span class="flag-label">Menangis Kesal</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ಥ_ಥ" aria-label="Salin ಥ_ಥ">ಥ_ಥ</button>
+      <span class="flag-label">Mata Berkaca-kaca</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(;﹏;)" aria-label="Salin (;﹏;)">(;﹏;)</button>
+      <span class="flag-label">Terisak</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(T_T)" aria-label="Salin (T_T)">(T_T)</button>
+      <span class="flag-label">Menangis</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(｡•́︿•̀｡)" aria-label="Salin (｡•́︿•̀｡)">(｡•́︿•̀｡)</button>
+      <span class="flag-label">Cemberut Sedih</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SHRUG & CONFUSION -->
+<section class="mood-explainers" id="angkat-bahu-bingung">
+  <span class="article-section-label">Angkat Bahu &amp; Bingung</span>
+  <h2>Kaomoji Angkat Bahu &amp; Bingung</h2>
+  <p class="u-secondary-tight">Wajah teks angkat bahu, bingung, dan datar tanpa ekspresi.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="¯\_(ツ)_/¯" aria-label="Salin ¯\_(ツ)_/¯">¯\_(ツ)_/¯</button>
+      <span class="flag-label">Angkat Bahu</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ಠ_ಠ" aria-label="Salin ಠ_ಠ">ಠ_ಠ</button>
+      <span class="flag-label">Tatapan Tak Setuju</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(⊙_⊙)" aria-label="Salin (⊙_⊙)">(⊙_⊙)</button>
+      <span class="flag-label">Mata Membelalak</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(°ロ°)!" aria-label="Salin (°ロ°)!">(°ロ°)!</button>
+      <span class="flag-label">Kaget</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(￣_￣|||)" aria-label="Salin (￣_￣|||)">(￣_￣|||)</button>
+      <span class="flag-label">Keringat Canggung</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(¬_¬)" aria-label="Salin (¬_¬)">(¬_¬)</button>
+      <span class="flag-label">Lirikan Sinis</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- LOVE & AFFECTION -->
+<section class="mood-explainers" id="cinta-sayang">
+  <span class="article-section-label">Cinta &amp; Sayang</span>
+  <h2>Kaomoji Cinta &amp; Sayang</h2>
+  <p class="u-secondary-tight">Wajah teks penuh cinta dan kasih sayang.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(♥ω♥)" aria-label="Salin (♥ω♥)">(♥ω♥)</button>
+      <span class="flag-label">Mata Cinta</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(◍•ᴗ•◍)❤" aria-label="Salin (◍•ᴗ•◍)❤">(◍•ᴗ•◍)❤</button>
+      <span class="flag-label">Wajah Jatuh Cinta</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(≧◡≦)" aria-label="Salin (≧◡≦)">(≧◡≦)</button>
+      <span class="flag-label">Super Senang</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(✿ ♥‿♥)" aria-label="Salin (✿ ♥‿♥)">(✿ ♥‿♥)</button>
+      <span class="flag-label">Bunga Cinta</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(⁄ ⁄•⁄ω⁄•⁄ ⁄)" aria-label="Salin (⁄ ⁄•⁄ω⁄•⁄ ⁄)">(⁄ ⁄•⁄ω⁄•⁄ ⁄)</button>
+      <span class="flag-label">Tersipu Malu</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♡(˃͈ દ ˂͈ ༶ )" aria-label="Salin ♡(˃͈ દ ˂͈ ༶ )">♡(˃͈ દ ˂͈ ༶ )</button>
+      <span class="flag-label">Mata Hati Malu</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- ANIMALS & CREATURES -->
+<section class="mood-explainers" id="hewan-makhluk">
+  <span class="article-section-label">Hewan &amp; Makhluk Lucu</span>
+  <h2>Kaomoji Hewan &amp; Makhluk Lucu</h2>
+  <p class="u-secondary-tight">Wajah teks hewan lucu untuk pesan dan media sosial.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ʕ•ᴥ•ʔ" aria-label="Salin ʕ•ᴥ•ʔ">ʕ•ᴥ•ʔ</button>
+      <span class="flag-label">Beruang</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(=^・ω・^=)" aria-label="Salin (=^・ω・^=)">(=^・ω・^=)</button>
+      <span class="flag-label">Kucing</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(◕ᴗ◕✿)" aria-label="Salin (◕ᴗ◕✿)">(◕ᴗ◕✿)</button>
+      <span class="flag-label">Makhluk Lucu</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(U ᵕ U❁)" aria-label="Salin (U ᵕ U❁)">(U ᵕ U❁)</button>
+      <span class="flag-label">Kelinci</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="∩｡• ᵕ •｡∩" aria-label="Salin ∩｡• ᵕ •｡∩">∩｡• ᵕ •｡∩</button>
+      <span class="flag-label">Anak Anjing</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(^•ω•^)" aria-label="Salin (^•ω•^)">(^•ω•^)</button>
+      <span class="flag-label">Peliharaan Senang</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- ACTION & EXPRESSION -->
+<section class="mood-explainers" id="aksi-ekspresi">
+  <span class="article-section-label">Aksi &amp; Ekspresi</span>
+  <h2>Kaomoji Aksi &amp; Ekspresi</h2>
+  <p class="u-secondary-tight">Kaomoji aksi yang menggambarkan gerakan, kekesalan, dan reaksi dramatis.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ᕕ(ᐛ)ᕗ" aria-label="Salin ᕕ(ᐛ)ᕗ">ᕕ(ᐛ)ᕗ</button>
+      <span class="flag-label">Lari Senang</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(╯°□°）╯︵ ┻━┻" aria-label="Salin (╯°□°）╯︵ ┻━┻">(╯°□°）╯︵ ┻━┻</button>
+      <span class="flag-label">Banting Meja (Marah)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="┬─┬ノ(º_ºノ)" aria-label="Salin ┬─┬ノ(º_ºノ)">┬─┬ノ(º_ºノ)</button>
+      <span class="flag-label">Kembalikan Meja</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(ノ°▽°)ノ" aria-label="Salin (ノ°▽°)ノ">(ノ°▽°)ノ</button>
+      <span class="flag-label">Angkat Kedua Tangan</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(づ｡◕‿‿◕｡)づ" aria-label="Salin (づ｡◕‿‿◕｡)づ">(づ｡◕‿‿◕｡)づ</button>
+      <span class="flag-label">Menawarkan Pelukan</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(ˆ_ˆ)/" aria-label="Salin (ˆ_ˆ)/">(ˆ_ˆ)/</button>
+      <span class="flag-label">Melambai Halo</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- LENNY FACES -->
+<section class="mood-explainers" id="lenny-faces">
+  <span class="article-section-label">Lenny &amp; Usil</span>
+  <h2>Lenny Faces</h2>
+  <p class="u-secondary-tight">Lenny face klasik beserta varian menyeringai, mengedip, dan angkat tangan. Tiap wajah disalin utuh.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="( ͡° ͜ʖ ͡°)" aria-label="Salin ( ͡° ͜ʖ ͡°)">( ͡° ͜ʖ ͡°)</button>
+      <span class="flag-label">Lenny Klasik</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="( ͠° ͟ʖ ͡°)" aria-label="Salin ( ͠° ͟ʖ ͡°)">( ͠° ͟ʖ ͡°)</button>
+      <span class="flag-label">Lenny Serius</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="( ͡~ ͜ʖ ͡°)" aria-label="Salin ( ͡~ ͜ʖ ͡°)">( ͡~ ͜ʖ ͡°)</button>
+      <span class="flag-label">Lenny Mengedip</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="( ͡ʘ ͜ʖ ͡ʘ)" aria-label="Salin ( ͡ʘ ͜ʖ ͡ʘ)">( ͡ʘ ͜ʖ ͡ʘ)</button>
+      <span class="flag-label">Lenny Terkejut</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="( ͡◉ ͜ʖ ͡◉)" aria-label="Salin ( ͡◉ ͜ʖ ͡◉)">( ͡◉ ͜ʖ ͡◉)</button>
+      <span class="flag-label">Lenny Mata Besar</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="( ͡⊙ ͜ʖ ͡⊙)" aria-label="Salin ( ͡⊙ ͜ʖ ͡⊙)">( ͡⊙ ͜ʖ ͡⊙)</button>
+      <span class="flag-label">Lenny Mata Lebar</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="¯\_( ͡° ͜ʖ ͡°)_/¯" aria-label="Salin ¯\_( ͡° ͜ʖ ͡°)_/¯">¯\_( ͡° ͜ʖ ͡°)_/¯</button>
+      <span class="flag-label">Lenny Angkat Bahu</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="( ͡° ͜ʖ ͡°)╭∩╮" aria-label="Salin ( ͡° ͜ʖ ͡°)╭∩╮">( ͡° ͜ʖ ͡°)╭∩╮</button>
+      <span class="flag-label">Lenny Usil</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="( ͡° ͜ʖ ͡°)つ──☆*:・ﾟ" aria-label="Salin ( ͡° ͜ʖ ͡°)つ──☆*:・ﾟ">( ͡° ͜ʖ ͡°)つ──☆*:・ﾟ</button>
+      <span class="flag-label">Lenny Sulap</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- LAUGHING & CRYING-LAUGHING -->
+<section class="mood-explainers" id="tertawa-ngakak">
+  <span class="article-section-label">Tertawa &amp; Ngakak</span>
+  <h2>Kaomoji Tertawa &amp; Ngakak</h2>
+  <p class="u-secondary-tight">Wajah teks tertawa keras sampai ngakak menangis — versi kaomoji dari emoji tertawa-menangis.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(≧▽≦)" aria-label="Salin (≧▽≦)">(≧▽≦)</button>
+      <span class="flag-label">Tertawa</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(＾▽＾)" aria-label="Salin (＾▽＾)">(＾▽＾)</button>
+      <span class="flag-label">Tawa Lebar</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="( ´∀｀)" aria-label="Salin ( ´∀｀)">( ´∀｀)</button>
+      <span class="flag-label">Tawa Lepas</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(*≧艸≦)" aria-label="Salin (*≧艸≦)">(*≧艸≦)</button>
+      <span class="flag-label">Terkikik</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ｗｗｗ" aria-label="Salin ｗｗｗ">ｗｗｗ</button>
+      <span class="flag-label">LOL Jepang</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(笑)" aria-label="Salin (笑)">(笑)</button>
+      <span class="flag-label">Tanda Tawa</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="＼(^o^)／" aria-label="Salin ＼(^o^)／">＼(^o^)／</button>
+      <span class="flag-label">Bersukacita</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(T▽T)" aria-label="Salin (T▽T)">(T▽T)</button>
+      <span class="flag-label">Tangis Bahagia</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(;´∀｀)" aria-label="Salin (;´∀｀)">(;´∀｀)</button>
+      <span class="flag-label">Tawa Keringat</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- COLLECTIONS -->
+<section class="mood-explainers" id="kaomoji-collections">
+  <span class="article-section-label">Set Kaomoji</span>
+  <h2>Set Kaomoji Bertema</h2>
+  <p class="u-secondary-block">Set kaomoji siap pakai yang dikelompokkan menurut suasana hati — salin satu set wajah sekaligus dengan satu klik untuk chat, caption, dan komentar.</p>
+  <div id="kaomojiCollectionsContainer"></div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- HUG EMOTICON -->
+<section class="mood-explainers" id="kaomoji-pelukan">
+  <span class="article-section-label">Kaomoji Pelukan</span>
+  <h2>Kaomoji Pelukan</h2>
+  <p class="u-secondary-tight">Salin kaomoji pelukan dengan varian tangan menjangkau dan dekapan — cara wajah teks untuk mengirim pelukan virtual.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(っ´▽｀)っ" aria-label="Salin (っ´▽｀)っ">(っ´▽｀)っ</button>
+      <span class="flag-label">Pelukan Menjangkau</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊂((・▽・))⊃" aria-label="Salin ⊂((・▽・))⊃">⊂((・▽・))⊃</button>
+      <span class="flag-label">Pelukan Erat</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(っ◕‿◕)っ" aria-label="Salin (っ◕‿◕)っ">(っ◕‿◕)っ</button>
+      <span class="flag-label">Pelukan Lucu</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⸜(｡˃ ᵕ ˂ )⸝♡" aria-label="Salin ⸜(｡˃ ᵕ ˂ )⸝♡">⸜(｡˃ ᵕ ˂ )⸝♡</button>
+      <span class="flag-label">Pelukan Bahagia</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(つ≧▽≦)つ" aria-label="Salin (つ≧▽≦)つ">(つ≧▽≦)つ</button>
+      <span class="flag-label">Pelukan Heboh</span>
+    </div>
+
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- CAT EYES KAOMOJI -->
+<section class="mood-explainers" id="kaomoji-mata-kucing">
+  <span class="article-section-label">Kaomoji Mata Kucing</span>
+  <h2>Kaomoji Mata Kucing &amp; Mata Lucu</h2>
+  <p class="u-secondary-tight">Salin kaomoji dengan mata besar berkilau — wajah kucing dan ekspresi mata lucu yang lebar.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(=^‥^=)" aria-label="Salin (=^‥^=)">(=^‥^=)</button>
+      <span class="flag-label">Mata Kucing</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(=｀ω´=)" aria-label="Salin (=｀ω´=)">(=｀ω´=)</button>
+      <span class="flag-label">Kucing Sombong</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(✿◕‿◕)" aria-label="Salin (✿◕‿◕)">(✿◕‿◕)</button>
+      <span class="flag-label">Mata Besar Lucu</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(◕ᴥ◕)" aria-label="Salin (◕ᴥ◕)">(◕ᴥ◕)</button>
+      <span class="flag-label">Mata Bulat</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(ↀᴥↀ)" aria-label="Salin (ↀᴥↀ)">(ↀᴥↀ)</button>
+      <span class="flag-label">Mata Kucing Lebar</span>
+    </div>
+
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- FAQ -->
+<section class="editorial-section" id="faq">
+  <span class="article-section-label">FAQ</span>
+  <h2>Kaomoji, dijawab</h2>
+  <details class="faq-item">
+    <summary class="faq-question">Apa itu kaomoji?</summary>
+    <p class="faq-answer">Kaomoji (顔文字) adalah emoticon yang berasal dari Jepang, dibuat dari karakter keyboard dan simbol Unicode. Berbeda dengan emoji yang dibaca menyamping, kaomoji dibaca tegak — misalnya (◕‿◕) — sehingga mata, mulut, bahkan tangannya langsung terlihat. Kata kaomoji berarti "karakter wajah" (kao = wajah, moji = karakter).</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">Bagaimana cara memakai kaomoji?</summary>
+    <p class="faq-answer">Klik kaomoji mana pun di halaman ini untuk menyalinnya, lalu tempel di chat, bio, atau caption Anda. Karena kaomoji hanyalah teks Unicode, ia langsung tertempel rapi tanpa berubah menjadi kotak kosong.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">Di mana kaomoji bisa ditempel?</summary>
+    <p class="faq-answer">Kaomoji berfungsi di hampir semua kolom teks: WhatsApp, Instagram, TikTok, Discord, Telegram, Facebook, komentar YouTube, sampai nama pengguna game. Karena ini karakter Unicode standar, kaomoji tampil sama di semua perangkat tanpa aplikasi tambahan.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">Apakah kaomoji aman dan gratis?</summary>
+    <p class="faq-answer">Ya. Kaomoji hanyalah teks Unicode — tidak mengandung kode atau aplikasi, sepenuhnya aman, dan gratis untuk disalin sebanyak yang Anda mau. Sebagian kaomoji rumit mungkin tampil sedikit berbeda tergantung font perangkat.</p>
+  </details>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- CTA -->
+<section class="editorial-section" id="font-aesthetic">
+  <span class="article-section-label">Tulisan aesthetic</span>
+  <h2>Mau huruf aesthetic juga, bukan cuma kaomoji?</h2>
+  <p class="section-lead">Kaomoji di atas untuk ekspresi. Untuk mengubah huruf biasa menjadi <strong>font huruf aesthetic</strong> — tebal, miring, kecil, atau gaya unik — ketik teks Anda di generator, lalu padukan dengan kaomoji dari halaman ini.</p>
+  <div class="cta-card">
+    <h3>Buat tulisan &amp; font aesthetic</h3>
+    <p>Ubah teks biasa menjadi 100+ gaya font Unicode keren — gratis dan langsung jadi. Padukan dengan kaomoji untuk pesan dan bio yang menonjol.</p>
+    <a href="/id/" class="cta-btn">Buka Generator Tulisan Aesthetic →</a>
+  </div>
+</section>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Halaman Terkait</span>
+  <div class="compare-grid">
+    <a href="/id/" class="compare-card variant-muted u-no-underline">
+      <h4>Generator Tulisan Aesthetic</h4>
+      <p>Ubah teks biasa menjadi font huruf aesthetic, keren, dan unik — gratis dan langsung jadi.</p>
+    </a>
+    <a href="/id/library/simbol-aesthetic/" class="compare-card variant-muted u-no-underline">
+      <h4>Simbol Aesthetic</h4>
+      <p>Koleksi simbol Unicode aesthetic — kilau, hati, bunga, dan pembatas untuk bio dan nama.</p>
+    </a>
+    <a href="/id/usecase/nama-ml-keren/" class="compare-card variant-muted u-no-underline">
+      <h4>Nama ML Keren</h4>
+      <p>Generator nama Mobile Legends keren dengan font dan simbol unik.</p>
+    </a>
+    <a href="/id/usecase/nama-ff-keren/" class="compare-card variant-muted u-no-underline">
+      <h4>Nama FF Keren</h4>
+      <p>Generator nama Free Fire keren dengan huruf dan simbol estetik.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js"></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    { name: "Set Kaomoji Senang", flags: ["(◠‿◠)","(^▽^)","(≧◡≦)","ヽ(•‿•)ノ"], defaultFormat: "inline" },
+    { name: "Kaomoji Hewan Lucu", flags: ["ʕ•ᴥ•ʔ","(=^・ω・^=)","(◕ᴗ◕✿)","(U ᵕ U❁)"], defaultFormat: "inline" },
+    { name: "Set Sedih & Menangis", flags: ["(T_T)","╥﹏╥","(;﹏;)","(｡•́︿•̀｡)"], defaultFormat: "inline" },
+    { name: "Set Angkat Bahu & Banting Meja", flags: ["¯\\_(ツ)_/¯","(╯°□°）╯︵ ┻━┻","┬─┬ノ(º_ºノ)"], defaultFormat: "inline" },
+    { name: "Set Cinta & Sayang", flags: ["(♥ω♥)","(◍•ᴗ•◍)❤","(✿ ♥‿♥)","(づ｡◕‿‿◕｡)づ"], defaultFormat: "inline" },
+    { name: "Set Lenny Face", flags: ["( ͡° ͜ʖ ͡°)","( ͡~ ͜ʖ ͡°)","( ͡◉ ͜ʖ ͡◉)"], defaultFormat: "inline" }
+  ];
+
+  ns.buildGrids("kaomojiCollectionsContainer", GROUPS);
+  ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js"></script>
+</body>
+</html>

--- a/id/library/simbol-aesthetic/index.html
+++ b/id/library/simbol-aesthetic/index.html
@@ -503,9 +503,9 @@
       <h4>Generator Tulisan Aesthetic</h4>
       <p>Ubah teks biasa menjadi font huruf aesthetic, keren, dan unik — gratis dan langsung jadi.</p>
     </a>
-    <a href="/id/usecase/zalgo-text/" class="compare-card variant-muted u-no-underline">
-      <h4>Generator Teks Zalgo</h4>
-      <p>Buat teks glitch dan menyeramkan dengan tanda Unicode kombinasi.</p>
+    <a href="/id/library/kaomoji/" class="compare-card variant-muted u-no-underline">
+      <h4>Kaomoji</h4>
+      <p>Wajah teks ala Jepang siap salin-tempel — senang, sedih, cinta, hewan, dan Lenny face.</p>
     </a>
     <a href="/id/usecase/nama-ml-keren/" class="compare-card variant-muted u-no-underline">
       <h4>Nama ML Keren</h4>

--- a/library/text-faces-kaomoji/index.html
+++ b/library/text-faces-kaomoji/index.html
@@ -18,6 +18,9 @@
 <meta name="description" content="Browse and copy text faces and kaomoji — Japanese emoticons using ASCII and Unicode characters. Happy, sad, shrug, love, animals, and action expressions. Click any to copy it instantly.">
 
 <link rel="canonical" href="https://ultratextgen.com/library/text-faces-kaomoji/">
+<link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/text-faces-kaomoji/">
+<link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/text-faces-kaomoji/">
+<link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/kaomoji/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/library-text-faces-kaomoji.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">


### PR DESCRIPTION
Indonesia is the site's #1 market (5,852 clicks) and /id/ is the #1 page, yet we capture zero of the ~201k/mo 'kaomoji' searches. This adds an ID translation of /library/text-faces-kaomoji/ targeting that gap, with bidirectional hreflang, breadcrumb/Article/WebPage/FAQPage JSON-LD, and internal links from the /id/ homepage and the simbol-aesthetic page.


Claude-Session: https://claude.ai/code/session_01KhC7EiUhoQcRhXFgtZ24xB