### PR TITLE
feat: rebuild tattoo fonts page as a purpose-built lettering studio

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,7 @@ ultratextgen/
 │                           #   (classify each page by presentation_class +
 │                           #    copy_patterns — see docs/emoji-combination-taxonomy.md)
 ├── js/vertical/            # Vertical text feature module
+├── js/tattoo/              # Tattoo lettering studio module (names, dates→roman, initials, symbols)
 │
 └── Platform pages:
     discord/ facebook/ instagram/ linkedin/ pinterest/

--- a/js/tattoo/tattooData.js
+++ b/js/tattoo/tattooData.js
@@ -1,0 +1,215 @@
+/* ==========================================================================
+   UltraTextGen — tattooData.js
+   Data for the tattoo lettering studio: curated lettering styles, digit
+   fonts for dates, roman-numeral rendering styles, monogram joiners and
+   the tattoo symbol library. Data only — logic lives in
+   tattooPageController.js.
+   ========================================================================== */
+
+(function () {
+  "use strict";
+
+  window.UTG_TATTOO_DATA = {
+
+    /* ----------------------------------------------------------------------
+       Curated lettering, most-requested first. `key` must exist in
+       window.textStyles. `hold` drives the aging badge:
+         'safe'  — keeps its shape at small sizes
+         'roomy' — thin strokes / small loops, needs room to age well
+       ---------------------------------------------------------------------- */
+    LETTERING: [
+      {
+        key: 'Ultra Script Bold', label: 'Bold Script', family: 'Script', hold: 'safe',
+        note: 'The classic name tattoo — connected and warm, holds its shape at small sizes.'
+      },
+      {
+        key: 'Ultra Script', label: 'Fine Script', family: 'Script', hold: 'roomy',
+        note: 'Delicate and airy — beautiful at medium size; the thin loops need room to age well.'
+      },
+      {
+        key: 'Ultra Chicano Script', label: 'Chicano Nameplate', family: 'Script', hold: 'safe',
+        note: 'Bold script inside an ornamental banner — the classic nameplate framing.'
+      },
+      {
+        key: 'Ultra Gothic', label: 'Gothic Blackletter', family: 'Gothic', hold: 'roomy',
+        note: 'Fraktur blackletter — dense and assertive, built to carry a strong word.'
+      },
+      {
+        key: 'Ultra Gothic Bold', label: 'Heavy Old English', family: 'Gothic', hold: 'safe',
+        note: 'The heavy Old English look — an old-school and Chicano lettering staple.'
+      },
+      {
+        key: 'Ultra Old English Banner', label: 'Old English Banner', family: 'Gothic', hold: 'safe',
+        note: 'Heavy blackletter in a banner — a nameplate with maximum presence.'
+      },
+      {
+        key: 'Ultra Italic', label: 'Fine Italic', family: 'Italic', hold: 'safe',
+        note: 'Understated slant — slips quietly along a rib, wrist or collarbone.'
+      },
+      {
+        key: 'Ultra Italic Serif', label: 'Italic Serif', family: 'Italic', hold: 'safe',
+        note: 'Bookish serif italic — reads like a line lifted from a novel.'
+      },
+      {
+        key: 'Ultra Typewriter Document', label: 'Typewriter', family: 'Minimal', hold: 'safe',
+        note: 'Raw, literary monospace — perfect for a date or a short line.'
+      },
+      {
+        key: 'Ultra Small Caps', label: 'Small Caps', family: 'Minimal', hold: 'safe',
+        note: 'Tiny even capitals — the fine-line minimalist pick.'
+      }
+    ],
+
+    /* ----------------------------------------------------------------------
+       Styles used to render roman numerals (letters I V X L C D M).
+       `key: null` = plain unstyled letters.
+       ---------------------------------------------------------------------- */
+    ROMAN_STYLES: [
+      { key: null,                        label: 'Classic',           note: 'Plain capitals — what most artists ink.' },
+      { key: 'Ultra Italic Serif',        label: 'Serif Italic',      note: 'The engraved-monument look, slanted.' },
+      { key: 'Ultra Script Bold',         label: 'Script',            note: 'Roman numerals in flowing script.' },
+      { key: 'Ultra Gothic',              label: 'Blackletter',       note: 'Fraktur numerals — dark and ornate.' },
+      { key: 'Ultra Gothic Bold',         label: 'Heavy Old English', note: 'Maximum-weight blackletter numerals.' },
+      { key: 'Ultra Typewriter Document', label: 'Typewriter',        note: 'Monospaced numerals — clean and documentary.' }
+    ],
+
+    /* ----------------------------------------------------------------------
+       Digit fonts for plain-figure dates and numbers.
+       `digits` maps 0–9 in order.
+       ---------------------------------------------------------------------- */
+    DIGIT_FONTS: [
+      { label: 'Typewriter',    digits: '𝟶𝟷𝟸𝟹𝟺𝟻𝟼𝟽𝟾𝟿', note: 'Monospace figures — the classic date look.' },
+      { label: 'Bold Serif',    digits: '𝟎𝟏𝟐𝟑𝟒𝟓𝟔𝟕𝟖𝟗', note: 'Heavy bookface figures — pairs with blackletter.' },
+      { label: 'Bold Sans',     digits: '𝟬𝟭𝟮𝟯𝟰𝟱𝟲𝟳𝟴𝟵', note: 'Modern heavy figures — pairs with bold script.' },
+      { label: 'Fine Sans',     digits: '𝟢𝟣𝟤𝟥𝟦𝟧𝟨𝟩𝟪𝟫', note: 'Light figures — pairs with fine script and italic.' },
+      { label: 'Double-Struck', digits: '𝟘𝟙𝟚𝟛𝟜𝟝𝟞𝟟𝟠𝟡', note: 'Outlined figures — an unexpected fine-line pick.' },
+      { label: 'Wide Spaced',   digits: '０１２３４５６７８９', note: 'Fullwidth figures — airy, editorial spacing.' },
+      { label: 'Tiny',          digits: '⁰¹²³⁴⁵⁶⁷⁸⁹', note: 'Miniature figures — behind-the-ear scale.' }
+    ],
+
+    /* Separators offered between date parts. `ch` is what goes in the text. */
+    DATE_SEPARATORS: [
+      { id: 'interpunct', label: '·',       ch: ' · ' },
+      { id: 'period',     label: '.',       ch: '.' },
+      { id: 'dash',       label: '–',       ch: ' – ' },
+      { id: 'bar',        label: '|',       ch: ' | ' },
+      { id: 'space',      label: 'space',   ch: '  ' },
+      { id: 'stack',      label: 'stacked', ch: '\n' }
+    ],
+
+    /* Date part orders. */
+    DATE_ORDERS: [
+      { id: 'dmy', label: 'Day · Month · Year' },
+      { id: 'mdy', label: 'Month · Day · Year' },
+      { id: 'y',   label: 'Year only' }
+    ],
+
+    /* Joiners between two initials in a monogram. */
+    JOINERS: [
+      { id: 'none',   label: 'None',  ch: ' ' },
+      { id: 'heart',  label: '♡',     ch: ' ♡ ' },
+      { id: 'inf',    label: '∞',     ch: ' ∞ ' },
+      { id: 'dot',    label: '·',     ch: ' · ' },
+      { id: 'amp',    label: '&',     ch: ' & ' },
+      { id: 'cross',  label: '✕',     ch: ' ✕ ' },
+      { id: 'star',   label: '⋆',     ch: ' ⋆ ' }
+    ],
+
+    /* ----------------------------------------------------------------------
+       Tattoo symbol library. Broadly-supported glyphs only; every symbol
+       carries the meaning people search for.
+       ---------------------------------------------------------------------- */
+    SYMBOL_GROUPS: [
+      {
+        id: 'minimal', label: 'Fine line & minimal',
+        items: [
+          { ch: ';',  name: 'Semicolon — the story continues' },
+          { ch: '∞',  name: 'Infinity — without end' },
+          { ch: '·',  name: 'Single dot — a pause' },
+          { ch: '—',  name: 'Dash — a line, a path' },
+          { ch: '~',  name: 'Wave — calm, flow' },
+          { ch: '✕',  name: 'Cross mark — a crossing point' },
+          { ch: '°',  name: 'Small circle — wholeness' },
+          { ch: '⋮',  name: 'Three dots — mi vida loca / unfinished' }
+        ]
+      },
+      {
+        id: 'celestial', label: 'Celestial',
+        items: [
+          { ch: '☾', name: 'Crescent moon — change, cycles' },
+          { ch: '☽', name: 'Waxing moon — growth' },
+          { ch: '☼', name: 'Sun — vitality' },
+          { ch: '✦', name: 'Four-point star — guidance' },
+          { ch: '✧', name: 'Open star — hope' },
+          { ch: '⋆', name: 'Small star — a quiet spark' },
+          { ch: '★', name: 'Filled star — ambition' },
+          { ch: '✵', name: 'Rayed star — energy' }
+        ]
+      },
+      {
+        id: 'love', label: 'Love & remembrance',
+        items: [
+          { ch: '♡', name: 'Open heart — love, lightly held' },
+          { ch: '❥', name: 'Turned heart — devotion' },
+          { ch: '❦', name: 'Floral heart — remembrance' },
+          { ch: '➳', name: 'Arrow — struck by love' },
+          { ch: '✿', name: 'Flower — in bloom' },
+          { ch: '❀', name: 'Blossom — memory of someone' }
+        ]
+      },
+      {
+        id: 'faith', label: 'Faith & protection',
+        items: [
+          { ch: '✝', name: 'Latin cross — faith' },
+          { ch: '†', name: 'Dagger cross — sacrifice' },
+          { ch: '☦', name: 'Orthodox cross' },
+          { ch: '☯', name: 'Yin yang — balance' },
+          { ch: 'ॐ', name: 'Om — the first sound' },
+          { ch: '✡', name: 'Star of David' },
+          { ch: '☪', name: 'Star and crescent' },
+          { ch: 'ᛉ', name: 'Algiz rune — protection' }
+        ]
+      },
+      {
+        id: 'journey', label: 'Strength & journey',
+        items: [
+          { ch: '⚓', name: 'Anchor — hold fast' },
+          { ch: '✈', name: 'Plane — leaving, returning' },
+          { ch: '➵', name: 'Arrow — forward only' },
+          { ch: '→', name: 'Arrow right — onward' },
+          { ch: '⚔', name: 'Crossed swords — fight on' },
+          { ch: '♆', name: 'Trident — the sea' },
+          { ch: 'Δ',  name: 'Delta — change' },
+          { ch: 'Ω',  name: 'Omega — the end, endurance' }
+        ]
+      },
+      {
+        id: 'music', label: 'Music & art',
+        items: [
+          { ch: '♪', name: 'Eighth note' },
+          { ch: '♫', name: 'Beamed notes' },
+          { ch: '♬', name: 'Double beamed notes' },
+          { ch: '𝄞', name: 'Treble clef' },
+          { ch: '✎', name: 'Pencil — maker’s mark' }
+        ]
+      },
+      {
+        id: 'zodiac', label: 'Zodiac',
+        items: [
+          { ch: '♈', name: 'Aries' },
+          { ch: '♉', name: 'Taurus' },
+          { ch: '♊', name: 'Gemini' },
+          { ch: '♋', name: 'Cancer' },
+          { ch: '♌', name: 'Leo' },
+          { ch: '♍', name: 'Virgo' },
+          { ch: '♎', name: 'Libra' },
+          { ch: '♏', name: 'Scorpio' },
+          { ch: '♐', name: 'Sagittarius' },
+          { ch: '♑', name: 'Capricorn' },
+          { ch: '♒', name: 'Aquarius' },
+          { ch: '♓', name: 'Pisces' }
+        ]
+      }
+    ]
+  };
+})();

--- a/js/tattoo/tattooPageController.js
+++ b/js/tattoo/tattooPageController.js
@@ -1,0 +1,511 @@
+/* ==========================================================================
+   UltraTextGen — tattooPageController.js
+   Takes over rendering for the tattoo fonts page.
+   Must be loaded AFTER script.js (which it suppresses via UTG_TATTOO_MODE).
+   Requires: styles.js, renderer.js, tattooData.js.
+
+   Four modes, one per tattoo-lettering job:
+     names   — compare lettering families on the exact word/name
+     date    — date or number → roman numerals + plain-figure fonts
+     letters — single letters and two-initial monograms
+     symbols — copyable tattoo symbols with their meanings
+   ========================================================================== */
+
+(function () {
+  "use strict";
+
+  const Render = window.UltraTextGenRender;
+  const stylesRegistry = window.textStyles || {};
+  const DATA = window.UTG_TATTOO_DATA;
+  if (!Render || !DATA) return;
+
+  const SAMPLE_TEXT = 'Sofia';
+  const SAMPLE_DATE = { d: 12, m: 6, y: 2020 };
+
+  const MODES = [
+    { id: 'names',   label: 'Names & words',   hint: 'Type a name, word or quote' },
+    { id: 'date',    label: 'Date → Roman',    hint: 'Turn a date or number into roman numerals' },
+    { id: 'letters', label: 'Letters & initials', hint: 'Single letters and monograms' },
+    { id: 'symbols', label: 'Symbols',         hint: 'Small symbols with meaning' }
+  ];
+
+  const SIZE_VIEWS = [
+    { id: 'close', label: 'Close-up' },
+    { id: 'arm',   label: 'At arm’s length' },
+    { id: 'room',  label: 'Across the room' }
+  ];
+
+  /* ---- State ---- */
+  let mode = 'names';
+  let sizeView = 'close';
+  let dateOrder = 'dmy';        // 'dmy' | 'mdy' | 'y'
+  let dateSep = 'interpunct';
+  let monoFirst = 'A';
+  let monoSecond = '';          // '' = single letter
+  let monoJoiner = 'heart';
+  let renderTimer = null;
+
+  /* ---- Helpers ---- */
+  function $(sel, root) { return (root || document).querySelector(sel); }
+  function $$(sel, root) { return Array.from((root || document).querySelectorAll(sel)); }
+
+  function el(tag, className, text) {
+    const node = document.createElement(tag);
+    if (className) node.className = className;
+    if (text != null) node.textContent = text;
+    return node;
+  }
+
+  function styleFor(key) {
+    return key ? stylesRegistry[key] : null;
+  }
+
+  function applyStyle(text, key) {
+    const style = styleFor(key);
+    if (!style) return text;
+    try { return Render.renderAny(text, style); } catch (e) { return text; }
+  }
+
+  /* --------------------------------------------------------------------------
+     Roman numerals (classic subtractive notation, 1–3999)
+     -------------------------------------------------------------------------- */
+  const ROMAN_TABLE = [
+    [1000, 'M'], [900, 'CM'], [500, 'D'], [400, 'CD'],
+    [100, 'C'], [90, 'XC'], [50, 'L'], [40, 'XL'],
+    [10, 'X'], [9, 'IX'], [5, 'V'], [4, 'IV'], [1, 'I']
+  ];
+
+  function toRoman(num) {
+    if (!Number.isInteger(num) || num < 1 || num > 3999) return null;
+    let out = '';
+    let n = num;
+    ROMAN_TABLE.forEach(function (pair) {
+      while (n >= pair[0]) { out += pair[1]; n -= pair[0]; }
+    });
+    return out;
+  }
+
+  /* --------------------------------------------------------------------------
+     Card building — same .style-card / .copy-btn contract as the core
+     generator, so script.js's document-level copy handler does copy + toast.
+     -------------------------------------------------------------------------- */
+  function buildCard(opts) {
+    const card = el('div', 'style-card tattoo-card');
+
+    const info = el('div', 'style-info');
+    const nameRow = el('div', 'style-name');
+    nameRow.appendChild(el('span', null, opts.label));
+    if (opts.family) nameRow.appendChild(el('span', 'style-tag', opts.family));
+    if (opts.hold) {
+      nameRow.appendChild(el('span', 'tattoo-badge ' + (opts.hold === 'safe' ? 'is-safe' : 'is-roomy'),
+        opts.hold === 'safe' ? 'holds up small' : 'needs room'));
+    }
+    info.appendChild(nameRow);
+
+    if (opts.note) info.appendChild(el('div', 'style-note', opts.note));
+
+    const preview = el('div', 'style-preview tattoo-preview', opts.text);
+    if (opts.sample) preview.classList.add('is-sample');
+    info.appendChild(preview);
+    card.appendChild(info);
+
+    const btn = el('button', 'copy-btn', 'Copy');
+    btn.type = 'button';
+    btn.dataset.text = opts.text;
+    if (opts.styleKey) btn.dataset.style = opts.styleKey;
+    card.appendChild(btn);
+
+    return card;
+  }
+
+  function gridHeading(text) {
+    return el('h3', 'tattoo-grid-heading', text);
+  }
+
+  function sampleHint(text) {
+    return el('p', 'tattoo-sample-hint', text);
+  }
+
+  /* --------------------------------------------------------------------------
+     Mode: names & words
+     -------------------------------------------------------------------------- */
+  function renderNames(grid) {
+    const input = $('#mainInput');
+    const raw = input ? input.value.trim() : '';
+    const text = raw || SAMPLE_TEXT;
+    if (!raw) grid.appendChild(sampleHint('Showing “' + SAMPLE_TEXT + '” — type your name, word or quote above.'));
+
+    DATA.LETTERING.forEach(function (entry) {
+      if (!styleFor(entry.key)) return;
+      grid.appendChild(buildCard({
+        label: entry.label,
+        family: entry.family,
+        hold: entry.hold,
+        note: entry.note,
+        text: applyStyle(text, entry.key),
+        styleKey: entry.key,
+        sample: !raw
+      }));
+    });
+  }
+
+  /* --------------------------------------------------------------------------
+     Mode: date → roman numerals + plain figures
+     -------------------------------------------------------------------------- */
+  function readDateInputs() {
+    const d = parseInt(($('#tattooDay') || {}).value, 10);
+    const m = parseInt(($('#tattooMonth') || {}).value, 10);
+    const y = parseInt(($('#tattooYear') || {}).value, 10);
+    return { d: d, m: m, y: y };
+  }
+
+  function dateParts() {
+    const typed = readDateInputs();
+    const isSample = isNaN(typed.d) && isNaN(typed.m) && isNaN(typed.y);
+    const d = isNaN(typed.d) ? SAMPLE_DATE.d : typed.d;
+    const m = isNaN(typed.m) ? SAMPLE_DATE.m : typed.m;
+    const y = isNaN(typed.y) ? SAMPLE_DATE.y : typed.y;
+
+    let parts;
+    if (dateOrder === 'y') parts = [y];
+    else if (dateOrder === 'mdy') parts = [m, d, y];
+    else parts = [d, m, y];
+    return { parts: parts, sample: isSample };
+  }
+
+  function currentSeparator() {
+    const found = DATA.DATE_SEPARATORS.filter(function (s) { return s.id === dateSep; })[0];
+    return found || DATA.DATE_SEPARATORS[0];
+  }
+
+  function renderDate(grid) {
+    const state = dateParts();
+    const sep = currentSeparator();
+    if (state.sample) {
+      grid.appendChild(sampleHint('Showing a sample date (12 · 6 · 2020) — enter your date or number above.'));
+    }
+
+    const romanParts = state.parts.map(toRoman);
+    if (romanParts.some(function (p) { return p === null; })) {
+      grid.appendChild(sampleHint('Roman numerals cover 1–3999 — check the values above.'));
+      return;
+    }
+
+    grid.appendChild(gridHeading('Roman numerals'));
+    const romanPlain = romanParts.join(sep.ch);
+    DATA.ROMAN_STYLES.forEach(function (entry) {
+      if (entry.key && !styleFor(entry.key)) return;
+      grid.appendChild(buildCard({
+        label: entry.label,
+        family: 'Roman',
+        note: entry.note,
+        text: entry.key ? applyStyle(romanPlain, entry.key) : romanPlain,
+        styleKey: entry.key || '',
+        sample: state.sample
+      }));
+    });
+
+    grid.appendChild(gridHeading('Plain figures'));
+    const digitsPlain = state.parts
+      .map(function (n, i) {
+        // Two-digit day/month (12.06.2020) — the standard tattoo date format.
+        return (dateOrder !== 'y' && i < 2 && n < 10) ? '0' + n : String(n);
+      })
+      .join(sep.ch);
+    DATA.DIGIT_FONTS.forEach(function (font) {
+      const text = digitsPlain.replace(/[0-9]/g, function (dch) {
+        return Array.from(font.digits)[Number(dch)] || dch;
+      });
+      grid.appendChild(buildCard({
+        label: font.label,
+        family: 'Figures',
+        note: font.note,
+        text: text,
+        sample: state.sample
+      }));
+    });
+  }
+
+  /* --------------------------------------------------------------------------
+     Mode: letters & initials
+     -------------------------------------------------------------------------- */
+  function currentJoiner() {
+    const found = DATA.JOINERS.filter(function (j) { return j.id === monoJoiner; })[0];
+    return found || DATA.JOINERS[0];
+  }
+
+  function renderLetters(grid) {
+    const joiner = currentJoiner();
+
+    DATA.LETTERING.forEach(function (entry) {
+      if (!styleFor(entry.key)) return;
+      // Style the combined string: joiner symbols pass through the letter
+      // maps untouched, and banner procedures frame the whole monogram.
+      const plain = monoSecond ? monoFirst + joiner.ch + monoSecond : monoFirst;
+      const text = applyStyle(plain, entry.key);
+      grid.appendChild(buildCard({
+        label: entry.label,
+        family: entry.family,
+        hold: entry.hold,
+        text: text,
+        styleKey: entry.key
+      }));
+    });
+  }
+
+  /* --------------------------------------------------------------------------
+     Mode: symbols
+     -------------------------------------------------------------------------- */
+  function renderSymbols(grid) {
+    DATA.SYMBOL_GROUPS.forEach(function (group) {
+      grid.appendChild(gridHeading(group.label));
+      const wrap = el('div', 'tattoo-symbol-grid');
+      group.items.forEach(function (item) {
+        const tile = el('button', 'glyph-copy tattoo-symbol-tile');
+        tile.type = 'button';
+        tile.dataset.text = item.ch;
+        tile.setAttribute('aria-label', 'Copy ' + item.name);
+        tile.appendChild(el('span', 'tattoo-symbol-glyph', item.ch));
+        tile.appendChild(el('span', 'tattoo-symbol-name', item.name));
+        wrap.appendChild(tile);
+      });
+      grid.appendChild(wrap);
+    });
+  }
+
+  /* --------------------------------------------------------------------------
+     Master render
+     -------------------------------------------------------------------------- */
+  function render() {
+    const grid = $('#resultsGrid');
+    if (!grid) return;
+    grid.innerHTML = '';
+    grid.classList.remove('tattoo-size-arm', 'tattoo-size-room');
+    if (sizeView === 'arm') grid.classList.add('tattoo-size-arm');
+    if (sizeView === 'room') grid.classList.add('tattoo-size-room');
+
+    if (mode === 'names') renderNames(grid);
+    else if (mode === 'date') renderDate(grid);
+    else if (mode === 'letters') renderLetters(grid);
+    else renderSymbols(grid);
+  }
+
+  function triggerRender() {
+    if (renderTimer) clearTimeout(renderTimer);
+    renderTimer = setTimeout(render, 120);
+  }
+
+  /* --------------------------------------------------------------------------
+     Controls
+     -------------------------------------------------------------------------- */
+  function buildModeTabs() {
+    const host = $('#tattooModeTabs');
+    if (!host) return;
+    MODES.forEach(function (m) {
+      const tab = el('button', 'tattoo-mode-tab' + (m.id === mode ? ' active' : ''));
+      tab.type = 'button';
+      tab.dataset.mode = m.id;
+      tab.appendChild(el('span', 'tattoo-mode-tab-label', m.label));
+      tab.appendChild(el('span', 'tattoo-mode-tab-hint', m.hint));
+      tab.addEventListener('click', function () { setMode(m.id); });
+      host.appendChild(tab);
+    });
+  }
+
+  function setMode(next) {
+    mode = next;
+    $$('.tattoo-mode-tab').forEach(function (t) {
+      t.classList.toggle('active', t.dataset.mode === mode);
+    });
+    const textWrap = $('#tattooTextWrap');
+    if (textWrap) textWrap.classList.toggle('u-hidden', mode !== 'names');
+    $$('[data-tattoo-panel]').forEach(function (panel) {
+      panel.classList.toggle('u-hidden', panel.dataset.tattooPanel !== mode);
+    });
+    // The ink test only makes sense where lettering renders at display size.
+    $$('[data-tattoo-size]').forEach(function (panel) {
+      panel.classList.toggle('u-hidden', mode !== 'names' && mode !== 'letters');
+    });
+    try {
+      const url = new URL(window.location.href);
+      if (mode === 'names') url.searchParams.delete('mode');
+      else url.searchParams.set('mode', mode);
+      history.replaceState(null, '', url.toString());
+    } catch (e) {}
+    render();
+  }
+
+  function chipRow(labelText, chips, isActive, onPick) {
+    const row = el('div', 'vertical-control-row');
+    row.appendChild(el('span', 'vertical-control-label', labelText));
+    const group = el('div', 'vertical-mode-chips');
+    chips.forEach(function (chip) {
+      const btn = el('button', 'vertical-chip' + (isActive(chip) ? ' active' : ''), chip.label);
+      btn.type = 'button';
+      btn.addEventListener('click', function () {
+        onPick(chip);
+        $$('.vertical-chip', group).forEach(function (b, i) {
+          b.classList.toggle('active', isActive(chips[i]));
+        });
+        render();
+      });
+      group.appendChild(btn);
+    });
+    row.appendChild(group);
+    return row;
+  }
+
+  function buildSizePanel(host) {
+    // The ink test applies to names + letters — the "will it stay readable?" check.
+    const panel = el('div', 'tattoo-control-group');
+    panel.dataset.tattooSize = '1';
+    panel.appendChild(chipRow('Ink test', SIZE_VIEWS,
+      function (chip) { return chip.id === sizeView; },
+      function (chip) { sizeView = chip.id; }));
+    host.appendChild(panel);
+  }
+
+  function buildDatePanel(host) {
+    const panel = el('div', 'tattoo-control-group u-hidden');
+    panel.dataset.tattooPanel = 'date';
+
+    const inputRow = el('div', 'vertical-control-row');
+    inputRow.appendChild(el('span', 'vertical-control-label', 'Your date'));
+    const fields = el('div', 'tattoo-date-fields');
+
+    function numField(id, placeholder, label, max) {
+      const wrap = el('label', 'tattoo-date-field');
+      const input = document.createElement('input');
+      input.type = 'number';
+      input.id = id;
+      input.min = '1';
+      input.max = String(max);
+      input.placeholder = placeholder;
+      input.setAttribute('aria-label', label);
+      input.addEventListener('input', triggerRender);
+      wrap.appendChild(input);
+      wrap.appendChild(el('span', 'tattoo-date-field-label', label));
+      return wrap;
+    }
+
+    fields.appendChild(numField('tattooDay', '12', 'Day', 31));
+    fields.appendChild(numField('tattooMonth', '6', 'Month', 12));
+    fields.appendChild(numField('tattooYear', '2020', 'Year or number', 3999));
+    inputRow.appendChild(fields);
+    panel.appendChild(inputRow);
+
+    panel.appendChild(chipRow('Order', DATA.DATE_ORDERS,
+      function (chip) { return chip.id === dateOrder; },
+      function (chip) { dateOrder = chip.id; }));
+
+    panel.appendChild(chipRow('Separator', DATA.DATE_SEPARATORS,
+      function (chip) { return chip.id === dateSep; },
+      function (chip) { dateSep = chip.id; }));
+
+    host.appendChild(panel);
+  }
+
+  function buildLettersPanel(host) {
+    const panel = el('div', 'tattoo-control-group u-hidden');
+    panel.dataset.tattooPanel = 'letters';
+
+    const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
+
+    const firstRow = el('div', 'vertical-control-row');
+    firstRow.appendChild(el('span', 'vertical-control-label', 'Your letter'));
+    const letterGrid = el('div', 'tattoo-letter-grid');
+    alphabet.forEach(function (letter) {
+      const btn = el('button', 'tattoo-letter-btn' + (letter === monoFirst ? ' active' : ''), letter);
+      btn.type = 'button';
+      btn.addEventListener('click', function () {
+        monoFirst = letter;
+        $$('.tattoo-letter-btn', letterGrid).forEach(function (b) {
+          b.classList.toggle('active', b.textContent === monoFirst);
+        });
+        render();
+      });
+      letterGrid.appendChild(btn);
+    });
+    firstRow.appendChild(letterGrid);
+    panel.appendChild(firstRow);
+
+    const secondRow = el('div', 'vertical-control-row');
+    secondRow.appendChild(el('span', 'vertical-control-label', 'Second initial'));
+    const secondWrap = el('div', 'vertical-mode-chips');
+    const select = document.createElement('select');
+    select.className = 'vertical-layout-select tattoo-second-select';
+    select.setAttribute('aria-label', 'Second initial');
+    const noneOpt = document.createElement('option');
+    noneOpt.value = '';
+    noneOpt.textContent = 'None — single letter';
+    select.appendChild(noneOpt);
+    alphabet.forEach(function (letter) {
+      const opt = document.createElement('option');
+      opt.value = letter;
+      opt.textContent = letter;
+      select.appendChild(opt);
+    });
+    select.addEventListener('change', function () {
+      monoSecond = select.value;
+      joinerRow.classList.toggle('disabled-row', !monoSecond);
+      render();
+    });
+    secondWrap.appendChild(select);
+    secondRow.appendChild(secondWrap);
+    panel.appendChild(secondRow);
+
+    const joinerRow = chipRow('Joined by', DATA.JOINERS,
+      function (chip) { return chip.id === monoJoiner; },
+      function (chip) { monoJoiner = chip.id; });
+    joinerRow.classList.add('vertical-divider-row', 'disabled-row');
+    panel.appendChild(joinerRow);
+
+    host.appendChild(panel);
+  }
+
+  function buildSymbolsPanel(host) {
+    const panel = el('div', 'tattoo-control-group u-hidden');
+    panel.dataset.tattooPanel = 'symbols';
+    panel.appendChild(el('p', 'tattoo-panel-note',
+      'Tap any symbol to copy it — pair one with a name or date, or wear it alone.'));
+    host.appendChild(panel);
+  }
+
+  /* --------------------------------------------------------------------------
+     Init
+     -------------------------------------------------------------------------- */
+  function readUrlState() {
+    try {
+      const params = new URLSearchParams(window.location.search);
+      const text = params.get('text') || params.get('q');
+      const input = $('#mainInput');
+      if (text && input && !input.value) input.value = text;
+      const urlMode = params.get('mode');
+      if (urlMode && MODES.some(function (m) { return m.id === urlMode; })) mode = urlMode;
+    } catch (e) {}
+  }
+
+  function init() {
+    const host = $('#tattooControlPanel');
+    if (!host) return;
+
+    readUrlState();
+    buildModeTabs();
+    buildSizePanel(host);
+    buildDatePanel(host);
+    buildLettersPanel(host);
+    buildSymbolsPanel(host);
+
+    const input = $('#mainInput');
+    if (input) input.addEventListener('input', triggerRender);
+
+    // Apply initial visibility for a non-default URL mode, then paint.
+    setMode(mode);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/script.js
+++ b/script.js
@@ -869,6 +869,7 @@ const decorations = window.UTG_DECORATIONS || {
     if (window.UTG_VERTICAL_MODE) return;
     if (window.UTG_ZALGO_MODE) return;
     if (window.UTG_DECORATOR_MODE) return;
+    if (window.UTG_TATTOO_MODE) return;
     if (!el.decorationGrid) return;
 
     const grid = el.decorationGrid;
@@ -917,7 +918,7 @@ const decorations = window.UTG_DECORATIONS || {
   // editing each HTML file (skipped on the dedicated vertical/zalgo pages,
   // which run their own controllers).
   function ensureScopeControl() {
-    if (window.UTG_VERTICAL_MODE || window.UTG_ZALGO_MODE || window.UTG_DECORATOR_MODE) return null;
+    if (window.UTG_VERTICAL_MODE || window.UTG_ZALGO_MODE || window.UTG_DECORATOR_MODE || window.UTG_TATTOO_MODE) return null;
     if (!el.resultsGrid) return null;
 
     let control = $("#scopeControl");
@@ -1002,7 +1003,7 @@ const decorations = window.UTG_DECORATIONS || {
   // style is generated, so every card in the grid gains the formatting at once.
   function ensureFormatControl() {
     if (!window.UTG_FORMAT_MARKS) return null;
-    if (window.UTG_VERTICAL_MODE || window.UTG_ZALGO_MODE || window.UTG_DECORATOR_MODE) return null;
+    if (window.UTG_VERTICAL_MODE || window.UTG_ZALGO_MODE || window.UTG_DECORATOR_MODE || window.UTG_TATTOO_MODE) return null;
     if (!el.resultsGrid) return null;
 
     let control = $("#formatControl");
@@ -1092,6 +1093,7 @@ const decorations = window.UTG_DECORATIONS || {
     if (window.UTG_VERTICAL_MODE) return;
     if (window.UTG_ZALGO_MODE) return;
     if (window.UTG_DECORATOR_MODE) return;
+    if (window.UTG_TATTOO_MODE) return;
     if (!el.resultsGrid) return;
 
     const section = ensureSavedSection();
@@ -1134,6 +1136,7 @@ const decorations = window.UTG_DECORATIONS || {
     if (window.UTG_VERTICAL_MODE) return;
     if (window.UTG_ZALGO_MODE) return;
     if (window.UTG_DECORATOR_MODE) return;
+    if (window.UTG_TATTOO_MODE) return;
     if (!el.resultsGrid) return;
 
     const grid = el.resultsGrid;

--- a/style.css
+++ b/style.css
@@ -4592,3 +4592,276 @@ body.dark-mode .deco-symbol-input {
   color: var(--text-dark, #e2e8f0);
   border-color: var(--border-dark, #334155);
 }
+
+/* ==========================================================================
+   TATTOO LETTERING STUDIO (/usecase/tattoo-fonts/)
+   Prefix: tattoo-*. Reuses .vertical-chip / .vertical-control-row for the
+   control panel and .style-card / .copy-btn for cards, like the decorator.
+   ========================================================================== */
+
+/* Generic hide utility (mode panels toggle it) */
+.u-hidden {
+  display: none !important;
+}
+
+/* Mode tabs — four big pills under the headline */
+.tattoo-mode-tabs {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+  margin: 16px 0 14px;
+}
+
+.tattoo-mode-tab {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  padding: 10px 12px;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius);
+  background: var(--bg-white);
+  color: var(--text-primary);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color .15s, background .15s, box-shadow .15s;
+}
+
+.tattoo-mode-tab:hover {
+  border-color: var(--accent-purple);
+}
+
+.tattoo-mode-tab.active {
+  border-color: var(--accent-purple);
+  background: rgba(139, 92, 246, 0.08);
+  box-shadow: inset 0 0 0 1px var(--accent-purple);
+}
+
+.tattoo-mode-tab-label {
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.tattoo-mode-tab-hint {
+  font-size: 0.68rem;
+  color: var(--text-muted);
+  line-height: 1.35;
+}
+
+@media (max-width: 640px) {
+  .tattoo-mode-tabs {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+/* Control panel groups */
+.tattoo-control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.tattoo-panel-note {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+/* Date fields */
+.tattoo-date-fields {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.tattoo-date-field {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.tattoo-date-field input {
+  width: 110px;
+  padding: 8px 10px;
+  border: 1px solid var(--border-light);
+  border-radius: 8px;
+  background: var(--bg-white);
+  color: var(--text-primary);
+  font-family: inherit;
+  font-size: 0.95rem;
+}
+
+.tattoo-date-field input:focus {
+  outline: none;
+  border-color: var(--accent-purple);
+  box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.1);
+}
+
+.tattoo-date-field-label {
+  font-size: 0.68rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: .04em;
+}
+
+/* Letter picker */
+.tattoo-letter-grid {
+  flex: 1;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(36px, 1fr));
+  gap: 5px;
+  min-width: 220px;
+}
+
+.tattoo-letter-btn {
+  padding: 7px 0;
+  border: 1px solid var(--border-light);
+  border-radius: 8px;
+  background: var(--bg-white);
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: border-color .15s, background .15s, color .15s;
+}
+
+.tattoo-letter-btn:hover {
+  border-color: var(--accent-purple);
+  color: var(--accent-purple);
+}
+
+.tattoo-letter-btn.active {
+  background: var(--accent-purple);
+  border-color: var(--accent-purple);
+  color: #fff;
+}
+
+/* Results — cards with display-size previews */
+.tattoo-card {
+  align-items: center;
+}
+
+.tattoo-preview {
+  font-size: 1.8rem;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  transition: font-size .2s, filter .2s;
+}
+
+.tattoo-preview.is-sample {
+  color: var(--text-secondary);
+}
+
+/* Ink test: shrink previews toward real-world viewing sizes. The slight
+   blur on the smallest step approximates how ink spreads over the years. */
+.tattoo-size-arm .tattoo-preview {
+  font-size: 1.15rem;
+}
+
+.tattoo-size-room .tattoo-preview {
+  font-size: 0.85rem;
+  filter: blur(0.4px);
+}
+
+.tattoo-sample-hint {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.tattoo-grid-heading {
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: .05em;
+  margin-top: 14px;
+}
+
+/* Aging badges — reuse the trust/safety tokens (green/amber, dark-aware) */
+.tattoo-badge {
+  font-size: 0.625rem;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.tattoo-badge.is-safe {
+  color: var(--ts-safe);
+  background: rgba(22, 163, 74, 0.1);
+}
+
+.tattoo-badge.is-roomy {
+  color: var(--ts-risk);
+  background: rgba(217, 119, 6, 0.1);
+}
+
+/* Symbol library */
+.tattoo-symbol-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 8px;
+}
+
+.tattoo-symbol-tile {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 14px 10px 10px;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius);
+  background: var(--bg-white);
+  color: var(--text-primary);
+  font: inherit;
+  cursor: pointer;
+  transition: border-color .15s, box-shadow .15s;
+}
+
+.tattoo-symbol-tile:hover {
+  border-color: var(--accent-purple);
+  box-shadow: var(--shadow-hover);
+}
+
+/* Keep the tile surface on copy (override .glyph-copy.copied's purple fill,
+   which would drown the meaning caption) — signal with the border instead. */
+.tattoo-symbol-tile.copied {
+  background: var(--bg-white);
+  color: var(--text-primary);
+  border-color: var(--ts-safe);
+  box-shadow: inset 0 0 0 1px var(--ts-safe);
+}
+
+.tattoo-symbol-glyph {
+  font-size: 1.9rem;
+  line-height: 1.1;
+}
+
+.tattoo-symbol-name {
+  font-size: 0.68rem;
+  color: var(--text-muted);
+  text-align: center;
+  line-height: 1.35;
+}
+
+.tattoo-second-select {
+  max-width: 220px;
+}
+
+/* Dark mode — chips/selects reused from vertical already have overrides;
+   tattoo-specific surfaces inherit the swapped custom properties above. */
+body.dark-mode .tattoo-mode-tab.active {
+  background: rgba(139, 92, 246, 0.16);
+}
+
+body.dark-mode .tattoo-badge.is-safe {
+  background: rgba(74, 222, 128, 0.12);
+}
+
+body.dark-mode .tattoo-badge.is-roomy {
+  background: rgba(251, 191, 36, 0.12);
+}

--- a/usecase/tattoo-fonts/index.html
+++ b/usecase/tattoo-fonts/index.html
@@ -11,7 +11,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Tattoo Fonts — Free Tattoo Lettering Generator (Preview Your Ink) | UltraTextGen</title>
-  <meta name="description" content="Tattoo fonts: type your name, word, or date and compare cursive, gothic, and script tattoo lettering before the needle. Free tattoo font generator — no app.">
+  <meta name="description" content="Tattoo fonts: compare cursive, gothic, and script lettering on your exact name, turn a date into roman numerals, and preview initials and symbols — free, before the needle.">
   <link rel="canonical" href="https://ultratextgen.com/usecase/tattoo-fonts/">
 
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/usecase/tattoo-fonts/">
@@ -54,7 +54,14 @@
   "inLanguage": "en",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Any",
-  "description": "Preview tattoo lettering before the needle: type a name, word, or date and compare cursive, gothic, fine italic, and typewriter tattoo fonts side by side — then screenshot your favorites and show your tattoo artist. Free, no app.",
+  "description": "Preview tattoo lettering before the needle: compare cursive, gothic, fine italic, and typewriter tattoo fonts on your exact name, convert a date into roman numerals, build letter monograms, and browse tattoo symbols with their meanings — then screenshot your favorites and show your tattoo artist. Free, no app.",
+  "featureList": [
+    "Compare 10 tattoo lettering styles on your exact name or word",
+    "Date and number to roman numerals converter with tattoo formats",
+    "Single letter and two-initial monogram generator",
+    "Tattoo symbol library with meanings",
+    "Ink test — preview lettering at real-world viewing sizes"
+  ],
   "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
 }
 </script>
@@ -89,6 +96,11 @@
       "@type": "Question",
       "name": "How do I show a lettering style to my tattoo artist?",
       "acceptedAnswer": { "@type": "Answer", "text": "Type your exact word (not a sample word) at the top of the page, screenshot the two or three renderings you like best, and bring them to your appointment. Say what you like about each — \"the connections in the cursive,\" \"the weight of the gothic\" — rather than asking for a pixel-perfect copy. A good artist takes the direction and redraws the lettering by hand for your skin and placement." }
+    },
+    {
+      "@type": "Question",
+      "name": "How do I write a date in roman numerals for a tattoo?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Convert each part of the date separately — day, month, year — and join them with a separator: 12 June 2020 becomes XII·VI·MMXX. The Date → Roman mode on this page does the conversion for you and lets you compare separators (dots, dashes, bars, stacked lines) and orders (day-month-year or month-day-year). Double-check the numerals with your artist before the appointment: a misconverted date is the single most common lettering-tattoo regret." }
     }
   ]
 }
@@ -127,26 +139,18 @@
   <div class="hero-inner">
     <div class="hero-card">
       <h1 class="hero-headline">Tattoo font generator</h1>
-      <p class="hero-tagline">Type the word, name, or date you're thinking of getting inked and compare tattoo lettering styles instantly — cursive, gothic, italic, typewriter. Screenshot the renderings you like and show them to your tattoo artist: they'll draw the final lettering, this page just helps you pick the direction.</p>
-      <div class="input-wrapper">
-        <textarea class="main-input" id="mainInput" placeholder="Type your text here..." maxlength="500" autofocus=""></textarea>
+      <p class="hero-tagline">Everything a lettering tattoo needs, in one place: compare tattoo fonts on your exact name or word, turn a date into roman numerals, build a letter monogram, or pick a small symbol with meaning. Screenshot what you like and show your tattoo artist — they'll draw the final lettering, this page helps you pick the direction.</p>
+      <div class="tattoo-mode-tabs" id="tattooModeTabs"></div>
+      <div class="input-wrapper" id="tattooTextWrap">
+        <textarea class="main-input" id="mainInput" placeholder="Type your name, word, or quote..." maxlength="500" autofocus=""></textarea>
         <span class="char-count"><span id="charCount">0</span>/500</span>
       </div>
-      <div class="decoration-section">
-        <div class="decoration-label">Add decoration to results</div>
-        <div class="decoration-tabs">
-          <button class="decoration-tab active" data-deco-tab="symbols">Symbols</button>
-          <button class="decoration-tab" data-deco-tab="frames">Frames</button>
-          <button class="decoration-tab" data-deco-tab="minimal">Minimal</button>
-        </div>
-        <div class="decoration-grid" id="decorationGrid"></div>
-      </div>
+      <div id="tattooControlPanel"></div>
     </div>
   </div>
 </section>
 
 <main class="container">
-  <div class="category-section"><div class="category-tabs" id="categoryTabs"></div></div>
   <div class="results-grid" id="resultsGrid"></div>
 
   <!-- Preview before the needle -->
@@ -218,6 +222,18 @@
     <p>To dig into one family before committing, the <a href="/category/cursive-fonts/">cursive fonts</a> and <a href="/category/gothic-fonts/">gothic fonts</a> pages break down every variant — and if your idea leans subtle rather than ornate, <a href="/category/italic-fonts/">italic fonts</a> covers the quiet end of the spectrum.</p>
   </section>
 
+  <!-- Dates, numerals, initials, symbols -->
+  <section class="editorial-section">
+    <h2>Dates in roman numerals, initials, and symbols</h2>
+    <p class="editorial-intro">Half of lettering tattoos aren't words at all — they're a date, a pair of initials, or a small symbol. The modes at the top of this page are built for exactly those jobs:</p>
+    <div class="block-example">
+      — <strong>Date → Roman</strong>: enter a date and get XII·VI·MMXX with your choice of separator (dots, dashes, bars, stacked) and order — then the same numerals in script, blackletter, and typewriter, plus plain-figure fonts<br>
+      — <strong>Letters &amp; initials</strong>: a single letter carries the whole design — compare your initial in every alphabet, or join two initials with ♡, ∞, or &amp;<br>
+      — <strong>Symbols</strong>: the small marks people actually get — semicolon (the story continues), infinity, crescent moon, anchor — each with its meaning
+    </div>
+    <p>Two honest warnings from the numbers side. First, <strong>verify the conversion</strong>: a misconverted roman-numeral date is the most common lettering regret, so have your artist double-check the numerals this page generates. Second, <strong>most script alphabets have no matching ornate digits</strong> — that's why dates usually switch to roman numerals or typewriter figures, and why mixing a cursive name with a plain date on a second line is a completely standard, good-looking solution.</p>
+  </section>
+
   <!-- From screenshot to artist -->
   <section class="editorial-section">
     <h2>From screenshot to tattoo artist</h2>
@@ -272,6 +288,7 @@
     <div class="faq-item"><button class="faq-question" type="button">Can I use these fonts as-is for my tattoo?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">No — and it matters to say so plainly. These Unicode renderings are a working base, not a stencil-ready design. They help you pick a direction — cursive, gothic, italic — and show it clearly to your tattoo artist. The artist then adapts the lettering to your skin: stroke weight, the connections between letters, the curve of the placement. Final lettering is their craft, not a generator's.</div></div>
     <div class="faq-item"><button class="faq-question" type="button">What is the minimum size for fine-line lettering?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">The finer and more detailed the lettering, the more room it needs. Thin strokes and small loops tend to thicken and close up over the years — a fine-script word under half an inch tall can become unreadable. Simple rule: if you want it small, choose a simple style (italic, typewriter); if you want ornate cursive, give it space. Your artist will tell you the exact minimum size for your placement.</div></div>
     <div class="faq-item"><button class="faq-question" type="button">How do I show a lettering style to my tattoo artist?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Type your exact word (not a sample word) at the top of the page, screenshot the two or three renderings you like best, and bring them to your appointment. Say what you like about each — "the connections in the cursive," "the weight of the gothic" — rather than asking for a pixel-perfect copy. A good artist takes the direction and redraws the lettering by hand for your skin and placement.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">How do I write a date in roman numerals for a tattoo?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Convert each part of the date separately — day, month, year — and join them with a separator: 12 June 2020 becomes XII·VI·MMXX. The Date → Roman mode on this page does the conversion for you and lets you compare separators (dots, dashes, bars, stacked lines) and orders (day-month-year or month-day-year). Double-check the numerals with your artist before the appointment: a misconverted date is the single most common lettering-tattoo regret.</div></div>
 
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="Language switcher">
@@ -292,9 +309,12 @@
 <div class="copy-toast" id="copyToast">Copied!</div>
 <div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
 
-<script src="/styles.js"></script>
-<script src="/renderer.js"></script>
-<script src="/script.js" defer=""></script>
-<script src="/symbol-explorer.js"></script>
+<script>window.UTG_TATTOO_MODE = true;</script>
+<script src="/styles.js" defer></script>
+<script src="/renderer.js" defer></script>
+<script src="/js/tattoo/tattooData.js" defer></script>
+<script src="/script.js" defer></script>
+<script src="/js/tattoo/tattooPageController.js" defer></script>
+<script src="/symbol-explorer.js" defer></script>
 <script src="/footer.js"></script>
 </body></html>


### PR DESCRIPTION
Replace the generic-generator template on /usecase/tattoo-fonts/ with a dedicated controller module (js/tattoo/), following the vertical-text / decorator pattern. Four modes, one per lettering-tattoo job:

- Names & words: 10 curated lettering styles with family tags, aging badges (holds up small / needs room) and an ink test that previews the render at real-world viewing sizes
- Date -> Roman: date/number to roman numerals converter with order and separator options (incl. stacked), numerals rendered in script, blackletter and typewriter, plus 7 plain-figure digit fonts
- Letters & initials: A-Z picker with two-initial monograms joined by heart/infinity/ampersand and more
- Symbols: 55 copyable tattoo symbols grouped by theme, each with the meaning people search for

script.js gains UTG_TATTOO_MODE suppression guards (same mechanism as UTG_VERTICAL_MODE); cards reuse the .style-card/.copy-btn contract so the global copy handler keeps working. New tattoo-* CSS section with dark-mode support. FAQ + JSON-LD extended with the roman-numeral date question; deep links via ?text= and ?mode=.


Claude-Session: https://claude.ai/code/session_01DCPGnGu32zuLvDCTKau1s2