### PR TITLE
feat: add three Tier-1 answer pages (Vietnamese, IG username, paste)

### DIFF
--- a/answers/do-fancy-fonts-work-with-vietnamese/index.html
+++ b/answers/do-fancy-fonts-work-with-vietnamese/index.html
@@ -1,0 +1,205 @@
+<!DOCTYPE html><html lang="en"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8242324164413945"
+       crossorigin="anonymous"></script>
+
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <title>Do Fancy Fonts Work With Vietnamese? (Chữ Kiểu Có Dấu) | UltraTextGen</title>
+  <meta name="description" content="Fancy fonts break Vietnamese because most syllables carry stacked marks and đ has no styled form. Here's which styles keep dấu, and how Vietnamese users style names anyway.">
+  <link rel="canonical" href="https://ultratextgen.com/answers/do-fancy-fonts-work-with-vietnamese/">
+  <meta property="og:title" content="Do Fancy Fonts Work With Vietnamese? (Chữ Kiểu Có Dấu)">
+  <meta property="og:description" content="Fancy fonts break Vietnamese because most syllables carry stacked marks and đ has no styled form. Here's which styles keep dấu — and how to style Vietnamese names anyway.">
+  <meta property="og:url" content="https://ultratextgen.com/answers/do-fancy-fonts-work-with-vietnamese/">
+  <meta property="og:type" content="article">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/answers-do-fancy-fonts-work-with-vietnamese.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Do Fancy Fonts Work With Vietnamese? (Chữ Kiểu Có Dấu)">
+  <meta name="twitter:description" content="Why fancy fonts break Vietnamese có dấu, which styles keep the marks, and how Vietnamese users style names anyway.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/answers-do-fancy-fonts-work-with-vietnamese.png">
+
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Do fancy fonts work with Vietnamese có dấu?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Only partly. The letter-swap styles (bold, italic, script) can't handle accented Vietnamese, because almost every syllable stacks a vowel mark and a tone mark and Unicode has no styled version of those letters — so most of the word falls back to plain and you get a half-styled result. The styles that keep dấu are the ones that add a mark or a symbol instead of replacing the letter: strikethrough, underline, slash, and the bracket/symbol wraps. For a bold or script look, Vietnamese users usually remove the tone marks first (bỏ dấu) so the whole word styles evenly."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Why does the letter đ never change?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Because đ / Đ is its own letter in Unicode (d-with-stroke), not a d carrying a mark. It has no decomposition, so it can't be reduced to d plus an accent, and there is no styled đ glyph to swap in. Every letter-swap style therefore leaves đ exactly as it is — and the same property means đ also survives accent-removal tools, which is why bỏ dấu code has to convert đ→d by hand."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Which styles keep Vietnamese tone marks?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The mark-based and symbol styles: strikethrough, underline, slash, wavy, and the bracket / arrow / symbol word-wraps. They draw over or around your letters instead of replacing them, so ữ, ế, ệ, ơ, ư and đ all survive intact. Bold, italic, script, cursive, fraktur, bubble and small caps cannot keep the marks."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How do Vietnamese gamers get styled names on Free Fire and Liên Quân?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "They decorate a plain, mark-free name with special characters (kí tự đặc biệt) — symbol frames like ꧁ ༒ 亗 ★ around the letters — rather than restyling the letters. They also drop tone marks (bỏ dấu), keep names within the game's length cap, and test the name in a chat box first, because games like Liên Quân reject foreign or invisible characters and Free Fire caps names at 12 characters."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does styled Vietnamese text work on Zalo and Facebook?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "In display names and posts it can, but with caveats. Zalo restricts fancy/emoji characters in the main display name (they only work in a private friend alias), and Facebook rejects decorative symbols in the name field and strips diacritics from the @username. Both are also subject to device rendering — some Facebook layouts have historically misplaced Vietnamese marks — so test before you rely on it."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ultratextgen.com/" },
+    { "@type": "ListItem", "position": 2, "name": "Answers", "item": "https://ultratextgen.com/answers/" },
+    { "@type": "ListItem", "position": 3, "name": "Do Fancy Fonts Work With Vietnamese", "item": "https://ultratextgen.com/answers/do-fancy-fonts-work-with-vietnamese/" }
+  ]
+}
+</script>
+</head>
+<body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<script src="/header.js"></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/">Home</a>
+  <span class="breadcrumb-separator">›</span>
+  <a href="/answers/">Answers</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Do Fancy Fonts Work With Vietnamese</span>
+</nav>
+
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Do Fancy Fonts Work With Vietnamese?</h1>
+    <p class="hero-tagline">Type <strong>chữ kiểu</strong> into a bold generator and most of the word falls apart. Here's why Vietnamese is the hardest language for fancy text — and how to style it anyway.</p>
+  </div>
+</section>
+
+<section class="editorial-section">
+  <span class="article-section-label">Short answer</span>
+  <div class="editorial-block">
+    <p><strong>Only partly.</strong> Vietnamese is the hardest case for fancy text. Nearly every syllable stacks a vowel mark <em>and</em> a tone mark (ữ, ế, ệ, ơ), and Unicode has no styled version of those letters — so a bold or script style leaves most of the word plain, producing a half-styled mess. The letter <strong>đ</strong> never converts at all. The styles that <strong>keep dấu</strong> are the ones that add a mark or symbol instead of swapping the letter — strikethrough, underline, and symbol wraps. For a bold/script look, the Vietnamese fix is to <strong>bỏ dấu</strong> (remove the tone marks) first, or decorate a plain name with <strong>kí tự đặc biệt</strong>.</p>
+  </div>
+  <div class="block-example">
+    <strong>In one line:</strong> letter-swap styles break có dấu · mark &amp; symbol styles keep it · or bỏ dấu first for a uniform look.
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="editorial-section">
+  <span class="article-section-label">Why it breaks</span>
+  <h2>Stacked marks — and the đ that never budges</h2>
+  <div class="editorial-block">
+    <p>A "fancy font" swaps each letter for a styled Unicode character, but those styled characters only exist for the plain <strong>A–Z, a–z and 0–9</strong>. Vietnamese vowels are built by stacking a base letter, a vowel-shape mark (â, ă, ơ, ư) and a tone mark — "ế" is really e + circumflex + acute. A letter-swap style can only restyle the bare "e," so it strips the very marks that carry the meaning.</p>
+    <p>And <strong>đ / Đ</strong> is special: it's its own Unicode letter, not a "d" with a mark, so it has no styled twin and no decomposition. It stays plain in <em>every</em> letter-swap style, forever — the one character guaranteed to break.</p>
+    <div class="block-example">
+      <div class="example-pair">
+        <div class="ex-label">Bold "Việt Nam"</div>
+        <div class="ex-styled">𝗩𝗶ệ𝘁 𝗡𝗮𝗺</div>
+        <div class="ex-arrow">↓</div>
+        <div class="ex-label">the ệ has no bold form, so it drops to plain</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="editorial-section">
+  <span class="article-section-label">What works</span>
+  <h2>Two ways to style Vietnamese that actually hold up</h2>
+  <div class="compare-grid">
+    <div class="compare-card variant-positive">
+      <span class="compare-badge">1 · Keep the dấu</span>
+      <p>Use a style that <strong>marks or wraps</strong> instead of swapping — it never touches the letter, so every tone mark survives:</p>
+      <ul>
+        <li>Strikethrough, Underline, Slash, Wavy</li>
+        <li>Bracket / arrow / symbol word-wraps</li>
+      </ul>
+      <p class="mood-example">V̲i̲ệ̲t̲ ̲N̲a̲m̲ &nbsp;·&nbsp; ❨chữ kiểu❩</p>
+    </div>
+    <div class="compare-card variant-muted">
+      <span class="compare-badge">2 · Bỏ dấu, then style</span>
+      <p>Remove the tone marks first so the whole word has a styled form, then apply bold/script. This is the standard move for game names:</p>
+      <p class="mood-example">chữ kiểu → chu kieu → 𝗰𝗵𝘂 𝗸𝗶𝗲𝘂</p>
+      <p>Or decorate a plain name with <strong>kí tự đặc biệt</strong> (symbol frames), the way Free Fire and Liên Quân players do.</p>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="editorial-section">
+  <span class="article-section-label">Where it's used</span>
+  <h2>Game names, Zalo &amp; Facebook</h2>
+  <div class="editorial-block">
+    <ul>
+      <li><strong>Game names (Free Fire, Liên Quân, PUBG)</strong> — players use kí tự đặc biệt around a plain, mark-free nickname. Games cap length (Free Fire: 12 characters) and reject foreign or invisible characters, so test the name in a chat box before committing.</li>
+      <li><strong>Zalo</strong> — restricts fancy and emoji characters in the main display name; they only work in a private friend alias.</li>
+      <li><strong>Facebook</strong> — rejects decorative symbols in the name field and strips diacritics from the @username. Some layouts have historically misplaced Vietnamese marks, so rendering is not guaranteed.</li>
+    </ul>
+    <p>For the full device-by-device picture — including the NFC/NFD encoding trap when text is copied from a Mac — see the guide on <a href="/guide/fancy-fonts-and-accents/">accents &amp; diacritics in fancy fonts</a>.</p>
+  </div>
+</section>
+
+<div class="cta-card">
+  <h3>Try your Vietnamese text in every style</h3>
+  <p>Type chữ có dấu once and compare — the mark and symbol styles keep every dấu, and you can see exactly where the letter-swap styles drop them.</p>
+  <a href="/" class="cta-btn">Open the Text Generator →</a>
+</div>
+
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Related: <a href="/answers/why-fancy-text-removes-accents/">why fancy text removes accents</a> (the general version of this), the <a href="/library/accent-marks-diacritics/">accent marks &amp; diacritics library</a>, and <a href="/guide/why-fonts-show-as-boxes/">why fonts show as boxes</a> for the tofu problem on older devices.</p>
+  </div>
+</section>
+
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<script src="/footer.js"></script>
+</body>
+</html>

--- a/answers/index.html
+++ b/answers/index.html
@@ -154,6 +154,36 @@
         <p class="usecase-diff">Unicode has no styled version of accented letters, so letter-swap styles skip them. Mark &amp; symbol styles keep every accent.</p>
         <a class="usecase-cta" href="/answers/why-fancy-text-removes-accents/">Read the Answer →</a>
       </div>
+
+      <div class="style-card usecase-cards">
+        <div class="style-name">
+          <span class="style-tag">🇻🇳</span>
+          Do Fancy Fonts Work With Vietnamese?
+        </div>
+        <p class="usecase-outcome">Why chữ có dấu breaks in bold and script — and which styles keep every dấu.</p>
+        <p class="usecase-diff">Stacked vowel + tone marks and the đ that never converts. Covers the bỏ dấu fix and how gamers use kí tự đặc biệt.</p>
+        <a class="usecase-cta" href="/answers/do-fancy-fonts-work-with-vietnamese/">Read the Answer →</a>
+      </div>
+
+      <div class="style-card usecase-cards">
+        <div class="style-name">
+          <span class="style-tag">📸</span>
+          Why Won't Instagram Accept My Fancy Username?
+        </div>
+        <p class="usecase-outcome">The @handle is ASCII-only — fancy fonts go in your Name and bio instead.</p>
+        <p class="usecase-diff">Untangles Name vs Username vs Bio, so you know exactly which field takes styled text.</p>
+        <a class="usecase-cta" href="/answers/why-wont-instagram-accept-my-fancy-username/">Read the Answer →</a>
+      </div>
+
+      <div class="style-card usecase-cards">
+        <div class="style-name">
+          <span class="style-tag">📋</span>
+          Why Does Copied Fancy Text Lose Formatting?
+        </div>
+        <p class="usecase-outcome">Why styled text snaps back to normal on paste in some fields.</p>
+        <p class="usecase-diff">It was never formatting — it's substitute Unicode characters, and some fields normalize them to plain.</p>
+        <a class="usecase-cta" href="/answers/why-does-copied-fancy-text-lose-formatting/">Read the Answer →</a>
+      </div>
     </section>
 
     <div class="section-divider"></div>

--- a/answers/why-does-copied-fancy-text-lose-formatting/index.html
+++ b/answers/why-does-copied-fancy-text-lose-formatting/index.html
@@ -1,0 +1,203 @@
+<!DOCTYPE html><html lang="en"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8242324164413945"
+       crossorigin="anonymous"></script>
+
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <title>Why Does Copied Fancy Text Lose Its Formatting? | UltraTextGen</title>
+  <meta name="description" content="Fancy text turns back to normal on paste because it was never formatting — it's substitute Unicode characters, and some fields normalize them to plain. Here's where and why.">
+  <link rel="canonical" href="https://ultratextgen.com/answers/why-does-copied-fancy-text-lose-formatting/">
+  <meta property="og:title" content="Why Does Copied Fancy Text Lose Its Formatting?">
+  <meta property="og:description" content="Fancy text turns back to normal on paste because it was never formatting — it's substitute Unicode characters, and some fields normalize them to plain. Here's where and why.">
+  <meta property="og:url" content="https://ultratextgen.com/answers/why-does-copied-fancy-text-lose-formatting/">
+  <meta property="og:type" content="article">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/answers-why-does-copied-fancy-text-lose-formatting.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Why Does Copied Fancy Text Lose Its Formatting?">
+  <meta name="twitter:description" content="It was never formatting — fancy text is substitute Unicode characters, and some fields normalize them back to plain. Here's where and why.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/answers-why-does-copied-fancy-text-lose-formatting.png">
+
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Why does copied fancy text lose its formatting?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Because it was never formatting to begin with. A fancy font isn't bold applied to a letter — it's a different Unicode character that happens to look bold. When you paste it somewhere that normalizes text (search boxes, username fields, some editors), the system folds those special characters back to their plain equivalents, so 𝐛𝐨𝐥𝐝 becomes bold. Nothing was 'removed' in the formatting sense; the special characters were converted to normal ones."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Why does it work in some places but turn back to normal in others?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "It depends on whether the destination normalizes or restricts text. Display fields that store text as-is (social display names, bios, most chat messages) keep the styled characters. Fields that canonicalize input — search bars, @username fields, some form fields, and document editors saving to certain formats — convert or reject them. Same clipboard, different handling on the other end."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does pasting fancy text into Word or Google Docs remove it?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "It can. Word converts mathematical alphanumeric characters back to plain letters when writing certain formats or inside a math zone, and both Word and Docs may substitute a fallback font so the styling looks inconsistent. Because the styled look is baked into the character rather than a font setting, a document that normalizes or re-encodes text can flatten it to plain."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Why can't I search for fancy text with Ctrl+F?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Because a styled 'a' (𝗮) is a different character from a plain 'a', so a search for the normal spelling doesn't match it. Search engines and in-app search deliberately normalize styled Unicode to plain for indexing, which is good for being found — but it also means Ctrl+F, on-platform search and SEO won't match your fancy text against a normal query. Keep anything you want found in plain text."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How do I keep fancy text from reverting?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Paste it into fields that store text as-is: social display names, bios, chat messages and captions. Avoid putting it in search boxes, @username fields, or documents you'll export to formats that normalize text. And never rely on it for anything that must be searchable or machine-read — those systems are exactly the ones that flatten it back to plain."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ultratextgen.com/" },
+    { "@type": "ListItem", "position": 2, "name": "Answers", "item": "https://ultratextgen.com/answers/" },
+    { "@type": "ListItem", "position": 3, "name": "Why Copied Fancy Text Loses Formatting", "item": "https://ultratextgen.com/answers/why-does-copied-fancy-text-lose-formatting/" }
+  ]
+}
+</script>
+</head>
+<body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<script src="/header.js"></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/">Home</a>
+  <span class="breadcrumb-separator">›</span>
+  <a href="/answers/">Answers</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Why Copied Fancy Text Loses Formatting</span>
+</nav>
+
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Why Does Copied Fancy Text Lose Its Formatting?</h1>
+    <p class="hero-tagline">You paste your styled text and it snaps back to plain. The twist: it was never "formatting" in the first place — so nothing was lost. Something was <em>converted</em>.</p>
+  </div>
+</section>
+
+<section class="editorial-section">
+  <span class="article-section-label">Short answer</span>
+  <div class="editorial-block">
+    <p>Fancy text isn't bold <em>applied</em> to a letter — it's a <strong>different Unicode character</strong> that happens to look bold. So when you paste it somewhere that <strong>normalizes</strong> text — a search box, a username field, some editors — that system folds the special characters back to their plain equivalents, and <strong>𝗯𝗼𝗹𝗱</strong> becomes <strong>bold</strong>. Nothing was stripped in the formatting sense; the special characters were simply converted to normal ones. It survives in fields that store text as-is (display names, bios, chat) and reverts in fields that clean it up.</p>
+  </div>
+  <div class="block-example">
+    <strong>The key idea:</strong> it's characters, not formatting — so "losing the style" is really the characters being converted back to plain.
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="editorial-section">
+  <span class="article-section-label">Why</span>
+  <h2>It's characters, not formatting</h2>
+  <div class="editorial-block">
+    <p>Real formatting (like a word processor's <b>Bold</b> button) is a separate instruction attached <em>to</em> normal letters. Fancy text has no such instruction — the "boldness" is baked into the character itself. The bold <strong>𝗮</strong> and a normal <strong>a</strong> are two different code points that happen to look related.</p>
+    <p>Many systems run text through a cleanup step called <strong>normalization</strong> — and one common form (NFKC) is <em>defined</em> to strip these styled variants back to plain, because they're meant for maths, not styling. That's the step that turns your fancy text back to normal on the way in.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="editorial-section">
+  <span class="article-section-label">Where</span>
+  <h2>Where it survives, and where it reverts</h2>
+  <div class="compare-grid">
+    <div class="compare-card variant-positive">
+      <span class="compare-badge">Keeps the style</span>
+      <p>Fields that store your text exactly as pasted:</p>
+      <ul>
+        <li>Social display names &amp; bios</li>
+        <li>Chat messages &amp; captions</li>
+        <li>Most posts and comments</li>
+      </ul>
+    </div>
+    <div class="compare-card variant-muted">
+      <span class="compare-badge">Reverts or rejects</span>
+      <p>Fields that normalize or restrict input:</p>
+      <ul>
+        <li>Search boxes &amp; Ctrl+F</li>
+        <li>@username / handle fields (ASCII-only)</li>
+        <li>Word / Docs saving to some formats</li>
+        <li>Anything indexed for search</li>
+      </ul>
+    </div>
+  </div>
+  <div class="editorial-block">
+    <p>Here's the upside of the same mechanism: because search <em>normalizes</em> styled text to plain, your content still gets indexed correctly. The trade-off is that <strong>fancy text isn't searchable</strong> — a search for "bold" won't match <strong>𝗯𝗼𝗹𝗱</strong>, and Ctrl+F skips it. Keep anything you want found in plain text.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="editorial-section">
+  <span class="article-section-label">Not the same thing</span>
+  <h2>Reverting vs boxes vs stripped accents</h2>
+  <div class="editorial-block">
+    <ul>
+      <li><strong>Reverts to plain</strong> — the styled characters were normalized back to normal ones (this page). A conversion, not a loss.</li>
+      <li><strong>Shows as boxes</strong> — the characters arrived fine but the device has no glyph to draw them. See <a href="/guide/why-fonts-show-as-boxes/">why fonts show as boxes</a>.</li>
+      <li><strong>Accents go missing</strong> — a related normalization can strip diacritics too. See <a href="/answers/why-fancy-text-removes-accents/">why fancy text removes accents</a>.</li>
+    </ul>
+  </div>
+</section>
+
+<div class="cta-card">
+  <h3>Generate text you can paste anywhere</h3>
+  <p>Make your styled text, then drop it into a display name, bio or caption — the fields that keep it exactly as you copied it.</p>
+  <a href="/" class="cta-btn">Open the Text Generator →</a>
+</div>
+
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Related reading: <a href="/guide/fancy-fonts-and-accents/">fancy fonts &amp; accents</a>, <a href="/answers/why-wont-instagram-accept-my-fancy-username/">why Instagram won't accept a fancy username</a>, and <a href="/answers/is-linkedin-bold-text-safe/">is LinkedIn bold text safe</a> for the searchability angle.</p>
+  </div>
+</section>
+
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<script src="/footer.js"></script>
+</body>
+</html>

--- a/answers/why-wont-instagram-accept-my-fancy-username/index.html
+++ b/answers/why-wont-instagram-accept-my-fancy-username/index.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html><html lang="en"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8242324164413945"
+       crossorigin="anonymous"></script>
+
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <title>Why Won't Instagram Accept My Fancy Username? | UltraTextGen</title>
+  <meta name="description" content="Instagram rejects fancy fonts in your @username because the handle is ASCII-only. Fancy text works in your Name and bio instead — here's exactly where each one goes.">
+  <link rel="canonical" href="https://ultratextgen.com/answers/why-wont-instagram-accept-my-fancy-username/">
+  <meta property="og:title" content="Why Won't Instagram Accept My Fancy Username?">
+  <meta property="og:description" content="Instagram rejects fancy fonts in your @username because the handle is ASCII-only. Fancy text works in your Name and bio instead — here's exactly where each one goes.">
+  <meta property="og:url" content="https://ultratextgen.com/answers/why-wont-instagram-accept-my-fancy-username/">
+  <meta property="og:type" content="article">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/answers-why-wont-instagram-accept-my-fancy-username.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Why Won't Instagram Accept My Fancy Username?">
+  <meta name="twitter:description" content="The @username is ASCII-only — fancy fonts work in your Name and bio instead. Here's exactly where each goes.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/answers-why-wont-instagram-accept-my-fancy-username.png">
+
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Why won't Instagram accept my fancy username?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Because the @username field is ASCII-only. Instagram restricts the handle to lowercase letters, numbers, periods and underscores — no styled Unicode, no accents, no symbols. That's a deliberate rule so handles stay unique and typeable, and it's why your fancy version is rejected or silently reverts. Fancy fonts aren't blocked on Instagram in general; they just can't live in the handle."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Where can I use fancy fonts on Instagram then?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "In the Name field (the bold line above your bio) and in the bio text itself. Both accept styled Unicode, so that's where your fancy font goes. The @username underneath must stay plain. So the pattern is: styled Name, plain @handle — for example a Name of 𝗔𝘀𝗵 𝗕𝗮𝗸𝗲𝘀 above the handle @ashbakes."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I use fancy text in my Instagram Name?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. The Name field accepts styled Unicode and emoji, up to about 30 characters. It's the safest place for fancy text on Instagram because it's separate from the searchable @handle. Keep in mind the Name is what Instagram search matches on, so heavily styling it can make you harder to find — style a word or two, not the whole thing."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Why does my Instagram bio remove some fancy letters?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The bio accepts most styled Unicode, but Instagram filters out some of the more extreme styles — heavy glitch/zalgo text built from stacked combining marks in particular — to prevent abuse. Bold, italic, sans and small caps survive reliably; the very decorative styles are the ones most likely to be stripped or to show as boxes on older devices."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Do accented letters work in an Instagram username?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. The @username is ASCII-only, so accented letters (á, ñ, ü) and Vietnamese diacritics are rejected there too, along with styled Unicode. Accents are fine in your Name and bio. If you need your real accented name, put it in the Name field and keep the handle as a plain-ASCII version."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ultratextgen.com/" },
+    { "@type": "ListItem", "position": 2, "name": "Answers", "item": "https://ultratextgen.com/answers/" },
+    { "@type": "ListItem", "position": 3, "name": "Why Won't Instagram Accept My Fancy Username", "item": "https://ultratextgen.com/answers/why-wont-instagram-accept-my-fancy-username/" }
+  ]
+}
+</script>
+</head>
+<body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<script src="/header.js"></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/">Home</a>
+  <span class="breadcrumb-separator">›</span>
+  <a href="/answers/">Answers</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Why Won't Instagram Accept My Fancy Username</span>
+</nav>
+
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Why Won't Instagram Accept My Fancy Username?</h1>
+    <p class="hero-tagline">You styled your handle, hit save, and it snapped back to plain — or wouldn't save at all. Here's the one rule behind it, and exactly where fancy fonts <em>do</em> work.</p>
+  </div>
+</section>
+
+<section class="editorial-section">
+  <span class="article-section-label">Short answer</span>
+  <div class="editorial-block">
+    <p>Because the <strong>@username is ASCII-only</strong>. Instagram restricts the handle to lowercase letters, numbers, periods and underscores — no styled Unicode, no accents, no symbols — so handles stay unique and typeable. Your fancy version isn't a valid handle, so it's rejected or reverts. Fancy fonts aren't banned on Instagram; they just can't live in the handle. Put them in the <strong>Name</strong> field and <strong>bio</strong> instead, and keep the @handle plain.</p>
+  </div>
+  <div class="block-example">
+    <strong>The rule:</strong> styled <b>Name</b> + plain <b>@handle</b>. Fancy text goes above the handle, never in it.
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="editorial-section">
+  <span class="article-section-label">The three fields</span>
+  <h2>Name vs Username vs Bio — where each one allows fancy text</h2>
+  <div class="editorial-block">
+    <p>Instagram has three separate identity fields, and they follow different rules. Almost every "why won't it accept my font" question comes from confusing the first two.</p>
+    <div class="data-table-wrap">
+      <table class="data-table">
+        <thead><tr><th>Field</th><th>Where it is</th><th>Fancy fonts?</th></tr></thead>
+        <tbody>
+          <tr><td><strong>Name</strong></td><td>The bold line at the top of your profile</td><td><strong>Yes</strong> — styled Unicode &amp; emoji, ~30 chars</td></tr>
+          <tr><td><strong>Username (@handle)</strong></td><td>The @ line underneath, and your URL</td><td><strong>No</strong> — ASCII only (a–z, 0–9, . and _)</td></tr>
+          <tr><td><strong>Bio</strong></td><td>The description below</td><td><strong>Mostly</strong> — styled text works; extreme glitch styles get filtered</td></tr>
+        </tbody>
+      </table>
+    </div>
+    <div class="block-example">
+      <div class="example-pair">
+        <div class="ex-label">Name (fancy — allowed)</div>
+        <div class="ex-styled">𝗔𝘀𝗵 𝗕𝗮𝗸𝗲𝘀 🍰</div>
+        <div class="ex-arrow">↓</div>
+        <div class="ex-label">Username (plain — required)</div>
+        <div class="ex-styled">@ashbakes</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="editorial-section">
+  <span class="article-section-label">Two things to know</span>
+  <h2>Search &amp; accents</h2>
+  <div class="editorial-block">
+    <p><strong>The Name is searchable.</strong> Instagram matches search against your Name, and styled letters are different characters from plain ones — so a fully styled Name can make you harder to find. Style a word or two for flair and keep your searchable name readable.</p>
+    <p><strong>Accents are blocked in the handle too.</strong> The ASCII rule means accented letters (á, ñ, ü) and Vietnamese diacritics are also rejected in the @username — only in the handle. Your real accented name is fine in the Name field. If your language uses accents, see <a href="/answers/why-fancy-text-removes-accents/">why fancy text removes accents</a>.</p>
+  </div>
+</section>
+
+<div class="cta-card">
+  <h3>Make a styled Name for your profile</h3>
+  <p>Generate a bold, italic or script Name in seconds, copy it, and paste it into Instagram's Name field — leave the @handle plain.</p>
+  <a href="/instagram/" class="cta-btn">Open the Instagram Font Generator →</a>
+</div>
+
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Related: <a href="/answers/why-fancy-text-removes-accents/">why fancy text removes accents</a>, <a href="/guide/why-fonts-show-as-boxes/">why fonts show as boxes</a> on some devices, and the full <a href="/guide/fancy-fonts-and-accents/">fancy fonts &amp; accents</a> guide. The same handle-vs-display-name rule applies on Discord, TikTok, X, Telegram and Snapchat.</p>
+  </div>
+</section>
+
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<script src="/footer.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Fills the top zero-click gaps from the question-gap research, each FAQPage + BreadcrumbList (no Article), leading with a Short answer block and cross-linked into the fancy-fonts-and-accents guide and the accent answer:

- answers/do-fancy-fonts-work-with-vietnamese/ — VN market page (có dấu, stacked marks, đ, bỏ dấu, kí tự đặc biệt game names, Zalo/Facebook).
- answers/why-wont-instagram-accept-my-fancy-username/ — the ASCII-only @handle vs Name vs bio confusion, plus the search + accents caveats.
- answers/why-does-copied-fancy-text-lose-formatting/ — it's characters not formatting; NFKC normalization reverts styled text in search/ username/editor fields; where it survives vs reverts.

All three listed on the answers hub.


Claude-Session: https://claude.ai/code/session_01DDv3fYNPxsy97aKvWpNvuN