### PR TITLE
feat: add Indonesian invisible-character page /id/spasi-kosong + href…

### DIFF
--- a/de/unsichtbares-zeichen/index.html
+++ b/de/unsichtbares-zeichen/index.html
@@ -1,0 +1,367 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Unsichtbares Zeichen (Unsichtbarer Text) — Leerzeichen Kopieren & Einfügen | UltraTextGen</title>
+<meta name="description" content="Kopiere unsichtbaren Text und unsichtbare Zeichen (Zero Width Space, Hangul-Filler, Braille) für leere Namen in Free Fire, eine Instagram-Bio und leere WhatsApp-Nachrichten. Zum Kopieren klicken — kostenlos.">
+
+<link rel="canonical" href="https://ultratextgen.com/de/unsichtbares-zeichen/">
+
+<link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/invisible-character/">
+<link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/spasi-kosong/">
+<link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/texto-invisible/">
+<link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/texto-invisivel/">
+<link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/texte-invisible/">
+<link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/unsichtbares-zeichen/">
+<link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/testo-invisibile/">
+<link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/onzichtbare-tekst/">
+<link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/gorunmez-karakter/">
+<link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/ky-tu-vo-hinh/">
+<link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/niewidzialny-znak/">
+<link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/invisible-character/">
+
+<meta name="robots" content="index, follow">
+<meta property="og:site_name" content="UltraTextGen">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/library-invisible-character.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Unsichtbares Zeichen (Unsichtbarer Text) — Leerzeichen Kopieren & Einfügen">
+<meta name="twitter:description" content="Kopiere unsichtbaren Text und unsichtbare Zeichen für leere Namen, Instagram-Bio und WhatsApp-Nachrichten. Zum Kopieren klicken.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/library-invisible-character.png">
+<meta property="og:title" content="Unsichtbares Zeichen (Unsichtbarer Text) — Leerzeichen Kopieren & Einfügen">
+<meta property="og:description" content="Kopiere unsichtbaren Text und unsichtbare Zeichen (Zero Width Space, Hangul-Filler, Braille) für leere Namen, Instagram-Bio und leere WhatsApp-Nachrichten. Kostenlos, ohne App.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/de/unsichtbares-zeichen/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Unsichtbares Zeichen (Unsichtbarer Text) — Leerzeichen Kopieren & Einfügen",
+  "alternateName": ["Unsichtbares Zeichen", "Unsichtbarer Text", "Leerzeichen", "Leerer Name", "Unsichtbarer Buchstabe", "Unsichtbares Leerzeichen", "Leerzeichen Kopieren"],
+  "description": "Kopiere unsichtbaren Text und unsichtbare Zeichen (Zero Width Space, Hangul-Filler, Braille) für leere Namen in Free Fire, eine Instagram-Bio und leere WhatsApp-Nachrichten. Zum Kopieren klicken — kostenlos.",
+  "inLanguage": "de",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/library-invisible-character.png",
+  "mainEntityOfPage": "https://ultratextgen.com/de/unsichtbares-zeichen/",
+  "datePublished": "2026-07-03",
+  "dateModified": "2026-07-03"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "de",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Was ist unsichtbarer Text oder ein unsichtbares Zeichen?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Unsichtbarer Text ist ein echtes Unicode-Zeichen, das leer erscheint — man sieht nichts, aber es zählt weiterhin als Text. Deshalb kannst du es dort einsetzen, wo ein leeres Feld normalerweise nicht akzeptiert wird, etwa im Spielnamen, in einer Bio oder in einer Chat-Nachricht. Beispiele: Zero Width Space, Hangul-Filler und leeres Braille. Die Buttons auf dieser Seite wirken leer, aber die Beschriftung zeigt genau, welches Zeichen du kopierst." }
+    },
+    {
+      "@type": "Question",
+      "name": "Wie mache ich einen unsichtbaren Namen in Free Fire oder Mobile Legends?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Klicke auf eines der unsichtbaren Zeichen auf dieser Seite (am besten funktionieren meist der Hangul Filler U+3164 oder der Braille Pattern Blank U+2800) und füge es im Feld zum Ändern des Namens in Free Fire oder Mobile Legends ein. Verlangt das Spiel mehrere Zeichen, füge es zwei- oder dreimal ein. Da es ein Unicode-Zeichen ist, ist das Feld gefüllt, aber dein Name erscheint leer." }
+    },
+    {
+      "@type": "Question",
+      "name": "Welches unsichtbare Zeichen funktioniert am besten für Spielnamen?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Am besten funktionieren der Hangul Filler (U+3164) und der Braille Pattern Blank (U+2800), da sie leere „Buchstaben“ sind, die von Spielfiltern selten blockiert werden. Funktioniert eines nicht, probiere das andere — jedes Spiel prüft Text anders." }
+    },
+    {
+      "@type": "Question",
+      "name": "Warum wird das Leerzeichen manchmal abgelehnt oder als Kästchen angezeigt?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Manche Apps entfernen das normale Leerzeichen oder unterstützen bestimmte unsichtbare Zeichen noch nicht, daher erscheint ein Kästchen oder das Feld gilt als leer. Wechsle dann das Zeichen — etwa vom Zero Width Space zum Hangul Filler oder zum leeren Braille — oder probiere es in einer anderen App oder auf einem anderen Handy." }
+    },
+    {
+      "@type": "Question",
+      "name": "Funktioniert es für eine leere Instagram-Bio oder eine leere WhatsApp-Nachricht?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Ja. Kopiere ein unsichtbares Zeichen und füge es in die Instagram-Bio ein, um leere Zeilen oder sauberen Abstand zu erzeugen, oder sende es als scheinbar leere WhatsApp-Nachricht. Für leere Zeilen in der Bio nutze ein Leerzeichen-Zeichen (kein Zero Width), damit die Zeile nicht entfernt wird." }
+    },
+    {
+      "@type": "Question",
+      "name": "Ist es kostenlos und ohne App?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Es ist 100 % kostenlos, läuft direkt im Browser, ohne Anmeldung und ohne App-Installation. Klicke einfach auf das gewünschte unsichtbare Zeichen und füge es ein, wo du willst." }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Startseite",
+      "item": "https://ultratextgen.com/de/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Unsichtbares Zeichen",
+      "item": "https://ultratextgen.com/de/unsichtbares-zeichen/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/de/">Startseite</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Unsichtbares Zeichen</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Unsichtbares Zeichen &amp; Unsichtbarer Text</h1>
+    <p class="hero-tagline">Alle leeren und unsichtbaren Zeichen, die Unicode bietet — Zero Width Spaces, Filler und leeres Braille. Klicke auf ein Zeichen, um es sofort zu kopieren.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/library-invisible-character.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Ein unsichtbares Zeichen ist ein echtes Unicode-Zeichen, das als Nichts dargestellt wird — ein Leerzeichen, das du kopieren und dort einfügen kannst, wo Plattformen leere Eingaben normalerweise ablehnen. Man nutzt es, um einen unsichtbaren Namen in Free Fire und Mobile Legends zu erstellen, leere Zeilen in eine Instagram-Bio oder Bildunterschrift einzufügen, eine scheinbar leere WhatsApp-Nachricht zu senden oder Gaming-Namen sauber zu setzen. Jeder Button unten enthält ein echtes unsichtbares oder leeres Zeichen: Die Felder wirken leer, aber die Beschriftung sagt dir genau, welches Zeichen du kopierst.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="zero-width-characters">
+  <span class="article-section-label">Zero Width</span>
+  <h2>Zero-Width- und Unsichtbare Zeichen</h2>
+  <p class="u-secondary-tight">Diese Zeichen haben gar keine sichtbare Breite — ideal für unsichtbare Namen und um Text zu trennen, ohne etwas anzuzeigen.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="​" aria-label="Kopieren Zero Width Space — U+200B">​</button>
+      <span class="flag-label">Zero Width Space — U+200B</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‌" aria-label="Kopieren Zero Width Non-Joiner — U+200C">‌</button>
+      <span class="flag-label">Zero Width Non-Joiner — U+200C</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‍" aria-label="Kopieren Zero Width Joiner — U+200D">‍</button>
+      <span class="flag-label">Zero Width Joiner — U+200D</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⁠" aria-label="Kopieren Word Joiner — U+2060">⁠</button>
+      <span class="flag-label">Word Joiner — U+2060</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="﻿" aria-label="Kopieren Zero Width No-Break Space — U+FEFF">﻿</button>
+      <span class="flag-label">Zero Width No-Break Space — U+FEFF</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‎" aria-label="Kopieren Left-to-Right Mark — U+200E">‎</button>
+      <span class="flag-label">Left-to-Right Mark — U+200E</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‏" aria-label="Kopieren Right-to-Left Mark — U+200F">‏</button>
+      <span class="flag-label">Right-to-Left Mark — U+200F</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="­" aria-label="Kopieren Soft Hyphen — U+00AD">­</button>
+      <span class="flag-label">Soft Hyphen — U+00AD</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="blank-spaces">
+  <span class="article-section-label">Leerzeichen</span>
+  <h2>Leerzeichen-Zeichen</h2>
+  <p class="u-secondary-tight">Sichtbare Breite, aber leer: Diese Leerzeichen überleben dort, wo das normale Leerzeichen der Leertaste entfernt oder zusammengefasst wird.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopieren No-Break Space — U+00A0"> </button>
+      <span class="flag-label">No-Break Space — U+00A0</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopieren En Space — U+2002"> </button>
+      <span class="flag-label">En Space — U+2002</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopieren Em Space — U+2003"> </button>
+      <span class="flag-label">Em Space — U+2003</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopieren Figure Space — U+2007"> </button>
+      <span class="flag-label">Figure Space — U+2007</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopieren Punctuation Space — U+2008"> </button>
+      <span class="flag-label">Punctuation Space — U+2008</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopieren Thin Space — U+2009"> </button>
+      <span class="flag-label">Thin Space — U+2009</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopieren Hair Space — U+200A"> </button>
+      <span class="flag-label">Hair Space — U+200A</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopieren Narrow No-Break Space — U+202F"> </button>
+      <span class="flag-label">Narrow No-Break Space — U+202F</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="wide-spaces">
+  <span class="article-section-label">Breite Leerzeichen</span>
+  <h2>Breite & Spezielle Leerzeichen</h2>
+  <p class="u-secondary-tight">Besonders breite Leerzeichen, darunter das Ideographic Space in voller Breite aus der CJK-Typografie — super für große leere Lücken.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopieren En Quad — U+2000"> </button>
+      <span class="flag-label">En Quad — U+2000</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopieren Em Quad — U+2001"> </button>
+      <span class="flag-label">Em Quad — U+2001</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopieren Three-Per-Em Space — U+2004"> </button>
+      <span class="flag-label">Three-Per-Em Space — U+2004</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopieren Four-Per-Em Space — U+2005"> </button>
+      <span class="flag-label">Four-Per-Em Space — U+2005</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopieren Six-Per-Em Space — U+2006"> </button>
+      <span class="flag-label">Six-Per-Em Space — U+2006</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopieren Medium Mathematical Space — U+205F"> </button>
+      <span class="flag-label">Medium Mathematical Space — U+205F</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="　" aria-label="Kopieren Ideographic Space — U+3000">　</button>
+      <span class="flag-label">Ideographic Space — U+3000</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="filler-characters">
+  <span class="article-section-label">Filler</span>
+  <h2>Filler- & Leer-Glyphen-Zeichen</h2>
+  <p class="u-secondary-tight">Buchstaben und Muster, die als leere Glyphen erscheinen — leeres Braille und der Hangul-Filler sind die Favoriten für unsichtbare Spielnamen.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⠀" aria-label="Kopieren Braille Pattern Blank — U+2800">⠀</button>
+      <span class="flag-label">Braille Pattern Blank — U+2800</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ㅤ" aria-label="Kopieren Hangul Filler — U+3164">ㅤ</button>
+      <span class="flag-label">Hangul Filler — U+3164</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ᅟ" aria-label="Kopieren Hangul Choseong Filler — U+115F">ᅟ</button>
+      <span class="flag-label">Hangul Choseong Filler — U+115F</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ᅠ" aria-label="Kopieren Hangul Jungseong Filler — U+1160">ᅠ</button>
+      <span class="flag-label">Hangul Jungseong Filler — U+1160</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ﾠ" aria-label="Kopieren Halfwidth Hangul Filler — U+FFA0">ﾠ</button>
+      <span class="flag-label">Halfwidth Hangul Filler — U+FFA0</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="᠎" aria-label="Kopieren Mongolian Vowel Separator — U+180E">᠎</button>
+      <span class="flag-label">Mongolian Vowel Separator — U+180E</span>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Text in Unicode-Schriften verwandeln</h3>
+  <p>Mit UltraTextGen wandelst du normalen Text in fette, kursive, geschwungene und über 100 weitere Unicode-Schriftstile um — kostenlos und sofort.</p>
+  <a href="https://ultratextgen.com/de/" class="cta-btn">UltraTextGen öffnen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Verwandte Ressourcen</span>
+  <div class="compare-grid">
+    <a href="/de/usecase/zalgo-text/" class="compare-card variant-muted u-no-underline">
+      <h4>Zalgo-Text</h4>
+      <p>Erzeuge Glitch-, verfluchten und gruseligen Text mit gestapelten Zeichen.</p>
+    </a>
+    <a href="/de/" class="compare-card variant-muted u-no-underline">
+      <h4>Schrift-Generator</h4>
+      <p>Verwandle deinen Text in fett, kursiv und über 100 Unicode-Stile.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/es/texto-invisible/index.html
+++ b/es/texto-invisible/index.html
@@ -1,0 +1,360 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Texto Invisible (Carácter Invisible) — Copiar y Pegar Espacio en Blanco | UltraTextGen</title>
+<meta name="description" content="Copia texto invisible y caracteres invisibles (zero width space, filler Hangul, braille) para nombres vacíos de Free Fire, bios de Instagram y mensajes en blanco de WhatsApp. Clic para copiar al instante — gratis.">
+
+<link rel="canonical" href="https://ultratextgen.com/es/texto-invisible/">
+
+<link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/invisible-character/">
+<link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/spasi-kosong/">
+<link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/texto-invisible/">
+<link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/texto-invisivel/">
+<link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/invisible-character/">
+
+<meta name="robots" content="index, follow">
+<meta property="og:site_name" content="UltraTextGen">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/library-invisible-character.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Texto Invisible (Carácter Invisible) — Copiar y Pegar Espacio en Blanco">
+<meta name="twitter:description" content="Copia texto invisible y caracteres invisibles para nombres vacíos, bios de Instagram y mensajes de WhatsApp. Clic para copiar.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/library-invisible-character.png">
+<meta property="og:title" content="Texto Invisible (Carácter Invisible) — Copiar y Pegar Espacio en Blanco">
+<meta property="og:description" content="Copia texto invisible y caracteres invisibles (zero width space, filler Hangul, braille) para nombres vacíos, bios de Instagram y mensajes en blanco de WhatsApp. Gratis, sin apps.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/es/texto-invisible/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Texto Invisible (Carácter Invisible) — Copiar y Pegar Espacio en Blanco",
+  "alternateName": ["Texto Invisible", "Carácter Invisible", "Espacio en Blanco", "Nombre Vacío", "Letra Invisible", "Espacio Invisible", "Copiar Espacio en Blanco"],
+  "description": "Copia texto invisible y caracteres invisibles (zero width space, filler Hangul, braille) para nombres vacíos de Free Fire, bios de Instagram y mensajes en blanco de WhatsApp. Clic para copiar al instante — gratis.",
+  "inLanguage": "es",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/library-invisible-character.png",
+  "mainEntityOfPage": "https://ultratextgen.com/es/texto-invisible/",
+  "datePublished": "2026-07-03",
+  "dateModified": "2026-07-03"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "es",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "¿Qué es el texto invisible o un carácter invisible?",
+      "acceptedAnswer": { "@type": "Answer", "text": "El texto invisible es un carácter Unicode real que se muestra vacío — no se ve nada, pero sigue contando como texto. Por eso puedes ponerlo donde normalmente no se acepta un campo vacío, como el nombre de un juego, una bio o un mensaje de chat. Ejemplos: el zero width space, el filler Hangul y el braille en blanco. Los botones de esta página parecen vacíos, pero la etiqueta te dice exactamente qué carácter estás copiando." }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Cómo hago un nombre invisible en Free Fire o Mobile Legends?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Haz clic en uno de los caracteres invisibles de esta página (los que mejor funcionan suelen ser el Hangul Filler U+3164 o el Braille Pattern Blank U+2800) y pégalo en el campo para cambiar el nombre en Free Fire o Mobile Legends. Si el juego exige varios caracteres, pégalo dos o tres veces. Como es un carácter Unicode, el campo queda relleno pero tu nombre se ve vacío." }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Qué carácter invisible funciona mejor para nombres de juegos?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Los que más funcionan son el Hangul Filler (U+3164) y el Braille Pattern Blank (U+2800), porque son 'letras' vacías que rara vez rechazan los filtros de los juegos. Si uno no funciona, prueba con el otro — cada juego valida el texto de forma distinta." }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Por qué el espacio en blanco a veces se rechaza o sale un cuadrado?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Algunas apps recortan el espacio normal o todavía no admiten ciertos caracteres invisibles, así que aparece un cuadrado o el campo se considera vacío. En ese caso, cambia de carácter — por ejemplo del zero width space al Hangul Filler o al braille en blanco — o pruébalo en otra app o teléfono." }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Sirve para una bio vacía en Instagram o un mensaje en blanco de WhatsApp?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Sí. Copia un carácter invisible y pégalo en la bio de Instagram para crear líneas vacías o espaciado limpio, o envíalo como un mensaje de WhatsApp que se ve en blanco. Para líneas vacías en la bio, usa un carácter de espacio en blanco (no zero width) para que la línea no se recorte." }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Es gratis y sin instalar apps?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Es 100% gratis, funciona directamente en el navegador, sin registro y sin instalar ninguna app. Solo haz clic en el carácter invisible que quieras y pégalo donde lo necesites." }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Inicio",
+      "item": "https://ultratextgen.com/es/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Texto Invisible",
+      "item": "https://ultratextgen.com/es/texto-invisible/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/es/">Inicio</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Texto Invisible</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Texto Invisible &amp; Carácter Invisible</h1>
+    <p class="hero-tagline">Todos los espacios en blanco y caracteres invisibles que ofrece Unicode — zero width spaces, fillers y braille vacío. Haz clic en cualquier carácter para copiarlo al instante.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/library-invisible-character.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Un carácter invisible es un carácter Unicode real que se muestra como nada — un espacio en blanco que puedes copiar y pegar donde las plataformas normalmente rechazan un campo vacío. La gente lo usa para crear un nombre invisible en Free Fire y Mobile Legends, añadir líneas vacías a una bio o descripción de Instagram, enviar un mensaje de WhatsApp que parece vacío, o dar un espaciado limpio a los nicks de los juegos. Cada botón de abajo contiene un carácter invisible o en blanco auténtico: las casillas parecen vacías, pero las etiquetas te dicen exactamente qué carácter estás copiando.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="zero-width-characters">
+  <span class="article-section-label">Zero Width</span>
+  <h2>Caracteres Zero Width e Invisibles</h2>
+  <p class="u-secondary-tight">Estos caracteres no ocupan ningún ancho visible — ideales para nombres invisibles y para separar texto sin mostrar nada.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="​" aria-label="Copiar Zero Width Space — U+200B">​</button>
+      <span class="flag-label">Zero Width Space — U+200B</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‌" aria-label="Copiar Zero Width Non-Joiner — U+200C">‌</button>
+      <span class="flag-label">Zero Width Non-Joiner — U+200C</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‍" aria-label="Copiar Zero Width Joiner — U+200D">‍</button>
+      <span class="flag-label">Zero Width Joiner — U+200D</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⁠" aria-label="Copiar Word Joiner — U+2060">⁠</button>
+      <span class="flag-label">Word Joiner — U+2060</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="﻿" aria-label="Copiar Zero Width No-Break Space — U+FEFF">﻿</button>
+      <span class="flag-label">Zero Width No-Break Space — U+FEFF</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‎" aria-label="Copiar Left-to-Right Mark — U+200E">‎</button>
+      <span class="flag-label">Left-to-Right Mark — U+200E</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‏" aria-label="Copiar Right-to-Left Mark — U+200F">‏</button>
+      <span class="flag-label">Right-to-Left Mark — U+200F</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="­" aria-label="Copiar Soft Hyphen — U+00AD">­</button>
+      <span class="flag-label">Soft Hyphen — U+00AD</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="blank-spaces">
+  <span class="article-section-label">Espacios en Blanco</span>
+  <h2>Caracteres de Espacio en Blanco</h2>
+  <p class="u-secondary-tight">Con ancho visible pero vacíos: estos espacios sobreviven donde el espacio normal de la barra se recorta o se colapsa.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copiar No-Break Space — U+00A0"> </button>
+      <span class="flag-label">No-Break Space — U+00A0</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copiar En Space — U+2002"> </button>
+      <span class="flag-label">En Space — U+2002</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copiar Em Space — U+2003"> </button>
+      <span class="flag-label">Em Space — U+2003</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copiar Figure Space — U+2007"> </button>
+      <span class="flag-label">Figure Space — U+2007</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copiar Punctuation Space — U+2008"> </button>
+      <span class="flag-label">Punctuation Space — U+2008</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copiar Thin Space — U+2009"> </button>
+      <span class="flag-label">Thin Space — U+2009</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copiar Hair Space — U+200A"> </button>
+      <span class="flag-label">Hair Space — U+200A</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copiar Narrow No-Break Space — U+202F"> </button>
+      <span class="flag-label">Narrow No-Break Space — U+202F</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="wide-spaces">
+  <span class="article-section-label">Espacios Anchos</span>
+  <h2>Espacios en Blanco Anchos y Especiales</h2>
+  <p class="u-secondary-tight">Caracteres en blanco extra anchos, incluido el ideographic space de ancho completo usado en la tipografía CJK — perfectos para huecos vacíos grandes.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copiar En Quad — U+2000"> </button>
+      <span class="flag-label">En Quad — U+2000</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copiar Em Quad — U+2001"> </button>
+      <span class="flag-label">Em Quad — U+2001</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copiar Three-Per-Em Space — U+2004"> </button>
+      <span class="flag-label">Three-Per-Em Space — U+2004</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copiar Four-Per-Em Space — U+2005"> </button>
+      <span class="flag-label">Four-Per-Em Space — U+2005</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copiar Six-Per-Em Space — U+2006"> </button>
+      <span class="flag-label">Six-Per-Em Space — U+2006</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copiar Medium Mathematical Space — U+205F"> </button>
+      <span class="flag-label">Medium Mathematical Space — U+205F</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="　" aria-label="Copiar Ideographic Space — U+3000">　</button>
+      <span class="flag-label">Ideographic Space — U+3000</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="filler-characters">
+  <span class="article-section-label">Fillers</span>
+  <h2>Caracteres de Relleno y Glifo Vacío</h2>
+  <p class="u-secondary-tight">Letras y patrones que se muestran como glifos vacíos — el braille en blanco y el filler Hangul son las opciones favoritas para nombres de juego invisibles.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⠀" aria-label="Copiar Braille Pattern Blank — U+2800">⠀</button>
+      <span class="flag-label">Braille Pattern Blank — U+2800</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ㅤ" aria-label="Copiar Hangul Filler — U+3164">ㅤ</button>
+      <span class="flag-label">Hangul Filler — U+3164</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ᅟ" aria-label="Copiar Hangul Choseong Filler — U+115F">ᅟ</button>
+      <span class="flag-label">Hangul Choseong Filler — U+115F</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ᅠ" aria-label="Copiar Hangul Jungseong Filler — U+1160">ᅠ</button>
+      <span class="flag-label">Hangul Jungseong Filler — U+1160</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ﾠ" aria-label="Copiar Halfwidth Hangul Filler — U+FFA0">ﾠ</button>
+      <span class="flag-label">Halfwidth Hangul Filler — U+FFA0</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="᠎" aria-label="Copiar Mongolian Vowel Separator — U+180E">᠎</button>
+      <span class="flag-label">Mongolian Vowel Separator — U+180E</span>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Convierte texto en fuentes Unicode</h3>
+  <p>Usa UltraTextGen para convertir texto normal en fuentes Unicode en negrita, cursiva, caligráficas y más de 100 estilos — gratis e instantáneo.</p>
+  <a href="https://ultratextgen.com/es/" class="cta-btn">Abrir UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Recursos Relacionados</span>
+  <div class="compare-grid">
+    <a href="/es/usecase/zalgo-text/" class="compare-card variant-muted u-no-underline">
+      <h4>Texto Zalgo</h4>
+      <p>Genera texto glitch, maldito y espeluznante con diacríticos apilados.</p>
+    </a>
+    <a href="/es/" class="compare-card variant-muted u-no-underline">
+      <h4>Generador de Fuentes</h4>
+      <p>Convierte tu texto en negrita, cursiva y más de 100 estilos Unicode.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/es/texto-invisible/index.html
+++ b/es/texto-invisible/index.html
@@ -22,6 +22,13 @@
 <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/spasi-kosong/">
 <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/texto-invisible/">
 <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/texto-invisivel/">
+<link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/texte-invisible/">
+<link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/unsichtbares-zeichen/">
+<link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/testo-invisibile/">
+<link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/onzichtbare-tekst/">
+<link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/gorunmez-karakter/">
+<link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/ky-tu-vo-hinh/">
+<link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/niewidzialny-znak/">
 <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/invisible-character/">
 
 <meta name="robots" content="index, follow">

--- a/fr/texte-invisible/index.html
+++ b/fr/texte-invisible/index.html
@@ -1,0 +1,375 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Texte Invisible (Caractère Invisible) — Copier-Coller un Espace Vide | UltraTextGen</title>
+<meta name="description" content="Copiez du texte invisible et des caractères invisibles (zero width space, filler Hangul, braille) pour des pseudos vides sur Free Fire, une bio Instagram et des messages WhatsApp vides. Cliquez pour copier — gratuit.">
+
+<link rel="canonical" href="https://ultratextgen.com/fr/texte-invisible/">
+
+<link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/invisible-character/">
+<link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/spasi-kosong/">
+<link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/texto-invisible/">
+<link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/texto-invisivel/">
+<link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/texte-invisible/">
+<link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/unsichtbares-zeichen/">
+<link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/testo-invisibile/">
+<link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/onzichtbare-tekst/">
+<link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/gorunmez-karakter/">
+<link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/ky-tu-vo-hinh/">
+<link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/niewidzialny-znak/">
+<link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/invisible-character/">
+
+<meta name="robots" content="index, follow">
+<meta property="og:site_name" content="UltraTextGen">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/library-invisible-character.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Texte Invisible (Caractère Invisible) — Copier-Coller un Espace Vide">
+<meta name="twitter:description" content="Copiez du texte invisible et des caractères invisibles pour pseudos vides, bio Instagram et messages WhatsApp. Cliquez pour copier.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/library-invisible-character.png">
+<meta property="og:title" content="Texte Invisible (Caractère Invisible) — Copier-Coller un Espace Vide">
+<meta property="og:description" content="Copiez du texte invisible et des caractères invisibles (zero width space, filler Hangul, braille) pour pseudos vides, bio Instagram et messages WhatsApp vides. Gratuit, sans appli.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/fr/texte-invisible/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Texte Invisible (Caractère Invisible) — Copier-Coller un Espace Vide",
+  "alternateName": ["Texte Invisible", "Caractère Invisible", "Espace Vide", "Pseudo Vide", "Lettre Invisible", "Espace Invisible", "Copier Espace Vide"],
+  "description": "Copiez du texte invisible et des caractères invisibles (zero width space, filler Hangul, braille) pour des pseudos vides sur Free Fire, une bio Instagram et des messages WhatsApp vides. Cliquez pour copier — gratuit.",
+  "inLanguage": "fr",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/library-invisible-character.png",
+  "mainEntityOfPage": "https://ultratextgen.com/fr/texte-invisible/",
+  "datePublished": "2026-07-03",
+  "dateModified": "2026-07-03"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "fr",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Qu’est-ce que le texte invisible ou un caractère invisible ?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Le texte invisible est un vrai caractère Unicode qui s’affiche vide — on ne voit rien, mais il compte toujours comme du texte. On peut donc le placer là où un champ vide est normalement refusé, comme le pseudo d’un jeu, une bio ou un message. Exemples : le zero width space, le filler Hangul et le braille vide. Les boutons de cette page semblent vides, mais le libellé indique exactement quel caractère vous copiez." }
+    },
+    {
+      "@type": "Question",
+      "name": "Comment faire un pseudo invisible sur Free Fire ou Mobile Legends ?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Cliquez sur l’un des caractères invisibles de cette page (les plus efficaces sont souvent le Hangul Filler U+3164 ou le Braille Pattern Blank U+2800) et collez-le dans le champ de changement de pseudo sur Free Fire ou Mobile Legends. Si le jeu exige plusieurs caractères, collez-le deux ou trois fois. Comme c’est un caractère Unicode, le champ est rempli mais votre pseudo paraît vide." }
+    },
+    {
+      "@type": "Question",
+      "name": "Quel caractère invisible marche le mieux pour les pseudos de jeu ?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Les plus efficaces sont le Hangul Filler (U+3164) et le Braille Pattern Blank (U+2800), car ce sont des « lettres » vides rarement bloquées par les filtres des jeux. Si l’un ne marche pas, essayez l’autre — chaque jeu valide le texte différemment." }
+    },
+    {
+      "@type": "Question",
+      "name": "Pourquoi l’espace vide est parfois refusé ou affiché comme un carré ?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Certaines applis rognent l’espace normal ou ne prennent pas encore en charge certains caractères invisibles ; un carré apparaît alors, ou le champ est considéré comme vide. Dans ce cas, changez de caractère — par exemple du zero width space au Hangul Filler ou au braille vide — ou essayez sur une autre appli ou un autre téléphone." }
+    },
+    {
+      "@type": "Question",
+      "name": "Ça marche pour une bio Instagram vide ou un message WhatsApp vide ?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Oui. Copiez un caractère invisible et collez-le dans la bio Instagram pour créer des lignes vides ou un espacement propre, ou envoyez-le comme message WhatsApp qui paraît vide. Pour des lignes vides dans la bio, utilisez un caractère d’espace vide (pas zero width) afin que la ligne ne soit pas rognée." }
+    },
+    {
+      "@type": "Question",
+      "name": "Est-ce gratuit et sans application ?",
+      "acceptedAnswer": { "@type": "Answer", "text": "C’est 100 % gratuit, ça fonctionne directement dans le navigateur, sans inscription et sans installer d’application. Cliquez simplement sur le caractère invisible voulu et collez-le où vous voulez." }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Accueil",
+      "item": "https://ultratextgen.com/fr/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Texte Invisible",
+      "item": "https://ultratextgen.com/fr/texte-invisible/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/fr/">Accueil</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Texte Invisible</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Texte Invisible &amp; Caractère Invisible</h1>
+    <p class="hero-tagline">Tous les espaces vides et caractères invisibles offerts par Unicode — zero width spaces, fillers et braille vide. Cliquez sur un caractère pour le copier instantanément.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/library-invisible-character.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Un caractère invisible est un vrai caractère Unicode qui ne s’affiche pas — un espace vide que vous pouvez copier-coller là où les plateformes refusent normalement un champ vide. On l’utilise pour créer un pseudo invisible sur Free Fire et Mobile Legends, ajouter des lignes vides à une bio ou une légende Instagram, envoyer un message WhatsApp qui paraît vide, ou aérer les pseudos de jeu. Chaque bouton ci-dessous contient un caractère invisible ou vide authentique : les cases semblent vides, mais les libellés indiquent exactement quel caractère vous copiez.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="zero-width-characters">
+  <span class="article-section-label">Zero Width</span>
+  <h2>Caractères Zero Width et Invisibles</h2>
+  <p class="u-secondary-tight">Ces caractères n’occupent aucune largeur visible — parfaits pour des pseudos invisibles et pour séparer du texte sans rien afficher.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="​" aria-label="Copier Zero Width Space — U+200B">​</button>
+      <span class="flag-label">Zero Width Space — U+200B</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‌" aria-label="Copier Zero Width Non-Joiner — U+200C">‌</button>
+      <span class="flag-label">Zero Width Non-Joiner — U+200C</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‍" aria-label="Copier Zero Width Joiner — U+200D">‍</button>
+      <span class="flag-label">Zero Width Joiner — U+200D</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⁠" aria-label="Copier Word Joiner — U+2060">⁠</button>
+      <span class="flag-label">Word Joiner — U+2060</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="﻿" aria-label="Copier Zero Width No-Break Space — U+FEFF">﻿</button>
+      <span class="flag-label">Zero Width No-Break Space — U+FEFF</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‎" aria-label="Copier Left-to-Right Mark — U+200E">‎</button>
+      <span class="flag-label">Left-to-Right Mark — U+200E</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‏" aria-label="Copier Right-to-Left Mark — U+200F">‏</button>
+      <span class="flag-label">Right-to-Left Mark — U+200F</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="­" aria-label="Copier Soft Hyphen — U+00AD">­</button>
+      <span class="flag-label">Soft Hyphen — U+00AD</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="blank-spaces">
+  <span class="article-section-label">Espaces Vides</span>
+  <h2>Caractères d’Espace Vide</h2>
+  <p class="u-secondary-tight">De largeur visible mais vides : ces espaces survivent là où l’espace de la barre normale est rogné ou fusionné.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copier No-Break Space — U+00A0"> </button>
+      <span class="flag-label">No-Break Space — U+00A0</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copier En Space — U+2002"> </button>
+      <span class="flag-label">En Space — U+2002</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copier Em Space — U+2003"> </button>
+      <span class="flag-label">Em Space — U+2003</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copier Figure Space — U+2007"> </button>
+      <span class="flag-label">Figure Space — U+2007</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copier Punctuation Space — U+2008"> </button>
+      <span class="flag-label">Punctuation Space — U+2008</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copier Thin Space — U+2009"> </button>
+      <span class="flag-label">Thin Space — U+2009</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copier Hair Space — U+200A"> </button>
+      <span class="flag-label">Hair Space — U+200A</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copier Narrow No-Break Space — U+202F"> </button>
+      <span class="flag-label">Narrow No-Break Space — U+202F</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="wide-spaces">
+  <span class="article-section-label">Espaces Larges</span>
+  <h2>Espaces Vides Larges et Spéciaux</h2>
+  <p class="u-secondary-tight">Caractères vides très larges, dont l’ideographic space pleine largeur utilisé en typographie CJK — idéals pour de grands espaces vides.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copier En Quad — U+2000"> </button>
+      <span class="flag-label">En Quad — U+2000</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copier Em Quad — U+2001"> </button>
+      <span class="flag-label">Em Quad — U+2001</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copier Three-Per-Em Space — U+2004"> </button>
+      <span class="flag-label">Three-Per-Em Space — U+2004</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copier Four-Per-Em Space — U+2005"> </button>
+      <span class="flag-label">Four-Per-Em Space — U+2005</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copier Six-Per-Em Space — U+2006"> </button>
+      <span class="flag-label">Six-Per-Em Space — U+2006</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copier Medium Mathematical Space — U+205F"> </button>
+      <span class="flag-label">Medium Mathematical Space — U+205F</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="　" aria-label="Copier Ideographic Space — U+3000">　</button>
+      <span class="flag-label">Ideographic Space — U+3000</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="filler-characters">
+  <span class="article-section-label">Fillers</span>
+  <h2>Caractères de Remplissage et Glyphe Vide</h2>
+  <p class="u-secondary-tight">Lettres et motifs qui s’affichent comme des glyphes vides — le braille vide et le filler Hangul sont les préférés pour des pseudos de jeu invisibles.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⠀" aria-label="Copier Braille Pattern Blank — U+2800">⠀</button>
+      <span class="flag-label">Braille Pattern Blank — U+2800</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ㅤ" aria-label="Copier Hangul Filler — U+3164">ㅤ</button>
+      <span class="flag-label">Hangul Filler — U+3164</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ᅟ" aria-label="Copier Hangul Choseong Filler — U+115F">ᅟ</button>
+      <span class="flag-label">Hangul Choseong Filler — U+115F</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ᅠ" aria-label="Copier Hangul Jungseong Filler — U+1160">ᅠ</button>
+      <span class="flag-label">Hangul Jungseong Filler — U+1160</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ﾠ" aria-label="Copier Halfwidth Hangul Filler — U+FFA0">ﾠ</button>
+      <span class="flag-label">Halfwidth Hangul Filler — U+FFA0</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="᠎" aria-label="Copier Mongolian Vowel Separator — U+180E">᠎</button>
+      <span class="flag-label">Mongolian Vowel Separator — U+180E</span>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Transformez du texte en polices Unicode</h3>
+  <p>Utilisez UltraTextGen pour convertir du texte normal en polices Unicode gras, italique, cursive et plus de 100 styles — gratuit et instantané.</p>
+  <a href="https://ultratextgen.com/fr/" class="cta-btn">Ouvrir UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Ressources Associées</span>
+  <div class="compare-grid">
+    <a href="/fr/usecase/pseudo-fortnite/" class="compare-card variant-muted u-no-underline">
+      <h4>Pseudo Fortnite</h4>
+      <p>Pseudos Fortnite stylés avec symboles et caractères invisibles.</p>
+    </a>
+    <a href="/fr/petite-ecriture/" class="compare-card variant-muted u-no-underline">
+      <h4>Petite Écriture</h4>
+      <p>Créez des petites lettres et exposants pour bio, légende et pseudos.</p>
+    </a>
+    <a href="/fr/library/symboles/" class="compare-card variant-muted u-no-underline">
+      <h4>Symboles</h4>
+      <p>Collection de symboles pour noms, bios et légendes.</p>
+    </a>
+    <a href="/fr/usecase/zalgo-text/" class="compare-card variant-muted u-no-underline">
+      <h4>Texte Zalgo</h4>
+      <p>Générez du texte glitch, maudit et effrayant.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/id/spasi-kosong/index.html
+++ b/id/spasi-kosong/index.html
@@ -22,6 +22,13 @@
 <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/spasi-kosong/">
 <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/texto-invisible/">
 <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/texto-invisivel/">
+<link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/texte-invisible/">
+<link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/unsichtbares-zeichen/">
+<link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/testo-invisibile/">
+<link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/onzichtbare-tekst/">
+<link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/gorunmez-karakter/">
+<link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/ky-tu-vo-hinh/">
+<link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/niewidzialny-znak/">
 <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/invisible-character/">
 
 <meta name="robots" content="index, follow">

--- a/id/spasi-kosong/index.html
+++ b/id/spasi-kosong/index.html
@@ -20,6 +20,8 @@
 
 <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/invisible-character/">
 <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/spasi-kosong/">
+<link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/texto-invisible/">
+<link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/texto-invisivel/">
 <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/invisible-character/">
 
 <meta name="robots" content="index, follow">

--- a/id/spasi-kosong/index.html
+++ b/id/spasi-kosong/index.html
@@ -1,0 +1,366 @@
+<!DOCTYPE html>
+<html lang="id">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Spasi Kosong (Karakter Kosong) — Copy Paste Nama & Teks Kosong | UltraTextGen</title>
+<meta name="description" content="Salin spasi kosong & karakter kosong (zero width space, Hangul filler, braille) buat nama kosong FF/ML, bio IG kosong, & pesan WA kosong. Klik langsung salin — gratis, tanpa aplikasi.">
+
+<link rel="canonical" href="https://ultratextgen.com/id/spasi-kosong/">
+
+<link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/invisible-character/">
+<link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/spasi-kosong/">
+<link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/invisible-character/">
+
+<meta name="robots" content="index, follow">
+<meta property="og:site_name" content="UltraTextGen">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/library-invisible-character.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Spasi Kosong (Karakter Kosong) — Copy Paste Nama & Teks Kosong">
+<meta name="twitter:description" content="Salin spasi kosong & karakter kosong buat nama kosong FF/ML, bio IG, & status WA. Klik langsung salin.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/library-invisible-character.png">
+<meta property="og:title" content="Spasi Kosong (Karakter Kosong) — Copy Paste Nama & Teks Kosong">
+<meta property="og:description" content="Salin spasi kosong & karakter kosong (zero width space, Hangul filler, braille) buat nama kosong FF/ML, bio IG kosong, & pesan WA kosong. Gratis, tanpa aplikasi.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/id/spasi-kosong/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Spasi Kosong (Karakter Kosong) — Copy Paste Nama & Teks Kosong",
+  "alternateName": ["Spasi Kosong", "Karakter Kosong", "Teks Kosong", "Nama Kosong", "Font Kosong", "Huruf Kosong", "Blank Space Copy Paste"],
+  "description": "Salin spasi kosong & karakter kosong (zero width space, Hangul filler, braille) buat nama kosong FF/ML, bio IG kosong, & pesan WA kosong. Klik langsung salin — gratis, tanpa aplikasi.",
+  "inLanguage": "id",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/library-invisible-character.png",
+  "mainEntityOfPage": "https://ultratextgen.com/id/spasi-kosong/",
+  "datePublished": "2026-07-03",
+  "dateModified": "2026-07-03"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "id",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Apa itu spasi kosong atau karakter kosong?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Spasi kosong (atau karakter kosong) adalah karakter Unicode asli yang tampil kosong — nggak kelihatan apa-apa, tapi tetap dianggap teks. Jadi kamu bisa menaruhnya di tempat yang biasanya menolak input kosong, misalnya kolom nama game, bio, atau pesan chat. Contohnya zero width space, Hangul filler, dan braille blank. Tombol di halaman ini kelihatan kosong, tapi labelnya kasih tahu persis karakter apa yang kamu salin." }
+    },
+    {
+      "@type": "Question",
+      "name": "Gimana cara bikin nama kosong di Free Fire atau Mobile Legends?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Klik salah satu karakter kosong di halaman ini (yang paling sering work adalah Hangul Filler U+3164 atau Braille Pattern Blank U+2800), lalu tempel ke kolom ganti nama di Free Fire atau Mobile Legends. Kalau game minta minimal beberapa karakter, tempel dua atau tiga kali. Karena ini karakter Unicode, kolomnya terisi tapi namamu tampil kosong." }
+    },
+    {
+      "@type": "Question",
+      "name": "Karakter kosong mana yang paling work buat nama game?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Yang paling sering berhasil adalah Hangul Filler (U+3164) dan Braille Pattern Blank (U+2800), karena keduanya berupa 'huruf' kosong yang jarang ditolak filter game. Kalau salah satu ditolak, coba yang lain — tiap game punya aturan validasi berbeda." }
+    },
+    {
+      "@type": "Question",
+      "name": "Kenapa spasi kosong kadang ditolak atau muncul kotak?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Sebagian aplikasi memangkas spasi biasa atau belum mendukung karakter kosong tertentu, jadi muncul kotak atau input dianggap kosong. Kalau begitu, ganti ke karakter lain — misalnya dari zero width space ke Hangul Filler atau braille blank — atau coba di aplikasi/HP lain." }
+    },
+    {
+      "@type": "Question",
+      "name": "Bisa dipakai buat bio IG kosong atau status WA kosong?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Bisa. Salin karakter kosong lalu tempel ke bio Instagram untuk bikin baris kosong/jarak rapi, atau kirim sebagai pesan WhatsApp yang kelihatan kosong. Untuk baris kosong di bio, pakai karakter blank space (bukan zero width) supaya barisnya tidak terpangkas." }
+    },
+    {
+      "@type": "Question",
+      "name": "Gratis dan tanpa aplikasi?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Gratis 100%, jalan langsung di browser, tanpa daftar dan tanpa install aplikasi. Tinggal klik karakter kosong yang kamu mau, lalu tempel di mana pun." }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Tulisan Aesthetic",
+      "item": "https://ultratextgen.com/id/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Spasi Kosong",
+      "item": "https://ultratextgen.com/id/spasi-kosong/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/id/">Tulisan Aesthetic</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Spasi Kosong</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Spasi Kosong &amp; Karakter Kosong</h1>
+    <p class="hero-tagline">Semua spasi kosong dan karakter kosong yang disediakan Unicode — zero width space, filler, dan braille kosong. Klik karakter mana pun untuk langsung menyalinnya.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/library-invisible-character.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Karakter kosong adalah karakter Unicode asli yang tampil kosong — spasi yang bisa kamu salin dan tempel di tempat yang biasanya menolak input kosong. Orang memakainya untuk membuat nama kosong di Free Fire dan Mobile Legends, menambah baris kosong di bio atau caption Instagram, mengirim pesan WhatsApp yang kelihatan kosong, atau merapikan jarak pada nickname game. Setiap tombol di bawah berisi karakter kosong atau blank yang asli: tampilannya kosong, tapi labelnya memberi tahu persis karakter apa yang kamu salin.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="zero-width-characters">
+  <span class="article-section-label">Zero Width</span>
+  <h2>Karakter Zero Width &amp; Tak Terlihat</h2>
+  <p class="u-secondary-tight">Karakter ini sama sekali tidak punya lebar — paling pas buat nama kosong dan memecah teks tanpa menampilkan apa pun.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="​" aria-label="Salin Zero Width Space — U+200B">​</button>
+      <span class="flag-label">Zero Width Space — U+200B</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‌" aria-label="Salin Zero Width Non-Joiner — U+200C">‌</button>
+      <span class="flag-label">Zero Width Non-Joiner — U+200C</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‍" aria-label="Salin Zero Width Joiner — U+200D">‍</button>
+      <span class="flag-label">Zero Width Joiner — U+200D</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⁠" aria-label="Salin Word Joiner — U+2060">⁠</button>
+      <span class="flag-label">Word Joiner — U+2060</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="﻿" aria-label="Salin Zero Width No-Break Space — U+FEFF">﻿</button>
+      <span class="flag-label">Zero Width No-Break Space — U+FEFF</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‎" aria-label="Salin Left-to-Right Mark — U+200E">‎</button>
+      <span class="flag-label">Left-to-Right Mark — U+200E</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‏" aria-label="Salin Right-to-Left Mark — U+200F">‏</button>
+      <span class="flag-label">Right-to-Left Mark — U+200F</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="­" aria-label="Salin Soft Hyphen — U+00AD">­</button>
+      <span class="flag-label">Soft Hyphen — U+00AD</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="blank-spaces">
+  <span class="article-section-label">Spasi Kosong</span>
+  <h2>Karakter Spasi Kosong</h2>
+  <p class="u-secondary-tight">Punya lebar tapi tetap kosong: spasi ini bertahan di tempat yang biasanya memangkas atau menggabungkan spasi bar biasa.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Salin No-Break Space — U+00A0"> </button>
+      <span class="flag-label">No-Break Space — U+00A0</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Salin En Space — U+2002"> </button>
+      <span class="flag-label">En Space — U+2002</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Salin Em Space — U+2003"> </button>
+      <span class="flag-label">Em Space — U+2003</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Salin Figure Space — U+2007"> </button>
+      <span class="flag-label">Figure Space — U+2007</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Salin Punctuation Space — U+2008"> </button>
+      <span class="flag-label">Punctuation Space — U+2008</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Salin Thin Space — U+2009"> </button>
+      <span class="flag-label">Thin Space — U+2009</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Salin Hair Space — U+200A"> </button>
+      <span class="flag-label">Hair Space — U+200A</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Salin Narrow No-Break Space — U+202F"> </button>
+      <span class="flag-label">Narrow No-Break Space — U+202F</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="wide-spaces">
+  <span class="article-section-label">Spasi Lebar</span>
+  <h2>Spasi Kosong Lebar &amp; Khusus</h2>
+  <p class="u-secondary-tight">Karakter kosong ekstra lebar, termasuk ideographic space full-width yang dipakai di tipografi CJK — pas buat jarak kosong yang besar.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Salin En Quad — U+2000"> </button>
+      <span class="flag-label">En Quad — U+2000</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Salin Em Quad — U+2001"> </button>
+      <span class="flag-label">Em Quad — U+2001</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Salin Three-Per-Em Space — U+2004"> </button>
+      <span class="flag-label">Three-Per-Em Space — U+2004</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Salin Four-Per-Em Space — U+2005"> </button>
+      <span class="flag-label">Four-Per-Em Space — U+2005</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Salin Six-Per-Em Space — U+2006"> </button>
+      <span class="flag-label">Six-Per-Em Space — U+2006</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Salin Medium Mathematical Space — U+205F"> </button>
+      <span class="flag-label">Medium Mathematical Space — U+205F</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="　" aria-label="Salin Ideographic Space — U+3000">　</button>
+      <span class="flag-label">Ideographic Space — U+3000</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="filler-characters">
+  <span class="article-section-label">Filler</span>
+  <h2>Karakter Filler &amp; Glyph Kosong</h2>
+  <p class="u-secondary-tight">Huruf dan pola yang tampil sebagai glyph kosong — braille blank dan Hangul filler adalah pilihan utama buat nama game kosong.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⠀" aria-label="Salin Braille Pattern Blank — U+2800">⠀</button>
+      <span class="flag-label">Braille Pattern Blank — U+2800</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ㅤ" aria-label="Salin Hangul Filler — U+3164">ㅤ</button>
+      <span class="flag-label">Hangul Filler — U+3164</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ᅟ" aria-label="Salin Hangul Choseong Filler — U+115F">ᅟ</button>
+      <span class="flag-label">Hangul Choseong Filler — U+115F</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ᅠ" aria-label="Salin Hangul Jungseong Filler — U+1160">ᅠ</button>
+      <span class="flag-label">Hangul Jungseong Filler — U+1160</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ﾠ" aria-label="Salin Halfwidth Hangul Filler — U+FFA0">ﾠ</button>
+      <span class="flag-label">Halfwidth Hangul Filler — U+FFA0</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="᠎" aria-label="Salin Mongolian Vowel Separator — U+180E">᠎</button>
+      <span class="flag-label">Mongolian Vowel Separator — U+180E</span>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Ubah teks jadi font Unicode keren</h3>
+  <p>Pakai UltraTextGen untuk mengubah teks biasa jadi font Unicode tebal, miring, cursive, dan 100+ gaya lain — gratis dan instan.</p>
+  <a href="https://ultratextgen.com/id/" class="cta-btn">Buka UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Halaman Terkait</span>
+  <div class="compare-grid">
+    <a href="/id/usecase/nama-ff-keren/" class="compare-card variant-muted u-no-underline">
+      <h4>Nama FF Keren</h4>
+      <p>Nickname Free Fire keren beserta simbol dan karakter kosong.</p>
+    </a>
+    <a href="/id/usecase/nama-ml-keren/" class="compare-card variant-muted u-no-underline">
+      <h4>Nama ML Keren</h4>
+      <p>Nickname Mobile Legends estetik dengan simbol dan spasi kosong.</p>
+    </a>
+    <a href="/id/tulisan-kecil/" class="compare-card variant-muted u-no-underline">
+      <h4>Tulisan Kecil</h4>
+      <p>Bikin huruf kecil dan superscript buat bio, caption, dan nickname.</p>
+    </a>
+    <a href="/id/library/simbol-aesthetic/" class="compare-card variant-muted u-no-underline">
+      <h4>Simbol Aesthetic</h4>
+      <p>Kumpulan simbol aesthetic buat nama, bio, dan status.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/it/testo-invisibile/index.html
+++ b/it/testo-invisibile/index.html
@@ -1,0 +1,367 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Testo Invisibile (Carattere Invisibile) — Copia e Incolla Spazio Vuoto | UltraTextGen</title>
+<meta name="description" content="Copia testo invisibile e caratteri invisibili (zero width space, filler Hangul, braille) per nomi vuoti su Free Fire, bio di Instagram e messaggi vuoti su WhatsApp. Clicca per copiare — gratis.">
+
+<link rel="canonical" href="https://ultratextgen.com/it/testo-invisibile/">
+
+<link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/invisible-character/">
+<link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/spasi-kosong/">
+<link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/texto-invisible/">
+<link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/texto-invisivel/">
+<link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/texte-invisible/">
+<link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/unsichtbares-zeichen/">
+<link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/testo-invisibile/">
+<link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/onzichtbare-tekst/">
+<link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/gorunmez-karakter/">
+<link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/ky-tu-vo-hinh/">
+<link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/niewidzialny-znak/">
+<link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/invisible-character/">
+
+<meta name="robots" content="index, follow">
+<meta property="og:site_name" content="UltraTextGen">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/library-invisible-character.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Testo Invisibile (Carattere Invisibile) — Copia e Incolla Spazio Vuoto">
+<meta name="twitter:description" content="Copia testo invisibile e caratteri invisibili per nomi vuoti, bio di Instagram e messaggi WhatsApp. Clicca per copiare.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/library-invisible-character.png">
+<meta property="og:title" content="Testo Invisibile (Carattere Invisibile) — Copia e Incolla Spazio Vuoto">
+<meta property="og:description" content="Copia testo invisibile e caratteri invisibili (zero width space, filler Hangul, braille) per nomi vuoti, bio di Instagram e messaggi vuoti su WhatsApp. Gratis, senza app.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/it/testo-invisibile/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Testo Invisibile (Carattere Invisibile) — Copia e Incolla Spazio Vuoto",
+  "alternateName": ["Testo Invisibile", "Carattere Invisibile", "Spazio Vuoto", "Nome Vuoto", "Lettera Invisibile", "Spazio Invisibile", "Copia Spazio Vuoto"],
+  "description": "Copia testo invisibile e caratteri invisibili (zero width space, filler Hangul, braille) per nomi vuoti su Free Fire, bio di Instagram e messaggi vuoti su WhatsApp. Clicca per copiare — gratis.",
+  "inLanguage": "it",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/library-invisible-character.png",
+  "mainEntityOfPage": "https://ultratextgen.com/it/testo-invisibile/",
+  "datePublished": "2026-07-03",
+  "dateModified": "2026-07-03"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "it",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Che cos’è il testo invisibile o un carattere invisibile?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Il testo invisibile è un vero carattere Unicode che appare vuoto — non si vede nulla, ma conta comunque come testo. Per questo puoi metterlo dove di solito non si accetta un campo vuoto, come il nome di un gioco, una bio o un messaggio in chat. Esempi: lo zero width space, il filler Hangul e il braille vuoto. I pulsanti di questa pagina sembrano vuoti, ma l’etichetta indica esattamente quale carattere stai copiando." }
+    },
+    {
+      "@type": "Question",
+      "name": "Come faccio un nome invisibile su Free Fire o Mobile Legends?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Clicca su uno dei caratteri invisibili di questa pagina (i più efficaci di solito sono l’Hangul Filler U+3164 o il Braille Pattern Blank U+2800) e incollalo nel campo per cambiare nome su Free Fire o Mobile Legends. Se il gioco richiede più caratteri, incollalo due o tre volte. Essendo un carattere Unicode, il campo risulta pieno ma il tuo nome appare vuoto." }
+    },
+    {
+      "@type": "Question",
+      "name": "Quale carattere invisibile funziona meglio per i nomi dei giochi?",
+      "acceptedAnswer": { "@type": "Answer", "text": "I più efficaci sono l’Hangul Filler (U+3164) e il Braille Pattern Blank (U+2800), perché sono «lettere» vuote raramente bloccate dai filtri dei giochi. Se uno non funziona, prova l’altro — ogni gioco valida il testo in modo diverso." }
+    },
+    {
+      "@type": "Question",
+      "name": "Perché lo spazio vuoto a volte viene rifiutato o diventa un quadratino?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Alcune app tagliano lo spazio normale o non supportano ancora certi caratteri invisibili, così appare un quadratino o il campo è considerato vuoto. In quel caso cambia carattere — ad esempio dallo zero width space all’Hangul Filler o al braille vuoto — oppure provalo su un’altra app o su un altro telefono." }
+    },
+    {
+      "@type": "Question",
+      "name": "Va bene per una bio Instagram vuota o un messaggio WhatsApp vuoto?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Sì. Copia un carattere invisibile e incollalo nella bio di Instagram per creare righe vuote o spaziatura pulita, oppure invialo come messaggio WhatsApp che appare vuoto. Per righe vuote nella bio usa un carattere di spazio vuoto (non zero width) così la riga non viene tagliata." }
+    },
+    {
+      "@type": "Question",
+      "name": "È gratis e senza app?",
+      "acceptedAnswer": { "@type": "Answer", "text": "È 100% gratis, funziona direttamente nel browser, senza registrazione e senza installare app. Basta cliccare sul carattere invisibile che vuoi e incollarlo dove ti serve." }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://ultratextgen.com/it/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Testo Invisibile",
+      "item": "https://ultratextgen.com/it/testo-invisibile/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/it/">Home</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Testo Invisibile</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Testo Invisibile &amp; Carattere Invisibile</h1>
+    <p class="hero-tagline">Tutti gli spazi vuoti e i caratteri invisibili offerti da Unicode — zero width space, filler e braille vuoto. Clicca su un carattere per copiarlo all’istante.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/library-invisible-character.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Un carattere invisibile è un vero carattere Unicode che appare come niente — uno spazio vuoto che puoi copiare e incollare dove le piattaforme di solito rifiutano un campo vuoto. Si usa per creare un nome invisibile su Free Fire e Mobile Legends, aggiungere righe vuote a una bio o didascalia di Instagram, inviare un messaggio WhatsApp che sembra vuoto, o dare spaziatura pulita ai nick dei giochi. Ogni pulsante qui sotto contiene un carattere invisibile o vuoto autentico: le caselle sembrano vuote, ma le etichette dicono esattamente quale carattere stai copiando.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="zero-width-characters">
+  <span class="article-section-label">Zero Width</span>
+  <h2>Caratteri Zero Width e Invisibili</h2>
+  <p class="u-secondary-tight">Questi caratteri non occupano alcuna larghezza visibile — ideali per nomi invisibili e per separare il testo senza mostrare nulla.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="​" aria-label="Copia Zero Width Space — U+200B">​</button>
+      <span class="flag-label">Zero Width Space — U+200B</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‌" aria-label="Copia Zero Width Non-Joiner — U+200C">‌</button>
+      <span class="flag-label">Zero Width Non-Joiner — U+200C</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‍" aria-label="Copia Zero Width Joiner — U+200D">‍</button>
+      <span class="flag-label">Zero Width Joiner — U+200D</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⁠" aria-label="Copia Word Joiner — U+2060">⁠</button>
+      <span class="flag-label">Word Joiner — U+2060</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="﻿" aria-label="Copia Zero Width No-Break Space — U+FEFF">﻿</button>
+      <span class="flag-label">Zero Width No-Break Space — U+FEFF</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‎" aria-label="Copia Left-to-Right Mark — U+200E">‎</button>
+      <span class="flag-label">Left-to-Right Mark — U+200E</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‏" aria-label="Copia Right-to-Left Mark — U+200F">‏</button>
+      <span class="flag-label">Right-to-Left Mark — U+200F</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="­" aria-label="Copia Soft Hyphen — U+00AD">­</button>
+      <span class="flag-label">Soft Hyphen — U+00AD</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="blank-spaces">
+  <span class="article-section-label">Spazi Vuoti</span>
+  <h2>Caratteri di Spazio Vuoto</h2>
+  <p class="u-secondary-tight">Di larghezza visibile ma vuoti: questi spazi sopravvivono dove lo spazio normale della barra viene tagliato o unito.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copia No-Break Space — U+00A0"> </button>
+      <span class="flag-label">No-Break Space — U+00A0</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copia En Space — U+2002"> </button>
+      <span class="flag-label">En Space — U+2002</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copia Em Space — U+2003"> </button>
+      <span class="flag-label">Em Space — U+2003</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copia Figure Space — U+2007"> </button>
+      <span class="flag-label">Figure Space — U+2007</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copia Punctuation Space — U+2008"> </button>
+      <span class="flag-label">Punctuation Space — U+2008</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copia Thin Space — U+2009"> </button>
+      <span class="flag-label">Thin Space — U+2009</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copia Hair Space — U+200A"> </button>
+      <span class="flag-label">Hair Space — U+200A</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copia Narrow No-Break Space — U+202F"> </button>
+      <span class="flag-label">Narrow No-Break Space — U+202F</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="wide-spaces">
+  <span class="article-section-label">Spazi Larghi</span>
+  <h2>Spazi Vuoti Larghi e Speciali</h2>
+  <p class="u-secondary-tight">Caratteri vuoti extra larghi, incluso l’ideographic space a larghezza piena usato nella tipografia CJK — perfetti per grandi spazi vuoti.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copia En Quad — U+2000"> </button>
+      <span class="flag-label">En Quad — U+2000</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copia Em Quad — U+2001"> </button>
+      <span class="flag-label">Em Quad — U+2001</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copia Three-Per-Em Space — U+2004"> </button>
+      <span class="flag-label">Three-Per-Em Space — U+2004</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copia Four-Per-Em Space — U+2005"> </button>
+      <span class="flag-label">Four-Per-Em Space — U+2005</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copia Six-Per-Em Space — U+2006"> </button>
+      <span class="flag-label">Six-Per-Em Space — U+2006</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copia Medium Mathematical Space — U+205F"> </button>
+      <span class="flag-label">Medium Mathematical Space — U+205F</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="　" aria-label="Copia Ideographic Space — U+3000">　</button>
+      <span class="flag-label">Ideographic Space — U+3000</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="filler-characters">
+  <span class="article-section-label">Filler</span>
+  <h2>Caratteri di Riempimento e Glifo Vuoto</h2>
+  <p class="u-secondary-tight">Lettere e motivi che appaiono come glifi vuoti — il braille vuoto e il filler Hangul sono i preferiti per nomi di gioco invisibili.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⠀" aria-label="Copia Braille Pattern Blank — U+2800">⠀</button>
+      <span class="flag-label">Braille Pattern Blank — U+2800</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ㅤ" aria-label="Copia Hangul Filler — U+3164">ㅤ</button>
+      <span class="flag-label">Hangul Filler — U+3164</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ᅟ" aria-label="Copia Hangul Choseong Filler — U+115F">ᅟ</button>
+      <span class="flag-label">Hangul Choseong Filler — U+115F</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ᅠ" aria-label="Copia Hangul Jungseong Filler — U+1160">ᅠ</button>
+      <span class="flag-label">Hangul Jungseong Filler — U+1160</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ﾠ" aria-label="Copia Halfwidth Hangul Filler — U+FFA0">ﾠ</button>
+      <span class="flag-label">Halfwidth Hangul Filler — U+FFA0</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="᠎" aria-label="Copia Mongolian Vowel Separator — U+180E">᠎</button>
+      <span class="flag-label">Mongolian Vowel Separator — U+180E</span>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Trasforma il testo in font Unicode</h3>
+  <p>Usa UltraTextGen per convertire il testo normale in font Unicode grassetto, corsivo, calligrafico e oltre 100 stili — gratis e istantaneo.</p>
+  <a href="https://ultratextgen.com/it/" class="cta-btn">Apri UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Risorse Correlate</span>
+  <div class="compare-grid">
+    <a href="/it/usecase/zalgo-text/" class="compare-card variant-muted u-no-underline">
+      <h4>Testo Zalgo</h4>
+      <p>Genera testo glitch, maledetto e inquietante con segni sovrapposti.</p>
+    </a>
+    <a href="/it/" class="compare-card variant-muted u-no-underline">
+      <h4>Generatore di Font</h4>
+      <p>Converti il tuo testo in grassetto, corsivo e oltre 100 stili Unicode.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/library/invisible-character/index.html
+++ b/library/invisible-character/index.html
@@ -20,6 +20,8 @@
 
 <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/invisible-character/">
 <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/spasi-kosong/">
+<link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/texto-invisible/">
+<link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/texto-invisivel/">
 <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/invisible-character/">
 
 <meta property="og:image" content="https://ultratextgen.com/assets/og/library-invisible-character.png">

--- a/library/invisible-character/index.html
+++ b/library/invisible-character/index.html
@@ -17,6 +17,11 @@
 <meta name="description" content="Copy an invisible character or blank space — zero width space, Hangul filler, braille blank — for empty names and bios. Click any symbol to copy it instantly.">
 
 <link rel="canonical" href="https://ultratextgen.com/library/invisible-character/">
+
+<link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/invisible-character/">
+<link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/spasi-kosong/">
+<link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/invisible-character/">
+
 <meta property="og:image" content="https://ultratextgen.com/assets/og/library-invisible-character.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">

--- a/library/invisible-character/index.html
+++ b/library/invisible-character/index.html
@@ -22,6 +22,13 @@
 <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/spasi-kosong/">
 <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/texto-invisible/">
 <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/texto-invisivel/">
+<link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/texte-invisible/">
+<link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/unsichtbares-zeichen/">
+<link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/testo-invisibile/">
+<link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/onzichtbare-tekst/">
+<link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/gorunmez-karakter/">
+<link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/ky-tu-vo-hinh/">
+<link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/niewidzialny-znak/">
 <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/invisible-character/">
 
 <meta property="og:image" content="https://ultratextgen.com/assets/og/library-invisible-character.png">

--- a/nl/onzichtbare-tekst/index.html
+++ b/nl/onzichtbare-tekst/index.html
@@ -1,0 +1,375 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Onzichtbare Tekst (Onzichtbaar Teken) — Lege Spatie Kopiëren en Plakken | UltraTextGen</title>
+<meta name="description" content="Kopieer onzichtbare tekst en onzichtbare tekens (zero width space, Hangul-filler, braille) voor lege namen in Free Fire, een Instagram-bio en lege WhatsApp-berichten. Klik om te kopiëren — gratis.">
+
+<link rel="canonical" href="https://ultratextgen.com/nl/onzichtbare-tekst/">
+
+<link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/invisible-character/">
+<link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/spasi-kosong/">
+<link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/texto-invisible/">
+<link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/texto-invisivel/">
+<link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/texte-invisible/">
+<link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/unsichtbares-zeichen/">
+<link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/testo-invisibile/">
+<link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/onzichtbare-tekst/">
+<link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/gorunmez-karakter/">
+<link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/ky-tu-vo-hinh/">
+<link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/niewidzialny-znak/">
+<link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/invisible-character/">
+
+<meta name="robots" content="index, follow">
+<meta property="og:site_name" content="UltraTextGen">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/library-invisible-character.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Onzichtbare Tekst (Onzichtbaar Teken) — Lege Spatie Kopiëren en Plakken">
+<meta name="twitter:description" content="Kopieer onzichtbare tekst en onzichtbare tekens voor lege namen, Instagram-bio en WhatsApp-berichten. Klik om te kopiëren.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/library-invisible-character.png">
+<meta property="og:title" content="Onzichtbare Tekst (Onzichtbaar Teken) — Lege Spatie Kopiëren en Plakken">
+<meta property="og:description" content="Kopieer onzichtbare tekst en onzichtbare tekens (zero width space, Hangul-filler, braille) voor lege namen, Instagram-bio en lege WhatsApp-berichten. Gratis, zonder app.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/nl/onzichtbare-tekst/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Onzichtbare Tekst (Onzichtbaar Teken) — Lege Spatie Kopiëren en Plakken",
+  "alternateName": ["Onzichtbare Tekst", "Onzichtbaar Teken", "Lege Spatie", "Lege Naam", "Onzichtbare Letter", "Onzichtbare Spatie", "Lege Spatie Kopiëren"],
+  "description": "Kopieer onzichtbare tekst en onzichtbare tekens (zero width space, Hangul-filler, braille) voor lege namen in Free Fire, een Instagram-bio en lege WhatsApp-berichten. Klik om te kopiëren — gratis.",
+  "inLanguage": "nl",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/library-invisible-character.png",
+  "mainEntityOfPage": "https://ultratextgen.com/nl/onzichtbare-tekst/",
+  "datePublished": "2026-07-03",
+  "dateModified": "2026-07-03"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "nl",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Wat is onzichtbare tekst of een onzichtbaar teken?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Onzichtbare tekst is een echt Unicode-teken dat leeg wordt weergegeven — je ziet niets, maar het telt nog steeds als tekst. Daarom kun je het plaatsen waar een leeg veld normaal niet wordt geaccepteerd, zoals een gamenaam, een bio of een chatbericht. Voorbeelden: de zero width space, de Hangul-filler en het lege braille. De knoppen op deze pagina lijken leeg, maar het label laat precies zien welk teken je kopieert." }
+    },
+    {
+      "@type": "Question",
+      "name": "Hoe maak ik een onzichtbare naam in Free Fire of Mobile Legends?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Klik op een van de onzichtbare tekens op deze pagina (de Hangul Filler U+3164 of de Braille Pattern Blank U+2800 werken meestal het best) en plak het in het naamveld in Free Fire of Mobile Legends. Vraagt het spel om meerdere tekens, plak het dan twee of drie keer. Omdat het een Unicode-teken is, is het veld gevuld maar lijkt je naam leeg." }
+    },
+    {
+      "@type": "Question",
+      "name": "Welk onzichtbaar teken werkt het best voor gamenamen?",
+      "acceptedAnswer": { "@type": "Answer", "text": "De Hangul Filler (U+3164) en de Braille Pattern Blank (U+2800) werken het best, omdat het lege ‘letters’ zijn die zelden worden geblokkeerd door gamefilters. Werkt de een niet, probeer dan de ander — elk spel controleert tekst anders." }
+    },
+    {
+      "@type": "Question",
+      "name": "Waarom wordt de lege spatie soms geweigerd of als een blokje getoond?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Sommige apps kappen de gewone spatie af of ondersteunen bepaalde onzichtbare tekens nog niet, dus verschijnt er een blokje of geldt het veld als leeg. Wissel dan van teken — bijvoorbeeld van de zero width space naar de Hangul Filler of het lege braille — of probeer het in een andere app of op een andere telefoon." }
+    },
+    {
+      "@type": "Question",
+      "name": "Werkt het voor een lege Instagram-bio of een leeg WhatsApp-bericht?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Ja. Kopieer een onzichtbaar teken en plak het in de Instagram-bio voor lege regels of nette witruimte, of stuur het als een schijnbaar leeg WhatsApp-bericht. Gebruik voor lege regels in de bio een lege-spatie-teken (geen zero width), zodat de regel niet wordt afgekapt." }
+    },
+    {
+      "@type": "Question",
+      "name": "Is het gratis en zonder app?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Het is 100% gratis, werkt direct in de browser, zonder registratie en zonder app te installeren. Klik gewoon op het gewenste onzichtbare teken en plak het waar je wilt." }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://ultratextgen.com/nl/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Onzichtbare Tekst",
+      "item": "https://ultratextgen.com/nl/onzichtbare-tekst/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/nl/">Home</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Onzichtbare Tekst</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Onzichtbare Tekst &amp; Onzichtbaar Teken</h1>
+    <p class="hero-tagline">Alle lege spaties en onzichtbare tekens die Unicode biedt — zero width spaces, fillers en leeg braille. Klik op een teken om het meteen te kopiëren.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/library-invisible-character.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Een onzichtbaar teken is een echt Unicode-teken dat als niets wordt weergegeven — een lege spatie die je kunt kopiëren en plakken waar platforms normaal een lege invoer weigeren. Mensen gebruiken het om een onzichtbare naam in Free Fire en Mobile Legends te maken, lege regels aan een Instagram-bio of bijschrift toe te voegen, een schijnbaar leeg WhatsApp-bericht te sturen, of gamenamen netjes uit te lijnen. Elke knop hieronder bevat een echt onzichtbaar of leeg teken: de vakjes lijken leeg, maar de labels vertellen precies welk teken je kopieert.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="zero-width-characters">
+  <span class="article-section-label">Zero Width</span>
+  <h2>Zero-Width- en Onzichtbare Tekens</h2>
+  <p class="u-secondary-tight">Deze tekens nemen helemaal geen zichtbare breedte in — ideaal voor onzichtbare namen en om tekst te splitsen zonder iets te tonen.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="​" aria-label="Kopieer Zero Width Space — U+200B">​</button>
+      <span class="flag-label">Zero Width Space — U+200B</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‌" aria-label="Kopieer Zero Width Non-Joiner — U+200C">‌</button>
+      <span class="flag-label">Zero Width Non-Joiner — U+200C</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‍" aria-label="Kopieer Zero Width Joiner — U+200D">‍</button>
+      <span class="flag-label">Zero Width Joiner — U+200D</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⁠" aria-label="Kopieer Word Joiner — U+2060">⁠</button>
+      <span class="flag-label">Word Joiner — U+2060</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="﻿" aria-label="Kopieer Zero Width No-Break Space — U+FEFF">﻿</button>
+      <span class="flag-label">Zero Width No-Break Space — U+FEFF</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‎" aria-label="Kopieer Left-to-Right Mark — U+200E">‎</button>
+      <span class="flag-label">Left-to-Right Mark — U+200E</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‏" aria-label="Kopieer Right-to-Left Mark — U+200F">‏</button>
+      <span class="flag-label">Right-to-Left Mark — U+200F</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="­" aria-label="Kopieer Soft Hyphen — U+00AD">­</button>
+      <span class="flag-label">Soft Hyphen — U+00AD</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="blank-spaces">
+  <span class="article-section-label">Lege Spaties</span>
+  <h2>Lege-Spatie-Tekens</h2>
+  <p class="u-secondary-tight">Zichtbare breedte maar leeg: deze spaties overleven waar de gewone spatiebalk-spatie wordt afgekapt of samengevoegd.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopieer No-Break Space — U+00A0"> </button>
+      <span class="flag-label">No-Break Space — U+00A0</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopieer En Space — U+2002"> </button>
+      <span class="flag-label">En Space — U+2002</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopieer Em Space — U+2003"> </button>
+      <span class="flag-label">Em Space — U+2003</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopieer Figure Space — U+2007"> </button>
+      <span class="flag-label">Figure Space — U+2007</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopieer Punctuation Space — U+2008"> </button>
+      <span class="flag-label">Punctuation Space — U+2008</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopieer Thin Space — U+2009"> </button>
+      <span class="flag-label">Thin Space — U+2009</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopieer Hair Space — U+200A"> </button>
+      <span class="flag-label">Hair Space — U+200A</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopieer Narrow No-Break Space — U+202F"> </button>
+      <span class="flag-label">Narrow No-Break Space — U+202F</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="wide-spaces">
+  <span class="article-section-label">Brede Spaties</span>
+  <h2>Brede & Speciale Spaties</h2>
+  <p class="u-secondary-tight">Extra brede lege tekens, waaronder de ideographic space op volle breedte uit de CJK-typografie — ideaal voor grote lege gaten.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopieer En Quad — U+2000"> </button>
+      <span class="flag-label">En Quad — U+2000</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopieer Em Quad — U+2001"> </button>
+      <span class="flag-label">Em Quad — U+2001</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopieer Three-Per-Em Space — U+2004"> </button>
+      <span class="flag-label">Three-Per-Em Space — U+2004</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopieer Four-Per-Em Space — U+2005"> </button>
+      <span class="flag-label">Four-Per-Em Space — U+2005</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopieer Six-Per-Em Space — U+2006"> </button>
+      <span class="flag-label">Six-Per-Em Space — U+2006</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopieer Medium Mathematical Space — U+205F"> </button>
+      <span class="flag-label">Medium Mathematical Space — U+205F</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="　" aria-label="Kopieer Ideographic Space — U+3000">　</button>
+      <span class="flag-label">Ideographic Space — U+3000</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="filler-characters">
+  <span class="article-section-label">Fillers</span>
+  <h2>Filler- & Leeg-Glief-Tekens</h2>
+  <p class="u-secondary-tight">Letters en patronen die als lege gliefen verschijnen — het lege braille en de Hangul-filler zijn favoriet voor onzichtbare gamenamen.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⠀" aria-label="Kopieer Braille Pattern Blank — U+2800">⠀</button>
+      <span class="flag-label">Braille Pattern Blank — U+2800</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ㅤ" aria-label="Kopieer Hangul Filler — U+3164">ㅤ</button>
+      <span class="flag-label">Hangul Filler — U+3164</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ᅟ" aria-label="Kopieer Hangul Choseong Filler — U+115F">ᅟ</button>
+      <span class="flag-label">Hangul Choseong Filler — U+115F</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ᅠ" aria-label="Kopieer Hangul Jungseong Filler — U+1160">ᅠ</button>
+      <span class="flag-label">Hangul Jungseong Filler — U+1160</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ﾠ" aria-label="Kopieer Halfwidth Hangul Filler — U+FFA0">ﾠ</button>
+      <span class="flag-label">Halfwidth Hangul Filler — U+FFA0</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="᠎" aria-label="Kopieer Mongolian Vowel Separator — U+180E">᠎</button>
+      <span class="flag-label">Mongolian Vowel Separator — U+180E</span>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Zet tekst om in Unicode-lettertypes</h3>
+  <p>Gebruik UltraTextGen om gewone tekst om te zetten naar vetgedrukte, cursieve, sierlijke en meer dan 100 Unicode-stijlen — gratis en direct.</p>
+  <a href="https://ultratextgen.com/nl/" class="cta-btn">UltraTextGen openen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Gerelateerde Bronnen</span>
+  <div class="compare-grid">
+    <a href="/nl/library/speciale-tekens/" class="compare-card variant-muted u-no-underline">
+      <h4>Speciale Tekens</h4>
+      <p>Bijzondere Unicode-tekens en symbolen buiten het toetsenbord.</p>
+    </a>
+    <a href="/nl/kleine-letters/" class="compare-card variant-muted u-no-underline">
+      <h4>Kleine Letters</h4>
+      <p>Maak kleine letters en superscript voor bio, bijschrift en namen.</p>
+    </a>
+    <a href="/nl/mooie-letters/" class="compare-card variant-muted u-no-underline">
+      <h4>Mooie Letters</h4>
+      <p>Mooie letters en lettertypes voor naam, bio en status.</p>
+    </a>
+    <a href="/nl/usecase/zalgo-text/" class="compare-card variant-muted u-no-underline">
+      <h4>Zalgo-Tekst</h4>
+      <p>Genereer glitch-, vervloekte en griezelige tekst.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/pl/niewidzialny-znak/index.html
+++ b/pl/niewidzialny-znak/index.html
@@ -1,0 +1,367 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Niewidzialny Znak (Niewidzialny Tekst) — Kopiuj i Wklej Pustą Spację | UltraTextGen</title>
+<meta name="description" content="Kopiuj niewidzialny tekst i niewidzialne znaki (zero width space, filler Hangul, brajl) na puste nazwy w Free Fire, bio na Instagramie i puste wiadomości na WhatsAppie. Kliknij, aby skopiować — za darmo.">
+
+<link rel="canonical" href="https://ultratextgen.com/pl/niewidzialny-znak/">
+
+<link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/invisible-character/">
+<link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/spasi-kosong/">
+<link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/texto-invisible/">
+<link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/texto-invisivel/">
+<link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/texte-invisible/">
+<link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/unsichtbares-zeichen/">
+<link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/testo-invisibile/">
+<link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/onzichtbare-tekst/">
+<link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/gorunmez-karakter/">
+<link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/ky-tu-vo-hinh/">
+<link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/niewidzialny-znak/">
+<link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/invisible-character/">
+
+<meta name="robots" content="index, follow">
+<meta property="og:site_name" content="UltraTextGen">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/library-invisible-character.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Niewidzialny Znak (Niewidzialny Tekst) — Kopiuj i Wklej Pustą Spację">
+<meta name="twitter:description" content="Kopiuj niewidzialny tekst i niewidzialne znaki na puste nazwy, bio na Instagramie i wiadomości WhatsApp. Kliknij, aby skopiować.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/library-invisible-character.png">
+<meta property="og:title" content="Niewidzialny Znak (Niewidzialny Tekst) — Kopiuj i Wklej Pustą Spację">
+<meta property="og:description" content="Kopiuj niewidzialny tekst i niewidzialne znaki (zero width space, filler Hangul, brajl) na puste nazwy, bio na Instagramie i puste wiadomości na WhatsAppie. Za darmo, bez aplikacji.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/pl/niewidzialny-znak/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Niewidzialny Znak (Niewidzialny Tekst) — Kopiuj i Wklej Pustą Spację",
+  "alternateName": ["Niewidzialny Znak", "Niewidzialny Tekst", "Pusta Spacja", "Pusta Nazwa", "Niewidzialna Litera", "Niewidzialna Spacja", "Kopiuj Pustą Spację"],
+  "description": "Kopiuj niewidzialny tekst i niewidzialne znaki (zero width space, filler Hangul, brajl) na puste nazwy w Free Fire, bio na Instagramie i puste wiadomości na WhatsAppie. Kliknij, aby skopiować — za darmo.",
+  "inLanguage": "pl",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/library-invisible-character.png",
+  "mainEntityOfPage": "https://ultratextgen.com/pl/niewidzialny-znak/",
+  "datePublished": "2026-07-03",
+  "dateModified": "2026-07-03"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "pl",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Czym jest niewidzialny tekst lub niewidzialny znak?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Niewidzialny tekst to prawdziwy znak Unicode wyświetlany jako pusty — nic nie widać, ale nadal liczy się jako tekst. Dlatego możesz go umieścić tam, gdzie puste pole zwykle nie jest akceptowane, np. w nazwie w grze, w bio lub w wiadomości na czacie. Przykłady: zero width space, filler Hangul i pusty brajl. Przyciski na tej stronie wyglądają na puste, ale etykieta pokazuje dokładnie, który znak kopiujesz." }
+    },
+    {
+      "@type": "Question",
+      "name": "Jak zrobić niewidzialną nazwę w Free Fire lub Mobile Legends?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Kliknij jeden z niewidzialnych znaków na tej stronie (zwykle najlepiej działają Hangul Filler U+3164 lub Braille Pattern Blank U+2800) i wklej go w pole zmiany nazwy w Free Fire lub Mobile Legends. Jeśli gra wymaga kilku znaków, wklej dwa lub trzy razy. Ponieważ to znak Unicode, pole jest wypełnione, ale Twoja nazwa wygląda na pustą." }
+    },
+    {
+      "@type": "Question",
+      "name": "Który niewidzialny znak działa najlepiej do nazw w grach?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Najlepiej działają Hangul Filler (U+3164) i Braille Pattern Blank (U+2800), bo są to puste „litery”, które rzadko są blokowane przez filtry gier. Jeśli jeden nie działa, spróbuj drugiego — każda gra sprawdza tekst inaczej." }
+    },
+    {
+      "@type": "Question",
+      "name": "Dlaczego pusta spacja bywa odrzucana lub pokazywana jako kwadrat?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Niektóre aplikacje przycinają zwykłą spację lub nie obsługują jeszcze pewnych niewidzialnych znaków, więc pojawia się kwadrat albo pole jest uznawane za puste. Wtedy zmień znak — np. z zero width space na Hangul Filler lub pusty brajl — albo wypróbuj go w innej aplikacji lub na innym telefonie." }
+    },
+    {
+      "@type": "Question",
+      "name": "Czy nadaje się do pustego bio na Instagramie lub pustej wiadomości na WhatsAppie?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Tak. Skopiuj niewidzialny znak i wklej go w bio na Instagramie, aby utworzyć puste linie lub czyste odstępy, albo wyślij go jako pozornie pustą wiadomość na WhatsAppie. Do pustych linii w bio użyj znaku pustej spacji (nie zero width), aby linia nie została przycięta." }
+    },
+    {
+      "@type": "Question",
+      "name": "Czy to za darmo i bez aplikacji?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Jest w 100% za darmo, działa bezpośrednio w przeglądarce, bez rejestracji i bez instalowania aplikacji. Po prostu kliknij wybrany niewidzialny znak i wklej go, gdzie chcesz." }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Strona główna",
+      "item": "https://ultratextgen.com/pl/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Niewidzialny Znak",
+      "item": "https://ultratextgen.com/pl/niewidzialny-znak/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/pl/">Strona główna</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Niewidzialny Znak</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Niewidzialny Znak &amp; Niewidzialny Tekst</h1>
+    <p class="hero-tagline">Wszystkie puste spacje i niewidzialne znaki, które oferuje Unicode — zero width spaces, fillery i pusty brajl. Kliknij dowolny znak, aby od razu go skopiować.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/library-invisible-character.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Niewidzialny znak to prawdziwy znak Unicode, który wyświetla się jako nic — pusta spacja, którą możesz skopiować i wkleić tam, gdzie platformy zwykle odrzucają puste pole. Ludzie używają go, aby stworzyć niewidzialną nazwę w Free Fire i Mobile Legends, dodać puste linie do bio lub opisu na Instagramie, wysłać pozornie pustą wiadomość na WhatsAppie albo równo rozmieścić nicki w grach. Każdy przycisk poniżej zawiera prawdziwy niewidzialny lub pusty znak: pola wyglądają na puste, ale etykiety mówią dokładnie, który znak kopiujesz.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="zero-width-characters">
+  <span class="article-section-label">Zero Width</span>
+  <h2>Znaki Zero Width i Niewidzialne</h2>
+  <p class="u-secondary-tight">Te znaki nie zajmują żadnej widocznej szerokości — idealne do niewidzialnych nazw i do dzielenia tekstu bez pokazywania czegokolwiek.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="​" aria-label="Kopiuj Zero Width Space — U+200B">​</button>
+      <span class="flag-label">Zero Width Space — U+200B</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‌" aria-label="Kopiuj Zero Width Non-Joiner — U+200C">‌</button>
+      <span class="flag-label">Zero Width Non-Joiner — U+200C</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‍" aria-label="Kopiuj Zero Width Joiner — U+200D">‍</button>
+      <span class="flag-label">Zero Width Joiner — U+200D</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⁠" aria-label="Kopiuj Word Joiner — U+2060">⁠</button>
+      <span class="flag-label">Word Joiner — U+2060</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="﻿" aria-label="Kopiuj Zero Width No-Break Space — U+FEFF">﻿</button>
+      <span class="flag-label">Zero Width No-Break Space — U+FEFF</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‎" aria-label="Kopiuj Left-to-Right Mark — U+200E">‎</button>
+      <span class="flag-label">Left-to-Right Mark — U+200E</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‏" aria-label="Kopiuj Right-to-Left Mark — U+200F">‏</button>
+      <span class="flag-label">Right-to-Left Mark — U+200F</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="­" aria-label="Kopiuj Soft Hyphen — U+00AD">­</button>
+      <span class="flag-label">Soft Hyphen — U+00AD</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="blank-spaces">
+  <span class="article-section-label">Puste Spacje</span>
+  <h2>Znaki Pustej Spacji</h2>
+  <p class="u-secondary-tight">Widoczna szerokość, ale puste: te spacje przetrwają tam, gdzie zwykła spacja jest przycinana lub scalana.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopiuj No-Break Space — U+00A0"> </button>
+      <span class="flag-label">No-Break Space — U+00A0</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopiuj En Space — U+2002"> </button>
+      <span class="flag-label">En Space — U+2002</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopiuj Em Space — U+2003"> </button>
+      <span class="flag-label">Em Space — U+2003</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopiuj Figure Space — U+2007"> </button>
+      <span class="flag-label">Figure Space — U+2007</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopiuj Punctuation Space — U+2008"> </button>
+      <span class="flag-label">Punctuation Space — U+2008</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopiuj Thin Space — U+2009"> </button>
+      <span class="flag-label">Thin Space — U+2009</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopiuj Hair Space — U+200A"> </button>
+      <span class="flag-label">Hair Space — U+200A</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopiuj Narrow No-Break Space — U+202F"> </button>
+      <span class="flag-label">Narrow No-Break Space — U+202F</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="wide-spaces">
+  <span class="article-section-label">Szerokie Spacje</span>
+  <h2>Szerokie i Specjalne Spacje</h2>
+  <p class="u-secondary-tight">Wyjątkowo szerokie puste znaki, w tym ideographic space o pełnej szerokości używany w typografii CJK — świetne do dużych pustych przerw.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopiuj En Quad — U+2000"> </button>
+      <span class="flag-label">En Quad — U+2000</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopiuj Em Quad — U+2001"> </button>
+      <span class="flag-label">Em Quad — U+2001</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopiuj Three-Per-Em Space — U+2004"> </button>
+      <span class="flag-label">Three-Per-Em Space — U+2004</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopiuj Four-Per-Em Space — U+2005"> </button>
+      <span class="flag-label">Four-Per-Em Space — U+2005</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopiuj Six-Per-Em Space — U+2006"> </button>
+      <span class="flag-label">Six-Per-Em Space — U+2006</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopiuj Medium Mathematical Space — U+205F"> </button>
+      <span class="flag-label">Medium Mathematical Space — U+205F</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="　" aria-label="Kopiuj Ideographic Space — U+3000">　</button>
+      <span class="flag-label">Ideographic Space — U+3000</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="filler-characters">
+  <span class="article-section-label">Fillery</span>
+  <h2>Znaki Wypełniające i Pusty Glif</h2>
+  <p class="u-secondary-tight">Litery i wzory wyświetlane jako puste glify — pusty brajl i filler Hangul to ulubione wybory do niewidzialnych nazw w grach.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⠀" aria-label="Kopiuj Braille Pattern Blank — U+2800">⠀</button>
+      <span class="flag-label">Braille Pattern Blank — U+2800</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ㅤ" aria-label="Kopiuj Hangul Filler — U+3164">ㅤ</button>
+      <span class="flag-label">Hangul Filler — U+3164</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ᅟ" aria-label="Kopiuj Hangul Choseong Filler — U+115F">ᅟ</button>
+      <span class="flag-label">Hangul Choseong Filler — U+115F</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ᅠ" aria-label="Kopiuj Hangul Jungseong Filler — U+1160">ᅠ</button>
+      <span class="flag-label">Hangul Jungseong Filler — U+1160</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ﾠ" aria-label="Kopiuj Halfwidth Hangul Filler — U+FFA0">ﾠ</button>
+      <span class="flag-label">Halfwidth Hangul Filler — U+FFA0</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="᠎" aria-label="Kopiuj Mongolian Vowel Separator — U+180E">᠎</button>
+      <span class="flag-label">Mongolian Vowel Separator — U+180E</span>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Zamień tekst w czcionki Unicode</h3>
+  <p>Użyj UltraTextGen, aby zamienić zwykły tekst w pogrubione, kursywę, ozdobne i ponad 100 innych stylów Unicode — za darmo i natychmiast.</p>
+  <a href="https://ultratextgen.com/pl/" class="cta-btn">Otwórz UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Powiązane Zasoby</span>
+  <div class="compare-grid">
+    <a href="/pl/usecase/zalgo-text/" class="compare-card variant-muted u-no-underline">
+      <h4>Tekst Zalgo</h4>
+      <p>Twórz tekst glitch, przeklęty i upiorny ze spiętrzonymi znakami.</p>
+    </a>
+    <a href="/pl/" class="compare-card variant-muted u-no-underline">
+      <h4>Generator Czcionek</h4>
+      <p>Zamień swój tekst na pogrubienie, kursywę i ponad 100 stylów Unicode.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/pt/texto-invisivel/index.html
+++ b/pt/texto-invisivel/index.html
@@ -22,6 +22,13 @@
 <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/spasi-kosong/">
 <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/texto-invisible/">
 <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/texto-invisivel/">
+<link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/texte-invisible/">
+<link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/unsichtbares-zeichen/">
+<link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/testo-invisibile/">
+<link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/onzichtbare-tekst/">
+<link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/gorunmez-karakter/">
+<link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/ky-tu-vo-hinh/">
+<link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/niewidzialny-znak/">
 <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/invisible-character/">
 
 <meta name="robots" content="index, follow">

--- a/pt/texto-invisivel/index.html
+++ b/pt/texto-invisivel/index.html
@@ -1,0 +1,368 @@
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Texto Invisível (Caractere Invisível) — Copiar e Colar Espaço em Branco | UltraTextGen</title>
+<meta name="description" content="Copie texto invisível e caracteres invisíveis (zero width space, filler Hangul, braille) para nomes vazios de Free Fire, bio do Instagram e mensagens em branco no WhatsApp. Clique para copiar na hora — grátis.">
+
+<link rel="canonical" href="https://ultratextgen.com/pt/texto-invisivel/">
+
+<link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/invisible-character/">
+<link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/spasi-kosong/">
+<link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/texto-invisible/">
+<link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/texto-invisivel/">
+<link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/invisible-character/">
+
+<meta name="robots" content="index, follow">
+<meta property="og:site_name" content="UltraTextGen">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/library-invisible-character.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Texto Invisível (Caractere Invisível) — Copiar e Colar Espaço em Branco">
+<meta name="twitter:description" content="Copie texto invisível e caracteres invisíveis para nomes vazios, bio do Instagram e mensagens do WhatsApp. Clique para copiar.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/library-invisible-character.png">
+<meta property="og:title" content="Texto Invisível (Caractere Invisível) — Copiar e Colar Espaço em Branco">
+<meta property="og:description" content="Copie texto invisível e caracteres invisíveis (zero width space, filler Hangul, braille) para nomes vazios, bio do Instagram e mensagens em branco no WhatsApp. Grátis, sem app.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/pt/texto-invisivel/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Texto Invisível (Caractere Invisível) — Copiar e Colar Espaço em Branco",
+  "alternateName": ["Texto Invisível", "Caractere Invisível", "Espaço em Branco", "Nome Vazio", "Letra Invisível", "Espaço Invisível", "Copiar Espaço em Branco"],
+  "description": "Copie texto invisível e caracteres invisíveis (zero width space, filler Hangul, braille) para nomes vazios de Free Fire, bio do Instagram e mensagens em branco no WhatsApp. Clique para copiar na hora — grátis.",
+  "inLanguage": "pt",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/library-invisible-character.png",
+  "mainEntityOfPage": "https://ultratextgen.com/pt/texto-invisivel/",
+  "datePublished": "2026-07-03",
+  "dateModified": "2026-07-03"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "pt",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "O que é texto invisível ou um caractere invisível?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Texto invisível é um caractere Unicode real que aparece vazio — não se vê nada, mas continua contando como texto. Por isso dá para colocá-lo onde normalmente não se aceita um campo vazio, como o nome de um jogo, uma bio ou uma mensagem de chat. Exemplos: o zero width space, o filler Hangul e o braille em branco. Os botões desta página parecem vazios, mas o rótulo mostra exatamente qual caractere você está copiando." }
+    },
+    {
+      "@type": "Question",
+      "name": "Como faço um nome invisível no Free Fire ou Mobile Legends?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Clique em um dos caracteres invisíveis desta página (os que mais funcionam costumam ser o Hangul Filler U+3164 ou o Braille Pattern Blank U+2800) e cole no campo de trocar o nome no Free Fire ou Mobile Legends. Se o jogo exigir vários caracteres, cole duas ou três vezes. Como é um caractere Unicode, o campo fica preenchido, mas o seu nome aparece vazio." }
+    },
+    {
+      "@type": "Question",
+      "name": "Qual caractere invisível funciona melhor para nomes de jogos?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Os que mais funcionam são o Hangul Filler (U+3164) e o Braille Pattern Blank (U+2800), porque são 'letras' vazias que raramente são barradas pelos filtros dos jogos. Se um não funcionar, tente o outro — cada jogo valida o texto de um jeito diferente." }
+    },
+    {
+      "@type": "Question",
+      "name": "Por que o espaço em branco às vezes é recusado ou vira um quadrado?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Alguns apps cortam o espaço normal ou ainda não suportam certos caracteres invisíveis, então aparece um quadrado ou o campo é considerado vazio. Nesse caso, troque de caractere — por exemplo do zero width space para o Hangul Filler ou para o braille em branco — ou teste em outro app ou celular." }
+    },
+    {
+      "@type": "Question",
+      "name": "Serve para bio vazia no Instagram ou mensagem em branco no WhatsApp?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Serve. Copie um caractere invisível e cole na bio do Instagram para criar linhas vazias ou espaçamento limpo, ou envie como uma mensagem de WhatsApp que aparece em branco. Para linhas vazias na bio, use um caractere de espaço em branco (não zero width) para a linha não ser cortada." }
+    },
+    {
+      "@type": "Question",
+      "name": "É grátis e sem instalar app?",
+      "acceptedAnswer": { "@type": "Answer", "text": "É 100% grátis, funciona direto no navegador, sem cadastro e sem instalar nenhum app. Basta clicar no caractere invisível que você quer e colar onde precisar." }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Início",
+      "item": "https://ultratextgen.com/pt/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Texto Invisível",
+      "item": "https://ultratextgen.com/pt/texto-invisivel/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/pt/">Início</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Texto Invisível</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Texto Invisível &amp; Caractere Invisível</h1>
+    <p class="hero-tagline">Todos os espaços em branco e caracteres invisíveis que o Unicode oferece — zero width spaces, fillers e braille vazio. Clique em qualquer caractere para copiar na hora.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/library-invisible-character.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Um caractere invisível é um caractere Unicode real que aparece como nada — um espaço em branco que você pode copiar e colar onde as plataformas normalmente recusam um campo vazio. As pessoas usam para criar um nome invisível no Free Fire e no Mobile Legends, adicionar linhas vazias à bio ou legenda do Instagram, enviar uma mensagem de WhatsApp que parece vazia, ou dar um espaçamento limpo aos nicks dos jogos. Cada botão abaixo contém um caractere invisível ou em branco de verdade: as caixas parecem vazias, mas os rótulos mostram exatamente qual caractere você está copiando.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="zero-width-characters">
+  <span class="article-section-label">Zero Width</span>
+  <h2>Caracteres Zero Width e Invisíveis</h2>
+  <p class="u-secondary-tight">Estes caracteres não ocupam nenhuma largura visível — ideais para nomes invisíveis e para separar texto sem mostrar nada.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="​" aria-label="Copiar Zero Width Space — U+200B">​</button>
+      <span class="flag-label">Zero Width Space — U+200B</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‌" aria-label="Copiar Zero Width Non-Joiner — U+200C">‌</button>
+      <span class="flag-label">Zero Width Non-Joiner — U+200C</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‍" aria-label="Copiar Zero Width Joiner — U+200D">‍</button>
+      <span class="flag-label">Zero Width Joiner — U+200D</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⁠" aria-label="Copiar Word Joiner — U+2060">⁠</button>
+      <span class="flag-label">Word Joiner — U+2060</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="﻿" aria-label="Copiar Zero Width No-Break Space — U+FEFF">﻿</button>
+      <span class="flag-label">Zero Width No-Break Space — U+FEFF</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‎" aria-label="Copiar Left-to-Right Mark — U+200E">‎</button>
+      <span class="flag-label">Left-to-Right Mark — U+200E</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‏" aria-label="Copiar Right-to-Left Mark — U+200F">‏</button>
+      <span class="flag-label">Right-to-Left Mark — U+200F</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="­" aria-label="Copiar Soft Hyphen — U+00AD">­</button>
+      <span class="flag-label">Soft Hyphen — U+00AD</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="blank-spaces">
+  <span class="article-section-label">Espaços em Branco</span>
+  <h2>Caracteres de Espaço em Branco</h2>
+  <p class="u-secondary-tight">Com largura visível mas vazios: estes espaços sobrevivem onde o espaço normal da barra é cortado ou colapsado.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copiar No-Break Space — U+00A0"> </button>
+      <span class="flag-label">No-Break Space — U+00A0</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copiar En Space — U+2002"> </button>
+      <span class="flag-label">En Space — U+2002</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copiar Em Space — U+2003"> </button>
+      <span class="flag-label">Em Space — U+2003</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copiar Figure Space — U+2007"> </button>
+      <span class="flag-label">Figure Space — U+2007</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copiar Punctuation Space — U+2008"> </button>
+      <span class="flag-label">Punctuation Space — U+2008</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copiar Thin Space — U+2009"> </button>
+      <span class="flag-label">Thin Space — U+2009</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copiar Hair Space — U+200A"> </button>
+      <span class="flag-label">Hair Space — U+200A</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copiar Narrow No-Break Space — U+202F"> </button>
+      <span class="flag-label">Narrow No-Break Space — U+202F</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="wide-spaces">
+  <span class="article-section-label">Espaços Largos</span>
+  <h2>Espaços em Branco Largos e Especiais</h2>
+  <p class="u-secondary-tight">Caracteres em branco extra largos, incluindo o ideographic space de largura total usado na tipografia CJK — ótimos para lacunas vazias grandes.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copiar En Quad — U+2000"> </button>
+      <span class="flag-label">En Quad — U+2000</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copiar Em Quad — U+2001"> </button>
+      <span class="flag-label">Em Quad — U+2001</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copiar Three-Per-Em Space — U+2004"> </button>
+      <span class="flag-label">Three-Per-Em Space — U+2004</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copiar Four-Per-Em Space — U+2005"> </button>
+      <span class="flag-label">Four-Per-Em Space — U+2005</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copiar Six-Per-Em Space — U+2006"> </button>
+      <span class="flag-label">Six-Per-Em Space — U+2006</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Copiar Medium Mathematical Space — U+205F"> </button>
+      <span class="flag-label">Medium Mathematical Space — U+205F</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="　" aria-label="Copiar Ideographic Space — U+3000">　</button>
+      <span class="flag-label">Ideographic Space — U+3000</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="filler-characters">
+  <span class="article-section-label">Fillers</span>
+  <h2>Caracteres de Preenchimento e Glifo Vazio</h2>
+  <p class="u-secondary-tight">Letras e padrões que aparecem como glifos vazios — o braille em branco e o filler Hangul são as escolhas favoritas para nomes de jogo invisíveis.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⠀" aria-label="Copiar Braille Pattern Blank — U+2800">⠀</button>
+      <span class="flag-label">Braille Pattern Blank — U+2800</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ㅤ" aria-label="Copiar Hangul Filler — U+3164">ㅤ</button>
+      <span class="flag-label">Hangul Filler — U+3164</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ᅟ" aria-label="Copiar Hangul Choseong Filler — U+115F">ᅟ</button>
+      <span class="flag-label">Hangul Choseong Filler — U+115F</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ᅠ" aria-label="Copiar Hangul Jungseong Filler — U+1160">ᅠ</button>
+      <span class="flag-label">Hangul Jungseong Filler — U+1160</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ﾠ" aria-label="Copiar Halfwidth Hangul Filler — U+FFA0">ﾠ</button>
+      <span class="flag-label">Halfwidth Hangul Filler — U+FFA0</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="᠎" aria-label="Copiar Mongolian Vowel Separator — U+180E">᠎</button>
+      <span class="flag-label">Mongolian Vowel Separator — U+180E</span>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Transforme texto em fontes Unicode</h3>
+  <p>Use o UltraTextGen para transformar texto normal em fontes Unicode em negrito, itálico, cursiva e mais de 100 estilos — grátis e instantâneo.</p>
+  <a href="https://ultratextgen.com/pt/" class="cta-btn">Abrir UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Recursos Relacionados</span>
+  <div class="compare-grid">
+    <a href="/pt/usecase/nick-ff/" class="compare-card variant-muted u-no-underline">
+      <h4>Nick Free Fire</h4>
+      <p>Nicks de Free Fire estilosos com símbolos e caracteres invisíveis.</p>
+    </a>
+    <a href="/pt/letras-pequenas/" class="compare-card variant-muted u-no-underline">
+      <h4>Letras Pequenas</h4>
+      <p>Crie letras pequenas e sobrescritas para bio, legenda e nicks.</p>
+    </a>
+    <a href="/pt/letras-aesthetic/" class="compare-card variant-muted u-no-underline">
+      <h4>Letras Aesthetic</h4>
+      <p>Letras e fontes aesthetic para nome, bio e status.</p>
+    </a>
+    <a href="/pt/library/simbolos/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos</h4>
+      <p>Coleção de símbolos para nomes, bio e legendas.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/tr/gorunmez-karakter/index.html
+++ b/tr/gorunmez-karakter/index.html
@@ -1,0 +1,375 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Görünmez Karakter (Görünmez Yazı) — Boşluk Kopyala Yapıştır | UltraTextGen</title>
+<meta name="description" content="Free Fire için boş isim, Instagram biyografisi ve boş WhatsApp mesajları için görünmez yazı ve görünmez karakterleri (zero width space, Hangul filler, braille) kopyala. Kopyalamak için tıkla — ücretsiz.">
+
+<link rel="canonical" href="https://ultratextgen.com/tr/gorunmez-karakter/">
+
+<link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/invisible-character/">
+<link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/spasi-kosong/">
+<link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/texto-invisible/">
+<link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/texto-invisivel/">
+<link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/texte-invisible/">
+<link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/unsichtbares-zeichen/">
+<link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/testo-invisibile/">
+<link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/onzichtbare-tekst/">
+<link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/gorunmez-karakter/">
+<link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/ky-tu-vo-hinh/">
+<link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/niewidzialny-znak/">
+<link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/invisible-character/">
+
+<meta name="robots" content="index, follow">
+<meta property="og:site_name" content="UltraTextGen">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/library-invisible-character.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Görünmez Karakter (Görünmez Yazı) — Boşluk Kopyala Yapıştır">
+<meta name="twitter:description" content="Boş isim, Instagram biyografisi ve WhatsApp mesajları için görünmez yazı ve görünmez karakter kopyala. Kopyalamak için tıkla.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/library-invisible-character.png">
+<meta property="og:title" content="Görünmez Karakter (Görünmez Yazı) — Boşluk Kopyala Yapıştır">
+<meta property="og:description" content="Boş isim, Instagram biyografisi ve boş WhatsApp mesajları için görünmez yazı ve görünmez karakterleri (zero width space, Hangul filler, braille) kopyala. Ücretsiz, uygulamasız.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/tr/gorunmez-karakter/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Görünmez Karakter (Görünmez Yazı) — Boşluk Kopyala Yapıştır",
+  "alternateName": ["Görünmez Karakter", "Görünmez Yazı", "Boşluk", "Boş İsim", "Görünmez Harf", "Görünmez Boşluk", "Boşluk Kopyala"],
+  "description": "Free Fire için boş isim, Instagram biyografisi ve boş WhatsApp mesajları için görünmez yazı ve görünmez karakterleri (zero width space, Hangul filler, braille) kopyala. Kopyalamak için tıkla — ücretsiz.",
+  "inLanguage": "tr",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/library-invisible-character.png",
+  "mainEntityOfPage": "https://ultratextgen.com/tr/gorunmez-karakter/",
+  "datePublished": "2026-07-03",
+  "dateModified": "2026-07-03"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "tr",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Görünmez yazı veya görünmez karakter nedir?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Görünmez yazı, boş görünen gerçek bir Unicode karakteridir — hiçbir şey görünmez ama yine de metin olarak sayılır. Bu yüzden boş girişin normalde kabul edilmediği yerlere, örneğin oyun ismine, biyografiye veya sohbet mesajına koyabilirsin. Örnekler: zero width space, Hangul filler ve boş braille. Bu sayfadaki düğmeler boş görünür ama etiket tam olarak hangi karakteri kopyaladığını gösterir." }
+    },
+    {
+      "@type": "Question",
+      "name": "Free Fire veya Mobile Legends’ta görünmez isim nasıl yapılır?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Bu sayfadaki görünmez karakterlerden birine tıkla (genelde en iyi çalışanlar Hangul Filler U+3164 veya Braille Pattern Blank U+2800’dür) ve Free Fire ya da Mobile Legends’ta isim değiştirme alanına yapıştır. Oyun birden fazla karakter isterse iki ya da üç kez yapıştır. Unicode karakteri olduğu için alan dolu görünür ama ismin boş görünür." }
+    },
+    {
+      "@type": "Question",
+      "name": "Oyun isimleri için hangi görünmez karakter en iyi çalışır?",
+      "acceptedAnswer": { "@type": "Answer", "text": "En iyi çalışanlar Hangul Filler (U+3164) ve Braille Pattern Blank (U+2800)’dir, çünkü bunlar oyun filtrelerinin nadiren engellediği boş ‘harfler’dir. Biri çalışmazsa diğerini dene — her oyun metni farklı doğrular." }
+    },
+    {
+      "@type": "Question",
+      "name": "Boşluk neden bazen reddediliyor veya kutu olarak görünüyor?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Bazı uygulamalar normal boşluğu kırpar veya belirli görünmez karakterleri henüz desteklemez, bu yüzden kutu görünür ya da alan boş sayılır. Bu durumda karakteri değiştir — örneğin zero width space’ten Hangul Filler’a veya boş braille’e — ya da başka bir uygulamada veya telefonda dene." }
+    },
+    {
+      "@type": "Question",
+      "name": "Boş Instagram biyografisi veya boş WhatsApp mesajı için işe yarar mı?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Evet. Bir görünmez karakter kopyala ve boş satır ya da temiz boşluk için Instagram biyografisine yapıştır, ya da boş görünen bir WhatsApp mesajı olarak gönder. Biyografide boş satır için boşluk karakteri kullan (zero width değil) ki satır kırpılmasın." }
+    },
+    {
+      "@type": "Question",
+      "name": "Ücretsiz mi ve uygulamasız mı?",
+      "acceptedAnswer": { "@type": "Answer", "text": "%100 ücretsiz, doğrudan tarayıcıda çalışır, kayıt gerektirmez ve uygulama kurulumu istemez. İstediğin görünmez karaktere tıkla ve istediğin yere yapıştır." }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Ana Sayfa",
+      "item": "https://ultratextgen.com/tr/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Görünmez Karakter",
+      "item": "https://ultratextgen.com/tr/gorunmez-karakter/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/tr/">Ana Sayfa</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Görünmez Karakter</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Görünmez Karakter &amp; Görünmez Yazı</h1>
+    <p class="hero-tagline">Unicode’un sunduğu tüm boşluklar ve görünmez karakterler — zero width space, filler ve boş braille. Bir karaktere tıklayıp anında kopyala.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/library-invisible-character.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Görünmez karakter, hiçbir şey görünmeyecek şekilde görüntülenen gerçek bir Unicode karakteridir — platformların normalde boş girişi reddettiği yerlere kopyalayıp yapıştırabileceğin bir boşluk. İnsanlar bunu Free Fire ve Mobile Legends’ta görünmez isim yapmak, Instagram biyografisine veya açıklamasına boş satır eklemek, boş görünen bir WhatsApp mesajı göndermek ya da oyun takma adlarını düzenli hizalamak için kullanır. Aşağıdaki her düğme gerçek bir görünmez veya boş karakter içerir: kutular boş görünür, ama etiketler tam olarak hangi karakteri kopyaladığını söyler.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="zero-width-characters">
+  <span class="article-section-label">Zero Width</span>
+  <h2>Zero Width ve Görünmez Karakterler</h2>
+  <p class="u-secondary-tight">Bu karakterler hiç görünür genişlik kaplamaz — görünmez isimler için ve hiçbir şey göstermeden metni bölmek için idealdir.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="​" aria-label="Kopyala Zero Width Space — U+200B">​</button>
+      <span class="flag-label">Zero Width Space — U+200B</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‌" aria-label="Kopyala Zero Width Non-Joiner — U+200C">‌</button>
+      <span class="flag-label">Zero Width Non-Joiner — U+200C</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‍" aria-label="Kopyala Zero Width Joiner — U+200D">‍</button>
+      <span class="flag-label">Zero Width Joiner — U+200D</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⁠" aria-label="Kopyala Word Joiner — U+2060">⁠</button>
+      <span class="flag-label">Word Joiner — U+2060</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="﻿" aria-label="Kopyala Zero Width No-Break Space — U+FEFF">﻿</button>
+      <span class="flag-label">Zero Width No-Break Space — U+FEFF</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‎" aria-label="Kopyala Left-to-Right Mark — U+200E">‎</button>
+      <span class="flag-label">Left-to-Right Mark — U+200E</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‏" aria-label="Kopyala Right-to-Left Mark — U+200F">‏</button>
+      <span class="flag-label">Right-to-Left Mark — U+200F</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="­" aria-label="Kopyala Soft Hyphen — U+00AD">­</button>
+      <span class="flag-label">Soft Hyphen — U+00AD</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="blank-spaces">
+  <span class="article-section-label">Boşluklar</span>
+  <h2>Boşluk Karakterleri</h2>
+  <p class="u-secondary-tight">Görünür genişlikte ama boş: bu boşluklar, normal boşluk tuşunun kırpıldığı veya birleştirildiği yerlerde hayatta kalır.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopyala No-Break Space — U+00A0"> </button>
+      <span class="flag-label">No-Break Space — U+00A0</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopyala En Space — U+2002"> </button>
+      <span class="flag-label">En Space — U+2002</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopyala Em Space — U+2003"> </button>
+      <span class="flag-label">Em Space — U+2003</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopyala Figure Space — U+2007"> </button>
+      <span class="flag-label">Figure Space — U+2007</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopyala Punctuation Space — U+2008"> </button>
+      <span class="flag-label">Punctuation Space — U+2008</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopyala Thin Space — U+2009"> </button>
+      <span class="flag-label">Thin Space — U+2009</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopyala Hair Space — U+200A"> </button>
+      <span class="flag-label">Hair Space — U+200A</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopyala Narrow No-Break Space — U+202F"> </button>
+      <span class="flag-label">Narrow No-Break Space — U+202F</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="wide-spaces">
+  <span class="article-section-label">Geniş Boşluklar</span>
+  <h2>Geniş ve Özel Boşluklar</h2>
+  <p class="u-secondary-tight">CJK tipografisinde kullanılan tam genişlikteki ideographic space dahil, ekstra geniş boş karakterler — büyük boş aralıklar için harika.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopyala En Quad — U+2000"> </button>
+      <span class="flag-label">En Quad — U+2000</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopyala Em Quad — U+2001"> </button>
+      <span class="flag-label">Em Quad — U+2001</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopyala Three-Per-Em Space — U+2004"> </button>
+      <span class="flag-label">Three-Per-Em Space — U+2004</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopyala Four-Per-Em Space — U+2005"> </button>
+      <span class="flag-label">Four-Per-Em Space — U+2005</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopyala Six-Per-Em Space — U+2006"> </button>
+      <span class="flag-label">Six-Per-Em Space — U+2006</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Kopyala Medium Mathematical Space — U+205F"> </button>
+      <span class="flag-label">Medium Mathematical Space — U+205F</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="　" aria-label="Kopyala Ideographic Space — U+3000">　</button>
+      <span class="flag-label">Ideographic Space — U+3000</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="filler-characters">
+  <span class="article-section-label">Filler</span>
+  <h2>Dolgu ve Boş Glif Karakterleri</h2>
+  <p class="u-secondary-tight">Boş glif olarak görünen harf ve desenler — boş braille ve Hangul filler, görünmez oyun isimleri için favori seçimlerdir.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⠀" aria-label="Kopyala Braille Pattern Blank — U+2800">⠀</button>
+      <span class="flag-label">Braille Pattern Blank — U+2800</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ㅤ" aria-label="Kopyala Hangul Filler — U+3164">ㅤ</button>
+      <span class="flag-label">Hangul Filler — U+3164</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ᅟ" aria-label="Kopyala Hangul Choseong Filler — U+115F">ᅟ</button>
+      <span class="flag-label">Hangul Choseong Filler — U+115F</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ᅠ" aria-label="Kopyala Hangul Jungseong Filler — U+1160">ᅠ</button>
+      <span class="flag-label">Hangul Jungseong Filler — U+1160</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ﾠ" aria-label="Kopyala Halfwidth Hangul Filler — U+FFA0">ﾠ</button>
+      <span class="flag-label">Halfwidth Hangul Filler — U+FFA0</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="᠎" aria-label="Kopyala Mongolian Vowel Separator — U+180E">᠎</button>
+      <span class="flag-label">Mongolian Vowel Separator — U+180E</span>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Metni Unicode fontlarına dönüştür</h3>
+  <p>UltraTextGen ile normal metni kalın, italik, el yazısı ve 100’den fazla Unicode font stiline dönüştür — ücretsiz ve anında.</p>
+  <a href="https://ultratextgen.com/tr/" class="cta-btn">UltraTextGen’i Aç →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">İlgili Kaynaklar</span>
+  <div class="compare-grid">
+    <a href="/tr/sekilli-nick/" class="compare-card variant-muted u-no-underline">
+      <h4>Şekilli Nick</h4>
+      <p>Sembol ve görünmez karakterlerle havalı oyun nickleri.</p>
+    </a>
+    <a href="/tr/usecase/pubg-nick/" class="compare-card variant-muted u-no-underline">
+      <h4>PUBG Nick</h4>
+      <p>PUBG için şekilli, sembollü nick fikirleri.</p>
+    </a>
+    <a href="/tr/kucuk-yazi/" class="compare-card variant-muted u-no-underline">
+      <h4>Küçük Yazı</h4>
+      <p>Biyografi, açıklama ve nickler için küçük harf ve üst simge.</p>
+    </a>
+    <a href="/tr/library/semboller/" class="compare-card variant-muted u-no-underline">
+      <h4>Semboller</h4>
+      <p>İsim, biyografi ve açıklamalar için sembol koleksiyonu.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/vi/ky-tu-vo-hinh/index.html
+++ b/vi/ky-tu-vo-hinh/index.html
@@ -1,0 +1,367 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Kí Tự Vô Hình (Chữ Vô Hình) — Copy Paste Khoảng Trắng Trống | UltraTextGen</title>
+<meta name="description" content="Copy chữ vô hình và kí tự vô hình (zero width space, Hangul filler, braille) để đặt tên trống Free Fire, bio Instagram và tin nhắn trống WhatsApp. Bấm để sao chép — miễn phí.">
+
+<link rel="canonical" href="https://ultratextgen.com/vi/ky-tu-vo-hinh/">
+
+<link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/invisible-character/">
+<link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/spasi-kosong/">
+<link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/texto-invisible/">
+<link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/texto-invisivel/">
+<link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/texte-invisible/">
+<link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/unsichtbares-zeichen/">
+<link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/testo-invisibile/">
+<link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/onzichtbare-tekst/">
+<link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/gorunmez-karakter/">
+<link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/ky-tu-vo-hinh/">
+<link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/niewidzialny-znak/">
+<link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/invisible-character/">
+
+<meta name="robots" content="index, follow">
+<meta property="og:site_name" content="UltraTextGen">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/library-invisible-character.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Kí Tự Vô Hình (Chữ Vô Hình) — Copy Paste Khoảng Trắng Trống">
+<meta name="twitter:description" content="Copy chữ vô hình và kí tự vô hình để đặt tên trống, bio Instagram và tin nhắn WhatsApp. Bấm để sao chép.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/library-invisible-character.png">
+<meta property="og:title" content="Kí Tự Vô Hình (Chữ Vô Hình) — Copy Paste Khoảng Trắng Trống">
+<meta property="og:description" content="Copy chữ vô hình và kí tự vô hình (zero width space, Hangul filler, braille) để đặt tên trống, bio Instagram và tin nhắn trống WhatsApp. Miễn phí, không cần app.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/vi/ky-tu-vo-hinh/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Kí Tự Vô Hình (Chữ Vô Hình) — Copy Paste Khoảng Trắng Trống",
+  "alternateName": ["Kí Tự Vô Hình", "Chữ Vô Hình", "Khoảng Trắng", "Tên Trống", "Chữ Cái Vô Hình", "Khoảng Trắng Vô Hình", "Copy Khoảng Trắng"],
+  "description": "Copy chữ vô hình và kí tự vô hình (zero width space, Hangul filler, braille) để đặt tên trống Free Fire, bio Instagram và tin nhắn trống WhatsApp. Bấm để sao chép — miễn phí.",
+  "inLanguage": "vi",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/library-invisible-character.png",
+  "mainEntityOfPage": "https://ultratextgen.com/vi/ky-tu-vo-hinh/",
+  "datePublished": "2026-07-03",
+  "dateModified": "2026-07-03"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "vi",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Kí tự vô hình hay chữ vô hình là gì?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Chữ vô hình là một kí tự Unicode thật hiển thị trống — không thấy gì cả, nhưng vẫn được tính là chữ. Vì vậy bạn có thể đặt nó ở nơi mà ô trống thường không được chấp nhận, như tên game, bio hoặc tin nhắn chat. Ví dụ: zero width space, Hangul filler và braille trống. Các nút trên trang này trông trống, nhưng nhãn cho biết chính xác kí tự bạn đang sao chép." }
+    },
+    {
+      "@type": "Question",
+      "name": "Cách tạo tên vô hình trong Free Fire hoặc Mobile Legends?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Bấm vào một trong các kí tự vô hình trên trang này (hiệu quả nhất thường là Hangul Filler U+3164 hoặc Braille Pattern Blank U+2800) rồi dán vào ô đổi tên trong Free Fire hoặc Mobile Legends. Nếu game yêu cầu nhiều kí tự, hãy dán hai hoặc ba lần. Vì là kí tự Unicode, ô sẽ được điền nhưng tên bạn trông trống." }
+    },
+    {
+      "@type": "Question",
+      "name": "Kí tự vô hình nào hoạt động tốt nhất cho tên game?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Hiệu quả nhất là Hangul Filler (U+3164) và Braille Pattern Blank (U+2800), vì chúng là những ‘chữ cái’ trống hiếm khi bị bộ lọc của game chặn. Nếu cái này không được, hãy thử cái kia — mỗi game kiểm tra chữ theo cách khác nhau." }
+    },
+    {
+      "@type": "Question",
+      "name": "Vì sao khoảng trắng đôi khi bị từ chối hoặc hiện thành ô vuông?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Một số app cắt khoảng trắng thường hoặc chưa hỗ trợ một số kí tự vô hình, nên hiện ô vuông hoặc ô bị coi là trống. Khi đó hãy đổi kí tự — ví dụ từ zero width space sang Hangul Filler hoặc braille trống — hoặc thử trên app hay điện thoại khác." }
+    },
+    {
+      "@type": "Question",
+      "name": "Có dùng được cho bio Instagram trống hay tin nhắn WhatsApp trống không?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Có. Copy một kí tự vô hình rồi dán vào bio Instagram để tạo dòng trống hoặc khoảng cách gọn, hoặc gửi như một tin nhắn WhatsApp trông trống. Để có dòng trống trong bio, hãy dùng kí tự khoảng trắng (không phải zero width) để dòng không bị cắt." }
+    },
+    {
+      "@type": "Question",
+      "name": "Có miễn phí và không cần app không?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Hoàn toàn miễn phí, chạy trực tiếp trên trình duyệt, không cần đăng ký và không cần cài app. Chỉ cần bấm vào kí tự vô hình bạn muốn rồi dán vào bất cứ đâu." }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Trang chủ",
+      "item": "https://ultratextgen.com/vi/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Kí Tự Vô Hình",
+      "item": "https://ultratextgen.com/vi/ky-tu-vo-hinh/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/vi/">Trang chủ</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Kí Tự Vô Hình</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Kí Tự Vô Hình &amp; Chữ Vô Hình</h1>
+    <p class="hero-tagline">Mọi khoảng trắng và kí tự vô hình mà Unicode cung cấp — zero width space, filler và braille trống. Bấm vào bất kỳ kí tự nào để sao chép ngay.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/library-invisible-character.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Kí tự vô hình là một kí tự Unicode thật hiển thị thành trống rỗng — một khoảng trắng bạn có thể copy và paste ở nơi mà các nền tảng thường từ chối ô trống. Người ta dùng nó để tạo tên vô hình trong Free Fire và Mobile Legends, thêm dòng trống vào bio hoặc caption Instagram, gửi tin nhắn WhatsApp trông như trống, hoặc căn chỉnh nick game cho gọn. Mỗi nút bên dưới chứa một kí tự vô hình hoặc trống thật: các ô trông trống, nhưng nhãn cho biết chính xác kí tự bạn đang sao chép.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="zero-width-characters">
+  <span class="article-section-label">Zero Width</span>
+  <h2>Kí Tự Zero Width và Vô Hình</h2>
+  <p class="u-secondary-tight">Những kí tự này hoàn toàn không chiếm chiều rộng hiển thị — lý tưởng để đặt tên vô hình và tách chữ mà không hiển thị gì.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="​" aria-label="Sao chép Zero Width Space — U+200B">​</button>
+      <span class="flag-label">Zero Width Space — U+200B</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‌" aria-label="Sao chép Zero Width Non-Joiner — U+200C">‌</button>
+      <span class="flag-label">Zero Width Non-Joiner — U+200C</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‍" aria-label="Sao chép Zero Width Joiner — U+200D">‍</button>
+      <span class="flag-label">Zero Width Joiner — U+200D</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⁠" aria-label="Sao chép Word Joiner — U+2060">⁠</button>
+      <span class="flag-label">Word Joiner — U+2060</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="﻿" aria-label="Sao chép Zero Width No-Break Space — U+FEFF">﻿</button>
+      <span class="flag-label">Zero Width No-Break Space — U+FEFF</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‎" aria-label="Sao chép Left-to-Right Mark — U+200E">‎</button>
+      <span class="flag-label">Left-to-Right Mark — U+200E</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‏" aria-label="Sao chép Right-to-Left Mark — U+200F">‏</button>
+      <span class="flag-label">Right-to-Left Mark — U+200F</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="­" aria-label="Sao chép Soft Hyphen — U+00AD">­</button>
+      <span class="flag-label">Soft Hyphen — U+00AD</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="blank-spaces">
+  <span class="article-section-label">Khoảng Trắng</span>
+  <h2>Kí Tự Khoảng Trắng</h2>
+  <p class="u-secondary-tight">Có chiều rộng nhưng trống: những khoảng trắng này sống sót ở nơi khoảng trắng thường bị cắt hoặc gộp lại.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Sao chép No-Break Space — U+00A0"> </button>
+      <span class="flag-label">No-Break Space — U+00A0</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Sao chép En Space — U+2002"> </button>
+      <span class="flag-label">En Space — U+2002</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Sao chép Em Space — U+2003"> </button>
+      <span class="flag-label">Em Space — U+2003</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Sao chép Figure Space — U+2007"> </button>
+      <span class="flag-label">Figure Space — U+2007</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Sao chép Punctuation Space — U+2008"> </button>
+      <span class="flag-label">Punctuation Space — U+2008</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Sao chép Thin Space — U+2009"> </button>
+      <span class="flag-label">Thin Space — U+2009</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Sao chép Hair Space — U+200A"> </button>
+      <span class="flag-label">Hair Space — U+200A</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Sao chép Narrow No-Break Space — U+202F"> </button>
+      <span class="flag-label">Narrow No-Break Space — U+202F</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="wide-spaces">
+  <span class="article-section-label">Khoảng Trắng Rộng</span>
+  <h2>Khoảng Trắng Rộng và Đặc Biệt</h2>
+  <p class="u-secondary-tight">Kí tự trống siêu rộng, gồm cả ideographic space toàn chiều rộng dùng trong kiểu chữ CJK — tuyệt cho các khoảng trống lớn.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Sao chép En Quad — U+2000"> </button>
+      <span class="flag-label">En Quad — U+2000</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Sao chép Em Quad — U+2001"> </button>
+      <span class="flag-label">Em Quad — U+2001</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Sao chép Three-Per-Em Space — U+2004"> </button>
+      <span class="flag-label">Three-Per-Em Space — U+2004</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Sao chép Four-Per-Em Space — U+2005"> </button>
+      <span class="flag-label">Four-Per-Em Space — U+2005</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Sao chép Six-Per-Em Space — U+2006"> </button>
+      <span class="flag-label">Six-Per-Em Space — U+2006</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol=" " aria-label="Sao chép Medium Mathematical Space — U+205F"> </button>
+      <span class="flag-label">Medium Mathematical Space — U+205F</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="　" aria-label="Sao chép Ideographic Space — U+3000">　</button>
+      <span class="flag-label">Ideographic Space — U+3000</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="filler-characters">
+  <span class="article-section-label">Filler</span>
+  <h2>Kí Tự Filler và Glyph Trống</h2>
+  <p class="u-secondary-tight">Chữ cái và họa tiết hiển thị thành glyph trống — braille trống và Hangul filler là lựa chọn hàng đầu cho tên game vô hình.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⠀" aria-label="Sao chép Braille Pattern Blank — U+2800">⠀</button>
+      <span class="flag-label">Braille Pattern Blank — U+2800</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ㅤ" aria-label="Sao chép Hangul Filler — U+3164">ㅤ</button>
+      <span class="flag-label">Hangul Filler — U+3164</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ᅟ" aria-label="Sao chép Hangul Choseong Filler — U+115F">ᅟ</button>
+      <span class="flag-label">Hangul Choseong Filler — U+115F</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ᅠ" aria-label="Sao chép Hangul Jungseong Filler — U+1160">ᅠ</button>
+      <span class="flag-label">Hangul Jungseong Filler — U+1160</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ﾠ" aria-label="Sao chép Halfwidth Hangul Filler — U+FFA0">ﾠ</button>
+      <span class="flag-label">Halfwidth Hangul Filler — U+FFA0</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="᠎" aria-label="Sao chép Mongolian Vowel Separator — U+180E">᠎</button>
+      <span class="flag-label">Mongolian Vowel Separator — U+180E</span>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Biến chữ thành font Unicode</h3>
+  <p>Dùng UltraTextGen để chuyển chữ thường thành font Unicode in đậm, in nghiêng, chữ viết tay và hơn 100 kiểu khác — miễn phí và tức thì.</p>
+  <a href="https://ultratextgen.com/vi/" class="cta-btn">Mở UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Tài Nguyên Liên Quan</span>
+  <div class="compare-grid">
+    <a href="/vi/usecase/zalgo-text/" class="compare-card variant-muted u-no-underline">
+      <h4>Chữ Zalgo</h4>
+      <p>Tạo chữ glitch, ma quái với dấu chồng lên nhau.</p>
+    </a>
+    <a href="/vi/" class="compare-card variant-muted u-no-underline">
+      <h4>Tạo Font Chữ</h4>
+      <p>Chuyển chữ của bạn sang in đậm, in nghiêng và hơn 100 kiểu Unicode.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script src="/footer.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
…lang cluster

Localized flagship for the ~260k "spasi kosong" / "teks kosong" cluster, mirroring the /library/invisible-character/ tool (same 29 blank/invisible Unicode characters, shared symbol-explorer runtime). Fully localized copy, FF/ML-focused FAQ, Article + FAQPage + BreadcrumbList JSON-LD in Indonesian.

Wires an en <-> id hreflang cluster (x-default = English) onto both pages so Search maps the alternates. GSC shows the English page already surfaces #1 by impressions from Indonesia at avg position ~8 with zero localized content.


Claude-Session: https://claude.ai/code/session_01Ww6XBWTAh2u1MAcBfozA3H