### PR TITLE
feat: Gothic UX redesign + Old English deepening (Phase 2)

### DIFF
--- a/category/gothic-fonts/index.html
+++ b/category/gothic-fonts/index.html
@@ -27,6 +27,7 @@
   <meta name="twitter:description" content="Dark gothic, fraktur, and blackletter fonts for edgy profiles, gaming usernames, metal band aesthetics, and mysterious vibes. Copy and paste anywhere.">
   <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category-gothic-fonts.png">
   <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=UnifrakturCook:wght@700&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/style.css">
 
 
@@ -182,7 +183,7 @@
 }
 </script>
 </head>
-<body>
+<body class="theme-gothic">
   <!-- Google Tag Manager (noscript) -->
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -206,7 +207,9 @@
   <section class="hero">
     <div class="hero-inner">
       <div class="hero-card">
-        <h1 class="hero-headline">Gothic Fonts Generator</h1>
+        <p class="g-eyebrow">Blackletter · Fraktur · Old English</p>
+        <h1 class="g-title">Gothic Font Generator</h1>
+        <div class="g-live is-empty" id="gLive" data-style="Ultra Gothic Bold" data-placeholder="Your name" aria-hidden="true"></div>
         <div class="input-wrapper">
           <textarea class="main-input" id="mainInput" placeholder="Type your text here..." maxlength="500"></textarea>
           <span class="char-count"><span id="charCount">0</span>/500</span>
@@ -223,7 +226,7 @@
     <div class="decoration-tabs">
     <button class="decoration-tab active" data-deco-tab="crosses">Crosses</button>
     <button class="decoration-tab" data-deco-tab="occult">Occult</button>
-    <button class="decoration-tab" data-deco-tab="runes">Runes</button>
+    <button class="decoration-tab" data-deco-tab="emoji">Emoji</button>
     <button class="decoration-tab" data-deco-tab="frames">Frames</button>
     <button class="decoration-tab" data-deco-tab="dividers">Dividers</button>
       </div>
@@ -258,6 +261,16 @@
     <!-- ============================================================
          UNIQUE EDITORIAL CONTENT (indexing + JTBD coverage)
          ============================================================ -->
+    <section class="editorial-section">
+      <h2>Check it renders before you paste</h2>
+      <p>
+        The #1 gothic complaint is boxes or squares (□□□) — that happens when a device is missing
+        the blackletter glyphs. This checks, live on your current device, which styles render
+        cleanly. Each result above also shows the platforms it works on.
+      </p>
+      <div class="gothic-compat" id="gothicCompat"></div>
+    </section>
+
     <section class="editorial-section">
       <h2>Gothic, Fraktur &amp; Blackletter — what you're copying</h2>
       <p>
@@ -330,13 +343,13 @@
     </section>
 
     <section class="editorial-section">
-      <h2>Will gothic text show up on your device?</h2>
+      <h2>Gothic symbols to pair with your text</h2>
       <p>
-        The #1 gothic complaint is boxes or squares (□□□) — that happens when a device is
-        missing the blackletter glyphs. This checks, live on your current device, which styles
-        render cleanly before you paste them somewhere public:
+        People searching gothic fonts also want the symbols that go with them — crosses, daggers,
+        and occult/medieval marks (not math symbols). Tap any to copy, then drop it into a bio or
+        beside a name:
       </p>
-      <div class="gothic-compat" id="gothicCompat"></div>
+      <div class="gsym-strip" data-symbols="☩ ⛧ ⸸ ✝ ✟ † ‡ ☠ 𖤐 ⚰ ☦ ♰ ♱ ⛤ ☥ ⚱ ❦ ⚜ ✠ ♆"></div>
     </section>
 
     <section class="editorial-section">
@@ -572,6 +585,7 @@
   <!-- Category filter + gothic-themed decorations -->
   <script>
     window.UTG_FAMILY = "gothic";
+    window.UTG_SHOW_PLATFORMS = true;
     window.UTG_DEFAULT_DECO_TAB = "crosses";
     window.UTG_DECORATIONS = {
       crosses: [
@@ -598,15 +612,19 @@
         { text: "𓆩 text 𓆪", prefix: "𓆩 ", suffix: " 𓆪" },
         { text: "♆ text ♆", prefix: "♆ ", suffix: " ♆" }
       ],
-      runes: [
-        { text: "ᚱ text ᚱ", prefix: "ᚱ ", suffix: " ᚱ" },
-        { text: "ᚢ text ᚢ", prefix: "ᚢ ", suffix: " ᚢ" },
-        { text: "ᚾ text ᚾ", prefix: "ᚾ ", suffix: " ᚾ" },
-        { text: "ᚦ text ᚦ", prefix: "ᚦ ", suffix: " ᚦ" },
-        { text: "ᛟ text ᛟ", prefix: "ᛟ ", suffix: " ᛟ" },
-        { text: "ᛉ text ᛉ", prefix: "ᛉ ", suffix: " ᛉ" },
-        { text: "ᚨ text ᚨ", prefix: "ᚨ ", suffix: " ᚨ" },
-        { text: "ᛊ text ᛊ", prefix: "ᛊ ", suffix: " ᛊ" }
+      emoji: [
+        { text: "🦇 text 🦇", prefix: "🦇 ", suffix: " 🦇" },
+        { text: "💀 text 💀", prefix: "💀 ", suffix: " 💀" },
+        { text: "⚰️ text ⚰️", prefix: "⚰️ ", suffix: " ⚰️" },
+        { text: "🕯️ text 🕯️", prefix: "🕯️ ", suffix: " 🕯️" },
+        { text: "🥀 text 🥀", prefix: "🥀 ", suffix: " 🥀" },
+        { text: "🕸️ text 🕸️", prefix: "🕸️ ", suffix: " 🕸️" },
+        { text: "⛓️ text ⛓️", prefix: "⛓️ ", suffix: " ⛓️" },
+        { text: "🌹 text 🌹", prefix: "🌹 ", suffix: " 🌹" },
+        { text: "🗡️ text 🗡️", prefix: "🗡️ ", suffix: " 🗡️" },
+        { text: "🌑 text 🌑", prefix: "🌑 ", suffix: " 🌑" },
+        { text: "🔥 text 🔥", prefix: "🔥 ", suffix: " 🔥" },
+        { text: "🐍 text 🐍", prefix: "🐍 ", suffix: " 🐍" }
       ],
       frames: [
         { text: "꧁ text ꧂", prefix: "꧁ ", suffix: " ꧂" },

--- a/category/old-english-fonts/index.html
+++ b/category/old-english-fonts/index.html
@@ -146,6 +146,15 @@
           <span class="char-count"><span id="charCount">0</span>/500</span>
         </div>
 
+        <div class="quickfill">
+          <span class="quickfill-label">Try</span>
+          <button type="button" data-fill="Maria">a name</button>
+          <button type="button" data-fill="RIP">RIP</button>
+          <button type="button" data-fill="Est. 2024">Est. 2024</button>
+          <button type="button" data-fill="23">jersey #</button>
+          <button type="button" data-fill="Maria &amp; David">couple</button>
+        </div>
+
         <!-- Decoration Selector -->
         <div class="decoration-section">
           <div class="decoration-label">
@@ -251,6 +260,31 @@
         years, and dates:
       </p>
       <div class="glyph-row">𝟎 𝟏 𝟐 𝟑 𝟒 𝟓 𝟔 𝟕 𝟖 𝟗</div>
+    </section>
+
+    <section class="editorial-section">
+      <h2>Old English dates &amp; Roman numerals</h2>
+      <p>
+        For "Est." dates, birth years, and memorial tattoos, Roman numerals look the part — and
+        unlike digits, the letters <strong>do</strong> have true blackletter forms. Enter a year
+        and copy it in Old English:
+      </p>
+      <div id="oeRoman" class="roman-tool"></div>
+      <p class="glyph-sub">Example: 2024 → MMXXIV → <span lang="und">𝕸𝕸𝖃𝖃𝕴𝖁</span></p>
+    </section>
+
+    <section class="editorial-section">
+      <h2>Using Old English for tattoos</h2>
+      <p>
+        Old English is the most-requested script for name and memorial tattoos. A few things worth
+        knowing before you take a design to an artist:
+      </p>
+      <div class="editorial-grid">
+        <div class="style-card"><h3>Preview, not stencil</h3><p>Copy-paste Unicode is perfect for mocking up a name and sharing the idea. Your artist will redraw it at high resolution for the actual stencil.</p></div>
+        <div class="style-card"><h3>Keep it legible</h3><p>Blackletter capitals are ornate — for long words, the lighter Fraktur weight reads more clearly than the heavy one. Test both above.</p></div>
+        <div class="style-card"><h3>Add a cross or banner</h3><p>Pair a name with a cross (✝) or a chicano banner (꧁༺ ༻꧂) — the "Banner" style above wraps your name automatically.</p></div>
+        <div class="style-card"><h3>Dates in Roman</h3><p>Use Roman numerals for birth/memorial years (MMXXIV) — they have real blackletter letterforms, unlike digits.</p></div>
+      </div>
     </section>
 
     <section class="editorial-section">

--- a/category/old-english-fonts/index.html
+++ b/category/old-english-fonts/index.html
@@ -27,6 +27,7 @@
   <meta name="twitter:description" content="Copy and paste Old English blackletter text for name tattoos, jerseys, the Old English D, and chicano lettering.">
   <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category-gothic-fonts.png">
   <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=UnifrakturCook:wght@700&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/style.css">
 
 <script type="application/ld+json">
@@ -113,7 +114,7 @@
 }
 </script>
 </head>
-<body>
+<body class="theme-gothic">
   <!-- Google Tag Manager (noscript) -->
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -137,7 +138,9 @@
   <section class="hero">
     <div class="hero-inner">
       <div class="hero-card">
-        <h1 class="hero-headline">Old English Font Generator</h1>
+        <p class="g-eyebrow">Old English · Blackletter · Tattoo Lettering</p>
+        <h1 class="g-title">Old English Font Generator</h1>
+        <div class="g-live is-empty" id="gLive" data-style="Ultra Gothic Bold" data-placeholder="Your name" aria-hidden="true"></div>
         <div class="input-wrapper">
           <textarea class="main-input" id="mainInput" placeholder="Type a name or word…" maxlength="500"></textarea>
           <span class="char-count"><span id="charCount">0</span>/500</span>
@@ -183,6 +186,16 @@
     <!-- ============================================================
          UNIQUE EDITORIAL CONTENT
          ============================================================ -->
+    <section class="editorial-section">
+      <h2>Check it renders before you paste</h2>
+      <p>
+        Old English sometimes shows as boxes (□□□) on older devices. This checks, live on your
+        current device, which styles render cleanly. Each result above also shows the platforms
+        it works on.
+      </p>
+      <div class="gothic-compat" id="gothicCompat"></div>
+    </section>
+
     <section class="editorial-section">
       <h2>Old English lettering, ready to copy</h2>
       <p>
@@ -241,12 +254,12 @@
     </section>
 
     <section class="editorial-section">
-      <h2>Will Old English text show up on your device?</h2>
+      <h2>Symbols to pair with Old English</h2>
       <p>
-        Blackletter sometimes shows as boxes (□□□) on older devices. This checks, live on your
-        current device, which styles render cleanly before you post a name or paste it into a bio:
+        The marks that go with Old English lettering — crosses, banners, stars, and fleur-de-lis
+        for tattoos, jerseys, and monograms. Tap any to copy:
       </p>
-      <div class="gothic-compat" id="gothicCompat"></div>
+      <div class="gsym-strip" data-symbols="✝ ✟ ☩ ☦ ✠ ♰ ♱ † ‡ ★ ✪ ✦ ❖ ⚜ ❦ ❧"></div>
     </section>
 
     <section class="editorial-section">
@@ -359,6 +372,7 @@
   <!-- Category filter + Old English decorations -->
   <script>
     window.UTG_FAMILY = "old-english";
+    window.UTG_SHOW_PLATFORMS = true;
     window.UTG_DEFAULT_DECO_TAB = "crosses";
     window.UTG_DECORATIONS = {
       crosses: [

--- a/gothic-tools.js
+++ b/gothic-tools.js
@@ -1,152 +1,213 @@
 /* ==========================================================================
    UltraTextGen — gothic-tools.js
-   Live "will it render on your device?" compatibility tester for gothic /
-   blackletter styles. Self-contained IIFE. Loads AFTER styles.js + renderer.js.
+   Progressive enhancements for the Gothic / Old English pages. Loads AFTER
+   styles.js + renderer.js + script.js (all defer, so order is preserved).
 
-   It mounts into #gothicCompat (if present) and answers the single biggest
-   gothic complaint: "why do I see boxes/squares?" — by detecting, on THIS
-   device, whether each blackletter style actually has glyphs.
+   Adds, without touching the shared generator:
+     1. Live blackletter preview in the hero (#gLive)
+     2. Click-to-copy glyph tiles + "copy series" for the A–Z / 0–9 charts
+     3. Copyable gothic-symbol strips (.gsym-strip[data-symbols])
+     4. The device compatibility tester (#gothicCompat)
+
+   Raw glyph text stays in the DOM for SEO; JS only enhances it in place.
    ========================================================================== */
 (function () {
   "use strict";
 
-  const mount = document.getElementById("gothicCompat");
-  if (!mount) return;
-
   const Render = window.UltraTextGenRender;
   const styles = window.textStyles || {};
-  if (!Render || typeof Render.renderAny !== "function") return;
+  const hasRender = Render && typeof Render.renderAny === "function";
 
-  // Styles surfaced in the tester, in display order. Each maps to a registry key.
-  const TESTS = [
-    { label: "Fraktur — 𝔤𝔬𝔱𝔥𝔦𝔠", key: "Ultra Gothic" },
-    { label: "Bold Fraktur / Old English — 𝖌𝖔𝖙𝖍𝖎𝖈", key: "Ultra Gothic Bold" },
-    { label: "Gothic Underline", key: "Ultra Gothic Underline" },
-    { label: "Gothic + Cross", key: "Ultra Gothic Cross" },
-    { label: "Gothic Occult", key: "Ultra Gothic Occult" },
-    { label: "Gothic Strikethrough", key: "Ultra Gothic Strikethrough" }
-  ].filter(t => styles[t.key]);
-
-  // --- Canvas glyph-support detector -------------------------------------
-  // Compares the drawn width of a glyph against the width of a code point no
-  // font has (every browser falls back to the same .notdef "tofu" box, so an
-  // unsupported glyph measures identical to the reference).
-  function makeDetector() {
-    let ctx;
-    try {
-      ctx = document.createElement("canvas").getContext("2d");
-    } catch (e) {
-      return null;
-    }
-    if (!ctx) return null;
-    const family = (getComputedStyle(mount).fontFamily || "sans-serif");
-    ctx.font = "36px " + family;
-    const refWidth = ctx.measureText(String.fromCodePoint(0x10fffd)).width;
-    return function supported(ch) {
-      if (!ch) return true;
-      return ctx.measureText(ch).width !== refWidth;
-    };
-  }
-
-  const detect = makeDetector();
-
-  // Representative base glyph for a style: render lowercase "a" and grab the
-  // first Mathematical-Alphanumeric code point (skips wrapper symbols like ✝/⛧).
-  function baseGlyph(key) {
-    const out = Render.renderAny("a", styles[key]);
-    for (const c of out) {
-      if (c.codePointAt(0) >= 0x1d400) return c;
-    }
-    return null;
-  }
-
-  const supportMap = {};
-  TESTS.forEach(t => {
-    supportMap[t.key] = detect ? detect(baseGlyph(t.key)) : true;
-  });
-
-  // --- Build the widget ---------------------------------------------------
-  const input = document.createElement("input");
-  input.type = "text";
-  input.className = "compat-input";
-  input.maxLength = 60;
-  input.setAttribute("aria-label", "Text to test for gothic compatibility");
-  input.placeholder = "Type a name to test…";
-
-  // Seed from the main generator input if it already has text.
-  const mainInput = document.getElementById("mainInput");
-  input.value = (mainInput && mainInput.value.trim()) || "Your Name";
-
-  const list = document.createElement("div");
-  list.className = "compat-rows";
-
-  const note = document.createElement("p");
-  note.className = "compat-note";
-  note.innerHTML = detect
-    ? 'Checked live on <strong>this device</strong>. A ⚠ flag means your current device is missing those glyphs — they may show as boxes for some viewers too. Tap a sample to copy it.'
-    : "Showing how each style renders. Tap a sample to copy it.";
-
-  function badge(ok) {
-    const b = document.createElement("span");
-    b.className = "compat-badge " + (ok ? "is-ok" : "is-warn");
-    b.textContent = ok ? "✓ Renders" : "⚠ May break";
-    return b;
-  }
-
-  function rowFor(t) {
-    const row = document.createElement("button");
-    row.type = "button";
-    row.className = "compat-row";
-    row.dataset.ok = String(supportMap[t.key]);
-
-    const name = document.createElement("span");
-    name.className = "compat-name";
-    name.textContent = t.label;
-
-    const sample = document.createElement("span");
-    sample.className = "compat-sample";
-
-    row.appendChild(badge(supportMap[t.key]));
-    row.appendChild(name);
-    row.appendChild(sample);
-    row.addEventListener("click", () => copyRow(t, sample.textContent, row));
-    return { row, sample, key: t.key };
-  }
-
-  const built = TESTS.map(rowFor);
-  built.forEach(b => list.appendChild(b.row));
-
-  function render() {
-    const text = input.value.trim() || "Your Name";
-    built.forEach(b => {
-      b.sample.textContent = Render.renderAny(text, styles[b.key]);
-    });
-  }
-
-  function copyRow(t, text, row) {
+  /* ---- shared copy helper ---------------------------------------------- */
+  function flashCopy(text, el) {
     if (!text) return;
     const done = () => {
-      row.classList.add("is-copied");
-      setTimeout(() => row.classList.remove("is-copied"), 1100);
+      el.classList.add("is-copied");
+      setTimeout(() => el.classList.remove("is-copied"), 1000);
     };
     if (navigator.clipboard && navigator.clipboard.writeText) {
       navigator.clipboard.writeText(text).then(done).catch(() => {});
+    } else {
+      done();
     }
   }
 
-  input.addEventListener("input", render);
-  if (mainInput) {
-    mainInput.addEventListener("input", () => {
-      const v = mainInput.value.trim();
-      if (v) {
-        input.value = v.slice(0, 60);
-        render();
+  /* ---- 1. Live hero preview -------------------------------------------- */
+  function initLivePreview() {
+    const live = document.getElementById("gLive");
+    const input = document.getElementById("mainInput");
+    if (!live || !input || !hasRender) return;
+
+    const styleKey = live.dataset.style && styles[live.dataset.style]
+      ? live.dataset.style
+      : (styles["Ultra Gothic Bold"] ? "Ultra Gothic Bold" : Object.keys(styles)[0]);
+    const placeholder = live.dataset.placeholder || "Your name";
+
+    function update() {
+      const text = input.value.trim();
+      if (text) {
+        live.classList.remove("is-empty");
+        live.textContent = Render.renderAny(text, styles[styleKey]);
+      } else {
+        live.classList.add("is-empty");
+        live.textContent = Render.renderAny(placeholder, styles[styleKey]);
       }
+    }
+    input.addEventListener("input", update);
+    update();
+  }
+
+  /* ---- 2. Click-to-copy glyph charts ----------------------------------- */
+  function initGlyphCharts() {
+    document.querySelectorAll(".glyph-row").forEach(row => {
+      if (row.dataset.enhanced) return;
+      const tokens = (row.textContent || "").trim().split(/\s+/).filter(Boolean);
+      if (tokens.length < 2) return;
+      row.dataset.enhanced = "1";
+      row.textContent = "";
+
+      tokens.forEach(tok => {
+        const b = document.createElement("button");
+        b.type = "button";
+        b.className = "glyph-tile";
+        b.textContent = tok;
+        b.setAttribute("aria-label", "Copy " + tok);
+        b.addEventListener("click", () => flashCopy(tok, b));
+        row.appendChild(b);
+      });
+
+      const series = document.createElement("button");
+      series.type = "button";
+      series.className = "copy-series";
+      series.textContent = "Copy series";
+      series.title = "Copy the whole row: " + tokens.join(" ");
+      series.addEventListener("click", () => flashCopy(tokens.join(" "), series));
+      row.appendChild(series);
     });
   }
 
-  mount.appendChild(input);
-  mount.appendChild(list);
-  mount.appendChild(note);
-  render();
+  /* ---- 3. Copyable gothic-symbol strips -------------------------------- */
+  function initSymbolStrips() {
+    document.querySelectorAll(".gsym-strip[data-symbols]").forEach(strip => {
+      if (strip.dataset.enhanced) return;
+      strip.dataset.enhanced = "1";
+      const syms = strip.dataset.symbols.trim().split(/\s+/).filter(Boolean);
+      strip.textContent = "";
+      syms.forEach(s => {
+        const b = document.createElement("button");
+        b.type = "button";
+        b.className = "gsym-tile";
+        b.textContent = s;
+        b.setAttribute("aria-label", "Copy " + s);
+        b.addEventListener("click", () => flashCopy(s, b));
+        strip.appendChild(b);
+      });
+    });
+  }
+
+  /* ---- 4. Device compatibility tester ---------------------------------- */
+  function initCompatTester() {
+    const mount = document.getElementById("gothicCompat");
+    if (!mount || !hasRender) return;
+
+    const TESTS = [
+      { label: "Fraktur — 𝔤𝔬𝔱𝔥𝔦𝔠", key: "Ultra Gothic" },
+      { label: "Bold Fraktur / Old English — 𝖌𝖔𝖙𝖍", key: "Ultra Gothic Bold" },
+      { label: "Gothic Underline", key: "Ultra Gothic Underline" },
+      { label: "Gothic + Cross", key: "Ultra Gothic Cross" },
+      { label: "Gothic Occult", key: "Ultra Gothic Occult" },
+      { label: "Gothic Strikethrough", key: "Ultra Gothic Strikethrough" }
+    ].filter(t => styles[t.key]);
+
+    function makeDetector() {
+      let ctx;
+      try { ctx = document.createElement("canvas").getContext("2d"); }
+      catch (e) { return null; }
+      if (!ctx) return null;
+      ctx.font = "36px " + (getComputedStyle(mount).fontFamily || "sans-serif");
+      const refWidth = ctx.measureText(String.fromCodePoint(0x10fffd)).width;
+      return ch => !ch ? true : ctx.measureText(ch).width !== refWidth;
+    }
+    const detect = makeDetector();
+
+    function baseGlyph(key) {
+      const out = Render.renderAny("a", styles[key]);
+      for (const c of out) if (c.codePointAt(0) >= 0x1d400) return c;
+      return null;
+    }
+    const supportMap = {};
+    TESTS.forEach(t => { supportMap[t.key] = detect ? detect(baseGlyph(t.key)) : true; });
+
+    const input = document.createElement("input");
+    input.type = "text";
+    input.className = "compat-input";
+    input.maxLength = 60;
+    input.setAttribute("aria-label", "Text to test for gothic compatibility");
+    input.placeholder = "Type a name to test…";
+    const mainInput = document.getElementById("mainInput");
+    input.value = (mainInput && mainInput.value.trim()) || "Your Name";
+
+    const list = document.createElement("div");
+    list.className = "compat-rows";
+
+    const note = document.createElement("p");
+    note.className = "compat-note";
+    note.innerHTML = detect
+      ? 'Checked live on <strong>this device</strong>. A ⚠ flag means your device is missing those glyphs — they may show as boxes for some viewers too. Tap a sample to copy it.'
+      : "Showing how each style renders. Tap a sample to copy it.";
+
+    function badge(ok) {
+      const b = document.createElement("span");
+      b.className = "compat-badge " + (ok ? "is-ok" : "is-warn");
+      b.textContent = ok ? "✓ Renders" : "⚠ May break";
+      return b;
+    }
+
+    const built = TESTS.map(t => {
+      const row = document.createElement("button");
+      row.type = "button";
+      row.className = "compat-row";
+      row.dataset.ok = String(supportMap[t.key]);
+      const name = document.createElement("span");
+      name.className = "compat-name";
+      name.textContent = t.label;
+      const sample = document.createElement("span");
+      sample.className = "compat-sample";
+      row.appendChild(badge(supportMap[t.key]));
+      row.appendChild(name);
+      row.appendChild(sample);
+      row.addEventListener("click", () => flashCopy(sample.textContent, row));
+      list.appendChild(row);
+      return { sample, key: t.key };
+    });
+
+    function render() {
+      const text = input.value.trim() || "Your Name";
+      built.forEach(b => { b.sample.textContent = Render.renderAny(text, styles[b.key]); });
+    }
+    input.addEventListener("input", render);
+    if (mainInput) {
+      mainInput.addEventListener("input", () => {
+        const v = mainInput.value.trim();
+        if (v) { input.value = v.slice(0, 60); render(); }
+      });
+    }
+    mount.appendChild(input);
+    mount.appendChild(list);
+    mount.appendChild(note);
+    render();
+  }
+
+  /* ---- boot ------------------------------------------------------------ */
+  function boot() {
+    initLivePreview();
+    initGlyphCharts();
+    initSymbolStrips();
+    initCompatTester();
+  }
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", boot);
+  } else {
+    boot();
+  }
 })();

--- a/gothic-tools.js
+++ b/gothic-tools.js
@@ -198,12 +198,77 @@
     render();
   }
 
+  /* ---- 5. Quick-fill use-case chips ------------------------------------ */
+  function initQuickfill() {
+    const input = document.getElementById("mainInput");
+    if (!input) return;
+    document.querySelectorAll(".quickfill [data-fill]").forEach(btn => {
+      btn.addEventListener("click", () => {
+        input.value = btn.dataset.fill;
+        input.dispatchEvent(new Event("input", { bubbles: true }));
+        input.focus();
+        const top = input.getBoundingClientRect().top;
+        if (top < 0 || top > window.innerHeight) input.scrollIntoView({ block: "center" });
+      });
+    });
+  }
+
+  /* ---- 6. Old English Roman-numeral / date tool ------------------------ */
+  function toRoman(n) {
+    n = Math.max(1, Math.min(3999, Math.floor(n || 0)));
+    const map = [[1000,"M"],[900,"CM"],[500,"D"],[400,"CD"],[100,"C"],[90,"XC"],
+      [50,"L"],[40,"XL"],[10,"X"],[9,"IX"],[5,"V"],[4,"IV"],[1,"I"]];
+    let out = "";
+    for (const [v, s] of map) while (n >= v) { out += s; n -= v; }
+    return out;
+  }
+
+  function initRomanTool() {
+    const wrap = document.getElementById("oeRoman");
+    if (!wrap || !hasRender) return;
+    const styleKey = styles["Ultra Gothic Bold"] ? "Ultra Gothic Bold" : Object.keys(styles)[0];
+
+    const input = document.createElement("input");
+    input.type = "number";
+    input.min = "1";
+    input.max = "3999";
+    input.value = "2024";
+    input.className = "compat-input roman-input";
+    input.setAttribute("aria-label", "Year or number to convert to Old English Roman numerals");
+
+    const plain = document.createElement("span");
+    plain.className = "roman-plain";
+
+    const out = document.createElement("button");
+    out.type = "button";
+    out.className = "gsym-tile roman-out";
+    out.setAttribute("aria-label", "Copy Old English Roman numerals");
+
+    function update() {
+      const roman = toRoman(parseInt(input.value, 10));
+      plain.textContent = roman || "—";
+      out.textContent = roman ? Render.renderAny(roman, styles[styleKey]) : "—";
+    }
+    out.addEventListener("click", () => flashCopy(out.textContent, out));
+    input.addEventListener("input", update);
+
+    const row = document.createElement("div");
+    row.className = "roman-row";
+    row.appendChild(input);
+    row.appendChild(plain);
+    row.appendChild(out);
+    wrap.appendChild(row);
+    update();
+  }
+
   /* ---- boot ------------------------------------------------------------ */
   function boot() {
     initLivePreview();
     initGlyphCharts();
     initSymbolStrips();
     initCompatTester();
+    initQuickfill();
+    initRomanTool();
   }
   if (document.readyState === "loading") {
     document.addEventListener("DOMContentLoaded", boot);

--- a/renderer.js
+++ b/renderer.js
@@ -450,6 +450,12 @@ function renderMap(text, style) {
       text.trim()
         ? [...renderMap(text, textStyles['Ultra Gothic'])]
             .map(c => (c === ' ' || c === '\n') ? c : c + '̶').join('')
+        : text,
+
+    // Old English name inside a chicano-style banner — the nameplate intent.
+    'ultra-old-english-banner': text =>
+      text.trim()
+        ? `꧁༺ ${renderMap(text, textStyles['Ultra Gothic Bold'])} ༻꧂`
         : text
   };
 

--- a/script.js
+++ b/script.js
@@ -409,6 +409,29 @@ const decorations = window.UTG_DECORATIONS || {
     return String(name).toLowerCase().includes(String(q).toLowerCase());
   }
 
+  // Where a style works, surfaced on each result card (opt-in per page via
+  // window.UTG_SHOW_PLATFORMS). Reads the style's own `platforms` array.
+  const PLATFORM_LABELS = {
+    instagram: "IG", x: "X", discord: "Discord", tiktok: "TikTok",
+    whatsapp: "WhatsApp", facebook: "Facebook", telegram: "Telegram",
+    youtube: "YouTube", snapchat: "Snapchat", linkedin: "LinkedIn"
+  };
+
+  function platformChipsHtml(style) {
+    if (!window.UTG_SHOW_PLATFORMS) return "";
+    const list = Array.isArray(style && style.platforms) ? style.platforms : null;
+    if (!list || !list.length) return "";
+    if (list.includes("all")) {
+      return `<div class="style-platforms"><span class="plat-chip is-all">Works everywhere</span></div>`;
+    }
+    const chips = list
+      .map(p => PLATFORM_LABELS[p])
+      .filter(Boolean)
+      .map(lbl => `<span class="plat-chip">${lbl}</span>`)
+      .join("");
+    return chips ? `<div class="style-platforms">${chips}</div>` : "";
+  }
+
   function createStyleCard(name, convertedText, decoratedText, style) {
     const card = document.createElement("div");
     card.className = "style-card";
@@ -430,6 +453,7 @@ const decorations = window.UTG_DECORATIONS || {
          ${style?.note ? `<p class="style-note">${style.note}</p>` : ""}
         <p class="style-preview ${!convertedText ? "placeholder" : ""}">${convertedText || "Type something above..."}</p>
         ${decoHtml}
+        ${platformChipsHtml(style)}
       </div>
       <div class="style-actions">
         <button class="copy-btn" data-text="${safeText}" ${!fullText ? "disabled" : ""} title="Copy to clipboard">Copy <kbd class="copy-kbd">↵</kbd></button>

--- a/style.css
+++ b/style.css
@@ -3870,3 +3870,53 @@ body.theme-gothic .category-section { position: static; background: transparent;
 @media (prefers-reduced-motion: reduce) {
   .glyph-tile, .gsym-tile, .copy-series { transition: none; }
 }
+
+/* Old English: quick-fill use-case chips + Roman-numeral date tool */
+.quickfill {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin-top: 12px;
+}
+.quickfill-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  letter-spacing: 0.03em;
+}
+.quickfill button {
+  font-size: 0.8rem;
+  font-weight: 500;
+  padding: 5px 12px;
+  border-radius: 999px;
+  background: var(--bg-base);
+  border: 1px solid var(--border-light);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: border-color 0.12s ease, color 0.12s ease;
+}
+.quickfill button:hover {
+  border-color: var(--accent-purple);
+  color: var(--accent-purple);
+}
+
+.roman-tool { margin-top: 12px; }
+.roman-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+.roman-input { width: 130px; }
+.roman-plain {
+  font-size: 0.95rem;
+  letter-spacing: 0.12em;
+  color: var(--text-secondary);
+  font-weight: 600;
+}
+.roman-out {
+  font-size: 1.5rem;
+  min-width: 70px;
+  padding: 8px 14px;
+}

--- a/style.css
+++ b/style.css
@@ -3684,3 +3684,189 @@ body.dark-mode .vertical-chip {
   padding-top: 8px;
   border-top: 1px solid var(--border-light);
 }
+
+
+/* ==========================================================================
+   GOTHIC / OLD ENGLISH PAGE THEME
+   Keeps the UltraTextGen brand palette (purple → blue, off-white panels, dot
+   grid). The "gothic feel" comes from SHAPES & ORNAMENTS, not new colors:
+   a blackletter display face, a pointed-arch hero crown, quatrefoil section
+   dividers, and an illuminated drop-cap. Scoped to body.theme-gothic.
+   ========================================================================== */
+
+/* ---- Blackletter display type (brand colors) -------------------------- */
+body.theme-gothic .hero-headline,
+body.theme-gothic .g-title,
+body.theme-gothic .editorial-section > h2,
+body.theme-gothic .glyph-chart h3,
+body.theme-gothic .editorial-grid .style-card h3,
+body.theme-gothic .style-card .style-name,
+body.theme-gothic .faq-category,
+body.theme-gothic .g-eyebrow {
+  font-family: 'UnifrakturCook', Georgia, serif;
+  font-weight: 700;
+}
+
+body.theme-gothic .g-eyebrow {
+  font-size: 1rem;
+  letter-spacing: 0.12em;
+  color: var(--accent-purple);
+  text-align: center;
+  margin: 6px 0 2px;
+}
+
+body.theme-gothic .hero-headline,
+body.theme-gothic .g-title {
+  color: var(--text-primary);
+  text-align: center;
+  font-size: clamp(2.2rem, 5vw, 3.4rem);
+  line-height: 1.05;
+  letter-spacing: 0.01em;
+  margin: 0 auto 6px;
+}
+/* Illuminated drop-cap in brand purple. */
+body.theme-gothic .g-title::first-letter,
+body.theme-gothic .hero-headline::first-letter {
+  font-size: 1.5em;
+  color: var(--accent-purple);
+  padding-right: 0.04em;
+}
+
+/* ---- Hero card: brand panel + gothic ornament frame ------------------- */
+body.theme-gothic .page-hero-figure { display: none; }
+body.theme-gothic .hero { padding-top: 40px; }
+body.theme-gothic .hero-card { position: relative; overflow: visible; }
+
+/* Pointed-arch "crown" — the signature gothic shape, in brand purple. */
+body.theme-gothic .hero-card::after {
+  content: "";
+  position: absolute;
+  top: -34px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 120px;
+  height: 40px;
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 120 84' fill='none' stroke='%238b5cf6' stroke-width='3'%3E%3Cpath d='M12 84 L12 42 Q12 10 60 6 Q108 10 108 42 L108 84'/%3E%3Cpath d='M32 84 L32 48 Q32 26 60 24 Q88 26 88 48 L88 84'/%3E%3Ccircle cx='60' cy='33' r='6'/%3E%3C/svg%3E") center bottom / contain no-repeat;
+}
+
+/* Live preview — types your text in blackletter immediately (brand purple). */
+body.theme-gothic .g-live {
+  min-height: 3.2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  font-size: clamp(1.8rem, 5vw, 2.8rem);
+  color: var(--accent-purple);
+  padding: 6px 14px 14px;
+  word-break: break-word;
+}
+body.theme-gothic .g-live.is-empty { opacity: 0.4; }
+
+/* ---- Editorial sections: quatrefoil dividers + brand underline -------- */
+body.theme-gothic .editorial-section { position: relative; }
+body.theme-gothic .editorial-section + .editorial-section {
+  border-top: 1px solid var(--border-light);
+  margin-top: 40px;
+  padding-top: 40px;
+}
+/* Quatrefoil medallion sitting on the divider rule. */
+body.theme-gothic .editorial-section + .editorial-section::before {
+  content: "";
+  position: absolute;
+  top: -13px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 26px;
+  height: 26px;
+  background:
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%23ffffff' stroke='%238b5cf6' stroke-width='1.3'%3E%3Ccircle cx='12' cy='7.5' r='4.6'/%3E%3Ccircle cx='12' cy='16.5' r='4.6'/%3E%3Ccircle cx='7.5' cy='12' r='4.6'/%3E%3Ccircle cx='16.5' cy='12' r='4.6'/%3E%3C/svg%3E") center / 26px no-repeat,
+    var(--bg-base);
+  padding: 0 10px;
+}
+body.theme-gothic .editorial-section > h2 {
+  color: var(--text-primary);
+}
+body.theme-gothic .editorial-section > h2::after {
+  content: "";
+  display: block;
+  width: 88px;
+  height: 2px;
+  margin-top: 8px;
+  background: linear-gradient(90deg, var(--accent-purple), var(--accent-blue));
+}
+
+/* ---- Result cards: brand panel, blackletter names -------------------- */
+body.theme-gothic .style-card .style-name {
+  color: var(--accent-purple);
+  font-size: 1.15rem;
+}
+
+/* Per-card platform capability chips. */
+.style-platforms {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin-top: 8px;
+}
+.style-platforms .plat-chip {
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--bg-base);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-light);
+}
+.style-platforms .plat-chip.is-all {
+  background: color-mix(in srgb, var(--accent-purple) 12%, transparent);
+  color: var(--accent-purple);
+  border-color: color-mix(in srgb, var(--accent-purple) 30%, transparent);
+}
+
+/* ---- Click-to-copy glyph tiles + symbol strip (brand) ---------------- */
+body.theme-gothic .glyph-row { gap: 6px; }
+.glyph-tile,
+.gsym-tile {
+  font-size: 1.25rem;
+  line-height: 1;
+  padding: 8px 10px;
+  min-width: 40px;
+  text-align: center;
+  background: var(--bg-white);
+  border: 1px solid var(--border-light);
+  border-radius: 8px;
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: background 0.12s ease, transform 0.04s ease, border-color 0.12s ease;
+}
+.glyph-tile:hover,
+.gsym-tile:hover { border-color: var(--accent-purple); transform: translateY(-1px); }
+.glyph-tile.is-copied,
+.gsym-tile.is-copied { background: var(--accent-purple); color: #fff; border-color: var(--accent-purple); }
+
+.copy-series {
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  padding: 6px 12px;
+  margin-left: 4px;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--accent-purple);
+  border: 1px solid var(--accent-purple);
+  cursor: pointer;
+  white-space: nowrap;
+}
+.copy-series:hover { background: color-mix(in srgb, var(--accent-purple) 10%, transparent); }
+.copy-series.is-copied { background: var(--accent-purple); color: #fff; }
+
+.gsym-strip { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 12px; }
+
+/* ---- Decoration tabs: subtle gothic active state (brand) ------------- */
+body.theme-gothic .category-section { position: static; background: transparent; padding-top: 16px; }
+
+@media (prefers-reduced-motion: reduce) {
+  .glyph-tile, .gsym-tile, .copy-series { transition: none; }
+}

--- a/styles.js
+++ b/styles.js
@@ -412,6 +412,18 @@ const textStyles = {
     platforms: ['all', 'instagram', 'x', 'discord']
   },
 
+  // Old English nameplate — bold blackletter inside a chicano banner. Old
+  // English page only (the nameplate / name-tattoo intent).
+  'Ultra Old English Banner': {
+    type: 'procedure',
+    procedureId: 'ultra-old-english-banner',
+    category: 'gothic',
+    familySlug: ['old-english'],
+    groupSlug: 'fraktur',
+    slug: 'ultra-old-english-banner',
+    platforms: ['all', 'instagram', 'tiktok', 'x', 'discord']
+  },
+
   /* =========================
      BUBBLE
      ========================= */


### PR DESCRIPTION
Follow-up to #354 (Phase 1, already merged). This adds a real gothic identity to the Gothic + Old English pages and fixes the copy/discovery UX — **without changing the brand palette** (purple→blue, off-white panels, dot grid stay intact). Gothic feel comes from shapes and ornaments, not new colors.

### Visual identity (brand colors kept)
- Gothic feel via **shapes/ornaments**: a pointed-arch hero crown, quatrefoil section dividers, a blackletter display face (UnifrakturCook) for headings, and an illuminated brand-purple drop-cap.
- Live blackletter preview in the hero (renders as you type).
- Everything scoped to `body.theme-gothic` — no other page is affected.

### UX fixes (both pages)
- **Click-to-copy charts** — every A–Z / a–z / 0–9 glyph is now a copy button, with a **"copy series"** action per row. Progressive enhancement: the raw glyph text stays in the DOM for SEO.
- **Per-card platform chips** — each result card surfaces where the style works (e.g. "Works everywhere"), at the point of choosing. Behind a `UTG_SHOW_PLATFORMS` flag in `script.js`.
- **Device compatibility check** moved into the generator area instead of the page bottom.
- **Copyable gothic-symbol strips** — occult/medieval/cross on Gothic; cross/banner/star on Old English. (Keyword data shows the adjacent symbol demand is occult/medieval, not mathematical.)
- Swapped the zero-demand "Runes" decoration tab for a gothic-paired **Emoji** set on the hub.

### Old English, taken further
- **New "Ultra Old English Banner" style** — bold blackletter inside a chicano nameplate banner (`꧁༺ name ༻꧂`).
- **Quick-fill use-case chips** in the hero (name / RIP / Est. year / jersey # / couple) that populate the generator instantly.
- **Old English dates & Roman-numeral tool** — enter a year, get true blackletter Roman numerals (`2024 → MMXXIV → 𝕸𝕸𝖃𝖃𝕴𝖁`), click to copy. Roman letters have real blackletter forms in Unicode (unlike digits), so this serves the est./memorial/jersey-date intent.
- **"Using Old English for tattoos"** guidance section (preview vs stencil, legibility, pairing crosses/banners, dates in Roman).

### Verification
Verified locally with Playwright screenshots + interaction tests: 134 copyable glyph tiles, copy-series, platform chips, quick-fill, the Roman tool (`1990 → MCMXC → 𝕸𝕮𝕸𝖃𝕮`), and the Banner style all functional; no page errors. The external-resource console errors seen in the sandbox are just GTM/AdSense/Google-Fonts being blocked, not code issues.

Files: `style.css`, `script.js`, `styles.js`, `renderer.js`, `gothic-tools.js`, `category/gothic-fonts/index.html`, `category/old-english-fonts/index.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJi817Du87hTT5dmhd4Kwo)_