### PR TITLE
feat: kaomoji emotion-modifier spoke pages + hub-and-spoke wiring

### DIFF
--- a/data/library_page_specs/cat-kaomoji.json
+++ b/data/library_page_specs/cat-kaomoji.json
@@ -1,0 +1,84 @@
+{
+  "slug": "cat-kaomoji",
+  "title": "Cat Kaomoji: Copy & Paste Cute Cat Text Faces",
+  "meta_description": "Browse and copy cat kaomoji — also spelled cat kamoji — cute Japanese cat text faces with whiskers and paws. Happy, sad, and sleepy cats. Click any to copy.",
+  "breadcrumb": "Cat Kaomoji",
+  "hero_h1": "Cat Kaomoji",
+  "hero_tagline": "Copy and paste cat kaomoji — cute Japanese cat text faces with whiskers, paws, and big eyes. Click any face to copy it instantly.",
+  "intro": "Cat kaomoji (also spelled cat kamoji) are Japanese-style text faces built around the classic whisker shape =^・ω・^= — the most expressive single-animal family of kaomoji. A cat kaomoji like (=^・ω・^=) or ฅ^•ﻌ•^ฅ is plain Unicode text, so it pastes cleanly into bios, captions, comments, and usernames. Browse happy, sad, sleepy, and paw-raised cats below and click any face to copy it instantly.",
+  "date_published": "2026-06-30",
+  "date_modified": "2026-06-30",
+  "copy_pattern": "single",
+  "sections": [
+    {
+      "id": "classic-cats",
+      "label": "Classic Cats",
+      "h2": "Classic Cat Kaomoji",
+      "intro": "The core whisker-faced cats every cat kaomoji set starts with.",
+      "symbols": [
+        { "char": "(=^・ω・^=)", "label": "Classic Cat" },
+        { "char": "(=^‥^=)", "label": "Cat Eyes" },
+        { "char": "(=｀ω´=)", "label": "Smug Cat" },
+        { "char": "(＾• ω •＾)", "label": "Soft Cat" },
+        { "char": "(=ↀωↀ=)", "label": "Wide-Eyed Cat" },
+        { "char": "(=^◡^=)", "label": "Smiling Cat" }
+      ]
+    },
+    {
+      "id": "happy-cats",
+      "label": "Happy Cats",
+      "h2": "Happy Cat Kaomoji",
+      "intro": "Cheerful, content cats for a good mood.",
+      "symbols": [
+        { "char": "(=^▽^=)", "label": "Happy Cat" },
+        { "char": "＼(=^‥^)/", "label": "Cheering Cat" },
+        { "char": "(=˘ω˘=)", "label": "Cozy Cat" },
+        { "char": "ฅ(＾・ω・＾ฅ)", "label": "Paws-Up Cat" },
+        { "char": "(=•ㅅ•=)", "label": "Cute Cat" }
+      ]
+    },
+    {
+      "id": "sad-cats",
+      "label": "Sad Cats",
+      "h2": "Sad & Crying Cat Kaomoji",
+      "intro": "Teary and upset cats for sad or pleading moments.",
+      "symbols": [
+        { "char": "(=；ェ；=)", "label": "Crying Cat" },
+        { "char": "(=ＴェＴ=)", "label": "Sobbing Cat" },
+        { "char": "(=｀╥´=)", "label": "Upset Cat" },
+        { "char": "(╥ω╥)", "label": "Teary Cat" }
+      ]
+    },
+    {
+      "id": "paws-whiskers",
+      "label": "Paws & Whiskers",
+      "h2": "Cats with Paws & Whiskers",
+      "intro": "Cats reaching out with little paws and ฅ-shaped whiskers.",
+      "symbols": [
+        { "char": "ฅ^•ﻌ•^ฅ", "label": "Whisker Paws" },
+        { "char": "(ↀДↀ)✧", "label": "Sparkle Cat" },
+        { "char": "ฅ(•ㅅ•❀)ฅ", "label": "Flower Paws" },
+        { "char": "(=^･ｪ･^=)づ", "label": "Reaching Cat" },
+        { "char": "(＾• ω •＾)づ", "label": "Offering Paw" }
+      ]
+    },
+    {
+      "id": "big-eyed-cats",
+      "label": "Big-Eyed Cats",
+      "h2": "Big-Eyed Cat Kaomoji",
+      "intro": "Wide, sparkly-eyed cats for an extra-cute look.",
+      "symbols": [
+        { "char": "(=①ω①=)", "label": "Big Eyes Cat" },
+        { "char": "(=ＯｴＯ=)", "label": "Surprised Cat" },
+        { "char": "(✧ᆺ✧)", "label": "Sparkly Eyes Cat" }
+      ]
+    }
+  ],
+  "cta": "Use UltraTextGen to convert plain text into bold, italic, cursive, and 100+ other Unicode font styles — free and instant.",
+  "related": [
+    { "href": "/library/text-faces-kaomoji/", "title": "Text Faces & Kaomoji", "desc": "The full kaomoji hub — every mood of Japanese text face in one place." },
+    { "href": "/library/cute-kaomoji/", "title": "Cute Kaomoji", "desc": "Cute and kawaii text faces with sparkly eyes and blushing cheeks." },
+    { "href": "/library/animal-emojis/", "title": "Animal Emojis", "desc": "Cats, dogs, and every other animal emoji to copy and paste." },
+    { "href": "/library/kawaii-cute-symbols/", "title": "Kawaii Cute Symbols", "desc": "Soft, cute Unicode symbols for kawaii and aesthetic text." }
+  ]
+}

--- a/data/library_page_specs/crying-kaomoji.json
+++ b/data/library_page_specs/crying-kaomoji.json
@@ -1,0 +1,72 @@
+{
+  "slug": "crying-kaomoji",
+  "title": "Crying & Sad Kaomoji: Copy & Paste Crying Text Faces",
+  "meta_description": "Browse and copy crying and sad kaomoji — also spelled kamoji — Japanese text faces for tears, sobbing, and gloomy moods. Click any to copy it instantly.",
+  "breadcrumb": "Crying & Sad Kaomoji",
+  "hero_h1": "Crying & Sad Kaomoji",
+  "hero_tagline": "Copy and paste crying and sad kaomoji — Japanese text faces for tears, sobbing, and low moods. Click any face to copy it instantly.",
+  "intro": "Crying and sad kaomoji (also spelled kamoji) are Japanese-style text faces that express tears, sobbing, and gloom using streaming-eye characters like ﹏ and ╥. A crying kaomoji such as (╥﹏╥) or (｡•́︿•̀｡) is plain Unicode text, so it pastes cleanly into bios, captions, comments, and messages. Browse by intensity below — from a single tear to full sobbing — and click any face to copy it instantly.",
+  "date_published": "2026-06-30",
+  "date_modified": "2026-06-30",
+  "copy_pattern": "single",
+  "sections": [
+    {
+      "id": "crying",
+      "label": "Crying",
+      "h2": "Crying Kaomoji",
+      "intro": "Everyday crying faces for sad or overwhelmed moments.",
+      "symbols": [
+        { "char": "(╥﹏╥)", "label": "Crying" },
+        { "char": "(T_T)", "label": "Tears" },
+        { "char": "(；﹏；)", "label": "Quiet Cry" },
+        { "char": "(ㄒoㄒ)", "label": "Crying Eyes" },
+        { "char": "(个_个)", "label": "Weepy" },
+        { "char": "(;_;)", "label": "Single Tear" }
+      ]
+    },
+    {
+      "id": "sobbing",
+      "label": "Sobbing",
+      "h2": "Sobbing & Streaming Tears Kaomoji",
+      "intro": "Heavier, streaming-tear faces for full-on sobbing.",
+      "symbols": [
+        { "char": "(｡•́︿•̀｡)", "label": "Sobbing" },
+        { "char": "(πーπ)", "label": "Streaming Tears" },
+        { "char": "(ToT)", "label": "Wailing" },
+        { "char": "(Q_Q)", "label": "Heavy Tears" },
+        { "char": "(；へ：)", "label": "Trembling Cry" }
+      ]
+    },
+    {
+      "id": "sad",
+      "label": "Sad",
+      "h2": "Sad & Upset Kaomoji",
+      "intro": "Downcast faces for sadness, hurt, and disappointment.",
+      "symbols": [
+        { "char": "(._.)", "label": "Downcast" },
+        { "char": "(´；ω；`)", "label": "Tearful" },
+        { "char": "( ; ω ; )", "label": "About to Cry" },
+        { "char": "(╯︵╰,)", "label": "Sad and Crying" }
+      ]
+    },
+    {
+      "id": "gloomy",
+      "label": "Gloomy",
+      "h2": "Gloomy & Disappointed Kaomoji",
+      "intro": "Flat, deflated faces for gloomy or let-down moods.",
+      "symbols": [
+        { "char": "(¬_¬)", "label": "Unimpressed" },
+        { "char": "(；￣Д￣)", "label": "Distressed" },
+        { "char": "(´-ω-`)", "label": "Deflated" },
+        { "char": "(⇀‸↼‶)", "label": "Sulking" }
+      ]
+    }
+  ],
+  "cta": "Use UltraTextGen to convert plain text into bold, italic, cursive, and 100+ other Unicode font styles — free and instant.",
+  "related": [
+    { "href": "/library/text-faces-kaomoji/", "title": "Text Faces & Kaomoji", "desc": "The full kaomoji hub — every mood of Japanese text face in one place." },
+    { "href": "/library/happy-kaomoji/", "title": "Happy Kaomoji", "desc": "Smiling, excited, and joyful Japanese text faces to copy and paste." },
+    { "href": "/library/sad-emoji/", "title": "Sad Emoji", "desc": "Sad and downcast emoji to copy and paste for low moods." },
+    { "href": "/library/crying-emoji/", "title": "Crying Emoji", "desc": "Crying and sobbing emoji for tears, grief, and big feelings." }
+  ]
+}

--- a/data/library_page_specs/cute-kaomoji.json
+++ b/data/library_page_specs/cute-kaomoji.json
@@ -1,0 +1,72 @@
+{
+  "slug": "cute-kaomoji",
+  "title": "Cute Kaomoji: Copy & Paste Cute & Kawaii Text Faces",
+  "meta_description": "Browse and copy cute kaomoji — also spelled cute kamoji — kawaii Japanese text faces with sparkly eyes, blushing cheeks, and animals. Click any to copy.",
+  "breadcrumb": "Cute Kaomoji",
+  "hero_h1": "Cute Kaomoji",
+  "hero_tagline": "Copy and paste cute kaomoji — kawaii Japanese text faces with sparkly eyes, blushing cheeks, and tiny animals. Click any face to copy it instantly.",
+  "intro": "Cute kaomoji (also spelled cute kamoji) are kawaii Japanese-style text faces built from soft, rounded characters — sparkly eyes, little flowers, and blushing cheeks. A cute kaomoji such as (◕‿◕✿) or (ﾉ◕ヮ◕)ﾉ*:･ﾟ✧ is plain Unicode text, so it pastes cleanly into bios, captions, comments, and usernames. Browse the cutest faces, kawaii animals, and sparkly looks below and click any to copy it instantly.",
+  "date_published": "2026-06-30",
+  "date_modified": "2026-06-30",
+  "copy_pattern": "single",
+  "sections": [
+    {
+      "id": "cute-faces",
+      "label": "Cute Faces",
+      "h2": "Cute Kaomoji Faces",
+      "intro": "Soft, rounded faces that read as instantly cute.",
+      "symbols": [
+        { "char": "(◕‿◕)", "label": "Cute Smile" },
+        { "char": "(｡◕‿◕｡)", "label": "Sweet Face" },
+        { "char": "(◠‿◠✿)", "label": "Flower Smile" },
+        { "char": "(✿◡‿◡)", "label": "Happy Flower" },
+        { "char": "( ◜‿◝ )♡", "label": "Loving Cutie" },
+        { "char": "(＾▽＾)", "label": "Bright Cutie" }
+      ]
+    },
+    {
+      "id": "kawaii-animals",
+      "label": "Kawaii Animals",
+      "h2": "Kawaii Animal Kaomoji",
+      "intro": "Tiny bears, cats, and critters in their cutest form.",
+      "symbols": [
+        { "char": "ʕ•ᴥ•ʔ", "label": "Bear" },
+        { "char": "(=^・ω・^=)", "label": "Cat" },
+        { "char": "(◕ᴥ◕)", "label": "Puppy" },
+        { "char": "ʕ •ᴥ•ʔ♡", "label": "Loving Bear" },
+        { "char": "(U ᵕ U❁)", "label": "Sweet Pup" }
+      ]
+    },
+    {
+      "id": "shy-blushing",
+      "label": "Shy & Blushing",
+      "h2": "Shy & Blushing Cute Kaomoji",
+      "intro": "Bashful, flustered faces for shy little moments.",
+      "symbols": [
+        { "char": "(⁄ ⁄>⁄ ▽ ⁄<⁄ ⁄)", "label": "Very Shy" },
+        { "char": "(//▽//)", "label": "Blushing" },
+        { "char": "(๑•́ ₃ •̀๑)", "label": "Pouty Cute" },
+        { "char": "(◡‿◡✿)", "label": "Quiet Cutie" }
+      ]
+    },
+    {
+      "id": "sparkly-cute",
+      "label": "Sparkly Cute",
+      "h2": "Cute Kaomoji with Sparkles",
+      "intro": "Extra-cute faces with stars and sparkle accents.",
+      "symbols": [
+        { "char": "(★ω★)", "label": "Star Eyes" },
+        { "char": "✧(≖ ‿ ≖)✧", "label": "Sparkle Smirk" },
+        { "char": "(ﾉ◕ヮ◕)ﾉ*:･ﾟ✧", "label": "Throwing Sparkles" },
+        { "char": "(◍•ᴗ•◍)✧", "label": "Sparkly Joy" }
+      ]
+    }
+  ],
+  "cta": "Use UltraTextGen to convert plain text into bold, italic, cursive, and 100+ other Unicode font styles — free and instant.",
+  "related": [
+    { "href": "/library/text-faces-kaomoji/", "title": "Text Faces & Kaomoji", "desc": "The full kaomoji hub — every mood of Japanese text face in one place." },
+    { "href": "/library/cat-kaomoji/", "title": "Cat Kaomoji", "desc": "Cute Japanese cat text faces with whiskers, paws, and big eyes." },
+    { "href": "/library/kawaii-cute-symbols/", "title": "Kawaii Cute Symbols", "desc": "Soft, cute Unicode symbols for kawaii and aesthetic text." },
+    { "href": "/library/happy-kaomoji/", "title": "Happy Kaomoji", "desc": "Smiling, excited, and joyful Japanese text faces to copy and paste." }
+  ]
+}

--- a/data/library_page_specs/happy-kaomoji.json
+++ b/data/library_page_specs/happy-kaomoji.json
@@ -1,0 +1,73 @@
+{
+  "slug": "happy-kaomoji",
+  "title": "Happy Kaomoji: Copy & Paste Smiling & Joyful Text Faces",
+  "meta_description": "Browse and copy happy kaomoji — also spelled kamoji — smiling, excited, and joyful Japanese text faces. Click any to copy it instantly.",
+  "breadcrumb": "Happy Kaomoji",
+  "hero_h1": "Happy Kaomoji",
+  "hero_tagline": "Copy and paste happy kaomoji — smiling, excited, and cheerful Japanese text faces. Click any face to copy it instantly.",
+  "intro": "Happy kaomoji (also spelled kamoji) are Japanese-style text faces that capture every shade of good mood — a quiet smile, pure excitement, or a celebratory dance. A happy kaomoji such as (◠‿◠) or ＼(≧▽≦)／ is plain Unicode text, so it pastes cleanly into bios, captions, comments, and usernames without breaking. Browse by mood below and click any face to copy it instantly.",
+  "date_published": "2026-06-30",
+  "date_modified": "2026-06-30",
+  "copy_pattern": "single",
+  "sections": [
+    {
+      "id": "smiling",
+      "label": "Smiling",
+      "h2": "Smiling Kaomoji",
+      "intro": "Gentle, friendly smiles for everyday happy messages.",
+      "symbols": [
+        { "char": "(◠‿◠)", "label": "Soft Smile" },
+        { "char": "(^▽^)", "label": "Big Smile" },
+        { "char": "(≧◡≦)", "label": "Happy Eyes" },
+        { "char": "( ´ ▽ ` )", "label": "Relaxed Smile" },
+        { "char": "(＾▽＾)", "label": "Bright Smile" },
+        { "char": "(｡◕‿◕｡)", "label": "Sweet Smile" },
+        { "char": "(•‿•)", "label": "Simple Smile" }
+      ]
+    },
+    {
+      "id": "excited",
+      "label": "Excited",
+      "h2": "Excited & Joyful Kaomoji",
+      "intro": "Arms-up, high-energy faces for excitement and celebration.",
+      "symbols": [
+        { "char": "ヽ(•‿•)ノ", "label": "Cheering" },
+        { "char": "٩(◕‿◕)۶", "label": "Hooray" },
+        { "char": "＼(≧▽≦)／", "label": "So Happy" },
+        { "char": "ヽ(>∀<☆)ノ", "label": "Thrilled" },
+        { "char": "(★^O^★)", "label": "Star Eyes Joy" }
+      ]
+    },
+    {
+      "id": "content",
+      "label": "Content",
+      "h2": "Content & Pleased Kaomoji",
+      "intro": "Calm, satisfied faces for a quietly good mood.",
+      "symbols": [
+        { "char": "(─‿─)", "label": "Pleased" },
+        { "char": "(｡•̀ᴗ-)✧", "label": "Confident Wink" },
+        { "char": "( ˙▿˙ )", "label": "Content" },
+        { "char": "(✯◡✯)", "label": "Sparkly Happy" }
+      ]
+    },
+    {
+      "id": "celebrating",
+      "label": "Celebrating",
+      "h2": "Celebrating & Dancing Kaomoji",
+      "intro": "Dancing and celebrating faces for wins and good news.",
+      "symbols": [
+        { "char": "ヽ(´▽`)/", "label": "Joyful Cheer" },
+        { "char": "⊂(´• ω •`⊂)", "label": "Happy Dance" },
+        { "char": "♪┏(・o･)┛♪", "label": "Dancing" },
+        { "char": "＼(^o^)／", "label": "Celebration" }
+      ]
+    }
+  ],
+  "cta": "Use UltraTextGen to convert plain text into bold, italic, cursive, and 100+ other Unicode font styles — free and instant.",
+  "related": [
+    { "href": "/library/text-faces-kaomoji/", "title": "Text Faces & Kaomoji", "desc": "The full kaomoji hub — every mood of Japanese text face in one place." },
+    { "href": "/library/love-kaomoji/", "title": "Love & Heart Kaomoji", "desc": "Hearts, kisses, and hugs in cute Japanese text-face form." },
+    { "href": "/library/cute-kaomoji/", "title": "Cute Kaomoji", "desc": "Cute and kawaii text faces with sparkly eyes and blushing cheeks." },
+    { "href": "/library/happy-emoji/", "title": "Happy Emoji", "desc": "Smiling and joyful emoji to copy and paste for any happy moment." }
+  ]
+}

--- a/data/library_page_specs/love-kaomoji.json
+++ b/data/library_page_specs/love-kaomoji.json
@@ -1,0 +1,75 @@
+{
+  "slug": "love-kaomoji",
+  "title": "Love & Heart Kaomoji: Copy & Paste Cute Love Text Faces",
+  "meta_description": "Browse and copy love and heart kaomoji — also spelled kamoji — Japanese text faces for affection, kisses, hugs, and crushes. Click any to copy it instantly.",
+  "breadcrumb": "Love & Heart Kaomoji",
+  "hero_h1": "Love & Heart Kaomoji",
+  "hero_tagline": "Copy and paste love and heart kaomoji — cute Japanese text faces for crushes, kisses, and hugs. Click any face to copy it instantly.",
+  "intro": "Love and heart kaomoji (also spelled kamoji) are Japanese-style text faces that show affection using hearts, blushing cheeks, and outstretched arms. Unlike a plain heart emoji, a heart kaomoji such as (♥ω♥) or (づ｡◕‿‿◕｡)づ pastes as pure Unicode text into any bio, caption, comment, or message — so it looks the same everywhere. Pick a mood below and click any face to copy it instantly.",
+  "date_published": "2026-06-30",
+  "date_modified": "2026-06-30",
+  "copy_pattern": "single",
+  "sections": [
+    {
+      "id": "hearts-love",
+      "label": "Hearts & Love",
+      "h2": "Heart & Love Kaomoji",
+      "intro": "Classic heart kaomoji for showing love, adoration, and a happy crush.",
+      "symbols": [
+        { "char": "(♥ω♥)", "label": "Heart Eyes" },
+        { "char": "(◍•ᴗ•◍)❤", "label": "In Love" },
+        { "char": "(✿ ♥‿♥)", "label": "Flower Heart" },
+        { "char": "(｡♥‿♥｡)", "label": "Smiling Heart" },
+        { "char": "(♡μ_μ)", "label": "Lovestruck" },
+        { "char": "(◕‿◕)♡", "label": "Sweet Heart" },
+        { "char": "(♥‿♥)", "label": "Heart Smile" },
+        { "char": "(´｡• ᵕ •｡`) ♡", "label": "Content Love" }
+      ]
+    },
+    {
+      "id": "blowing-kisses",
+      "label": "Kisses",
+      "h2": "Blowing a Kiss Kaomoji",
+      "intro": "Kiss kaomoji for sending a smooch, a flirt, or a goodnight.",
+      "symbols": [
+        { "char": "( ˘ ³˘)♥", "label": "Blowing a Kiss" },
+        { "char": "(*^3^)/~☆", "label": "Throwing a Kiss" },
+        { "char": "(っ˘ω˘ς )", "label": "Shy Kiss" },
+        { "char": "(づ￣ ³￣)づ", "label": "Kissy Face" },
+        { "char": "( ˘ ³˘)♡", "label": "Soft Kiss" }
+      ]
+    },
+    {
+      "id": "hugging",
+      "label": "Hugs",
+      "h2": "Hugging & Affection Kaomoji",
+      "intro": "Hug kaomoji with open arms for comfort, support, and closeness.",
+      "symbols": [
+        { "char": "(づ｡◕‿‿◕｡)づ", "label": "Big Hug" },
+        { "char": "(つ≧▽≦)つ", "label": "Come Here Hug" },
+        { "char": "⊂((・▽・))⊃", "label": "Squeeze Hug" },
+        { "char": "٩(♡ε♡ )۶", "label": "Loving Hug" },
+        { "char": "⊂(´• ω •`⊂)", "label": "Reaching Hug" }
+      ]
+    },
+    {
+      "id": "in-love-blushing",
+      "label": "Blushing",
+      "h2": "In Love & Blushing Kaomoji",
+      "intro": "Blushing kaomoji for shy, flustered, and butterflies-in-the-stomach moments.",
+      "symbols": [
+        { "char": "(⁄ ⁄•⁄ω⁄•⁄ ⁄)", "label": "Blushing" },
+        { "char": "(//ω//)", "label": "Flustered" },
+        { "char": "(*ﾉ∀ﾉ)", "label": "Shy Smile" },
+        { "char": "(„ᵕᴗᵕ„)", "label": "Bashful" }
+      ]
+    }
+  ],
+  "cta": "Use UltraTextGen to convert plain text into bold, italic, cursive, and 100+ other Unicode font styles — free and instant.",
+  "related": [
+    { "href": "/library/text-faces-kaomoji/", "title": "Text Faces & Kaomoji", "desc": "The full kaomoji hub — every mood of Japanese text face in one place." },
+    { "href": "/library/happy-kaomoji/", "title": "Happy Kaomoji", "desc": "Smiling, excited, and joyful Japanese text faces to copy and paste." },
+    { "href": "/library/cute-kaomoji/", "title": "Cute Kaomoji", "desc": "Cute and kawaii text faces with sparkly eyes and blushing cheeks." },
+    { "href": "/library/heart-symbols/", "title": "Heart Symbols", "desc": "Heart emojis and Unicode heart characters in every color and style." }
+  ]
+}

--- a/data/library_page_specs/sparkle-kaomoji.json
+++ b/data/library_page_specs/sparkle-kaomoji.json
@@ -1,0 +1,69 @@
+{
+  "slug": "sparkle-kaomoji",
+  "title": "Sparkle & Star Kaomoji: Copy & Paste Sparkly Text Faces",
+  "meta_description": "Browse and copy sparkle and star kaomoji — also spelled kamoji — Japanese text faces with sparkles, stars, and glitter. Click any to copy it instantly.",
+  "breadcrumb": "Sparkle & Star Kaomoji",
+  "hero_h1": "Sparkle & Star Kaomoji",
+  "hero_tagline": "Copy and paste sparkle and star kaomoji — Japanese text faces with sparkles, stars, and glitter accents. Click any face to copy it instantly.",
+  "intro": "Sparkle and star kaomoji (also spelled kamoji) are Japanese-style text faces decorated with sparkle and star characters like ✧, ☆, and ﾟ.* for an aesthetic, magical look. A sparkle kaomoji such as (★ω★) or (ﾉ◕ヮ◕)ﾉ*:･ﾟ✧ is plain Unicode text, so it pastes cleanly into bios, captions, comments, and usernames. Browse sparkling faces, star faces, and glitter-throwing kaomoji below and click any to copy it instantly.",
+  "date_published": "2026-06-30",
+  "date_modified": "2026-06-30",
+  "copy_pattern": "single",
+  "sections": [
+    {
+      "id": "sparkling-faces",
+      "label": "Sparkling Faces",
+      "h2": "Sparkling Face Kaomoji",
+      "intro": "Bright faces with sparkle eyes and shine accents.",
+      "symbols": [
+        { "char": "(★ω★)", "label": "Star Eyes" },
+        { "char": "(✧ω✧)", "label": "Sparkle Eyes" },
+        { "char": "✧(•̀ᴗ•́)✧", "label": "Determined Sparkle" },
+        { "char": "(ﾉ◕ヮ◕)ﾉ*:･ﾟ✧", "label": "Throwing Sparkles" },
+        { "char": "(☆▽☆)", "label": "Shining Eyes" }
+      ]
+    },
+    {
+      "id": "stars",
+      "label": "Stars",
+      "h2": "Star Kaomoji",
+      "intro": "Star-eyed and star-accented faces for a starry look.",
+      "symbols": [
+        { "char": "(★≧▽≦)", "label": "Starstruck" },
+        { "char": "(≧▽≦)/☆", "label": "Catching a Star" },
+        { "char": "☆ﾐ(o*･ω･)ﾉ", "label": "Star Wave" },
+        { "char": "⋆｡˚☽˚｡⋆", "label": "Starry Night" }
+      ]
+    },
+    {
+      "id": "magic-glitter",
+      "label": "Magic & Glitter",
+      "h2": "Magic & Glitter Kaomoji",
+      "intro": "Dreamy, magical faces with glitter and shine.",
+      "symbols": [
+        { "char": "(＊♡∀♡)", "label": "Dazzled" },
+        { "char": "(∩˃o˂∩)♡", "label": "Sparkle Hug" },
+        { "char": "٩(✧ω✧)۶", "label": "Sparkle Cheer" },
+        { "char": "(´｡• ω •｡`) ✧", "label": "Soft Sparkle" }
+      ]
+    },
+    {
+      "id": "throwing-sparkles",
+      "label": "Throwing Sparkles",
+      "h2": "Throwing Sparkles Kaomoji",
+      "intro": "Faces flinging sparkles and stars for a magical flourish.",
+      "symbols": [
+        { "char": "(∩^o^)⊃━☆ﾟ.*", "label": "Casting Sparkles" },
+        { "char": "(ﾉ>ω<)ﾉ", "label": "Tossing Up" },
+        { "char": "☆*:.｡.o(≧▽≦)o.｡.:*☆", "label": "Surrounded by Stars" }
+      ]
+    }
+  ],
+  "cta": "Use UltraTextGen to convert plain text into bold, italic, cursive, and 100+ other Unicode font styles — free and instant.",
+  "related": [
+    { "href": "/library/text-faces-kaomoji/", "title": "Text Faces & Kaomoji", "desc": "The full kaomoji hub — every mood of Japanese text face in one place." },
+    { "href": "/library/cute-kaomoji/", "title": "Cute Kaomoji", "desc": "Cute and kawaii text faces with sparkly eyes and blushing cheeks." },
+    { "href": "/library/sparkle-symbols/", "title": "Sparkle Symbols", "desc": "Sparkles, glitter, and shine characters for aesthetic text." },
+    { "href": "/library/star-symbols/", "title": "Star Symbols", "desc": "Star characters and symbols in every style to copy and paste." }
+  ]
+}

--- a/docs/page-vs-section-decisions.md
+++ b/docs/page-vs-section-decisions.md
@@ -91,9 +91,18 @@ not about the item count — it's about whether a spoke page exists:**
 
 ## 6. Worked example — kaomoji / text faces (US data, 2026-06)
 
-Demand for `[subject] kaomoji` (broad-match, US — the only market with real
-intent; MX is near-zero, ID is the *Situ Kamojing* lake place-name, and any
-"Yakuza 0" rows are the video game — all noise):
+Demand for `[subject] kaomoji` (broad-match, US — the market analysed here;
+any "Yakuza 0" rows are the video game and person-name rows are noise).
+
+> **Correction (2026-06):** an earlier draft of this section read "MX is
+> near-zero." That was true only for the *modifier* broad-match it sampled.
+> The **head term is huge outside the US** — `kaomoji` is ~165K/mo in MX and
+> ~1.4M globally (ID 201K · MX 165K · PH 135K · US 90.5K). "kaomoji" is a
+> script-identical loanword, so the English page competes in every market
+> (emojicombos' English page ranks #1 for "kaomoji" in Brazil). The lever is
+> owning the **loanword**, not translating it — native-language terms
+> (`caritas japonesas` ~1.1K, `carinhas` low thousands) are a rounding error
+> by comparison. See §7.
 
 **Emotion / aesthetic cluster (real demand):**
 `heart 480 · cute 390 · sad 260 · happy 170 · star 90 · shrug 70 · flower 50 · angel 40`
@@ -131,3 +140,52 @@ showing in a section:
    ├─ spoke page exists ..................... teaser 6–8 + "see all →"
    └─ no spoke page ........................ show everything
 ```
+
+---
+
+## 7. Built — kaomoji emotion-modifier spokes (2026-06)
+
+Re-scoped against keyword-level demand (deduped exact `[mood] kaomoji/kamoji`,
+not the inflated topic buckets) × the international multiplier (the loanword
+and its modifiers are script-identical, so each spoke also captures
+MX/BR/ID/PH). Supply was checked per mood — every shipped spoke carries
+16–23 distinct faces, clearing the thin-content gate.
+
+### Canonical ownership table
+
+| Page | Owns the intent | Status |
+|---|---|---|
+| `/library/text-faces-kaomoji/` (hub) | the **head term** — `kaomoji` / `kamoji` / `text faces` | live |
+| `/library/love-kaomoji/` | `heart / love / kiss / hug kaomoji` (~6,080 US) | **built** |
+| `/library/happy-kaomoji/` | `happy / smiling kaomoji` (~4,430 US) | **built** |
+| `/library/cat-kaomoji/` | `cat kaomoji` (~3,700 US) | **built** |
+| `/library/crying-kaomoji/` | `crying / sad kaomoji` (~2,660 US) | **built** |
+| `/library/cute-kaomoji/` | `cute kaomoji` | **built** |
+| `/library/sparkle-kaomoji/` | `sparkle / star kaomoji` (~1,690 US) | **built** |
+
+Hub keeps each mood as a **teaser section + "see all →"** linking its spoke;
+each spoke links back to the hub. Hub owns the head term, spokes own
+`[mood] kaomoji` — different queries, no self-cannibalization.
+
+**Tier 2 (not yet built):** `angry-kaomoji` (~1,040) and `shocked-kaomoji`
+(nervous/surprised, ~1,210).
+
+**Stays a section/teaser, not a page:** dog + other animals (demand exists at
+`dog kaomoji` 590 but supply fails the gate — dog kaomoji are sparse and read
+as generic animal); shrug, lenny, hug, sleepy, table-flip (thin exact demand).
+
+### Note on `cute` — why it's a page despite thin US exact volume
+
+`cute kamoji` is only ~390 US exact, which would normally fail the gate. It
+ships as a page because the demand is **international**: `cute kaomoji` is
+~2,900 in Brazil alone, and the script-identical loanword means the English
+page serves those markets. This is the one spoke justified by global rather
+than US-only demand — flagged so it doesn't read as a gate violation.
+
+### Superseded
+
+§6's row "`cute / heart / sad / happy` kaomoji … belong on the **face /
+emotion** hubs, not animal" is now realised as dedicated kaomoji spokes under
+`/library/` (the kaomoji hub IS the emotion hub for text faces). Cat earned a
+page after all — re-checked, it clears **both** demand (×international) and
+supply, where §6 only had the thin US-exact 170.

--- a/library/cat-kaomoji/index.html
+++ b/library/cat-kaomoji/index.html
@@ -1,0 +1,292 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8242324164413945"
+       crossorigin="anonymous"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Cat Kaomoji: Copy &amp; Paste Cute Cat Text Faces</title>
+<meta name="description" content="Browse and copy cat kaomoji — also spelled cat kamoji — cute Japanese cat text faces with whiskers and paws. Happy, sad, and sleepy cats. Click any to copy.">
+
+<link rel="canonical" href="https://ultratextgen.com/library/cat-kaomoji/">
+<meta property="og:image" content="https://ultratextgen.com/logo.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Cat Kaomoji: Copy &amp; Paste Cute Cat Text Faces">
+<meta name="twitter:description" content="Browse and copy cat kaomoji — also spelled cat kamoji — cute Japanese cat text faces with whiskers and paws. Happy, sad, and sleepy cats. Click any to copy.">
+<meta name="twitter:image" content="https://ultratextgen.com/logo.png">
+<meta property="og:title" content="Cat Kaomoji: Copy &amp; Paste Cute Cat Text Faces">
+<meta property="og:description" content="Browse and copy cat kaomoji — also spelled cat kamoji — cute Japanese cat text faces with whiskers and paws. Happy, sad, and sleepy cats. Click any to copy.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/library/cat-kaomoji/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Cat Kaomoji: Copy & Paste Cute Cat Text Faces",
+  "description": "Browse and copy cat kaomoji — also spelled cat kamoji — cute Japanese cat text faces with whiskers and paws. Happy, sad, and sleepy cats. Click any to copy.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "mainEntityOfPage": "https://ultratextgen.com/library/cat-kaomoji/",
+  "datePublished": "2026-06-30",
+  "dateModified": "2026-06-30"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://ultratextgen.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Library",
+      "item": "https://ultratextgen.com/library/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Cat Kaomoji",
+      "item": "https://ultratextgen.com/library/cat-kaomoji/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<script src="/header.js"></script>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Cat Kaomoji</h1>
+    <p class="hero-tagline">Copy and paste cat kaomoji — cute Japanese cat text faces with whiskers, paws, and big eyes. Click any face to copy it instantly.</p>
+  </div>
+</section>
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Cat kaomoji (also spelled cat kamoji) are Japanese-style text faces built around the classic whisker shape =^・ω・^= — the most expressive single-animal family of kaomoji. A cat kaomoji like (=^・ω・^=) or ฅ^•ﻌ•^ฅ is plain Unicode text, so it pastes cleanly into bios, captions, comments, and usernames. Browse happy, sad, sleepy, and paw-raised cats below and click any face to copy it instantly.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="classic-cats">
+  <span class="article-section-label">Classic Cats</span>
+  <h2>Classic Cat Kaomoji</h2>
+  <p class="u-secondary-tight">The core whisker-faced cats every cat kaomoji set starts with.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(=^・ω・^=)" aria-label="Copy Classic Cat">(=^・ω・^=)</button>
+      <span class="flag-label">Classic Cat</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(=^‥^=)" aria-label="Copy Cat Eyes">(=^‥^=)</button>
+      <span class="flag-label">Cat Eyes</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(=｀ω´=)" aria-label="Copy Smug Cat">(=｀ω´=)</button>
+      <span class="flag-label">Smug Cat</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(＾• ω •＾)" aria-label="Copy Soft Cat">(＾• ω •＾)</button>
+      <span class="flag-label">Soft Cat</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(=ↀωↀ=)" aria-label="Copy Wide-Eyed Cat">(=ↀωↀ=)</button>
+      <span class="flag-label">Wide-Eyed Cat</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(=^◡^=)" aria-label="Copy Smiling Cat">(=^◡^=)</button>
+      <span class="flag-label">Smiling Cat</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="happy-cats">
+  <span class="article-section-label">Happy Cats</span>
+  <h2>Happy Cat Kaomoji</h2>
+  <p class="u-secondary-tight">Cheerful, content cats for a good mood.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(=^▽^=)" aria-label="Copy Happy Cat">(=^▽^=)</button>
+      <span class="flag-label">Happy Cat</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="＼(=^‥^)/" aria-label="Copy Cheering Cat">＼(=^‥^)/</button>
+      <span class="flag-label">Cheering Cat</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(=˘ω˘=)" aria-label="Copy Cozy Cat">(=˘ω˘=)</button>
+      <span class="flag-label">Cozy Cat</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ฅ(＾・ω・＾ฅ)" aria-label="Copy Paws-Up Cat">ฅ(＾・ω・＾ฅ)</button>
+      <span class="flag-label">Paws-Up Cat</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(=•ㅅ•=)" aria-label="Copy Cute Cat">(=•ㅅ•=)</button>
+      <span class="flag-label">Cute Cat</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="sad-cats">
+  <span class="article-section-label">Sad Cats</span>
+  <h2>Sad &amp; Crying Cat Kaomoji</h2>
+  <p class="u-secondary-tight">Teary and upset cats for sad or pleading moments.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(=；ェ；=)" aria-label="Copy Crying Cat">(=；ェ；=)</button>
+      <span class="flag-label">Crying Cat</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(=ＴェＴ=)" aria-label="Copy Sobbing Cat">(=ＴェＴ=)</button>
+      <span class="flag-label">Sobbing Cat</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(=｀╥´=)" aria-label="Copy Upset Cat">(=｀╥´=)</button>
+      <span class="flag-label">Upset Cat</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(╥ω╥)" aria-label="Copy Teary Cat">(╥ω╥)</button>
+      <span class="flag-label">Teary Cat</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="paws-whiskers">
+  <span class="article-section-label">Paws &amp; Whiskers</span>
+  <h2>Cats with Paws &amp; Whiskers</h2>
+  <p class="u-secondary-tight">Cats reaching out with little paws and ฅ-shaped whiskers.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ฅ^•ﻌ•^ฅ" aria-label="Copy Whisker Paws">ฅ^•ﻌ•^ฅ</button>
+      <span class="flag-label">Whisker Paws</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(ↀДↀ)✧" aria-label="Copy Sparkle Cat">(ↀДↀ)✧</button>
+      <span class="flag-label">Sparkle Cat</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ฅ(•ㅅ•❀)ฅ" aria-label="Copy Flower Paws">ฅ(•ㅅ•❀)ฅ</button>
+      <span class="flag-label">Flower Paws</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(=^･ｪ･^=)づ" aria-label="Copy Reaching Cat">(=^･ｪ･^=)づ</button>
+      <span class="flag-label">Reaching Cat</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(＾• ω •＾)づ" aria-label="Copy Offering Paw">(＾• ω •＾)づ</button>
+      <span class="flag-label">Offering Paw</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="big-eyed-cats">
+  <span class="article-section-label">Big-Eyed Cats</span>
+  <h2>Big-Eyed Cat Kaomoji</h2>
+  <p class="u-secondary-tight">Wide, sparkly-eyed cats for an extra-cute look.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(=①ω①=)" aria-label="Copy Big Eyes Cat">(=①ω①=)</button>
+      <span class="flag-label">Big Eyes Cat</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(=ＯｴＯ=)" aria-label="Copy Surprised Cat">(=ＯｴＯ=)</button>
+      <span class="flag-label">Surprised Cat</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(✧ᆺ✧)" aria-label="Copy Sparkly Eyes Cat">(✧ᆺ✧)</button>
+      <span class="flag-label">Sparkly Eyes Cat</span>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Transform text with Unicode fonts</h3>
+  <p>Use UltraTextGen to convert plain text into bold, italic, cursive, and 100+ other Unicode font styles — free and instant.</p>
+  <a href="https://ultratextgen.com/" class="cta-btn">Open UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Related Resources</span>
+  <div class="compare-grid">
+    <a href="/library/text-faces-kaomoji/" class="compare-card variant-muted u-no-underline">
+      <h4>Text Faces &amp; Kaomoji</h4>
+      <p>The full kaomoji hub — every mood of Japanese text face in one place.</p>
+    </a>
+    <a href="/library/cute-kaomoji/" class="compare-card variant-muted u-no-underline">
+      <h4>Cute Kaomoji</h4>
+      <p>Cute and kawaii text faces with sparkly eyes and blushing cheeks.</p>
+    </a>
+    <a href="/library/animal-emojis/" class="compare-card variant-muted u-no-underline">
+      <h4>Animal Emojis</h4>
+      <p>Cats, dogs, and every other animal emoji to copy and paste.</p>
+    </a>
+    <a href="/library/kawaii-cute-symbols/" class="compare-card variant-muted u-no-underline">
+      <h4>Kawaii Cute Symbols</h4>
+      <p>Soft, cute Unicode symbols for kawaii and aesthetic text.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js"></script>
+<script src="/footer.js"></script>
+</body>
+</html>

--- a/library/crying-kaomoji/index.html
+++ b/library/crying-kaomoji/index.html
@@ -1,0 +1,266 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8242324164413945"
+       crossorigin="anonymous"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Crying &amp; Sad Kaomoji: Copy &amp; Paste Crying Text Faces</title>
+<meta name="description" content="Browse and copy crying and sad kaomoji — also spelled kamoji — Japanese text faces for tears, sobbing, and gloomy moods. Click any to copy it instantly.">
+
+<link rel="canonical" href="https://ultratextgen.com/library/crying-kaomoji/">
+<meta property="og:image" content="https://ultratextgen.com/logo.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Crying &amp; Sad Kaomoji: Copy &amp; Paste Crying Text Faces">
+<meta name="twitter:description" content="Browse and copy crying and sad kaomoji — also spelled kamoji — Japanese text faces for tears, sobbing, and gloomy moods. Click any to copy it instantly.">
+<meta name="twitter:image" content="https://ultratextgen.com/logo.png">
+<meta property="og:title" content="Crying &amp; Sad Kaomoji: Copy &amp; Paste Crying Text Faces">
+<meta property="og:description" content="Browse and copy crying and sad kaomoji — also spelled kamoji — Japanese text faces for tears, sobbing, and gloomy moods. Click any to copy it instantly.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/library/crying-kaomoji/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Crying & Sad Kaomoji: Copy & Paste Crying Text Faces",
+  "description": "Browse and copy crying and sad kaomoji — also spelled kamoji — Japanese text faces for tears, sobbing, and gloomy moods. Click any to copy it instantly.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "mainEntityOfPage": "https://ultratextgen.com/library/crying-kaomoji/",
+  "datePublished": "2026-06-30",
+  "dateModified": "2026-06-30"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://ultratextgen.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Library",
+      "item": "https://ultratextgen.com/library/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Crying & Sad Kaomoji",
+      "item": "https://ultratextgen.com/library/crying-kaomoji/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<script src="/header.js"></script>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Crying &amp; Sad Kaomoji</h1>
+    <p class="hero-tagline">Copy and paste crying and sad kaomoji — Japanese text faces for tears, sobbing, and low moods. Click any face to copy it instantly.</p>
+  </div>
+</section>
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Crying and sad kaomoji (also spelled kamoji) are Japanese-style text faces that express tears, sobbing, and gloom using streaming-eye characters like ﹏ and ╥. A crying kaomoji such as (╥﹏╥) or (｡•́︿•̀｡) is plain Unicode text, so it pastes cleanly into bios, captions, comments, and messages. Browse by intensity below — from a single tear to full sobbing — and click any face to copy it instantly.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="crying">
+  <span class="article-section-label">Crying</span>
+  <h2>Crying Kaomoji</h2>
+  <p class="u-secondary-tight">Everyday crying faces for sad or overwhelmed moments.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(╥﹏╥)" aria-label="Copy Crying">(╥﹏╥)</button>
+      <span class="flag-label">Crying</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(T_T)" aria-label="Copy Tears">(T_T)</button>
+      <span class="flag-label">Tears</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(；﹏；)" aria-label="Copy Quiet Cry">(；﹏；)</button>
+      <span class="flag-label">Quiet Cry</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(ㄒoㄒ)" aria-label="Copy Crying Eyes">(ㄒoㄒ)</button>
+      <span class="flag-label">Crying Eyes</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(个_个)" aria-label="Copy Weepy">(个_个)</button>
+      <span class="flag-label">Weepy</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(;_;)" aria-label="Copy Single Tear">(;_;)</button>
+      <span class="flag-label">Single Tear</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="sobbing">
+  <span class="article-section-label">Sobbing</span>
+  <h2>Sobbing &amp; Streaming Tears Kaomoji</h2>
+  <p class="u-secondary-tight">Heavier, streaming-tear faces for full-on sobbing.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(｡•́︿•̀｡)" aria-label="Copy Sobbing">(｡•́︿•̀｡)</button>
+      <span class="flag-label">Sobbing</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(πーπ)" aria-label="Copy Streaming Tears">(πーπ)</button>
+      <span class="flag-label">Streaming Tears</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(ToT)" aria-label="Copy Wailing">(ToT)</button>
+      <span class="flag-label">Wailing</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(Q_Q)" aria-label="Copy Heavy Tears">(Q_Q)</button>
+      <span class="flag-label">Heavy Tears</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(；へ：)" aria-label="Copy Trembling Cry">(；へ：)</button>
+      <span class="flag-label">Trembling Cry</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="sad">
+  <span class="article-section-label">Sad</span>
+  <h2>Sad &amp; Upset Kaomoji</h2>
+  <p class="u-secondary-tight">Downcast faces for sadness, hurt, and disappointment.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(._.)" aria-label="Copy Downcast">(._.)</button>
+      <span class="flag-label">Downcast</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(´；ω；`)" aria-label="Copy Tearful">(´；ω；`)</button>
+      <span class="flag-label">Tearful</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="( ; ω ; )" aria-label="Copy About to Cry">( ; ω ; )</button>
+      <span class="flag-label">About to Cry</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(╯︵╰,)" aria-label="Copy Sad and Crying">(╯︵╰,)</button>
+      <span class="flag-label">Sad and Crying</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="gloomy">
+  <span class="article-section-label">Gloomy</span>
+  <h2>Gloomy &amp; Disappointed Kaomoji</h2>
+  <p class="u-secondary-tight">Flat, deflated faces for gloomy or let-down moods.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(¬_¬)" aria-label="Copy Unimpressed">(¬_¬)</button>
+      <span class="flag-label">Unimpressed</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(；￣Д￣)" aria-label="Copy Distressed">(；￣Д￣)</button>
+      <span class="flag-label">Distressed</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(´-ω-`)" aria-label="Copy Deflated">(´-ω-`)</button>
+      <span class="flag-label">Deflated</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(⇀‸↼‶)" aria-label="Copy Sulking">(⇀‸↼‶)</button>
+      <span class="flag-label">Sulking</span>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Transform text with Unicode fonts</h3>
+  <p>Use UltraTextGen to convert plain text into bold, italic, cursive, and 100+ other Unicode font styles — free and instant.</p>
+  <a href="https://ultratextgen.com/" class="cta-btn">Open UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Related Resources</span>
+  <div class="compare-grid">
+    <a href="/library/text-faces-kaomoji/" class="compare-card variant-muted u-no-underline">
+      <h4>Text Faces &amp; Kaomoji</h4>
+      <p>The full kaomoji hub — every mood of Japanese text face in one place.</p>
+    </a>
+    <a href="/library/happy-kaomoji/" class="compare-card variant-muted u-no-underline">
+      <h4>Happy Kaomoji</h4>
+      <p>Smiling, excited, and joyful Japanese text faces to copy and paste.</p>
+    </a>
+    <a href="/library/sad-emoji/" class="compare-card variant-muted u-no-underline">
+      <h4>Sad Emoji</h4>
+      <p>Sad and downcast emoji to copy and paste for low moods.</p>
+    </a>
+    <a href="/library/crying-emoji/" class="compare-card variant-muted u-no-underline">
+      <h4>Crying Emoji</h4>
+      <p>Crying and sobbing emoji for tears, grief, and big feelings.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js"></script>
+<script src="/footer.js"></script>
+</body>
+</html>

--- a/library/cute-kaomoji/index.html
+++ b/library/cute-kaomoji/index.html
@@ -1,0 +1,266 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8242324164413945"
+       crossorigin="anonymous"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Cute Kaomoji: Copy &amp; Paste Cute &amp; Kawaii Text Faces</title>
+<meta name="description" content="Browse and copy cute kaomoji — also spelled cute kamoji — kawaii Japanese text faces with sparkly eyes, blushing cheeks, and animals. Click any to copy.">
+
+<link rel="canonical" href="https://ultratextgen.com/library/cute-kaomoji/">
+<meta property="og:image" content="https://ultratextgen.com/logo.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Cute Kaomoji: Copy &amp; Paste Cute &amp; Kawaii Text Faces">
+<meta name="twitter:description" content="Browse and copy cute kaomoji — also spelled cute kamoji — kawaii Japanese text faces with sparkly eyes, blushing cheeks, and animals. Click any to copy.">
+<meta name="twitter:image" content="https://ultratextgen.com/logo.png">
+<meta property="og:title" content="Cute Kaomoji: Copy &amp; Paste Cute &amp; Kawaii Text Faces">
+<meta property="og:description" content="Browse and copy cute kaomoji — also spelled cute kamoji — kawaii Japanese text faces with sparkly eyes, blushing cheeks, and animals. Click any to copy.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/library/cute-kaomoji/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Cute Kaomoji: Copy & Paste Cute & Kawaii Text Faces",
+  "description": "Browse and copy cute kaomoji — also spelled cute kamoji — kawaii Japanese text faces with sparkly eyes, blushing cheeks, and animals. Click any to copy.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "mainEntityOfPage": "https://ultratextgen.com/library/cute-kaomoji/",
+  "datePublished": "2026-06-30",
+  "dateModified": "2026-06-30"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://ultratextgen.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Library",
+      "item": "https://ultratextgen.com/library/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Cute Kaomoji",
+      "item": "https://ultratextgen.com/library/cute-kaomoji/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<script src="/header.js"></script>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Cute Kaomoji</h1>
+    <p class="hero-tagline">Copy and paste cute kaomoji — kawaii Japanese text faces with sparkly eyes, blushing cheeks, and tiny animals. Click any face to copy it instantly.</p>
+  </div>
+</section>
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Cute kaomoji (also spelled cute kamoji) are kawaii Japanese-style text faces built from soft, rounded characters — sparkly eyes, little flowers, and blushing cheeks. A cute kaomoji such as (◕‿◕✿) or (ﾉ◕ヮ◕)ﾉ*:･ﾟ✧ is plain Unicode text, so it pastes cleanly into bios, captions, comments, and usernames. Browse the cutest faces, kawaii animals, and sparkly looks below and click any to copy it instantly.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="cute-faces">
+  <span class="article-section-label">Cute Faces</span>
+  <h2>Cute Kaomoji Faces</h2>
+  <p class="u-secondary-tight">Soft, rounded faces that read as instantly cute.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(◕‿◕)" aria-label="Copy Cute Smile">(◕‿◕)</button>
+      <span class="flag-label">Cute Smile</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(｡◕‿◕｡)" aria-label="Copy Sweet Face">(｡◕‿◕｡)</button>
+      <span class="flag-label">Sweet Face</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(◠‿◠✿)" aria-label="Copy Flower Smile">(◠‿◠✿)</button>
+      <span class="flag-label">Flower Smile</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(✿◡‿◡)" aria-label="Copy Happy Flower">(✿◡‿◡)</button>
+      <span class="flag-label">Happy Flower</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="( ◜‿◝ )♡" aria-label="Copy Loving Cutie">( ◜‿◝ )♡</button>
+      <span class="flag-label">Loving Cutie</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(＾▽＾)" aria-label="Copy Bright Cutie">(＾▽＾)</button>
+      <span class="flag-label">Bright Cutie</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="kawaii-animals">
+  <span class="article-section-label">Kawaii Animals</span>
+  <h2>Kawaii Animal Kaomoji</h2>
+  <p class="u-secondary-tight">Tiny bears, cats, and critters in their cutest form.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ʕ•ᴥ•ʔ" aria-label="Copy Bear">ʕ•ᴥ•ʔ</button>
+      <span class="flag-label">Bear</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(=^・ω・^=)" aria-label="Copy Cat">(=^・ω・^=)</button>
+      <span class="flag-label">Cat</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(◕ᴥ◕)" aria-label="Copy Puppy">(◕ᴥ◕)</button>
+      <span class="flag-label">Puppy</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ʕ •ᴥ•ʔ♡" aria-label="Copy Loving Bear">ʕ •ᴥ•ʔ♡</button>
+      <span class="flag-label">Loving Bear</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(U ᵕ U❁)" aria-label="Copy Sweet Pup">(U ᵕ U❁)</button>
+      <span class="flag-label">Sweet Pup</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="shy-blushing">
+  <span class="article-section-label">Shy &amp; Blushing</span>
+  <h2>Shy &amp; Blushing Cute Kaomoji</h2>
+  <p class="u-secondary-tight">Bashful, flustered faces for shy little moments.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(⁄ ⁄&gt;⁄ ▽ ⁄&lt;⁄ ⁄)" aria-label="Copy Very Shy">(⁄ ⁄&gt;⁄ ▽ ⁄&lt;⁄ ⁄)</button>
+      <span class="flag-label">Very Shy</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(//▽//)" aria-label="Copy Blushing">(//▽//)</button>
+      <span class="flag-label">Blushing</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(๑•́ ₃ •̀๑)" aria-label="Copy Pouty Cute">(๑•́ ₃ •̀๑)</button>
+      <span class="flag-label">Pouty Cute</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(◡‿◡✿)" aria-label="Copy Quiet Cutie">(◡‿◡✿)</button>
+      <span class="flag-label">Quiet Cutie</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="sparkly-cute">
+  <span class="article-section-label">Sparkly Cute</span>
+  <h2>Cute Kaomoji with Sparkles</h2>
+  <p class="u-secondary-tight">Extra-cute faces with stars and sparkle accents.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(★ω★)" aria-label="Copy Star Eyes">(★ω★)</button>
+      <span class="flag-label">Star Eyes</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✧(≖ ‿ ≖)✧" aria-label="Copy Sparkle Smirk">✧(≖ ‿ ≖)✧</button>
+      <span class="flag-label">Sparkle Smirk</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(ﾉ◕ヮ◕)ﾉ*:･ﾟ✧" aria-label="Copy Throwing Sparkles">(ﾉ◕ヮ◕)ﾉ*:･ﾟ✧</button>
+      <span class="flag-label">Throwing Sparkles</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(◍•ᴗ•◍)✧" aria-label="Copy Sparkly Joy">(◍•ᴗ•◍)✧</button>
+      <span class="flag-label">Sparkly Joy</span>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Transform text with Unicode fonts</h3>
+  <p>Use UltraTextGen to convert plain text into bold, italic, cursive, and 100+ other Unicode font styles — free and instant.</p>
+  <a href="https://ultratextgen.com/" class="cta-btn">Open UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Related Resources</span>
+  <div class="compare-grid">
+    <a href="/library/text-faces-kaomoji/" class="compare-card variant-muted u-no-underline">
+      <h4>Text Faces &amp; Kaomoji</h4>
+      <p>The full kaomoji hub — every mood of Japanese text face in one place.</p>
+    </a>
+    <a href="/library/cat-kaomoji/" class="compare-card variant-muted u-no-underline">
+      <h4>Cat Kaomoji</h4>
+      <p>Cute Japanese cat text faces with whiskers, paws, and big eyes.</p>
+    </a>
+    <a href="/library/kawaii-cute-symbols/" class="compare-card variant-muted u-no-underline">
+      <h4>Kawaii Cute Symbols</h4>
+      <p>Soft, cute Unicode symbols for kawaii and aesthetic text.</p>
+    </a>
+    <a href="/library/happy-kaomoji/" class="compare-card variant-muted u-no-underline">
+      <h4>Happy Kaomoji</h4>
+      <p>Smiling, excited, and joyful Japanese text faces to copy and paste.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js"></script>
+<script src="/footer.js"></script>
+</body>
+</html>

--- a/library/happy-kaomoji/index.html
+++ b/library/happy-kaomoji/index.html
@@ -1,0 +1,270 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8242324164413945"
+       crossorigin="anonymous"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Happy Kaomoji: Copy &amp; Paste Smiling &amp; Joyful Text Faces</title>
+<meta name="description" content="Browse and copy happy kaomoji — also spelled kamoji — smiling, excited, and joyful Japanese text faces. Click any to copy it instantly.">
+
+<link rel="canonical" href="https://ultratextgen.com/library/happy-kaomoji/">
+<meta property="og:image" content="https://ultratextgen.com/logo.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Happy Kaomoji: Copy &amp; Paste Smiling &amp; Joyful Text Faces">
+<meta name="twitter:description" content="Browse and copy happy kaomoji — also spelled kamoji — smiling, excited, and joyful Japanese text faces. Click any to copy it instantly.">
+<meta name="twitter:image" content="https://ultratextgen.com/logo.png">
+<meta property="og:title" content="Happy Kaomoji: Copy &amp; Paste Smiling &amp; Joyful Text Faces">
+<meta property="og:description" content="Browse and copy happy kaomoji — also spelled kamoji — smiling, excited, and joyful Japanese text faces. Click any to copy it instantly.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/library/happy-kaomoji/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Happy Kaomoji: Copy & Paste Smiling & Joyful Text Faces",
+  "description": "Browse and copy happy kaomoji — also spelled kamoji — smiling, excited, and joyful Japanese text faces. Click any to copy it instantly.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "mainEntityOfPage": "https://ultratextgen.com/library/happy-kaomoji/",
+  "datePublished": "2026-06-30",
+  "dateModified": "2026-06-30"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://ultratextgen.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Library",
+      "item": "https://ultratextgen.com/library/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Happy Kaomoji",
+      "item": "https://ultratextgen.com/library/happy-kaomoji/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<script src="/header.js"></script>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Happy Kaomoji</h1>
+    <p class="hero-tagline">Copy and paste happy kaomoji — smiling, excited, and cheerful Japanese text faces. Click any face to copy it instantly.</p>
+  </div>
+</section>
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Happy kaomoji (also spelled kamoji) are Japanese-style text faces that capture every shade of good mood — a quiet smile, pure excitement, or a celebratory dance. A happy kaomoji such as (◠‿◠) or ＼(≧▽≦)／ is plain Unicode text, so it pastes cleanly into bios, captions, comments, and usernames without breaking. Browse by mood below and click any face to copy it instantly.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="smiling">
+  <span class="article-section-label">Smiling</span>
+  <h2>Smiling Kaomoji</h2>
+  <p class="u-secondary-tight">Gentle, friendly smiles for everyday happy messages.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(◠‿◠)" aria-label="Copy Soft Smile">(◠‿◠)</button>
+      <span class="flag-label">Soft Smile</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(^▽^)" aria-label="Copy Big Smile">(^▽^)</button>
+      <span class="flag-label">Big Smile</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(≧◡≦)" aria-label="Copy Happy Eyes">(≧◡≦)</button>
+      <span class="flag-label">Happy Eyes</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="( ´ ▽ ` )" aria-label="Copy Relaxed Smile">( ´ ▽ ` )</button>
+      <span class="flag-label">Relaxed Smile</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(＾▽＾)" aria-label="Copy Bright Smile">(＾▽＾)</button>
+      <span class="flag-label">Bright Smile</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(｡◕‿◕｡)" aria-label="Copy Sweet Smile">(｡◕‿◕｡)</button>
+      <span class="flag-label">Sweet Smile</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(•‿•)" aria-label="Copy Simple Smile">(•‿•)</button>
+      <span class="flag-label">Simple Smile</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="excited">
+  <span class="article-section-label">Excited</span>
+  <h2>Excited &amp; Joyful Kaomoji</h2>
+  <p class="u-secondary-tight">Arms-up, high-energy faces for excitement and celebration.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ヽ(•‿•)ノ" aria-label="Copy Cheering">ヽ(•‿•)ノ</button>
+      <span class="flag-label">Cheering</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="٩(◕‿◕)۶" aria-label="Copy Hooray">٩(◕‿◕)۶</button>
+      <span class="flag-label">Hooray</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="＼(≧▽≦)／" aria-label="Copy So Happy">＼(≧▽≦)／</button>
+      <span class="flag-label">So Happy</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ヽ(&gt;∀&lt;☆)ノ" aria-label="Copy Thrilled">ヽ(&gt;∀&lt;☆)ノ</button>
+      <span class="flag-label">Thrilled</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(★^O^★)" aria-label="Copy Star Eyes Joy">(★^O^★)</button>
+      <span class="flag-label">Star Eyes Joy</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="content">
+  <span class="article-section-label">Content</span>
+  <h2>Content &amp; Pleased Kaomoji</h2>
+  <p class="u-secondary-tight">Calm, satisfied faces for a quietly good mood.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(─‿─)" aria-label="Copy Pleased">(─‿─)</button>
+      <span class="flag-label">Pleased</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(｡•̀ᴗ-)✧" aria-label="Copy Confident Wink">(｡•̀ᴗ-)✧</button>
+      <span class="flag-label">Confident Wink</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="( ˙▿˙ )" aria-label="Copy Content">( ˙▿˙ )</button>
+      <span class="flag-label">Content</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(✯◡✯)" aria-label="Copy Sparkly Happy">(✯◡✯)</button>
+      <span class="flag-label">Sparkly Happy</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="celebrating">
+  <span class="article-section-label">Celebrating</span>
+  <h2>Celebrating &amp; Dancing Kaomoji</h2>
+  <p class="u-secondary-tight">Dancing and celebrating faces for wins and good news.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ヽ(´▽`)/" aria-label="Copy Joyful Cheer">ヽ(´▽`)/</button>
+      <span class="flag-label">Joyful Cheer</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊂(´• ω •`⊂)" aria-label="Copy Happy Dance">⊂(´• ω •`⊂)</button>
+      <span class="flag-label">Happy Dance</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♪┏(・o･)┛♪" aria-label="Copy Dancing">♪┏(・o･)┛♪</button>
+      <span class="flag-label">Dancing</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="＼(^o^)／" aria-label="Copy Celebration">＼(^o^)／</button>
+      <span class="flag-label">Celebration</span>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Transform text with Unicode fonts</h3>
+  <p>Use UltraTextGen to convert plain text into bold, italic, cursive, and 100+ other Unicode font styles — free and instant.</p>
+  <a href="https://ultratextgen.com/" class="cta-btn">Open UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Related Resources</span>
+  <div class="compare-grid">
+    <a href="/library/text-faces-kaomoji/" class="compare-card variant-muted u-no-underline">
+      <h4>Text Faces &amp; Kaomoji</h4>
+      <p>The full kaomoji hub — every mood of Japanese text face in one place.</p>
+    </a>
+    <a href="/library/love-kaomoji/" class="compare-card variant-muted u-no-underline">
+      <h4>Love &amp; Heart Kaomoji</h4>
+      <p>Hearts, kisses, and hugs in cute Japanese text-face form.</p>
+    </a>
+    <a href="/library/cute-kaomoji/" class="compare-card variant-muted u-no-underline">
+      <h4>Cute Kaomoji</h4>
+      <p>Cute and kawaii text faces with sparkly eyes and blushing cheeks.</p>
+    </a>
+    <a href="/library/happy-emoji/" class="compare-card variant-muted u-no-underline">
+      <h4>Happy Emoji</h4>
+      <p>Smiling and joyful emoji to copy and paste for any happy moment.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js"></script>
+<script src="/footer.js"></script>
+</body>
+</html>

--- a/library/love-kaomoji/index.html
+++ b/library/love-kaomoji/index.html
@@ -1,0 +1,278 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8242324164413945"
+       crossorigin="anonymous"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Love &amp; Heart Kaomoji: Copy &amp; Paste Cute Love Text Faces</title>
+<meta name="description" content="Browse and copy love and heart kaomoji — also spelled kamoji — Japanese text faces for affection, kisses, hugs, and crushes. Click any to copy it instantly.">
+
+<link rel="canonical" href="https://ultratextgen.com/library/love-kaomoji/">
+<meta property="og:image" content="https://ultratextgen.com/logo.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Love &amp; Heart Kaomoji: Copy &amp; Paste Cute Love Text Faces">
+<meta name="twitter:description" content="Browse and copy love and heart kaomoji — also spelled kamoji — Japanese text faces for affection, kisses, hugs, and crushes. Click any to copy it instantly.">
+<meta name="twitter:image" content="https://ultratextgen.com/logo.png">
+<meta property="og:title" content="Love &amp; Heart Kaomoji: Copy &amp; Paste Cute Love Text Faces">
+<meta property="og:description" content="Browse and copy love and heart kaomoji — also spelled kamoji — Japanese text faces for affection, kisses, hugs, and crushes. Click any to copy it instantly.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/library/love-kaomoji/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Love & Heart Kaomoji: Copy & Paste Cute Love Text Faces",
+  "description": "Browse and copy love and heart kaomoji — also spelled kamoji — Japanese text faces for affection, kisses, hugs, and crushes. Click any to copy it instantly.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "mainEntityOfPage": "https://ultratextgen.com/library/love-kaomoji/",
+  "datePublished": "2026-06-30",
+  "dateModified": "2026-06-30"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://ultratextgen.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Library",
+      "item": "https://ultratextgen.com/library/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Love & Heart Kaomoji",
+      "item": "https://ultratextgen.com/library/love-kaomoji/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<script src="/header.js"></script>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Love &amp; Heart Kaomoji</h1>
+    <p class="hero-tagline">Copy and paste love and heart kaomoji — cute Japanese text faces for crushes, kisses, and hugs. Click any face to copy it instantly.</p>
+  </div>
+</section>
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Love and heart kaomoji (also spelled kamoji) are Japanese-style text faces that show affection using hearts, blushing cheeks, and outstretched arms. Unlike a plain heart emoji, a heart kaomoji such as (♥ω♥) or (づ｡◕‿‿◕｡)づ pastes as pure Unicode text into any bio, caption, comment, or message — so it looks the same everywhere. Pick a mood below and click any face to copy it instantly.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="hearts-love">
+  <span class="article-section-label">Hearts &amp; Love</span>
+  <h2>Heart &amp; Love Kaomoji</h2>
+  <p class="u-secondary-tight">Classic heart kaomoji for showing love, adoration, and a happy crush.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(♥ω♥)" aria-label="Copy Heart Eyes">(♥ω♥)</button>
+      <span class="flag-label">Heart Eyes</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(◍•ᴗ•◍)❤" aria-label="Copy In Love">(◍•ᴗ•◍)❤</button>
+      <span class="flag-label">In Love</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(✿ ♥‿♥)" aria-label="Copy Flower Heart">(✿ ♥‿♥)</button>
+      <span class="flag-label">Flower Heart</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(｡♥‿♥｡)" aria-label="Copy Smiling Heart">(｡♥‿♥｡)</button>
+      <span class="flag-label">Smiling Heart</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(♡μ_μ)" aria-label="Copy Lovestruck">(♡μ_μ)</button>
+      <span class="flag-label">Lovestruck</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(◕‿◕)♡" aria-label="Copy Sweet Heart">(◕‿◕)♡</button>
+      <span class="flag-label">Sweet Heart</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(♥‿♥)" aria-label="Copy Heart Smile">(♥‿♥)</button>
+      <span class="flag-label">Heart Smile</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(´｡• ᵕ •｡`) ♡" aria-label="Copy Content Love">(´｡• ᵕ •｡`) ♡</button>
+      <span class="flag-label">Content Love</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="blowing-kisses">
+  <span class="article-section-label">Kisses</span>
+  <h2>Blowing a Kiss Kaomoji</h2>
+  <p class="u-secondary-tight">Kiss kaomoji for sending a smooch, a flirt, or a goodnight.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="( ˘ ³˘)♥" aria-label="Copy Blowing a Kiss">( ˘ ³˘)♥</button>
+      <span class="flag-label">Blowing a Kiss</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(*^3^)/~☆" aria-label="Copy Throwing a Kiss">(*^3^)/~☆</button>
+      <span class="flag-label">Throwing a Kiss</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(っ˘ω˘ς )" aria-label="Copy Shy Kiss">(っ˘ω˘ς )</button>
+      <span class="flag-label">Shy Kiss</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(づ￣ ³￣)づ" aria-label="Copy Kissy Face">(づ￣ ³￣)づ</button>
+      <span class="flag-label">Kissy Face</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="( ˘ ³˘)♡" aria-label="Copy Soft Kiss">( ˘ ³˘)♡</button>
+      <span class="flag-label">Soft Kiss</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="hugging">
+  <span class="article-section-label">Hugs</span>
+  <h2>Hugging &amp; Affection Kaomoji</h2>
+  <p class="u-secondary-tight">Hug kaomoji with open arms for comfort, support, and closeness.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(づ｡◕‿‿◕｡)づ" aria-label="Copy Big Hug">(づ｡◕‿‿◕｡)づ</button>
+      <span class="flag-label">Big Hug</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(つ≧▽≦)つ" aria-label="Copy Come Here Hug">(つ≧▽≦)つ</button>
+      <span class="flag-label">Come Here Hug</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊂((・▽・))⊃" aria-label="Copy Squeeze Hug">⊂((・▽・))⊃</button>
+      <span class="flag-label">Squeeze Hug</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="٩(♡ε♡ )۶" aria-label="Copy Loving Hug">٩(♡ε♡ )۶</button>
+      <span class="flag-label">Loving Hug</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊂(´• ω •`⊂)" aria-label="Copy Reaching Hug">⊂(´• ω •`⊂)</button>
+      <span class="flag-label">Reaching Hug</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="in-love-blushing">
+  <span class="article-section-label">Blushing</span>
+  <h2>In Love &amp; Blushing Kaomoji</h2>
+  <p class="u-secondary-tight">Blushing kaomoji for shy, flustered, and butterflies-in-the-stomach moments.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(⁄ ⁄•⁄ω⁄•⁄ ⁄)" aria-label="Copy Blushing">(⁄ ⁄•⁄ω⁄•⁄ ⁄)</button>
+      <span class="flag-label">Blushing</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(//ω//)" aria-label="Copy Flustered">(//ω//)</button>
+      <span class="flag-label">Flustered</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(*ﾉ∀ﾉ)" aria-label="Copy Shy Smile">(*ﾉ∀ﾉ)</button>
+      <span class="flag-label">Shy Smile</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(„ᵕᴗᵕ„)" aria-label="Copy Bashful">(„ᵕᴗᵕ„)</button>
+      <span class="flag-label">Bashful</span>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Transform text with Unicode fonts</h3>
+  <p>Use UltraTextGen to convert plain text into bold, italic, cursive, and 100+ other Unicode font styles — free and instant.</p>
+  <a href="https://ultratextgen.com/" class="cta-btn">Open UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Related Resources</span>
+  <div class="compare-grid">
+    <a href="/library/text-faces-kaomoji/" class="compare-card variant-muted u-no-underline">
+      <h4>Text Faces &amp; Kaomoji</h4>
+      <p>The full kaomoji hub — every mood of Japanese text face in one place.</p>
+    </a>
+    <a href="/library/happy-kaomoji/" class="compare-card variant-muted u-no-underline">
+      <h4>Happy Kaomoji</h4>
+      <p>Smiling, excited, and joyful Japanese text faces to copy and paste.</p>
+    </a>
+    <a href="/library/cute-kaomoji/" class="compare-card variant-muted u-no-underline">
+      <h4>Cute Kaomoji</h4>
+      <p>Cute and kawaii text faces with sparkly eyes and blushing cheeks.</p>
+    </a>
+    <a href="/library/heart-symbols/" class="compare-card variant-muted u-no-underline">
+      <h4>Heart Symbols</h4>
+      <p>Heart emojis and Unicode heart characters in every color and style.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js"></script>
+<script src="/footer.js"></script>
+</body>
+</html>

--- a/library/sparkle-kaomoji/index.html
+++ b/library/sparkle-kaomoji/index.html
@@ -1,0 +1,254 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8242324164413945"
+       crossorigin="anonymous"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Sparkle &amp; Star Kaomoji: Copy &amp; Paste Sparkly Text Faces</title>
+<meta name="description" content="Browse and copy sparkle and star kaomoji — also spelled kamoji — Japanese text faces with sparkles, stars, and glitter. Click any to copy it instantly.">
+
+<link rel="canonical" href="https://ultratextgen.com/library/sparkle-kaomoji/">
+<meta property="og:image" content="https://ultratextgen.com/logo.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Sparkle &amp; Star Kaomoji: Copy &amp; Paste Sparkly Text Faces">
+<meta name="twitter:description" content="Browse and copy sparkle and star kaomoji — also spelled kamoji — Japanese text faces with sparkles, stars, and glitter. Click any to copy it instantly.">
+<meta name="twitter:image" content="https://ultratextgen.com/logo.png">
+<meta property="og:title" content="Sparkle &amp; Star Kaomoji: Copy &amp; Paste Sparkly Text Faces">
+<meta property="og:description" content="Browse and copy sparkle and star kaomoji — also spelled kamoji — Japanese text faces with sparkles, stars, and glitter. Click any to copy it instantly.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/library/sparkle-kaomoji/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Sparkle & Star Kaomoji: Copy & Paste Sparkly Text Faces",
+  "description": "Browse and copy sparkle and star kaomoji — also spelled kamoji — Japanese text faces with sparkles, stars, and glitter. Click any to copy it instantly.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "mainEntityOfPage": "https://ultratextgen.com/library/sparkle-kaomoji/",
+  "datePublished": "2026-06-30",
+  "dateModified": "2026-06-30"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://ultratextgen.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Library",
+      "item": "https://ultratextgen.com/library/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Sparkle & Star Kaomoji",
+      "item": "https://ultratextgen.com/library/sparkle-kaomoji/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<script src="/header.js"></script>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Sparkle &amp; Star Kaomoji</h1>
+    <p class="hero-tagline">Copy and paste sparkle and star kaomoji — Japanese text faces with sparkles, stars, and glitter accents. Click any face to copy it instantly.</p>
+  </div>
+</section>
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Sparkle and star kaomoji (also spelled kamoji) are Japanese-style text faces decorated with sparkle and star characters like ✧, ☆, and ﾟ.* for an aesthetic, magical look. A sparkle kaomoji such as (★ω★) or (ﾉ◕ヮ◕)ﾉ*:･ﾟ✧ is plain Unicode text, so it pastes cleanly into bios, captions, comments, and usernames. Browse sparkling faces, star faces, and glitter-throwing kaomoji below and click any to copy it instantly.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="sparkling-faces">
+  <span class="article-section-label">Sparkling Faces</span>
+  <h2>Sparkling Face Kaomoji</h2>
+  <p class="u-secondary-tight">Bright faces with sparkle eyes and shine accents.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(★ω★)" aria-label="Copy Star Eyes">(★ω★)</button>
+      <span class="flag-label">Star Eyes</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(✧ω✧)" aria-label="Copy Sparkle Eyes">(✧ω✧)</button>
+      <span class="flag-label">Sparkle Eyes</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✧(•̀ᴗ•́)✧" aria-label="Copy Determined Sparkle">✧(•̀ᴗ•́)✧</button>
+      <span class="flag-label">Determined Sparkle</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(ﾉ◕ヮ◕)ﾉ*:･ﾟ✧" aria-label="Copy Throwing Sparkles">(ﾉ◕ヮ◕)ﾉ*:･ﾟ✧</button>
+      <span class="flag-label">Throwing Sparkles</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(☆▽☆)" aria-label="Copy Shining Eyes">(☆▽☆)</button>
+      <span class="flag-label">Shining Eyes</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="stars">
+  <span class="article-section-label">Stars</span>
+  <h2>Star Kaomoji</h2>
+  <p class="u-secondary-tight">Star-eyed and star-accented faces for a starry look.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(★≧▽≦)" aria-label="Copy Starstruck">(★≧▽≦)</button>
+      <span class="flag-label">Starstruck</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(≧▽≦)/☆" aria-label="Copy Catching a Star">(≧▽≦)/☆</button>
+      <span class="flag-label">Catching a Star</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☆ﾐ(o*･ω･)ﾉ" aria-label="Copy Star Wave">☆ﾐ(o*･ω･)ﾉ</button>
+      <span class="flag-label">Star Wave</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⋆｡˚☽˚｡⋆" aria-label="Copy Starry Night">⋆｡˚☽˚｡⋆</button>
+      <span class="flag-label">Starry Night</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="magic-glitter">
+  <span class="article-section-label">Magic &amp; Glitter</span>
+  <h2>Magic &amp; Glitter Kaomoji</h2>
+  <p class="u-secondary-tight">Dreamy, magical faces with glitter and shine.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(＊♡∀♡)" aria-label="Copy Dazzled">(＊♡∀♡)</button>
+      <span class="flag-label">Dazzled</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(∩˃o˂∩)♡" aria-label="Copy Sparkle Hug">(∩˃o˂∩)♡</button>
+      <span class="flag-label">Sparkle Hug</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="٩(✧ω✧)۶" aria-label="Copy Sparkle Cheer">٩(✧ω✧)۶</button>
+      <span class="flag-label">Sparkle Cheer</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(´｡• ω •｡`) ✧" aria-label="Copy Soft Sparkle">(´｡• ω •｡`) ✧</button>
+      <span class="flag-label">Soft Sparkle</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="throwing-sparkles">
+  <span class="article-section-label">Throwing Sparkles</span>
+  <h2>Throwing Sparkles Kaomoji</h2>
+  <p class="u-secondary-tight">Faces flinging sparkles and stars for a magical flourish.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(∩^o^)⊃━☆ﾟ.*" aria-label="Copy Casting Sparkles">(∩^o^)⊃━☆ﾟ.*</button>
+      <span class="flag-label">Casting Sparkles</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(ﾉ&gt;ω&lt;)ﾉ" aria-label="Copy Tossing Up">(ﾉ&gt;ω&lt;)ﾉ</button>
+      <span class="flag-label">Tossing Up</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☆*:.｡.o(≧▽≦)o.｡.:*☆" aria-label="Copy Surrounded by Stars">☆*:.｡.o(≧▽≦)o.｡.:*☆</button>
+      <span class="flag-label">Surrounded by Stars</span>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Transform text with Unicode fonts</h3>
+  <p>Use UltraTextGen to convert plain text into bold, italic, cursive, and 100+ other Unicode font styles — free and instant.</p>
+  <a href="https://ultratextgen.com/" class="cta-btn">Open UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Related Resources</span>
+  <div class="compare-grid">
+    <a href="/library/text-faces-kaomoji/" class="compare-card variant-muted u-no-underline">
+      <h4>Text Faces &amp; Kaomoji</h4>
+      <p>The full kaomoji hub — every mood of Japanese text face in one place.</p>
+    </a>
+    <a href="/library/cute-kaomoji/" class="compare-card variant-muted u-no-underline">
+      <h4>Cute Kaomoji</h4>
+      <p>Cute and kawaii text faces with sparkly eyes and blushing cheeks.</p>
+    </a>
+    <a href="/library/sparkle-symbols/" class="compare-card variant-muted u-no-underline">
+      <h4>Sparkle Symbols</h4>
+      <p>Sparkles, glitter, and shine characters for aesthetic text.</p>
+    </a>
+    <a href="/library/star-symbols/" class="compare-card variant-muted u-no-underline">
+      <h4>Star Symbols</h4>
+      <p>Star characters and symbols in every style to copy and paste.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js"></script>
+<script src="/footer.js"></script>
+</body>
+</html>

--- a/library/text-faces-kaomoji/index.html
+++ b/library/text-faces-kaomoji/index.html
@@ -203,6 +203,7 @@
       <span class="flag-label">Celebrating</span>
     </div>
   </div>
+  <p class="u-secondary-tight"><a href="/library/happy-kaomoji/">See all happy kaomoji →</a></p>
 </section>
 
 <div class="section-divider"></div>
@@ -238,6 +239,7 @@
       <span class="flag-label">Sad Pout</span>
     </div>
   </div>
+  <p class="u-secondary-tight"><a href="/library/crying-kaomoji/">See all crying &amp; sad kaomoji →</a></p>
 </section>
 
 <div class="section-divider"></div>
@@ -308,6 +310,7 @@
       <span class="flag-label">Heart Eyes Shy</span>
     </div>
   </div>
+  <p class="u-secondary-tight"><a href="/library/love-kaomoji/">See all love &amp; heart kaomoji →</a></p>
 </section>
 
 <div class="section-divider"></div>
@@ -343,6 +346,7 @@
       <span class="flag-label">Happy Pet</span>
     </div>
   </div>
+  <p class="u-secondary-tight"><a href="/library/cat-kaomoji/">See all cat kaomoji →</a></p>
 </section>
 
 <div class="section-divider"></div>
@@ -482,6 +486,7 @@
   <h2>Themed Kaomoji Sets</h2>
   <p class="u-secondary-block">Ready-made kaomoji sets grouped by mood — copy a whole set of related faces in one click for chats, captions, and comments.</p>
   <div id="kaomojiCollectionsContainer"></div>
+  <p class="u-secondary-tight"><a href="/library/sparkle-kaomoji/">See all sparkle &amp; star kaomoji →</a></p>
 </section>
 
 <div class="section-divider"></div>
@@ -546,6 +551,7 @@
     </div>
 
   </div>
+  <p class="u-secondary-tight"><a href="/library/cute-kaomoji/">See all cute kaomoji →</a></p>
 </section>
 
 <!-- FAQ -->


### PR DESCRIPTION
## Summary

Expands the kaomoji English-language cluster with six emotion/mood **spoke pages** and wires them to the existing `/library/text-faces-kaomoji/` hub. This is the follow-up to the merged "kamoji" alias work — capturing the `[mood] kaomoji` demand that the single hub page couldn't rank for on its own.

All six pages were generated via the canonical `scripts/generate_library_page_from_spec.py` from new JSON specs, so they match library-page conventions exactly (GTM + ads, canonical/OG/Twitter meta, `Article` + `BreadcrumbList` JSON-LD, shared header/footer, symbol-explorer runtime).

## New spoke pages

| Page | Faces | Owns the intent |
|---|---|---|
| `/library/love-kaomoji/` | 22 | heart / love / kiss / hug kaomoji (~6,080 US + intl) |
| `/library/happy-kaomoji/` | 20 | happy / smiling kaomoji (~4,430 US + intl) |
| `/library/cat-kaomoji/` | 23 | cat kaomoji (~3,700 US + intl) |
| `/library/crying-kaomoji/` | 19 | crying / sad kaomoji (~2,660 US + intl) |
| `/library/cute-kaomoji/` | 19 | cute / kawaii kaomoji (international-led: BR ~2,900) |
| `/library/sparkle-kaomoji/` | 16 | sparkle / star kaomoji (~1,690 US + intl) |

Each page carries 16–23 distinct faces (clears the thin-content / supply gate), weaves the **"kamoji"** spelling alias into the intro, and links back to the hub.

## Hub-and-spoke wiring (`/library/text-faces-kaomoji/`)

- Each mood section now ends with a **"see all →"** teaser link to its spoke.
- Spokes link back to the hub.
- **Canonical ownership declared:** the hub owns the head term (`kaomoji` / `kamoji` / `text faces`); each spoke owns `[mood] kaomoji`. Different queries → no self-cannibalization.

## Docs

`docs/page-vs-section-decisions.md`:
- New **§7** with the canonical ownership table, the Tier-2 backlog (`angry`, `shocked`), and the dog-stays-a-section rationale (demand exists but supply fails the gate).
- Corrected the "MX near-zero" line — the head term is ~165K/mo in MX and ~1.4M globally (a script-identical loanword the English page competes for in every market).
- Recorded why `cute` ships as a page despite thin US-exact volume (international demand).

## Notes

- `sitemap.xml` intentionally untouched — it regenerates via the daily workflow.
- `library/index.html` not hand-edited; the spokes are internally linked via hub teasers + related cards. Adding them to the index is a reasonable follow-up.

## Validation

- All 18 JSON-LD blocks (3 hub + Article/BreadcrumbList × 6 spokes... 2×6 + hub) parse cleanly.
- All sibling cross-links and hub↔spoke links resolve.
- Pages produced by the validated generator (`copy_pattern: single`, ≥3 H2 sections each).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9GjqScqEehKWAkt5CVap6)_