### PR TITLE
feat: alias text-faces-kaomoji page for "kamoji" spelling variant

### DIFF
--- a/library/text-faces-kaomoji/index.html
+++ b/library/text-faces-kaomoji/index.html
@@ -14,8 +14,8 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Text Faces &amp; Kaomoji: Copy &amp; Paste Japanese Emoticons</title>
-<meta name="description" content="Browse and copy text faces and kaomoji — Japanese emoticons using ASCII and Unicode characters. Happy, sad, shrug, love, animals, and action expressions. Click any to copy it instantly.">
+<title>Text Faces &amp; Kaomoji (Kamoji): Copy &amp; Paste Japanese Emoticons</title>
+<meta name="description" content="Browse and copy text faces and kaomoji — also spelled kamoji — Japanese emoticons using ASCII and Unicode characters. Happy, sad, shrug, love, animals, and action expressions. Click any to copy it instantly.">
 
 <link rel="canonical" href="https://ultratextgen.com/library/text-faces-kaomoji/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/library-text-faces-kaomoji.png">
@@ -23,11 +23,11 @@
 <meta property="og:image:height" content="630">
 <meta property="og:image:type" content="image/png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Text Faces &amp; Kaomoji: Copy &amp; Paste Japanese Emoticons">
-<meta name="twitter:description" content="Browse and copy text faces and kaomoji — Japanese emoticons using ASCII and Unicode characters. Happy, sad, shrug, love, animals, and action expressions. Click any to copy it instantly.">
+<meta name="twitter:title" content="Text Faces &amp; Kaomoji (Kamoji): Copy &amp; Paste Japanese Emoticons">
+<meta name="twitter:description" content="Browse and copy text faces and kaomoji — also spelled kamoji — Japanese emoticons using ASCII and Unicode characters. Happy, sad, shrug, love, animals, and action expressions. Click any to copy it instantly.">
 <meta name="twitter:image" content="https://ultratextgen.com/assets/og/library-text-faces-kaomoji.png">
-<meta property="og:title" content="Text Faces &amp; Kaomoji: Copy &amp; Paste Japanese Emoticons">
-<meta property="og:description" content="Browse and copy text faces and kaomoji — Japanese emoticons using ASCII and Unicode characters. Happy, sad, shrug, love, animals, and action expressions. Click any to copy it instantly.">
+<meta property="og:title" content="Text Faces &amp; Kaomoji (Kamoji): Copy &amp; Paste Japanese Emoticons">
+<meta property="og:description" content="Browse and copy text faces and kaomoji — also spelled kamoji — Japanese emoticons using ASCII and Unicode characters. Happy, sad, shrug, love, animals, and action expressions. Click any to copy it instantly.">
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://ultratextgen.com/library/text-faces-kaomoji/">
 
@@ -42,7 +42,7 @@
   "@context": "https://schema.org",
   "@type": "Article",
   "headline": "Text Faces & Kaomoji: Copy & Paste Japanese Emoticons",
-  "alternateName": ["Kaomoji Copy and Paste", "Japanese Text Faces", "Text Emoticons", "Cute Text Faces", "Kaomoji Emoticons", "ASCII Faces Copy Paste"],
+  "alternateName": ["Kaomoji Copy and Paste", "Japanese Text Faces", "Text Emoticons", "Cute Text Faces", "Kaomoji Emoticons", "ASCII Faces Copy Paste", "Kamoji", "Kamoji Copy and Paste", "Cute Kamoji"],
   "description": "Browse and copy text faces and kaomoji — Japanese emoticons using ASCII and Unicode characters. Happy, sad, shrug, love, animals, and action expressions. Click any to copy it instantly.",
   "author": {
     "@type": "Organization",
@@ -57,7 +57,7 @@
   "image": "https://ultratextgen.com/assets/og/library-text-faces-kaomoji.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/text-faces-kaomoji/",
   "datePublished": "2026-03-31",
-  "dateModified": "2026-06-08"
+  "dateModified": "2026-06-30"
 }
 </script>
 
@@ -83,6 +83,47 @@
       "position": 3,
       "name": "Text Faces & Kaomoji",
       "item": "https://ultratextgen.com/library/text-faces-kaomoji/"
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is a kamoji?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "A kamoji is a Japanese-style text emoticon — a little face built from standard keyboard and Unicode characters, like (◕‿◕), ¯\\_(ツ)_/¯, or (｡•́︿•̀｡). Unlike emoji, kamoji are read upright rather than sideways, so the eyes, mouth, and arms are easy to recognise at a glance. Every kamoji on this page is plain text you can copy and paste into any bio, caption, comment, or username."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is kamoji the same as kaomoji?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Kamoji is simply a common shortened spelling of kaomoji (顔文字), the Japanese term for text-based emoticons. The two words refer to exactly the same thing — text faces such as (^▽^) and (T_T) — so searching for kamoji or kaomoji brings up the same kind of faces."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How do I copy and paste a kamoji?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Click any kamoji on this page to copy it instantly, then paste it wherever you type — Instagram and TikTok bios, Discord and WhatsApp messages, YouTube comments, or usernames. Because each kamoji is pure Unicode text rather than an image, it pastes cleanly without turning into a broken box."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the difference between a kamoji and an emoji?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "An emoji is a single coloured picture character rendered by the device's emoji font (😀), while a kamoji is a face assembled from ordinary text characters that you read upright, like (≧◡≦). Kamoji are more flexible and expressive for nuanced moods, and they look the same everywhere because they are built from standard Unicode text."
+      }
     }
   ]
 }
@@ -113,7 +154,7 @@
 <section class="editorial-section">
   <div class="editorial-block">
     <p>Kaomoji (顔文字) are emoticons that originated in Japan, built from standard keyboard characters and Unicode symbols. Unlike emoji, kaomoji are read horizontally and often capture nuanced expressions that emoji can't fully convey. They work in any text field and add personality to messages, bios, and captions.</p>
-    <p>The word <em>kaomoji</em> literally means "face characters" (顔 <em>kao</em>, "face" + 文字 <em>moji</em>, "character"). Where Western emoticons like <code>:-)</code> are read sideways, kaomoji such as <code>(◕‿◕)</code> are read upright, which makes the eyes, mouth, and even arms much easier to recognize at a glance. Because every kaomoji on this page is pure Unicode text — not an image or emoji font — it pastes cleanly into Instagram bios, TikTok captions, Discord messages, YouTube comments, usernames, and almost any other text field without turning into a broken box.</p>
+    <p>The word <em>kaomoji</em> literally means "face characters" (顔 <em>kao</em>, "face" + 文字 <em>moji</em>, "character") — and is also very commonly spelled <strong>kamoji</strong>, so a search for "kamoji" and a search for "kaomoji" mean the same thing. Where Western emoticons like <code>:-)</code> are read sideways, kaomoji such as <code>(◕‿◕)</code> are read upright, which makes the eyes, mouth, and even arms much easier to recognize at a glance. Because every kaomoji on this page is pure Unicode text — not an image or emoji font — it pastes cleanly into Instagram bios, TikTok captions, Discord messages, YouTube comments, usernames, and almost any other text field without turning into a broken box.</p>
     <p>Browse the categories below and click any face to copy it instantly. Each one is grouped by mood — happy, sad, shrug, love, cute, angry, sleepy, and more — so you can find the right expression in seconds.</p>
   </div>
 </section>
@@ -502,6 +543,28 @@
     </div>
 
   </div>
+</section>
+
+<!-- FAQ -->
+<section class="editorial-section" id="faq">
+  <span class="article-section-label">FAQ</span>
+  <h2>Kamoji &amp; Kaomoji FAQ</h2>
+  <details class="faq-item">
+    <summary class="faq-question">What is a kamoji?</summary>
+    <p class="faq-answer">A kamoji is a Japanese-style text emoticon — a little face built from standard keyboard and Unicode characters, like <code>(◕‿◕)</code>, <code>¯\_(ツ)_/¯</code>, or <code>(｡•́︿•̀｡)</code>. Unlike emoji, kamoji are read upright rather than sideways, so the eyes, mouth, and arms are easy to recognise at a glance. Every kamoji on this page is plain text you can copy and paste into any bio, caption, comment, or username.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">Is kamoji the same as kaomoji?</summary>
+    <p class="faq-answer">Yes. <strong>Kamoji</strong> is simply a common shortened spelling of <strong>kaomoji</strong> (顔文字), the Japanese term for text-based emoticons. The two words refer to exactly the same thing — text faces such as <code>(^▽^)</code> and <code>(T_T)</code> — so searching for kamoji or kaomoji brings up the same kind of faces.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">How do I copy and paste a kamoji?</summary>
+    <p class="faq-answer">Click any kamoji on this page to copy it instantly, then paste it wherever you type — Instagram and TikTok bios, Discord and WhatsApp messages, YouTube comments, or usernames. Because each kamoji is pure Unicode text rather than an image, it pastes cleanly without turning into a broken box.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">What is the difference between a kamoji and an emoji?</summary>
+    <p class="faq-answer">An emoji is a single coloured picture character rendered by the device's emoji font (😀), while a kamoji is a face assembled from ordinary text characters that you read upright, like <code>(≧◡≦)</code>. Kamoji are more flexible and expressive for nuanced moods, and they look the same everywhere because they are built from standard Unicode text.</p>
+  </details>
 </section>
 
 <!-- CTA -->


### PR DESCRIPTION
Capture the ~8.6k/mo US "kamoji" search demand (head term 5,400/mo, KD 27) that the page was missing because the exact token appeared nowhere on it. "Kamoji" is the common shortened spelling of kaomoji.

- Alt-name signals: add "kamoji" to title, meta/OG/Twitter descriptions, JSON-LD alternateName, and the intro etymology line (disambiguates the spelling, not keyword-stuffed — kaomoji still dominates 58:16).
- FAQ layer: add a 4-question "Kamoji & Kaomoji FAQ" section plus mirrored FAQPage JSON-LD, targeting the People-Also-Ask SERP feature present on kamoji queries and resolving the "is it a typo?" intent.
- Bump dateModified to 2026-06-30.


Claude-Session: https://claude.ai/code/session_01P9GjqScqEehKWAkt5CVap6