### PR TITLE
Host Journey ads.txt statically + daily auto-sync, drop AdSense

### DIFF
--- a/.github/workflows/update-ads-txt.yml
+++ b/.github/workflows/update-ads-txt.yml
@@ -1,0 +1,28 @@
+name: Update ads.txt
+
+on:
+  schedule:
+    - cron: '30 0 * * *'  # daily at 00:30 UTC (after the sitemap job)
+  workflow_dispatch:
+
+jobs:
+  update-ads-txt:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Refresh ads.txt from Journey
+        run: bash scripts/update-ads-txt.sh
+
+      - name: Commit updated ads.txt
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add ads.txt
+          git diff --cached --quiet || git commit -m "chore: refresh ads.txt from Journey [skip ci]"
+          git push

--- a/ads.txt
+++ b/ads.txt
@@ -1,1 +1,167 @@
-google.com, pub-8242324164413945, DIRECT, f08c47fec0942fa0
+# Ads.txt v20260526
+managerdomain=journeymv.com
+contact=sales@journeymv.com
+ownerdomain=ultratextgen.com
+journeymv.com, e381520a-ca23-48ca-a066-83c420ddddea, DIRECT, 1363c924529b3998
+
+google.com, pub-1601477034266482, DIRECT, f08c47fec0942fa0
+google.com, pub-7585907861569631, DIRECT, f08c47fec0942fa0
+google.com, pub-1601477034266482, RESELLER, f08c47fec0942fa0
+media.net, 8CU41446D, DIRECT
+media.net, 8CUE82J0B, DIRECT
+pubmatic.com, 159463, RESELLER, 5d62403b186f2ace
+openx.com, 537100188, RESELLER, 6a698e2ec38604c6
+rubiconproject.com, 19396, RESELLER, 0bfd66d529a55807
+onetag.com, 5d49f482552c9b6, RESELLER
+improvedigital.com, 2368, DIRECT
+yieldmo.com, 3443142311460937743, DIRECT
+rubiconproject.com, 17070, RESELLER, 0bfd66d529a55807
+pubmatic.com, 160648, RESELLER, 5d62403b186f2ace
+openx.com, 558228330, RESELLER, 6a698e2ec38604c6
+contextweb.com, 561118, RESELLER, 89ff185a4c4e857c
+appnexus.com, 7911, RESELLER, f5ab79cb980f11d1
+rhythmone.com, 3463482822, RESELLER, a670c89d4a324e47
+video.unrulymedia.com, 3463482822, RESELLER
+smartadserver.com, 4524, RESELLER, 060d053dcf45cbf3
+smartadserver.com, 4071, RESELLER, 060d053dcf45cbf3
+gumgum.com, 15958, RESELLER, ffdef49475d318a9
+rubiconproject.com, 26278, DIRECT, 0bfd66d529a55807
+indexexchange.com, 207882, DIRECT, 50b1c356f2c5c8fc
+indexexchange.com, 208002, DIRECT, 50b1c356f2c5c8fc
+indexexchange.com, 214230, DIRECT, 50b1c356f2c5c8fc 
+kargo.com, 8851, DIRECT
+rubiconproject.com, 11864, RESELLER, 0bfd66d529a55807
+appnexus.com, 8173, RESELLER, f5ab79cb980f11d1
+contextweb.com, 562001, RESELLER, 89ff185a4c4e857c
+video.unrulymedia.com, 1858504412, RESELLER
+fabrik.com, 87, DIRECT
+contextweb.com, 563243, DIRECT, 89ff185a4c4e857c
+rubiconproject.com, 26184, RESELLER, 0bfd66d529a55807
+pubmatic.com, 164271, DIRECT, 5d62403b186f2ace
+pubmatic.com, 168029, DIRECT, 5d62403b186f2ace
+appnexus.com, 15770, DIRECT, f5ab79cb980f11d1
+openx.com, 560606532, DIRECT, 6a698e2ec38604c6
+triplelift.com, 14132, DIRECT, 6c33edb13117fd86
+themediagrid.com, GODNC4, RESELLER, 35d5010d7789b49d
+minutemedia.com, 01kqs9mfw3jw, DIRECT
+pubmatic.com, 161683, RESELLER, 5d62403b186f2ace
+rubiconproject.com, 17598, RESELLER, 0bfd66d529a55807
+media.net, 8CUWNDO6S, RESELLER
+video.unrulymedia.com, 699546687, RESELLER
+yieldmo.com, 2954622693783052507, RESELLER
+lijit.com, 264726, RESELLER, fafdf38b16bf6b2b
+appnexus.com, 8381, RESELLER
+smartadserver.com, 4106, RESELLER, 060d053dcf45cbf3
+admanmedia.com, 953, RESELLER
+inmobi.com, 0dbf247dad584297bb489ded580cc6a1, RESELLER, 83e75a7ae333ca9d
+onetag.com, 765b4e6bb9c8438, RESELLER
+sharethrough.com, xz7QjFBY, RESELLER, d53b998a7bd4ecd2
+zetaglobal.net, 591, RESELLER
+33across.com, 0013300001jlr99AAA, RESELLER, bbea06d9c4d2853c
+sonobi.com, 37fbaf262c, RESELLER, d1a215d9eb5aee9e
+visiblemeasures.com, 2009VM, RESELLER
+risecodes.com, 65a3efa13a58f100018b923c, DIRECT
+pubmatic.com, 160295, RESELLER, 5d62403b186f2ace
+xandr.com, 14082, RESELLER
+sharethrough.com, 5926d422, RESELLER, d53b998a7bd4ecd2
+sharethrough.com, 4284, RESELLER, d53b998a7bd4ecd2
+media.net, 8CUQ6928Q, RESELLER
+smaato.com, 1100057444, RESELLER, 07bcf65f187117b4
+triplelift.com, 12465, RESELLER, 6c33edb13117fd86
+rubiconproject.com, 23876, RESELLER, 0bfd66d529a55807
+nativo.com, 6072, RESELLER, 59521ca7cc5e9fee
+onetag.com, 69f48c2160c8113, RESELLER
+seedtag.com, 69849fd5adf28a0008bc0458, RESELLER
+33across.com, 0010b00002Xbn7QAAR, RESELLER, bbea06d9c4d2853c
+ogury.com, 534c7459-fba8-48b1-82d1-9a6c008551ea, RESELLER
+aps.amazon.com,fc983fef-a09b-46c9-b3c8-44d705e51b5d,DIRECT
+openx.com,540191398,RESELLER,6a698e2ec38604c6
+rubiconproject.com,18020,RESELLER,0bfd66d529a55807
+contextweb.com,562541,RESELLER,89ff185a4c4e857c
+sovrn.com,375328,RESELLER,fafdf38b16bf6b2b
+lijit.com,375328,RESELLER,fafdf38b16bf6b2b
+smaato.com,1100044650,RESELLER,07bcf65f187117b4
+ad-generation.jp,12474,RESELLER,7f4ea9029ac04e53
+districtm.io,100962,RESELLER,3fd707be9c4527c3
+yieldmo.com,2719019867620450718,RESELLER
+appnexus.com,3663,RESELLER,f5ab79cb980f11d1
+rhythmone.com,1654642120,RESELLER,a670c89d4a324e47
+smartadserver.com,4125,RESELLER,060d053dcf45cbf3
+indexexchange.com,192410,RESELLER,50b1c356f2c5c8fc
+pubmatic.com,160006,RESELLER,5d62403b186f2ace
+pubmatic.com,160096,RESELLER,5d62403b186f2ace
+undertone.com,4205,RESELLER,d954590d0cb265b9
+sharethrough.com,7144eb80,RESELLER,d53b998a7bd4ecd2
+appnexus.com,1356,RESELLER,f5ab79cb980f11d1
+themediagrid.com,JTQKMP,RESELLER,35d5010d7789b49d
+beachfront.com,14804,RESELLER,e2541279e8e2ca4d
+improvedigital.com,2050,RESELLER
+onetag.com,770a440e65869c2,RESELLER
+media.net,8CUZ1MK22,RESELLER
+visiblemeasures.com,1052,RESELLER
+mediago.io,045ac24b888bcf59a09731e7f0f2084f,RESELLER
+adyoulike.com,7463c359225e043c111036d7a29affa5,RESELLER, 4ad745ead2958bf7
+minutemedia.com,01gya4708ddm,RESELLER
+vidazoo.com,6538cece8ffdc67b51188b9b,RESELLER,b6ada874b4d7d0b2
+imds.tv,AM1601,RESELLER,ae6c32151e71f19d
+start.io,123111883,RESELLER
+yieldmo.com, 3078438591206989879, RESELLER
+aniview.com, 66ba73a97566d9303e011704, RESELLER, 78b21b97965ec3f8
+sharethrough.com, zLsEa05k, RESELLER, d53b998a7bd4ecd2
+sharethrough.com, UXUWG46h, RESELLER, d53b998a7bd4ecd2
+pubmatic.com, 161335, RESELLER, 5d62403b186f2ace
+rubiconproject.com, 13918, RESELLER, 0bfd66d529a55807
+richaudience.com, 1ru8dKmJJV, RESELLER
+rubiconproject.com, 13510, RESELLER, 0bfd66d529a55807
+aniview.com, 66ba73a97566d9303e011704, DIRECT, 78b21b97965ec3f8
+pubmatic.com, 160993, RESELLER, 5d62403b186f2ace
+richaudience.com, 1ru8dKmJJV, RESELLER
+appnexus.com, 8233, RESELLER, f5ab79cb980f11d1
+openx.com, 539625136, RESELLER, 6a698e2ec38604c6
+
+themediagrid.com, 72YI3C, DIRECT, 35d5010d7789b49d
+emxdgt.com, 1403, DIRECT, 1e1d41537f7cad7f
+conversantmedia.com, 100316, RESELLER, 03113cd04947736d
+ssp.cadent.com, 1403, DIRECT, 1e1d41537f7cad7f
+video.unrulymedia.com, 232050197, DIRECT
+trustx.org, 5606, DIRECT, 1d2c8a747a749d25
+smilewanted.com, 5675, DIRECT
+pubmatic.com, 158810, RESELLER, 5d62403b186f2ace
+rubiconproject.com, 19814, RESELLER, 0bfd66d529a55807
+openx.com, 557083110, RESELLER, 6a698e2ec38604c6
+appnexus.com, 10040, RESELLER
+e-planning.net, 6aa967d41dd8d254, RESELLER, c1ba615865ed87b2
+pubmatic.com, 156631, RESELLER, 5d62403b186f2ace
+sharethrough.com, 23830661, DIRECT, d53b998a7bd4ecd2
+onetag.com, 5927d926323dc2c, DIRECT
+nextmillennium.io, 16425, DIRECT, 65bd090fa4a1e3d6
+amxrtb.com, 105199731, DIRECT
+appnexus.com, 12290, RESELLER
+lijit.com, 260380, RESELLER
+pubmatic.com, 161527, RESELLER
+rubiconproject.com, 23844, RESELLER
+adform.com, 2865, RESELLER
+smartadserver.com, 3056, RESELLER
+openx.com, 559680764, RESELLER
+sharethrough.com, a6a34444, RESELLER
+smartadserver.com, 5277, DIRECT, 060d053dcf45cbf3
+trustedstack.com, TSUKNZU26, DIRECT
+onetag.com, 87f58fe90234d0e, RESELLER
+sharethrough.com, KGPeiFc6, RESELLER, d53b998a7bd4ecd2
+smartadserver.com, 5302, RESELLER, 060d053dcf45cbf3
+lijit.com, 551846, RESELLER, fafdf38b16bf6b2b
+insticator.com, 43219255-112b-4498-9611-d971f8327962, DIRECT, b3511ffcafb23a32
+rubiconproject.com, 17062, DIRECT, 0bfd66d529a55807
+triplelift.com, 6998, DIRECT, 6c33edb13117fd86
+themediagrid.com, DQ6AMB, DIRECT, 35d5010d7789b49d
+lijit.com, 257618, DIRECT, fafdf38b16bf6b2b
+sharethrough.com, Q9IzHdvp, DIRECT, d53b998a7bd4ecd2
+risecodes.com, 6124caed9c7adb0001c028d8, DIRECT
+minutemedia.com, 01garg96c88b, DIRECT
+smartadserver.com, 3262, DIRECT, 060d053dcf45cbf3
+video.unrulymedia.com, 136898039, DIRECT
+pubmatic.com, 95054, DIRECT, 5d62403b186f2ace
+adform.com, 2996, DIRECT
+
+
+

--- a/scripts/update-ads-txt.sh
+++ b/scripts/update-ads-txt.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Refresh ads.txt from Journey's managed, hosted file.
+#
+# Journey (journeymv.com) maintains the authorized-sellers list and updates it
+# over time. We host a static copy at /ads.txt (guaranteed 200, in version
+# control) and keep it current with the daily update-ads-txt workflow, which
+# runs this script and commits any change.
+#
+# The download is validated before overwriting so a transient failure or a bad
+# response can never blank out the live ads.txt.
+
+set -euo pipefail
+
+URL="https://adstxt.journeymv.com/sites/e381520a-ca23-48ca-a066-83c420ddddea/ads.txt"
+DEST="$(cd "$(dirname "$0")/.." && pwd)/ads.txt"
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+
+curl -sSfL --max-time 30 "$URL" -o "$TMP"
+
+# Sanity checks: non-empty and clearly Journey's file before we overwrite.
+if [ ! -s "$TMP" ]; then
+  echo "ERROR: downloaded ads.txt is empty — refusing to overwrite" >&2
+  exit 1
+fi
+if ! grep -q "journeymv.com" "$TMP"; then
+  echo "ERROR: downloaded ads.txt missing journeymv.com — refusing to overwrite" >&2
+  exit 1
+fi
+
+mv "$TMP" "$DEST"
+trap - EXIT
+echo "ads.txt refreshed from Journey ($(wc -l < "$DEST") lines)"


### PR DESCRIPTION
## Summary

Sets up `ads.txt` for Journey and removes the previous ad partner's entry. Follow-up to #367 (which handled the ads script + AdSense `<script>` removal).

Rather than redirecting `/ads.txt` to Journey's hosted file, this hosts Journey's authorized-sellers list **as a static file in the repo** and keeps it current with a daily sync job — so `/ads.txt` returns `200` directly with no cross-domain redirect dependency, and never goes stale.

## Changes

- **Replace `ads.txt`** — the old self-hosted AdSense list (`google.com, pub-8242324164413945`) is replaced with Journey's full authorized-sellers list (167 lines).
- **`scripts/update-ads-txt.sh`** — fetches Journey's managed file and writes `ads.txt`. Validates the download (non-empty + contains `journeymv.com`) before overwriting, so a transient failure or bad response can never blank the live file.
- **`.github/workflows/update-ads-txt.yml`** — daily (00:30 UTC) + manual `workflow_dispatch`. Runs the script and commits any change with `[skip ci]`, mirroring the existing `update-sitemap` workflow. Keeps the static copy in sync as Journey rotates sellers.

## Why static + sync (not a redirect)

- **Guaranteed `200`** at `/ads.txt` — no reliance on crawlers following a cross-domain 301, and no runtime dependency on `journeymv.com`.
- **Transparent** — the authorized sellers are visible in version control.
- **Never stale** — the daily job re-fetches Journey's versioned file (`# Ads.txt v…`) and commits diffs automatically, which is the one advantage a redirect otherwise had.

## Verification

- `bash scripts/update-ads-txt.sh` → writes 167 lines; AdSense entry gone, Journey seller line present.
- Committed `ads.txt` is byte-identical to what the workflow produces (generated by the same script), so the first scheduled run won't create a spurious diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)