### PR TITLE
[codex] Add Norwegian locale

### DIFF
--- a/404.html
+++ b/404.html
@@ -128,6 +128,7 @@
         <a class="lang-option" href="/pl/" hreflang="pl">PL</a>
         <a class="lang-option" href="/vi/" hreflang="vi">VI</a>
         <a class="lang-option" href="/sv/" hreflang="sv">SV</a>
+        <a class="lang-option" href="/no/" hreflang="no">NO</a>
       </div>
     </div>
   </footer>

--- a/_redirects
+++ b/_redirects
@@ -56,6 +56,7 @@ https://www.ultratextgen.com/*  https://ultratextgen.com/:splat  301!
 /?lang=vi                                   /vi/    301
 /?lang=tl                                   /tl/    301
 /?lang=sv                                   /sv/    301
+/?lang=no                                   /no/    301
 
 # Bold: thin/duplicate group pages folded into the parent family page (301)
 /category/bold-fonts/bold/                     /category/bold-fonts/ 301

--- a/_root.html
+++ b/_root.html
@@ -32,6 +32,7 @@
 <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/">
 <link rel="alternate" hreflang="tl" href="https://ultratextgen.com/tl/">
 <link rel="alternate" hreflang="sv" href="https://ultratextgen.com/sv/">
+<link rel="alternate" hreflang="no" href="https://ultratextgen.com/no/">
 
 <meta name="robots" content="index, follow">
 
@@ -809,6 +810,7 @@
         <a class="lang-option" href="/vi/" hreflang="vi">VI</a>
         <a class="lang-option" href="/tl/" hreflang="tl">TL</a>
         <a class="lang-option" href="/sv/" hreflang="sv">SV</a>
+        <a class="lang-option" href="/no/" hreflang="no">NO</a>
       </div>
     </div>
   </footer>

--- a/category/cursive-fonts/index.html
+++ b/category/cursive-fonts/index.html
@@ -20,6 +20,7 @@
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/letra-cursiva/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/el-yazisi-fontu/">
   <link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/sierlijke-letters/">
+  <link rel="alternate" hreflang="no" href="https://ultratextgen.com/no/kursiv-tekst/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/category/cursive-fonts/">
 
   <meta property="og:title" content="Cursive Generator — Cursive Text &amp; Font Generator | UltraTextGen">

--- a/de/index.html
+++ b/de/index.html
@@ -30,6 +30,7 @@
 <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/">
 <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/">
 <link rel="alternate" hreflang="sv" href="https://ultratextgen.com/sv/">
+<link rel="alternate" hreflang="no" href="https://ultratextgen.com/no/">
 
 <meta name="robots" content="index, follow">
 
@@ -990,6 +991,7 @@
         <a class="lang-option" href="/pl/" hreflang="pl">PL</a>
         <a class="lang-option" href="/vi/" hreflang="vi">VI</a>
         <a class="lang-option" href="/sv/" hreflang="sv">SV</a>
+        <a class="lang-option" href="/no/" hreflang="no">NO</a>
       </div>
     </div>
   </footer>

--- a/es/index.html
+++ b/es/index.html
@@ -30,6 +30,7 @@
 <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/">
 <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/">
 <link rel="alternate" hreflang="sv" href="https://ultratextgen.com/sv/">
+<link rel="alternate" hreflang="no" href="https://ultratextgen.com/no/">
 
 <meta name="robots" content="index, follow">
 
@@ -1011,6 +1012,7 @@
         <a class="lang-option" href="/pl/" hreflang="pl">PL</a>
         <a class="lang-option" href="/vi/" hreflang="vi">VI</a>
         <a class="lang-option" href="/sv/" hreflang="sv">SV</a>
+        <a class="lang-option" href="/no/" hreflang="no">NO</a>
       </div>
     </div>
   </footer>

--- a/fr/ecriture-cursive/index.html
+++ b/fr/ecriture-cursive/index.html
@@ -20,6 +20,7 @@
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/letra-cursiva/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/el-yazisi-fontu/">
   <link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/sierlijke-letters/">
+  <link rel="alternate" hreflang="no" href="https://ultratextgen.com/no/kursiv-tekst/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/category/cursive-fonts/">
 
   <meta name="robots" content="index, follow">
@@ -295,6 +296,7 @@
       <a class="lang-option" href="/nl/sierlijke-letters/" hreflang="nl">NL</a>
       <a class="lang-option" href="/pt/letra-cursiva/" hreflang="pt">PT</a>
       <a class="lang-option" href="/tr/el-yazisi-fontu/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/no/kursiv-tekst/" hreflang="no">NO</a>
     </div>
   </div>
 </footer>

--- a/fr/index.html
+++ b/fr/index.html
@@ -30,6 +30,7 @@
 <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/">
 <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/">
 <link rel="alternate" hreflang="sv" href="https://ultratextgen.com/sv/">
+<link rel="alternate" hreflang="no" href="https://ultratextgen.com/no/">
 
 <meta name="robots" content="index, follow">
 
@@ -1099,6 +1100,7 @@
         <a class="lang-option" href="/pl/" hreflang="pl">PL</a>
         <a class="lang-option" href="/vi/" hreflang="vi">VI</a>
         <a class="lang-option" href="/sv/" hreflang="sv">SV</a>
+        <a class="lang-option" href="/no/" hreflang="no">NO</a>
       </div>
     </div>
   </footer>

--- a/i18n.js
+++ b/i18n.js
@@ -91,7 +91,7 @@
   }
 
   function detectLang() {
-    var supported = ["en", "es", "fr", "pt", "de", "id", "it", "nl", "tr", "pl", "vi", "tl", "sv"];
+    var supported = ["en", "es", "fr", "pt", "de", "id", "it", "nl", "tr", "pl", "vi", "tl", "sv", "no"];
 
     // 1. Detect from URL path prefix (e.g. /fr/, /de/)
     var pathMatch = window.location.pathname.match(/^\/([a-z]{2})\//);

--- a/id/index.html
+++ b/id/index.html
@@ -30,6 +30,7 @@
 <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/">
 <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/">
 <link rel="alternate" hreflang="sv" href="https://ultratextgen.com/sv/">
+<link rel="alternate" hreflang="no" href="https://ultratextgen.com/no/">
 
 <meta name="robots" content="index, follow">
 
@@ -1083,6 +1084,7 @@ O</pre>
         <a class="lang-option" href="/pl/" hreflang="pl">PL</a>
         <a class="lang-option" href="/vi/" hreflang="vi">VI</a>
         <a class="lang-option" href="/sv/" hreflang="sv">SV</a>
+        <a class="lang-option" href="/no/" hreflang="no">NO</a>
       </div>
     </div>
   </footer>

--- a/id/tulisan-sambung/index.html
+++ b/id/tulisan-sambung/index.html
@@ -20,6 +20,7 @@
   <link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/sierlijke-letters/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/letra-cursiva/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/el-yazisi-fontu/">
+  <link rel="alternate" hreflang="no" href="https://ultratextgen.com/no/kursiv-tekst/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/category/cursive-fonts/">
 
   <meta name="robots" content="index, follow">
@@ -209,6 +210,7 @@
       <a class="lang-option" href="/nl/sierlijke-letters/" hreflang="nl">NL</a>
       <a class="lang-option" href="/pt/letra-cursiva/" hreflang="pt">PT</a>
       <a class="lang-option" href="/tr/el-yazisi-fontu/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/no/kursiv-tekst/" hreflang="no">NO</a>
     </div>
   </div>
 </footer>

--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
 <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/">
 <link rel="alternate" hreflang="tl" href="https://ultratextgen.com/tl/">
 <link rel="alternate" hreflang="sv" href="https://ultratextgen.com/sv/">
+<link rel="alternate" hreflang="no" href="https://ultratextgen.com/no/">
 
 <meta name="robots" content="index, follow">
 
@@ -809,6 +810,7 @@
         <a class="lang-option" href="/vi/" hreflang="vi">VI</a>
         <a class="lang-option" href="/tl/" hreflang="tl">TL</a>
         <a class="lang-option" href="/sv/" hreflang="sv">SV</a>
+        <a class="lang-option" href="/no/" hreflang="no">NO</a>
       </div>
     </div>
   </footer>

--- a/it/index.html
+++ b/it/index.html
@@ -30,6 +30,7 @@
 <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/">
 <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/">
 <link rel="alternate" hreflang="sv" href="https://ultratextgen.com/sv/">
+<link rel="alternate" hreflang="no" href="https://ultratextgen.com/no/">
 
 <meta name="robots" content="index, follow">
 
@@ -1029,6 +1030,7 @@
         <a class="lang-option" href="/pl/" hreflang="pl">PL</a>
         <a class="lang-option" href="/vi/" hreflang="vi">VI</a>
         <a class="lang-option" href="/sv/" hreflang="sv">SV</a>
+        <a class="lang-option" href="/no/" hreflang="no">NO</a>
       </div>
     </div>
   </footer>

--- a/locales/no.json
+++ b/locales/no.json
@@ -1,0 +1,190 @@
+{
+  "meta": {
+    "title": "Tekstgenerator - 88 Unicode-skrifttyper (kopier og lim inn)",
+    "description": "Gjør vanlig tekst om til kul tekst med 88 Unicode-skrifttyper: fet skrift, kursiv tekst, håndskrift, gotisk, bobler, små bokstaver, aesthetic, opp ned og Zalgo. Kopier til Instagram-bio, TikTok, Discord, LinkedIn og WhatsApp. Gratis, raskt og uten konto."
+  },
+  "hero": {
+    "title": "Tekstgenerator for kule skrifttyper",
+    "subtitle": "Skriv én gang og få 88 fine skrifttyper du kan kopiere og lime inn direkte: håndskrift, fet skrift, kursiv tekst, fine bokstaver, Instagram-skrifttyper, TikTok-tekst, Discord-navn og WhatsApp-status."
+  },
+  "decorations": {
+    "label": "Legg til symboler, rammer og pynt",
+    "tabs": {
+      "symbols": "Symboler",
+      "frames": "Rammer",
+      "dividers": "Skillere",
+      "arrows": "Piler",
+      "minimal": "Minimal",
+      "emojis": "Emojier",
+      "flags": "Flagg"
+    }
+  },
+  "ui": {
+    "placeholder": "Skriv teksten din her...",
+    "advertisement": "Annonse"
+  },
+  "useCases": {
+    "title": "Hva folk bruker kul tekst til",
+    "viewAll": "Vis alle bruksområder ->",
+    "items": [
+      {
+        "title": "Instagram-bio, navn og captions",
+        "description": "Gjør bioen eller visningsnavnet mer personlig med håndskrift, fet skrift, fine bokstaver og diskrete symboler som kan limes inn med en gang."
+      },
+      {
+        "title": "TikTok-tekster som synes",
+        "description": "Gi første linje mer trykk med fet, kursiv eller aesthetic tekst, slik at captionen skiller seg ut uten å bli vanskelig å lese."
+      },
+      {
+        "title": "Discord, Roblox og gaming-navn",
+        "description": "Bytt stil på visningsnavn, servernavn eller gamertag med gotiske bokstaver, bobletekst, small caps eller glitch-effekter. Ingen app, ingen Nitro."
+      },
+      {
+        "title": "Håndskrift og vertikal tekst",
+        "description": "Lag gammeldags håndskrift, stablet tekst og dekorative linjeskift for profiler, grupper, pins og meldinger."
+      }
+    ]
+  },
+  "guides": {
+    "title": "Populære guider",
+    "viewAll": "Vis alle guider ->",
+    "items": [
+      {
+        "title": "Hvilken skrifttype passer til hvilken følelse?",
+        "description": "Lett, elegant, tydelig eller edgy: lær å velge Unicode-stil etter bio, caption, overskrift eller navn."
+      },
+      {
+        "title": "Personlig merkevare med typografi",
+        "description": "Lag en gjenkjennelig stil på tvers av sosiale kanaler uten bilder, apper eller spesialfonter."
+      },
+      {
+        "title": "Stopp scrollingen med tekstvariasjon",
+        "description": "Se hvordan små forskjeller i fet skrift, kursiv, small caps og symboler kan gjøre en linje mer synlig i feeden."
+      }
+    ]
+  },
+  "faq": {
+    "categories": [
+      {
+        "title": "Grunnleggende om tekstgeneratoren",
+        "items": [
+          {
+            "question": "Hva er en tekstgenerator for kule skrifttyper?",
+            "answer": "En tekstgenerator bytter bokstavene du skriver med andre Unicode-tegn som allerede ser fete, kursiverte, håndskrevne, gotiske, boblete eller dekorative ut. Skriv <code>hei</code> og få for eksempel fet skrift, kursiv tekst, håndskrift, gotisk tekst eller bobletekst.<br><br>Fordi resultatet er ekte Unicode, ikke et bilde og ikke en installert font, kan du kopiere og lime det inn i Instagram-bioer, TikTok-captions, Discord-navn, LinkedIn-overskrifter, WhatsApp-statuser og nesten alle felt som godtar vanlig tekst."
+          },
+          {
+            "question": "Hvordan skiller Unicode-skrifttyper seg fra vanlige skrifttyper som Arial?",
+            "answer": "En vanlig skrifttype er en fil på enheten din som forteller hvordan bokstaven A skal tegnes. Hvis fonten mangler, vises den samme A-en bare med et annet utseende.<br><br>Unicode-skrifttyper fungerer annerledes. De er egne tegn med egne kodepunkter: A, matematisk fet A, kursiv A, script-A, gotisk A og innringet A er forskjellige tegn. Derfor overlever de copy paste. Du limer ikke inn formatering, du limer inn en annen bokstav som allerede ser stylet ut.<br><br>Ulempen er tilgjengelighet: skjermlesere kan lese opp tegnet bokstavelig, for eksempel \"mathematical bold capital A\". Bruk derfor kul tekst til korte aksenter, ikke hele avsnitt."
+          },
+          {
+            "question": "Er UltraTextGen gratis, og hva er haken?",
+            "answer": "Ja. Gratis, ingen konto, ingen daglig grense, ingen vannmerke og ingen e-postinnsamling. Siden finansieres med annonser. Vi tar ikke betalt per kopiering, skjuler ikke stiler bak registrering og legger ikke inn usynlige sporingstegn i teksten du kopierer."
+          }
+        ]
+      },
+      {
+        "title": "Fet, kursiv og stylet tekst på plattformer",
+        "items": [
+          {
+            "question": "Hvordan gjør jeg Instagram-bioen min fet eller kursiv?",
+            "answer": "Instagram har ingen ekte formateringsknapp for bio, navn eller kommentarer. Derfor bruker mange en tekstgenerator som lager Unicode-bokstaver som allerede ser fete eller kursiverte ut.<br><br><strong>Slik gjør du:</strong><br>1. Skriv bioen din i UltraTextGen.<br>2. Velg fet skrift, kursiv tekst, håndskrift eller en annen stil.<br>3. Trykk på Kopier.<br>4. Lim inn i Instagram-appen under Bio eller Navn.<br><br>For best kompatibilitet, velg enkel fet sans-serif eller kursiv stil. Ikke bruk for mye Zalgo eller veldig dekorative tegn i brukernavn, siden Instagram kan avvise dem."
+          },
+          {
+            "question": "Kan jeg lage fet tekst på Discord uten Nitro?",
+            "answer": "Ja. I Discord-meldinger kan du bruke Markdown, for eksempel <code>**tekst**</code> for fet skrift. Men Markdown fungerer ikke i visningsnavn, serverkallenavn, status eller About me.<br><br>Unicode-fet skrift fungerer i disse feltene uten Nitro fordi selve tegnene er fete. Lim inn en fet versjon av navnet ditt, og den vises som fet tekst på servere der Discord godtar tegnene."
+          },
+          {
+            "question": "Hvilken skrifttype bruker LinkedIn, og hvorfor fungerer Unicode-fet skrift der?",
+            "answer": "LinkedIn bruker sin egen typografi, ofte kalt LinkedIn Sans, for mye av teksten på plattformen. Men LinkedIn gir deg ingen fet-knapp i overskrift, Om-seksjon eller innlegg.<br><br>Unicode-fet skrift fungerer fordi tegnene er egne Unicode-tegn. LinkedIn trenger ikke tolke formatering, det viser bare tegnene. Bruk enkel fet skrift til overskrifter og korte uthevinger. Unngå Zalgo, fullwidth og tung dekorasjon i profesjonelle profiler, siden det kan forstyrre søk og skjermlesere."
+          },
+          {
+            "question": "Hvordan lager jeg vertikal eller stablet tekst?",
+            "answer": "Vertikal tekst plasserer en bokstav per linje, slik at ordet leses ovenfra og ned. Det brukes i Discord-kanaler, Pinterest-pins, estetiske Instagram-innlegg og noen ganger i kommentarer som skal skille seg ut.<br><br>Du kan skrive teksten her, velge en stil og deretter bruke den vertikale tekstgeneratoren for å få linjeskiftene automatisk. Det fungerer bra med fet skrift, håndskrift og fullwidth."
+          }
+        ]
+      },
+      {
+        "title": "Skrifttyper, symboler og dekorasjon",
+        "items": [
+          {
+            "question": "Hvilke stiler finnes i generatoren?",
+            "answer": "Det finnes rundt 88 stiler organisert i familier: fet skrift, kursiv, håndskrift, gotisk/fraktur, boblebokstaver, small caps, fullwidth, innringede bokstaver, understrek, gjennomstreket tekst, opp ned, speilvendt tekst, baklengs tekst, Zalgo/glitch og flere dekorative ordrammer.<br><br>Det betyr at du kan lage alt fra diskret fin skrift til en bio til tydeligere gaming- og aesthetic-stiler."
+          },
+          {
+            "question": "Kan jeg blande flere stiler med symboler?",
+            "answer": "Ja. Unicode-stiler kan kombineres med rammer, skillere, piler, hjerter og andre symboler. Du kan for eksempel ta et navn i håndskrift, legge til en tynn stjerne mellom ordene og ramme inn linjen med enkle symboler.<br><br>Ryddige resultater kommer ofte fra maks to stiler om gangen: fet + understrek, kursiv + small caps eller bobletekst + luftige mellomrom. For mye dekorasjon blir fort vanskelig å lese."
+          },
+          {
+            "question": "Hva er Zalgo eller glitch-tekst?",
+            "answer": "Zalgo er tekst som ser ødelagt, hacket eller dryppende ut. Den lages med kombinerende merker over og under bokstavene. Effekten er populær for skrekk, memes, Halloween, Discord-navn og visuelt ekstreme captions.<br><br>Bruk den sparsomt. Mange plattformer godtar den i visningsnavn, men ikke i brukernavn, og for mye Zalgo kan bli vanskelig å lese på mobil."
+          }
+        ]
+      },
+      {
+        "title": "Kompatibilitet og feilsøking",
+        "items": [
+          {
+            "question": "Hvorfor vises noen bokstaver som ruter eller spørsmålstegn?",
+            "answer": "Ruter, tomme blokker eller spørsmålstegn betyr som regel at enheten som viser teksten mangler en font som kan tegne akkurat det Unicode-tegnet. Det er et visningsproblem hos mottakeren, ikke at den kopierte teksten er ødelagt.<br><br>For bredest støtte, velg fet skrift, kursiv, small caps, fullwidth eller innringede bokstaver. Gotiske og veldig dekorative stiler kan av og til mangle på eldre telefoner."
+          },
+          {
+            "question": "Kan jeg bruke kule skrifttyper i brukernavn og visningsnavn?",
+            "answer": "Ofte ja, men det avhenger av plattformen. Visningsnavn på Instagram, TikTok, Discord, Steam, Roblox og Telegram pleier å godta flere Unicode-tegn. Ekte @-handles er strengere og tillater ofte bare vanlige bokstaver, tall, punktum og understrek.<br><br>En god regel: bruk kul tekst i visningsnavn, bio og status. Hold selve brukernavnet enkelt hvis plattformen klager."
+          },
+          {
+            "question": "Er kul Unicode-tekst bra for tilgjengelighet?",
+            "answer": "Ikke alltid. Skjermlesere kan lese opp hvert Unicode-tegn med sitt tekniske navn, noe som gjør lange linjer med stylet tekst slitsomme å høre på.<br><br>Bruk derfor kul tekst som aksent: ett ord, en kort overskrift eller en linje i en bio. Hold viktig informasjon, kontaktinfo og lengre avsnitt i vanlig tekst. Unngå Zalgo og tung dekorasjon der tilgjengelighet er viktig."
+          },
+          {
+            "question": "Kan jeg bruke fet Unicode i e-postemner?",
+            "answer": "Ja, e-postemner er vanlig tekst, så Unicode er en av få måter å få et ord til å se fetere ut i innboksen. Bruk det på ett eller to ord, ikke hele emnelinjen.<br><br>For mange spesialtegn kan trigge spamfiltre eller se rotete ut i enkelte e-postklienter, så hold det kort og tydelig."
+          }
+        ]
+      },
+      {
+        "title": "Språk og alfabet",
+        "items": [
+          {
+            "question": "Hvilke språk og alfabet fungerer?",
+            "answer": "Unicode-stylede varianter finnes hovedsakelig for latinske bokstaver (A-Z, a-z) og arabiske sifre (0-9). Det betyr at norsk, engelsk, svensk, dansk, spansk, fransk, tysk, nederlandsk, polsk, tyrkisk, vietnamesisk og mange andre språk med latinsk alfabet fungerer.<br><br>Norske bokstaver som æ, ø og å har ikke alltid egne stylede Unicode-varianter. I mange stiler blir de stående uendret, eller beholder markeringen sin. Prøv en annen stil hvis akkurat disse bokstavene må se perfekte ut."
+          },
+          {
+            "question": "Hvorfor endres ikke arabiske, kyrilliske, hindi, kinesiske eller japanske tegn?",
+            "answer": "Unicode definerer ikke samme sett med dekorative, fete og kursiverte varianter for alle skriftsystemer. Derfor finnes det ingen direkte erstatning for arabiske, hebraiske, devanagari, kinesiske, japanske, koreanske, kyrilliske eller greske tegn.<br><br>Latinske ord midt i en annen tekst, for eksempel merkenavn, hashtags eller engelske uttrykk, kan fortsatt styles. Resten av teksten blir stående som den er."
+          }
+        ]
+      },
+      {
+        "title": "Personvern og sikkerhet",
+        "items": [
+          {
+            "question": "Lagres, logges eller sendes teksten jeg skriver?",
+            "answer": "Nei. Selve konverteringen skjer i nettleseren din med JavaScript. Teksten du skriver sendes ikke til en server for å genereres.<br><br>Siden bruker analyse og annonser, men innholdet i tekstfeltet trenger ikke forlate nettleseren. Det du kopierer er ren Unicode uten skjulte vannmerker."
+          },
+          {
+            "question": "Fungerer generatoren på mobil og nettbrett?",
+            "answer": "Ja. UltraTextGen fungerer i moderne mobilnettlesere på iPhone, Android og nettbrett. Du skriver, trykker på Kopier og limer direkte inn i Instagram, TikTok, WhatsApp, Discord eller hvilken app du vil."
+          }
+        ]
+      }
+    ]
+  },
+  "footer": {
+    "copyright": "© 2026 UltraTextGen. Kul tekst som fungerer overalt."
+  },
+  "notFound": {
+    "eyebrow": "ERR · 404 · SIDE MANGLER",
+    "title": "Denne siden gled ut av stilbiblioteket.",
+    "subtitle": "Adressen finnes ikke i samlingen vår, men generatoren fungerer fortsatt. Prøv 404 i fet skrift, bobler, gotisk tekst, Zalgo og flere stiler.",
+    "backCta": "<- Til generatoren",
+    "browseCta": "Bla gjennom stiler",
+    "wallTitle": "404 i alle stiler vi kan.",
+    "wallSubtitle": "Alt her nede genereres av samme motor som driver UltraTextGen.",
+    "playgroundTitle": "Test din egen manglende tekst.",
+    "playgroundSubtitle": "Skriv noe og se det i noen favorittstiler før du går tilbake.",
+    "playgroundPlaceholder": "Skriv teksten din her...",
+    "fullGeneratorCta": "Åpne hele generatoren",
+    "copy": "Kopier",
+    "copied": "Kopiert"
+  }
+}

--- a/nl/index.html
+++ b/nl/index.html
@@ -30,6 +30,7 @@
 <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/">
 <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/">
 <link rel="alternate" hreflang="sv" href="https://ultratextgen.com/sv/">
+<link rel="alternate" hreflang="no" href="https://ultratextgen.com/no/">
 
 <meta name="robots" content="index, follow">
 
@@ -696,6 +697,7 @@
         <a class="lang-option" href="/pl/" hreflang="pl">PL</a>
         <a class="lang-option" href="/vi/" hreflang="vi">VI</a>
         <a class="lang-option" href="/sv/" hreflang="sv">SV</a>
+        <a class="lang-option" href="/no/" hreflang="no">NO</a>
       </div>
     </div>
   </footer>

--- a/nl/sierlijke-letters/index.html
+++ b/nl/sierlijke-letters/index.html
@@ -20,6 +20,7 @@
   <link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/sierlijke-letters/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/letra-cursiva/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/el-yazisi-fontu/">
+  <link rel="alternate" hreflang="no" href="https://ultratextgen.com/no/kursiv-tekst/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/category/cursive-fonts/">
 
   <meta name="robots" content="index, follow">
@@ -245,6 +246,7 @@
       <a class="lang-option active" href="/nl/sierlijke-letters/" hreflang="nl">NL</a>
       <a class="lang-option" href="/pt/letra-cursiva/" hreflang="pt">PT</a>
       <a class="lang-option" href="/tr/el-yazisi-fontu/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/no/kursiv-tekst/" hreflang="no">NO</a>
     </div>
   </div>
 </footer>

--- a/no/index.html
+++ b/no/index.html
@@ -1,0 +1,768 @@
+<!DOCTYPE html><html lang="no"><head>
+  <meta name="yandex-verification" content="aa326290e0338f4f">
+  <meta name="p:domain_verify" content="b2362cbc0f13ddea3e632da9bc7df05">
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title data-i18n="meta.title">Tekstgenerator - 88 Unicode-skrifttyper (kopier og lim inn)</title>
+<meta name="description" data-i18n-content="meta.description" content="Gjør vanlig tekst om til kul tekst med 88 Unicode-skrifttyper: fet skrift, kursiv tekst, håndskrift, gotisk, bobler, små bokstaver, aesthetic, opp ned og Zalgo. Kopier til Instagram-bio, TikTok, Discord, LinkedIn og WhatsApp. Gratis, raskt og uten konto.">
+
+<link rel="canonical" href="https://ultratextgen.com/no/">
+
+<link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/">
+<link rel="alternate" hreflang="en" href="https://ultratextgen.com/">
+<link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/">
+<link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/">
+<link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/">
+<link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/">
+<link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/">
+<link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/">
+<link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/">
+<link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/">
+<link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/">
+<link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/">
+<link rel="alternate" hreflang="tl" href="https://ultratextgen.com/tl/">
+<link rel="alternate" hreflang="sv" href="https://ultratextgen.com/sv/">
+<link rel="alternate" hreflang="no" href="https://ultratextgen.com/no/">
+
+<meta name="robots" content="index, follow">
+
+<meta property="og:site_name" content="UltraTextGen">
+<meta property="og:title" content="Tekstgenerator - 88 Unicode-skrifttyper (kopier og lim inn)">
+<meta property="og:description" content="Gjør tekst om til kule Unicode-skrifttyper for Instagram, TikTok, Discord, LinkedIn og WhatsApp. Fet skrift, kursiv tekst, fine bokstaver og symboler du kan kopiere direkte.">
+<meta property="og:url" content="https://ultratextgen.com/no/">
+<meta property="og:type" content="website">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/fancy-text-generator-preview.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Tekstgenerator - 88 Unicode-skrifttyper (kopier og lim inn)">
+<meta name="twitter:description" content="Gjør tekst om til kule Unicode-skrifttyper for Instagram, TikTok, Discord, LinkedIn og WhatsApp. Fet skrift, kursiv tekst, fine bokstaver og symboler du kan kopiere direkte.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/fancy-text-generator-preview.png">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/style.css">
+
+ <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+[
+  {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/",
+    "description": "Rask og enkel generator for kul tekst, håndskrift og Unicode-skrifttyper.",
+    "potentialAction": {
+      "@type": "SearchAction",
+      "target": {
+        "@type": "EntryPoint",
+        "urlTemplate": "https://ultratextgen.com/?q={search_term_string}"
+      },
+      "query-input": "required name=search_term_string"
+    },
+    "inLanguage": "no"
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com",
+    "logo": "https://ultratextgen.com/logo.png",
+    "sameAs": [
+      "https://www.youtube.com/@UltraTextGen",
+      "https://www.facebook.com/profile.php?id=61588587387596",
+      "https://www.linkedin.com/company/71290348/",
+      "https://x.com/UltraTextGen"
+    ]
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "WebApplication",
+    "name": "UltraTextGen Tekstgenerator",
+    "alternateName": [
+      "Unicode Font Generator",
+      "Fancy Font Generator",
+      "Stylish Text Generator",
+      "Font Changer",
+      "Copy and Paste Fonts"
+    ],
+    "url": "https://ultratextgen.com/no/",
+    "applicationCategory": "UtilitiesApplication",
+    "applicationSubCategory": "Text Generator",
+    "operatingSystem": "All",
+    "browserRequirements": "Requires JavaScript",
+    "isAccessibleForFree": true,
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "featureList": [
+      "88 Unicode font styles (bold, italic, cursive, gothic, bubble, small caps, fullwidth, squared, parenthesized)",
+      "Aesthetic and decorative styles for Instagram, TikTok and Pinterest bios",
+      "Upside-down, mirror, backwards and Zalgo (glitch) text",
+      "One-click style mixing and decorative frames, borders, dividers and symbols",
+      "Vertical and stacked text generator",
+      "Copy and paste into Instagram, TikTok, Discord, LinkedIn, WhatsApp, X (Twitter), Snapchat, Roblox, Steam and email subject lines",
+      "Real-time preview as you type",
+      "Runs entirely in the browser — no sign-up, no account, no tracking of input text"
+    ],
+    "description": "Gjør vanlig tekst om til kul tekst med 88 Unicode-skrifttyper: fet skrift, kursiv tekst, håndskrift, gotisk, bobler, små bokstaver, aesthetic, opp ned og Zalgo. Kopier til Instagram-bio, TikTok, Discord, LinkedIn og WhatsApp. Gratis, raskt og uten konto.",
+    "inLanguage": "no"
+  }
+]
+</script>
+
+
+
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Hva er en tekstgenerator for kule skrifttyper?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "En tekstgenerator bytter bokstavene du skriver med andre Unicode-tegn som allerede ser fete, kursiverte, håndskrevne, gotiske, boblete eller dekorative ut. Skriv hei og få for eksempel fet skrift, kursiv tekst, håndskrift, gotisk tekst eller bobletekst. Fordi resultatet er ekte Unicode, ikke et bilde og ikke en installert font, kan du kopiere og lime det inn i Instagram-bioer, TikTok-captions, Discord-navn, LinkedIn-overskrifter, WhatsApp-statuser og nesten alle felt som godtar vanlig tekst."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Hvordan skiller Unicode-skrifttyper seg fra vanlige skrifttyper som Arial?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "En vanlig skrifttype er en fil på enheten din som forteller hvordan bokstaven A skal tegnes. Hvis fonten mangler, vises den samme A-en bare med et annet utseende. Unicode-skrifttyper fungerer annerledes. De er egne tegn med egne kodepunkter: A, matematisk fet A, kursiv A, script-A, gotisk A og innringet A er forskjellige tegn. Derfor overlever de copy paste. Du limer ikke inn formatering, du limer inn en annen bokstav som allerede ser stylet ut. Ulempen er tilgjengelighet: skjermlesere kan lese opp tegnet bokstavelig, for eksempel \"mathematical bold capital A\". Bruk derfor kul tekst til korte aksenter, ikke hele avsnitt."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Er UltraTextGen gratis, og hva er haken?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ja. Gratis, ingen konto, ingen daglig grense, ingen vannmerke og ingen e-postinnsamling. Siden finansieres med annonser. Vi tar ikke betalt per kopiering, skjuler ikke stiler bak registrering og legger ikke inn usynlige sporingstegn i teksten du kopierer."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Hvordan gjør jeg Instagram-bioen min fet eller kursiv?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Instagram har ingen ekte formateringsknapp for bio, navn eller kommentarer. Derfor bruker mange en tekstgenerator som lager Unicode-bokstaver som allerede ser fete eller kursiverte ut. Slik gjør du: 1. Skriv bioen din i UltraTextGen. 2. Velg fet skrift, kursiv tekst, håndskrift eller en annen stil. 3. Trykk på Kopier. 4. Lim inn i Instagram-appen under Bio eller Navn. For best kompatibilitet, velg enkel fet sans-serif eller kursiv stil. Ikke bruk for mye Zalgo eller veldig dekorative tegn i brukernavn, siden Instagram kan avvise dem."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Kan jeg lage fet tekst på Discord uten Nitro?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ja. I Discord-meldinger kan du bruke Markdown, for eksempel **tekst** for fet skrift. Men Markdown fungerer ikke i visningsnavn, serverkallenavn, status eller About me. Unicode-fet skrift fungerer i disse feltene uten Nitro fordi selve tegnene er fete. Lim inn en fet versjon av navnet ditt, og den vises som fet tekst på servere der Discord godtar tegnene."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Hvilken skrifttype bruker LinkedIn, og hvorfor fungerer Unicode-fet skrift der?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "LinkedIn bruker sin egen typografi, ofte kalt LinkedIn Sans, for mye av teksten på plattformen. Men LinkedIn gir deg ingen fet-knapp i overskrift, Om-seksjon eller innlegg. Unicode-fet skrift fungerer fordi tegnene er egne Unicode-tegn. LinkedIn trenger ikke tolke formatering, det viser bare tegnene. Bruk enkel fet skrift til overskrifter og korte uthevinger. Unngå Zalgo, fullwidth og tung dekorasjon i profesjonelle profiler, siden det kan forstyrre søk og skjermlesere."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Hvordan lager jeg vertikal eller stablet tekst?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Vertikal tekst plasserer en bokstav per linje, slik at ordet leses ovenfra og ned. Det brukes i Discord-kanaler, Pinterest-pins, estetiske Instagram-innlegg og noen ganger i kommentarer som skal skille seg ut. Du kan skrive teksten her, velge en stil og deretter bruke den vertikale tekstgeneratoren for å få linjeskiftene automatisk. Det fungerer bra med fet skrift, håndskrift og fullwidth."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Hvilke stiler finnes i generatoren?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Det finnes rundt 88 stiler organisert i familier: fet skrift, kursiv, håndskrift, gotisk/fraktur, boblebokstaver, small caps, fullwidth, innringede bokstaver, understrek, gjennomstreket tekst, opp ned, speilvendt tekst, baklengs tekst, Zalgo/glitch og flere dekorative ordrammer. Det betyr at du kan lage alt fra diskret fin skrift til en bio til tydeligere gaming- og aesthetic-stiler."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Kan jeg blande flere stiler med symboler?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ja. Unicode-stiler kan kombineres med rammer, skillere, piler, hjerter og andre symboler. Du kan for eksempel ta et navn i håndskrift, legge til en tynn stjerne mellom ordene og ramme inn linjen med enkle symboler. Ryddige resultater kommer ofte fra maks to stiler om gangen: fet + understrek, kursiv + small caps eller bobletekst + luftige mellomrom. For mye dekorasjon blir fort vanskelig å lese."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Hva er Zalgo eller glitch-tekst?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Zalgo er tekst som ser ødelagt, hacket eller dryppende ut. Den lages med kombinerende merker over og under bokstavene. Effekten er populær for skrekk, memes, Halloween, Discord-navn og visuelt ekstreme captions. Bruk den sparsomt. Mange plattformer godtar den i visningsnavn, men ikke i brukernavn, og for mye Zalgo kan bli vanskelig å lese på mobil."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Hvorfor vises noen bokstaver som ruter eller spørsmålstegn?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ruter, tomme blokker eller spørsmålstegn betyr som regel at enheten som viser teksten mangler en font som kan tegne akkurat det Unicode-tegnet. Det er et visningsproblem hos mottakeren, ikke at den kopierte teksten er ødelagt. For bredest støtte, velg fet skrift, kursiv, small caps, fullwidth eller innringede bokstaver. Gotiske og veldig dekorative stiler kan av og til mangle på eldre telefoner."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Kan jeg bruke kule skrifttyper i brukernavn og visningsnavn?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ofte ja, men det avhenger av plattformen. Visningsnavn på Instagram, TikTok, Discord, Steam, Roblox og Telegram pleier å godta flere Unicode-tegn. Ekte @-handles er strengere og tillater ofte bare vanlige bokstaver, tall, punktum og understrek. En god regel: bruk kul tekst i visningsnavn, bio og status. Hold selve brukernavnet enkelt hvis plattformen klager."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Er kul Unicode-tekst bra for tilgjengelighet?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ikke alltid. Skjermlesere kan lese opp hvert Unicode-tegn med sitt tekniske navn, noe som gjør lange linjer med stylet tekst slitsomme å høre på. Bruk derfor kul tekst som aksent: ett ord, en kort overskrift eller en linje i en bio. Hold viktig informasjon, kontaktinfo og lengre avsnitt i vanlig tekst. Unngå Zalgo og tung dekorasjon der tilgjengelighet er viktig."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Kan jeg bruke fet Unicode i e-postemner?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ja, e-postemner er vanlig tekst, så Unicode er en av få måter å få et ord til å se fetere ut i innboksen. Bruk det på ett eller to ord, ikke hele emnelinjen. For mange spesialtegn kan trigge spamfiltre eller se rotete ut i enkelte e-postklienter, så hold det kort og tydelig."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Hvilke språk og alfabet fungerer?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Unicode-stylede varianter finnes hovedsakelig for latinske bokstaver (A-Z, a-z) og arabiske sifre (0-9). Det betyr at norsk, engelsk, svensk, dansk, spansk, fransk, tysk, nederlandsk, polsk, tyrkisk, vietnamesisk og mange andre språk med latinsk alfabet fungerer. Norske bokstaver som æ, ø og å har ikke alltid egne stylede Unicode-varianter. I mange stiler blir de stående uendret, eller beholder markeringen sin. Prøv en annen stil hvis akkurat disse bokstavene må se perfekte ut."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Hvorfor endres ikke arabiske, kyrilliske, hindi, kinesiske eller japanske tegn?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Unicode definerer ikke samme sett med dekorative, fete og kursiverte varianter for alle skriftsystemer. Derfor finnes det ingen direkte erstatning for arabiske, hebraiske, devanagari, kinesiske, japanske, koreanske, kyrilliske eller greske tegn. Latinske ord midt i en annen tekst, for eksempel merkenavn, hashtags eller engelske uttrykk, kan fortsatt styles. Resten av teksten blir stående som den er."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Lagres, logges eller sendes teksten jeg skriver?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Nei. Selve konverteringen skjer i nettleseren din med JavaScript. Teksten du skriver sendes ikke til en server for å genereres. Siden bruker analyse og annonser, men innholdet i tekstfeltet trenger ikke forlate nettleseren. Det du kopierer er ren Unicode uten skjulte vannmerker."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Fungerer generatoren på mobil og nettbrett?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ja. UltraTextGen fungerer i moderne mobilnettlesere på iPhone, Android og nettbrett. Du skriver, trykker på Kopier og limer direkte inn i Instagram, TikTok, WhatsApp, Discord eller hvilken app du vil."
+      }
+    }
+  ],
+  "inLanguage": "sv"
+}
+</script>
+</head>
+
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer=""></script>
+
+  <!-- Hero Section -->
+  <section class="hero">
+    <div class="hero-inner">
+      <div class="hero-card">
+        <h1 class="hero-headline" data-i18n="hero.title">Tekstgenerator for kule skrifttyper</h1>
+        <p class="hero-tagline" data-i18n="hero.subtitle">Skriv én gang og få 88 fine skrifttyper du kan kopiere og lime inn direkte: håndskrift, fet skrift, kursiv tekst, fine bokstaver, Instagram-skrifttyper, TikTok-tekst, Discord-navn og WhatsApp-status.</p>
+        <div class="input-wrapper">
+          <textarea class="main-input" id="mainInput" placeholder="Skriv teksten din her..." data-i18n-placeholder="ui.placeholder" maxlength="500" autofocus=""></textarea>
+          <button class="input-clear-btn" id="inputClearBtn" aria-label="Clear input" hidden="">✕</button>
+          <span class="char-count" id="charCountWrapper" hidden=""><span id="charCount">0</span>/500</span>
+        </div>
+
+        <!-- Accent-aware hint: shows only when the input contains diacritics -->
+        <div class="accent-notice" id="accentNotice" role="note" hidden="">
+          <span class="accent-notice-icon" aria-hidden="true">◌́</span>
+          <span class="accent-notice-text">Your text has accent marks. Most styles leave letters like <b>é</b> and <b>ữ</b> plain — <b>strikethrough, underline and symbol-wrap</b> styles keep them. <a href="/guide/fancy-fonts-and-accents/">Which styles keep accents →</a></span>
+          <button type="button" class="accent-notice-close" id="accentNoticeClose" aria-label="Dismiss">✕</button>
+        </div>
+
+        <!-- Decoration Selector -->
+        <div class="decoration-section">
+          <div class="decoration-label">
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"></path>
+            </svg>
+            <span data-i18n="decorations.label">Legg til symboler, rammer og pynt</span>
+       </div>
+    <div class="decoration-tabs">
+    <button class="decoration-tab active" data-deco-tab="symbols" data-i18n="decorations.tabs.symbols">Symboler</button>
+    <button class="decoration-tab" data-deco-tab="frames" data-i18n="decorations.tabs.frames">Rammer</button>
+    <button class="decoration-tab" data-deco-tab="dividers" data-i18n="decorations.tabs.dividers">Skillere</button>
+    <button class="decoration-tab" data-deco-tab="arrows" data-i18n="decorations.tabs.arrows">Piler</button>
+    <button class="decoration-tab" data-deco-tab="minimal" data-i18n="decorations.tabs.minimal">Minimal</button>
+    <button class="decoration-tab" data-deco-tab="emojis" data-i18n="decorations.tabs.emojis">Emojier</button>
+    <button class="decoration-tab" data-deco-tab="flags" data-i18n="decorations.tabs.flags">Flagg</button>
+      </div>
+          <div class="decoration-grid" id="decorationGrid"></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Main Content -->
+  <main class="container">
+    <!-- Category Tabs -->
+    <div class="category-section">
+      <div class="category-tabs" id="categoryTabs">
+        <!-- Tabs will be dynamically loaded from fonts.json -->
+      </div>
+    </div>
+
+    <!-- Results -->
+    <div class="results-grid" id="resultsGrid"></div>
+  </main>
+
+  <!-- Intro / topical anchor -->
+  <section class="editorial-section" aria-labelledby="intro-heading">
+    <h2 id="intro-heading">What this fancy text generator actually does</h2>
+    <p>
+      UltraTextGen is a free Unicode font generator. You type plain text, it swaps each letter for a styled character that lives inside the Unicode standard, and you copy the result wherever you want it: an Instagram bio, a TikTok caption, a Discord display name, a LinkedIn headline, a Roblox profile, a WhatsApp status, even an email subject line. Because the styled letters <em>are</em> the text — not a font file your phone has to load, and not Markdown that gets stripped — they survive copy-paste into apps that don’t allow formatting.
+    </p>
+    <p>
+      Type <code>hello</code> and you get:
+      𝗵𝗲𝗹𝗹𝗼 (bold),
+      𝘩𝘦𝘭𝘭𝘰 (italic),
+      𝒽ℯ𝓁𝓁ℴ (cursive script),
+      𝔥𝔢𝔩𝔩𝔬 (gothic),
+      🅗🅔🅛🅛🅞 (bubble),
+      ʰᵉˡˡᵒ (tiny / superscript),
+      ʜᴇʟʟᴏ (small caps),
+      ⓗⓔⓛⓛⓞ (circled),
+      ｈｅｌｌｏ (fullwidth),
+      h̶e̶l̶l̶o̶ (strikethrough),
+      h̳e̳l̳l̳o̳ (underline),
+      oʅʅǝɥ (upside-down),
+      ollǝɥ (mirror),
+      h̷̢̛e̴̜͝l̸̼͝l̷͔͠o̵̗͝ (Zalgo / glitch),
+      and roughly 50 more — including aesthetic spaced styles like <strong>𝓱 𝓮 𝓵 𝓵 𝓸</strong> people use for Pinterest pins and Y2K-style usernames.
+    </p>
+    <h3>Where these fonts actually work (and where they don’t)</h3>
+    <p>
+      Compatibility varies because Unicode rendering depends on the device font, not the website. Here’s what we’ve tested:
+    </p>
+    <ul class="compat-list">
+      <li><strong>Instagram</strong> — bio, post caption, comments, story stickers: works in every style. Username field: works only with Latin-script styles (bold, italic, cursive, bubble); won’t accept Zalgo or fullwidth.</li>
+      <li><strong>TikTok</strong> — bio, caption, comments, video description: works in all core styles. The "nickname" field is more permissive than Instagram’s username.</li>
+      <li><strong>Discord</strong> — server nickname, display name, messages, “About me”: Unicode fonts work without Nitro. Markdown bold (<code>**text**</code>) only renders inside messages; Unicode bold renders <em>everywhere</em>, including your nickname.</li>
+      <li><strong>LinkedIn</strong> — headline, About section, post body: bold, italic and small caps render reliably. Avoid Zalgo and heavily decorated styles on a professional profile — they trigger recruiter filters and screen-reader issues.</li>
+      <li><strong>WhatsApp</strong> — status, group names, broadcasts: all Unicode fonts work. WhatsApp’s own <code>*bold*</code>, <code>_italic_</code> and <code>~strike~</code> only render inside chat messages, so Unicode is the only option for status and group names.</li>
+      <li><strong>X (Twitter)</strong> — display name, bio, tweets: works everywhere. Some Zalgo styles get visually clipped on mobile.</li>
+      <li><strong>Snapchat, Pinterest, Telegram, Signal, iMessage</strong> — bios, captions, messages: all work.</li>
+      <li><strong>Roblox, Steam, Minecraft, Fortnite</strong> — display names usually accept bold/italic/gothic. Each platform’s name filter rejects different characters — try a different style if one is blocked.</li>
+      <li><strong>Email subject lines</strong> (Gmail, Outlook, Apple Mail) — render Unicode fonts as written. This is the one place where there is no rich-text alternative.</li>
+      <li><strong>Won’t work:</strong> Microsoft Word, Google Docs body text styling (use the built-in toolbar instead), printed documents with non-Unicode fonts, and anywhere the recipient’s device is missing the glyph (rare on phones made after 2018).</li>
+    </ul>
+    <h3>Why Unicode fonts ≠ regular fonts</h3>
+    <p>
+      A regular font (Helvetica, Arial, the LinkedIn Sans typeface, etc.) is a file that lives on your device and tells the screen how to draw a letter. If the website doesn’t load that font, the letter still says "A" — it just gets drawn in a default font instead. Unicode “fonts” aren’t fonts at all in that sense. They’re separate characters in the Unicode standard — A, 𝐀, 𝘈, 𝓐, 𝔄, 𝕬, Ⓐ are all different characters with different code points. That’s why they travel: you’re not styling the letter A, you’re using a different letter entirely that happens to look styled.
+    </p>
+    <h3>What’s in the library</h3>
+    <p>
+      About 65 styles across twelve families: <strong>bold</strong> (sans, serif, italic-bold), <strong>italic</strong>, <strong>cursive / script</strong> (regular and bold), <strong>gothic / fraktur</strong>, <strong>bubble</strong> (filled, light, tiles, curly, angle, spaced, and more — 12 variants), <strong>strikethrough</strong> (slash, tilde, short, long), <strong>underline</strong>, <strong>monospace / fullwidth</strong>, <strong>small caps and superscript</strong>, <strong>aesthetic / spaced</strong>, <strong>upside-down + mirror + backwards</strong>, <strong>Zalgo (glitch)</strong>, and a ten-style <strong>text decorator</strong> that auto-brackets each word with symbols. Stack two styles together with one click, or wrap the whole result in a frame, divider, arrow, emoji or flag.
+    </p>
+  </section>
+
+  <!-- Popular Use Cases -->
+  <section class="editorial-section">
+    <h2 data-i18n="useCases.title">Hva folk bruker kul tekst til</h2>
+    <div class="tips-grid">
+      <a class="tip-card" href="/usecase/linkedin-headline/" aria-label="LinkedIn headline font generator">
+        <div class="tip-icon">💼</div>
+        <h3 data-i18n="useCases.items.0.title">Instagram-bio, navn og captions</h3>
+        <p data-i18n="useCases.items.0.description">Gjør bioen eller visningsnavnet mer personlig med håndskrift, fet skrift, fine bokstaver og diskrete symboler som kan limes inn med en gang.</p>
+      </a>
+      <a class="tip-card" href="/usecase/comment-font/" aria-label="Comment fonts for Instagram, YouTube and TikTok">
+        <div class="tip-icon">💬</div>
+        <h3 data-i18n="useCases.items.1.title">TikTok-tekster som synes</h3>
+        <p data-i18n="useCases.items.1.description">Gi første linje mer trykk med fet, kursiv eller aesthetic tekst, slik at captionen skiller seg ut uten å bli vanskelig å lese.</p>
+      </a>
+      <a class="tip-card" href="/usecase/vertical-text/" aria-label="Vertical and stacked text generator">
+        <div class="tip-icon">↕️</div>
+        <h3 data-i18n="useCases.items.2.title">Discord, Roblox og gaming-navn</h3>
+        <p data-i18n="useCases.items.2.description">Bytt stil på visningsnavn, servernavn eller gamertag med gotiske bokstaver, bobletekst, small caps eller glitch-effekter. Ingen app, ingen Nitro.</p>
+      </a>
+      <a class="tip-card" href="/discord/" aria-label="Discord font generator">
+        <div class="tip-icon">🎮</div>
+        <h3 data-i18n="useCases.items.3.title">Håndskrift og vertikal tekst</h3>
+        <p data-i18n="useCases.items.3.description">Lag gammeldags håndskrift, stablet tekst og dekorative linjeskift for profiler, grupper, pins og meldinger.</p>
+      </a>
+      <a class="tip-card" href="/usecase/zalgo-text/" aria-label="Zalgo glitch text generator">
+        <div class="tip-icon">👻</div>
+        <h3>Zalgo &amp; cursed glitch text</h3>
+        <p>Corrupt any text with stacked Unicode marks — one-click presets from subtle to full chaos, a "will it fit?" check for Discord and X limits, plus a decoder that un-zalgos text back to normal.</p>
+      </a>
+    </div>
+    <p class="u-mt-15 u-text-center"><a class="cat-cta" href="/usecase/" data-i18n="useCases.viewAll">Vis alle bruksområder -&gt;</a></p>
+  </section>
+
+  <!-- Popular Guides -->
+  <section class="editorial-section">
+    <h2 data-i18n="guides.title">Populære guider</h2>
+    <div class="tips-grid">
+      <a class="tip-card" href="/guide/the-rhetoric-of-fonts/" aria-label="The Rhetoric of Fonts guide">
+        <div class="tip-icon">📚</div>
+        <h3 data-i18n="guides.items.0.title">Hvilken skrifttype passer til hvilken følelse?</h3>
+        <p data-i18n="guides.items.0.description">Lett, elegant, tydelig eller edgy: lær å velge Unicode-stil etter bio, caption, overskrift eller navn.</p>
+      </a>
+      <a class="tip-card" href="/guide/personal-branding-through-typography/" aria-label="Personal Branding Through Typography guide">
+        <div class="tip-icon">🎨</div>
+        <h3 data-i18n="guides.items.1.title">Personlig merkevare med typografi</h3>
+        <p data-i18n="guides.items.1.description">Lag en gjenkjennelig stil på tvers av sosiale kanaler uten bilder, apper eller spesialfonter.</p>
+      </a>
+      <a class="tip-card" href="/guide/stop-the-scroll-with-font-variation/" aria-label="Stop the Scroll With Font Variation guide">
+        <div class="tip-icon">📱</div>
+        <h3 data-i18n="guides.items.2.title">Stopp scrollingen med tekstvariasjon</h3>
+        <p data-i18n="guides.items.2.description">Se hvordan små forskjeller i fet skrift, kursiv, small caps og symboler kan gjøre en linje mer synlig i feeden.</p>
+      </a>
+    </div>
+    <p class="u-mt-15 u-text-center"><a class="cat-cta" href="/guide/" data-i18n="guides.viewAll">Vis alle guider -&gt;</a></p>
+  </section>
+
+  <!-- Popular Categories -->
+  <section class="editorial-section">
+    <h2>Popular font categories</h2>
+    <div class="tips-grid">
+      <a class="tip-card" href="/category/bold-fonts/" aria-label="Bold font generator">
+        <div class="tip-icon">🅱️</div>
+        <h3>Bold (𝗕𝗼𝗹𝗱 / 𝐁𝐨𝐥𝐝)</h3>
+        <p>The most-used style on the site. Sans and serif variants, plus bold-italic. Use it for the first line of a LinkedIn post, the hook in an Instagram caption, or to make a single word in a paragraph carry weight.</p>
+      </a>
+      <a class="tip-card" href="/category/cursive-fonts/" aria-label="Cursive and script font generator">
+        <div class="tip-icon">✍️</div>
+        <h3>Cursive &amp; script (𝓒𝓾𝓻𝓼𝓲𝓿𝓮)</h3>
+        <p>Two flowing script variants. People paste these into Instagram bios, Pinterest pin titles, wedding-y captions, and aesthetic usernames. Bold script reads better at small sizes — use it on TikTok.</p>
+      </a>
+      <a class="tip-card" href="/category/gothic-fonts/" aria-label="Gothic and fraktur font generator">
+        <div class="tip-icon">🖤</div>
+        <h3>Gothic / fraktur (𝔊𝔬𝔱𝔥𝔦𝔠)</h3>
+        <p>Old-English / Fraktur letterforms. Common in gaming clan tags, metal/horror branding, dark academia bios, and Discord display names. Looks heaviest at large sizes — pair with one decorative symbol, not five.</p>
+      </a>
+      <a class="tip-card" href="/category/bubble-fonts/" aria-label="Bubble and aesthetic font generator">
+        <div class="tip-icon">🫧</div>
+        <h3>Bubble &amp; aesthetic (🅑🅤🅑🅑🅛🅔)</h3>
+        <p>12 bubble variants plus aesthetic spaced styles. Top pick for Y2K, kidcore, and "aesthetic font copy and paste" energy on TikTok, Pinterest, and Tumblr. Filled-bubble has the widest device support; the rest can break on older Android.</p>
+      </a>
+    </div>
+    <p class="u-mt-15 u-text-center"><a class="cat-cta" href="/category/">Browse all font categories →</a></p>
+  </section>
+
+  <!-- Popular Library References -->
+  <section class="editorial-section">
+    <h2>Popular symbol &amp; emoji libraries</h2>
+    <div class="tips-grid">
+      <a class="tip-card" href="/library/text-faces-kaomoji/" aria-label="Text faces and kaomoji library">
+        <div class="tip-icon">(•‿•)</div>
+        <h3>Text faces &amp; kaomoji</h3>
+        <p>Japanese emoticons and ASCII text faces — shrug, happy, table-flip and more — that copy and paste cleanly into any bio, comment, or chat without breaking.</p>
+      </a>
+      <a class="tip-card" href="/library/math-symbols/" aria-label="Math symbols library">
+        <div class="tip-icon">∑</div>
+        <h3>Math symbols</h3>
+        <p>Operators, Greek letters, set theory, calculus and superscripts as plain Unicode — write equations in emails, posts and docs with no LaTeX needed.</p>
+      </a>
+      <a class="tip-card" href="/library/aesthetic-symbols/" aria-label="Aesthetic symbols library">
+        <div class="tip-icon">✦</div>
+        <h3>Aesthetic symbols</h3>
+        <p>Coquette, Y2K, kawaii and soft decorative characters for usernames, bios and captions. Tap any symbol to copy it instantly.</p>
+      </a>
+      <a class="tip-card" href="/library/emoji-combos/" aria-label="Emoji combos library">
+        <div class="tip-icon">🎀🌸✨</div>
+        <h3>Emoji combos</h3>
+        <p>100+ aesthetic emoji combos — soft girl, cottagecore, night sky, Y2K and more. Tap any combo to copy the whole set for your bio, caption or username.</p>
+      </a>
+      <a class="tip-card" href="/library/y2k-symbols/" aria-label="Y2K symbols library">
+        <div class="tip-icon">✦♱🦋</div>
+        <h3>Y2K symbols</h3>
+        <p>80+ Y2K aesthetic symbols — sparkle stars, gothic crosses, butterflies, CDs and cyber glyphs. Tap any symbol or combo to copy it straight into a bio or caption.</p>
+      </a>
+      <a class="tip-card" href="/library/special-characters/" aria-label="Special characters library">
+        <div class="tip-icon">✧</div>
+        <h3>Special characters</h3>
+        <p>Unusual Unicode symbols, fancy punctuation and rare glyphs for names, design and formatting — a quick reference you can copy from in one tap.</p>
+      </a>
+    </div>
+    <p class="u-mt-15 u-text-center"><a class="cat-cta" href="/library/">Browse the full symbol &amp; emoji library →</a></p>
+  </section>
+
+  <!-- FAQ Section -->
+  <section class="faq-section-wrapper" aria-label="Frequently asked questions">
+    <div class="faq-inner">
+
+<!-- Basics -->
+<h2 class="faq-category" data-i18n="faq.categories.0.title">Grunnleggende om tekstgeneratoren</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.0.items.0.question">Hva er en tekstgenerator for kule skrifttyper?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.0.items.0.answer">En tekstgenerator bytter bokstavene du skriver med andre Unicode-tegn som allerede ser fete, kursiverte, håndskrevne, gotiske, boblete eller dekorative ut. Skriv <code>hei</code> og få for eksempel fet skrift, kursiv tekst, håndskrift, gotisk tekst eller bobletekst.<br><br>Fordi resultatet er ekte Unicode, ikke et bilde og ikke en installert font, kan du kopiere og lime det inn i Instagram-bioer, TikTok-captions, Discord-navn, LinkedIn-overskrifter, WhatsApp-statuser og nesten alle felt som godtar vanlig tekst.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.0.items.1.question">Hvordan skiller Unicode-skrifttyper seg fra vanlige skrifttyper som Arial?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.0.items.1.answer">En vanlig skrifttype er en fil på enheten din som forteller hvordan bokstaven A skal tegnes. Hvis fonten mangler, vises den samme A-en bare med et annet utseende.<br><br>Unicode-skrifttyper fungerer annerledes. De er egne tegn med egne kodepunkter: A, matematisk fet A, kursiv A, script-A, gotisk A og innringet A er forskjellige tegn. Derfor overlever de copy paste. Du limer ikke inn formatering, du limer inn en annen bokstav som allerede ser stylet ut.<br><br>Ulempen er tilgjengelighet: skjermlesere kan lese opp tegnet bokstavelig, for eksempel "mathematical bold capital A". Bruk derfor kul tekst til korte aksenter, ikke hele avsnitt.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.0.items.2.question">Er UltraTextGen gratis, og hva er haken?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.0.items.2.answer">Ja. Gratis, ingen konto, ingen daglig grense, ingen vannmerke og ingen e-postinnsamling. Siden finansieres med annonser. Vi tar ikke betalt per kopiering, skjuler ikke stiler bak registrering og legger ikke inn usynlige sporingstegn i teksten du kopierer.</div>
+</div>
+
+
+<!-- Platform how-tos -->
+<h2 class="faq-category" data-i18n="faq.categories.1.title">Fet, kursiv og stylet tekst på plattformer</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.1.items.0.question">Hvordan gjør jeg Instagram-bioen min fet eller kursiv?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.1.items.0.answer">Instagram har ingen ekte formateringsknapp for bio, navn eller kommentarer. Derfor bruker mange en tekstgenerator som lager Unicode-bokstaver som allerede ser fete eller kursiverte ut.<br><br><strong>Slik gjør du:</strong><br>1. Skriv bioen din i UltraTextGen.<br>2. Velg fet skrift, kursiv tekst, håndskrift eller en annen stil.<br>3. Trykk på Kopier.<br>4. Lim inn i Instagram-appen under Bio eller Navn.<br><br>For best kompatibilitet, velg enkel fet sans-serif eller kursiv stil. Ikke bruk for mye Zalgo eller veldig dekorative tegn i brukernavn, siden Instagram kan avvise dem.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.1.items.1.question">Kan jeg lage fet tekst på Discord uten Nitro?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.1.items.1.answer">Ja. I Discord-meldinger kan du bruke Markdown, for eksempel <code>**tekst**</code> for fet skrift. Men Markdown fungerer ikke i visningsnavn, serverkallenavn, status eller About me.<br><br>Unicode-fet skrift fungerer i disse feltene uten Nitro fordi selve tegnene er fete. Lim inn en fet versjon av navnet ditt, og den vises som fet tekst på servere der Discord godtar tegnene.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.1.items.2.question">Hvilken skrifttype bruker LinkedIn, og hvorfor fungerer Unicode-fet skrift der?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.1.items.2.answer">LinkedIn bruker sin egen typografi, ofte kalt LinkedIn Sans, for mye av teksten på plattformen. Men LinkedIn gir deg ingen fet-knapp i overskrift, Om-seksjon eller innlegg.<br><br>Unicode-fet skrift fungerer fordi tegnene er egne Unicode-tegn. LinkedIn trenger ikke tolke formatering, det viser bare tegnene. Bruk enkel fet skrift til overskrifter og korte uthevinger. Unngå Zalgo, fullwidth og tung dekorasjon i profesjonelle profiler, siden det kan forstyrre søk og skjermlesere.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.1.items.3.question">Hvordan lager jeg vertikal eller stablet tekst?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.1.items.3.answer">Vertikal tekst plasserer en bokstav per linje, slik at ordet leses ovenfra og ned. Det brukes i Discord-kanaler, Pinterest-pins, estetiske Instagram-innlegg og noen ganger i kommentarer som skal skille seg ut.<br><br>Du kan skrive teksten her, velge en stil og deretter bruke den vertikale tekstgeneratoren for å få linjeskiftene automatisk. Det fungerer bra med fet skrift, håndskrift og fullwidth.</div>
+</div>
+
+
+<!-- Styles & decoration -->
+<h2 class="faq-category" data-i18n="faq.categories.2.title">Skrifttyper, symboler og dekorasjon</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.2.items.0.question">Hvilke stiler finnes i generatoren?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.2.items.0.answer">Det finnes rundt 88 stiler organisert i familier: fet skrift, kursiv, håndskrift, gotisk/fraktur, boblebokstaver, small caps, fullwidth, innringede bokstaver, understrek, gjennomstreket tekst, opp ned, speilvendt tekst, baklengs tekst, Zalgo/glitch og flere dekorative ordrammer.<br><br>Det betyr at du kan lage alt fra diskret fin skrift til en bio til tydeligere gaming- og aesthetic-stiler.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.2.items.1.question">Kan jeg blande flere stiler med symboler?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.2.items.1.answer">Ja. Unicode-stiler kan kombineres med rammer, skillere, piler, hjerter og andre symboler. Du kan for eksempel ta et navn i håndskrift, legge til en tynn stjerne mellom ordene og ramme inn linjen med enkle symboler.<br><br>Ryddige resultater kommer ofte fra maks to stiler om gangen: fet + understrek, kursiv + small caps eller bobletekst + luftige mellomrom. For mye dekorasjon blir fort vanskelig å lese.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.2.items.2.question">Hva er Zalgo eller glitch-tekst?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.2.items.2.answer">Zalgo er tekst som ser ødelagt, hacket eller dryppende ut. Den lages med kombinerende merker over og under bokstavene. Effekten er populær for skrekk, memes, Halloween, Discord-navn og visuelt ekstreme captions.<br><br>Bruk den sparsomt. Mange plattformer godtar den i visningsnavn, men ikke i brukernavn, og for mye Zalgo kan bli vanskelig å lese på mobil.</div>
+</div>
+
+
+<!-- Compatibility & troubleshooting -->
+<h2 class="faq-category" data-i18n="faq.categories.3.title">Kompatibilitet og feilsøking</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.3.items.0.question">Hvorfor vises noen bokstaver som ruter eller spørsmålstegn?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.3.items.0.answer">Ruter, tomme blokker eller spørsmålstegn betyr som regel at enheten som viser teksten mangler en font som kan tegne akkurat det Unicode-tegnet. Det er et visningsproblem hos mottakeren, ikke at den kopierte teksten er ødelagt.<br><br>For bredest støtte, velg fet skrift, kursiv, small caps, fullwidth eller innringede bokstaver. Gotiske og veldig dekorative stiler kan av og til mangle på eldre telefoner.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.3.items.1.question">Kan jeg bruke kule skrifttyper i brukernavn og visningsnavn?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.3.items.1.answer">Ofte ja, men det avhenger av plattformen. Visningsnavn på Instagram, TikTok, Discord, Steam, Roblox og Telegram pleier å godta flere Unicode-tegn. Ekte @-handles er strengere og tillater ofte bare vanlige bokstaver, tall, punktum og understrek.<br><br>En god regel: bruk kul tekst i visningsnavn, bio og status. Hold selve brukernavnet enkelt hvis plattformen klager.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.3.items.2.question">Er kul Unicode-tekst bra for tilgjengelighet?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.3.items.2.answer">Ikke alltid. Skjermlesere kan lese opp hvert Unicode-tegn med sitt tekniske navn, noe som gjør lange linjer med stylet tekst slitsomme å høre på.<br><br>Bruk derfor kul tekst som aksent: ett ord, en kort overskrift eller en linje i en bio. Hold viktig informasjon, kontaktinfo og lengre avsnitt i vanlig tekst. Unngå Zalgo og tung dekorasjon der tilgjengelighet er viktig.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.3.items.3.question">Kan jeg bruke fet Unicode i e-postemner?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.3.items.3.answer">Ja, e-postemner er vanlig tekst, så Unicode er en av få måter å få et ord til å se fetere ut i innboksen. Bruk det på ett eller to ord, ikke hele emnelinjen.<br><br>For mange spesialtegn kan trigge spamfiltre eller se rotete ut i enkelte e-postklienter, så hold det kort og tydelig.</div>
+</div>
+
+
+<!-- Languages -->
+<h2 class="faq-category" data-i18n="faq.categories.4.title">Språk og alfabet</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.4.items.0.question">Hvilke språk og alfabet fungerer?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.4.items.0.answer">Unicode-stylede varianter finnes hovedsakelig for latinske bokstaver (A-Z, a-z) og arabiske sifre (0-9). Det betyr at norsk, engelsk, svensk, dansk, spansk, fransk, tysk, nederlandsk, polsk, tyrkisk, vietnamesisk og mange andre språk med latinsk alfabet fungerer.<br><br>Norske bokstaver som æ, ø og å har ikke alltid egne stylede Unicode-varianter. I mange stiler blir de stående uendret, eller beholder markeringen sin. Prøv en annen stil hvis akkurat disse bokstavene må se perfekte ut.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.4.items.1.question">Hvorfor endres ikke arabiske, kyrilliske, hindi, kinesiske eller japanske tegn?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.4.items.1.answer">Unicode definerer ikke samme sett med dekorative, fete og kursiverte varianter for alle skriftsystemer. Derfor finnes det ingen direkte erstatning for arabiske, hebraiske, devanagari, kinesiske, japanske, koreanske, kyrilliske eller greske tegn.<br><br>Latinske ord midt i en annen tekst, for eksempel merkenavn, hashtags eller engelske uttrykk, kan fortsatt styles. Resten av teksten blir stående som den er.</div>
+</div>
+
+
+<!-- Privacy -->
+<h2 class="faq-category" data-i18n="faq.categories.5.title">Personvern og sikkerhet</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.5.items.0.question">Lagres, logges eller sendes teksten jeg skriver?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.5.items.0.answer">Nei. Selve konverteringen skjer i nettleseren din med JavaScript. Teksten du skriver sendes ikke til en server for å genereres.<br><br>Siden bruker analyse og annonser, men innholdet i tekstfeltet trenger ikke forlate nettleseren. Det du kopierer er ren Unicode uten skjulte vannmerker.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.5.items.1.question">Fungerer generatoren på mobil og nettbrett?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.5.items.1.answer">Ja. UltraTextGen fungerer i moderne mobilnettlesere på iPhone, Android og nettbrett. Du skriver, trykker på Kopier og limer direkte inn i Instagram, TikTok, WhatsApp, Discord eller hvilken app du vil.</div>
+</div>
+
+    </div>
+  </section>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-inner">
+      <!-- Language Switcher -->
+      <div class="lang-switcher" role="navigation" aria-label="Language switcher">
+        <a class="lang-option" href="/" hreflang="en">EN</a>
+        <a class="lang-option" href="/es/" hreflang="es">ES</a>
+        <a class="lang-option" href="/fr/" hreflang="fr">FR</a>
+        <a class="lang-option" href="/pt/" hreflang="pt">PT</a>
+        <a class="lang-option" href="/de/" hreflang="de">DE</a>
+        <a class="lang-option" href="/id/" hreflang="id">ID</a>
+        <a class="lang-option" href="/it/" hreflang="it">IT</a>
+        <a class="lang-option" href="/nl/" hreflang="nl">NL</a>
+        <a class="lang-option" href="/tr/" hreflang="tr">TR</a>
+        <a class="lang-option" href="/pl/" hreflang="pl">PL</a>
+        <a class="lang-option" href="/vi/" hreflang="vi">VI</a>
+        <a class="lang-option" href="/tl/" hreflang="tl">TL</a>
+        <a class="lang-option" href="/sv/" hreflang="sv">SV</a>
+        <a class="lang-option active" href="/no/" hreflang="no">NO</a>
+      </div>
+    </div>
+  </footer>
+
+  <div class="copy-toast" id="copyToast">Kopiert!</div>
+
+  <script src="/styles.js" defer=""></script>
+<script src="/renderer.js" defer=""></script>
+<script src="/script.js" defer=""></script>
+<script src="/accent-notice.js" defer=""></script>
+<script src="/i18n.js" defer=""></script>
+
+
+
+
+<script src="/footer.js" defer=""></script>
+
+</body></html>

--- a/no/kursiv-tekst/index.html
+++ b/no/kursiv-tekst/index.html
@@ -1,0 +1,243 @@
+<!DOCTYPE html><html lang="no"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Kursiv tekst - kopier og lim inn kursiv skrift | UltraTextGen</title>
+  <meta name="description" content="Lag kursiv tekst og kursiv skrift du kan kopiere og lime inn. Skriv teksten din og få Unicode-kursiv, håndskrift og fine bokstaver til Instagram, Facebook, Discord og bio.">
+  <link rel="canonical" href="https://ultratextgen.com/no/kursiv-tekst/">
+
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/category/cursive-fonts/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/ecriture-cursive/">
+  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/tulisan-sambung/">
+  <link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/sierlijke-letters/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/letra-cursiva/">
+  <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/el-yazisi-fontu/">
+  <link rel="alternate" hreflang="no" href="https://ultratextgen.com/no/kursiv-tekst/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/category/cursive-fonts/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Kursiv tekst - kopier og lim inn kursiv skrift">
+  <meta property="og:description" content="Skriv vanlig tekst og få kursiv Unicode-tekst, håndskrift og fine bokstaver klare til å kopiere.">
+  <meta property="og:url" content="https://ultratextgen.com/no/kursiv-tekst/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category-cursive-fonts.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Kursiv tekst - kopier og lim inn kursiv skrift">
+  <meta name="twitter:description" content="Gratis generator for kursiv tekst, håndskrift og fine bokstaver.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category-cursive-fonts.png">
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+  <link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Kursiv tekst generator",
+  "alternateName": ["Kursiv tekst", "Kursiv skrift", "Kursiv font", "Håndskrift generator", "Fine bokstaver"],
+  "url": "https://ultratextgen.com/no/kursiv-tekst/",
+  "inLanguage": "no",
+  "applicationCategory": "UtilitiesApplication",
+  "operatingSystem": "Any",
+  "description": "Gratis generator for kursiv tekst og kursiv skrift i Unicode. Skriv vanlig tekst, velg kursiv eller håndskrift, og kopier resultatet til Instagram, Facebook, Discord, WhatsApp eller bio.",
+  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "no",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Hvordan lager jeg kursiv tekst?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Skriv teksten din i feltet øverst på siden. Resultatene vises automatisk i kursiv, håndskrift og andre Unicode-stiler. Trykk på Kopier ved den varianten du liker, og lim den inn i bio, melding, caption eller dokument." }
+    },
+    {
+      "@type": "Question",
+      "name": "Er dette ekte kursiv formatering?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Nei. Dette er Unicode-tegn som ser kursiverte ut. Det betyr at stilen følger med når du kopierer teksten, også på steder som ikke har en kursiv-knapp, for eksempel Instagram-bioer, Discord-navn og Facebook-kommentarer." }
+    },
+    {
+      "@type": "Question",
+      "name": "Fungerer kursiv tekst på Instagram og Facebook?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Ja, i bio, captions, kommentarer, innlegg og visningsnavn fungerer kursiv Unicode vanligvis fint. Brukernavn og @-handles er strengere og godtar ofte bare vanlige bokstaver, tall, punktum og understrek." }
+    },
+    {
+      "@type": "Question",
+      "name": "Hva skjer med norske bokstaver som æ, ø og å?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Unicode har ikke alltid egne kursiv-varianter av æ, ø og å. I de stilene blir bokstavene stående som vanlige tegn mens resten av ordet blir kursiv. For helt jevn pyntetekst kan du skrive ae, o eller a, men til vanlig tekst er det best å beholde de norske bokstavene." }
+    },
+    {
+      "@type": "Question",
+      "name": "Kan jeg bruke kursiv tekst til hele avsnitt?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Det er bedre å bruke det til korte linjer, navn eller ett viktig ord. Lang Unicode-kursiv kan være tyngre å lese og kan gi dårligere tilgjengelighet for skjermlesere." }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Tekstgenerator", "item": "https://ultratextgen.com/no/" },
+    { "@type": "ListItem", "position": 2, "name": "Kursiv tekst", "item": "https://ultratextgen.com/no/kursiv-tekst/" }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Brødsmule">
+  <a href="/no/">Tekstgenerator</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Kursiv tekst</span>
+</nav>
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/category-cursive-fonts.svg" width="1200" height="340" loading="lazy" alt="">
+</figure>
+
+<section class="hero">
+  <div class="hero-inner">
+    <div class="hero-card">
+      <h1 class="hero-headline">Kursiv tekst - kopier og lim inn</h1>
+      <p class="hero-tagline">Skriv vanlig tekst og få kursiv skrift, håndskrift og fine bokstaver du kan lime inn i Instagram, Facebook, Discord, TikTok, WhatsApp eller en bio.</p>
+      <div class="input-wrapper">
+        <textarea class="main-input" id="mainInput" placeholder="Skriv teksten din her..." maxlength="500" autofocus></textarea>
+        <span class="char-count"><span id="charCount">0</span>/500</span>
+      </div>
+      <div class="accent-notice" id="accentNotice" role="note" hidden>
+        <span class="accent-notice-icon" aria-hidden="true">◌̊</span>
+        <span class="accent-notice-text">Teksten din inneholder æ, ø eller å. Mange Unicode-stiler lar disse bokstavene stå vanlige. Stiler som understrek, gjennomstreking og rammer beholder dem best.</span>
+        <button type="button" class="accent-notice-close" id="accentNoticeClose" aria-label="Lukk">×</button>
+      </div>
+      <div class="decoration-section">
+        <div class="decoration-label">Legg pynt rundt resultatet</div>
+        <div class="decoration-tabs">
+          <button class="decoration-tab active" data-deco-tab="symbols">Symboler</button>
+          <button class="decoration-tab" data-deco-tab="frames">Rammer</button>
+          <button class="decoration-tab" data-deco-tab="minimal">Minimal</button>
+        </div>
+        <div class="decoration-grid" id="decorationGrid"></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<main class="container">
+  <div class="category-section"><div class="category-tabs" id="categoryTabs"></div></div>
+  <div class="results-grid" id="resultsGrid"></div>
+
+  <section class="editorial-section">
+    <h2>Kursiv tekst som faktisk kan kopieres</h2>
+    <p class="editorial-intro"><strong>Kursiv tekst</strong> her betyr ikke vanlig formatering fra Word. Generatoren bytter bokstavene til Unicode-tegn som allerede ser kursiverte eller håndskrevne ut. Derfor beholder teksten stilen når du limer den inn i en bio, kommentar, status eller melding.</p>
+    <div class="block-example">
+      <strong>Eksempel:</strong> "hei Norge" kan bli 𝘩𝘦𝘪 𝘕𝘰𝘳𝘨𝘦, 𝒽ℯ𝒾 𝒩ℴ𝓇ℊℯ eller 𝓱𝓮𝓲 𝓝𝓸𝓻𝓰𝓮.
+    </div>
+    <p>Vil du ha mer trykk enn kursiv? Bruk <a href="/category/bold-fonts/">fet skrift</a>. Vil du ha en roligere stil til navn eller bio, fungerer håndskrift og fine bokstaver ofte bedre enn tung dekorasjon.</p>
+  </section>
+
+  <section class="editorial-section glyph-section">
+    <h2>Kursiv alfabet og håndskrift</h2>
+    <p class="editorial-intro">Her er de vanligste kursiv- og script-variantene. Klikk på en linje for å kopiere hele alfabetet.</p>
+    <div class="alpha-list">
+      <div class="alpha-row">
+        <span class="alpha-label">Kursiv sans</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝘈𝘉𝘊𝘋𝘌𝘍𝘎𝘏𝘐𝘑𝘒𝘓𝘔𝘕𝘖𝘗𝘘𝘙𝘚𝘛𝘜𝘝𝘞𝘟𝘠𝘡 𝘢𝘣𝘤𝘥𝘦𝘧𝘨𝘩𝘪𝘫𝘬𝘭𝘮𝘯𝘰𝘱𝘲𝘳𝘴𝘵𝘶𝘷𝘸𝘹𝘺𝘻" aria-label="Kopier kursiv sans alfabet">𝘈𝘉𝘊𝘋𝘌𝘍𝘎𝘏𝘐𝘑𝘒𝘓𝘔𝘕𝘖𝘗𝘘𝘙𝘚𝘛𝘜𝘝𝘞𝘟𝘠𝘡 · 𝘢𝘣𝘤𝘥𝘦𝘧𝘨𝘩𝘪𝘫𝘬𝘭𝘮𝘯𝘰𝘱𝘲𝘳𝘴𝘵𝘶𝘷𝘸𝘹𝘺𝘻</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Håndskrift</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵 𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏" aria-label="Kopier håndskrift alfabet">𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵 · 𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Fet håndskrift</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩 𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃" aria-label="Kopier fet håndskrift alfabet">𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩 · 𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃</button>
+      </div>
+    </div>
+    <p class="u-mt-15">Unicode har ikke egne kursiv-varianter for alle tegn. Derfor kan æ, ø og å bli stående vanlige i noen stiler. Det er normalt, og teksten er fortsatt trygg å kopiere.</p>
+  </section>
+
+  <section class="editorial-section">
+    <h2>Hvor fungerer kursiv skrift?</h2>
+    <ul class="compat-list">
+      <li><span class="ts-pill-safe">Fungerer</span> Instagram-bio, Facebook-innlegg, Discord-navn, TikTok-captions, WhatsApp-status, X-innlegg, YouTube-kommentarer og de fleste dokumenter.</li>
+      <li><span class="ts-pill-risk">Begrenset</span> Brukernavn og @-handles. Plattformene kan avvise kursiv Unicode fordi de vil ha enkle bokstaver.</li>
+      <li><span class="ts-pill-risk">Begrenset</span> Lange avsnitt. Kursiv Unicode er best som pynt, ikke som brødtekst.</li>
+    </ul>
+  </section>
+
+  <section class="editorial-section">
+    <h2>Kursiv tekst, fet skrift og fin skrift</h2>
+    <p class="editorial-intro">De norske søkene blander ofte <strong>kursiv tekst</strong>, <strong>fet skrift</strong>, <strong>fin skrift</strong> og <strong>tekst generator</strong>. Du kan lage alt dette fra samme felt øverst: velg kursiv for en mykere linje, fet skrift for mer vekt, eller håndskrift når du vil ha en mer personlig bio.</p>
+    <div class="compare-grid">
+      <a href="/no/" class="compare-card variant-muted u-no-underline">
+        <h4>Tekstgenerator</h4>
+        <p>Alle stilene på norsk: fet, kursiv, håndskrift, bobler, gotisk og mer.</p>
+      </a>
+      <a href="/category/bold-fonts/" class="compare-card variant-muted u-no-underline">
+        <h4>Fet skrift</h4>
+        <p>Når ordet skal få mer tyngde i bio, innlegg eller kommentar.</p>
+      </a>
+      <a href="/instagram/" class="compare-card variant-muted u-no-underline">
+        <h4>Instagram fonts</h4>
+        <p>Stiler som fungerer godt i bio, caption og visningsnavn.</p>
+      </a>
+    </div>
+  </section>
+</main>
+
+<footer class="footer">
+  <div class="footer-inner">
+    <h2 class="faq-category">Spørsmål om kursiv tekst</h2>
+    <div class="faq-item"><button class="faq-question" type="button">Hvordan lager jeg kursiv tekst?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Skriv teksten din i feltet øverst på siden. Resultatene vises automatisk i kursiv, håndskrift og andre Unicode-stiler. Trykk på Kopier ved varianten du liker, og lim den inn der du vil bruke den.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Er dette ekte kursiv formatering?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Det er Unicode-tegn som ser kursiverte ut. Fordelen er at de kan kopieres til steder som ikke har formatering, som Instagram-bioer og Discord-navn.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Fungerer kursiv tekst på Instagram og Facebook?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Ja, i bio, captions, kommentarer, innlegg og visningsnavn fungerer det vanligvis fint. Brukernavn er strengere og bør holdes vanlige.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Hva skjer med æ, ø og å?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Mange Unicode-stiler har ikke egne varianter for æ, ø og å. De blir ofte stående vanlige mens resten av ordet styles. Det er normalt.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Kan jeg bruke kursiv tekst til hele avsnitt?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Bruk det helst til korte linjer, navn eller ett viktig ord. Vanlig tekst er bedre for lesbarhet og tilgjengelighet.</div></div>
+
+    <div class="lang-switcher" role="navigation" aria-label="Language switcher">
+      <a class="lang-option" href="/category/cursive-fonts/" hreflang="en">EN</a>
+      <a class="lang-option" href="/fr/ecriture-cursive/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/id/tulisan-sambung/" hreflang="id">ID</a>
+      <a class="lang-option" href="/nl/sierlijke-letters/" hreflang="nl">NL</a>
+      <a class="lang-option" href="/pt/letra-cursiva/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/tr/el-yazisi-fontu/" hreflang="tr">TR</a>
+      <a class="lang-option active" href="/no/kursiv-tekst/" hreflang="no">NO</a>
+    </div>
+  </div>
+</footer>
+
+<div class="copy-toast" id="copyToast">Kopiert!</div>
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script>window.UTG_FAMILY = "cursive";</script>
+<script src="/styles.js" defer></script>
+<script src="/renderer.js" defer></script>
+<script src="/script.js" defer></script>
+<script src="/symbol-explorer.js" defer></script>
+<script src="/accent-notice.js" defer></script>
+<script src="/footer.js" defer></script>
+</body></html>

--- a/pl/index.html
+++ b/pl/index.html
@@ -30,6 +30,7 @@
 <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/">
 <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/">
 <link rel="alternate" hreflang="sv" href="https://ultratextgen.com/sv/">
+<link rel="alternate" hreflang="no" href="https://ultratextgen.com/no/">
 
 <meta name="robots" content="index, follow">
 
@@ -997,6 +998,7 @@
         <a class="lang-option active" href="/pl/" hreflang="pl">PL</a>
         <a class="lang-option" href="/vi/" hreflang="vi">VI</a>
         <a class="lang-option" href="/sv/" hreflang="sv">SV</a>
+        <a class="lang-option" href="/no/" hreflang="no">NO</a>
       </div>
     </div>
   </footer>

--- a/pt/index.html
+++ b/pt/index.html
@@ -30,6 +30,7 @@
 <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/">
 <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/">
 <link rel="alternate" hreflang="sv" href="https://ultratextgen.com/sv/">
+<link rel="alternate" hreflang="no" href="https://ultratextgen.com/no/">
 
 <meta name="robots" content="index, follow">
 
@@ -986,6 +987,7 @@
         <a class="lang-option" href="/pl/" hreflang="pl">PL</a>
         <a class="lang-option" href="/vi/" hreflang="vi">VI</a>
         <a class="lang-option" href="/sv/" hreflang="sv">SV</a>
+        <a class="lang-option" href="/no/" hreflang="no">NO</a>
       </div>
     </div>
   </footer>

--- a/pt/letra-cursiva/index.html
+++ b/pt/letra-cursiva/index.html
@@ -20,6 +20,7 @@
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/tulisan-sambung/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/el-yazisi-fontu/">
   <link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/sierlijke-letters/">
+  <link rel="alternate" hreflang="no" href="https://ultratextgen.com/no/kursiv-tekst/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/category/cursive-fonts/">
 
   <meta name="robots" content="index, follow">
@@ -314,6 +315,7 @@
       <a class="lang-option" href="/nl/sierlijke-letters/" hreflang="nl">NL</a>
       <a class="lang-option active" href="/pt/letra-cursiva/" hreflang="pt">PT</a>
       <a class="lang-option" href="/tr/el-yazisi-fontu/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/no/kursiv-tekst/" hreflang="no">NO</a>
     </div>
   </div>
 </footer>

--- a/scripts/prerender-i18n.js
+++ b/scripts/prerender-i18n.js
@@ -33,7 +33,7 @@ const cheerio = require("cheerio");
 
 const ROOT = path.resolve(__dirname, "..");
 const LOCALES_DIR = path.join(ROOT, "locales");
-const SUPPORTED = ["es", "fr", "pt", "de", "id", "it", "nl", "tr", "pl", "vi", "tl", "sv"];
+const SUPPORTED = ["es", "fr", "pt", "de", "id", "it", "nl", "tr", "pl", "vi", "tl", "sv", "no"];
 
 /* ───────────────────────── helpers ───────────────────────── */
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -3,7 +3,7 @@
 
   <url>
     <loc>https://ultratextgen.com/</loc>
-    <lastmod>2026-07-03</lastmod>
+    <lastmod>2026-07-04</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>
@@ -332,7 +332,7 @@
 
   <url>
     <loc>https://ultratextgen.com/de/</loc>
-    <lastmod>2026-07-02</lastmod>
+    <lastmod>2026-07-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -367,7 +367,7 @@
 
   <url>
     <loc>https://ultratextgen.com/es/</loc>
-    <lastmod>2026-07-02</lastmod>
+    <lastmod>2026-07-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -458,7 +458,7 @@
 
   <url>
     <loc>https://ultratextgen.com/fr/</loc>
-    <lastmod>2026-07-02</lastmod>
+    <lastmod>2026-07-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -514,7 +514,7 @@
 
   <url>
     <loc>https://ultratextgen.com/fr/police-instagram/</loc>
-    <lastmod>2026-07-03</lastmod>
+    <lastmod>2026-07-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -724,7 +724,7 @@
 
   <url>
     <loc>https://ultratextgen.com/id/</loc>
-    <lastmod>2026-07-03</lastmod>
+    <lastmod>2026-07-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -738,7 +738,7 @@
 
   <url>
     <loc>https://ultratextgen.com/id/font-ig/</loc>
-    <lastmod>2026-07-03</lastmod>
+    <lastmod>2026-07-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -927,14 +927,14 @@
 
   <url>
     <loc>https://ultratextgen.com/instagram/</loc>
-    <lastmod>2026-07-03</lastmod>
+    <lastmod>2026-07-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/it/</loc>
-    <lastmod>2026-07-02</lastmod>
+    <lastmod>2026-07-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -2754,7 +2754,7 @@
 
   <url>
     <loc>https://ultratextgen.com/nl/</loc>
-    <lastmod>2026-07-02</lastmod>
+    <lastmod>2026-07-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -2775,7 +2775,7 @@
 
   <url>
     <loc>https://ultratextgen.com/nl/instagram-lettertype/</loc>
-    <lastmod>2026-07-03</lastmod>
+    <lastmod>2026-07-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -2830,6 +2830,20 @@
   </url>
 
   <url>
+    <loc>https://ultratextgen.com/no/</loc>
+    <lastmod>2026-07-05</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/no/kursiv-tekst/</loc>
+    <lastmod>2026-07-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
     <loc>https://ultratextgen.com/pinterest/</loc>
     <lastmod>2026-07-02</lastmod>
     <changefreq>weekly</changefreq>
@@ -2838,7 +2852,7 @@
 
   <url>
     <loc>https://ultratextgen.com/pl/</loc>
-    <lastmod>2026-07-02</lastmod>
+    <lastmod>2026-07-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -2866,7 +2880,7 @@
 
   <url>
     <loc>https://ultratextgen.com/pt/</loc>
-    <lastmod>2026-07-02</lastmod>
+    <lastmod>2026-07-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -3006,14 +3020,14 @@
 
   <url>
     <loc>https://ultratextgen.com/tl/</loc>
-    <lastmod>2026-07-02</lastmod>
+    <lastmod>2026-07-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/tr/</loc>
-    <lastmod>2026-07-02</lastmod>
+    <lastmod>2026-07-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -3034,7 +3048,7 @@
 
   <url>
     <loc>https://ultratextgen.com/tr/instagram-yazi-tipi/</loc>
-    <lastmod>2026-07-03</lastmod>
+    <lastmod>2026-07-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -3181,7 +3195,7 @@
 
   <url>
     <loc>https://ultratextgen.com/vi/</loc>
-    <lastmod>2026-07-02</lastmod>
+    <lastmod>2026-07-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/sv/index.html
+++ b/sv/index.html
@@ -32,6 +32,7 @@
 <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/">
 <link rel="alternate" hreflang="tl" href="https://ultratextgen.com/tl/">
 <link rel="alternate" hreflang="sv" href="https://ultratextgen.com/sv/">
+<link rel="alternate" hreflang="no" href="https://ultratextgen.com/no/">
 
 <meta name="robots" content="index, follow">
 
@@ -746,6 +747,7 @@
         <a class="lang-option" href="/vi/" hreflang="vi">VI</a>
         <a class="lang-option" href="/tl/" hreflang="tl">TL</a>
         <a class="lang-option active" href="/sv/" hreflang="sv">SV</a>
+        <a class="lang-option" href="/no/" hreflang="no">NO</a>
       </div>
     </div>
   </footer>

--- a/tl/index.html
+++ b/tl/index.html
@@ -31,6 +31,7 @@
 <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/">
 <link rel="alternate" hreflang="tl" href="https://ultratextgen.com/tl/">
 <link rel="alternate" hreflang="sv" href="https://ultratextgen.com/sv/">
+<link rel="alternate" hreflang="no" href="https://ultratextgen.com/no/">
 
 <meta name="robots" content="index, follow">
 
@@ -940,6 +941,7 @@ O</pre>
         <a class="lang-option" href="/pl/" hreflang="pl">PL</a>
         <a class="lang-option" href="/vi/" hreflang="vi">VI</a>
         <a class="lang-option" href="/sv/" hreflang="sv">SV</a>
+        <a class="lang-option" href="/no/" hreflang="no">NO</a>
         <a class="lang-option active" href="/tl/" hreflang="tl">TL</a>
       </div>
     </div>

--- a/tr/el-yazisi-fontu/index.html
+++ b/tr/el-yazisi-fontu/index.html
@@ -20,6 +20,7 @@
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/tulisan-sambung/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/el-yazisi-fontu/">
   <link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/sierlijke-letters/">
+  <link rel="alternate" hreflang="no" href="https://ultratextgen.com/no/kursiv-tekst/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/category/cursive-fonts/">
 
   <meta name="robots" content="index, follow">
@@ -314,6 +315,7 @@
       <a class="lang-option" href="/nl/sierlijke-letters/" hreflang="nl">NL</a>
       <a class="lang-option" href="/pt/letra-cursiva/" hreflang="pt">PT</a>
       <a class="lang-option active" href="/tr/el-yazisi-fontu/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/no/kursiv-tekst/" hreflang="no">NO</a>
     </div>
   </div>
 </footer>

--- a/tr/index.html
+++ b/tr/index.html
@@ -30,6 +30,7 @@
 <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/">
 <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/">
 <link rel="alternate" hreflang="sv" href="https://ultratextgen.com/sv/">
+<link rel="alternate" hreflang="no" href="https://ultratextgen.com/no/">
 
 <meta name="robots" content="index, follow">
 
@@ -956,6 +957,7 @@
         <a class="lang-option" href="/pl/" hreflang="pl">PL</a>
         <a class="lang-option" href="/vi/" hreflang="vi">VI</a>
         <a class="lang-option" href="/sv/" hreflang="sv">SV</a>
+        <a class="lang-option" href="/no/" hreflang="no">NO</a>
       </div>
     </div>
   </footer>

--- a/vi/index.html
+++ b/vi/index.html
@@ -30,6 +30,7 @@
 <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/">
 <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/">
 <link rel="alternate" hreflang="sv" href="https://ultratextgen.com/sv/">
+<link rel="alternate" hreflang="no" href="https://ultratextgen.com/no/">
 
 <meta name="robots" content="index, follow">
 
@@ -964,6 +965,7 @@
         <a class="lang-option" href="/pl/" hreflang="pl">PL</a>
         <a class="lang-option active" href="/vi/" hreflang="vi">VI</a>
         <a class="lang-option" href="/sv/" hreflang="sv">SV</a>
+        <a class="lang-option" href="/no/" hreflang="no">NO</a>
       </div>
     </div>
   </footer>


### PR DESCRIPTION
## Summary
- Add Norwegian homepage localization at `/no/` with Norwegian metadata, FAQ content, JSON-LD, hreflang, redirects, and language selector wiring.
- Add a Norwegian cursive text opportunity page at `/no/kursiv-tekst/` based on the attached Norway keyword volume.
- Regenerate `sitemap.xml` so the new Norwegian URLs are discoverable.

## Validation
- Parsed `locales/no.json` and JSON-LD blocks for `/no/` and `/no/kursiv-tekst/`.
- Ran `npm.cmd run check:gtm`.
- Ran `npm.cmd run check:ads`.
- Ran `git diff --check`.
- Smoke-tested `/no/` and `/no/kursiv-tekst/` locally: both returned 200.