### PR TITLE
UX: reposition Text Decorator under Use Cases hub

### DIFF
--- a/category/index.html
+++ b/category/index.html
@@ -224,11 +224,6 @@
               <td>Meme comments, playful tone</td>
             </tr>
             <tr>
-              <td><a href="#cat-wrappers" style="color:var(--text-primary);font-weight:600;text-decoration:underline;">Text Decorator</a></td>
-              <td>Framing, structure, drama</td>
-              <td>Styled posts, aesthetic layouts</td>
-            </tr>
-            <tr>
               <td><a href="#cat-classified" style="color:var(--text-primary);font-weight:600;text-decoration:underline;">Classified Style</a></td>
               <td>Coded, secretive, restricted</td>
               <td>Mystery tone, storytelling hooks</td>
@@ -546,31 +541,6 @@
         <strong>Example:</strong> "hello" → ollǝɥ — surprise is the message.
       </div>
       <a class="cat-cta" href="/category/upside-down-text/">Open Upside Down Generator →</a>
-    </div>
-
-    <!-- Text Decorator -->
-    <div class="style-card cat-anchor" id="cat-wrappers" style="flex-direction:column;align-items:stretch;gap:12px;">
-      <div class="style-name">
-        <span class="style-tag">【 】</span>
-        Text Decorator
-      </div>
-      <div class="style-preview">
-        The text decorator frames your message visually — wrapping words in symbols, brackets, and borders. It structures emotion, controls layout, and turns plain text into a visual container.
-      </div>
-      <p style="font-size:0.875rem;color:var(--text-secondary);line-height:1.6;margin:0;">
-        <strong>Signals:</strong> framing, structure, visual drama.
-        Use when you want dramatic formatting, boxed text, styled storytelling, or aesthetic social posts that stand apart from the feed.
-      </p>
-      <div class="platform-pills">
-        <span class="platform-pill">Styled posts</span>
-        <span class="platform-pill">Aesthetic layouts</span>
-        <span class="platform-pill">Boxed text</span>
-        <span class="platform-pill">Visual storytelling</span>
-      </div>
-      <div class="block-example">
-        <strong>Example:</strong> "hello" → ★彡[ hello ]彡★ — framed and memorable.
-      </div>
-      <a class="cat-cta" href="/category/text-decorator/">Open Text Decorator →</a>
     </div>
 
     <!-- Classified Style -->

--- a/category/text-decorator/index.html
+++ b/category/text-decorator/index.html
@@ -135,8 +135,8 @@
     {
       "@type": "ListItem",
       "position": 2,
-      "name": "Categories",
-      "item": "https://ultratextgen.com/category/"
+      "name": "Use Cases",
+      "item": "https://ultratextgen.com/usecase/"
     },
     {
       "@type": "ListItem",
@@ -178,7 +178,7 @@
 <nav class="breadcrumbs" aria-label="Breadcrumb">
   <a href="/">Home</a>
   <span class="breadcrumb-separator">›</span>
-  <a href="/category/">Categories</a>
+  <a href="/usecase/">Use Cases</a>
   <span class="breadcrumb-separator">›</span>
   <span class="breadcrumb-current">Text Decorator</span>
 </nav>
@@ -425,7 +425,7 @@
   <div class="faq-answer">
     Yes. After generating decorated text, you can paste it into other tools on our site for additional effects like bold, italic, cursive, or gothic styles.
     <br><br>
-    Check out our other categories like <a href="/category/bubble-fonts/">Bubble Fonts</a> or the style filters (Cool, Fancy, Bold, Gothic) for mixing and matching.
+    Check out our font categories like <a href="/category/bubble-fonts/">Bubble Fonts</a> or the style filters (Cool, Fancy, Bold, Gothic) for mixing and matching.
     For stand-alone separators, browse the <a href="/library/line-divider-symbols/">line dividers &amp; separators</a> library.
   </div>
 </div>

--- a/usecase/index.html
+++ b/usecase/index.html
@@ -103,6 +103,17 @@ l
 o</div>
         <a class="usecase-cta" href="/usecase/vertical-text/">Generate Vertical Text →</a>
       </div>
+
+      <div class="style-card usecase-cards" style="flex-direction:column;align-items:stretch;gap:8px;">
+        <div class="style-name">
+          <span class="style-tag">【 】</span>
+          Text Decorator
+        </div>
+        <p class="usecase-outcome">Frame your words in symbols, brackets, and borders.</p>
+        <p class="usecase-diff">Wrap text in visual containers — boxed names, emoji banners, and decorated captions that stand apart from the feed.</p>
+        <div class="usecase-example" aria-label="Example showing text wrapped in decorative symbols">★彡[ hello ]彡★</div>
+        <a class="usecase-cta" href="/category/text-decorator/">Open Text Decorator →</a>
+      </div>
     </section>
 
     <!-- Glitch & Special Effects -->


### PR DESCRIPTION
The Text Decorator (formerly word-wrappers) is a use case, not a font category. Move its sitewide positioning without changing the URL:

- Add a Text Decorator card to /usecase/ (Vertical & Decorative Text section), linking to the existing /category/text-decorator/ URL
- Switch the page's breadcrumb trail (visible nav + BreadcrumbList JSON-LD) from Categories to Use Cases
- Remove its comparison-table row and detail card from /category/
- Reword the page's FAQ so it no longer calls itself a category


Claude-Session: https://claude.ai/code/session_01KDbnyzMXWAgDWQXSFwuJKS