### PR TITLE
UX: move bubble generator results above the A–Z explorer

### DIFF
--- a/category/bubble-fonts/index.html
+++ b/category/bubble-fonts/index.html
@@ -250,6 +250,25 @@
   <!-- Main Content -->
   <main class="container">
 
+    <!-- Category Tabs -->
+    <div class="category-section">
+      <div class="category-tabs" id="categoryTabs">
+        <button class="category-tab active" data-category="all">All</button>
+        <button class="category-tab" data-category="cool">✦ Cool</button>
+        <button class="category-tab" data-category="fancy">✧ Fancy</button>
+        <button class="category-tab" data-category="cursive">𝒞 Cursive</button>
+        <button class="category-tab" data-category="bold">𝗕 Bold</button>
+        <button class="category-tab" data-category="gothic">𝔊 Gothic</button>
+        <button class="category-tab" data-category="bubble">Ⓑ Bubble</button>
+        <button class="category-tab" data-category="special">⚡ Special</button>
+      </div>
+    </div>
+
+    <!-- Compatibility Notice -->
+
+    <!-- Results -->
+    <div class="results-grid" id="resultsGrid"></div>
+
     <!-- ===== Bubble Letters A–Z explorer ===== -->
     <section class="bubble-az" id="bubbleAZ" aria-labelledby="bubbleAZHeading">
       <h2 class="bubble-az-heading" id="bubbleAZHeading">Bubble Letters A–Z</h2>
@@ -275,25 +294,6 @@
       </p>
       <div class="bubble-alphabet-grid" id="bubbleAlphabetGrid"></div>
     </section>
-
-    <!-- Category Tabs -->
-    <div class="category-section">
-      <div class="category-tabs" id="categoryTabs">
-        <button class="category-tab active" data-category="all">All</button>
-        <button class="category-tab" data-category="cool">✦ Cool</button>
-        <button class="category-tab" data-category="fancy">✧ Fancy</button>
-        <button class="category-tab" data-category="cursive">𝒞 Cursive</button>
-        <button class="category-tab" data-category="bold">𝗕 Bold</button>
-        <button class="category-tab" data-category="gothic">𝔊 Gothic</button>
-        <button class="category-tab" data-category="bubble">Ⓑ Bubble</button>
-        <button class="category-tab" data-category="special">⚡ Special</button>
-      </div>
-    </div>
-
-    <!-- Compatibility Notice -->
-    
-    <!-- Results -->
-    <div class="results-grid" id="resultsGrid"></div>
   </main>
 
   <!-- Footer -->


### PR DESCRIPTION
Reorder the bubble-fonts category page so the generated font results appear directly under the input, and move the Bubble Letters A–Z explorer and printable alphabet below as a secondary section. Closes the gap where users had to scroll past the printable A–Z sections to reach the generator output after typing.


Claude-Session: https://claude.ai/code/session_019mm8T2tVsazbmKU7sTF1mY