### PR TITLE
feat: add Tagalog (/tl/) localized homepage for Philippines

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -91,7 +91,7 @@
   }
 
   function detectLang() {
-    var supported = ["en", "es", "fr", "pt", "de", "id", "it", "nl", "tr", "pl", "vi"];
+    var supported = ["en", "es", "fr", "pt", "de", "id", "it", "nl", "tr", "pl", "vi", "tl"];
 
     // 1. Detect from URL path prefix (e.g. /fr/, /de/)
     var pathMatch = window.location.pathname.match(/^\/([a-z]{2})\//);

--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
 <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/">
 <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/">
 <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/">
+<link rel="alternate" hreflang="tl" href="https://ultratextgen.com/tl/">
 
 <meta name="robots" content="index, follow">
 
@@ -790,6 +791,7 @@
         <a class="lang-option" href="/tr/" hreflang="tr">TR</a>
         <a class="lang-option" href="/pl/" hreflang="pl">PL</a>
         <a class="lang-option" href="/vi/" hreflang="vi">VI</a>
+        <a class="lang-option" href="/tl/" hreflang="tl">TL</a>
       </div>
     </div>
   </footer>

--- a/locales/tl.json
+++ b/locales/tl.json
@@ -1,0 +1,208 @@
+{
+  "meta": {
+    "title": "Stylish Text & Fancy Fonts — Cool Font Generator (Copy-Paste)",
+    "description": "Gawing stylish ang text mo — fancy fonts, cool na letra & aesthetic symbols para sa FB & IG bio, TikTok caption, WhatsApp status, at name style sa Mobile Legends & Free Fire. Copy-paste, libre, walang sign up."
+  },
+  "hero": {
+    "title": "Stylish Text & Fancy Fonts",
+    "subtitle": "Gawing fancy font, stylish na letra, at aesthetic symbols ang ordinaryong text — handa nang i-copy paste sa Facebook & Instagram bio, TikTok caption, WhatsApp status, at name style sa ML & Free Fire."
+  },
+  "decorations": {
+    "label": "Magdagdag ng dekorasyon sa resulta",
+    "tabs": {
+      "symbols": "Simbolo",
+      "frames": "Frame",
+      "dividers": "Pang-hati",
+      "arrows": "Arrow",
+      "minimal": "Minimal",
+      "emojis": "Emoji",
+      "flags": "Bandila"
+    }
+  },
+  "ui": {
+    "placeholder": "I-type ang text mo dito...",
+    "advertisement": "Patalastas"
+  },
+  "useCases": {
+    "title": "Pinaka-Ginagamit Para Sa",
+    "viewAll": "Tingnan lahat ng gamit →",
+    "items": [
+      {
+        "title": "Aesthetic na FB & IG Bio",
+        "description": "Gawing standout ang Facebook at Instagram bio mo gamit ang stylish text, fancy na letra, at maliliit na simbolo — readable pa rin pero eye-catching agad."
+      },
+      {
+        "title": "TikTok Caption na Pumipigil sa Scroll",
+        "description": "Mas matindi ang hook gamit ang bold, cursive, o glitch na text na nagpapatigil sa tao para basahin ang buong caption."
+      },
+      {
+        "title": "WhatsApp & Messenger Status",
+        "description": "Mas buhay ang status at profile name mo — stylish text plus aesthetic symbols na direktang i-paste, walang kailangang app."
+      }
+    ]
+  },
+  "guides": {
+    "title": "Mga Gabay Para Mas Maging Stylish Ka",
+    "viewAll": "Tingnan lahat ng gabay →",
+    "items": [
+      {
+        "title": "Paano Gumawa ng Aesthetic IG Bio",
+        "description": "Mga trick sa pag-ayos ng Instagram bio gamit ang kombinasyon ng stylish text, simbolo, at pang-hati para malinis pero may personality."
+      },
+      {
+        "title": "Ang Sikreto ng Font na Nagpapaiba",
+        "description": "Bakit nakakaapekto ang pinili mong font sa impression, tiwala, at vibe ng account mo — plus paano ito gamitin."
+      },
+      {
+        "title": "Stop the Scroll: Font Variation",
+        "description": "Paano laruin ang font variation para masira ng content mo ang pattern ng feed at kumuha ng mas mataas na engagement."
+      }
+    ]
+  },
+  "faq": {
+    "categories": [
+      {
+        "title": "Stylish Text & Paano Gamitin",
+        "items": [
+          {
+            "question": "Ano ba talaga ang stylish text?",
+            "answer": "Ang stylish text ay mga letrang mukhang special font — pwedeng bold, cursive, gothic, o glitch — pero ordinaryong text pa rin na pwede mong i-copy paste.\n    <br><br>\n    Sa Facebook at TikTok iba't iba ang tawag dito: fancy text, cool text, aesthetic font, o stylish na letra. Pero iisa lang ang ibig sabihin — letrang stylish na mula sa character mismo, hindi mula sa format ng app.\n    <br><br>\n    Ang pinagkaiba sa normal na format: bawat letra dito ay sariling Unicode character. Kaya pag in-paste mo sa Instagram bio, TikTok caption, o WhatsApp status, hindi nawawala ang estilo.\n    <br><br>\n    <strong>Mabilis na halimbawa</strong><br>\n    I-type ang \"ganda\" → pwedeng maging 𝗴𝗮𝗻𝗱𝗮 (bold), 𝑔𝒶𝓃𝒹𝒶 (cursive), ⓖⓐⓝⓓⓐ (bubble), o 𝔤𝔞𝔫𝔡𝔞 (gothic).\n    <br><br>\n    Walang i-install na app, walang sign up. I-type, pumili ng estilo, i-copy."
+          },
+          {
+            "question": "Paano i-copy paste ang text?",
+            "answer": "Ilang segundo lang:\n    <br><br>\n    1. I-type o i-paste ang text mo sa pinakataas na box.<br>\n    2. Lalabas agad sa ibaba ang mga stylish version — maraming estilo nang sabay-sabay.<br>\n    3. Gusto mo mas specific? Pumili ng category tulad ng Bold, Cursive, Gothic, o Bubble.<br>\n    4. Gustong gawing mas cool? I-click ang \"Magdagdag ng dekorasyon\" para sa frame, simbolo, o pang-hati.<br>\n    5. I-click ang Copy sa tabi ng gustong estilo — tapos i-paste kahit saan.\n    <br><br>\n    Smooth sa phone at laptop. Walang account, walang limit."
+          },
+          {
+            "question": "Libre ba talaga? May daily limit ba?",
+            "answer": "100% libre. Walang watermark, walang sign up, at walang daily limit. Isa man o sandaang stylish text ang gawin mo, pareho lang — gamitin anumang oras."
+          }
+        ]
+      },
+      {
+        "title": "Pagkaiba sa Normal na Font sa App",
+        "items": [
+          {
+            "question": "Ano ang pinagkaiba sa bold text sa Word, IG, o Discord?",
+            "answer": "Ang bold sa Word, Discord (**bold**), o katulad na app ay format lang — nakatagong code na nasa app lang mismo.\n    <br><br>\n    Pag kinopya mo sa Instagram bio, TikTok caption, o sa nickname field, nawawala ang format. Plain text na lang ang na-paste.\n    <br><br>\n    Iba ang UltraTextGen. Bawat letra ay pinapalitan ng sariling Unicode character na \"hugis\" na bold, cursive, o kung ano man. Dahil ang character mismo ang stylish, hindi nawawala ang estilo kahit saan i-paste.\n    <br><br>\n    <strong>Totoong halimbawa</strong><br>\n    \"Sale\" na bold sa Google Docs → pag in-paste sa TikTok bio nagiging \"Sale\" na ordinaryo.<br>\n    \"Sale\" sa UltraTextGen → 𝗦𝗮𝗹𝗲 — bold pa rin sa bio, nickname, hanggang email subject."
+          },
+          {
+            "question": "Ano ang kaya nito na hindi kaya ng Word o IG?",
+            "answer": "Maraming bagay na hindi kayang ibigay ng Word o ng toolbar ng IG:\n    <br><br>\n    — Bold & italic text diretso sa Instagram bio, TikTok caption, at YouTube description.<br>\n    — Gothic, bubble, at cursive na walang sa kahit anong word processor.<br>\n    — Upside down, baligtad, at mirror na text.<br>\n    — Zalgo / glitch text para sa horror o edgy na vibe.<br>\n    — Frame at border na simbolo sa paligid ng text.<br>\n    — Cool na nickname para sa Discord, Roblox, Steam, ML, FF, at PUBG.<br>\n    — Strikethrough at underline sa mga field na karaniwang hindi sumusuporta.\n    <br><br>\n    Ang punto: nakadikit sa character ang lahat ng visual effect — kaya stylish pa rin kahit saan i-paste."
+          },
+          {
+            "question": "Pwede ba ito sa email subject o work message?",
+            "answer": "Oo naman. Plain text ang email subject, kaya nawawala ang normal na bold bago pa mabasa ng tatanggap.\n    <br><br>\n    Gamit ang bold na Unicode text, makikita ng inbox ng tatanggap ang tunay na bold na letra. Bagay sa newsletter, broadcast, hanggang work email na gustong mas tumampok.\n    <br><br>\n    <strong>Halimbawa</strong><br>\n    Normal: \"Flash Sale — 50% Off Today\"<br>\n    Unicode: \"𝗙𝗹𝗮𝘀𝗵 𝗦𝗮𝗹𝗲 — 𝟱𝟬% 𝗢𝗳𝗳 𝗧𝗼𝗱𝗮𝘆\"\n    <br><br>\n    Tama ang display sa Gmail, Outlook, at Apple Mail."
+          }
+        ]
+      },
+      {
+        "title": "Mga Estilo, Simbolo & Dekorasyon",
+        "items": [
+          {
+            "question": "Anong mga estilo ng text ang meron dito?",
+            "answer": "Isa ito sa pinaka-kumpletong koleksyon sa internet — lahat may prefix na \"Ultra\" para madaling makilala.\n    <br><br>\n    <strong>Pinaka-ginagamit</strong><br>\n    Ultra Bold, Ultra Italic (cursive), Ultra Script (aesthetic cursive), Ultra Gothic, Ultra Bubble, Ultra Strike (strikethrough), Ultra Underline.\n    <br><br>\n    <strong>Unique para sa gustong kakaiba</strong><br>\n    Upside Down, Mirror, Small Caps, Zalgo / glitch, Double Struck, Fullwidth, Squared, Parenthesized, at marami pa.\n    <br><br>\n    May bagong estilo na idinadagdag kada ilang linggo — i-bookmark para hindi ma-miss."
+          },
+          {
+            "question": "Pwede bang pagsamahin ang ilang estilo plus aesthetic symbols?",
+            "answer": "Oo, at ito ang nagpapaiba sa amin sa ibang generator — pagsamahin ang estilo plus dekorasyon sa isang click lang.\n    <br><br>\n    Paboritong combo ng mga creator: Bubble + Zalgo, Gothic + Upside Down, Small Caps + Underline. Tapos balutin ng frame o simbolo para mas pumop.\n    <br><br>\n    <strong>Handa nang dekorasyon</strong><br>\n    Frame (★彡[ text ]彡★, ╭─▸ text ╰─▸), arrow, maliliit na simbolo, minimal na pang-hati, emoji, hanggang bandila.\n    <br><br>\n    <strong>Halimbawang resulta</strong><br>\n    \"ganda\" → Ultra Gothic → dagdagan ng star frame → ★彡[ 𝔤𝔞𝔫𝔡𝔞 ]彡★"
+          },
+          {
+            "question": "Ano ang Zalgo / glitch text na lumalabas sa TikTok?",
+            "answer": "Ang Zalgo ay sirang estilo ng text — pinapatungan ang mga letra ng diacritic sa itaas, gilid, at ibaba, kaya mukhang glitchy, creepy, o parang \"sumpa.\"\n    <br><br>\n    <strong>Halimbawa</strong><br>\n    \"ganda\" → g̷a̷n̷d̷a̷\n    <br><br>\n    Sikat ngayon sa horror TikTok content, dark meme, edgy bio, hanggang prank sa group chat. I-type ang text, piliin ang Zalgo, i-copy, i-paste — automatic ang stacking ng diacritic."
+          }
+        ]
+      },
+      {
+        "title": "IG Bio, TikTok Caption, Status & Game Nickname",
+        "items": [
+          {
+            "question": "Bagay ba ito sa aesthetic na Instagram bio?",
+            "answer": "Ito ang paboritong gamit. Stylish text, fancy na letra, at maliliit na simbolo na direktang i-paste sa IG bio nang walang kailangang app.\n    <br><br>\n    <strong>Halimbawang bio</strong><br>\n    — ✦ 𝒸𝒽𝒶𝓈𝒾𝓃ℊ 𝓁𝒾ℊ𝒽𝓉 ✦<br>\n    — ☾ 𝔡𝔯𝔢𝔞𝔪𝔢𝔯 · 𝔪𝔞𝔫𝔦𝔩𝔞 ☽<br>\n    — ⌗ 𝙨𝙩𝙧𝙖𝙮 𝙠𝙞𝙙 · 𝙨𝙞𝙣𝙘𝙚 '02\n    <br><br>\n    Tip: gumamit ng 1–2 estilo lang para readable. Dagdagan ng maliliit na simbolo (✦ ☾ ⌗ ·) para paghiwalayin ang linya."
+          },
+          {
+            "question": "Pwede ba sa ML, Free Fire, o PUBG nickname?",
+            "answer": "Oo naman — marami nga ang gumagamit nito para diyan. Tanggap ang Unicode character sa username field ng Mobile Legends, Free Fire, PUBG, Genshin, hanggang Roblox.\n    <br><br>\n    <strong>Halimbawang cool nickname</strong><br>\n    Mula sa \"DarkWolf\" → pwedeng maging:<br>\n    — 𝔇𝔞𝔯𝔨𝔚𝔬𝔩𝔣 (gothic, astig na vibe)<br>\n    — ꧁༒𝓓𝓪𝓻𝓴𝓦𝓸𝓵𝓯༒꧂ (script + ornament — paborito sa ML)<br>\n    — ⓓⓐⓡⓚⓦⓞⓛⓕ (bubble, mas playful)<br>\n    — ᴅᴀʀᴋᴡᴏʟꜰ (small caps, simple pero kakaiba)\n    <br><br>\n    <strong>Tip</strong><br>\n    Kung tinanggihan ng game ang isang estilo, palitan — Small Caps at Ultra Bold ang karaniwang pinaka-safe. Gusto ng ornament? Tingnan ang Frame tab para sa ꧁ ꧂, ༒, at paboritong simbolo ng gamer."
+          },
+          {
+            "question": "Pwede ba sa WhatsApp status at TikTok caption?",
+            "answer": "Oo — pareho. May built-in nang *bold* at _italic_ ang WhatsApp, pero ang cursive, gothic, bubble, at Zalgo ay sa Unicode lang makukuha.\n    <br><br>\n    <strong>WhatsApp status</strong><br>\n    I-type ang pangungusap → piliin ang cursive o bubble → i-copy → buksan ang WhatsApp → Status → i-paste.\n    <br><br>\n    <strong>TikTok caption</strong><br>\n    Gumamit ng bold sa unang keyword para pigilin ang scroll. Halimbawa: \"𝗦𝗧𝗢𝗣 — 30-second aesthetic bio tutorial 👇\""
+          }
+        ]
+      },
+      {
+        "title": "Filipino/Tagalog & Suportadong Character",
+        "items": [
+          {
+            "question": "Gumagana ba lahat ng estilo sa Filipino at Tagalog?",
+            "answer": "Oo. Dahil gumagamit ang Filipino at Tagalog ng Latin alphabet (A–Z, a–z), gumagana nang normal ang lahat ng estilo — bold, cursive, gothic, bubble, hanggang Zalgo.\n    <br><br>\n    Nababago rin ang numero 0–9, kaya kung may numero sa bio o nickname mo (tulad ng birthday o jersey number), compact pa rin ang itsura.\n    <br><br>\n    Bukod sa Filipino, gumagana rin ang ibang wikang Latin — English, Bisaya, Bahasa, Vietnamese, Turkish, hanggang Spanish."
+          },
+          {
+            "question": "Anong mga script ang hindi nababago?",
+            "answer": "Walang stylish Unicode variant ang mga non-Latin script, kaya nananatiling ordinaryo ang letra. Hindi nababago ang:\n    <br><br>\n    Arabic, Hebrew, Hindi, Tamil, Thai, Chinese, Japanese (kanji/hiragana/katakana), Korean, at mga katutubong script tulad ng Baybayin.\n    <br><br>\n    Pero kung may halo ang text mo — halimbawa Filipino na may English na salita o brand name — ang bahaging Latin ay normal pa ring mako-convert."
+          },
+          {
+            "question": "Paano ang special character tulad ng tuldok, tanong, emoji?",
+            "answer": "Perpektong nababago ang A–Z, a–z, at 0–9 sa halos lahat ng estilo. Ang basic punctuation (tuldok, kuwit, tanong, padamdam) ay karaniwang iniiwan para readable pa rin ang pangungusap.\n    <br><br>\n    100% safe ang emoji — hindi ito nababago, kaya 🌸 ay 🌸 pa rin sa parehong posisyon. Gusto pagsamahin ang stylish text plus emoji sa bio? Isingit lang sa nakopyang resulta."
+          }
+        ]
+      },
+      {
+        "title": "Privacy & Kaligtasan",
+        "items": [
+          {
+            "question": "Ligtas ba ang text na tina-type ko?",
+            "answer": "Ligtas. Hindi sino-store ang text mo at hindi ipinapadala sa kahit anong server. Lahat ng pag-convert ng letra ay nangyayari sa browser mo mismo.\n    <br><br>\n    Pure Unicode character lang ang kinokopya mo — walang nakatagong character o tracker na nakadikit."
+          },
+          {
+            "question": "Ligtas ba i-paste sa WA, IG, o game?",
+            "answer": "Sobrang ligtas. Standard Unicode text lang ang output — walang script, walang nakatagong format, walang code na makakasama sa account.\n    <br><br>\n    Pwede i-paste sa kahit anong app: WA, IG, TikTok, Discord, ML, FF, Roblox, lahat. Kasing-ligtas ng manual na pag-type."
+          }
+        ]
+      },
+      {
+        "title": "Gamit sa Android & iPhone",
+        "items": [
+          {
+            "question": "Pwede ba gamitin sa Android at iPhone?",
+            "answer": "Oo, at madalas nga itong ginagamit sa phone. Fully responsive ang site — buksan sa phone browser (Chrome, Safari, o built-in), i-type ang text, piliin ang estilo, tapos i-tap ang Copy.\n    <br><br>\n    Walang i-download na app. Gumagana sa Android, iPhone, iPad, hanggang laptop. Sa phone, karaniwang dederetso ka agad sa IG, TikTok, o FB para i-paste — wala pang 10 segundo ang buong proseso."
+          }
+        ]
+      },
+      {
+        "title": "Bakit UltraTextGen",
+        "items": [
+          {
+            "question": "Ano ang pinagkaiba sa ibang text generator?",
+            "answer": "Dinisenyo ang UltraTextGen para maging pinaka-kumpleto pero magaan pa ring buksan, lalo na sa phone.\n    <br><br>\n    <strong>Ang nagpapaiba</strong><br>\n    — Pinakamaraming Ultra font — bold, aesthetic cursive, gothic, bubble, hanggang unique tulad ng Zalgo at mirror.<br>\n    — Pagsamahin ang estilo sa isang click — walang paulit-ulit na copy-paste.<br>\n    — Instant na dekorasyon: frame, border, maliliit na simbolo, pang-hati, arrow, emoji.<br>\n    — Hiwalay na page kada platform — TikTok, Instagram, Facebook, WhatsApp.<br>\n    — Mabilis buksan, walang nakakaabalang pop-up, walang auto-play na video ad.<br>\n    — Regular na update ng bagong estilo kada ilang linggo."
+          },
+          {
+            "question": "May bago bang estilo paminsan-minsan?",
+            "answer": "Madalas. Regular na idinadagdag ang bagong Ultra style at dekorasyon, karaniwang kada ilang linggo. I-bookmark ang page para madaling makabalik pag may bagong labas."
+          },
+          {
+            "question": "Paano hanapin ang estilong bagay sa kailangan ko?",
+            "answer": "May tatlong paraan na pwede mong piliin:\n    <br><br>\n    <strong>Sa pamamagitan ng category</strong><br>\n    Mag-browse kada category — bold, cursive, gothic, bubble, strikethrough, underline, upside down, at iba pa.\n    <br><br>\n    <strong>Sa pamamagitan ng platform</strong><br>\n    Gusto specific sa IG, TikTok, Facebook, o WA? Gamitin ang per-platform generator — testado na roon ang ipinapakitang estilo.\n    <br><br>\n    <strong>Sa pamamagitan ng gamit</strong><br>\n    Bisitahin ang use case pages — aesthetic bio, comment caption, game nickname, emoji combo, at marami pa."
+          }
+        ]
+      }
+    ]
+  },
+  "footer": {
+    "copyright": "© 2026 UltraTextGen. Stylish text & fancy fonts na dumidikit kahit saan."
+  },
+  "notFound": {
+    "eyebrow": "ERR · 404 · NAWAWALANG SPECIMEN",
+    "title": "Nawala ang page na ito sa koleksyon ng estilo.",
+    "subtitle": "Wala sa koleksyon namin ang URL na binuksan mo. Pero gumagana pa rin bilang text ang error na ito — subukan ang 404 sa Ultra Bold, Bubble, Gothic, Zalgo, at iba pa.",
+    "backCta": "← Balik sa generator",
+    "browseCta": "Mag-browse ng estilo",
+    "wallTitle": "404, ginawa sa lahat ng estilo namin.",
+    "wallSubtitle": "Bawat estilo sa ibaba ay galing sa parehong engine na nag-paandar sa UltraTextGen.",
+    "playgroundTitle": "Subukan ang sarili mong nawawalang text.",
+    "playgroundSubtitle": "I-type kahit ano at tingnan ang preview sa ilang Ultra style bago bumalik sa buong generator.",
+    "playgroundPlaceholder": "I-type ang text mo dito...",
+    "fullGeneratorCta": "Buksan ang buong generator",
+    "copy": "Copy",
+    "copied": "Nakopya"
+  }
+}

--- a/tl/index.html
+++ b/tl/index.html
@@ -1,0 +1,954 @@
+<!DOCTYPE html><html lang="tl"><head>
+  <meta name="yandex-verification" content="aa326290e0338f4f">
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8242324164413945"
+       crossorigin="anonymous"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title data-i18n="meta.title">Stylish Text &amp; Fancy Fonts — Cool Font Generator (Copy-Paste)</title>
+<meta name="description" data-i18n-content="meta.description" content="Gawing stylish ang text mo — fancy fonts, cool na letra & aesthetic symbols para sa FB & IG bio, TikTok caption, WhatsApp status, at name style sa Mobile Legends & Free Fire. Copy-paste, libre, walang sign up.">
+
+<link rel="canonical" href="https://ultratextgen.com/tl/">
+
+<link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/">
+<link rel="alternate" hreflang="en" href="https://ultratextgen.com/">
+<link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/">
+<link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/">
+<link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/">
+<link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/">
+<link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/">
+<link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/">
+<link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/">
+<link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/">
+<link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/">
+<link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/">
+<link rel="alternate" hreflang="tl" href="https://ultratextgen.com/tl/">
+
+<meta name="robots" content="index, follow">
+
+<meta property="og:site_name" content="UltraTextGen">
+<meta property="og:title" content="Stylish Text &amp; Fancy Fonts — Cool Font Generator (Copy-Paste)">
+<meta property="og:description" content="Gawing stylish ang text mo — fancy fonts, cool na letra & aesthetic symbols para sa FB & IG bio, TikTok caption, at name style sa Mobile Legends. Copy-paste, libre, walang sign up.">
+<meta property="og:url" content="https://ultratextgen.com/tl/">
+<meta property="og:type" content="website">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/generator-font-aesthetic-preview.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Stylish Text &amp; Fancy Fonts — Cool Font Generator (Copy-Paste)">
+<meta name="twitter:description" content="Gawing stylish ang text mo — fancy fonts, cool na letra & aesthetic symbols para sa FB & IG bio, TikTok caption, at name style sa Mobile Legends.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/generator-font-aesthetic-preview.png">
+
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/style.css">
+
+ <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+[
+  {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/",
+    "description": "Fast, clean Unicode text generator for social bios, captions, and usernames.",
+    "potentialAction": {
+      "@type": "SearchAction",
+      "target": {
+        "@type": "EntryPoint",
+        "urlTemplate": "https://ultratextgen.com/?q={search_term_string}"
+      },
+      "query-input": "required name=search_term_string"
+    }
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com",
+    "logo": "https://ultratextgen.com/logo.png",
+    "sameAs": [
+      "https://www.youtube.com/@UltraTextGen",
+      "https://www.facebook.com/profile.php?id=61588587387596",
+      "https://www.linkedin.com/company/71290348/",
+      "https://x.com/UltraTextGen"
+    ]
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "WebApplication",
+    "name": "UltraTextGen",
+    "alternateName": ["Stylish Text Generator", "Fancy Font Generator", "Cool Text Generator", "Font Copy Paste"],
+    "url": "https://ultratextgen.com/",
+    "applicationCategory": "UtilitiesApplication",
+    "operatingSystem": "All",
+    "browserRequirements": "Requires JavaScript",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "description": "Stylish text at fancy font generator para sa Facebook at Instagram bio, TikTok caption, WhatsApp status, at name style sa Mobile Legends & Free Fire."
+  }
+]
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Paano Gumawa ng Stylish Text",
+  "description": "Gawing fancy font, stylish na letra, at cool na text ang ordinaryong text na handa nang i-copy paste sa Facebook & Instagram bio, TikTok caption, WhatsApp status, at name style sa game.",
+  "totalTime": "PT1M",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "position": 1,
+      "name": "I-type ang text mo",
+      "text": "Isulat ang pangalan, salita, o pangungusap sa pinakataas na box. Pwede ring i-paste ang text na nakopya mo na."
+    },
+    {
+      "@type": "HowToStep",
+      "position": 2,
+      "name": "Pumili ng stylish na estilo",
+      "text": "Lalabas agad sa ibaba ang mga stylish version — bold, aesthetic cursive, gothic, bubble, hanggang glitch. Pumili ng category para mas specific."
+    },
+    {
+      "@type": "HowToStep",
+      "position": 3,
+      "name": "I-copy at i-paste",
+      "text": "I-click ang Copy, tapos i-paste sa FB o IG bio, TikTok caption, WhatsApp status, o game nickname. Dahil Unicode character ang bawat letra, hindi nawawala ang estilo kahit saan i-paste."
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "UltraTextGen",
+      "item": "https://ultratextgen.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Stylish Text & Fancy Fonts",
+      "item": "https://ultratextgen.com/tl/"
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Ano ba talaga ang stylish text?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ang stylish text ay mga letrang mukhang special font — pwedeng bold, cursive, gothic, o glitch — pero ordinaryong text pa rin na pwede mong i-copy paste. Sa Facebook at TikTok iba't iba ang tawag: fancy text, cool text, aesthetic font, o stylish na letra. Dahil Unicode character ang bawat letra, hindi nawawala ang estilo kahit i-paste sa Instagram bio, TikTok caption, o WhatsApp status. Walang i-install na app, walang sign up — i-type, pumili ng estilo, i-copy."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Libre ba talaga? May daily limit ba?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "100% libre. Walang watermark, walang sign up, at walang daily limit. Isa man o sandaang stylish text ang gawin mo, pareho lang — gamitin anumang oras."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Ano ang pinagkaiba sa bold text sa Word, IG, o Discord?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ang bold sa Word o Discord ay format lang na nasa app mismo, kaya nawawala pag in-paste sa bio o nickname field. Iba ang UltraTextGen — pinapalitan ang bawat letra ng Unicode character na 'hugis' na bold o cursive, kaya hindi nawawala ang estilo kahit saan i-paste. Halimbawa: 'Sale' sa UltraTextGen ay 𝗦𝗮𝗹𝗲 — bold pa rin sa bio, nickname, hanggang email subject."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Pwede ba sa ML, Free Fire, o PUBG nickname?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Oo — tanggap ang Unicode character sa username field ng Mobile Legends, Free Fire, PUBG, Genshin, hanggang Roblox. Halimbawa, ang 'DarkWolf' ay pwedeng maging 𝔇𝔞𝔯𝔨𝔚𝔬𝔩𝔣 (gothic), ꧁༒𝓓𝓪𝓻𝓴𝓦𝓸𝓵𝓯༒꧂ (script + ornament, paborito sa ML), o ᴅᴀʀᴋᴡᴏʟꜰ (small caps). Kung tinanggihan ng game ang isang estilo, Small Caps at Ultra Bold ang pinaka-safe."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Gumagana ba lahat ng estilo sa Filipino at Tagalog?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Oo. Dahil gumagamit ang Filipino at Tagalog ng Latin alphabet, gumagana nang normal ang lahat ng estilo — bold, cursive, gothic, bubble, hanggang Zalgo. Nababago rin ang numero 0–9. Gumagana rin sa English, Bisaya, at ibang wikang Latin. Ang non-Latin script tulad ng Baybayin ay nananatiling ordinaryo."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Pwede ba gamitin sa Android at iPhone?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Oo, at madalas nga itong ginagamit sa phone. Fully responsive ang site — buksan sa phone browser, i-type ang text, piliin ang estilo, tapos i-tap ang Copy. Walang i-download na app. Gumagana sa Android, iPhone, iPad, hanggang laptop."
+      }
+    }
+  ]
+}
+</script>
+</head>
+
+<body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<script src="/header.js"></script>
+
+  <!-- Hero Section -->
+  <section class="hero">
+    <div class="hero-inner">
+      <div class="hero-card">
+        <h1 class="hero-headline" data-i18n="hero.title">Stylish Text &amp; Fancy Fonts</h1>
+        <p class="hero-tagline" data-i18n="hero.subtitle">Gawing fancy font, stylish na letra, at aesthetic symbols ang ordinaryong text — handa nang i-copy paste sa Facebook &amp; Instagram bio, TikTok caption, WhatsApp status, at name style sa ML &amp; Free Fire.</p>
+        <div class="input-wrapper">
+          <textarea class="main-input" id="mainInput" placeholder="I-type ang text mo dito..." data-i18n-placeholder="ui.placeholder" maxlength="500" autofocus=""></textarea>
+          <button class="input-clear-btn" id="inputClearBtn" aria-label="Clear input" hidden="">✕</button>
+          <span class="char-count" id="charCountWrapper" hidden=""><span id="charCount">0</span>/500</span>
+        </div>
+
+        <!-- Decoration Selector -->
+        <div class="decoration-section">
+          <div class="decoration-label">
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"></path>
+            </svg>
+            <span data-i18n="decorations.label">Magdagdag ng dekorasyon sa resulta</span>
+       </div>
+    <div class="decoration-tabs">
+    <button class="decoration-tab active" data-deco-tab="symbols" data-i18n="decorations.tabs.symbols">Simbolo</button>
+    <button class="decoration-tab" data-deco-tab="frames" data-i18n="decorations.tabs.frames">Frame</button>
+    <button class="decoration-tab" data-deco-tab="dividers" data-i18n="decorations.tabs.dividers">Pang-hati</button>
+    <button class="decoration-tab" data-deco-tab="arrows" data-i18n="decorations.tabs.arrows">Arrow</button>
+    <button class="decoration-tab" data-deco-tab="minimal" data-i18n="decorations.tabs.minimal">Minimal</button>
+    <button class="decoration-tab" data-deco-tab="emojis" data-i18n="decorations.tabs.emojis">Emoji</button>
+    <button class="decoration-tab" data-deco-tab="flags" data-i18n="decorations.tabs.flags">Bandila</button>
+      </div>
+          <div class="decoration-grid" id="decorationGrid"></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Main Content -->
+  <main class="container">
+    <!-- Category Tabs -->
+    <div class="category-section">
+      <div class="category-tabs" id="categoryTabs">
+        <!-- Tabs will be dynamically loaded from fonts.json -->
+      </div>
+    </div>
+
+    <!-- Results -->
+    <div class="results-grid" id="resultsGrid"></div>
+  </main>
+
+  <!-- Popular Use Cases -->
+  <section class="editorial-section">
+    <h2 data-i18n="useCases.title">Pinaka-Ginagamit Para Sa</h2>
+    <div class="tips-grid">
+      <a class="tip-card" href="/instagram/" aria-label="Aesthetic na FB & IG Bio">
+        <div class="tip-icon">📸</div>
+        <h3 data-i18n="useCases.items.0.title">Aesthetic na FB &amp; IG Bio</h3>
+        <p data-i18n="useCases.items.0.description">Gawing standout ang Facebook at Instagram bio mo gamit ang stylish text, fancy na letra, at maliliit na simbolo — readable pa rin pero eye-catching agad.</p>
+      </a>
+      <a class="tip-card" href="/tiktok/" aria-label="TikTok Caption na Pumipigil sa Scroll">
+        <div class="tip-icon">🎵</div>
+        <h3 data-i18n="useCases.items.1.title">TikTok Caption na Pumipigil sa Scroll</h3>
+        <p data-i18n="useCases.items.1.description">Mas matindi ang hook gamit ang bold, cursive, o glitch na text na nagpapatigil sa tao para basahin ang buong caption.</p>
+      </a>
+      <a class="tip-card" href="/whatsapp/" aria-label="WhatsApp & Messenger Status">
+        <div class="tip-icon">💬</div>
+        <h3 data-i18n="useCases.items.2.title">WhatsApp &amp; Messenger Status</h3>
+        <p data-i18n="useCases.items.2.description">Mas buhay ang status at profile name mo — stylish text plus aesthetic symbols na direktang i-paste, walang kailangang app.</p>
+      </a>
+      <a class="tip-card" href="/usecase/" aria-label="Zalgo / Glitch Text">
+        <div class="tip-icon">👻</div>
+        <h3>Zalgo / Glitch Text</h3>
+        <p>Gumawa ng creepy, glitchy na text na may nakapatong na diacritic — bagay sa horror TikTok content, dark meme, at edgy na bio.</p>
+      </a>
+    </div>
+    <p class="u-mt-15 u-text-center"><a class="cat-cta" href="/usecase/" data-i18n="useCases.viewAll">Tingnan lahat ng gamit →</a></p>
+  </section>
+
+  <!-- Cool, Unique & Fun Text -->
+  <section class="editorial-section">
+    <h2>Cool, Unique &amp; Fun na Text — Hindi Lang Aesthetic</h2>
+    <p class="editorial-intro">Bukod sa stylish text, gumagawa rin ang generator na ito ng cool text, fancy font, hanggang fun na simbolo — i-type, i-copy, i-paste lang. Piliin ang estilong bagay sa vibe mo:</p>
+    <div class="tips-grid">
+      <div class="tip-card">
+        <div class="tip-icon">🔥</div>
+        <h3>Cool Text</h3>
+        <p>Bold, gothic, at matatapang na estilo na agad nagpapa-standout sa pangalan o caption — paborito sa post title at cool text copy paste.</p>
+      </div>
+      <div class="tip-card">
+        <div class="tip-icon">✨</div>
+        <h3>Unique Text</h3>
+        <p>Bihirang letra at kombinasyon ng simbolo na bihirang gamitin para iba ang bio at username mo sa iba.</p>
+      </div>
+      <div class="tip-card">
+        <div class="tip-icon">🧸</div>
+        <h3>Fancy Font &amp; Simbolo</h3>
+        <p>Bubble, cute na letra, at maliliit na aesthetic symbol para playful ang itsura sa IG, TikTok, o Facebook.</p>
+      </div>
+      <div class="tip-card">
+        <div class="tip-icon">🎮</div>
+        <h3>Font para sa Game Name</h3>
+        <p>Gumawa ng cool nickname para sa ML, Free Fire, at PUBG gamit ang font at simbolong suportado sa name field — copy-paste lang.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Popular Guides -->
+  <section class="editorial-section">
+    <h2 data-i18n="guides.title">Mga Gabay Para Mas Maging Stylish Ka</h2>
+    <div class="tips-grid">
+      <a class="tip-card" href="/guide/the-rhetoric-of-fonts/" aria-label="Paano Gumawa ng Aesthetic IG Bio">
+        <div class="tip-icon">🎨</div>
+        <h3 data-i18n="guides.items.0.title">Paano Gumawa ng Aesthetic IG Bio</h3>
+        <p data-i18n="guides.items.0.description">Mga trick sa pag-ayos ng Instagram bio gamit ang kombinasyon ng stylish text, simbolo, at pang-hati para malinis pero may personality.</p>
+      </a>
+      <a class="tip-card" href="/guide/personal-branding-through-typography/" aria-label="Ang Sikreto ng Font na Nagpapaiba">
+        <div class="tip-icon">📚</div>
+        <h3 data-i18n="guides.items.1.title">Ang Sikreto ng Font na Nagpapaiba</h3>
+        <p data-i18n="guides.items.1.description">Bakit nakakaapekto ang pinili mong font sa impression, tiwala, at vibe ng account mo — plus paano ito gamitin.</p>
+      </a>
+      <a class="tip-card" href="/guide/stop-the-scroll-with-font-variation/" aria-label="Stop the Scroll: Font Variation">
+        <div class="tip-icon">📱</div>
+        <h3 data-i18n="guides.items.2.title">Stop the Scroll: Font Variation</h3>
+        <p data-i18n="guides.items.2.description">Paano laruin ang font variation para masira ng content mo ang pattern ng feed at kumuha ng mas mataas na engagement.</p>
+      </a>
+    </div>
+    <p class="u-mt-15 u-text-center"><a class="cat-cta" href="/guide/" data-i18n="guides.viewAll">Tingnan lahat ng gabay →</a></p>
+  </section>
+
+  <!-- How To -->
+  <section class="editorial-section">
+    <h2>Paano Gumawa ng Stylish Text</h2>
+    <p class="editorial-intro">Ilang segundo lang ang paggawa ng stylish text, fancy font, o cool na text — walang i-install na app, walang sign up.</p>
+    <div class="steps-grid">
+      <div class="step-card">
+        <div class="step-number">1</div>
+        <h3>I-type ang text mo</h3>
+        <p>Isulat ang pangalan, salita, o pangungusap sa pinakataas na box. Pwede ring i-paste ang text na nakopya mo na.</p>
+      </div>
+      <div class="step-card">
+        <div class="step-number">2</div>
+        <h3>Pumili ng stylish na estilo</h3>
+        <p>Lalabas agad ang stylish text — bold, aesthetic cursive, gothic, bubble, hanggang glitch. Pumili ng category para mas specific.</p>
+      </div>
+      <div class="step-card">
+        <div class="step-number">3</div>
+        <h3>I-copy &amp; i-paste</h3>
+        <p>I-click ang Copy, tapos i-paste sa FB o IG bio, TikTok caption, WhatsApp status, o game nickname. Hindi mawawala ang estilo.</p>
+      </div>
+    </div>
+    <p class="u-mt-15 u-text-center">Pareho ang hakbang kung <strong>paano gumawa ng stylish text sa Facebook</strong>, Instagram, WhatsApp, hanggang TikTok bio.</p>
+  </section>
+
+  <!-- Stylish vs Fancy text terminology -->
+  <section class="editorial-section">
+    <h2>Stylish Text, Fancy Text, Cool Text: Iisa Lang</h2>
+    <p>"Stylish text", "fancy text", at "cool text" ay parehong tumutukoy sa iisang bagay — letrang may estilo na hindi default na font ng keyboard. Iba't iba lang ang tawag sa Facebook, TikTok, at search, pero pareho ang gamit: text na pwedeng i-copy paste sa bio, caption, o nickname.</p>
+    <p>Kaya kung naghahanap ka ng <strong>stylish text</strong> o <strong>fancy letters</strong> para sa Instagram, Facebook, o TikTok, hindi mo kailangan mag-alala sa tamang termino — i-type lang ang salita o pangalan sa generator sa itaas, at lalabas agad ang lahat ng estilo, mula simple hanggang puno ng ornament. Pareho ang hakbang para sa caption, name style, o status: i-type, pumili, i-copy.</p>
+    <div class="block-example">
+      <strong>Halimbawa:</strong> "ganda" → 𝓰𝓪𝓷𝓭𝓪 (cursive), 𝔤𝔞𝔫𝔡𝔞 (gothic), ⓖⓐⓝⓓⓐ (bubble), ɢᴀɴᴅᴀ (small caps)
+    </div>
+  </section>
+
+  <!-- Cool Text -->
+  <section class="editorial-section">
+    <h2>Cool Text: Gawing Astig ang Ordinaryong Text</h2>
+    <p class="editorial-intro">Gusto ng <strong>cool text</strong> na agad nagpapaiba sa bio, caption, o pangalan? I-type lang sa generator sa itaas — magiging dose-dosenang cool na estilo ang ordinaryong text, handa nang i-copy paste.</p>
+    <p>Ang pagkaiba sa bold sa chat app: dito, sariling Unicode character ang bawat letra, kaya pag <strong>ginawa mong cool ang text</strong> at in-paste sa Instagram, TikTok, o Facebook, hindi nawawala ang estilo. Bold, gothic, cursive, o cute na bubble — lahat lalabas nang sabay, piliin mo lang.</p>
+    <div class="block-example">
+      <strong>Halimbawa:</strong> "Kampeon" → 𝗞𝗮𝗺𝗽𝗲𝗼𝗻 (bold), 𝕶𝖆𝖒𝖕𝖊𝖔𝖓 (gothic), 𝙆𝙖𝙢𝙥𝙚𝙤𝙣 (bold italic), ᴋᴀᴍᴘᴇᴏɴ (small caps)
+    </div>
+    <p>Para sa <strong>cool name</strong> o game nickname, pagsamahin ang font at simbolo para mas standout. Gustong mag-focus sa isang estilo? Bisitahin ang <a href="/category/bold-fonts/">bold fonts</a>, <a href="/category/gothic-fonts/">gothic fonts</a>, o <a href="/category/cursive-fonts/">cursive fonts</a>.</p>
+  </section>
+
+  <!-- Vertical / Stacked -->
+  <section class="editorial-section">
+    <h2>Pataas-pababang Text (Vertical / Stacked)</h2>
+    <p class="editorial-intro">Gusto ng <strong>vertical text</strong> — letrang nakasalansan pataas-pababa, hindi pahalang? Gumamit ng dedikadong generator para bumaba isa-isang linya ang bawat letra at malinis pa rin pag in-paste.</p>
+    <p>Dahil Unicode character plus bagong linya lang ang resulta, dumidikit pa rin ang text sa Instagram bio, TikTok caption, WhatsApp status, hanggang game nickname. Naiiba ito sa karaniwang text dahil sinisira nito ang normal na pattern ng pagbasa.</p>
+    <div class="block-example">
+      <strong>Halimbawa — "HALO" na stacked:</strong>
+<pre>H
+A
+L
+O</pre>
+    </div>
+    <p>Gustong gumawa ng sarili? Buksan ang <a href="/usecase/vertical-text/"><strong>Vertical &amp; Stacked Text Generator</strong></a> — pumili ng layout (stack, hagdan, pyramid, o box frame), magdagdag ng pang-hati, tapos i-copy paste kahit saan.</p>
+  </section>
+
+  <!-- A–Z glyphs -->
+  <section class="editorial-section glyph-section">
+    <h2>Stylish Letters A–Z</h2>
+    <p class="editorial-intro">Gusto ng stylish na letra mula A hanggang Z? Ito ang buong alphabet sa pinakasikat na estilo. I-click ang isang row para kopyahin ang buong alphabet nang sabay.</p>
+    <div class="alpha-list">
+      <div class="alpha-row">
+        <span class="alpha-label">Bold</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇" aria-label="Kopyahin ang stylish letters na Bold">𝗮 𝗯 𝗰 𝗱 𝗲 𝗳 𝗴 𝗵 𝗶 𝗷 𝗸 𝗹 𝗺 𝗻 𝗼 𝗽 𝗾 𝗿 𝘀 𝘁 𝘂 𝘃 𝘄 𝘅 𝘆 𝘇</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Cursive</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃" aria-label="Kopyahin ang stylish letters na Cursive">𝓪 𝓫 𝓬 𝓭 𝓮 𝓯 𝓰 𝓱 𝓲 𝓳 𝓴 𝓵 𝓶 𝓷 𝓸 𝓹 𝓺 𝓻 𝓼 𝓽 𝓾 𝓿 𝔀 𝔁 𝔂 𝔃</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Gothic</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷" aria-label="Kopyahin ang stylish letters na Gothic">𝔞 𝔟 𝔠 𝔡 𝔢 𝔣 𝔤 𝔥 𝔦 𝔧 𝔨 𝔩 𝔪 𝔫 𝔬 𝔭 𝔮 𝔯 𝔰 𝔱 𝔲 𝔳 𝔴 𝔵 𝔶 𝔷</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Bubble</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ" aria-label="Kopyahin ang stylish letters na Bubble">ⓐ ⓑ ⓒ ⓓ ⓔ ⓕ ⓖ ⓗ ⓘ ⓙ ⓚ ⓛ ⓜ ⓝ ⓞ ⓟ ⓠ ⓡ ⓢ ⓣ ⓤ ⓥ ⓦ ⓧ ⓨ ⓩ</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Small Caps</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="ᴀʙᴄᴅᴇꜰɢʜɪᴊᴋʟᴍɴᴏᴘqʀsᴛᴜᴠᴡxʏᴢ" aria-label="Kopyahin ang stylish letters na Small Caps">ᴀ ʙ ᴄ ᴅ ᴇ ꜰ ɢ ʜ ɪ ᴊ ᴋ ʟ ᴍ ɴ ᴏ ᴘ q ʀ s ᴛ ᴜ ᴠ ᴡ x ʏ ᴢ</button>
+      </div>
+    </div>
+    <h3>Stylish Numbers 0–9</h3>
+    <div class="alpha-list">
+      <div class="alpha-row">
+        <span class="alpha-label">Bold</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝟬𝟭𝟮𝟯𝟰𝟱𝟲𝟳𝟴𝟵" aria-label="Kopyahin ang stylish numbers na Bold">𝟬 𝟭 𝟮 𝟯 𝟰 𝟱 𝟲 𝟳 𝟴 𝟵</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Double-Struck</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝟘𝟙𝟚𝟛𝟜𝟝𝟞𝟟𝟠𝟡" aria-label="Kopyahin ang stylish numbers na Double-Struck">𝟘 𝟙 𝟚 𝟛 𝟜 𝟝 𝟞 𝟟 𝟠 𝟡</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Bubble</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="⓪①②③④⑤⑥⑦⑧⑨" aria-label="Kopyahin ang stylish numbers na Bubble">⓪ ① ② ③ ④ ⑤ ⑥ ⑦ ⑧ ⑨</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Fullwidth</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="０１２３４５６７８９" aria-label="Kopyahin ang stylish numbers na Fullwidth">０ １ ２ ３ ４ ５ ６ ７ ８ ９</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Mono</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝟶𝟷𝟸𝟹𝟺𝟻𝟼𝟽𝟾𝟿" aria-label="Kopyahin ang stylish numbers na Mono">𝟶 𝟷 𝟸 𝟹 𝟺 𝟻 𝟼 𝟽 𝟾 𝟿</button>
+      </div>
+    </div>
+    <p class="u-mt-15">Gusto ng stylish na inisyal o numero para sa birthday sa bio? I-type lang sa generator sa itaas — lalabas agad ang lahat ng estilo.</p>
+  </section>
+
+  <!-- Symbols -->
+  <section class="editorial-section glyph-section">
+    <h2>Aesthetic Symbols &amp; Cool Characters</h2>
+    <p class="editorial-intro">Koleksyon ng aesthetic symbols, cool na simbolo, at unique na character para paghiwalayin ang linya ng IG bio, palamutian ang nickname, o dagdagan ng vibe ang caption. I-click ang simbolo para kopyahin agad.</p>
+    <div class="glyph-group">
+      <h3>Star &amp; Sparkle</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="✦">✦</button>
+        <button class="glyph-copy" type="button" data-text="✧">✧</button>
+        <button class="glyph-copy" type="button" data-text="⋆">⋆</button>
+        <button class="glyph-copy" type="button" data-text="✩">✩</button>
+        <button class="glyph-copy" type="button" data-text="★">★</button>
+        <button class="glyph-copy" type="button" data-text="☆">☆</button>
+        <button class="glyph-copy" type="button" data-text="✰">✰</button>
+        <button class="glyph-copy" type="button" data-text="⊹">⊹</button>
+        <button class="glyph-copy" type="button" data-text="࿐">࿐</button>
+        <button class="glyph-copy" type="button" data-text="˚">˚</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Puso</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="♡">♡</button>
+        <button class="glyph-copy" type="button" data-text="♥">♥</button>
+        <button class="glyph-copy" type="button" data-text="❤">❤</button>
+        <button class="glyph-copy" type="button" data-text="❥">❥</button>
+        <button class="glyph-copy" type="button" data-text="❣">❣</button>
+        <button class="glyph-copy" type="button" data-text="ஐ">ஐ</button>
+        <button class="glyph-copy" type="button" data-text="ꨄ">ꨄ</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Buwan &amp; Langit</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="☾">☾</button>
+        <button class="glyph-copy" type="button" data-text="☽">☽</button>
+        <button class="glyph-copy" type="button" data-text="☁">☁</button>
+        <button class="glyph-copy" type="button" data-text="✶">✶</button>
+        <button class="glyph-copy" type="button" data-text="⍣">⍣</button>
+        <button class="glyph-copy" type="button" data-text="ꕥ">ꕥ</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Frame &amp; Ornament</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="꧁">꧁</button>
+        <button class="glyph-copy" type="button" data-text="꧂">꧂</button>
+        <button class="glyph-copy" type="button" data-text="༺">༺</button>
+        <button class="glyph-copy" type="button" data-text="༻">༻</button>
+        <button class="glyph-copy" type="button" data-text="⌗">⌗</button>
+        <button class="glyph-copy" type="button" data-text="⟡">⟡</button>
+        <button class="glyph-copy" type="button" data-text="❪">❪</button>
+        <button class="glyph-copy" type="button" data-text="❫">❫</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Bulaklak</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="❀">❀</button>
+        <button class="glyph-copy" type="button" data-text="✿">✿</button>
+        <button class="glyph-copy" type="button" data-text="⚘">⚘</button>
+        <button class="glyph-copy" type="button" data-text="✾">✾</button>
+        <button class="glyph-copy" type="button" data-text="❁">❁</button>
+        <button class="glyph-copy" type="button" data-text="ꕤ">ꕤ</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Pang-hati</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="·">·</button>
+        <button class="glyph-copy" type="button" data-text="•">•</button>
+        <button class="glyph-copy" type="button" data-text="◦">◦</button>
+        <button class="glyph-copy" type="button" data-text="➛">➛</button>
+        <button class="glyph-copy" type="button" data-text="⟢">⟢</button>
+        <button class="glyph-copy" type="button" data-text="—">—</button>
+        <button class="glyph-copy" type="button" data-text="☰">☰</button>
+      </div>
+    </div>
+  </section>
+
+  <!-- Game Nickname (ML / FF) -->
+  <section class="editorial-section">
+    <h2>Stylish Name para sa ML, Free Fire &amp; Game</h2>
+    <p class="editorial-intro">Gumawa ng cool nickname para sa Mobile Legends, Free Fire, PUBG, hanggang Roblox. I-type ang pangalan mo, pumili ng stylish na font, i-copy — tanggap ang Unicode character sa username field ng game.</p>
+    <div class="block-example">
+      <strong>DarkWolf</strong> pwedeng maging:<br>
+      — 𝔇𝔞𝔯𝔨𝔚𝔬𝔩𝔣 (gothic, astig na vibe)<br>
+      — ꧁༒𝓓𝓪𝓻𝓴𝓦𝓸𝓵𝓯༒꧂ (script + ornament, paborito sa ML)<br>
+      — ᴅᴀʀᴋᴡᴏʟꜰ (small caps, simple pero kakaiba)
+    </div>
+    <p>Kung tinanggihan ng game ang isang estilo, palitan ng <strong>Small Caps</strong> o <strong>Ultra Bold</strong> — ito ang pinaka-safe na tanggapin. Gusto ng dagdag na ornament tulad ng ꧁ ꧂ ༒? Tingnan ang <strong>Frame</strong> tab sa generator sa itaas.</p>
+    <p>Para sa <strong>name style sa ML</strong> at squad name, pagsamahin ang font at ang payong na simbolo ꧁꧂ para mas tumampok ang IGN mo. Gustong tumuon sa isang gamit? Bisitahin ang <a href="/usecase/">use case pages</a> para sa bio, comment caption, at game nickname.</p>
+  </section>
+
+  <!-- FAQ Section -->
+  <section class="faq-section-wrapper" aria-label="Frequently asked questions">
+    <div class="faq-inner">
+
+<!-- Stylish Text & Paano Gamitin -->
+<h2 class="faq-category" data-i18n="faq.categories.0.title">Stylish Text &amp; Paano Gamitin</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.0.items.0.question">Ano ba talaga ang stylish text?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.0.items.0.answer">Ang stylish text ay mga letrang mukhang special font — pwedeng bold, cursive, gothic, o glitch — pero ordinaryong text pa rin na pwede mong i-copy paste.
+    <br><br>
+    Sa Facebook at TikTok iba't iba ang tawag dito: fancy text, cool text, aesthetic font, o stylish na letra. Pero iisa lang ang ibig sabihin — letrang stylish na mula sa character mismo, hindi mula sa format ng app.
+    <br><br>
+    Ang pinagkaiba sa normal na format: bawat letra dito ay sariling Unicode character. Kaya pag in-paste mo sa Instagram bio, TikTok caption, o WhatsApp status, hindi nawawala ang estilo.
+    <br><br>
+    <strong>Mabilis na halimbawa</strong><br>
+    I-type ang "ganda" → pwedeng maging 𝗴𝗮𝗻𝗱𝗮 (bold), 𝑔𝒶𝓃𝒹𝒶 (cursive), ⓖⓐⓝⓓⓐ (bubble), o 𝔤𝔞𝔫𝔡𝔞 (gothic).
+    <br><br>
+    Walang i-install na app, walang sign up. I-type, pumili ng estilo, i-copy.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.0.items.1.question">Paano i-copy paste ang text?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.0.items.1.answer">Ilang segundo lang:
+    <br><br>
+    1. I-type o i-paste ang text mo sa pinakataas na box.<br>
+    2. Lalabas agad sa ibaba ang mga stylish version — maraming estilo nang sabay-sabay.<br>
+    3. Gusto mo mas specific? Pumili ng category tulad ng Bold, Cursive, Gothic, o Bubble.<br>
+    4. Gustong gawing mas cool? I-click ang "Magdagdag ng dekorasyon" para sa frame, simbolo, o pang-hati.<br>
+    5. I-click ang Copy sa tabi ng gustong estilo — tapos i-paste kahit saan.
+    <br><br>
+    Smooth sa phone at laptop. Walang account, walang limit.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.0.items.2.question">Libre ba talaga? May daily limit ba?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.0.items.2.answer">100% libre. Walang watermark, walang sign up, at walang daily limit. Isa man o sandaang stylish text ang gawin mo, pareho lang — gamitin anumang oras.</div>
+</div>
+
+
+<!-- Pagkaiba sa Normal na Font sa App -->
+<h2 class="faq-category" data-i18n="faq.categories.1.title">Pagkaiba sa Normal na Font sa App</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.1.items.0.question">Ano ang pinagkaiba sa bold text sa Word, IG, o Discord?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.1.items.0.answer">Ang bold sa Word, Discord (**bold**), o katulad na app ay format lang — nakatagong code na nasa app lang mismo.
+    <br><br>
+    Pag kinopya mo sa Instagram bio, TikTok caption, o sa nickname field, nawawala ang format. Plain text na lang ang na-paste.
+    <br><br>
+    Iba ang UltraTextGen. Bawat letra ay pinapalitan ng sariling Unicode character na "hugis" na bold, cursive, o kung ano man. Dahil ang character mismo ang stylish, hindi nawawala ang estilo kahit saan i-paste.
+    <br><br>
+    <strong>Totoong halimbawa</strong><br>
+    "Sale" na bold sa Google Docs → pag in-paste sa TikTok bio nagiging "Sale" na ordinaryo.<br>
+    "Sale" sa UltraTextGen → 𝗦𝗮𝗹𝗲 — bold pa rin sa bio, nickname, hanggang email subject.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.1.items.1.question">Ano ang kaya nito na hindi kaya ng Word o IG?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.1.items.1.answer">Maraming bagay na hindi kayang ibigay ng Word o ng toolbar ng IG:
+    <br><br>
+    — Bold &amp; italic text diretso sa Instagram bio, TikTok caption, at YouTube description.<br>
+    — Gothic, bubble, at cursive na walang sa kahit anong word processor.<br>
+    — Upside down, baligtad, at mirror na text.<br>
+    — Zalgo / glitch text para sa horror o edgy na vibe.<br>
+    — Frame at border na simbolo sa paligid ng text.<br>
+    — Cool na nickname para sa Discord, Roblox, Steam, ML, FF, at PUBG.<br>
+    — Strikethrough at underline sa mga field na karaniwang hindi sumusuporta.
+    <br><br>
+    Ang punto: nakadikit sa character ang lahat ng visual effect — kaya stylish pa rin kahit saan i-paste.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.1.items.2.question">Pwede ba ito sa email subject o work message?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.1.items.2.answer">Oo naman. Plain text ang email subject, kaya nawawala ang normal na bold bago pa mabasa ng tatanggap.
+    <br><br>
+    Gamit ang bold na Unicode text, makikita ng inbox ng tatanggap ang tunay na bold na letra. Bagay sa newsletter, broadcast, hanggang work email na gustong mas tumampok.
+    <br><br>
+    <strong>Halimbawa</strong><br>
+    Normal: "Flash Sale — 50% Off Today"<br>
+    Unicode: "𝗙𝗹𝗮𝘀𝗵 𝗦𝗮𝗹𝗲 — 𝟱𝟬% 𝗢𝗳𝗳 𝗧𝗼𝗱𝗮𝘆"
+    <br><br>
+    Tama ang display sa Gmail, Outlook, at Apple Mail.</div>
+</div>
+
+
+<!-- Mga Estilo, Simbolo & Dekorasyon -->
+<h2 class="faq-category" data-i18n="faq.categories.2.title">Mga Estilo, Simbolo &amp; Dekorasyon</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.2.items.0.question">Anong mga estilo ng text ang meron dito?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.2.items.0.answer">Isa ito sa pinaka-kumpletong koleksyon sa internet — lahat may prefix na "Ultra" para madaling makilala.
+    <br><br>
+    <strong>Pinaka-ginagamit</strong><br>
+    Ultra Bold, Ultra Italic (cursive), Ultra Script (aesthetic cursive), Ultra Gothic, Ultra Bubble, Ultra Strike (strikethrough), Ultra Underline.
+    <br><br>
+    <strong>Unique para sa gustong kakaiba</strong><br>
+    Upside Down, Mirror, Small Caps, Zalgo / glitch, Double Struck, Fullwidth, Squared, Parenthesized, at marami pa.
+    <br><br>
+    May bagong estilo na idinadagdag kada ilang linggo — i-bookmark para hindi ma-miss.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.2.items.1.question">Pwede bang pagsamahin ang ilang estilo plus aesthetic symbols?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.2.items.1.answer">Oo, at ito ang nagpapaiba sa amin sa ibang generator — pagsamahin ang estilo plus dekorasyon sa isang click lang.
+    <br><br>
+    Paboritong combo ng mga creator: Bubble + Zalgo, Gothic + Upside Down, Small Caps + Underline. Tapos balutin ng frame o simbolo para mas pumop.
+    <br><br>
+    <strong>Handa nang dekorasyon</strong><br>
+    Frame (★彡[ text ]彡★, ╭─▸ text ╰─▸), arrow, maliliit na simbolo, minimal na pang-hati, emoji, hanggang bandila.
+    <br><br>
+    <strong>Halimbawang resulta</strong><br>
+    "ganda" → Ultra Gothic → dagdagan ng star frame → ★彡[ 𝔤𝔞𝔫𝔡𝔞 ]彡★</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.2.items.2.question">Ano ang Zalgo / glitch text na lumalabas sa TikTok?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.2.items.2.answer">Ang Zalgo ay sirang estilo ng text — pinapatungan ang mga letra ng diacritic sa itaas, gilid, at ibaba, kaya mukhang glitchy, creepy, o parang "sumpa."
+    <br><br>
+    <strong>Halimbawa</strong><br>
+    "ganda" → g̷a̷n̷d̷a̷
+    <br><br>
+    Sikat ngayon sa horror TikTok content, dark meme, edgy bio, hanggang prank sa group chat. I-type ang text, piliin ang Zalgo, i-copy, i-paste — automatic ang stacking ng diacritic.</div>
+</div>
+
+
+<!-- IG Bio, TikTok Caption, Status & Game Nickname -->
+<h2 class="faq-category" data-i18n="faq.categories.3.title">IG Bio, TikTok Caption, Status &amp; Game Nickname</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.3.items.0.question">Bagay ba ito sa aesthetic na Instagram bio?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.3.items.0.answer">Ito ang paboritong gamit. Stylish text, fancy na letra, at maliliit na simbolo na direktang i-paste sa IG bio nang walang kailangang app.
+    <br><br>
+    <strong>Halimbawang bio</strong><br>
+    — ✦ 𝒸𝒽𝒶𝓈𝒾𝓃ℊ 𝓁𝒾ℊ𝒽𝓉 ✦<br>
+    — ☾ 𝔡𝔯𝔢𝔞𝔪𝔢𝔯 · 𝔪𝔞𝔫𝔦𝔩𝔞 ☽<br>
+    — ⌗ 𝙨𝙩𝙧𝙖𝙮 𝙠𝙞𝙙 · 𝙨𝙞𝙣𝙘𝙚 '02
+    <br><br>
+    Tip: gumamit ng 1–2 estilo lang para readable. Dagdagan ng maliliit na simbolo (✦ ☾ ⌗ ·) para paghiwalayin ang linya.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.3.items.1.question">Pwede ba sa ML, Free Fire, o PUBG nickname?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.3.items.1.answer">Oo naman — marami nga ang gumagamit nito para diyan. Tanggap ang Unicode character sa username field ng Mobile Legends, Free Fire, PUBG, Genshin, hanggang Roblox.
+    <br><br>
+    <strong>Halimbawang cool nickname</strong><br>
+    Mula sa "DarkWolf" → pwedeng maging:<br>
+    — 𝔇𝔞𝔯𝔨𝔚𝔬𝔩𝔣 (gothic, astig na vibe)<br>
+    — ꧁༒𝓓𝓪𝓻𝓴𝓦𝓸𝓵𝓯༒꧂ (script + ornament — paborito sa ML)<br>
+    — ⓓⓐⓡⓚⓦⓞⓛⓕ (bubble, mas playful)<br>
+    — ᴅᴀʀᴋᴡᴏʟꜰ (small caps, simple pero kakaiba)
+    <br><br>
+    <strong>Tip</strong><br>
+    Kung tinanggihan ng game ang isang estilo, palitan — Small Caps at Ultra Bold ang karaniwang pinaka-safe. Gusto ng ornament? Tingnan ang Frame tab para sa ꧁ ꧂, ༒, at paboritong simbolo ng gamer.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.3.items.2.question">Pwede ba sa WhatsApp status at TikTok caption?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.3.items.2.answer">Oo — pareho. May built-in nang *bold* at _italic_ ang WhatsApp, pero ang cursive, gothic, bubble, at Zalgo ay sa Unicode lang makukuha.
+    <br><br>
+    <strong>WhatsApp status</strong><br>
+    I-type ang pangungusap → piliin ang cursive o bubble → i-copy → buksan ang WhatsApp → Status → i-paste.
+    <br><br>
+    <strong>TikTok caption</strong><br>
+    Gumamit ng bold sa unang keyword para pigilin ang scroll. Halimbawa: "𝗦𝗧𝗢𝗣 — 30-second aesthetic bio tutorial 👇"</div>
+</div>
+
+
+<!-- Filipino/Tagalog & Suportadong Character -->
+<h2 class="faq-category" data-i18n="faq.categories.4.title">Filipino/Tagalog &amp; Suportadong Character</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.4.items.0.question">Gumagana ba lahat ng estilo sa Filipino at Tagalog?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.4.items.0.answer">Oo. Dahil gumagamit ang Filipino at Tagalog ng Latin alphabet (A–Z, a–z), gumagana nang normal ang lahat ng estilo — bold, cursive, gothic, bubble, hanggang Zalgo.
+    <br><br>
+    Nababago rin ang numero 0–9, kaya kung may numero sa bio o nickname mo (tulad ng birthday o jersey number), compact pa rin ang itsura.
+    <br><br>
+    Bukod sa Filipino, gumagana rin ang ibang wikang Latin — English, Bisaya, Bahasa, Vietnamese, Turkish, hanggang Spanish.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.4.items.1.question">Anong mga script ang hindi nababago?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.4.items.1.answer">Walang stylish Unicode variant ang mga non-Latin script, kaya nananatiling ordinaryo ang letra. Hindi nababago ang:
+    <br><br>
+    Arabic, Hebrew, Hindi, Tamil, Thai, Chinese, Japanese (kanji/hiragana/katakana), Korean, at mga katutubong script tulad ng Baybayin.
+    <br><br>
+    Pero kung may halo ang text mo — halimbawa Filipino na may English na salita o brand name — ang bahaging Latin ay normal pa ring mako-convert.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.4.items.2.question">Paano ang special character tulad ng tuldok, tanong, emoji?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.4.items.2.answer">Perpektong nababago ang A–Z, a–z, at 0–9 sa halos lahat ng estilo. Ang basic punctuation (tuldok, kuwit, tanong, padamdam) ay karaniwang iniiwan para readable pa rin ang pangungusap.
+    <br><br>
+    100% safe ang emoji — hindi ito nababago, kaya 🌸 ay 🌸 pa rin sa parehong posisyon. Gusto pagsamahin ang stylish text plus emoji sa bio? Isingit lang sa nakopyang resulta.</div>
+</div>
+
+
+<!-- Privacy & Kaligtasan -->
+<h2 class="faq-category" data-i18n="faq.categories.5.title">Privacy &amp; Kaligtasan</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.5.items.0.question">Ligtas ba ang text na tina-type ko?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.5.items.0.answer">Ligtas. Hindi sino-store ang text mo at hindi ipinapadala sa kahit anong server. Lahat ng pag-convert ng letra ay nangyayari sa browser mo mismo.
+    <br><br>
+    Pure Unicode character lang ang kinokopya mo — walang nakatagong character o tracker na nakadikit.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.5.items.1.question">Ligtas ba i-paste sa WA, IG, o game?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.5.items.1.answer">Sobrang ligtas. Standard Unicode text lang ang output — walang script, walang nakatagong format, walang code na makakasama sa account.
+    <br><br>
+    Pwede i-paste sa kahit anong app: WA, IG, TikTok, Discord, ML, FF, Roblox, lahat. Kasing-ligtas ng manual na pag-type.</div>
+</div>
+
+
+<!-- Gamit sa Android & iPhone -->
+<h2 class="faq-category" data-i18n="faq.categories.6.title">Gamit sa Android &amp; iPhone</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.6.items.0.question">Pwede ba gamitin sa Android at iPhone?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.6.items.0.answer">Oo, at madalas nga itong ginagamit sa phone. Fully responsive ang site — buksan sa phone browser (Chrome, Safari, o built-in), i-type ang text, piliin ang estilo, tapos i-tap ang Copy.
+    <br><br>
+    Walang i-download na app. Gumagana sa Android, iPhone, iPad, hanggang laptop. Sa phone, karaniwang dederetso ka agad sa IG, TikTok, o FB para i-paste — wala pang 10 segundo ang buong proseso.</div>
+</div>
+
+
+<!-- Bakit UltraTextGen -->
+<h2 class="faq-category" data-i18n="faq.categories.7.title">Bakit UltraTextGen</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.7.items.0.question">Ano ang pinagkaiba sa ibang text generator?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.7.items.0.answer">Dinisenyo ang UltraTextGen para maging pinaka-kumpleto pero magaan pa ring buksan, lalo na sa phone.
+    <br><br>
+    <strong>Ang nagpapaiba</strong><br>
+    — Pinakamaraming Ultra font — bold, aesthetic cursive, gothic, bubble, hanggang unique tulad ng Zalgo at mirror.<br>
+    — Pagsamahin ang estilo sa isang click — walang paulit-ulit na copy-paste.<br>
+    — Instant na dekorasyon: frame, border, maliliit na simbolo, pang-hati, arrow, emoji.<br>
+    — Hiwalay na page kada platform — TikTok, Instagram, Facebook, WhatsApp.<br>
+    — Mabilis buksan, walang nakakaabalang pop-up, walang auto-play na video ad.<br>
+    — Regular na update ng bagong estilo kada ilang linggo.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.7.items.1.question">May bago bang estilo paminsan-minsan?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.7.items.1.answer">Madalas. Regular na idinadagdag ang bagong Ultra style at dekorasyon, karaniwang kada ilang linggo. I-bookmark ang page para madaling makabalik pag may bagong labas.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.7.items.2.question">Paano hanapin ang estilong bagay sa kailangan ko?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.7.items.2.answer">May tatlong paraan na pwede mong piliin:
+    <br><br>
+    <strong>Sa pamamagitan ng category</strong><br>
+    Mag-browse kada category — bold, cursive, gothic, bubble, strikethrough, underline, upside down, at iba pa.
+    <br><br>
+    <strong>Sa pamamagitan ng platform</strong><br>
+    Gusto specific sa IG, TikTok, Facebook, o WA? Gamitin ang per-platform generator — testado na roon ang ipinapakitang estilo.
+    <br><br>
+    <strong>Sa pamamagitan ng gamit</strong><br>
+    Bisitahin ang use case pages — aesthetic bio, comment caption, game nickname, emoji combo, at marami pa.</div>
+</div>
+
+    </div>
+  </section>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-inner">
+      <!-- Language Switcher -->
+      <div class="lang-switcher" role="navigation" aria-label="Language switcher">
+        <a class="lang-option" href="/" hreflang="en">EN</a>
+        <a class="lang-option" href="/es/" hreflang="es">ES</a>
+        <a class="lang-option" href="/fr/" hreflang="fr">FR</a>
+        <a class="lang-option" href="/pt/" hreflang="pt">PT</a>
+        <a class="lang-option" href="/de/" hreflang="de">DE</a>
+        <a class="lang-option" href="/id/" hreflang="id">ID</a>
+        <a class="lang-option" href="/it/" hreflang="it">IT</a>
+        <a class="lang-option" href="/nl/" hreflang="nl">NL</a>
+        <a class="lang-option" href="/tr/" hreflang="tr">TR</a>
+        <a class="lang-option" href="/pl/" hreflang="pl">PL</a>
+        <a class="lang-option" href="/vi/" hreflang="vi">VI</a>
+        <a class="lang-option active" href="/tl/" hreflang="tl">TL</a>
+      </div>
+    </div>
+  </footer>
+
+  <div class="copy-toast" id="copyToast">Copied!</div>
+
+  <script src="/styles.js"></script>
+<script src="/renderer.js"></script>
+<script src="/script.js" defer=""></script>
+<script src="/i18n.js"></script>
+
+
+
+
+<script src="/footer.js"></script>
+</body></html>


### PR DESCRIPTION
Philippines is the #4 organic market in Search Console (388 clicks, 8.3K impressions) but had no localized page — visitors landed on English while competitor yaytext.com ships a full /tl/ section.

Mirrors the proven /id/ pattern (stylish/aesthetic-text intent + Mobile Legends / Free Fire name-style intent) rather than a wide font-style tree.

- tl/index.html: full Tagalog/Taglish homepage (hero, generator, editorial, FAQ accordion, JSON-LD: WebSite/Org/WebApplication/ HowTo/BreadcrumbList/FAQPage), self-canonical + hreflang incl. tl.
- locales/tl.json: dynamic UI + FAQ strings (drives FAQ schema rebuild).
- i18n.js: add "tl" to supported locales.
- index.html: add TL to language switcher + hreflang for crawl discovery and reciprocity.


Claude-Session: https://claude.ai/code/session_017YQexr4j1eZuLgDQDC8p3t