### PR TITLE
feat(id): small-text page + homepage "tulisan keren" optimization

### DIFF
--- a/category/small-text/index.html
+++ b/category/small-text/index.html
@@ -13,6 +13,9 @@
   <title>Small Text Generator (ₛₘₐₗₗ &amp; ᵗⁱⁿʸ) | UltraTextGen</title>
   <meta name="description" content="Generate small and tiny Unicode text styles for bios, names, and posts. Copy superscript, small-caps, and mini text instantly.">
   <link rel="canonical" href="https://ultratextgen.com/category/small-text/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/category/small-text/">
+  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/tulisan-kecil/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/category/small-text/">
   <meta property="og:title" content="Small Text Generator (ₛₘₐₗₗ &amp; ᵗⁱⁿʸ) | UltraTextGen">
   <meta property="og:description" content="Create small or tiny copy-paste text styles for Discord, Instagram, TikTok, and more.">
   <meta property="og:url" content="https://ultratextgen.com/category/small-text/">

--- a/id/index.html
+++ b/id/index.html
@@ -581,7 +581,7 @@ O</pre>
         <button class="glyph-copy alpha-glyphs" type="button" data-text="𝟶𝟷𝟸𝟹𝟺𝟻𝟼𝟽𝟾𝟿" aria-label="Salin angka aesthetic gaya Mono">𝟶 𝟷 𝟸 𝟹 𝟺 𝟻 𝟼 𝟽 𝟾 𝟿</button>
       </div>
     </div>
-    <p class="u-mt-15">Mau huruf abjad aesthetic buat satu inisial nama doang, atau angka buat tanggal lahir di bio? Tinggal ketik di generator atas — semua gaya langsung muncul.</p>
+    <p class="u-mt-15">Mau huruf abjad aesthetic buat satu inisial nama doang, atau angka buat tanggal lahir di bio? Tinggal ketik di generator atas — semua gaya langsung muncul. Khusus nyari huruf mini? Mampir ke <a href="/id/tulisan-kecil/">generator tulisan kecil &amp; huruf kecil</a> (small caps + huruf kecil diatas).</p>
   </section>
 
   <!-- Simbol Aesthetic -->

--- a/id/index.html
+++ b/id/index.html
@@ -13,7 +13,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title data-i18n="meta.title">Tulisan Aesthetic &amp; Font Keren — Generator Tulisan Unik (Copy Paste)</title>
+<title data-i18n="meta.title">Tulisan Aesthetic &amp; Tulisan Keren — Generator Font Keren (Copy Paste)</title>
 <meta name="description" data-i18n-content="meta.description" content="Tulisan aesthetic, tulisan keren, huruf estetik & font unik buat bio IG, caption TikTok, status WA & nickname game. Salin-tempel — gratis, tanpa daftar.">
 
 <link rel="canonical" href="https://ultratextgen.com/id/">
@@ -344,8 +344,8 @@
   <section class="hero">
     <div class="hero-inner">
       <div class="hero-card">
-        <h1 class="hero-headline" data-i18n="hero.title">Tulisan Aesthetic &amp; Font Keren</h1>
-        <p class="hero-tagline" data-i18n="hero.subtitle">Ubah tulisan biasa jadi font unik, huruf estetik, dan simbol aesthetic yang siap copy paste ke bio Instagram, caption TikTok, status WhatsApp, sampai nickname ML &amp; Free Fire.</p>
+        <h1 class="hero-headline" data-i18n="hero.title">Tulisan Aesthetic &amp; Tulisan Keren</h1>
+        <p class="hero-tagline" data-i18n="hero.subtitle">Ubah tulisan biasa jadi tulisan keren, font keren, huruf estetik, dan simbol aesthetic yang siap copy paste ke bio Instagram, caption TikTok, status WhatsApp, sampai nickname ML &amp; Free Fire.</p>
         <div class="input-wrapper">
           <textarea class="main-input" id="mainInput" placeholder="Ketik tulisanmu di sini..." data-i18n-placeholder="ui.placeholder" maxlength="500" autofocus=""></textarea>
           <button class="input-clear-btn" id="inputClearBtn" aria-label="Clear input" hidden="">✕</button>
@@ -508,9 +508,10 @@
 
   <!-- Tulisan Keren -->
   <section class="editorial-section">
-    <h2>Tulisan Keren: Ubah Teks Biasa Jadi Keren</h2>
-    <p class="editorial-intro">Pengen <strong>tulisan keren</strong> yang langsung bikin bio, caption, atau nama kelihatan beda? Tinggal ketik di generator paling atas — teks biasa langsung berubah jadi puluhan gaya keren yang siap copy paste.</p>
-    <p>"Tulisan keren", "teks keren", dan "text keren" intinya sama: huruf bergaya yang bukan font bawaan keyboard. Bedanya sama format bold di aplikasi chat — di sini tiap huruf adalah karakter Unicode tersendiri, jadi waktu kamu <strong>ubah tulisan jadi keren</strong> lalu tempel ke Instagram, TikTok, atau WhatsApp, gayanya gak ilang. Mau yang tegas (bold), misterius (gotik), lembut (kursif), atau bulat lucu (bubble) — semua muncul sekaligus tinggal pilih.</p>
+    <h2>Tulisan Keren, Huruf Keren &amp; Font Keren</h2>
+    <p class="editorial-intro">Pengen <strong>tulisan keren</strong> yang langsung bikin bio, caption, atau nama kelihatan beda? Tinggal ketik di generator paling atas — teks biasa langsung berubah jadi puluhan <strong>gaya tulisan keren</strong> yang siap copy paste, gratis dan tanpa aplikasi.</p>
+    <p>"Tulisan keren", "huruf keren", "font keren", "teks keren", dan "text keren" intinya sama: huruf bergaya yang bukan font bawaan keyboard. Bedanya sama format bold di aplikasi chat — di sini tiap huruf adalah karakter Unicode tersendiri, jadi waktu kamu <strong>bikin tulisan keren</strong> atau <strong>edit tulisan keren</strong> lalu tempel ke Instagram, TikTok, atau WhatsApp, gayanya gak ilang. Mau yang tegas (bold), misterius (gotik), lembut (kursif), atau bulat lucu (bubble) — semua muncul sekaligus tinggal pilih.</p>
+    <p>Butuh <strong>huruf keren A sampai Z</strong>? Scroll ke bagian Huruf Aesthetic A–Z di bawah buat nyalin satu baris abjad keren sekaligus. Mau <strong>huruf keren untuk nickname</strong>? Tambahin simbol biar makin standout — atau kalau lagi nyari huruf mini, mampir ke <a href="/id/tulisan-kecil/">tulisan kecil &amp; huruf kecil</a>.</p>
     <div class="block-example">
       <strong>Contoh:</strong> "Juara" → 𝗝𝘂𝗮𝗿𝗮 (bold), 𝕵𝖚𝖆𝖗𝖆 (gotik), 𝙅𝙪𝙖𝙧𝙖 (italic tebal), ᴊᴜᴀʀᴀ (small caps)
     </div>

--- a/id/tulisan-kecil/index.html
+++ b/id/tulisan-kecil/index.html
@@ -1,0 +1,210 @@
+<!DOCTYPE html><html lang="id"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8242324164413945" crossorigin="anonymous"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tulisan Kecil &amp; Huruf Kecil (ₛₘₐₗₗ ᵗⁱⁿʸ) — Generator Copy Paste | UltraTextGen</title>
+  <meta name="description" content="Bikin tulisan kecil, huruf kecil, dan huruf kecil diatas (superscript) buat bio IG, status WA, caption, & nickname game. Ketik, salin, tempel — gratis, tanpa aplikasi.">
+  <link rel="canonical" href="https://ultratextgen.com/id/tulisan-kecil/">
+
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/category/small-text/">
+  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/tulisan-kecil/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/category/small-text/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Tulisan Kecil &amp; Huruf Kecil (ₛₘₐₗₗ ᵗⁱⁿʸ) — Generator Copy Paste">
+  <meta property="og:description" content="Bikin tulisan kecil, huruf kecil, dan huruf kecil diatas buat bio IG, status WA, & nickname game. Salin-tempel, gratis.">
+  <meta property="og:url" content="https://ultratextgen.com/id/tulisan-kecil/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category-small-text.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Tulisan Kecil &amp; Huruf Kecil (ₛₘₐₗₗ ᵗⁱⁿʸ) — Copy Paste">
+  <meta name="twitter:description" content="Salin tulisan kecil & huruf kecil diatas dalam sekali klik.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category-small-text.png">
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Generator Tulisan Kecil",
+  "alternateName": ["Generator Tulisan Kecil", "Generator Huruf Kecil", "Tulisan Kecil Diatas", "Huruf Kecil Copy Paste", "Small Caps Generator"],
+  "url": "https://ultratextgen.com/id/tulisan-kecil/",
+  "applicationCategory": "UtilitiesApplication",
+  "operatingSystem": "Any",
+  "description": "Generator tulisan kecil, huruf kecil, dan huruf kecil diatas (superscript) yang siap copy paste ke bio, caption, status, dan nickname game.",
+  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Apa itu tulisan kecil?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Tulisan kecil adalah huruf yang tampil jadi versi mini lewat karakter Unicode — kayak small caps (ʜᴜʀᴜꜰ ᴋᴀᴘɪᴛᴀʟ ᴋᴇᴄɪʟ) dan huruf kecil diatas alias superscript (ᵏᵉᶜⁱˡ). Hasilnya tetap teks biasa yang bisa kamu salin-tempel ke bio, caption, status, atau nickname tanpa aplikasi." }
+    },
+    {
+      "@type": "Question",
+      "name": "Gimana cara bikin huruf kecil diatas buat nickname?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Ketik teksmu di kolom paling atas, lalu pilih gaya huruf kecil diatas (superscript). Klik Salin, terus tempel ke kolom nickname ML, Free Fire, Roblox, atau username IG. Karena karakternya Unicode, ukurannya tetap mini ke mana pun ditempel." }
+    },
+    {
+      "@type": "Question",
+      "name": "Tulisan kecil bisa dipakai di mana aja?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Tulisan kecil jalan di hampir semua aplikasi yang support Unicode: Instagram, WhatsApp, TikTok, Discord, X, sampai kolom nickname game. Kompatibilitas tiap gaya bisa beda-beda tergantung font sistem HP." }
+    },
+    {
+      "@type": "Question",
+      "name": "Kenapa tulisan kecil kadang jadi kotak-kotak?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Beberapa karakter kecil yang langka belum ada di semua font sistem. Kalau muncul kotak-kotak, ganti ke gaya huruf kecil yang lebih umum (misalnya small caps), atau coba di aplikasi/HP lain." }
+    },
+    {
+      "@type": "Question",
+      "name": "Gratis dan tanpa aplikasi?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Gratis 100%, jalan langsung di browser, tanpa daftar dan tanpa install aplikasi. Tinggal ketik, pilih gaya tulisan kecil, salin, tempel." }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Tulisan Aesthetic", "item": "https://ultratextgen.com/id/" },
+    { "@type": "ListItem", "position": 2, "name": "Tulisan Kecil", "item": "https://ultratextgen.com/id/tulisan-kecil/" }
+  ]
+}
+</script>
+</head>
+<body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<script src="/header.js"></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/id/">Tulisan Aesthetic</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Tulisan Kecil</span>
+</nav>
+
+<section class="hero">
+  <div class="hero-inner">
+    <div class="hero-card">
+      <h1 class="hero-headline">Generator Tulisan Kecil &amp; Huruf Kecil (ₛₘₐₗₗ ᵗⁱⁿʸ)</h1>
+      <p class="hero-tagline">Ubah teks biasa jadi tulisan kecil, huruf kecil, dan huruf kecil diatas (superscript) yang siap copy paste ke bio IG, status WA, caption TikTok, sampai nickname game.</p>
+      <div class="input-wrapper">
+        <textarea class="main-input" id="mainInput" placeholder="Ketik tulisanmu di sini..." maxlength="500" autofocus=""></textarea>
+        <span class="char-count"><span id="charCount">0</span>/500</span>
+      </div>
+      <div class="decoration-section">
+        <div class="decoration-label">Tambahin dekorasi ke hasil</div>
+        <div class="decoration-tabs">
+          <button class="decoration-tab active" data-deco-tab="symbols">Simbol</button>
+          <button class="decoration-tab" data-deco-tab="frames">Bingkai</button>
+          <button class="decoration-tab" data-deco-tab="minimal">Minimal</button>
+        </div>
+        <div class="decoration-grid" id="decorationGrid"></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<main class="container">
+  <div class="category-section"><div class="category-tabs" id="categoryTabs"></div></div>
+  <div class="results-grid" id="resultsGrid"></div>
+
+  <!-- Apa itu tulisan kecil -->
+  <section class="editorial-section">
+    <h2>Tulisan Kecil &amp; Huruf Kecil: Bedanya Apa?</h2>
+    <p class="editorial-intro">"Tulisan kecil" dan "huruf kecil" intinya sama — huruf yang dibikin tampil mini lewat karakter Unicode, bukan font bawaan keyboard. Karena tiap huruf adalah karakter Unicode tersendiri, ukurannya tetap kecil waktu kamu tempel ke bio, caption, status, atau nickname.</p>
+    <p>Ada beberapa gaya tulisan kecil yang paling sering dipakai:</p>
+    <ul class="u-mt-15">
+      <li><strong>Small caps</strong> — huruf kapital versi mini: ʜᴀʟᴏ ᴅᴜɴɪᴀ. Cocok buat nama dan bio yang rapi tapi beda.</li>
+      <li><strong>Huruf kecil diatas (superscript)</strong> — huruf mini yang naik ke atas baris: ʰᵃˡᵒ. Favorit buat hiasan nickname.</li>
+      <li><strong>Huruf kecil dibawah (subscript)</strong> — huruf mini yang turun ke bawah baris (cuma sebagian huruf yang tersedia).</li>
+    </ul>
+  </section>
+
+  <!-- Huruf A-Z kecil -->
+  <section class="editorial-section glyph-section">
+    <h2>Huruf Kecil A–Z (Small Caps &amp; Superscript)</h2>
+    <p class="editorial-intro">Butuh huruf a kecil sampai z? Ini abjad lengkapnya dalam dua gaya tulisan kecil paling populer. Klik satu baris buat nyalin seluruh alfabetnya sekaligus.</p>
+    <div class="alpha-list">
+      <div class="alpha-row">
+        <span class="alpha-label">Small Caps</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="ᴀʙᴄᴅᴇꜰɢʜɪᴊᴋʟᴍɴᴏᴘqʀsᴛᴜᴠᴡxʏᴢ" aria-label="Salin huruf kecil gaya Small Caps">ᴀ ʙ ᴄ ᴅ ᴇ ꜰ ɢ ʜ ɪ ᴊ ᴋ ʟ ᴍ ɴ ᴏ ᴘ q ʀ s ᴛ ᴜ ᴠ ᴡ x ʏ ᴢ</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Huruf Kecil Diatas</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="ᵃᵇᶜᵈᵉᶠᵍʰⁱʲᵏˡᵐⁿᵒᵖqʳˢᵗᵘᵛʷˣʸᶻ" aria-label="Salin huruf kecil diatas (superscript)">ᵃ ᵇ ᶜ ᵈ ᵉ ᶠ ᵍ ʰ ⁱ ʲ ᵏ ˡ ᵐ ⁿ ᵒ ᵖ q ʳ ˢ ᵗ ᵘ ᵛ ʷ ˣ ʸ ᶻ</button>
+      </div>
+    </div>
+    <h3>Angka Kecil 0–9</h3>
+    <div class="alpha-list">
+      <div class="alpha-row">
+        <span class="alpha-label">Diatas (Superscript)</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="⁰¹²³⁴⁵⁶⁷⁸⁹" aria-label="Salin angka kecil diatas">⁰ ¹ ² ³ ⁴ ⁵ ⁶ ⁷ ⁸ ⁹</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Dibawah (Subscript)</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="₀₁₂₃₄₅₆₇₈₉" aria-label="Salin angka kecil dibawah">₀ ₁ ₂ ₃ ₄ ₅ ₆ ₇ ₈ ₉</button>
+      </div>
+    </div>
+    <p class="u-mt-15">Mau huruf a kecil buat satu inisial doang, atau angka kecil buat tanggal di bio? Ketik aja di generator paling atas — semua gaya tulisan kecil langsung muncul siap disalin.</p>
+  </section>
+
+  <!-- Use cases -->
+  <section class="editorial-section">
+    <h2>Tulisan Kecil Paling Sering Dipakai Buat</h2>
+    <div class="block-example">
+      — <strong>Bio IG &amp; status WA</strong>: bikin baris kedua yang lebih kalem pakai small caps, misal ᴊᴀᴋᴀʀᴛᴀ · '02<br>
+      — <strong>Nickname game</strong>: tambahin huruf kecil diatas biar beda, misal Xᴬᴿᴱˢ atau ᵗᵉᵃᵐ‧Ghost<br>
+      — <strong>Caption &amp; tag</strong>: tandai bagian kecil kayak ᵉᵖ¹, ᵇᵗˢ, atau ˢᵖᵒⁿˢᵒʳᵉᵈ<br>
+      — <strong>Watermark halus</strong>: nama atau tanggal kecil yang gak ganggu desain utama
+    </div>
+    <p>Tips: pakai tulisan kecil buat teks <em>pendukung</em> aja (1–2 kata), bukan kalimat panjang, biar tetap kebaca. Mau gaya lain kayak bold, kursif, atau bubble? Balik ke <a href="/id/">generator tulisan aesthetic lengkap</a>.</p>
+  </section>
+</main>
+
+<footer class="footer">
+  <div class="footer-inner">
+    <h2 class="faq-category">Panduan Tulisan Kecil &amp; Huruf Kecil</h2>
+    <div class="faq-item"><button class="faq-question" type="button">Apa itu tulisan kecil?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Tulisan kecil adalah huruf yang tampil jadi versi mini lewat karakter Unicode — kayak small caps (ʜᴜʀᴜꜰ ᴋᴇᴄɪʟ) dan huruf kecil diatas alias superscript (ᵏᵉᶜⁱˡ). Hasilnya tetap teks biasa yang bisa disalin-tempel ke bio, caption, status, atau nickname tanpa aplikasi.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Gimana cara bikin huruf kecil diatas buat nickname?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Ketik teksmu di kolom paling atas, lalu pilih gaya huruf kecil diatas (superscript). Klik Salin, terus tempel ke kolom nickname ML, Free Fire, Roblox, atau username IG. Karena karakternya Unicode, ukurannya tetap mini ke mana pun ditempel.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Tulisan kecil bisa dipakai di mana aja?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Tulisan kecil jalan di hampir semua aplikasi yang support Unicode: Instagram, WhatsApp, TikTok, Discord, X, sampai kolom nickname game. Kompatibilitas tiap gaya bisa beda tergantung font sistem HP.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Kenapa tulisan kecil kadang jadi kotak-kotak?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Beberapa karakter kecil yang langka belum ada di semua font sistem. Kalau muncul kotak-kotak, ganti ke gaya huruf kecil yang lebih umum (misalnya small caps), atau coba di aplikasi/HP lain.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Gratis dan tanpa aplikasi?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Gratis 100%, jalan langsung di browser, tanpa daftar dan tanpa install aplikasi. Tinggal ketik, pilih gaya tulisan kecil, salin, tempel.</div></div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Language switcher">
+      <a class="lang-option" href="/category/small-text/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/id/tulisan-kecil/" hreflang="id">ID</a>
+    </div>
+  </div>
+</footer>
+
+<script>window.UTG_FAMILY = "small-text";</script>
+<script src="/styles.js"></script>
+<script src="/renderer.js"></script>
+<script src="/script.js" defer=""></script>
+<script src="/footer.js"></script>
+</body></html>

--- a/locales/id.json
+++ b/locales/id.json
@@ -1,11 +1,11 @@
 {
   "meta": {
-    "title": "Tulisan Aesthetic & Font Keren — Generator Tulisan Unik (Copy Paste)",
+    "title": "Tulisan Aesthetic & Tulisan Keren — Generator Font Keren (Copy Paste)",
     "description": "Tulisan aesthetic, tulisan keren, huruf estetik & font unik buat bio IG, caption TikTok, status WA & nickname game. Salin-tempel — gratis, tanpa daftar."
   },
   "hero": {
-    "title": "Tulisan Aesthetic & Font Keren",
-    "subtitle": "Ubah tulisan biasa jadi font unik, huruf estetik, dan simbol aesthetic yang siap copy paste ke bio Instagram, caption TikTok, status WhatsApp, sampai nickname ML & Free Fire."
+    "title": "Tulisan Aesthetic & Tulisan Keren",
+    "subtitle": "Ubah tulisan biasa jadi tulisan keren, font keren, huruf estetik, dan simbol aesthetic yang siap copy paste ke bio Instagram, caption TikTok, status WhatsApp, sampai nickname ML & Free Fire."
   },
   "decorations": {
     "label": "Tambahin dekorasi ke hasil",


### PR DESCRIPTION
## Summary
Two data-driven Indonesian (`/id/`) SEO improvements, sized from GSC (Indonesia) + Semrush volume/SERP exports. Targets the largest genuinely-Indonesian demand clusters the site currently under-captures.

### 1. New page: `/id/tulisan-kecil/` (small text)
Targets the **`tulisan kecil` / `huruf kecil` cluster (~101K/mo)** — Bahasa, genuinely Indonesian demand that the `/id/` homepage covered **0×**.
- This is a distinct **output** (small caps + superscript "huruf kecil diatas"), so it has a different SERP and does **not** cannibalize the aesthetic/keren homepage.
- Mirrors the existing `/category/small-text/` template + `UTG_FAMILY="small-text"` generator filter.
- Small-caps + superscript A–Z copy rows capture `huruf a kecil` / `huruf kecil diatas` long-tail.
- Indonesian FAQ + 3 valid JSON-LD blocks (WebApplication / FAQPage / BreadcrumbList), self-canonical + hreflang cluster.
- Reciprocal `hreflang` (en/id/x-default) added to `/category/small-text/`.
- Hub→spoke link added from the `/id/` homepage.

### 2. Homepage optimization for the "keren" cluster (no new URL)
The **`keren` cluster (~453K/mo: `tulisan keren` 135K, `font keren` 90K, `huruf keren` 27K)** is the biggest Indonesian gap — the homepage ranked ~pos 7 for `tulisan keren` vs pos 4 for `aesthetic`. Since these are **synonyms of the same intent**, this is on-page **consolidation on the same URL — not a separate page — so there is no dilution/cannibalization**.
- `locales/id.json` + HTML fallback: title / H1 / subtitle now lead with `tulisan keren` + `font keren` alongside `tulisan aesthetic` (kept first to protect the existing ranking).
- Deepened the "Tulisan Keren" section: `huruf keren`, `gaya/bikin/edit tulisan keren`, `huruf keren A–Z`, `huruf keren untuk nickname`.

## Note: FF/ML gaming pages diagnostic (no change needed)
Investigated why `/id/usecase/nama-ff-keren`, `nama-ml-keren`, etc. show 0 Indonesian impressions. **They are structurally healthy** (self-canonical, in sitemap, linked from homepage, no `noindex`) — they were simply **created June 26–27, only 3–4 days before the GSC export window closed**. Expected to index/rank over the coming weeks; recommend "Request indexing" in GSC and re-checking in ~3–4 weeks.

## Validation
- All JSON-LD blocks parse; `id.json` valid; HTML/locale title parity confirmed.
- All internal links verified to existing pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017YQexr4j1eZuLgDQDC8p3t)_