### PR TITLE
feat: expand Vietnamese /vi/ cluster with 5 new pages

### DIFF
--- a/fr/library/symboles/index.html
+++ b/fr/library/symboles/index.html
@@ -19,6 +19,7 @@
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-aesthetic/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/semboller/">
+<link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/ki-tu-dac-biet/">
   <link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/library/speciale-tekens/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/aesthetic-symbols/">
 
@@ -347,6 +348,7 @@
       <a class="lang-option" href="/nl/library/speciale-tekens/" hreflang="nl">NL</a>
       <a class="lang-option" href="/pt/library/simbolos/" hreflang="pt">PT</a>
       <a class="lang-option" href="/tr/library/semboller/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/vi/ki-tu-dac-biet/" hreflang="vi">VI</a>
     </div>
   </div>
 </footer>

--- a/id/font-tiktok/index.html
+++ b/id/font-tiktok/index.html
@@ -16,6 +16,7 @@
 
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/tiktok/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/font-tiktok/">
+  <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/chu-kieu-tiktok/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/tiktok/">
 
   <meta name="robots" content="index, follow">
@@ -239,6 +240,7 @@
     <div class="lang-switcher" role="navigation" aria-label="Language switcher">
       <a class="lang-option" href="/tiktok/" hreflang="en">EN</a>
       <a class="lang-option active" href="/id/font-tiktok/" hreflang="id">ID</a>
+      <a class="lang-option" href="/vi/chu-kieu-tiktok/" hreflang="vi">VI</a>
     </div>
   </div>
 </footer>

--- a/id/library/simbol-aesthetic/index.html
+++ b/id/library/simbol-aesthetic/index.html
@@ -24,6 +24,7 @@
 <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-aesthetic/">
 <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos/">
 <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/semboller/">
+<link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/ki-tu-dac-biet/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/library-aesthetic-symbols.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">

--- a/library/aesthetic-symbols/index.html
+++ b/library/aesthetic-symbols/index.html
@@ -24,6 +24,7 @@
 <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-aesthetic/">
 <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos/">
 <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/semboller/">
+<link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/ki-tu-dac-biet/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/library-aesthetic-symbols.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">

--- a/nl/library/speciale-tekens/index.html
+++ b/nl/library/speciale-tekens/index.html
@@ -20,6 +20,7 @@
   <link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/library/speciale-tekens/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/semboller/">
+<link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/ki-tu-dac-biet/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/aesthetic-symbols/">
 
   <meta name="robots" content="index, follow">
@@ -336,6 +337,7 @@
       <a class="lang-option active" href="/nl/library/speciale-tekens/" hreflang="nl">NL</a>
       <a class="lang-option" href="/pt/library/simbolos/" hreflang="pt">PT</a>
       <a class="lang-option" href="/tr/library/semboller/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/vi/ki-tu-dac-biet/" hreflang="vi">VI</a>
     </div>
   </div>
 </footer>

--- a/pt/library/simbolos/index.html
+++ b/pt/library/simbolos/index.html
@@ -24,6 +24,7 @@
 <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-aesthetic/">
 <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos/">
 <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/semboller/">
+<link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/ki-tu-dac-biet/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/pt-library-simbolos.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -3201,8 +3201,43 @@
   </url>
 
   <url>
+    <loc>https://ultratextgen.com/vi/chu-kieu-tiktok/</loc>
+    <lastmod>2026-07-06</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/vi/chu-kieu/</loc>
+    <lastmod>2026-07-06</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/vi/font-chu-dep/</loc>
+    <lastmod>2026-07-06</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/vi/ki-tu-dac-biet/</loc>
+    <lastmod>2026-07-06</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
     <loc>https://ultratextgen.com/vi/ky-tu-vo-hinh/</loc>
     <lastmod>2026-07-03</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/vi/usecase/nick-ff/</loc>
+    <lastmod>2026-07-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>

--- a/tiktok/index.html
+++ b/tiktok/index.html
@@ -18,6 +18,7 @@
 
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/tiktok/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/font-tiktok/">
+  <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/chu-kieu-tiktok/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/tiktok/">
 
   <meta property="og:title" content="TikTok Font Generator — Bio, Display Name, Captions & Comments | UltraTextGen">

--- a/tr/library/semboller/index.html
+++ b/tr/library/semboller/index.html
@@ -24,6 +24,7 @@
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-aesthetic/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/semboller/">
+<link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/ki-tu-dac-biet/">
 
   <meta name="robots" content="index, follow">
   <meta property="og:site_name" content="UltraTextGen">
@@ -401,6 +402,7 @@
       <a class="lang-option" href="/nl/library/speciale-tekens/" hreflang="nl">NL</a>
       <a class="lang-option" href="/pt/library/simbolos/" hreflang="pt">PT</a>
       <a class="lang-option active" href="/tr/library/semboller/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/vi/ki-tu-dac-biet/" hreflang="vi">VI</a>
     </div>
   </div>
 </footer>

--- a/vi/chu-kieu-tiktok/index.html
+++ b/vi/chu-kieu-tiktok/index.html
@@ -1,0 +1,255 @@
+<!DOCTYPE html><html lang="vi"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Chữ Kiểu TikTok — Đổi Font Tên, Bio &amp; Caption TikTok | UltraTextGen</title>
+  <meta name="description" content="Tạo chữ kiểu TikTok online: đổi font tên hiển thị, bio, caption và bình luận. Gõ chữ, copy, dán vào TikTok — kèm mẫu bio đẹp và kí tự trang trí sẵn. Miễn phí, không cần app.">
+  <link rel="canonical" href="https://ultratextgen.com/vi/chu-kieu-tiktok/">
+
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/tiktok/">
+  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/font-tiktok/">
+  <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/chu-kieu-tiktok/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/tiktok/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Chữ Kiểu TikTok — Đổi Font Tên, Bio &amp; Caption TikTok">
+  <meta property="og:description" content="Đổi font tên hiển thị, bio, caption và bình luận TikTok. Gõ chữ, copy, dán — miễn phí, không cần app.">
+  <meta property="og:url" content="https://ultratextgen.com/vi/chu-kieu-tiktok/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/tiktok.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Chữ Kiểu TikTok — Đổi Font Tên, Bio &amp; Caption TikTok">
+  <meta name="twitter:description" content="Chữ kiểu TikTok: gõ chữ, copy, dán vào tên và bio TikTok — kèm mẫu bio đẹp sẵn.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/tiktok.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+  <link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Chữ Kiểu TikTok — Đổi Font Tên và Bio TikTok",
+  "alternateName": ["Chữ Kiểu TikTok", "Font TikTok", "Tạo Chữ Kiểu TikTok", "Kiểu Chữ TikTok", "Font Chữ TikTok"],
+  "url": "https://ultratextgen.com/vi/chu-kieu-tiktok/",
+  "inLanguage": "vi",
+  "applicationCategory": "UtilitiesApplication",
+  "operatingSystem": "Any",
+  "description": "Trình tạo chữ kiểu TikTok: đổi chữ thường sang font đẹp cho tên hiển thị, bio, caption và bình luận TikTok — copy paste là xong, miễn phí không cần app.",
+  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "vi",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Làm sao đổi font chữ trên TikTok?",
+      "acceptedAnswer": { "@type": "Answer", "text": "TikTok không có menu chọn font cho trang cá nhân — giải pháp là dùng chữ kiểu Unicode. Gõ chữ vào ô ở đầu trang, bấm Sao chép ở kiểu bạn thích, rồi mở TikTok → Hồ sơ → Sửa hồ sơ → dán vào ô tên hoặc tiểu sử. Kiểu chữ nằm ngay trong kí tự nên hiển thị y nguyên trên TikTok." }
+    },
+    {
+      "@type": "Question",
+      "name": "Chữ kiểu TikTok dùng được ở những phần nào?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Dùng được ở tên hiển thị, tiểu sử (bio), bình luận và caption video. Riêng username (@) thì không — TikTok chỉ nhận chữ thường, số, dấu chấm và gạch dưới ở đó. Để hiển thị tốt trên mọi máy, ưu tiên các kiểu phổ biến như đậm, small caps và script; kiểu hiếm đôi khi thành ô vuông (□) trên máy đời cũ." }
+    },
+    {
+      "@type": "Question",
+      "name": "Dùng chữ kiểu có an toàn cho tài khoản TikTok không?",
+      "acceptedAnswer": { "@type": "Answer", "text": "An toàn. Chữ kiểu là kí tự Unicode chuẩn — văn bản bình thường mà TikTok hỗ trợ sẵn, không vi phạm điều khoản, hàng triệu tài khoản đang dùng. Lưu ý nhỏ về trợ năng: trình đọc màn hình đôi khi đọc từng kí tự một với vài kiểu chữ, nên dùng chữ kiểu cho tên và điểm nhấn ngắn thay vì cả đoạn dài." }
+    },
+    {
+      "@type": "Question",
+      "name": "Có cần tải app để tạo chữ kiểu TikTok không?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Không. Mọi thứ chạy thẳng trên trình duyệt điện thoại hoặc máy tính — không cài app, không đăng ký, miễn phí 100%. Gõ chữ, chọn kiểu, copy, dán là xong." }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Trang chủ", "item": "https://ultratextgen.com/vi/" },
+    { "@type": "ListItem", "position": 2, "name": "Chữ Kiểu TikTok", "item": "https://ultratextgen.com/vi/chu-kieu-tiktok/" }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/vi/">Trang chủ</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Chữ Kiểu TikTok</span>
+</nav>
+
+<section class="hero">
+  <div class="hero-inner">
+    <div class="hero-card">
+      <h1 class="hero-headline">Chữ Kiểu TikTok — đổi font tên &amp; bio TikTok</h1>
+      <p class="hero-tagline">Gõ chữ của bạn, ra ngay hàng chục kiểu chữ hợp TikTok: đậm, script, small caps, bong bóng và nhiều kiểu độc hơn. Copy rồi dán vào tên hiển thị, bio, caption hay bình luận — miễn phí, không cần app.</p>
+      <div class="input-wrapper">
+        <textarea class="main-input" id="mainInput" placeholder="Gõ tên hoặc bio TikTok của bạn..." maxlength="500" autofocus=""></textarea>
+        <span class="char-count"><span id="charCount">0</span>/500</span>
+      </div>
+      <div class="decoration-section">
+        <div class="decoration-label">Thêm kí hiệu và trang trí vào kết quả</div>
+        <div class="decoration-tabs">
+          <button class="decoration-tab active" data-deco-tab="symbols">Kí hiệu</button>
+          <button class="decoration-tab" data-deco-tab="frames">Khung viền</button>
+          <button class="decoration-tab" data-deco-tab="dividers">Đường kẻ</button>
+          <button class="decoration-tab" data-deco-tab="minimal">Tối giản</button>
+          <button class="decoration-tab" data-deco-tab="emojis">Emoji</button>
+        </div>
+        <div class="decoration-grid" id="decorationGrid"></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<main class="container">
+  <div class="category-section"><div class="category-tabs" id="categoryTabs"></div></div>
+  <div class="results-grid" id="resultsGrid"></div>
+
+  <!-- Cách đổi font TikTok -->
+  <section class="editorial-section">
+    <h2>Cách đổi font chữ trên TikTok</h2>
+    <p class="editorial-intro">TikTok không có menu chọn font cho trang cá nhân — nhưng có đường vòng: <strong>Unicode</strong>. Chữ kiểu ở trang này là kí tự thật có sẵn kiểu dáng. Khi bạn copy, kiểu chữ đi theo từng kí tự, và TikTok nhận nó như văn bản bình thường.</p>
+    <div class="block-example">
+      <strong>Ví dụ dòng bio:</strong> ✧ 𝗠𝗶𝗻𝗵 𝗔𝗻𝗵 ✧ · ɴʜớ ꜰᴏʟʟᴏᴡ ᴍìɴʜ ɴʜᴀ ☾
+    </div>
+    <p>Các bước: gõ chữ vào ô trên → chọn kiểu → bấm «Sao chép» → mở TikTok → <em>Hồ sơ</em> → <em>Sửa hồ sơ</em> → dán vào ô tên hoặc tiểu sử. Cách này cũng áp dụng cho caption và bình luận. Muốn xem toàn bộ kho kiểu chữ, qua trang <a href="/vi/chu-kieu/">chữ kiểu</a>.</p>
+  </section>
+
+  <!-- Dùng được ở đâu -->
+  <section class="editorial-section">
+    <h2>Chữ kiểu TikTok dùng được ở đâu (và ở đâu không)</h2>
+    <p class="editorial-intro">Quy tắc giống các nền tảng khác: ô nội dung tự do thì nhận, ô định danh thì không.</p>
+    <div class="block-example">
+      ✔ <strong>Dùng được</strong>: tên hiển thị, tiểu sử (bio), bình luận, caption video<br>
+      ✘ <strong>Không được</strong>: username (@) — TikTok chỉ nhận chữ thường, số, dấu chấm và gạch dưới
+    </div>
+    <p>Lưu ý hiển thị: đậm, small caps, script và bong bóng an toàn trên hầu hết điện thoại; kiểu hiếm đôi khi thành ô vuông (□) trên máy đời cũ. Nếu tên của bạn cần ai xem cũng đọc được, cứ chọn các kiểu phổ biến.</p>
+  </section>
+
+  <!-- Bio TikTok sẵn -->
+  <section class="editorial-section" id="bio-tiktok-dep">
+    <h2>Mẫu bio TikTok đẹp — bấm là copy</h2>
+    <p class="editorial-intro">Bấm dòng bạn thích để copy, rồi thay chữ theo kênh của mình. Công thức gọn: một dòng dùng chữ kiểu, các dòng còn lại để chữ thường — bio thoáng mà vẫn nổi.</p>
+    <div class="uname-grid">
+      <button class="uname-chip symbol-tile" data-symbol="𝘅𝗲𝗺 𝗰𝗹𝗶𝗽 𝗺ớ𝗶 𝗻𝗵ấ𝘁 ✦" aria-label="Sao chép dòng bio 𝘅𝗲𝗺 𝗰𝗹𝗶𝗽 𝗺ớ𝗶 𝗻𝗵ấ𝘁 ✦">𝘅𝗲𝗺 𝗰𝗹𝗶𝗽 𝗺ớ𝗶 𝗻𝗵ấ𝘁 ✦</button>
+      <button class="uname-chip symbol-tile" data-symbol="ɴʜớ ꜰᴏʟʟᴏᴡ ᴍìɴʜ ɴʜᴀ ☾" aria-label="Sao chép dòng bio ɴʜớ ꜰᴏʟʟᴏᴡ ᴍìɴʜ ɴʜᴀ ☾">ɴʜớ ꜰᴏʟʟᴏᴡ ᴍìɴʜ ɴʜᴀ ☾</button>
+      <button class="uname-chip symbol-tile" data-symbol="⋆˚｡ ᴠʟᴏɢ ᴍỗɪ ɴɢàʏ ｡˚⋆" aria-label="Sao chép dòng bio ⋆˚｡ ᴠʟᴏɢ ᴍỗɪ ɴɢàʏ ｡˚⋆">⋆˚｡ ᴠʟᴏɢ ᴍỗɪ ɴɢàʏ ｡˚⋆</button>
+      <button class="uname-chip symbol-tile" data-symbol="✧ 𝗠𝗶𝗻𝗵 𝗔𝗻𝗵 ✧" aria-label="Sao chép dòng bio ✧ 𝗠𝗶𝗻𝗵 𝗔𝗻𝗵 ✧">✧ 𝗠𝗶𝗻𝗵 𝗔𝗻𝗵 ✧</button>
+      <button class="uname-chip symbol-tile" data-symbol="↳ ᴘʜầɴ 2 ᴛʀᴏɴɢ ᴛʀᴀɴɢ ᴄá ɴʜâɴ" aria-label="Sao chép dòng bio ↳ ᴘʜầɴ 2 ᴛʀᴏɴɢ ᴛʀᴀɴɢ ᴄá ɴʜâɴ">↳ ᴘʜầɴ 2 ᴛʀᴏɴɢ ᴛʀᴀɴɢ ᴄá ɴʜâɴ</button>
+      <button class="uname-chip symbol-tile" data-symbol="୨୧ 𝓬𝓸𝓷𝓽𝓮𝓷𝓽 𝓬𝓱𝓲𝓵𝓵 ୨୧" aria-label="Sao chép dòng bio ୨୧ 𝓬𝓸𝓷𝓽𝓮𝓷𝓽 𝓬𝓱𝓲𝓵𝓵 ୨୧">୨୧ 𝓬𝓸𝓷𝓽𝓮𝓷𝓽 𝓬𝓱𝓲𝓵𝓵 ୨୧</button>
+      <button class="uname-chip symbol-tile" data-symbol="— 𝘤𝘩ư𝘢 𝘷𝘪𝘳𝘢𝘭, 𝘵ừ 𝘵ừ —" aria-label="Sao chép dòng bio — 𝘤𝘩ư𝘢 𝘷𝘪𝘳𝘢𝘭, 𝘵ừ 𝘵ừ —">— 𝘤𝘩ư𝘢 𝘷𝘪𝘳𝘢𝘭, 𝘵ừ 𝘵ừ —</button>
+      <button class="uname-chip symbol-tile" data-symbol="✰ ᴄảᴍ ơɴ ᴠì đã ɢʜé ✰" aria-label="Sao chép dòng bio ✰ ᴄảᴍ ơɴ ᴠì đã ɢʜé ✰">✰ ᴄảᴍ ơɴ ᴠì đã ɢʜé ✰</button>
+    </div>
+    <p class="u-mt-15">Muốn kẻ dòng chia bio? Mở tab <strong>Đường kẻ</strong> ở ô tạo phía trên. Kí hiệu lẻ — tim, sao, nơ — có đủ trong kho <a href="/vi/ki-tu-dac-biet/">kí tự đặc biệt</a>.</p>
+  </section>
+
+  <!-- Kí hiệu bio TikTok -->
+  <section class="editorial-section glyph-section" id="ki-hieu-bio-tiktok">
+    <h2>Kí hiệu hay dùng trong bio TikTok</h2>
+    <p class="editorial-intro">Những kí hiệu xuất hiện nhiều nhất trong tên và bio TikTok — bấm là copy:</p>
+    <div class="glyph-grid">
+      <button class="glyph-copy" type="button" data-text="✦" aria-label="Sao chép sao bốn cánh ✦">✦</button>
+      <button class="glyph-copy" type="button" data-text="✧" aria-label="Sao chép sao rỗng ✧">✧</button>
+      <button class="glyph-copy" type="button" data-text="♡" aria-label="Sao chép trái tim ♡">♡</button>
+      <button class="glyph-copy" type="button" data-text="☾" aria-label="Sao chép trăng khuyết ☾">☾</button>
+      <button class="glyph-copy" type="button" data-text="⋆" aria-label="Sao chép sao nhỏ ⋆">⋆</button>
+      <button class="glyph-copy" type="button" data-text="୨୧" aria-label="Sao chép nơ ruy băng ୨୧">୨୧</button>
+      <button class="glyph-copy" type="button" data-text="ᥫ᭡" aria-label="Sao chép tim mini ᥫ᭡">ᥫ᭡</button>
+      <button class="glyph-copy" type="button" data-text="↳" aria-label="Sao chép mũi tên gạch đầu dòng ↳">↳</button>
+      <button class="glyph-copy" type="button" data-text="➤" aria-label="Sao chép mũi tên ➤">➤</button>
+      <button class="glyph-copy" type="button" data-text="⊹" aria-label="Sao chép kim tuyến ⊹">⊹</button>
+      <button class="glyph-copy" type="button" data-text="˚" aria-label="Sao chép chấm sáng ˚">˚</button>
+      <button class="glyph-copy" type="button" data-text="•" aria-label="Sao chép chấm tròn •">•</button>
+      <button class="glyph-copy" type="button" data-text="✰" aria-label="Sao chép sao viền ✰">✰</button>
+      <button class="glyph-copy" type="button" data-text="🦋" aria-label="Sao chép bươm bướm 🦋">🦋</button>
+      <button class="glyph-copy" type="button" data-text="༄" aria-label="Sao chép làn gió ༄">༄</button>
+      <button class="glyph-copy" type="button" data-text="❀" aria-label="Sao chép hoa ❀">❀</button>
+    </div>
+  </section>
+
+  <!-- Related -->
+  <section class="editorial-section">
+    <span class="article-section-label">Trang liên quan</span>
+    <div class="compare-grid">
+      <a href="/vi/chu-kieu/" class="compare-card variant-muted u-no-underline">
+        <h4>Chữ Kiểu</h4>
+        <p>Toàn bộ kho chữ kiểu — cho mọi nền tảng, không riêng TikTok.</p>
+      </a>
+      <a href="/vi/font-chu-dep/" class="compare-card variant-muted u-no-underline">
+        <h4>Font Chữ Đẹp</h4>
+        <p>Font chữ đẹp có dấu cho bio và caption tiếng Việt.</p>
+      </a>
+      <a href="/vi/ki-tu-dac-biet/" class="compare-card variant-muted u-no-underline">
+        <h4>Kí Tự Đặc Biệt</h4>
+        <p>Kho kí hiệu trang trí tên và bio — bấm là copy.</p>
+      </a>
+      <a href="/vi/usecase/nick-ff/" class="compare-card variant-muted u-no-underline">
+        <h4>Nick FF Đẹp</h4>
+        <p>Làm content game? Tạo nick Free Fire chất trong một chạm.</p>
+      </a>
+      <a href="/vi/" class="compare-card variant-muted u-no-underline">
+        <h4>Trang chủ tiếng Việt</h4>
+        <p>Tất cả kiểu chữ ở một trang — cho mọi mạng xã hội.</p>
+      </a>
+    </div>
+  </section>
+</main>
+
+<footer class="footer">
+  <div class="footer-inner">
+    <h2 class="faq-category">Hỏi đáp về chữ kiểu TikTok</h2>
+    <div class="faq-item"><button class="faq-question" type="button">Làm sao đổi font chữ trên TikTok?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">TikTok không có menu chọn font cho trang cá nhân — giải pháp là dùng chữ kiểu Unicode. Gõ chữ vào ô ở đầu trang, bấm Sao chép ở kiểu bạn thích, rồi mở TikTok → Hồ sơ → Sửa hồ sơ → dán vào ô tên hoặc tiểu sử. Kiểu chữ nằm ngay trong kí tự nên hiển thị y nguyên trên TikTok.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Chữ kiểu TikTok dùng được ở những phần nào?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Dùng được ở tên hiển thị, tiểu sử (bio), bình luận và caption video. Riêng username (@) thì không — TikTok chỉ nhận chữ thường, số, dấu chấm và gạch dưới ở đó. Để hiển thị tốt trên mọi máy, ưu tiên các kiểu phổ biến như đậm, small caps và script; kiểu hiếm đôi khi thành ô vuông (□) trên máy đời cũ.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Dùng chữ kiểu có an toàn cho tài khoản TikTok không?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">An toàn. Chữ kiểu là kí tự Unicode chuẩn — văn bản bình thường mà TikTok hỗ trợ sẵn, không vi phạm điều khoản, hàng triệu tài khoản đang dùng. Lưu ý nhỏ về trợ năng: trình đọc màn hình đôi khi đọc từng kí tự một với vài kiểu chữ, nên dùng chữ kiểu cho tên và điểm nhấn ngắn thay vì cả đoạn dài.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Có cần tải app để tạo chữ kiểu TikTok không?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Không. Mọi thứ chạy thẳng trên trình duyệt điện thoại hoặc máy tính — không cài app, không đăng ký, miễn phí 100%. Gõ chữ, chọn kiểu, copy, dán là xong.</div></div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Language switcher">
+      <a class="lang-option" href="/tiktok/" hreflang="en">EN</a>
+      <a class="lang-option" href="/id/font-tiktok/" hreflang="id">ID</a>
+      <a class="lang-option active" href="/vi/chu-kieu-tiktok/" hreflang="vi">VI</a>
+    </div>
+  </div>
+</footer>
+
+<div class="copy-toast" id="copyToast">Đã sao chép!</div>
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/styles.js"></script>
+<script src="/renderer.js"></script>
+<script src="/script.js" defer=""></script>
+<script src="/symbol-explorer.js"></script>
+<script src="/footer.js"></script>
+</body></html>

--- a/vi/chu-kieu/index.html
+++ b/vi/chu-kieu/index.html
@@ -1,0 +1,331 @@
+<!DOCTYPE html><html lang="vi"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Chữ Kiểu — 1001+ Mẫu Chữ Kiểu Đẹp Copy Paste (Giữ Dấu Tiếng Việt) | UltraTextGen</title>
+  <meta name="description" content="Tạo chữ kiểu online: gõ một dòng, ra ngay 100+ kiểu chữ đẹp — đậm, nghiêng, script, gothic, bong bóng. Giữ nguyên dấu tiếng Việt, copy paste vào tên game, bio, caption. Miễn phí, không cần app.">
+  <link rel="canonical" href="https://ultratextgen.com/vi/chu-kieu/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Chữ Kiểu — 1001+ Mẫu Chữ Kiểu Đẹp Copy Paste (Giữ Dấu Tiếng Việt)">
+  <meta property="og:description" content="Gõ một dòng, ra ngay 100+ kiểu chữ đẹp — đậm, nghiêng, script, gothic, bong bóng. Giữ nguyên dấu tiếng Việt, copy paste đi đâu cũng được.">
+  <meta property="og:url" content="https://ultratextgen.com/vi/chu-kieu/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/tao-chu-kieu-dep-preview.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Chữ Kiểu — 1001+ Mẫu Chữ Kiểu Đẹp Copy Paste">
+  <meta name="twitter:description" content="Tạo chữ kiểu online: gõ một dòng, ra 100+ kiểu chữ đẹp để copy paste. Giữ nguyên dấu tiếng Việt.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/tao-chu-kieu-dep-preview.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+  <link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Chữ Kiểu — Tạo Chữ Kiểu Đẹp Copy Paste",
+  "alternateName": ["Chữ Kiểu", "Tạo Chữ Kiểu", "Chữ Kiểu Đẹp", "Kiểu Chữ", "Chữ Kiểu Có Dấu", "Bảng Chữ Kiểu"],
+  "url": "https://ultratextgen.com/vi/chu-kieu/",
+  "inLanguage": "vi",
+  "applicationCategory": "UtilitiesApplication",
+  "operatingSystem": "Any",
+  "description": "Trình tạo chữ kiểu online: đổi chữ thường sang hơn 100 kiểu chữ đẹp — đậm, nghiêng, script, gothic, bong bóng — giữ nguyên dấu tiếng Việt, copy paste vào tên game, bio và caption.",
+  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "vi",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Chữ kiểu là gì?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Chữ kiểu là chữ được viết bằng các kí tự Unicode có sẵn kiểu dáng — đậm 𝗔, nghiêng 𝘈, cong nghệ thuật 𝒜, gothic 𝔄, bong bóng Ⓐ... Vì kiểu dáng nằm ngay trong kí tự chứ không phải định dạng của ứng dụng, bạn copy paste đi đâu chữ vẫn giữ nguyên kiểu — bio Facebook, tên TikTok, nick Free Fire, caption Instagram hay status Zalo." }
+    },
+    {
+      "@type": "Question",
+      "name": "Tạo chữ kiểu như thế nào?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Gõ hoặc dán chữ vào ô ở đầu trang — hàng loạt phiên bản chữ kiểu hiện ra ngay bên dưới. Cuộn xem các kiểu đậm, nghiêng, script, gothic, bong bóng, small caps, rồi bấm Sao chép cạnh kiểu bạn thích và dán vào bất kỳ đâu. Muốn xịn hơn thì thêm khung viền, kí hiệu trang trí chỉ với một cú nhấp." }
+    },
+    {
+      "@type": "Question",
+      "name": "Chữ kiểu có giữ được dấu tiếng Việt không?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Có. Công cụ đổi từng chữ cái Latin sang kí tự Unicode có kiểu dáng, còn các nguyên âm có dấu (á, ằ, ể, ữ, ợ, đ...) được giữ nguyên nên đọc vẫn đúng chính tả — không mất dấu, không ra ô vuông. Với caption tiếng Việt có dấu, ba kiểu Đậm, Nghiêng và Small Caps cho ra dấu đều và đẹp nhất." }
+    },
+    {
+      "@type": "Question",
+      "name": "Chữ kiểu dán được vào những đâu?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Chỗ nào nhập được chữ là dán được: Facebook, Instagram, TikTok, YouTube, X, Zalo, Messenger, Telegram, Discord; tên nhân vật Free Fire, Liên Quân Mobile, PUBG Mobile, Roblox; tiêu đề email, CV, slide trình chiếu. Vì là kí tự Unicode thật, chữ kiểu đi theo nội dung dù bạn dán ở đâu." }
+    },
+    {
+      "@type": "Question",
+      "name": "Chữ kiểu khác gì chữ in đậm trong Word?",
+      "acceptedAnswer": { "@type": "Answer", "text": "In đậm trong Word là định dạng của ứng dụng — paste sang chỗ chỉ nhận chữ thường (bio Facebook, tên TikTok, tiêu đề email) là mất. Chữ kiểu Unicode thì bản thân kí tự đã có kiểu sẵn, nên paste đi đâu cũng giữ nguyên — đó là lý do nó dùng được ở những chỗ không có nút in đậm." }
+    },
+    {
+      "@type": "Question",
+      "name": "Tạo chữ kiểu ở đây có miễn phí không?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Miễn phí 100% — không bắt đăng ký, không giới hạn lượt copy, không gắn watermark. Chạy thẳng trên trình duyệt điện thoại hoặc máy tính, không cần tải app." }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Trang chủ", "item": "https://ultratextgen.com/vi/" },
+    { "@type": "ListItem", "position": 2, "name": "Chữ Kiểu", "item": "https://ultratextgen.com/vi/chu-kieu/" }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/vi/">Trang chủ</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Chữ Kiểu</span>
+</nav>
+
+<section class="hero">
+  <div class="hero-inner">
+    <div class="hero-card">
+      <h1 class="hero-headline">Chữ Kiểu — tạo chữ kiểu đẹp copy paste</h1>
+      <p class="hero-tagline">Gõ một dòng chữ thường, ra ngay hơn 100 mẫu chữ kiểu: đậm, nghiêng, script, gothic, bong bóng, small caps và nhiều kiểu độc hơn. Giữ nguyên dấu tiếng Việt — bấm Sao chép rồi dán vào tên game, bio hay caption là xong.</p>
+      <div class="input-wrapper">
+        <textarea class="main-input" id="mainInput" placeholder="Gõ chữ bạn muốn đổi kiểu..." maxlength="500" autofocus=""></textarea>
+        <span class="char-count"><span id="charCount">0</span>/500</span>
+      </div>
+      <div class="decoration-section">
+        <div class="decoration-label">Thêm kí hiệu, khung, viền trang trí</div>
+        <div class="decoration-tabs">
+          <button class="decoration-tab active" data-deco-tab="symbols">Kí hiệu</button>
+          <button class="decoration-tab" data-deco-tab="frames">Khung viền</button>
+          <button class="decoration-tab" data-deco-tab="dividers">Đường kẻ</button>
+          <button class="decoration-tab" data-deco-tab="arrows">Mũi tên</button>
+          <button class="decoration-tab" data-deco-tab="minimal">Tối giản</button>
+          <button class="decoration-tab" data-deco-tab="emojis">Emoji</button>
+        </div>
+        <div class="decoration-grid" id="decorationGrid"></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<main class="container">
+  <div class="category-section"><div class="category-tabs" id="categoryTabs"></div></div>
+  <div class="results-grid" id="resultsGrid"></div>
+
+  <!-- Cách tạo chữ kiểu -->
+  <section class="editorial-section">
+    <h2>Cách tạo chữ kiểu trong 3 bước</h2>
+    <p class="editorial-intro">Không cần app, không cần đăng ký — toàn bộ chạy trên trình duyệt. Chữ kiểu ở đây là kí tự Unicode thật, nên kiểu dáng "dính" theo chữ dù bạn dán ở đâu.</p>
+    <div class="tips-grid">
+      <div class="tip-card">
+        <div class="tip-icon">⌨️</div>
+        <h3>1. Gõ chữ vào ô</h3>
+        <p>Nhập tên game, bio hay caption bạn muốn đổi kiểu. Gõ tiếng Việt có dấu thoải mái — dấu thanh và dấu mũ được giữ nguyên.</p>
+      </div>
+      <div class="tip-card">
+        <div class="tip-icon">🎨</div>
+        <h3>2. Chọn kiểu chữ</h3>
+        <p>Cuộn xuống xem cả loạt mẫu chữ kiểu — đậm, nghiêng, script, gothic, bong bóng, small caps. Thêm khung viền, kí tự đặc biệt chỉ với một cú nhấp.</p>
+      </div>
+      <div class="tip-card">
+        <div class="tip-icon">📋</div>
+        <h3>3. Copy &amp; paste</h3>
+        <p>Bấm Sao chép cạnh kiểu bạn thích rồi dán vào Facebook, TikTok, Zalo, Free Fire hay chỗ nào tuỳ ý — chữ kiểu giữ nguyên y hệt.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Bảng chữ kiểu A–Z -->
+  <section class="editorial-section abc-section" aria-label="Bảng chữ kiểu A–Z để copy paste">
+    <h2>Bảng chữ kiểu A–Z</h2>
+    <p class="editorial-intro">Các bảng chữ cái chữ kiểu hay dùng nhất — chữ hoa, chữ thường và số. Gõ ở ô trên để lấy cả câu theo kiểu, hoặc bôi đen từng kí tự trong bảng để copy thủ công.</p>
+    <div class="abc-list">
+      <div class="abc-row">
+        <span class="abc-name">Đậm</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝗔𝗕𝗖𝗗𝗘𝗙𝗚𝗛𝗜𝗝𝗞𝗟𝗠𝗡𝗢𝗣𝗤𝗥𝗦𝗧𝗨𝗩𝗪𝗫𝗬𝗭</span>
+          <span class="abc-line">𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇</span>
+          <span class="abc-line">𝟬𝟭𝟮𝟯𝟰𝟱𝟲𝟳𝟴𝟵</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Nghiêng</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝘈𝘉𝘊𝘋𝘌𝘍𝘎𝘏𝘐𝘑𝘒𝘓𝘔𝘕𝘖𝘗𝘘𝘙𝘚𝘛𝘜𝘝𝘞𝘟𝘠𝘡</span>
+          <span class="abc-line">𝘢𝘣𝘤𝘥𝘦𝘧𝘨𝘩𝘪𝘫𝘬𝘭𝘮𝘯𝘰𝘱𝘲𝘳𝘴𝘵𝘶𝘷𝘸𝘹𝘺𝘻</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Thư pháp (script)</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵</span>
+          <span class="abc-line">𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏</span>
+          <span class="abc-line">𝟢𝟣𝟤𝟥𝟦𝟧𝟨𝟩𝟪𝟫</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Gothic</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝔄𝔅ℭ𝔇𝔈𝔉𝔊ℌℑ𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔ℜ𝔖𝔗𝔘𝔙𝔚𝔛𝔜ℨ</span>
+          <span class="abc-line">𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Small Caps</span>
+        <div class="abc-lines">
+          <span class="abc-line">ᴀʙᴄᴅᴇꜰɢʜɪᴊᴋʟᴍɴᴏᴘQʀsᴛᴜᴠᴡxʏᴢ</span>
+          <span class="abc-line">ᴀʙᴄᴅᴇꜰɢʜɪᴊᴋʟᴍɴᴏᴘqʀsᴛᴜᴠᴡxʏᴢ</span>
+          <span class="abc-line">⁰¹²³⁴⁵⁶⁷⁸⁹</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Bong bóng</span>
+        <div class="abc-lines">
+          <span class="abc-line">ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ</span>
+          <span class="abc-line">ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ</span>
+          <span class="abc-line">⓪①②③④⑤⑥⑦⑧⑨</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Double Struck</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝔸𝔹ℂ𝔻𝔼𝔽𝔾ℍ𝕀𝕁𝕂𝕃𝕄ℕ𝕆ℙℚℝ𝕊𝕋𝕌𝕍𝕎𝕏𝕐ℤ</span>
+          <span class="abc-line">𝕒𝕓𝕔𝕕𝕖𝕗𝕘𝕙𝕚𝕛𝕜𝕝𝕞𝕟𝕠𝕡𝕢𝕣𝕤𝕥𝕦𝕧𝕨𝕩𝕪𝕫</span>
+          <span class="abc-line">𝟘𝟙𝟚𝟛𝟜𝟝𝟞𝟟𝟠𝟡</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Chữ kiểu có dấu -->
+  <section class="editorial-section">
+    <h2>Chữ kiểu có dấu — vẫn đọc đúng tiếng Việt</h2>
+    <p class="editorial-intro">Điểm ăn tiền của chữ kiểu tiếng Việt là <strong>giữ được dấu</strong>. Công cụ đổi các chữ cái Latin sang kí tự Unicode có kiểu, còn nguyên âm có dấu (á, ằ, ể, ữ, ợ, đ…) được giữ nguyên — không mất dấu, không ra ô vuông.</p>
+    <div class="abc-list">
+      <div class="abc-row">
+        <span class="abc-name">Đậm</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝗰𝗵ữ 𝗸𝗶ể𝘂 đẹ𝗽 · 𝗧𝗶ế𝗻𝗴 𝗩𝗶ệ𝘁 · 𝗖ả𝗺 ơ𝗻 𝗻𝗵𝗶ề𝘂</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Nghiêng</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝘤𝘩ữ 𝘬𝘪ể𝘶 đẹ𝘱 · 𝘛𝘪ế𝘯𝘨 𝘝𝘪ệ𝘵 · 𝘊ả𝘮 ơ𝘯 𝘯𝘩𝘪ề𝘶</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Small Caps</span>
+        <div class="abc-lines">
+          <span class="abc-line">ᴄʜữ ᴋɪểᴜ đẹᴘ · ᴛɪếɴɢ ᴠɪệᴛ · ᴄảᴍ ơɴ ɴʜɪềᴜ</span>
+        </div>
+      </div>
+    </div>
+    <p class="u-mt-15">Mẹo: với caption có dấu, ba kiểu Đậm, Nghiêng và Small Caps cho ra dấu đều và đẹp nhất. Kiểu cong nghệ thuật như Script hay Gothic hợp với đoạn không dấu hoặc tên tiếng Anh hơn.</p>
+  </section>
+
+  <!-- Mẫu chữ kiểu đẹp -->
+  <section class="editorial-section" id="mau-chu-kieu">
+    <h2>Mẫu chữ kiểu đẹp — bấm để copy</h2>
+    <p class="editorial-intro">Vài mẫu chữ kiểu đã ghép sẵn kí tự đặc biệt — bấm là copy ngay, về thay chữ của bạn ở ô tạo phía trên nếu muốn đổi nội dung.</p>
+    <div class="uname-grid">
+      <button class="uname-chip symbol-tile" data-symbol="✦ 𝗖𝗵à𝗼 𝗺ừ𝗻𝗴 𝗯ạ𝗻 ✦" aria-label="Sao chép mẫu ✦ 𝗖𝗵à𝗼 𝗺ừ𝗻𝗴 𝗯ạ𝗻 ✦">✦ 𝗖𝗵à𝗼 𝗺ừ𝗻𝗴 𝗯ạ𝗻 ✦</button>
+      <button class="uname-chip symbol-tile" data-symbol="꧁༒𝙃𝙪𝙣𝙩𝙚𝙧༒꧂" aria-label="Sao chép mẫu ꧁༒𝙃𝙪𝙣𝙩𝙚𝙧༒꧂">꧁༒𝙃𝙪𝙣𝙩𝙚𝙧༒꧂</button>
+      <button class="uname-chip symbol-tile" data-symbol="⋆˚｡ ꜱố𝗇𝗀 𝖼𝗁ậ𝗆 ʟạɪ ｡˚⋆" aria-label="Sao chép mẫu ⋆˚｡ ꜱố𝗇𝗀 𝖼𝗁ậ𝗆 ʟạɪ ｡˚⋆">⋆˚｡ ꜱố𝗇𝗀 𝖼𝗁ậ𝗆 ʟạɪ ｡˚⋆</button>
+      <button class="uname-chip symbol-tile" data-symbol="★彡[ᴍɪɴʜ ᴀɴʜ]彡★" aria-label="Sao chép mẫu ★彡[ᴍɪɴʜ ᴀɴʜ]彡★">★彡[ᴍɪɴʜ ᴀɴʜ]彡★</button>
+      <button class="uname-chip symbol-tile" data-symbol="✧ 𝓑é 𝓝𝓰ọ𝓬 ✧" aria-label="Sao chép mẫu ✧ 𝓑é 𝓝𝓰ọ𝓬 ✧">✧ 𝓑é 𝓝𝓰ọ𝓬 ✧</button>
+      <button class="uname-chip symbol-tile" data-symbol="— 𝘣ì𝘯𝘩 𝘺ê𝘯 𝘮ộ𝘵 𝘤𝘩ú𝘵 —" aria-label="Sao chép mẫu — 𝘣ì𝘯𝘩 𝘺ê𝘯 𝘮ộ𝘵 𝘤𝘩ú𝘵 —">— 𝘣ì𝘯𝘩 𝘺ê𝘯 𝘮ộ𝘵 𝘤𝘩ú𝘵 —</button>
+      <button class="uname-chip symbol-tile" data-symbol="ᥫ᭡ 𝗬ê𝘂 đờ𝗶 ᥫ᭡" aria-label="Sao chép mẫu ᥫ᭡ 𝗬ê𝘂 đờ𝗶 ᥫ᭡">ᥫ᭡ 𝗬ê𝘂 đờ𝗶 ᥫ᭡</button>
+      <button class="uname-chip symbol-tile" data-symbol="༺𝕭ó𝖓𝖌 𝕯ê𝖒༻" aria-label="Sao chép mẫu ༺𝕭ó𝖓𝖌 𝕯ê𝖒༻">༺𝕭ó𝖓𝖌 𝕯ê𝖒༻</button>
+    </div>
+    <p class="u-mt-15">Cần kí hiệu lẻ để tự ghép — trái tim, ngôi sao, khung ꧁꧂? Xem kho <a href="/vi/ki-tu-dac-biet/">kí tự đặc biệt</a> — bấm là copy từng kí hiệu.</p>
+  </section>
+
+  <!-- Related -->
+  <section class="editorial-section">
+    <span class="article-section-label">Trang liên quan</span>
+    <div class="compare-grid">
+      <a href="/vi/ki-tu-dac-biet/" class="compare-card variant-muted u-no-underline">
+        <h4>Kí Tự Đặc Biệt</h4>
+        <p>Kho kí hiệu đẹp — trái tim, sao, khung ꧁꧂ — bấm là copy.</p>
+      </a>
+      <a href="/vi/font-chu-dep/" class="compare-card variant-muted u-no-underline">
+        <h4>Font Chữ Đẹp</h4>
+        <p>Tạo font chữ đẹp có dấu cho bio, caption và tên hiển thị.</p>
+      </a>
+      <a href="/vi/chu-kieu-tiktok/" class="compare-card variant-muted u-no-underline">
+        <h4>Chữ Kiểu TikTok</h4>
+        <p>Kiểu chữ hợp TikTok — tên, bio, caption, bình luận.</p>
+      </a>
+      <a href="/vi/usecase/nick-ff/" class="compare-card variant-muted u-no-underline">
+        <h4>Nick FF Đẹp</h4>
+        <p>Tạo tên Free Fire chất với kí tự ꧁༒꧂ và font ngầu.</p>
+      </a>
+      <a href="/vi/" class="compare-card variant-muted u-no-underline">
+        <h4>Trang chủ tiếng Việt</h4>
+        <p>Toàn bộ kho chữ kiểu và kí tự đặc biệt ở một trang.</p>
+      </a>
+    </div>
+  </section>
+</main>
+
+<footer class="footer">
+  <div class="footer-inner">
+    <h2 class="faq-category">Hỏi đáp về chữ kiểu</h2>
+    <div class="faq-item"><button class="faq-question" type="button">Chữ kiểu là gì?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Chữ kiểu là chữ được viết bằng các kí tự Unicode có sẵn kiểu dáng — đậm 𝗔, nghiêng 𝘈, cong nghệ thuật 𝒜, gothic 𝔄, bong bóng Ⓐ... Vì kiểu dáng nằm ngay trong kí tự chứ không phải định dạng của ứng dụng, bạn copy paste đi đâu chữ vẫn giữ nguyên kiểu — bio Facebook, tên TikTok, nick Free Fire, caption Instagram hay status Zalo.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Tạo chữ kiểu như thế nào?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Gõ hoặc dán chữ vào ô ở đầu trang — hàng loạt phiên bản chữ kiểu hiện ra ngay bên dưới. Cuộn xem các kiểu đậm, nghiêng, script, gothic, bong bóng, small caps, rồi bấm Sao chép cạnh kiểu bạn thích và dán vào bất kỳ đâu. Muốn xịn hơn thì thêm khung viền, kí hiệu trang trí chỉ với một cú nhấp.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Chữ kiểu có giữ được dấu tiếng Việt không?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Có. Công cụ đổi từng chữ cái Latin sang kí tự Unicode có kiểu dáng, còn các nguyên âm có dấu (á, ằ, ể, ữ, ợ, đ...) được giữ nguyên nên đọc vẫn đúng chính tả — không mất dấu, không ra ô vuông. Với caption tiếng Việt có dấu, ba kiểu Đậm, Nghiêng và Small Caps cho ra dấu đều và đẹp nhất.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Chữ kiểu dán được vào những đâu?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Chỗ nào nhập được chữ là dán được: Facebook, Instagram, TikTok, YouTube, X, Zalo, Messenger, Telegram, Discord; tên nhân vật Free Fire, Liên Quân Mobile, PUBG Mobile, Roblox; tiêu đề email, CV, slide trình chiếu. Vì là kí tự Unicode thật, chữ kiểu đi theo nội dung dù bạn dán ở đâu.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Chữ kiểu khác gì chữ in đậm trong Word?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">In đậm trong Word là định dạng của ứng dụng — paste sang chỗ chỉ nhận chữ thường (bio Facebook, tên TikTok, tiêu đề email) là mất. Chữ kiểu Unicode thì bản thân kí tự đã có kiểu sẵn, nên paste đi đâu cũng giữ nguyên — đó là lý do nó dùng được ở những chỗ không có nút in đậm.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Tạo chữ kiểu ở đây có miễn phí không?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Miễn phí 100% — không bắt đăng ký, không giới hạn lượt copy, không gắn watermark. Chạy thẳng trên trình duyệt điện thoại hoặc máy tính, không cần tải app.</div></div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Language switcher">
+      <a class="lang-option" href="/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/vi/chu-kieu/" hreflang="vi">VI</a>
+    </div>
+  </div>
+</footer>
+
+<div class="copy-toast" id="copyToast">Đã sao chép!</div>
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/styles.js"></script>
+<script src="/renderer.js"></script>
+<script src="/script.js" defer=""></script>
+<script src="/symbol-explorer.js"></script>
+<script src="/footer.js"></script>
+</body></html>

--- a/vi/font-chu-dep/index.html
+++ b/vi/font-chu-dep/index.html
@@ -1,0 +1,265 @@
+<!DOCTYPE html><html lang="vi"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Font Chữ Đẹp — Tạo Font Chữ Đẹp Có Dấu, Copy Là Dán | UltraTextGen</title>
+  <meta name="description" content="Tạo font chữ đẹp online: gõ chữ, ra ngay 100+ font chữ đặc biệt — aesthetic, đậm, nghiêng, script, gothic. Giữ dấu tiếng Việt, copy paste vào bio, caption, tên game. Miễn phí, không cần cài font.">
+  <link rel="canonical" href="https://ultratextgen.com/vi/font-chu-dep/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Font Chữ Đẹp — Tạo Font Chữ Đẹp Có Dấu, Copy Là Dán">
+  <meta property="og:description" content="Gõ chữ, ra ngay 100+ font chữ đẹp và font chữ đặc biệt — giữ dấu tiếng Việt, copy paste vào bio, caption, tên game.">
+  <meta property="og:url" content="https://ultratextgen.com/vi/font-chu-dep/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/tao-chu-kieu-dep-preview.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Font Chữ Đẹp — Tạo Font Chữ Đẹp Có Dấu, Copy Là Dán">
+  <meta name="twitter:description" content="100+ font chữ đẹp và font chữ đặc biệt — giữ dấu tiếng Việt, copy paste đi đâu cũng được.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/tao-chu-kieu-dep-preview.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+  <link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Font Chữ Đẹp — Tạo Font Chữ Đẹp Có Dấu",
+  "alternateName": ["Font Chữ Đẹp", "Tạo Font Chữ Đẹp", "Font Chữ Đặc Biệt", "Font Chữ Copy", "Font Chữ Aesthetic", "Tạo Font Chữ Đẹp Có Dấu"],
+  "url": "https://ultratextgen.com/vi/font-chu-dep/",
+  "inLanguage": "vi",
+  "applicationCategory": "UtilitiesApplication",
+  "operatingSystem": "Any",
+  "description": "Trình tạo font chữ đẹp online: đổi chữ thường sang hơn 100 font chữ đặc biệt — aesthetic, đậm, nghiêng, script, gothic, bong bóng — giữ nguyên dấu tiếng Việt, copy paste không cần cài font.",
+  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "vi",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Tạo font chữ đẹp bằng cách nào?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Gõ hoặc dán chữ vào ô ở đầu trang — hơn 100 font chữ đẹp hiện ra ngay bên dưới: aesthetic, đậm, nghiêng, script, gothic, bong bóng, small caps. Bấm Sao chép cạnh font bạn thích rồi dán vào bio, caption, tên game hay tin nhắn. Không cần cài đặt gì — font nằm ngay trong kí tự Unicode." }
+    },
+    {
+      "@type": "Question",
+      "name": "Tạo font chữ đẹp có dấu tiếng Việt được không?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Được. Các chữ cái Latin được đổi sang kí tự Unicode có kiểu, còn nguyên âm có dấu (á, ằ, ể, ữ, ợ, đ...) giữ nguyên nên câu vẫn đúng chính tả. Ba font ra dấu đều và đẹp nhất là Đậm, Nghiêng và Small Caps — ví dụ \"font chữ đẹp\" ra 𝗳𝗼𝗻𝘁 𝗰𝗵ữ đẹ𝗽, 𝘧𝘰𝘯𝘵 𝘤𝘩ữ đẹ𝘱, ꜰᴏɴᴛ ᴄʜữ đẹᴘ." }
+    },
+    {
+      "@type": "Question",
+      "name": "Font chữ đặc biệt khác gì font cài vào máy?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Font cài vào máy (file .ttf) chỉ hiện đúng trên máy đã cài — người xem không cài thì không thấy. Font chữ đặc biệt ở đây là kí tự Unicode: kiểu dáng nằm ngay trong kí tự, nên ai xem cũng thấy đúng font mà không phải cài gì. Vì vậy nó dán được vào bio Facebook, tên TikTok, nick game — những chỗ không bao giờ cho bạn chọn font." }
+    },
+    {
+      "@type": "Question",
+      "name": "Font chữ copy về dùng được ở những app nào?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Gần như mọi app có ô nhập chữ: Facebook, Instagram, TikTok, YouTube, Zalo, Messenger, Telegram, Discord, tên nhân vật Free Fire, Liên Quân Mobile, PUBG Mobile, Roblox, cả tiêu đề email và slide trình chiếu. Nếu app nào hiện ô vuông, đổi sang font phổ thông hơn như Đậm, Nghiêng hoặc Bong bóng là ổn." }
+    },
+    {
+      "@type": "Question",
+      "name": "Trang tạo font chữ đẹp này có miễn phí không?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Miễn phí 100% — không đăng ký, không giới hạn lượt copy, không watermark. Mở trên trình duyệt điện thoại hay máy tính đều dùng được ngay, không cần tải app." }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Trang chủ", "item": "https://ultratextgen.com/vi/" },
+    { "@type": "ListItem", "position": 2, "name": "Font Chữ Đẹp", "item": "https://ultratextgen.com/vi/font-chu-dep/" }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/vi/">Trang chủ</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Font Chữ Đẹp</span>
+</nav>
+
+<section class="hero">
+  <div class="hero-inner">
+    <div class="hero-card">
+      <h1 class="hero-headline">Font Chữ Đẹp — tạo font chữ đẹp có dấu</h1>
+      <p class="hero-tagline">Gõ chữ vào ô dưới, ra ngay hơn 100 font chữ đẹp và font chữ đặc biệt: aesthetic, đậm, nghiêng, script, gothic, bong bóng. Giữ nguyên dấu tiếng Việt — copy là dán được vào bio, caption, tên game, không cần cài font.</p>
+      <div class="input-wrapper">
+        <textarea class="main-input" id="mainInput" placeholder="Gõ chữ để đổi font..." maxlength="500" autofocus=""></textarea>
+        <span class="char-count"><span id="charCount">0</span>/500</span>
+      </div>
+      <div class="decoration-section">
+        <div class="decoration-label">Thêm kí hiệu, khung, viền trang trí</div>
+        <div class="decoration-tabs">
+          <button class="decoration-tab active" data-deco-tab="symbols">Kí hiệu</button>
+          <button class="decoration-tab" data-deco-tab="frames">Khung viền</button>
+          <button class="decoration-tab" data-deco-tab="dividers">Đường kẻ</button>
+          <button class="decoration-tab" data-deco-tab="arrows">Mũi tên</button>
+          <button class="decoration-tab" data-deco-tab="minimal">Tối giản</button>
+          <button class="decoration-tab" data-deco-tab="emojis">Emoji</button>
+        </div>
+        <div class="decoration-grid" id="decorationGrid"></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<main class="container">
+  <div class="category-section"><div class="category-tabs" id="categoryTabs"></div></div>
+  <div class="results-grid" id="resultsGrid"></div>
+
+  <!-- Vì sao dán được khắp nơi -->
+  <section class="editorial-section">
+    <h2>Vì sao font chữ đẹp này dán được khắp nơi?</h2>
+    <p class="editorial-intro">Font ở đây không phải file font cài vào máy — mà là <strong>kí tự Unicode</strong> có sẵn kiểu dáng. Khi bạn copy, kiểu chữ đi theo từng kí tự, nên dán vào chỗ nào cũng giữ nguyên — kể cả những chỗ không bao giờ cho chọn font như bio Facebook, tên TikTok hay nick game.</p>
+    <div class="block-example">
+      <strong>Ví dụ:</strong> "Xin chào" → 𝗫𝗶𝗻 𝗰𝗵à𝗼 (đậm) · 𝘟𝘪𝘯 𝘤𝘩à𝘰 (nghiêng) · 𝒳𝒾𝓃 𝒸𝒽àℴ (script) · xɪɴ ᴄʜàᴏ (small caps)
+    </div>
+    <p>Người xem không cần cài gì hết — font hiển thị đúng trên mọi điện thoại và trình duyệt đời mới, vì đây là kí tự văn bản chuẩn quốc tế.</p>
+  </section>
+
+  <!-- Các nhóm font -->
+  <section class="editorial-section">
+    <h2>Các nhóm font chữ đẹp có gì?</h2>
+    <div class="tips-grid">
+      <div class="tip-card">
+        <div class="tip-icon">💪</div>
+        <h3>Font đậm &amp; nghiêng</h3>
+        <p>Nhóm phổ thông nhất — hiển thị tốt trên mọi máy, ra dấu tiếng Việt đều. Hợp caption bán hàng, tiêu đề bài đăng, bio cần dễ đọc.</p>
+      </div>
+      <div class="tip-card">
+        <div class="tip-icon">🌸</div>
+        <h3>Font aesthetic &amp; script</h3>
+        <p>Chữ cong nghệ thuật 𝓯𝓸𝓷𝓽, chữ mảnh, small caps — hợp bio Instagram, story và caption nhẹ nhàng kiểu thư giãn.</p>
+      </div>
+      <div class="tip-card">
+        <div class="tip-icon">🎮</div>
+        <h3>Font chất chơi</h3>
+        <p>Gothic 𝔣𝔬𝔫𝔱, bong bóng ⓕⓞⓝⓣ, lộn ngược, Zalgo glitch — hợp nick game, meme và bio cá tính mạnh.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Font chữ đẹp có dấu -->
+  <section class="editorial-section abc-section">
+    <h2>Font chữ đẹp có dấu — thử liền vài mẫu</h2>
+    <p class="editorial-intro">Dấu thanh và dấu mũ tiếng Việt được giữ nguyên khi đổi font. Ba font ra dấu đẹp nhất:</p>
+    <div class="abc-list">
+      <div class="abc-row">
+        <span class="abc-name">Đậm</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝗳𝗼𝗻𝘁 𝗰𝗵ữ đẹ𝗽 · 𝗖𝗵ú𝗰 𝗺ừ𝗻𝗴 𝘀𝗶𝗻𝗵 𝗻𝗵ậ𝘁 · 𝗠𝘂𝗮 𝗻𝗴𝗮𝘆 𝗵ô𝗺 𝗻𝗮𝘆</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Nghiêng</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝘧𝘰𝘯𝘵 𝘤𝘩ữ đẹ𝘱 · 𝘊𝘩ú𝘤 𝘮ừ𝘯𝘨 𝘴𝘪𝘯𝘩 𝘯𝘩ậ𝘵 · 𝘔𝘶𝘢 𝘯𝘨𝘢𝘺 𝘩ô𝘮 𝘯𝘢𝘺</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Small Caps</span>
+        <div class="abc-lines">
+          <span class="abc-line">ꜰᴏɴᴛ ᴄʜữ đẹᴘ · ᴄʜúᴄ ᴍừɴɢ ꜱɪɴʜ ɴʜậᴛ · ᴍᴜᴀ ɴɢᴀʏ ʜôᴍ ɴᴀʏ</span>
+        </div>
+      </div>
+    </div>
+    <p class="u-mt-15">Với font cong nghệ thuật (Script, Gothic), một số nguyên âm có dấu phức tạp sẽ được giữ nguyên chữ gốc để bạn vẫn đọc được — muốn đều tăm tắp thì dùng đoạn không dấu.</p>
+  </section>
+
+  <!-- Dùng cho gì -->
+  <section class="editorial-section">
+    <h2>Font chữ copy về hay được dùng cho gì?</h2>
+    <div class="block-example">
+      ✔ <strong>Bio &amp; trang cá nhân</strong>: Facebook, Instagram, TikTok, Zalo — chữ đẹp làm profile nổi hẳn<br>
+      ✔ <strong>Caption &amp; status</strong>: nhấn mạnh ý chính bằng font đậm, làm mềm câu bằng font script<br>
+      ✔ <strong>Tên game</strong>: nick Free Fire, Liên Quân với font gothic + kí tự đặc biệt<br>
+      ✔ <strong>Tiêu đề email &amp; CV</strong>: chữ đậm Unicode hiện được cả ở nơi không có nút in đậm
+    </div>
+    <p>Cần kí hiệu trang trí kèm font — trái tim, ngôi sao, khung viền? Bấm qua kho <a href="/vi/ki-tu-dac-biet/">kí tự đặc biệt</a>. Muốn xem mẫu ghép sẵn cho TikTok thì có trang <a href="/vi/chu-kieu-tiktok/">chữ kiểu TikTok</a> riêng.</p>
+  </section>
+
+  <!-- Related -->
+  <section class="editorial-section">
+    <span class="article-section-label">Trang liên quan</span>
+    <div class="compare-grid">
+      <a href="/vi/chu-kieu/" class="compare-card variant-muted u-no-underline">
+        <h4>Chữ Kiểu</h4>
+        <p>Bảng chữ kiểu A–Z và 1001+ mẫu chữ kiểu đẹp copy paste.</p>
+      </a>
+      <a href="/vi/ki-tu-dac-biet/" class="compare-card variant-muted u-no-underline">
+        <h4>Kí Tự Đặc Biệt</h4>
+        <p>Kho kí hiệu ꧁꧂ ♡ ✦ ➤ bấm là copy — ghép cùng font cho chất.</p>
+      </a>
+      <a href="/vi/chu-kieu-tiktok/" class="compare-card variant-muted u-no-underline">
+        <h4>Chữ Kiểu TikTok</h4>
+        <p>Font hợp TikTok cho tên, bio và caption — kèm mẫu bio sẵn.</p>
+      </a>
+      <a href="/vi/usecase/nick-ff/" class="compare-card variant-muted u-no-underline">
+        <h4>Nick FF Đẹp</h4>
+        <p>Tạo tên Free Fire ngầu với font + khung ꧁༒꧂.</p>
+      </a>
+      <a href="/vi/" class="compare-card variant-muted u-no-underline">
+        <h4>Trang chủ tiếng Việt</h4>
+        <p>Toàn bộ kho font chữ và kí tự đặc biệt ở một trang.</p>
+      </a>
+    </div>
+  </section>
+</main>
+
+<footer class="footer">
+  <div class="footer-inner">
+    <h2 class="faq-category">Hỏi đáp về font chữ đẹp</h2>
+    <div class="faq-item"><button class="faq-question" type="button">Tạo font chữ đẹp bằng cách nào?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Gõ hoặc dán chữ vào ô ở đầu trang — hơn 100 font chữ đẹp hiện ra ngay bên dưới: aesthetic, đậm, nghiêng, script, gothic, bong bóng, small caps. Bấm Sao chép cạnh font bạn thích rồi dán vào bio, caption, tên game hay tin nhắn. Không cần cài đặt gì — font nằm ngay trong kí tự Unicode.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Tạo font chữ đẹp có dấu tiếng Việt được không?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Được. Các chữ cái Latin được đổi sang kí tự Unicode có kiểu, còn nguyên âm có dấu (á, ằ, ể, ữ, ợ, đ...) giữ nguyên nên câu vẫn đúng chính tả. Ba font ra dấu đều và đẹp nhất là Đậm, Nghiêng và Small Caps — ví dụ "font chữ đẹp" ra 𝗳𝗼𝗻𝘁 𝗰𝗵ữ đẹ𝗽, 𝘧𝘰𝘯𝘵 𝘤𝘩ữ đẹ𝘱, ꜰᴏɴᴛ ᴄʜữ đẹᴘ.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Font chữ đặc biệt khác gì font cài vào máy?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Font cài vào máy (file .ttf) chỉ hiện đúng trên máy đã cài — người xem không cài thì không thấy. Font chữ đặc biệt ở đây là kí tự Unicode: kiểu dáng nằm ngay trong kí tự, nên ai xem cũng thấy đúng font mà không phải cài gì. Vì vậy nó dán được vào bio Facebook, tên TikTok, nick game — những chỗ không bao giờ cho bạn chọn font.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Font chữ copy về dùng được ở những app nào?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Gần như mọi app có ô nhập chữ: Facebook, Instagram, TikTok, YouTube, Zalo, Messenger, Telegram, Discord, tên nhân vật Free Fire, Liên Quân Mobile, PUBG Mobile, Roblox, cả tiêu đề email và slide trình chiếu. Nếu app nào hiện ô vuông, đổi sang font phổ thông hơn như Đậm, Nghiêng hoặc Bong bóng là ổn.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Trang tạo font chữ đẹp này có miễn phí không?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Miễn phí 100% — không đăng ký, không giới hạn lượt copy, không watermark. Mở trên trình duyệt điện thoại hay máy tính đều dùng được ngay, không cần tải app.</div></div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Language switcher">
+      <a class="lang-option" href="/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/vi/font-chu-dep/" hreflang="vi">VI</a>
+    </div>
+  </div>
+</footer>
+
+<div class="copy-toast" id="copyToast">Đã sao chép!</div>
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/styles.js"></script>
+<script src="/renderer.js"></script>
+<script src="/script.js" defer=""></script>
+<script src="/symbol-explorer.js"></script>
+<script src="/footer.js"></script>
+</body></html>

--- a/vi/index.html
+++ b/vi/index.html
@@ -524,17 +524,17 @@
   <section class="editorial-section">
     <h2 data-i18n="useCases.title">Người Việt thường dùng để làm gì?</h2>
     <div class="tips-grid">
-      <a class="tip-card" href="/usecase/linkedin-headline/" aria-label="Tên game Free Fire Liên Quân">
+      <a class="tip-card" href="/vi/usecase/nick-ff/" aria-label="Tên game Free Fire Liên Quân">
         <div class="tip-icon">🎮</div>
         <h3 data-i18n="useCases.items.0.title">Tên game Free Fire, Liên Quân</h3>
         <p data-i18n="useCases.items.0.description">Đổi nick game cực chất với kí tự đặc biệt và font chữ phong cách. Tên FF, Liên Quân Mobile, LOL hay PUBG đều dán mượt.</p>
       </a>
-      <a class="tip-card" href="/usecase/comment-font/" aria-label="Bio Facebook Instagram Zalo">
+      <a class="tip-card" href="/vi/font-chu-dep/" aria-label="Bio Facebook Instagram Zalo">
         <div class="tip-icon">💬</div>
         <h3 data-i18n="useCases.items.1.title">Bio Facebook, Instagram, Zalo</h3>
         <p data-i18n="useCases.items.1.description">Trang cá nhân nhìn xịn hẳn lên với font chữ aesthetic. Bio ngắn cũng nổi bật mà không cần biết thiết kế.</p>
       </a>
-      <a class="tip-card" href="/usecase/text-to-emoji/" aria-label="Caption TikTok và status">
+      <a class="tip-card" href="/vi/chu-kieu-tiktok/" aria-label="Caption TikTok và status">
         <div class="tip-icon">✨</div>
         <h3 data-i18n="useCases.items.2.title">Caption TikTok &amp; status</h3>
         <p data-i18n="useCases.items.2.description">Caption TikTok, story Instagram, status Zalo - chữ đẹp giúp người xem dừng tay scroll và đọc thật sự.</p>
@@ -564,6 +564,41 @@
       </a>
     </div>
     <p class="u-mt-15 u-text-center"><a class="cat-cta" href="/guide/" data-i18n="guides.viewAll">Xem tất cả mẹo →</a></p>
+  </section>
+
+  <!-- Công cụ tiếng Việt -->
+  <section class="editorial-section" aria-label="Công cụ chữ kiểu tiếng Việt">
+    <h2>Công cụ chữ kiểu tiếng Việt</h2>
+    <div class="compare-grid">
+      <a href="/vi/chu-kieu/" class="compare-card variant-muted u-no-underline">
+        <h4>Chữ Kiểu</h4>
+        <p>Bảng chữ kiểu A–Z và 1001+ mẫu chữ kiểu đẹp copy paste — giữ dấu tiếng Việt.</p>
+      </a>
+      <a href="/vi/ki-tu-dac-biet/" class="compare-card variant-muted u-no-underline">
+        <h4>Kí Tự Đặc Biệt</h4>
+        <p>Kho kí hiệu ꧁꧂ ♡ ✦ ➤ phân theo nhóm — bấm là copy.</p>
+      </a>
+      <a href="/vi/font-chu-dep/" class="compare-card variant-muted u-no-underline">
+        <h4>Font Chữ Đẹp</h4>
+        <p>Tạo font chữ đẹp có dấu cho bio, caption và tên hiển thị.</p>
+      </a>
+      <a href="/vi/chu-kieu-tiktok/" class="compare-card variant-muted u-no-underline">
+        <h4>Chữ Kiểu TikTok</h4>
+        <p>Đổi font tên, bio và caption TikTok — kèm mẫu bio sẵn.</p>
+      </a>
+      <a href="/vi/usecase/nick-ff/" class="compare-card variant-muted u-no-underline">
+        <h4>Nick FF Đẹp</h4>
+        <p>Tạo tên Free Fire chất với khung ꧁༒꧂ và font ngầu.</p>
+      </a>
+      <a href="/vi/ky-tu-vo-hinh/" class="compare-card variant-muted u-no-underline">
+        <h4>Kí Tự Vô Hình</h4>
+        <p>Kí tự trống để đặt tên có dấu cách và gửi tin nhắn trống.</p>
+      </a>
+      <a href="/vi/usecase/zalgo-text/" class="compare-card variant-muted u-no-underline">
+        <h4>Chữ Zalgo</h4>
+        <p>Chữ glitch, chữ rớt mạng cho meme và nick horror.</p>
+      </a>
+    </div>
   </section>
 
   <!-- FAQ Section -->

--- a/vi/ki-tu-dac-biet/index.html
+++ b/vi/ki-tu-dac-biet/index.html
@@ -1,0 +1,389 @@
+<!DOCTYPE html><html lang="vi"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Kí Tự Đặc Biệt ✓ Kho Kí Tự Đẹp Copy Paste — FF, Liên Quân, TikTok | UltraTextGen</title>
+  <meta name="description" content="Kho kí tự đặc biệt đầy đủ nhất: khung ꧁꧂, trái tim ♡, ngôi sao ✦, mũi tên ➤, hoa ✿ — bấm là copy. Ghép vào tên Free Fire, Liên Quân, bio Facebook, TikTok. Miễn phí, không cần app.">
+  <link rel="canonical" href="https://ultratextgen.com/vi/ki-tu-dac-biet/">
+
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/aesthetic-symbols/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles/">
+  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-aesthetic/">
+  <link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/library/speciale-tekens/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos/">
+  <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/semboller/">
+  <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/ki-tu-dac-biet/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/aesthetic-symbols/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Kí Tự Đặc Biệt ✓ Kho Kí Tự Đẹp Copy Paste — FF, Liên Quân, TikTok">
+  <meta property="og:description" content="Kho kí tự đặc biệt: khung ꧁꧂, trái tim ♡, ngôi sao ✦, mũi tên ➤ — bấm là copy, ghép vào tên game và bio.">
+  <meta property="og:url" content="https://ultratextgen.com/vi/ki-tu-dac-biet/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/library-aesthetic-symbols.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Kí Tự Đặc Biệt ✓ Kho Kí Tự Đẹp Copy Paste">
+  <meta name="twitter:description" content="Khung ꧁꧂, trái tim ♡, sao ✦, mũi tên ➤ — bấm là copy, ghép vào tên FF, Liên Quân, bio và caption.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/library-aesthetic-symbols.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+  <link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Kí Tự Đặc Biệt — Kho Kí Tự Đẹp Copy Paste",
+  "alternateName": ["Kí Tự Đặc Biệt", "Ký Tự Đặc Biệt", "Kí Tự Đẹp", "Kí Tự Đặc Biệt FF", "Kí Hiệu Đặc Biệt", "KTDB"],
+  "url": "https://ultratextgen.com/vi/ki-tu-dac-biet/",
+  "inLanguage": "vi",
+  "applicationCategory": "UtilitiesApplication",
+  "operatingSystem": "Any",
+  "description": "Kho kí tự đặc biệt phân theo nhóm — khung viền ꧁꧂, trái tim, ngôi sao, mũi tên, hoa, đường kẻ — bấm là copy, ghép vào tên Free Fire, Liên Quân, bio Facebook, Instagram và caption TikTok.",
+  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "vi",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Kí tự đặc biệt là gì?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Kí tự đặc biệt (hay viết tắt ktdb) là các kí hiệu Unicode nằm ngoài bảng chữ cái thường — dạng như ✿ ❀ ★ ✦ ღ ꧁ ꧂ ༒ ☬ メ 彡. Vì là kí tự văn bản thật, bạn copy được như chữ thường và dán vào mọi ô nhập chữ: tên game, bio mạng xã hội, caption, tin nhắn — không cần cài font hay app." }
+    },
+    {
+      "@type": "Question",
+      "name": "Cách copy kí tự đặc biệt như thế nào?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Bấm vào kí hiệu bạn thích trên trang này — kí tự được sao chép ngay vào bộ nhớ tạm, có thông báo xác nhận. Sau đó mở app đích (Free Fire, Facebook, Zalo, TikTok...) và dán vào ô nhập chữ. Muốn bọc kí hiệu quanh cả đoạn chữ tự động, gõ chữ vào ô tạo ở đầu trang rồi dùng các tab Kí hiệu và Khung viền." }
+    },
+    {
+      "@type": "Question",
+      "name": "Kí tự đặc biệt nào hợp cho tên Free Fire, Liên Quân?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Bộ được cộng đồng game Việt dùng nhiều nhất là khung ꧁ ꧂ (hay gọi khung cánh bướm), dấu ༒ ☬, gulungan ༺ ༻, katakana メ 彡, mặt cười ツ, vương miện ♛ và ™. Ghép kiểu ꧁༒Tên༒꧂ hoặc メTên彡 là ra nick chuẩn game thủ. Các kí hiệu này đã được test hiển thị tốt trong Free Fire và Liên Quân Mobile." }
+    },
+    {
+      "@type": "Question",
+      "name": "Dán kí tự đặc biệt có bị game hay app chặn không?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Đa số kí hiệu phổ biến (꧁ ꧂ ★ ✦ ♡ ➤) được Free Fire, Liên Quân, Facebook, TikTok, Zalo chấp nhận bình thường. Một số kí tự hiếm có thể hiện ô vuông (□) trên máy đời cũ hoặc bị ô tên của một vài game từ chối — khi đó cứ đổi sang kí hiệu phổ thông hơn là được. Kí tự ở đây là Unicode chuẩn, không có script hay mã ẩn nên hoàn toàn an toàn." }
+    },
+    {
+      "@type": "Question",
+      "name": "Kí tự vô hình để đặt tên có dấu cách lấy ở đâu?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Free Fire và nhiều game không cho dấu cách trong tên — mẹo là dùng kí tự vô hình (kí tự trống). UltraTextGen có trang riêng tổng hợp đầy đủ kí tự vô hình: zero width space, Hangul filler, braille trống — bấm là copy, dán vào giữa hai chữ là tên nhìn như có dấu cách." }
+    },
+    {
+      "@type": "Question",
+      "name": "Trang kí tự đặc biệt này có miễn phí không?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Miễn phí 100%, không cần đăng ký, không giới hạn lượt copy. Trang chạy thẳng trên trình duyệt điện thoại và máy tính — bấm kí hiệu, dán đi đâu tuỳ bạn." }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Trang chủ", "item": "https://ultratextgen.com/vi/" },
+    { "@type": "ListItem", "position": 2, "name": "Kí Tự Đặc Biệt", "item": "https://ultratextgen.com/vi/ki-tu-dac-biet/" }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/vi/">Trang chủ</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Kí Tự Đặc Biệt</span>
+</nav>
+
+<section class="hero">
+  <div class="hero-inner">
+    <div class="hero-card">
+      <h1 class="hero-headline">Kí Tự Đặc Biệt — bấm là copy</h1>
+      <p class="hero-tagline">Kho kí tự đặc biệt đầy đủ cho tên Free Fire, Liên Quân, bio Facebook, Instagram và caption TikTok: khung ꧁꧂, trái tim ♡, ngôi sao ✦, mũi tên ➤, hoa ✿. Bấm kí hiệu để copy, hoặc gõ chữ vào ô dưới để bọc khung tự động.</p>
+      <div class="input-wrapper">
+        <textarea class="main-input" id="mainInput" placeholder="Gõ tên hoặc chữ để ghép kí tự đặc biệt..." maxlength="500"></textarea>
+        <span class="char-count"><span id="charCount">0</span>/500</span>
+      </div>
+      <div class="decoration-section">
+        <div class="decoration-label">Bọc kí hiệu, khung, viền quanh chữ của bạn</div>
+        <div class="decoration-tabs">
+          <button class="decoration-tab active" data-deco-tab="symbols">Kí hiệu</button>
+          <button class="decoration-tab" data-deco-tab="frames">Khung viền</button>
+          <button class="decoration-tab" data-deco-tab="dividers">Đường kẻ</button>
+          <button class="decoration-tab" data-deco-tab="arrows">Mũi tên</button>
+          <button class="decoration-tab" data-deco-tab="minimal">Tối giản</button>
+          <button class="decoration-tab" data-deco-tab="emojis">Emoji</button>
+        </div>
+        <div class="decoration-grid" id="decorationGrid"></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<main class="container">
+  <div class="category-section"><div class="category-tabs" id="categoryTabs"></div></div>
+  <div class="results-grid" id="resultsGrid"></div>
+
+  <!-- Kí tự game -->
+  <section class="editorial-section glyph-section" id="ki-tu-ff">
+    <h2>Kí tự đặc biệt FF, Liên Quân — bo viền tên game</h2>
+    <p class="editorial-intro">Bộ kí hiệu được game thủ Việt dùng nhiều nhất để bo viền nick. Ghép kiểu ꧁༒Tên༒꧂ hoặc メTên彡 — bấm từng kí hiệu để copy:</p>
+    <div class="glyph-grid">
+      <button class="glyph-copy" type="button" data-text="꧁" aria-label="Sao chép khung trái ꧁">꧁</button>
+      <button class="glyph-copy" type="button" data-text="꧂" aria-label="Sao chép khung phải ꧂">꧂</button>
+      <button class="glyph-copy" type="button" data-text="༒" aria-label="Sao chép kí hiệu ༒">༒</button>
+      <button class="glyph-copy" type="button" data-text="☬" aria-label="Sao chép kí hiệu ☬">☬</button>
+      <button class="glyph-copy" type="button" data-text="༺" aria-label="Sao chép ngoặc trái ༺">༺</button>
+      <button class="glyph-copy" type="button" data-text="༻" aria-label="Sao chép ngoặc phải ༻">༻</button>
+      <button class="glyph-copy" type="button" data-text="メ" aria-label="Sao chép katakana メ">メ</button>
+      <button class="glyph-copy" type="button" data-text="彡" aria-label="Sao chép kí hiệu 彡">彡</button>
+      <button class="glyph-copy" type="button" data-text="ツ" aria-label="Sao chép mặt cười ツ">ツ</button>
+      <button class="glyph-copy" type="button" data-text="♛" aria-label="Sao chép vương miện ♛">♛</button>
+      <button class="glyph-copy" type="button" data-text="♚" aria-label="Sao chép vương miện ♚">♚</button>
+      <button class="glyph-copy" type="button" data-text="⚔" aria-label="Sao chép kiếm chéo ⚔">⚔</button>
+      <button class="glyph-copy" type="button" data-text="†" aria-label="Sao chép thánh giá †">†</button>
+      <button class="glyph-copy" type="button" data-text="™" aria-label="Sao chép kí hiệu ™">™</button>
+      <button class="glyph-copy" type="button" data-text="࿐" aria-label="Sao chép cờ trang trí ࿐">࿐</button>
+      <button class="glyph-copy" type="button" data-text="ೋ" aria-label="Sao chép kí hiệu ೋ">ೋ</button>
+      <button class="glyph-copy" type="button" data-text="๑" aria-label="Sao chép kí hiệu ๑">๑</button>
+      <button class="glyph-copy" type="button" data-text="⚝" aria-label="Sao chép sao viền ⚝">⚝</button>
+    </div>
+    <p class="u-mt-15">Muốn mẫu nick ghép sẵn cả khung lẫn font? Vào trang <a href="/vi/usecase/nick-ff/">nick FF đẹp</a> — bấm một lần copy được nguyên tên.</p>
+  </section>
+
+  <!-- Trái tim -->
+  <section class="editorial-section glyph-section" id="ki-tu-trai-tim">
+    <h2>Kí tự trái tim</h2>
+    <p class="editorial-intro">Trái tim Unicode cho bio, tin nhắn và tên — bấm để copy:</p>
+    <div class="glyph-grid">
+      <button class="glyph-copy" type="button" data-text="♡" aria-label="Sao chép tim rỗng ♡">♡</button>
+      <button class="glyph-copy" type="button" data-text="♥" aria-label="Sao chép tim đặc ♥">♥</button>
+      <button class="glyph-copy" type="button" data-text="❤" aria-label="Sao chép tim đỏ ❤">❤</button>
+      <button class="glyph-copy" type="button" data-text="❥" aria-label="Sao chép tim nghiêng ❥">❥</button>
+      <button class="glyph-copy" type="button" data-text="ღ" aria-label="Sao chép tim cách điệu ღ">ღ</button>
+      <button class="glyph-copy" type="button" data-text="ᥫ᭡" aria-label="Sao chép tim mini ᥫ᭡">ᥫ᭡</button>
+      <button class="glyph-copy" type="button" data-text="❣" aria-label="Sao chép tim chấm than ❣">❣</button>
+      <button class="glyph-copy" type="button" data-text="❦" aria-label="Sao chép tim hoa văn ❦">❦</button>
+      <button class="glyph-copy" type="button" data-text="🖤" aria-label="Sao chép tim đen 🖤">🖤</button>
+      <button class="glyph-copy" type="button" data-text="🩷" aria-label="Sao chép tim hồng 🩷">🩷</button>
+      <button class="glyph-copy" type="button" data-text="💖" aria-label="Sao chép tim lấp lánh 💖">💖</button>
+      <button class="glyph-copy" type="button" data-text="꒰♡꒱" aria-label="Sao chép tim trong khung ꒰♡꒱">꒰♡꒱</button>
+    </div>
+  </section>
+
+  <!-- Sao & lấp lánh -->
+  <section class="editorial-section glyph-section" id="ki-tu-ngoi-sao">
+    <h2>Kí tự ngôi sao &amp; lấp lánh</h2>
+    <p class="editorial-intro">Sao và kim tuyến — nhóm được dùng nhiều nhất trong bio aesthetic:</p>
+    <div class="glyph-grid">
+      <button class="glyph-copy" type="button" data-text="★" aria-label="Sao chép sao đặc ★">★</button>
+      <button class="glyph-copy" type="button" data-text="☆" aria-label="Sao chép sao rỗng ☆">☆</button>
+      <button class="glyph-copy" type="button" data-text="✦" aria-label="Sao chép sao bốn cánh ✦">✦</button>
+      <button class="glyph-copy" type="button" data-text="✧" aria-label="Sao chép sao bốn cánh rỗng ✧">✧</button>
+      <button class="glyph-copy" type="button" data-text="⋆" aria-label="Sao chép sao nhỏ ⋆">⋆</button>
+      <button class="glyph-copy" type="button" data-text="✩" aria-label="Sao chép sao viền ✩">✩</button>
+      <button class="glyph-copy" type="button" data-text="✯" aria-label="Sao chép sao xoay ✯">✯</button>
+      <button class="glyph-copy" type="button" data-text="✰" aria-label="Sao chép sao bóng ✰">✰</button>
+      <button class="glyph-copy" type="button" data-text="⭒" aria-label="Sao chép sao mờ ⭒">⭒</button>
+      <button class="glyph-copy" type="button" data-text="⊹" aria-label="Sao chép kim tuyến ⊹">⊹</button>
+      <button class="glyph-copy" type="button" data-text="˚" aria-label="Sao chép chấm sáng ˚">˚</button>
+      <button class="glyph-copy" type="button" data-text="｡ﾟ" aria-label="Sao chép chấm lấp lánh ｡ﾟ">｡ﾟ</button>
+    </div>
+  </section>
+
+  <!-- Hoa & thiên nhiên -->
+  <section class="editorial-section glyph-section" id="ki-tu-hoa">
+    <h2>Kí tự hoa, trăng &amp; thiên nhiên</h2>
+    <p class="editorial-intro">Hoa lá và trăng sao cho bio nhẹ nhàng, tên nữ tính:</p>
+    <div class="glyph-grid">
+      <button class="glyph-copy" type="button" data-text="✿" aria-label="Sao chép hoa đặc ✿">✿</button>
+      <button class="glyph-copy" type="button" data-text="❀" aria-label="Sao chép hoa rỗng ❀">❀</button>
+      <button class="glyph-copy" type="button" data-text="❁" aria-label="Sao chép hoa cánh tròn ❁">❁</button>
+      <button class="glyph-copy" type="button" data-text="✾" aria-label="Sao chép hoa cách điệu ✾">✾</button>
+      <button class="glyph-copy" type="button" data-text="❃" aria-label="Sao chép hoa tuyết ❃">❃</button>
+      <button class="glyph-copy" type="button" data-text="⚘" aria-label="Sao chép nhành hoa ⚘">⚘</button>
+      <button class="glyph-copy" type="button" data-text="☘" aria-label="Sao chép cỏ ba lá ☘">☘</button>
+      <button class="glyph-copy" type="button" data-text="ꕥ" aria-label="Sao chép hoa ꕥ">ꕥ</button>
+      <button class="glyph-copy" type="button" data-text="☾" aria-label="Sao chép trăng khuyết ☾">☾</button>
+      <button class="glyph-copy" type="button" data-text="☽" aria-label="Sao chép trăng lưỡi liềm ☽">☽</button>
+      <button class="glyph-copy" type="button" data-text="❄" aria-label="Sao chép bông tuyết ❄">❄</button>
+      <button class="glyph-copy" type="button" data-text="༄" aria-label="Sao chép làn gió ༄">༄</button>
+    </div>
+  </section>
+
+  <!-- Mũi tên -->
+  <section class="editorial-section glyph-section" id="ki-tu-mui-ten">
+    <h2>Kí tự mũi tên</h2>
+    <p class="editorial-intro">Mũi tên để trỏ link, tách ý trong bio và caption:</p>
+    <div class="glyph-grid">
+      <button class="glyph-copy" type="button" data-text="→" aria-label="Sao chép mũi tên phải →">→</button>
+      <button class="glyph-copy" type="button" data-text="➤" aria-label="Sao chép mũi tên đặc ➤">➤</button>
+      <button class="glyph-copy" type="button" data-text="➜" aria-label="Sao chép mũi tên tròn ➜">➜</button>
+      <button class="glyph-copy" type="button" data-text="⇒" aria-label="Sao chép mũi tên kép ⇒">⇒</button>
+      <button class="glyph-copy" type="button" data-text="↠" aria-label="Sao chép mũi tên hai đầu ↠">↠</button>
+      <button class="glyph-copy" type="button" data-text="⇢" aria-label="Sao chép mũi tên đứt ⇢">⇢</button>
+      <button class="glyph-copy" type="button" data-text="↳" aria-label="Sao chép mũi tên gạch đầu dòng ↳">↳</button>
+      <button class="glyph-copy" type="button" data-text="➸" aria-label="Sao chép mũi tên bắn ➸">➸</button>
+      <button class="glyph-copy" type="button" data-text="➵" aria-label="Sao chép mũi tên mảnh ➵">➵</button>
+      <button class="glyph-copy" type="button" data-text="⤳" aria-label="Sao chép mũi tên lượn ⤳">⤳</button>
+      <button class="glyph-copy" type="button" data-text="«" aria-label="Sao chép ngoặc kép trái «">«</button>
+      <button class="glyph-copy" type="button" data-text="»" aria-label="Sao chép ngoặc kép phải »">»</button>
+    </div>
+  </section>
+
+  <!-- Khung & ngoặc -->
+  <section class="editorial-section glyph-section" id="ki-tu-khung">
+    <h2>Kí tự khung &amp; ngoặc trang trí</h2>
+    <p class="editorial-intro">Cặp ngoặc để bọc tên và tiêu đề — copy từng bên rồi đặt chữ vào giữa:</p>
+    <div class="glyph-grid">
+      <button class="glyph-copy" type="button" data-text="【】" aria-label="Sao chép ngoặc đen 【】">【】</button>
+      <button class="glyph-copy" type="button" data-text="「」" aria-label="Sao chép ngoặc góc 「」">「」</button>
+      <button class="glyph-copy" type="button" data-text="『』" aria-label="Sao chép ngoặc góc kép 『』">『』</button>
+      <button class="glyph-copy" type="button" data-text="❰❱" aria-label="Sao chép ngoặc nhọn ❰❱">❰❱</button>
+      <button class="glyph-copy" type="button" data-text="⟦⟧" aria-label="Sao chép ngoặc vuông kép ⟦⟧">⟦⟧</button>
+      <button class="glyph-copy" type="button" data-text="꒰꒱" aria-label="Sao chép ngoặc mềm ꒰꒱">꒰꒱</button>
+      <button class="glyph-copy" type="button" data-text="★彡" aria-label="Sao chép khung sao trái ★彡">★彡</button>
+      <button class="glyph-copy" type="button" data-text="彡★" aria-label="Sao chép khung sao phải 彡★">彡★</button>
+      <button class="glyph-copy" type="button" data-text="•°•" aria-label="Sao chép chấm trang trí •°•">•°•</button>
+      <button class="glyph-copy" type="button" data-text="୨୧" aria-label="Sao chép nơ ruy băng ୨୧">୨୧</button>
+      <button class="glyph-copy" type="button" data-text="⌜⌟" aria-label="Sao chép góc khung ⌜⌟">⌜⌟</button>
+      <button class="glyph-copy" type="button" data-text="╰╮" aria-label="Sao chép góc kẻ ╰╮">╰╮</button>
+    </div>
+  </section>
+
+  <!-- Đường kẻ & dấu -->
+  <section class="editorial-section glyph-section" id="ki-tu-duong-ke">
+    <h2>Đường kẻ, chấm &amp; dấu hay dùng</h2>
+    <p class="editorial-intro">Kí hiệu tách dòng caption, gạch đầu dòng bio và các dấu tick quen thuộc:</p>
+    <div class="glyph-grid">
+      <button class="glyph-copy" type="button" data-text="•" aria-label="Sao chép chấm tròn •">•</button>
+      <button class="glyph-copy" type="button" data-text="●" aria-label="Sao chép chấm đặc ●">●</button>
+      <button class="glyph-copy" type="button" data-text="◦" aria-label="Sao chép chấm rỗng ◦">◦</button>
+      <button class="glyph-copy" type="button" data-text="▸" aria-label="Sao chép tam giác ▸">▸</button>
+      <button class="glyph-copy" type="button" data-text="┊" aria-label="Sao chép kẻ dọc đứt ┊">┊</button>
+      <button class="glyph-copy" type="button" data-text="─" aria-label="Sao chép kẻ ngang ─">─</button>
+      <button class="glyph-copy" type="button" data-text="═" aria-label="Sao chép kẻ ngang kép ═">═</button>
+      <button class="glyph-copy" type="button" data-text="✓" aria-label="Sao chép dấu tick ✓">✓</button>
+      <button class="glyph-copy" type="button" data-text="✔" aria-label="Sao chép dấu tick đậm ✔">✔</button>
+      <button class="glyph-copy" type="button" data-text="✗" aria-label="Sao chép dấu gạch chéo ✗">✗</button>
+      <button class="glyph-copy" type="button" data-text="©" aria-label="Sao chép kí hiệu bản quyền ©">©</button>
+      <button class="glyph-copy" type="button" data-text="®" aria-label="Sao chép kí hiệu đăng ký ®">®</button>
+    </div>
+  </section>
+
+  <!-- Kaomoji -->
+  <section class="editorial-section glyph-section" id="ki-tu-mat-cuoi">
+    <h2>Mặt cười kaomoji</h2>
+    <p class="editorial-intro">Biểu cảm ghép từ kí tự — bấm để copy nguyên cụm:</p>
+    <div class="glyph-grid">
+      <button class="glyph-copy" type="button" data-text="(◍•ᴗ•◍)" aria-label="Sao chép kaomoji (◍•ᴗ•◍)">(◍•ᴗ•◍)</button>
+      <button class="glyph-copy" type="button" data-text="(｡♥‿♥｡)" aria-label="Sao chép kaomoji (｡♥‿♥｡)">(｡♥‿♥｡)</button>
+      <button class="glyph-copy" type="button" data-text="ʕ•ᴥ•ʔ" aria-label="Sao chép kaomoji ʕ•ᴥ•ʔ">ʕ•ᴥ•ʔ</button>
+      <button class="glyph-copy" type="button" data-text="(＾▽＾)" aria-label="Sao chép kaomoji (＾▽＾)">(＾▽＾)</button>
+      <button class="glyph-copy" type="button" data-text="(づ｡◕‿‿◕｡)づ" aria-label="Sao chép kaomoji (づ｡◕‿‿◕｡)づ">(づ｡◕‿‿◕｡)づ</button>
+      <button class="glyph-copy" type="button" data-text="٩(◕‿◕)۶" aria-label="Sao chép kaomoji ٩(◕‿◕)۶">٩(◕‿◕)۶</button>
+      <button class="glyph-copy" type="button" data-text="(ㆆ_ㆆ)" aria-label="Sao chép kaomoji (ㆆ_ㆆ)">(ㆆ_ㆆ)</button>
+      <button class="glyph-copy" type="button" data-text="( ͡° ͜ʖ ͡°)" aria-label="Sao chép kaomoji ( ͡° ͜ʖ ͡°)">( ͡° ͜ʖ ͡°)</button>
+    </div>
+  </section>
+
+  <!-- Hướng dẫn dùng -->
+  <section class="editorial-section">
+    <h2>Cách dùng kí tự đặc biệt cho tên game và bio</h2>
+    <p class="editorial-intro">Công thức chung: <strong>chữ kiểu làm nền + kí tự đặc biệt bo hai đầu</strong>. Ví dụ tên "Hunter" → đổi font thành 𝙃𝙐𝙉𝙏𝙀𝙍 ở ô tạo phía trên → bọc khung thành ꧁༒𝙃𝙐𝙉𝙏𝙀𝙍༒꧂.</p>
+    <div class="block-example">
+      ✔ <strong>Tên game</strong>: ꧁༒Tên༒꧂ · メTên彡 · ★彡[Tên]彡★<br>
+      ✔ <strong>Bio</strong>: ✦ dòng giới thiệu ✦ · ୨୧ sở thích ୨୧ · ↳ link ở đây<br>
+      ✔ <strong>Caption</strong>: dùng ┊ hoặc ─ để tách dòng thay dấu xuống dòng
+    </div>
+    <p>Nếu game không cho dấu cách trong tên, dùng <a href="/vi/ky-tu-vo-hinh/">kí tự vô hình</a> chèn giữa hai chữ. Còn muốn đổi cả kiểu chữ (đậm, gothic, script...) thì qua trang <a href="/vi/chu-kieu/">chữ kiểu</a> — gõ một lần ra hơn 100 kiểu.</p>
+  </section>
+
+  <!-- Related -->
+  <section class="editorial-section">
+    <span class="article-section-label">Trang liên quan</span>
+    <div class="compare-grid">
+      <a href="/vi/usecase/nick-ff/" class="compare-card variant-muted u-no-underline">
+        <h4>Nick FF Đẹp</h4>
+        <p>Mẫu tên Free Fire ghép sẵn khung ꧁༒꧂ và font ngầu — copy một chạm.</p>
+      </a>
+      <a href="/vi/ky-tu-vo-hinh/" class="compare-card variant-muted u-no-underline">
+        <h4>Kí Tự Vô Hình</h4>
+        <p>Kí tự trống để đặt tên có dấu cách và gửi tin nhắn trống.</p>
+      </a>
+      <a href="/vi/chu-kieu/" class="compare-card variant-muted u-no-underline">
+        <h4>Chữ Kiểu</h4>
+        <p>Đổi chữ thường sang 100+ kiểu đậm, nghiêng, gothic, bong bóng.</p>
+      </a>
+      <a href="/vi/font-chu-dep/" class="compare-card variant-muted u-no-underline">
+        <h4>Font Chữ Đẹp</h4>
+        <p>Font chữ đẹp có dấu cho bio và caption tiếng Việt.</p>
+      </a>
+      <a href="/vi/" class="compare-card variant-muted u-no-underline">
+        <h4>Trang chủ tiếng Việt</h4>
+        <p>Toàn bộ công cụ chữ kiểu và kí tự đặc biệt ở một trang.</p>
+      </a>
+    </div>
+  </section>
+</main>
+
+<footer class="footer">
+  <div class="footer-inner">
+    <h2 class="faq-category">Hỏi đáp về kí tự đặc biệt</h2>
+    <div class="faq-item"><button class="faq-question" type="button">Kí tự đặc biệt là gì?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Kí tự đặc biệt (hay viết tắt ktdb) là các kí hiệu Unicode nằm ngoài bảng chữ cái thường — dạng như ✿ ❀ ★ ✦ ღ ꧁ ꧂ ༒ ☬ メ 彡. Vì là kí tự văn bản thật, bạn copy được như chữ thường và dán vào mọi ô nhập chữ: tên game, bio mạng xã hội, caption, tin nhắn — không cần cài font hay app.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Cách copy kí tự đặc biệt như thế nào?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Bấm vào kí hiệu bạn thích trên trang này — kí tự được sao chép ngay vào bộ nhớ tạm, có thông báo xác nhận. Sau đó mở app đích (Free Fire, Facebook, Zalo, TikTok...) và dán vào ô nhập chữ. Muốn bọc kí hiệu quanh cả đoạn chữ tự động, gõ chữ vào ô tạo ở đầu trang rồi dùng các tab Kí hiệu và Khung viền.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Kí tự đặc biệt nào hợp cho tên Free Fire, Liên Quân?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Bộ được cộng đồng game Việt dùng nhiều nhất là khung ꧁ ꧂ (hay gọi khung cánh bướm), dấu ༒ ☬, ngoặc ༺ ༻, katakana メ 彡, mặt cười ツ, vương miện ♛ và ™. Ghép kiểu ꧁༒Tên༒꧂ hoặc メTên彡 là ra nick chuẩn game thủ. Các kí hiệu này đã được test hiển thị tốt trong Free Fire và Liên Quân Mobile.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Dán kí tự đặc biệt có bị game hay app chặn không?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Đa số kí hiệu phổ biến (꧁ ꧂ ★ ✦ ♡ ➤) được Free Fire, Liên Quân, Facebook, TikTok, Zalo chấp nhận bình thường. Một số kí tự hiếm có thể hiện ô vuông (□) trên máy đời cũ hoặc bị ô tên của một vài game từ chối — khi đó cứ đổi sang kí hiệu phổ thông hơn là được. Kí tự ở đây là Unicode chuẩn, không có script hay mã ẩn nên hoàn toàn an toàn.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Kí tự vô hình để đặt tên có dấu cách lấy ở đâu?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Free Fire và nhiều game không cho dấu cách trong tên — mẹo là dùng kí tự vô hình (kí tự trống). UltraTextGen có trang riêng tổng hợp đầy đủ kí tự vô hình: zero width space, Hangul filler, braille trống — bấm là copy, dán vào giữa hai chữ là tên nhìn như có dấu cách.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Trang kí tự đặc biệt này có miễn phí không?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Miễn phí 100%, không cần đăng ký, không giới hạn lượt copy. Trang chạy thẳng trên trình duyệt điện thoại và máy tính — bấm kí hiệu, dán đi đâu tuỳ bạn.</div></div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Language switcher">
+      <a class="lang-option" href="/library/aesthetic-symbols/" hreflang="en">EN</a>
+      <a class="lang-option" href="/fr/library/symboles/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/id/library/simbol-aesthetic/" hreflang="id">ID</a>
+      <a class="lang-option" href="/nl/library/speciale-tekens/" hreflang="nl">NL</a>
+      <a class="lang-option" href="/pt/library/simbolos/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/tr/library/semboller/" hreflang="tr">TR</a>
+      <a class="lang-option active" href="/vi/ki-tu-dac-biet/" hreflang="vi">VI</a>
+    </div>
+  </div>
+</footer>
+
+<div class="copy-toast" id="copyToast">Đã sao chép!</div>
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/styles.js"></script>
+<script src="/renderer.js"></script>
+<script src="/script.js" defer=""></script>
+<script src="/symbol-explorer.js"></script>
+<script src="/footer.js"></script>
+</body></html>

--- a/vi/ky-tu-vo-hinh/index.html
+++ b/vi/ky-tu-vo-hinh/index.html
@@ -349,6 +349,14 @@
       <h4>Tạo Font Chữ</h4>
       <p>Chuyển chữ của bạn sang in đậm, in nghiêng và hơn 100 kiểu Unicode.</p>
     </a>
+    <a href="/vi/usecase/nick-ff/" class="compare-card variant-muted u-no-underline">
+      <h4>Nick FF Đẹp</h4>
+      <p>Tạo tên Free Fire chất — dùng kí tự vô hình để có dấu cách trong nick.</p>
+    </a>
+    <a href="/vi/ki-tu-dac-biet/" class="compare-card variant-muted u-no-underline">
+      <h4>Kí Tự Đặc Biệt</h4>
+      <p>Kho kí hiệu ꧁꧂ ♡ ✦ ➤ để trang trí tên và bio — bấm là copy.</p>
+    </a>
   </div>
 </section>
 

--- a/vi/usecase/nick-ff/index.html
+++ b/vi/usecase/nick-ff/index.html
@@ -1,0 +1,359 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Nick FF Đẹp ꧁꧂ — Tạo Tên Free Fire Chất, Kí Tự Đặc Biệt FF</title>
+  <meta name="description" content="Tạo nick FF đẹp với khung ꧁༒꧂, vương miện, katakana メ彡 và font ngầu. Gõ tên, copy, dán vào Free Fire. Kèm kho tên FF nam, nữ, chất, ngắn — miễn phí, không cần app.">
+  <link rel="canonical" href="https://ultratextgen.com/vi/usecase/nick-ff/">
+
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/library-free-fire-name-symbols.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/library-free-fire-name-symbols.png">
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="Nick FF Đẹp ꧁꧂ — Tạo Tên Free Fire Chất, Kí Tự Đặc Biệt FF">
+  <meta property="og:description" content="Tạo nick FF đẹp với khung ꧁༒꧂, vương miện và font ngầu. Gõ tên, copy, dán vào Free Fire — miễn phí, không cần app.">
+  <meta property="og:url" content="https://ultratextgen.com/vi/usecase/nick-ff/">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="UltraTextGen">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Nick FF Đẹp ꧁꧂ — Tạo Tên Free Fire Chất">
+  <meta name="twitter:description" content="Khung ꧁༒꧂, vương miện, katakana メ彡 và font ngầu cho tên Free Fire — gõ, copy, dán.">
+
+  <link rel="stylesheet" href="/style.css">
+  <link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "vi",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Tạo nick FF đẹp bằng cách nào?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Gõ tên của bạn vào ô tạo ở đầu trang, chọn kiểu chữ (đậm, gothic, script hoặc small caps), rồi thêm khung ꧁꧂ hoặc kí hiệu trang trí từ bảng bên dưới. Bấm Sao chép, mở Free Fire → Hồ sơ → đổi tên (cần Thẻ Đổi Tên), rồi dán vào. Toàn bộ là kí tự Unicode nên kiểu chữ không bị mất khi dán."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Kí tự ꧁꧂ trong nick FF là gì?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Đó là kí tự Unicode của chữ Java (Rerenggan) — ꧁ bên trái và ꧂ bên phải — cộng đồng Việt hay gọi là khung cánh bướm hoặc khung hoa văn. Đây là bộ khung được dùng nhiều nhất để bo viền nick Free Fire cho sang. Bấm copy ꧁ và ꧂ từ bảng kí hiệu trên trang này rồi đặt ở đầu và cuối tên."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Làm sao đặt tên FF có dấu cách?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Free Fire không nhận dấu cách thường trong nick. Mẹo là dùng kí tự vô hình (Hangul Filler U+3164 hoặc braille trống U+2800): copy kí tự trống đó rồi dán vào giữa hai chữ — tên nhìn như có dấu cách nhưng thực ra là một kí tự Unicode đặc biệt. UltraTextGen có trang kí tự vô hình riêng để copy nhanh."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Trang tạo nick FF này có miễn phí và an toàn không?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Miễn phí hoàn toàn, không cần đăng ký, không cần tải app. Mọi thứ chạy trên trình duyệt của bạn — tên bạn gõ không được gửi lên máy chủ nào. Kí tự tạo ra chỉ là văn bản Unicode chuẩn, không phải script hay mã, nên copy dán đi đâu cũng an toàn."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Vì sao nick FF bị từ chối hoặc hiện ô vuông?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Một số kiểu chữ hoặc kí hiệu hiếm không được máy chủ game hỗ trợ và hiện thành ô vuông (▯). Khi đó hãy đổi sang kiểu an toàn hơn như Small Caps hoặc Đậm, và dùng các kí hiệu phổ biến (꧁ ꧂ ༒ ™ メ) đã được test hiển thị tốt trong Free Fire. Nick quá dài cũng có thể bị từ chối — Free Fire giới hạn khoảng 12 kí tự."
+      }
+    }
+  ]
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Trang chủ", "item": "https://ultratextgen.com/vi/" },
+    { "@type": "ListItem", "position": 2, "name": "Nick FF Đẹp", "item": "https://ultratextgen.com/vi/usecase/nick-ff/" }
+  ]
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Tạo Nick FF Đẹp",
+  "alternateName": ["Nick FF Đẹp", "Tạo Nick FF", "Tên FF Đẹp", "Kí Tự Đặc Biệt FF", "Nick Free Fire Đẹp"],
+  "url": "https://ultratextgen.com/vi/usecase/nick-ff/",
+  "inLanguage": "vi",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+  "description": "Tạo nick FF đẹp với khung ꧁꧂, vương miện, katakana và font Unicode. Gõ tên, copy, dán vào Free Fire.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+
+  <div id="shared-header"></div>
+  <script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/vi/">Trang chủ</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Nick FF Đẹp</span>
+</nav>
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/library-free-fire-name-symbols.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Nick FF Đẹp</h1>
+    <p class="hero-tagline">Tạo nick FF đẹp với khung ꧁༒꧂, vương miện, katakana メ彡 và font Unicode ngầu. Gõ tên của bạn, chọn kiểu, copy — dán thẳng vào ô đổi tên Free Fire. Miễn phí, không cần app.</p>
+  </div>
+</section>
+
+<!-- GENERATOR -->
+<section class="hero"><div class="hero-inner"><div class="hero-card">
+  <div class="input-wrapper"><textarea class="main-input" id="mainInput" placeholder="Gõ tên hoặc nick của bạn…" maxlength="100">Hunter</textarea><span class="char-count"><span id="charCount">0</span>/100</span></div>
+  <div class="decoration-section"><div class="decoration-label">Thêm trang trí vào kết quả</div><div class="decoration-tabs"><button class="decoration-tab active" data-deco-tab="symbols">Kí hiệu</button><button class="decoration-tab" data-deco-tab="minimal">Tối giản</button><button class="decoration-tab" data-deco-tab="emojis">Emoji</button></div><div class="decoration-grid" id="decorationGrid"></div></div>
+</div></div></section>
+
+<main class="container">
+  <div class="category-section"><div class="category-tabs" id="categoryTabs"></div></div>
+  <div class="results-grid" id="resultsGrid"></div>
+</main>
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Nick FF đẹp gói gọn trong hai thứ: <strong>font khác biệt</strong> và <strong>kí tự đặc biệt bo hai đầu</strong>. Gõ tên vào ô tạo phía trên — bạn có ngay bản đậm, gothic, script, small caps để copy. Sau đó thêm kí hiệu từ bảng bên dưới: khung cánh bướm ꧁ ꧂, ngoặc Tây Tạng ༺ ༻ ༒, vương miện ♛, hay katakana メ 彡 cho cảm giác tốc độ. Ô tên Free Fire nhận các kí tự Unicode này bình thường, nên nick hiển thị đẹp ở sảnh chờ, thông báo hạ gục và danh sách quân đoàn.</p>
+    <p>Bên dưới còn có <strong>kho nick FF ghép sẵn</strong> — nam, nữ, kiểu pro, kiểu ngắn gọn — bấm là copy. Kéo xuống thêm để xem cách đổi tên trong game và mẹo đặt tên có dấu cách.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- READY-MADE WRAPPERS -->
+<section class="mood-explainers" id="khung-nick">
+  <span class="article-section-label">Khung ghép sẵn</span>
+  <h2>Khung Nick FF (Cánh Bướm &amp; Hoa Văn)</h2>
+  <p class="u-secondary-block">Copy nguyên khung trong một chạm, rồi thay chữ <em>TênBạn</em> ở giữa bằng tên của bạn trong màn hình đổi nick Free Fire.</p>
+  <div id="ffNickWrappersContainer"></div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SYMBOL PALETTE: KHUNG -->
+<section class="mood-explainers" id="ki-tu-khung-ff">
+  <span class="article-section-label">Kí Tự Khung</span>
+  <h2>Kí Tự Khung ꧁꧂ &amp; Hoa Văn</h2>
+  <p class="u-secondary-tight">Bộ hoa văn Java &amp; Tây Tạng — nền móng của hầu hết nick FF có viền. Bấm để copy.</p>
+  <div class="flag-rows">
+    <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="꧁" aria-label="Sao chép khung trái ꧁">꧁</button><span class="flag-label">Khung Trái (Rerenggan)</span></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="꧂" aria-label="Sao chép khung phải ꧂">꧂</button><span class="flag-label">Khung Phải (Rerenggan)</span></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="꧅" aria-label="Sao chép Pada Luhur ꧅">꧅</button><span class="flag-label">Pada Luhur</span></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="༺" aria-label="Sao chép ngoặc trái ༺">༺</button><span class="flag-label">Ngoặc Tây Tạng Trái</span></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="༻" aria-label="Sao chép ngoặc phải ༻">༻</button><span class="flag-label">Ngoặc Tây Tạng Phải</span></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="༒" aria-label="Sao chép dấu Tây Tạng ༒">༒</button><span class="flag-label">Dấu Rgya Gram</span></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="࿐" aria-label="Sao chép cờ trang trí ࿐">࿐</button><span class="flag-label">Cờ Trang Trí ࿐</span></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="❰" aria-label="Sao chép ngoặc trang trí trái ❰">❰</button><span class="flag-label">Ngoặc Trang Trí Trái</span></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="❱" aria-label="Sao chép ngoặc trang trí phải ❱">❱</button><span class="flag-label">Ngoặc Trang Trí Phải</span></div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SYMBOL PALETTE: VUONG MIEN + KATAKANA -->
+<section class="mood-explainers" id="ki-tu-vuong-mien">
+  <span class="article-section-label">Vương Miện &amp; Điểm Nhấn</span>
+  <h2>Vương Miện, Katakana &amp; Ngôi Sao</h2>
+  <p class="u-secondary-tight">Vương miện cho nick top rank, nét katakana メ 彡 cho cảm giác tốc độ, cộng thêm sao và hoa làm điểm nhấn.</p>
+  <div class="flag-rows">
+    <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="♛" aria-label="Sao chép hậu cờ vua ♛">♛</button><span class="flag-label">Vương Miện Hậu</span></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="♚" aria-label="Sao chép vua cờ vua ♚">♚</button><span class="flag-label">Vương Miện Vua</span></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="⚜" aria-label="Sao chép fleur-de-lis ⚜">⚜</button><span class="flag-label">Fleur-de-Lis</span></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="メ" aria-label="Sao chép katakana Me メ">メ</button><span class="flag-label">Katakana Me (Nét Chém)</span></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="彡" aria-label="Sao chép San 彡">彡</button><span class="flag-label">San — Ba Nét</span></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="ツ" aria-label="Sao chép Tsu ツ">ツ</button><span class="flag-label">Tsu (Mặt Cười)</span></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="★" aria-label="Sao chép sao đen ★">★</button><span class="flag-label">Sao Đen</span></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="✰" aria-label="Sao chép sao viền ✰">✰</button><span class="flag-label">Sao Viền</span></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="✿" aria-label="Sao chép hoa ✿">✿</button><span class="flag-label">Hoa Florette</span></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="†" aria-label="Sao chép dao găm †">†</button><span class="flag-label">Dao Găm</span></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="⚔" aria-label="Sao chép kiếm chéo ⚔">⚔</button><span class="flag-label">Kiếm Chéo</span></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="™" aria-label="Sao chép dấu TM ™">™</button><span class="flag-label">Dấu ™</span></div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- READY-MADE NAME LISTS -->
+<section class="editorial-section" id="kho-nick">
+  <span class="article-section-label">Kho Nick Ghép Sẵn</span>
+  <h2>Kho Nick FF Đẹp (Bấm Để Copy)</h2>
+
+  <h3>Nick FF Nam Chất</h3>
+  <p class="uname-note">Ngầu và có viền — hợp leo rank.</p>
+  <div class="uname-grid">
+    <button class="uname-chip symbol-tile" data-symbol="꧁༒𝙃𝙐𝙉𝙏𝙀𝙍༒꧂" aria-label="Sao chép nick">꧁༒𝙃𝙐𝙉𝙏𝙀𝙍༒꧂</button>
+    <button class="uname-chip symbol-tile" data-symbol="メ𝐒𝐎́𝐈彡" aria-label="Sao chép nick">メ𝐒𝐎́𝐈彡</button>
+    <button class="uname-chip symbol-tile" data-symbol="༺ᏉᎬᏁᎾᎷ༻" aria-label="Sao chép nick">༺ᏉᎬᏁᎾᎷ༻</button>
+    <button class="uname-chip symbol-tile" data-symbol="꧁☬ᏒᎯᏉᎬꞀ☬꧂" aria-label="Sao chép nick">꧁☬ᏒᎯᏉᎬꞀ☬꧂</button>
+    <button class="uname-chip symbol-tile" data-symbol="★彡[ʙóɴɢ đêᴍ]彡★" aria-label="Sao chép nick">★彡[ʙóɴɢ đêᴍ]彡★</button>
+    <button class="uname-chip symbol-tile" data-symbol="࿐ℜ𝔢𝔞𝔭𝔢𝔯࿐" aria-label="Sao chép nick">࿐ℜ𝔢𝔞𝔭𝔢𝔯࿐</button>
+  </div>
+
+  <h3>Nick FF Nữ Đẹp</h3>
+  <p class="uname-note">Nhẹ nhàng hơn, nhiều hoa và sao.</p>
+  <div class="uname-grid">
+    <button class="uname-chip symbol-tile" data-symbol="꧁✿𝓛𝓾𝓷𝓪✿꧂" aria-label="Sao chép nick">꧁✿𝓛𝓾𝓷𝓪✿꧂</button>
+    <button class="uname-chip symbol-tile" data-symbol="⋆｡˚𝓜𝓮𝓸𝓌˚｡⋆" aria-label="Sao chép nick">⋆｡˚𝓜𝓮𝓸𝓌˚｡⋆</button>
+    <button class="uname-chip symbol-tile" data-symbol="❀𝒩𝒶𝒩𝒶❀" aria-label="Sao chép nick">❀𝒩𝒶𝒩𝒶❀</button>
+    <button class="uname-chip symbol-tile" data-symbol="༺♛𝕷𝖎𝖓𝖍♛༻" aria-label="Sao chép nick">༺♛𝕷𝖎𝖓𝖍♛༻</button>
+    <button class="uname-chip symbol-tile" data-symbol="✧˖°𝕂𝕚𝕥𝕥𝕪°˖✧" aria-label="Sao chép nick">✧˖°𝕂𝕚𝕥𝕥𝕪°˖✧</button>
+    <button class="uname-chip symbol-tile" data-symbol="꧁⊹𝓜𝓲𝓪⊹꧂" aria-label="Sao chép nick">꧁⊹𝓜𝓲𝓪⊹꧂</button>
+  </div>
+
+  <h3>Nick FF Kiểu Pro</h3>
+  <p class="uname-note">Gọn gàng, sạch sẽ — phong cách tuyển thủ.</p>
+  <div class="uname-grid">
+    <button class="uname-chip symbol-tile" data-symbol="ᴮᴬᴰʙᴏʏ" aria-label="Sao chép nick">ᴮᴬᴰʙᴏʏ</button>
+    <button class="uname-chip symbol-tile" data-symbol="꧁•ᴾᴿᴼ•꧂" aria-label="Sao chép nick">꧁•ᴾᴿᴼ•꧂</button>
+    <button class="uname-chip symbol-tile" data-symbol="ꜱóɪ•ᵒᵍ" aria-label="Sao chép nick">ꜱóɪ•ᵒᵍ</button>
+    <button class="uname-chip symbol-tile" data-symbol="xX_ꜱɴɪᴘᴇʀ_Xx" aria-label="Sao chép nick">xX_ꜱɴɪᴘᴇʀ_Xx</button>
+    <button class="uname-chip symbol-tile" data-symbol="ᴀʟᴘʜᴀ™" aria-label="Sao chép nick">ᴀʟᴘʜᴀ™</button>
+    <button class="uname-chip symbol-tile" data-symbol="•ᴠᴇɴᴏᴍ•" aria-label="Sao chép nick">•ᴠᴇɴᴏᴍ•</button>
+  </div>
+
+  <h3>Nick FF Ngắn Gọn</h3>
+  <p class="uname-note">Ngắn, dễ nhớ — hợp làm tag quân đoàn.</p>
+  <div class="uname-grid">
+    <button class="uname-chip symbol-tile" data-symbol="𝐒Ó𝐈" aria-label="Sao chép nick">𝐒Ó𝐈</button>
+    <button class="uname-chip symbol-tile" data-symbol="ᴋɪɴɢ" aria-label="Sao chép nick">ᴋɪɴɢ</button>
+    <button class="uname-chip symbol-tile" data-symbol="꧁ᴢᴇᴜꜱ꧂" aria-label="Sao chép nick">꧁ᴢᴇᴜꜱ꧂</button>
+    <button class="uname-chip symbol-tile" data-symbol="メNOVA彡" aria-label="Sao chép nick">メNOVA彡</button>
+    <button class="uname-chip symbol-tile" data-symbol="𝔉𝔲𝔯𝔶" aria-label="Sao chép nick">𝔉𝔲𝔯𝔶</button>
+    <button class="uname-chip symbol-tile" data-symbol="•ᴀᴄᴇ•" aria-label="Sao chép nick">•ᴀᴄᴇ•</button>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- EDITORIAL: CACH DOI TEN -->
+<section class="editorial-section">
+  <h2>Cách Đổi Tên Trong Free Fire</h2>
+  <p>Để đổi nick Free Fire, bạn cần <strong>Thẻ Đổi Tên (Name Change Card)</strong>. Các bước:</p>
+  <p>1. Copy nick đẹp từ ô tạo hoặc kho nick phía trên.<br>
+     2. Mở Free Fire → chạm ảnh đại diện góc trái trên → vào hồ sơ.<br>
+     3. Chọn nút đổi tên (biểu tượng bút chì cạnh nick).<br>
+     4. Dán tên đã copy, xác nhận bằng Thẻ Đổi Tên (tài khoản mới thường được tặng một thẻ miễn phí lần đầu; sau đó mua bằng kim cương).</p>
+  <p>Vì mỗi chữ cái và kí hiệu là một kí tự Unicode độc lập, kiểu chữ không bị mất khi dán — khác hẳn kiểu in đậm trong app chat vốn trở về chữ thường ngay khi copy.</p>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- EDITORIAL: DAU CACH + DOC LA -->
+<section class="editorial-section">
+  <h2>Nick FF Có Dấu Cách &amp; Nick Chưa Ai Đặt</h2>
+  <p><strong>Đặt tên có dấu cách:</strong> Free Fire không nhận dấu cách thường trong nick. Mẹo là dùng <strong>kí tự vô hình</strong>: copy kí tự trống từ trang <a href="/vi/ky-tu-vo-hinh/">Kí Tự Vô Hình</a> của UltraTextGen, dán vào giữa hai chữ — tên nhìn như có dấu cách nhưng thực ra là một kí tự Unicode đặc biệt.</p>
+  <p><strong>Để nick chưa ai đặt:</strong> kết hợp tên + kiểu chữ + kí hiệu là cách chắc nhất để có nick độc. Thay vì tên trơn dễ trùng, bọc khung ꧁꧂, đổi chữ thường sang small caps hoặc gothic, chèn thêm 1–2 kí hiệu hiếm. Càng nhiều biến thể kí tự, khả năng trùng càng thấp.</p>
+  <p>Muốn thêm kiểu chữ làm nền cho nick? Thử <a href="/vi/chu-kieu/">chữ kiểu</a> hoặc kho <a href="/vi/ki-tu-dac-biet/">kí tự đặc biệt</a> — gõ tên, copy, rồi quay lại đây bọc khung.</p>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Muốn nhiều kiểu chữ hơn?</h3>
+  <p>Dùng UltraTextGen để đổi tên bạn sang 100+ kiểu Unicode — đậm, script, gothic, bong bóng, small caps — miễn phí và tức thì.</p>
+  <a href="/vi/" class="cta-btn">Mở UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Trang Liên Quan</span>
+  <div class="compare-grid">
+    <a href="/vi/ki-tu-dac-biet/" class="compare-card variant-muted u-no-underline">
+      <h4>Kí Tự Đặc Biệt</h4>
+      <p>Kho đầy đủ kí hiệu cho nick — khung, vương miện, tim, katakana.</p>
+    </a>
+    <a href="/vi/ky-tu-vo-hinh/" class="compare-card variant-muted u-no-underline">
+      <h4>Kí Tự Vô Hình</h4>
+      <p>Kí tự trống để đặt nick FF có dấu cách.</p>
+    </a>
+    <a href="/vi/chu-kieu/" class="compare-card variant-muted u-no-underline">
+      <h4>Chữ Kiểu</h4>
+      <p>Đổi tên sang đậm, gothic, script và 100+ kiểu Unicode khác.</p>
+    </a>
+    <a href="/vi/usecase/zalgo-text/" class="compare-card variant-muted u-no-underline">
+      <h4>Chữ Zalgo</h4>
+      <p>Chữ glitch ma quái cho nick kiểu horror.</p>
+    </a>
+    <a href="/vi/" class="compare-card variant-muted u-no-underline">
+      <h4>Trang chủ tiếng Việt</h4>
+      <p>Toàn bộ công cụ chữ kiểu và kí tự đặc biệt.</p>
+    </a>
+  </div>
+</section>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<!-- Generator scripts -->
+<script src="/styles.js" defer></script>
+<script src="/renderer.js" defer></script>
+<script src="/script.js" defer></script>
+
+<!-- Symbol explorer + wrappers -->
+<script src="/symbol-explorer.js" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    { name: "Khung Cánh Bướm Cổ Điển", flags: ["꧁༒", "TênBạn", "༒꧂"], defaultFormat: "inline" },
+    { name: "Khung Kiểu Pro", flags: ["꧁•ᴾᴿᴼ•", "TênBạn", "꧂"], defaultFormat: "inline" },
+    { name: "Ngoặc Tây Tạng", flags: ["༺", "TênBạn", "༻"], defaultFormat: "inline" },
+    { name: "Băng Rôn Lửa", flags: ["🔥", "TênBạn", "࿐"], defaultFormat: "inline" },
+    { name: "Vương Miện Booyah", flags: ["👑", "TênBạn", "♛"], defaultFormat: "inline" },
+    { name: "Dao Găm Sát Thủ", flags: ["꧁†", "TênBạn", "†꧂"], defaultFormat: "inline" },
+    { name: "Tag Sao Quân Đoàn", flags: ["★彡", "TênBạn", "彡★"], defaultFormat: "inline" }
+  ];
+
+  ns.buildGrids("ffNickWrappersContainer", GROUPS);
+  if (ns.parseTwemoji) ns.parseTwemoji(document.body);
+});
+</script>
+
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/vi/usecase/zalgo-text/index.html
+++ b/vi/usecase/zalgo-text/index.html
@@ -218,6 +218,28 @@
       <p><strong>TikTok, WhatsApp, YouTube</strong> và hầu hết các nền tảng chấp nhận văn bản Unicode thuần túy sẽ hiển thị chữ Zalgo. Hiệu ứng hình ảnh thay đổi tùy theo công cụ hiển thị của nền tảng.</p>
     </section>
 
+    <section class="editorial-section">
+      <span class="article-section-label">Trang Liên Quan</span>
+      <div class="compare-grid">
+        <a href="/vi/chu-kieu/" class="compare-card variant-muted u-no-underline">
+          <h4>Chữ Kiểu</h4>
+          <p>Đổi chữ thường sang 100+ kiểu đậm, nghiêng, gothic, bong bóng.</p>
+        </a>
+        <a href="/vi/usecase/nick-ff/" class="compare-card variant-muted u-no-underline">
+          <h4>Nick FF Đẹp</h4>
+          <p>Ghép chữ Zalgo với khung ꧁꧂ cho nick game kiểu horror.</p>
+        </a>
+        <a href="/vi/ki-tu-dac-biet/" class="compare-card variant-muted u-no-underline">
+          <h4>Kí Tự Đặc Biệt</h4>
+          <p>Kho kí hiệu trang trí tên và bio — bấm là copy.</p>
+        </a>
+        <a href="/vi/ky-tu-vo-hinh/" class="compare-card variant-muted u-no-underline">
+          <h4>Kí Tự Vô Hình</h4>
+          <p>Kí tự trống để đặt tên có dấu cách và gửi tin nhắn trống.</p>
+        </a>
+      </div>
+    </section>
+
   </main>
 
   <script>


### PR DESCRIPTION
Deepens the /vi/ locale (ranking pos 4-8 on the chữ kiểu cluster with only 3 pages) with dedicated pages for the highest-volume VN keywords:

- vi/chu-kieu/          — chữ kiểu / tạo chữ kiểu / chữ kiểu đẹp (90.5k/mo)
- vi/ki-tu-dac-biet/    — kí tự đặc biệt (450k/mo), joins the
                          aesthetic-symbols hreflang cluster
- vi/font-chu-dep/      — font chữ đẹp (90.5k/mo) / font chữ đặc biệt
- vi/chu-kieu-tiktok/   — chữ kiểu tiktok (already surfacing in GSC),
                          joins the /tiktok/ hreflang cluster
- vi/usecase/nick-ff/   — Free Fire nicknames, mirrors the id/nama-ff-keren
                          playbook (wrappers, symbol palettes, name lists)

Cross-linking: vi hub gains a tool-cards section and now routes its use-case cards to vi pages; ky-tu-vo-hinh and zalgo-text link the new pages; reciprocal vi hreflang added to /tiktok/, /id/font-tiktok/ and the 6 aesthetic-symbols cluster pages. Sitemap regenerated.


Claude-Session: https://claude.ai/code/session_01HgBd57My5NbW17Frx4tC2u