### PR TITLE
feat: roll out tattoo lettering studio to all 9 international pages

### DIFF
--- a/de/usecase/tattoo-schrift/index.html
+++ b/de/usecase/tattoo-schrift/index.html
@@ -14,7 +14,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Tattoo Schrift — Schriftarten für dein Tattoo testen | UltraTextGen</title>
-  <meta name="description" content="Tattoo Schrift testen: Tipp Wort, Name oder Datum ein und vergleiche Schriftarten fürs Tattoo — kursiv, gotisch, fein. Screenshot für deinen Tätowierer. Gratis.">
+  <meta name="description" content="Tattoo Schrift: Vergleiche Schreibschrift, Gotisch und Italic auf deinem Namen, mach aus einem Datum römische Ziffern, teste Initialen und Symbole — gratis.">
   <link rel="canonical" href="https://ultratextgen.com/de/usecase/tattoo-schrift/">
 
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/usecase/tattoo-fonts/">
@@ -52,13 +52,30 @@
   "@context": "https://schema.org",
   "@type": "WebApplication",
   "name": "Tattoo Schriftarten Generator",
-  "alternateName": ["Tattoo Schrift", "Schriftarten Tattoo", "Tattoo Schriften", "Schrift Tattoo Generator", "Tattoo Schrift Vorschau"],
+  "alternateName": [
+    "Tattoo Schrift",
+    "Schriftarten Tattoo",
+    "Tattoo Schriften",
+    "Schrift Tattoo Generator",
+    "Tattoo Schrift Vorschau"
+  ],
   "url": "https://ultratextgen.com/de/usecase/tattoo-schrift/",
   "inLanguage": "de",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Any",
-  "description": "Teste die Schrift für deine Tattoo-Idee: Tipp ein Wort, einen Namen oder ein Datum ein und vergleiche Schreibschrift, Gotisch, feine Italic und Schreibmaschinen-Stil — dann zeig den Screenshot deinem Tätowierer. Gratis, ohne App.",
-  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "EUR" }
+  "description": "Teste dein Tattoo-Lettering, bevor die Nadel ansetzt: Vergleiche Schreibschrift, Gotisch, feine Italic und Schreibmaschinen-Stil auf deinem exakten Namen, wandle ein Datum in römische Ziffern um, bau Buchstaben-Monogramme und stöbere durch Tattoo-Symbole mit ihren Bedeutungen — dann mach Screenshots von deinen Favoriten und zeig sie deinem Tätowierer. Gratis, ohne App.",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "EUR"
+  },
+  "featureList": [
+    "Vergleiche 10 Tattoo-Lettering-Stile auf deinem exakten Namen oder Wort",
+    "Datum und Zahl in römische Ziffern umwandeln — mit Tattoo-Formaten",
+    "Generator für einzelne Buchstaben und Monogramme aus zwei Initialen",
+    "Tattoo-Symbol-Bibliothek mit Bedeutungen",
+    "Tinten-Test — Lettering in realen Betrachtungsgrößen ansehen"
+  ]
 }
 </script>
 
@@ -71,27 +88,50 @@
     {
       "@type": "Question",
       "name": "Wie wähle ich die richtige Tattoo Schrift?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Geh vom Inhalt aus, nicht vom Look. Ein Name oder eine Liebeserklärung → Schreibschrift, warm und zeitlos. Ein starkes Wort, ein Motto → Gotisch, dicht und markant. Ein kurzes Zitat → feine Italic, dezent und elegant. Ein Datum → römische Ziffern oder Schreibmaschinen-Stil. Tipp deinen Text oben auf der Seite ein, vergleich die Ergebnisse nebeneinander und behalte die zwei, drei Varianten, die dich sofort ansprechen — beim Feinschliff hilft dir dein Tätowierer." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Geh vom Inhalt aus, nicht vom Look. Ein Name oder eine Liebeserklärung → Schreibschrift, warm und zeitlos. Ein starkes Wort, ein Motto → Gotisch, dicht und markant. Ein kurzes Zitat → feine Italic, dezent und elegant. Ein Datum → römische Ziffern oder Schreibmaschinen-Stil. Tipp deinen Text oben auf der Seite ein, vergleich die Ergebnisse nebeneinander und behalte die zwei, drei Varianten, die dich sofort ansprechen — beim Feinschliff hilft dir dein Tätowierer."
+      }
     },
     {
       "@type": "Question",
       "name": "Welche Schrift eignet sich für ein Namens-Tattoo?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Die Schreibschrift ist der Klassiker fürs Namens-Tattoo: Die verbundenen Buchstaben wirken handgeschrieben, persönlich und altern gut. Eine kräftige Script (𝓜𝓲𝓪) hat mehr Präsenz, eine feine Script (𝓂𝒾𝒶) mehr Zartheit. Ist der Name kurz und du willst Kante, probier auch Gotisch — im Chicano-Stil sehr verbreitet. Vergleich beides auf dieser Seite, bevor du dich festlegst." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Die Schreibschrift ist der Klassiker fürs Namens-Tattoo: Die verbundenen Buchstaben wirken handgeschrieben, persönlich und altern gut. Eine kräftige Script (𝓜𝓲𝓪) hat mehr Präsenz, eine feine Script (𝓂𝒾𝒶) mehr Zartheit. Ist der Name kurz und du willst Kante, probier auch Gotisch — im Chicano-Stil sehr verbreitet. Vergleich beides auf dieser Seite, bevor du dich festlegst."
+      }
     },
     {
       "@type": "Question",
       "name": "Kann ich diese Schriftarten eins zu eins fürs Tattoo verwenden?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Nein — und das sagen wir bewusst so deutlich: Diese Unicode-Schriften sind eine Arbeitsgrundlage, keine stichfertige Vorlage. Sie helfen dir, eine Richtung zu finden — Schreibschrift, Gotisch, Italic — und sie deinem Tätowierer klar zu zeigen. Er passt das Lettering dann an deine Haut an: Strichstärke, Verbindungen zwischen den Buchstaben, die Kurve der Körperstelle. Das finale Lettering ist sein Handwerk." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Nein — und das sagen wir bewusst so deutlich: Diese Unicode-Schriften sind eine Arbeitsgrundlage, keine stichfertige Vorlage. Sie helfen dir, eine Richtung zu finden — Schreibschrift, Gotisch, Italic — und sie deinem Tätowierer klar zu zeigen. Er passt das Lettering dann an deine Haut an: Strichstärke, Verbindungen zwischen den Buchstaben, die Kurve der Körperstelle. Das finale Lettering ist sein Handwerk."
+      }
     },
     {
       "@type": "Question",
       "name": "Wie klein darf eine feine Tattoo Schrift sein?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Je feiner und verspielter die Schrift, desto mehr Platz braucht sie. Sehr dünne Linien und kleine Schleifen laufen mit den Jahren auseinander und wachsen zu — ein Wort in feiner Script unter einem Zentimeter Höhe wird schnell unleserlich. Faustregel: Willst du es klein, nimm einen schlichten Stil (Italic, Schreibmaschine); willst du verschnörkelte Schreibschrift, plane Fläche ein. Die genaue Mindestgröße für deine Körperstelle nennt dir dein Tätowierer." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Je feiner und verspielter die Schrift, desto mehr Platz braucht sie. Sehr dünne Linien und kleine Schleifen laufen mit den Jahren auseinander und wachsen zu — ein Wort in feiner Script unter einem Zentimeter Höhe wird schnell unleserlich. Faustregel: Willst du es klein, nimm einen schlichten Stil (Italic, Schreibmaschine); willst du verschnörkelte Schreibschrift, plane Fläche ein. Die genaue Mindestgröße für deine Körperstelle nennt dir dein Tätowierer."
+      }
     },
     {
       "@type": "Question",
       "name": "Wie zeige ich meinem Tätowierer den Stil?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Tipp dein exaktes Wort ein (kein Beispielwort — die Buchstaben ändern alles), mach Screenshots von den zwei, drei Varianten, die dir gefallen, und bring sie zum Termin mit. Sag konkret, was dir an jeder gefällt — „die Schwünge der Schreibschrift“, „die Strichstärke der Gotischen“ — statt eine Pixel-für-Pixel-Kopie zu verlangen. Achtung bei Umlauten: ä, ö, ü und ß bleiben in den Unicode-Schriften meist normale Buchstaben, aber dein Tätowierer zeichnet sie im finalen Lettering problemlos mit." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Tipp dein exaktes Wort ein (kein Beispielwort — die Buchstaben ändern alles), mach Screenshots von den zwei, drei Varianten, die dir gefallen, und bring sie zum Termin mit. Sag konkret, was dir an jeder gefällt — „die Schwünge der Schreibschrift“, „die Strichstärke der Gotischen“ — statt eine Pixel-für-Pixel-Kopie zu verlangen. Achtung bei Umlauten: ä, ö, ü und ß bleiben in den Unicode-Schriften meist normale Buchstaben, aber dein Tätowierer zeichnet sie im finalen Lettering problemlos mit."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Wie schreibe ich ein Datum in römischen Ziffern für ein Tattoo?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Wandle jeden Teil des Datums einzeln um — Tag, Monat, Jahr — und verbinde sie mit einem Trennzeichen: Aus dem 12. Juni 2020 wird XII·VI·MMXX. Der Modus Datum → Römisch auf dieser Seite übernimmt die Umrechnung für dich und lässt dich Trennzeichen (Punkte, Striche, Balken, gestapelte Zeilen) und Reihenfolgen (Tag-Monat-Jahr oder Monat-Tag-Jahr) vergleichen. Prüf die Ziffern vor dem Termin gemeinsam mit deinem Tätowierer: Ein falsch umgerechnetes Datum ist die häufigste Reue beim Lettering-Tattoo."
+      }
     }
   ]
 }
@@ -133,26 +173,18 @@
   <div class="hero-inner">
     <div class="hero-card">
       <h1 class="hero-headline">Tattoo Schriftarten Generator</h1>
-      <p class="hero-tagline">Tipp das Wort, den Namen oder das Datum deiner Tattoo-Idee ein und vergleich sofort die Schriftarten — Schreibschrift, Gotisch, feine Italic, Schreibmaschine. Mach Screenshots von den Varianten, die dir gefallen, und zeig sie deinem Tätowierer: Das finale Lettering zeichnet er, diese Seite hilft dir nur, die Richtung zu finden.</p>
-      <div class="input-wrapper">
-        <textarea class="main-input" id="mainInput" placeholder="Gib deinen Text hier ein…" maxlength="500" autofocus=""></textarea>
+      <p class="hero-tagline">Alles, was ein Lettering-Tattoo braucht, an einem Ort: Vergleich Tattoo Schriften auf deinem exakten Namen oder Wort, mach aus einem Datum römische Ziffern, bau ein Buchstaben-Monogramm oder such dir ein kleines Symbol mit Bedeutung. Mach Screenshots von deinen Favoriten und zeig sie deinem Tätowierer — er zeichnet das finale Lettering, diese Seite hilft dir, die Richtung zu finden.</p>
+      <div class="tattoo-mode-tabs" id="tattooModeTabs"></div>
+      <div class="input-wrapper" id="tattooTextWrap">
+        <textarea class="main-input" id="mainInput" placeholder="Tipp deinen Namen, dein Wort oder Zitat ein…" maxlength="500" autofocus=""></textarea>
         <span class="char-count"><span id="charCount">0</span>/500</span>
       </div>
-      <div class="decoration-section">
-        <div class="decoration-label">Etwas Deko um dein Ergebnis legen</div>
-        <div class="decoration-tabs">
-          <button class="decoration-tab active" data-deco-tab="symbols">Symbole</button>
-          <button class="decoration-tab" data-deco-tab="frames">Rahmen</button>
-          <button class="decoration-tab" data-deco-tab="minimal">Minimal</button>
-        </div>
-        <div class="decoration-grid" id="decorationGrid"></div>
-      </div>
+      <div id="tattooControlPanel"></div>
     </div>
   </div>
 </section>
 
 <main class="container">
-  <div class="category-section"><div class="category-tabs" id="categoryTabs"></div></div>
   <div class="results-grid" id="resultsGrid"></div>
 
   <!-- Vor der Nadel testen -->
@@ -248,6 +280,8 @@
     <div class="faq-item"><button class="faq-question" type="button">Kann ich diese Schriftarten eins zu eins fürs Tattoo verwenden?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Nein — und das sagen wir bewusst so deutlich: Diese Unicode-Schriften sind eine Arbeitsgrundlage, keine stichfertige Vorlage. Sie helfen dir, eine Richtung zu finden — Schreibschrift, Gotisch, Italic — und sie deinem Tätowierer klar zu zeigen. Er passt das Lettering dann an deine Haut an: Strichstärke, Verbindungen zwischen den Buchstaben, die Kurve der Körperstelle. Das finale Lettering ist sein Handwerk.</div></div>
     <div class="faq-item"><button class="faq-question" type="button">Wie klein darf eine feine Tattoo Schrift sein?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Je feiner und verspielter die Schrift, desto mehr Platz braucht sie. Sehr dünne Linien und kleine Schleifen laufen mit den Jahren auseinander und wachsen zu — ein Wort in feiner Script unter einem Zentimeter Höhe wird schnell unleserlich. Faustregel: Willst du es klein, nimm einen schlichten Stil (Italic, Schreibmaschine); willst du verschnörkelte Schreibschrift, plane Fläche ein. Die genaue Mindestgröße für deine Körperstelle nennt dir dein Tätowierer.</div></div>
     <div class="faq-item"><button class="faq-question" type="button">Wie zeige ich meinem Tätowierer den Stil?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Tipp dein exaktes Wort ein (kein Beispielwort — die Buchstaben ändern alles), mach Screenshots von den zwei, drei Varianten, die dir gefallen, und bring sie zum Termin mit. Sag konkret, was dir an jeder gefällt — „die Schwünge der Schreibschrift“, „die Strichstärke der Gotischen“ — statt eine Pixel-für-Pixel-Kopie zu verlangen. Achtung bei Umlauten: ä, ö, ü und ß bleiben in den Unicode-Schriften meist normale Buchstaben, aber dein Tätowierer zeichnet sie im finalen Lettering problemlos mit.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Wie schreibe ich ein Datum in römischen Ziffern für ein Tattoo?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Wandle jeden Teil des Datums einzeln um — Tag, Monat, Jahr — und verbinde sie mit einem Trennzeichen: Aus dem 12. Juni 2020 wird XII·VI·MMXX. Der Modus Datum → Römisch auf dieser Seite übernimmt die Umrechnung für dich und lässt dich Trennzeichen (Punkte, Striche, Balken, gestapelte Zeilen) und Reihenfolgen (Tag-Monat-Jahr oder Monat-Tag-Jahr) vergleichen. Prüf die Ziffern vor dem Termin gemeinsam mit deinem Tätowierer: Ein falsch umgerechnetes Datum ist die häufigste Reue beim Lettering-Tattoo.</div></div>
+
 
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="Sprachauswahl">
@@ -268,9 +302,234 @@
 <div class="copy-toast" id="copyToast">Kopiert!</div>
 <div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
 
+<!-- Page configuration: tattoo mode flag + i18n -->
+<script>
+window.UTG_TATTOO_MODE = true;
+window.tattooI18n = {
+  "sampleName": "Mia",
+  "modeNamesLabel": "Namen & Wörter",
+  "modeNamesHint": "Tipp einen Namen, ein Wort oder Zitat ein",
+  "modeDateLabel": "Datum → Römisch",
+  "modeDateHint": "Wandle ein Datum oder eine Zahl in römische Ziffern um",
+  "modeLettersLabel": "Buchstaben & Initialen",
+  "modeLettersHint": "Einzelne Buchstaben und Monogramme",
+  "modeSymbolsLabel": "Symbole",
+  "modeSymbolsHint": "Kleine Symbole mit Bedeutung",
+  "sizeClose": "Nahaufnahme",
+  "sizeArm": "Auf Armlänge",
+  "sizeRoom": "Quer durch den Raum",
+  "inkTest": "Tinten-Test",
+  "yourDate": "Dein Datum",
+  "day": "Tag",
+  "month": "Monat",
+  "yearOrNumber": "Jahr oder Zahl",
+  "order": "Reihenfolge",
+  "separator": "Trennzeichen",
+  "yourLetter": "Dein Buchstabe",
+  "secondInitial": "Zweite Initiale",
+  "secondNone": "Keine — einzelner Buchstabe",
+  "joinedBy": "Verbunden durch",
+  "symbolsNote": "Tipp auf ein Symbol, um es zu kopieren — kombinier es mit einem Namen oder Datum, oder trag es allein.",
+  "sampleHintName": "Zeigt „{text}“ — tipp oben deinen Namen, dein Wort oder Zitat ein.",
+  "sampleHintDate": "Zeigt ein Beispieldatum (12 · 6 · 2020) — gib oben dein Datum oder deine Zahl ein.",
+  "romanRange": "Römische Ziffern reichen von 1 bis 3999 — prüf die Werte oben.",
+  "headingRoman": "Römische Ziffern",
+  "headingFigures": "Normale Ziffern",
+  "badgeSafe": "bleibt klein lesbar",
+  "badgeRoomy": "braucht Platz",
+  "copy": "Kopieren",
+  "copyAria": "{name} kopieren",
+  "families": {
+    "Script": "Schreibschrift",
+    "Gothic": "Gotisch",
+    "Italic": "Italic",
+    "Minimal": "Minimal",
+    "Roman": "Römisch",
+    "Figures": "Ziffern"
+  },
+  "orders": {
+    "dmy": "Tag · Monat · Jahr",
+    "mdy": "Monat · Tag · Jahr",
+    "y": "Nur Jahr"
+  },
+  "seps": {
+    "space": "Leerzeichen",
+    "stack": "gestapelt"
+  },
+  "joiners": {
+    "none": "Ohne"
+  },
+  "lettering": {
+    "Ultra Script Bold": {
+      "label": "Kräftige Script",
+      "note": "Der Klassiker fürs Namens-Tattoo — verbunden und warm, hält seine Form auch in kleinen Größen."
+    },
+    "Ultra Script": {
+      "label": "Feine Script",
+      "note": "Zart und luftig — wunderschön in mittlerer Größe; die dünnen Schleifen brauchen Platz, um gut zu altern."
+    },
+    "Ultra Chicano Script": {
+      "label": "Chicano-Namensband",
+      "note": "Kräftige Schreibschrift in einem verzierten Banner — die klassische Namensband-Rahmung."
+    },
+    "Ultra Gothic": {
+      "label": "Gotische Fraktur",
+      "note": "Fraktur — dicht und markant, gemacht für ein starkes Wort."
+    },
+    "Ultra Gothic Bold": {
+      "label": "Schwere Old English",
+      "note": "Der schwere Old-English-Look — ein Klassiker im Old-School- und Chicano-Lettering."
+    },
+    "Ultra Old English Banner": {
+      "label": "Old-English-Banner",
+      "note": "Schwere Fraktur im Banner — ein Namensband mit maximaler Präsenz."
+    },
+    "Ultra Italic": {
+      "label": "Feine Italic",
+      "note": "Dezente Schräglage — schmiegt sich still an Rippenbogen, Handgelenk oder Schlüsselbein."
+    },
+    "Ultra Italic Serif": {
+      "label": "Italic mit Serifen",
+      "note": "Buchmäßige Serifen-Italic — liest sich wie eine Zeile aus einem Roman."
+    },
+    "Ultra Typewriter Document": {
+      "label": "Schreibmaschine",
+      "note": "Roh und literarisch, monospaced — perfekt für ein Datum oder eine kurze Zeile."
+    },
+    "Ultra Small Caps": {
+      "label": "Kapitälchen",
+      "note": "Winzige, gleichmäßige Großbuchstaben — die Wahl der Fine-Line-Minimalisten."
+    }
+  },
+  "roman": {
+    "Classic": {
+      "label": "Klassisch",
+      "note": "Schlichte Großbuchstaben — das, was die meisten Tätowierer stechen."
+    },
+    "Serif Italic": {
+      "label": "Serifen-Italic",
+      "note": "Der Look gravierter Monumente — schräg gestellt."
+    },
+    "Script": {
+      "label": "Script",
+      "note": "Römische Ziffern in fließender Schreibschrift."
+    },
+    "Blackletter": {
+      "label": "Fraktur",
+      "note": "Fraktur-Ziffern — dunkel und ornamental."
+    },
+    "Heavy Old English": {
+      "label": "Schwere Old English",
+      "note": "Fraktur-Ziffern mit maximalem Gewicht."
+    },
+    "Typewriter": {
+      "label": "Schreibmaschine",
+      "note": "Monospace-Ziffern — klar und dokumentarisch."
+    }
+  },
+  "digits": {
+    "Typewriter": {
+      "label": "Schreibmaschine",
+      "note": "Monospace-Ziffern — der klassische Datums-Look."
+    },
+    "Bold Serif": {
+      "label": "Fette Serifen",
+      "note": "Schwere Buchdruck-Ziffern — passen zu Fraktur."
+    },
+    "Bold Sans": {
+      "label": "Fette Sans",
+      "note": "Moderne, schwere Ziffern — passen zu kräftiger Script."
+    },
+    "Fine Sans": {
+      "label": "Feine Sans",
+      "note": "Leichte Ziffern — passen zu feiner Script und Italic."
+    },
+    "Double-Struck": {
+      "label": "Konturziffern",
+      "note": "Umrissene Ziffern — die unerwartete Fine-Line-Wahl."
+    },
+    "Wide Spaced": {
+      "label": "Weit gesetzt",
+      "note": "Breite Ziffern — luftig und editorial gesetzt."
+    },
+    "Tiny": {
+      "label": "Winzig",
+      "note": "Miniatur-Ziffern — im Maßstab hinterm Ohr."
+    }
+  },
+  "groups": {
+    "minimal": "Fine Line & Minimal",
+    "celestial": "Himmlisch",
+    "love": "Liebe & Erinnerung",
+    "faith": "Glaube & Schutz",
+    "journey": "Stärke & Weg",
+    "music": "Musik & Kunst",
+    "zodiac": "Sternzeichen"
+  },
+  "symbols": {
+    ";": "Semikolon — die Geschichte geht weiter",
+    "∞": "Unendlichkeit — ohne Ende",
+    "·": "Einzelner Punkt — eine Pause",
+    "—": "Gedankenstrich — eine Linie, ein Weg",
+    "~": "Welle — Ruhe, Fluss",
+    "✕": "Kreuzzeichen — ein Kreuzungspunkt",
+    "°": "Kleiner Kreis — Ganzheit",
+    "⋮": "Drei Punkte — mi vida loca / unvollendet",
+    "☾": "Mondsichel — Wandel, Zyklen",
+    "☽": "Zunehmender Mond — Wachstum",
+    "☼": "Sonne — Lebenskraft",
+    "✦": "Vierzackiger Stern — Orientierung",
+    "✧": "Offener Stern — Hoffnung",
+    "⋆": "Kleiner Stern — ein stiller Funke",
+    "★": "Gefüllter Stern — Ehrgeiz",
+    "✵": "Strahlenstern — Energie",
+    "♡": "Offenes Herz — Liebe, leicht getragen",
+    "❥": "Gedrehtes Herz — Hingabe",
+    "❦": "Blumenherz — Andenken",
+    "➳": "Pfeil — von der Liebe getroffen",
+    "✿": "Blume — in voller Blüte",
+    "❀": "Blüte — Erinnerung an einen Menschen",
+    "✝": "Lateinisches Kreuz — Glaube",
+    "†": "Dolchkreuz — Opfer",
+    "☦": "Orthodoxes Kreuz",
+    "☯": "Yin und Yang — Balance",
+    "ॐ": "Om — der erste Klang",
+    "✡": "Davidstern",
+    "☪": "Stern und Halbmond",
+    "ᛉ": "Algiz-Rune — Schutz",
+    "⚓": "Anker — fester Halt",
+    "✈": "Flugzeug — gehen und wiederkommen",
+    "➵": "Pfeil — nur nach vorn",
+    "→": "Pfeil nach rechts — immer weiter",
+    "⚔": "Gekreuzte Schwerter — weiterkämpfen",
+    "♆": "Dreizack — das Meer",
+    "Δ": "Delta — Wandel",
+    "Ω": "Omega — das Ende, Ausdauer",
+    "♪": "Achtelnote",
+    "♫": "Verbundene Noten",
+    "♬": "Doppelt verbundene Noten",
+    "𝄞": "Violinschlüssel",
+    "✎": "Bleistift — Zeichen des Schaffens",
+    "♈": "Widder",
+    "♉": "Stier",
+    "♊": "Zwillinge",
+    "♋": "Krebs",
+    "♌": "Löwe",
+    "♍": "Jungfrau",
+    "♎": "Waage",
+    "♏": "Skorpion",
+    "♐": "Schütze",
+    "♑": "Steinbock",
+    "♒": "Wassermann",
+    "♓": "Fische"
+  }
+};
+</script>
 <script src="/styles.js" defer></script>
 <script src="/renderer.js" defer></script>
-<script src="/script.js" defer=""></script>
+<script src="/js/tattoo/tattooData.js" defer></script>
+<script src="/script.js" defer></script>
+<script src="/js/tattoo/tattooPageController.js" defer></script>
 <script src="/symbol-explorer.js" defer></script>
 <script src="/footer.js" defer></script>
 </body>

--- a/es/usecase/letras-para-tatuajes/index.html
+++ b/es/usecase/letras-para-tatuajes/index.html
@@ -14,7 +14,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Letras para Tatuajes — Tipos de Letra para tu Tattoo | UltraTextGen</title>
-  <meta name="description" content="Letras para tatuajes: escribe tu palabra o nombre y compara tipos de letra — cursiva, gótica, itálica — antes de la tinta. Enséñaselas a tu tatuador. Gratis.">
+  <meta name="description" content="Letras para tatuajes: compara cursiva, gótica e itálica sobre tu nombre, pasa una fecha a números romanos y prueba iniciales y símbolos — gratis.">
   <link rel="canonical" href="https://ultratextgen.com/es/usecase/letras-para-tatuajes/">
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/usecase/tattoo-fonts/">
   <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/usecase/tattoo-schrift/">
@@ -57,13 +57,30 @@
   "@context": "https://schema.org",
   "@type": "WebApplication",
   "name": "Letras para Tatuajes",
-  "alternateName": ["Tipos de letras para tatuajes", "Tipografía para tatuajes", "Fuentes para tatuajes", "Letras cursivas para tatuajes", "Letras góticas para tatuajes"],
+  "alternateName": [
+    "Tipos de letras para tatuajes",
+    "Tipografía para tatuajes",
+    "Fuentes para tatuajes",
+    "Letras cursivas para tatuajes",
+    "Letras góticas para tatuajes"
+  ],
   "url": "https://ultratextgen.com/es/usecase/letras-para-tatuajes/",
   "inLanguage": "es",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Any",
-  "description": "Previsualiza las letras de tu idea de tatuaje: escribe una palabra, un nombre o una fecha y compara cursiva, gótica, itálica y máquina de escribir — luego enséñale la captura a tu tatuador. Gratis, sin apps.",
-  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
+  "description": "Previsualiza las letras de tu tatuaje antes de la aguja: compara cursiva, gótica, itálica fina y máquina de escribir sobre tu nombre exacto, convierte una fecha en números romanos, crea monogramas con iniciales y explora símbolos para tatuajes con su significado — luego haz captura de tus favoritos y enséñasela a tu tatuador. Gratis, sin apps.",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "featureList": [
+    "Compara 10 estilos de letras para tatuajes sobre tu nombre o palabra exacta",
+    "Conversor de fechas y números a números romanos con formatos de tatuaje",
+    "Generador de monogramas de una letra o dos iniciales",
+    "Biblioteca de símbolos para tatuajes con su significado",
+    "Prueba de tinta — previsualiza el lettering a distancias reales"
+  ]
 }
 </script>
 
@@ -76,27 +93,50 @@
     {
       "@type": "Question",
       "name": "¿Cómo elegir el tipo de letra para un tatuaje?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Empieza por el significado, no por el diseño. ¿Un nombre o una declaración? Cursiva: cálida y atemporal. ¿Una palabra con fuerza, un lema? Gótica: densa y contundente. ¿Una frase corta? Itálica fina: discreta y elegante. ¿Una fecha? Números romanos o estilo máquina de escribir. Escribe tu texto arriba, compara los estilos lado a lado y quédate con los dos o tres que te digan algo — tu tatuador te ayudará a decidir." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Empieza por el significado, no por el diseño. ¿Un nombre o una declaración? Cursiva: cálida y atemporal. ¿Una palabra con fuerza, un lema? Gótica: densa y contundente. ¿Una frase corta? Itálica fina: discreta y elegante. ¿Una fecha? Números romanos o estilo máquina de escribir. Escribe tu texto arriba, compara los estilos lado a lado y quédate con los dos o tres que te digan algo — tu tatuador te ayudará a decidir."
+      }
     },
     {
       "@type": "Question",
       "name": "¿Qué letra queda mejor para tatuarse un nombre?",
-      "acceptedAnswer": { "@type": "Answer", "text": "La cursiva sigue siendo el gran clásico del nombre tatuado: las letras enlazadas dan un acabado manuscrito, personal, que envejece bien. Una cursiva gruesa (𝓛𝓾𝓬𝓲𝓪) tiene más presencia; una cursiva fina (𝓁𝓊𝒸𝒾𝒶), más delicadeza. Si el nombre es corto y quieres carácter, prueba también la gótica — muy habitual en el estilo chicano. Compara las dos en esta página antes de decidir." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "La cursiva sigue siendo el gran clásico del nombre tatuado: las letras enlazadas dan un acabado manuscrito, personal, que envejece bien. Una cursiva gruesa (𝓛𝓾𝓬𝓲𝓪) tiene más presencia; una cursiva fina (𝓁𝓊𝒸𝒾𝒶), más delicadeza. Si el nombre es corto y quieres carácter, prueba también la gótica — muy habitual en el estilo chicano. Compara las dos en esta página antes de decidir."
+      }
     },
     {
       "@type": "Question",
       "name": "¿Se pueden usar estas fuentes tal cual para un tatuaje?",
-      "acceptedAnswer": { "@type": "Answer", "text": "No, y es importante decirlo claro: estas letras Unicode son una base de trabajo, no un diseño listo para tatuar. Te sirven para elegir una dirección — cursiva, gótica, itálica — y enseñársela a tu tatuador sin rodeos. Él adaptará después el lettering a tu piel: grosor de los trazos, enlaces entre letras, curva de la zona elegida. El lettering final es su oficio." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No, y es importante decirlo claro: estas letras Unicode son una base de trabajo, no un diseño listo para tatuar. Te sirven para elegir una dirección — cursiva, gótica, itálica — y enseñársela a tu tatuador sin rodeos. Él adaptará después el lettering a tu piel: grosor de los trazos, enlaces entre letras, curva de la zona elegida. El lettering final es su oficio."
+      }
     },
     {
       "@type": "Question",
       "name": "¿Cuál es el tamaño mínimo para un tatuaje de letras finas?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Cuanto más fina y detallada es la letra, más espacio necesita. Los trazos muy finos y los bucles pequeños tienden a engrosarse y cerrarse con los años — una palabra en cursiva fina de menos de un centímetro de alto puede acabar siendo ilegible. Regla simple: si lo quieres pequeño, elige un estilo sencillo (itálica, máquina de escribir); si quieres cursiva adornada, dale espacio. Tu tatuador te dirá el tamaño mínimo exacto según la zona." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Cuanto más fina y detallada es la letra, más espacio necesita. Los trazos muy finos y los bucles pequeños tienden a engrosarse y cerrarse con los años — una palabra en cursiva fina de menos de un centímetro de alto puede acabar siendo ilegible. Regla simple: si lo quieres pequeño, elige un estilo sencillo (itálica, máquina de escribir); si quieres cursiva adornada, dale espacio. Tu tatuador te dirá el tamaño mínimo exacto según la zona."
+      }
     },
     {
       "@type": "Question",
       "name": "¿Cómo le enseño el estilo a mi tatuador?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Escribe tu palabra exacta (no una de ejemplo) arriba de la página, haz una captura de los dos o tres estilos que más te gusten y llévalos a la cita. Explícale qué te gusta de cada uno — «los enlaces de la cursiva», «el grosor de la gótica» — en vez de pedirle una copia píxel a píxel. Ojo con las tildes y la ñ: á, é o ñ suelen quedarse como letras normales en los estilos Unicode, pero tu tatuador las dibujará sin problema en el lettering final." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Escribe tu palabra exacta (no una de ejemplo) arriba de la página, haz una captura de los dos o tres estilos que más te gusten y llévalos a la cita. Explícale qué te gusta de cada uno — «los enlaces de la cursiva», «el grosor de la gótica» — en vez de pedirle una copia píxel a píxel. Ojo con las tildes y la ñ: á, é o ñ suelen quedarse como letras normales en los estilos Unicode, pero tu tatuador las dibujará sin problema en el lettering final."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Cómo se escribe una fecha en números romanos para un tatuaje?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Convierte cada parte de la fecha por separado — día, mes, año — y únelas con un separador: el 12 de junio de 2020 se convierte en XII·VI·MMXX. El modo Fecha → Romanos de esta página hace la conversión por ti y te deja comparar separadores (puntos, guiones, barras, líneas apiladas) y órdenes (día-mes-año o mes-día-año). Repasa los números con tu tatuador antes de la cita: una fecha mal convertida es el arrepentimiento más común en los tatuajes de letras."
+      }
     }
   ]
 }
@@ -137,26 +177,18 @@
   <div class="hero-inner">
     <div class="hero-card">
       <h1 class="hero-headline">Letras para tatuajes</h1>
-      <p class="hero-tagline">Escribe la palabra, el nombre o la fecha de tu idea de tatuaje y compara al instante los tipos de letra — cursiva, gótica, itálica, máquina de escribir. Haz captura de los estilos que te gusten y enséñaselos a tu tatuador: el lettering final lo dibuja él, esta página solo te ayuda a elegir la dirección.</p>
-      <div class="input-wrapper">
-        <textarea class="main-input" id="mainInput" placeholder="Escribe tu texto aquí…" maxlength="500" autofocus=""></textarea>
+      <p class="hero-tagline">Todo lo que necesita un tatuaje de letras, en un solo sitio: compara tipos de letras para tatuajes sobre tu nombre o palabra exacta, convierte una fecha en números romanos, crea un monograma con tus iniciales o elige un pequeño símbolo con significado. Haz captura de lo que te guste y enséñasela a tu tatuador: el lettering final lo dibuja él, esta página te ayuda a elegir la dirección.</p>
+      <div class="tattoo-mode-tabs" id="tattooModeTabs"></div>
+      <div class="input-wrapper" id="tattooTextWrap">
+        <textarea class="main-input" id="mainInput" placeholder="Escribe tu nombre, palabra o frase..." maxlength="500" autofocus=""></textarea>
         <span class="char-count"><span id="charCount">0</span>/500</span>
       </div>
-      <div class="decoration-section">
-        <div class="decoration-label">Añade decoración al resultado</div>
-        <div class="decoration-tabs">
-          <button class="decoration-tab active" data-deco-tab="symbols">Símbolos</button>
-          <button class="decoration-tab" data-deco-tab="frames">Marcos</button>
-          <button class="decoration-tab" data-deco-tab="minimal">Minimal</button>
-        </div>
-        <div class="decoration-grid" id="decorationGrid"></div>
-      </div>
+      <div id="tattooControlPanel"></div>
     </div>
   </div>
 </section>
 
 <main class="container">
-  <div class="category-section"><div class="category-tabs" id="categoryTabs"></div></div>
   <div class="results-grid" id="resultsGrid"></div>
 
   <!-- Visualiza antes de la aguja -->
@@ -252,6 +284,8 @@
     <div class="faq-item"><button class="faq-question" type="button">¿Se pueden usar estas fuentes tal cual para un tatuaje?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">No, y es importante decirlo claro: estas letras Unicode son una base de trabajo, no un diseño listo para tatuar. Te sirven para elegir una dirección — cursiva, gótica, itálica — y enseñársela a tu tatuador sin rodeos. Él adaptará después el lettering a tu piel: grosor de los trazos, enlaces entre letras, curva de la zona elegida. El lettering final es su oficio.</div></div>
     <div class="faq-item"><button class="faq-question" type="button">¿Cuál es el tamaño mínimo para un tatuaje de letras finas?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Cuanto más fina y detallada es la letra, más espacio necesita. Los trazos muy finos y los bucles pequeños tienden a engrosarse y cerrarse con los años — una palabra en cursiva fina de menos de un centímetro de alto puede acabar siendo ilegible. Regla simple: si lo quieres pequeño, elige un estilo sencillo (itálica, máquina de escribir); si quieres cursiva adornada, dale espacio. Tu tatuador te dirá el tamaño mínimo exacto según la zona.</div></div>
     <div class="faq-item"><button class="faq-question" type="button">¿Cómo le enseño el estilo a mi tatuador?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Escribe tu palabra exacta (no una de ejemplo) arriba de la página, haz una captura de los dos o tres estilos que más te gusten y llévalos a la cita. Explícale qué te gusta de cada uno — «los enlaces de la cursiva», «el grosor de la gótica» — en vez de pedirle una copia píxel a píxel. Ojo con las tildes y la ñ: á, é o ñ suelen quedarse como letras normales en los estilos Unicode, pero tu tatuador las dibujará sin problema en el lettering final.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">¿Cómo se escribe una fecha en números romanos para un tatuaje?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Convierte cada parte de la fecha por separado — día, mes, año — y únelas con un separador: el 12 de junio de 2020 se convierte en XII·VI·MMXX. El modo Fecha → Romanos de esta página hace la conversión por ti y te deja comparar separadores (puntos, guiones, barras, líneas apiladas) y órdenes (día-mes-año o mes-día-año). Repasa los números con tu tatuador antes de la cita: una fecha mal convertida es el arrepentimiento más común en los tatuajes de letras.</div></div>
+
 
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="Selector de idioma">
@@ -272,9 +306,234 @@
 <div class="copy-toast" id="copyToast">Copiado</div>
 <div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
 
-<script src="/styles.js"></script>
-<script src="/renderer.js"></script>
+<!-- Page configuration: tattoo mode flag + i18n -->
+<script>
+window.UTG_TATTOO_MODE = true;
+window.tattooI18n = {
+  "sampleName": "Lucía",
+  "modeNamesLabel": "Nombres y palabras",
+  "modeNamesHint": "Escribe un nombre, palabra o frase",
+  "modeDateLabel": "Fecha → Romanos",
+  "modeDateHint": "Convierte una fecha o número en números romanos",
+  "modeLettersLabel": "Letras e iniciales",
+  "modeLettersHint": "Letras sueltas y monogramas",
+  "modeSymbolsLabel": "Símbolos",
+  "modeSymbolsHint": "Pequeños símbolos con significado",
+  "sizeClose": "De cerca",
+  "sizeArm": "A un brazo",
+  "sizeRoom": "Desde lejos",
+  "inkTest": "Prueba de tinta",
+  "yourDate": "Tu fecha",
+  "day": "Día",
+  "month": "Mes",
+  "yearOrNumber": "Año o número",
+  "order": "Orden",
+  "separator": "Separador",
+  "yourLetter": "Tu letra",
+  "secondInitial": "Segunda inicial",
+  "secondNone": "Ninguna — letra suelta",
+  "joinedBy": "Unidas por",
+  "symbolsNote": "Toca cualquier símbolo para copiarlo — combínalo con un nombre o una fecha, o llévalo solo.",
+  "sampleHintName": "Mostrando «{text}» — escribe tu nombre, palabra o frase arriba.",
+  "sampleHintDate": "Mostrando una fecha de ejemplo (12 · 6 · 2020) — introduce tu fecha o número arriba.",
+  "romanRange": "Los números romanos cubren del 1 al 3999 — revisa los valores de arriba.",
+  "headingRoman": "Números romanos",
+  "headingFigures": "Cifras normales",
+  "badgeSafe": "aguanta en pequeño",
+  "badgeRoomy": "necesita espacio",
+  "copy": "Copiar",
+  "copyAria": "Copiar {name}",
+  "families": {
+    "Script": "Cursiva",
+    "Gothic": "Gótica",
+    "Italic": "Itálica",
+    "Minimal": "Minimal",
+    "Roman": "Romanos",
+    "Figures": "Cifras"
+  },
+  "orders": {
+    "dmy": "Día · Mes · Año",
+    "mdy": "Mes · Día · Año",
+    "y": "Solo el año"
+  },
+  "seps": {
+    "space": "espacio",
+    "stack": "apilado"
+  },
+  "joiners": {
+    "none": "Ninguno"
+  },
+  "lettering": {
+    "Ultra Script Bold": {
+      "label": "Cursiva Gruesa",
+      "note": "El gran clásico del nombre tatuado — enlazada y cálida, mantiene su forma en tamaños pequeños."
+    },
+    "Ultra Script": {
+      "label": "Cursiva Fina",
+      "note": "Delicada y ligera — preciosa en tamaño medio; los bucles finos necesitan espacio para envejecer bien."
+    },
+    "Ultra Chicano Script": {
+      "label": "Placa Chicano",
+      "note": "Cursiva gruesa dentro de un banner ornamental — el marco clásico del nombre tatuado."
+    },
+    "Ultra Gothic": {
+      "label": "Gótica",
+      "note": "Blackletter estilo Fraktur — densa y contundente, hecha para llevar una palabra con fuerza."
+    },
+    "Ultra Gothic Bold": {
+      "label": "Old English Gruesa",
+      "note": "El look Old English pesado — un básico del lettering old school y chicano."
+    },
+    "Ultra Old English Banner": {
+      "label": "Banner Old English",
+      "note": "Blackletter pesada dentro de un banner — un nombre con la máxima presencia."
+    },
+    "Ultra Italic": {
+      "label": "Itálica Fina",
+      "note": "Inclinación discreta — se desliza en silencio por una costilla, una muñeca o una clavícula."
+    },
+    "Ultra Italic Serif": {
+      "label": "Itálica Serif",
+      "note": "Itálica con serifas, de aire literario — se lee como una línea sacada de una novela."
+    },
+    "Ultra Typewriter Document": {
+      "label": "Máquina de Escribir",
+      "note": "Monoespaciada, cruda y literaria — perfecta para una fecha o una frase corta."
+    },
+    "Ultra Small Caps": {
+      "label": "Versalitas",
+      "note": "Mayúsculas diminutas y uniformes — la elección minimalista de línea fina."
+    }
+  },
+  "roman": {
+    "Classic": {
+      "label": "Clásicos",
+      "note": "Mayúsculas sencillas — lo que tatúa la mayoría de tatuadores."
+    },
+    "Serif Italic": {
+      "label": "Serif Itálica",
+      "note": "El look de monumento grabado, inclinado."
+    },
+    "Script": {
+      "label": "Cursiva",
+      "note": "Números romanos en cursiva fluida."
+    },
+    "Blackletter": {
+      "label": "Blackletter",
+      "note": "Números en Fraktur — oscuros y ornamentados."
+    },
+    "Heavy Old English": {
+      "label": "Old English Gruesa",
+      "note": "Números blackletter de máximo peso."
+    },
+    "Typewriter": {
+      "label": "Máquina de Escribir",
+      "note": "Números monoespaciados — limpios y documentales."
+    }
+  },
+  "digits": {
+    "Typewriter": {
+      "label": "Máquina de Escribir",
+      "note": "Cifras monoespaciadas — el look clásico de fecha."
+    },
+    "Bold Serif": {
+      "label": "Serif Gruesa",
+      "note": "Cifras de libro con peso — combinan con la blackletter."
+    },
+    "Bold Sans": {
+      "label": "Sans Gruesa",
+      "note": "Cifras modernas y pesadas — combinan con la cursiva gruesa."
+    },
+    "Fine Sans": {
+      "label": "Sans Fina",
+      "note": "Cifras ligeras — combinan con la cursiva fina y la itálica."
+    },
+    "Double-Struck": {
+      "label": "Doble Trazo",
+      "note": "Cifras con contorno — una elección inesperada de línea fina."
+    },
+    "Wide Spaced": {
+      "label": "Espaciada",
+      "note": "Cifras de ancho completo — espaciado aireado, editorial."
+    },
+    "Tiny": {
+      "label": "Diminuta",
+      "note": "Cifras en miniatura — a escala de detrás de la oreja."
+    }
+  },
+  "groups": {
+    "minimal": "Línea fina y minimal",
+    "celestial": "Celestial",
+    "love": "Amor y recuerdo",
+    "faith": "Fe y protección",
+    "journey": "Fuerza y camino",
+    "music": "Música y arte",
+    "zodiac": "Zodiaco"
+  },
+  "symbols": {
+    ";": "Punto y coma — la historia continúa",
+    "∞": "Infinito — sin final",
+    "·": "Punto — una pausa",
+    "—": "Guion largo — una línea, un camino",
+    "~": "Ola — calma, fluir",
+    "✕": "Cruz en aspa — un punto de cruce",
+    "°": "Círculo pequeño — plenitud",
+    "⋮": "Tres puntos — mi vida loca / inacabado",
+    "☾": "Luna creciente — cambio, ciclos",
+    "☽": "Luna en cuarto creciente — crecimiento",
+    "☼": "Sol — vitalidad",
+    "✦": "Estrella de cuatro puntas — guía",
+    "✧": "Estrella hueca — esperanza",
+    "⋆": "Estrella pequeña — una chispa serena",
+    "★": "Estrella llena — ambición",
+    "✵": "Estrella con rayos — energía",
+    "♡": "Corazón hueco — amor, con ligereza",
+    "❥": "Corazón inclinado — devoción",
+    "❦": "Corazón floral — recuerdo",
+    "➳": "Flecha — flechado de amor",
+    "✿": "Flor — en plena flor",
+    "❀": "Flor abierta — la memoria de alguien",
+    "✝": "Cruz latina — fe",
+    "†": "Cruz daga — sacrificio",
+    "☦": "Cruz ortodoxa",
+    "☯": "Yin yang — equilibrio",
+    "ॐ": "Om — el primer sonido",
+    "✡": "Estrella de David",
+    "☪": "Estrella y media luna",
+    "ᛉ": "Runa Algiz — protección",
+    "⚓": "Ancla — mantente firme",
+    "✈": "Avión — irse, volver",
+    "➵": "Flecha — solo hacia delante",
+    "→": "Flecha a la derecha — siempre adelante",
+    "⚔": "Espadas cruzadas — sigue luchando",
+    "♆": "Tridente — el mar",
+    "Δ": "Delta — cambio",
+    "Ω": "Omega — el final, la resistencia",
+    "♪": "Corchea",
+    "♫": "Corcheas unidas",
+    "♬": "Semicorcheas unidas",
+    "𝄞": "Clave de sol",
+    "✎": "Lápiz — la marca del creador",
+    "♈": "Aries",
+    "♉": "Tauro",
+    "♊": "Géminis",
+    "♋": "Cáncer",
+    "♌": "Leo",
+    "♍": "Virgo",
+    "♎": "Libra",
+    "♏": "Escorpio",
+    "♐": "Sagitario",
+    "♑": "Capricornio",
+    "♒": "Acuario",
+    "♓": "Piscis"
+  }
+};
+</script>
+<script src="/styles.js" defer></script>
+<script src="/renderer.js" defer></script>
+<script src="/js/tattoo/tattooData.js" defer></script>
 <script src="/script.js" defer></script>
+<script src="/js/tattoo/tattooPageController.js" defer></script>
 <script src="/symbol-explorer.js"></script>
 <script src="/footer.js" defer></script>
 </body>

--- a/fr/usecase/ecriture-tatouage/index.html
+++ b/fr/usecase/ecriture-tatouage/index.html
@@ -11,7 +11,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Style d'Écriture Tatouage — Teste ton Texte Avant l'Encre | UltraTextGen</title>
-  <meta name="description" content="Style d'écriture tatouage : tape ton mot, prénom ou date et compare cursive, gothique et italique avant l'encre. Screenshote et montre à ton tatoueur — gratuit.">
+  <meta name="description" content="Écriture tatouage : compare cursive, gothique et script sur ton prénom exact, passe une date en chiffres romains, teste initiales et symboles — gratuit.">
   <link rel="canonical" href="https://ultratextgen.com/fr/usecase/ecriture-tatouage/">
 
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/usecase/tattoo-fonts/">
@@ -49,13 +49,30 @@
   "@context": "https://schema.org",
   "@type": "WebApplication",
   "name": "Style d'Écriture pour Tatouage",
-  "alternateName": ["Écriture Tatouage", "Style d'Écriture Tatouage", "Écriture Stylée Tatouage", "Écriture Italique Tatouage", "Police Tatouage en Ligne"],
+  "alternateName": [
+    "Écriture Tatouage",
+    "Style d'Écriture Tatouage",
+    "Écriture Stylée Tatouage",
+    "Écriture Italique Tatouage",
+    "Police Tatouage en Ligne"
+  ],
   "url": "https://ultratextgen.com/fr/usecase/ecriture-tatouage/",
   "inLanguage": "fr",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Any",
-  "description": "Prévisualise le style d'écriture de ton idée de tatouage : tape un mot, un prénom ou une date et compare les rendus cursive, gothique, italique et machine à écrire — puis montre le screenshot à ton tatoueur. Gratuit, sans appli.",
-  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "EUR" }
+  "description": "Prévisualise ton lettrage tatouage avant l'aiguille : compare cursive, gothique, italique fine et machine à écrire sur ton prénom exact, convertis une date en chiffres romains, compose des monogrammes et parcours les symboles tatouage avec leur signification — puis screenshote tes préférés et montre-les à ton tatoueur. Gratuit, sans appli.",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "EUR"
+  },
+  "featureList": [
+    "Compare 10 styles de lettrage tatouage sur ton prénom ou ton mot exact",
+    "Convertisseur de dates et de nombres en chiffres romains, aux formats tatouage",
+    "Générateur de lettres seules et de monogrammes à deux initiales",
+    "Bibliothèque de symboles tatouage avec leur signification",
+    "Test d'encre — prévisualise le lettrage à des distances de lecture réelles"
+  ]
 }
 </script>
 
@@ -68,27 +85,50 @@
     {
       "@type": "Question",
       "name": "Comment choisir un style d'écriture pour un tatouage ?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Pars du sens, pas du look. Un prénom ou une déclaration → cursive, chaleureuse et intemporelle. Un mot fort, une devise → gothique, dense et affirmé. Une citation courte → italique fine, discrète et élégante. Une date → chiffres romains ou style machine à écrire. Tape ton texte en haut de la page, compare les rendus côte à côte et garde les deux ou trois qui te parlent — ton tatoueur t'aidera à trancher." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Pars du sens, pas du look. Un prénom ou une déclaration → cursive, chaleureuse et intemporelle. Un mot fort, une devise → gothique, dense et affirmé. Une citation courte → italique fine, discrète et élégante. Une date → chiffres romains ou style machine à écrire. Tape ton texte en haut de la page, compare les rendus côte à côte et garde les deux ou trois qui te parlent — ton tatoueur t'aidera à trancher."
+      }
     },
     {
       "@type": "Question",
       "name": "Quelle écriture pour un prénom tatoué ?",
-      "acceptedAnswer": { "@type": "Answer", "text": "La cursive reste le grand classique du prénom tatoué : les lettres liées donnent un rendu manuscrit, personnel, qui vieillit bien. Une script grasse (𝓜𝓪𝓷𝓸𝓷) a plus de présence, une script fine (𝓂𝒶𝓃ℴ𝓃) plus de délicatesse. Si le prénom est court et que tu veux du caractère, essaie aussi le gothique — très courant dans le style chicano. Compare les deux sur cette page avant de décider." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "La cursive reste le grand classique du prénom tatoué : les lettres liées donnent un rendu manuscrit, personnel, qui vieillit bien. Une script grasse (𝓜𝓪𝓷𝓸𝓷) a plus de présence, une script fine (𝓂𝒶𝓃ℴ𝓃) plus de délicatesse. Si le prénom est court et que tu veux du caractère, essaie aussi le gothique — très courant dans le style chicano. Compare les deux sur cette page avant de décider."
+      }
     },
     {
       "@type": "Question",
       "name": "Peut-on utiliser ces polices telles quelles pour un tatouage ?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Non, et c'est important de le dire : ces rendus Unicode sont une base de travail, pas un dessin prêt à encrer. Ils te servent à choisir une direction — cursive, gothique, italique — et à la montrer clairement à ton tatoueur. Lui adaptera ensuite le lettrage à ta peau : épaisseur des traits, liaisons entre les lettres, courbe de l'emplacement. Le lettrage final, c'est son métier." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Non, et c'est important de le dire : ces rendus Unicode sont une base de travail, pas un dessin prêt à encrer. Ils te servent à choisir une direction — cursive, gothique, italique — et à la montrer clairement à ton tatoueur. Lui adaptera ensuite le lettrage à ta peau : épaisseur des traits, liaisons entre les lettres, courbe de l'emplacement. Le lettrage final, c'est son métier."
+      }
     },
     {
       "@type": "Question",
       "name": "Quelle taille minimale pour une écriture fine ?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Plus l'écriture est fine et détaillée, plus il lui faut de place. Les traits très fins et les petites boucles ont tendance à s'épaissir et à se refermer avec les années — un mot en script fine de moins d'un centimètre de haut risque de devenir illisible. Règle simple : si tu veux petit, choisis un style simple (italique, machine à écrire) ; si tu veux de la cursive ornée, prévois de la place. Ton tatoueur te donnera la taille minimale exacte selon l'emplacement." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Plus l'écriture est fine et détaillée, plus il lui faut de place. Les traits très fins et les petites boucles ont tendance à s'épaissir et à se refermer avec les années — un mot en script fine de moins d'un centimètre de haut risque de devenir illisible. Règle simple : si tu veux petit, choisis un style simple (italique, machine à écrire) ; si tu veux de la cursive ornée, prévois de la place. Ton tatoueur te donnera la taille minimale exacte selon l'emplacement."
+      }
     },
     {
       "@type": "Question",
       "name": "Comment montrer le style à mon tatoueur ?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Tape ton mot exact (pas un mot d'exemple) en haut de la page, fais un screenshot des deux ou trois rendus que tu préfères et apporte-les au rendez-vous. Précise ce qui te plaît dans chacun — «les liaisons de la cursive», «l'épaisseur du gothique» — plutôt que de demander une copie pixel par pixel. Attention aux accents : é, à ou ç restent souvent en lettres normales dans les rendus Unicode, mais ton tatoueur les dessinera sans problème dans le lettrage final." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Tape ton mot exact (pas un mot d'exemple) en haut de la page, fais un screenshot des deux ou trois rendus que tu préfères et apporte-les au rendez-vous. Précise ce qui te plaît dans chacun — «les liaisons de la cursive», «l'épaisseur du gothique» — plutôt que de demander une copie pixel par pixel. Attention aux accents : é, à ou ç restent souvent en lettres normales dans les rendus Unicode, mais ton tatoueur les dessinera sans problème dans le lettrage final."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Comment écrire une date en chiffres romains pour un tatouage ?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Convertis chaque partie de la date séparément — jour, mois, année — puis relie-les avec un séparateur : 12 juin 2020 devient XII·VI·MMXX. Le mode Date → Romains de cette page fait la conversion pour toi et te laisse comparer les séparateurs (points, tirets, barres, lignes empilées) et les ordres (jour-mois-année ou mois-jour-année). Vérifie bien les chiffres avec ton tatoueur avant le rendez-vous : une date mal convertie est le regret numéro un des tatouages écrits."
+      }
     }
   ]
 }
@@ -125,9 +165,10 @@
   <div class="hero-inner">
     <div class="hero-card">
       <h1 class="hero-headline">Style d'écriture pour tatouage</h1>
-      <p class="hero-tagline">Tape le mot, le prénom ou la date de ton idée de tatouage et compare aussitôt les styles — cursive, gothique, italique, machine à écrire. Screenshot les rendus qui te plaisent et montre-les à ton tatoueur : c'est lui qui dessinera le lettrage final, cette page t'aide juste à choisir la direction.</p>
-      <div class="input-wrapper">
-        <textarea class="main-input" id="mainInput" placeholder="Tape ton texte ici…" maxlength="500" autofocus=""></textarea>
+      <p class="hero-tagline">Tout ce qu'il faut pour un tatouage écrit, au même endroit : compare les écritures tatouage sur ton prénom ou ton mot exact, convertis une date en chiffres romains, compose un monogramme de lettres ou choisis un petit symbole chargé de sens. Screenshote ce qui te plaît et montre-le à ton tatoueur — c'est lui qui dessinera le lettrage final, cette page t'aide juste à choisir la direction.</p>
+      <div class="tattoo-mode-tabs" id="tattooModeTabs"></div>
+      <div class="input-wrapper" id="tattooTextWrap">
+        <textarea class="main-input" id="mainInput" placeholder="Tape ton prénom, ton mot ou ta citation…" maxlength="500" autofocus=""></textarea>
         <span class="char-count"><span id="charCount">0</span>/500</span>
       </div>
       <div class="accent-notice" id="accentNotice" role="note" hidden>
@@ -135,21 +176,12 @@
         <span class="accent-notice-text">Ton texte contient des accents. La plupart des styles laissent <b>é</b>, <b>à</b> ou <b>ç</b> en lettres normales — les styles <b>barré, souligné et cadres</b> les gardent. <a href="/guide/fancy-fonts-and-accents/">Quels styles gardent les accents →</a></span>
         <button type="button" class="accent-notice-close" id="accentNoticeClose" aria-label="Fermer">✕</button>
       </div>
-      <div class="decoration-section">
-        <div class="decoration-label">Ajoute un peu de déco autour du résultat</div>
-        <div class="decoration-tabs">
-          <button class="decoration-tab active" data-deco-tab="symbols">Symboles</button>
-          <button class="decoration-tab" data-deco-tab="frames">Cadres</button>
-          <button class="decoration-tab" data-deco-tab="minimal">Minimaliste</button>
-        </div>
-        <div class="decoration-grid" id="decorationGrid"></div>
-      </div>
+      <div id="tattooControlPanel"></div>
     </div>
   </div>
 </section>
 
 <main class="container">
-  <div class="category-section"><div class="category-tabs" id="categoryTabs"></div></div>
   <div class="results-grid" id="resultsGrid"></div>
 
   <!-- Visualise avant l'aiguille -->
@@ -245,6 +277,8 @@
     <div class="faq-item"><button class="faq-question" type="button">Peut-on utiliser ces polices telles quelles pour un tatouage ?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Non, et c'est important de le dire : ces rendus Unicode sont une base de travail, pas un dessin prêt à encrer. Ils te servent à choisir une direction — cursive, gothique, italique — et à la montrer clairement à ton tatoueur. Lui adaptera ensuite le lettrage à ta peau : épaisseur des traits, liaisons entre les lettres, courbe de l'emplacement. Le lettrage final, c'est son métier.</div></div>
     <div class="faq-item"><button class="faq-question" type="button">Quelle taille minimale pour une écriture fine ?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Plus l'écriture est fine et détaillée, plus il lui faut de place. Les traits très fins et les petites boucles ont tendance à s'épaissir et à se refermer avec les années — un mot en script fine de moins d'un centimètre de haut risque de devenir illisible. Règle simple : si tu veux petit, choisis un style simple (italique, machine à écrire) ; si tu veux de la cursive ornée, prévois de la place. Ton tatoueur te donnera la taille minimale exacte selon l'emplacement.</div></div>
     <div class="faq-item"><button class="faq-question" type="button">Comment montrer le style à mon tatoueur ?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Tape ton mot exact (pas un mot d'exemple) en haut de la page, fais un screenshot des deux ou trois rendus que tu préfères et apporte-les au rendez-vous. Précise ce qui te plaît dans chacun — «les liaisons de la cursive», «l'épaisseur du gothique» — plutôt que de demander une copie pixel par pixel. Attention aux accents : é, à ou ç restent souvent en lettres normales dans les rendus Unicode, mais ton tatoueur les dessinera sans problème dans le lettrage final.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Comment écrire une date en chiffres romains pour un tatouage ?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Convertis chaque partie de la date séparément — jour, mois, année — puis relie-les avec un séparateur : 12 juin 2020 devient XII·VI·MMXX. Le mode Date → Romains de cette page fait la conversion pour toi et te laisse comparer les séparateurs (points, tirets, barres, lignes empilées) et les ordres (jour-mois-année ou mois-jour-année). Vérifie bien les chiffres avec ton tatoueur avant le rendez-vous : une date mal convertie est le regret numéro un des tatouages écrits.</div></div>
+
 
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="Sélecteur de langue">
@@ -265,9 +299,234 @@
 <div class="copy-toast" id="copyToast">Copié !</div>
 <div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
 
-<script src="/styles.js"></script>
-<script src="/renderer.js"></script>
-<script src="/script.js" defer=""></script>
+<!-- Page configuration: tattoo mode flag + i18n -->
+<script>
+window.UTG_TATTOO_MODE = true;
+window.tattooI18n = {
+  "sampleName": "Manon",
+  "modeNamesLabel": "Prénoms & mots",
+  "modeNamesHint": "Tape un prénom, un mot ou une citation",
+  "modeDateLabel": "Date → Romains",
+  "modeDateHint": "Convertis une date ou un nombre en chiffres romains",
+  "modeLettersLabel": "Lettres & initiales",
+  "modeLettersHint": "Lettres seules et monogrammes",
+  "modeSymbolsLabel": "Symboles",
+  "modeSymbolsHint": "Petits symboles chargés de sens",
+  "sizeClose": "De près",
+  "sizeArm": "À bout de bras",
+  "sizeRoom": "De loin",
+  "inkTest": "Test d'encre",
+  "yourDate": "Ta date",
+  "day": "Jour",
+  "month": "Mois",
+  "yearOrNumber": "Année ou nombre",
+  "order": "Ordre",
+  "separator": "Séparateur",
+  "yourLetter": "Ta lettre",
+  "secondInitial": "Seconde initiale",
+  "secondNone": "Aucune — lettre seule",
+  "joinedBy": "Reliées par",
+  "symbolsNote": "Touche un symbole pour le copier — associe-le à un prénom ou une date, ou porte-le seul.",
+  "sampleHintName": "Aperçu avec « {text} » — tape ton prénom, ton mot ou ta citation ci-dessus.",
+  "sampleHintDate": "Aperçu avec une date d'exemple (12 · 6 · 2020) — saisis ta date ou ton nombre ci-dessus.",
+  "romanRange": "Les chiffres romains couvrent 1–3999 — vérifie les valeurs ci-dessus.",
+  "headingRoman": "Chiffres romains",
+  "headingFigures": "Chiffres simples",
+  "badgeSafe": "tient en petit",
+  "badgeRoomy": "demande de la place",
+  "copy": "Copier",
+  "copyAria": "Copier {name}",
+  "families": {
+    "Script": "Script",
+    "Gothic": "Gothique",
+    "Italic": "Italique",
+    "Minimal": "Minimaliste",
+    "Roman": "Romains",
+    "Figures": "Chiffres"
+  },
+  "orders": {
+    "dmy": "Jour · Mois · Année",
+    "mdy": "Mois · Jour · Année",
+    "y": "Année seule"
+  },
+  "seps": {
+    "space": "espace",
+    "stack": "empilé"
+  },
+  "joiners": {
+    "none": "Aucun"
+  },
+  "lettering": {
+    "Ultra Script Bold": {
+      "label": "Script grasse",
+      "note": "Le grand classique du prénom tatoué — liée et chaleureuse, elle garde sa forme en petit."
+    },
+    "Ultra Script": {
+      "label": "Script fine",
+      "note": "Délicate et aérienne — superbe en taille moyenne ; ses boucles fines demandent de la place pour bien vieillir."
+    },
+    "Ultra Chicano Script": {
+      "label": "Banderole Chicano",
+      "note": "Une script grasse dans une banderole ornementale — l'encadrement classique du prénom."
+    },
+    "Ultra Gothic": {
+      "label": "Gothique Fraktur",
+      "note": "Blackletter Fraktur — dense et affirmé, fait pour porter un mot fort."
+    },
+    "Ultra Gothic Bold": {
+      "label": "Old English épais",
+      "note": "Le look Old English épais — un incontournable du lettrage old school et chicano."
+    },
+    "Ultra Old English Banner": {
+      "label": "Banderole Old English",
+      "note": "Un blackletter massif dans une banderole — le prénom avec un maximum de présence."
+    },
+    "Ultra Italic": {
+      "label": "Italique fine",
+      "note": "Une inclinaison discrète — se glisse le long d'une côte, d'un poignet ou d'une clavicule."
+    },
+    "Ultra Italic Serif": {
+      "label": "Italique serif",
+      "note": "Une italique à empattements, littéraire — comme une ligne tirée d'un roman."
+    },
+    "Ultra Typewriter Document": {
+      "label": "Machine à écrire",
+      "note": "Une monospace brute et littéraire — parfaite pour une date ou une phrase courte."
+    },
+    "Ultra Small Caps": {
+      "label": "Petites capitales",
+      "note": "De petites capitales régulières — le choix minimaliste en fine line."
+    }
+  },
+  "roman": {
+    "Classic": {
+      "label": "Classique",
+      "note": "Des capitales simples — ce que la plupart des tatoueurs encrent."
+    },
+    "Serif Italic": {
+      "label": "Serif italique",
+      "note": "Le look monument gravé, version inclinée."
+    },
+    "Script": {
+      "label": "Script",
+      "note": "Des chiffres romains en script fluide."
+    },
+    "Blackletter": {
+      "label": "Blackletter",
+      "note": "Des chiffres en Fraktur — sombres et ornés."
+    },
+    "Heavy Old English": {
+      "label": "Old English épais",
+      "note": "Des chiffres blackletter au poids maximal."
+    },
+    "Typewriter": {
+      "label": "Machine à écrire",
+      "note": "Des chiffres monospace — nets et documentaires."
+    }
+  },
+  "digits": {
+    "Typewriter": {
+      "label": "Machine à écrire",
+      "note": "Des chiffres monospace — le look classique de la date."
+    },
+    "Bold Serif": {
+      "label": "Serif grasse",
+      "note": "Des chiffres serif épais — se marient avec le blackletter."
+    },
+    "Bold Sans": {
+      "label": "Sans grasse",
+      "note": "Des chiffres épais et modernes — se marient avec la script grasse."
+    },
+    "Fine Sans": {
+      "label": "Sans fine",
+      "note": "Des chiffres légers — se marient avec la script fine et l'italique."
+    },
+    "Double-Struck": {
+      "label": "Ajouré",
+      "note": "Des chiffres évidés — un choix fine line inattendu."
+    },
+    "Wide Spaced": {
+      "label": "Espacé large",
+      "note": "Des chiffres pleine chasse — un espacement aéré, éditorial."
+    },
+    "Tiny": {
+      "label": "Minuscule",
+      "note": "Des chiffres miniatures — l'échelle derrière l'oreille."
+    }
+  },
+  "groups": {
+    "minimal": "Fine line & minimaliste",
+    "celestial": "Céleste",
+    "love": "Amour & souvenir",
+    "faith": "Foi & protection",
+    "journey": "Force & voyage",
+    "music": "Musique & art",
+    "zodiac": "Zodiaque"
+  },
+  "symbols": {
+    ";": "Point-virgule — l'histoire continue",
+    "∞": "Infini — sans fin",
+    "·": "Point seul — une pause",
+    "—": "Tiret — une ligne, un chemin",
+    "~": "Vague — calme, fluidité",
+    "✕": "Croix en X — un point de croisement",
+    "°": "Petit cercle — la plénitude",
+    "⋮": "Trois points — mi vida loca / inachevé",
+    "☾": "Croissant de lune — changement, cycles",
+    "☽": "Lune croissante — la croissance",
+    "☼": "Soleil — vitalité",
+    "✦": "Étoile à quatre branches — un guide",
+    "✧": "Étoile évidée — l'espoir",
+    "⋆": "Petite étoile — une étincelle discrète",
+    "★": "Étoile pleine — l'ambition",
+    "✵": "Étoile rayonnante — l'énergie",
+    "♡": "Cœur évidé — l'amour, en toute légèreté",
+    "❥": "Cœur incliné — la dévotion",
+    "❦": "Cœur floral — le souvenir",
+    "➳": "Flèche — frappé par l'amour",
+    "✿": "Fleur — en pleine floraison",
+    "❀": "Fleur épanouie — le souvenir de quelqu'un",
+    "✝": "Croix latine — la foi",
+    "†": "Croix dague — le sacrifice",
+    "☦": "Croix orthodoxe",
+    "☯": "Yin et yang — l'équilibre",
+    "ॐ": "Om — le premier son",
+    "✡": "Étoile de David",
+    "☪": "Étoile et croissant",
+    "ᛉ": "Rune Algiz — la protection",
+    "⚓": "Ancre — tenir bon",
+    "✈": "Avion — partir, revenir",
+    "➵": "Flèche — toujours en avant",
+    "→": "Flèche vers la droite — aller de l'avant",
+    "⚔": "Épées croisées — continuer le combat",
+    "♆": "Trident — la mer",
+    "Δ": "Delta — le changement",
+    "Ω": "Oméga — la fin, l'endurance",
+    "♪": "Croche",
+    "♫": "Notes liées",
+    "♬": "Doubles croches liées",
+    "𝄞": "Clé de sol",
+    "✎": "Crayon — la marque du créateur",
+    "♈": "Bélier",
+    "♉": "Taureau",
+    "♊": "Gémeaux",
+    "♋": "Cancer",
+    "♌": "Lion",
+    "♍": "Vierge",
+    "♎": "Balance",
+    "♏": "Scorpion",
+    "♐": "Sagittaire",
+    "♑": "Capricorne",
+    "♒": "Verseau",
+    "♓": "Poissons"
+  }
+};
+</script>
+<script src="/styles.js" defer></script>
+<script src="/renderer.js" defer></script>
+<script src="/js/tattoo/tattooData.js" defer></script>
+<script src="/script.js" defer></script>
+<script src="/js/tattoo/tattooPageController.js" defer></script>
 <script src="/symbol-explorer.js"></script>
 <script src="/accent-notice.js" defer></script>
 <script src="/footer.js"></script>

--- a/id/usecase/font-tato/index.html
+++ b/id/usecase/font-tato/index.html
@@ -11,7 +11,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Font Tato — Tes Tulisan Tatomu Sebelum Ditinta | UltraTextGen</title>
-  <meta name="description" content="Font tato &amp; huruf tato: ketik kata, nama, atau tanggal dan bandingkan tulisan tato kursif, gotik, dan italic sebelum ditinta. Screenshot, tunjukin ke artist-mu — gratis.">
+  <meta name="description" content="Font tato: bandingkan huruf kursif, gotik, dan script di namamu, ubah tanggal jadi angka romawi, dan preview inisial serta simbol — gratis, sebelum ditinta.">
   <link rel="canonical" href="https://ultratextgen.com/id/usecase/font-tato/">
 
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/usecase/tattoo-fonts/">
@@ -49,13 +49,31 @@
   "@context": "https://schema.org",
   "@type": "WebApplication",
   "name": "Font Tulisan Tato",
-  "alternateName": ["Font Tato", "Huruf Tato", "Tulisan Tato", "Font Tulisan Tato", "Font Tato Keren", "Generator Huruf Tato"],
+  "alternateName": [
+    "Font Tato",
+    "Huruf Tato",
+    "Tulisan Tato",
+    "Font Tulisan Tato",
+    "Font Tato Keren",
+    "Generator Huruf Tato"
+  ],
   "url": "https://ultratextgen.com/id/usecase/font-tato/",
   "inLanguage": "id",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Any",
-  "description": "Preview tulisan tato kamu sebelum ditinta: ketik kata, nama, atau tanggal dan bandingkan font tato kursif, gotik, italic, dan mesin tik — lalu screenshot dan tunjukin ke tattoo artist. Gratis, tanpa aplikasi.",
-  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
+  "description": "Preview tulisan tato sebelum ditinta: bandingkan font tato kursif, gotik, italic tipis, dan mesin tik di nama kamu yang sebenarnya, ubah tanggal jadi angka romawi, bikin monogram huruf, dan jelajahi simbol tato beserta maknanya — lalu screenshot favoritmu dan tunjukin ke tattoo artist. Gratis, tanpa aplikasi.",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "featureList": [
+    "Bandingkan 10 gaya tulisan tato di nama atau kata kamu yang sebenarnya",
+    "Konverter tanggal dan angka ke angka romawi dengan format tato",
+    "Generator huruf tunggal dan monogram dua inisial",
+    "Perpustakaan simbol tato lengkap dengan maknanya",
+    "Tes tinta — preview tulisan di ukuran pandang dunia nyata"
+  ]
 }
 </script>
 
@@ -68,27 +86,50 @@
     {
       "@type": "Question",
       "name": "Gimana cara milih font tato yang pas?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Mulai dari maknanya, bukan dari tampilannya. Nama orang tersayang → kursif, hangat dan gak lekang zaman. Satu kata kuat atau motto → gotik, tebal dan tegas. Kutipan pendek → italic tipis, kalem tapi elegan. Tanggal → angka romawi atau gaya mesin tik. Ketik teks kamu di atas halaman ini, bandingkan hasilnya berdampingan, dan simpan dua-tiga gaya yang paling ngena — tattoo artist-mu bakal bantu mutusin yang final." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Mulai dari maknanya, bukan dari tampilannya. Nama orang tersayang → kursif, hangat dan gak lekang zaman. Satu kata kuat atau motto → gotik, tebal dan tegas. Kutipan pendek → italic tipis, kalem tapi elegan. Tanggal → angka romawi atau gaya mesin tik. Ketik teks kamu di atas halaman ini, bandingkan hasilnya berdampingan, dan simpan dua-tiga gaya yang paling ngena — tattoo artist-mu bakal bantu mutusin yang final."
+      }
     },
     {
       "@type": "Question",
       "name": "Huruf tato apa yang cocok buat tato nama?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Kursif tetap juaranya buat tato nama: hurufnya nyambung, kesannya kayak tulisan tangan pribadi, dan awet secara visual bertahun-tahun. Script tebal (𝓐𝓾𝓵𝓲𝓪) lebih berkarakter, script tipis (𝒶𝓊𝓁𝒾𝒶) lebih lembut. Kalau namanya pendek dan kamu pengen kesan sangar, coba juga gotik — gaya klasik di dunia lettering chicano. Bandingkan dua-duanya di halaman ini sebelum mutusin." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Kursif tetap juaranya buat tato nama: hurufnya nyambung, kesannya kayak tulisan tangan pribadi, dan awet secara visual bertahun-tahun. Script tebal (𝓐𝓾𝓵𝓲𝓪) lebih berkarakter, script tipis (𝒶𝓊𝓁𝒾𝒶) lebih lembut. Kalau namanya pendek dan kamu pengen kesan sangar, coba juga gotik — gaya klasik di dunia lettering chicano. Bandingkan dua-duanya di halaman ini sebelum mutusin."
+      }
     },
     {
       "@type": "Question",
       "name": "Font di halaman ini bisa langsung dipakai buat tato?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Enggak, dan ini penting: hasil Unicode di sini adalah bahan referensi, bukan desain yang siap ditinta. Fungsinya buat nentuin arah — kursif, gotik, atau italic — dan nunjukin arah itu dengan jelas ke tattoo artist-mu. Nanti dia yang nyesuaikan lettering-nya ke kulit kamu: ketebalan garis, sambungan antar huruf, lengkungan area badan. Lettering final itu keahliannya dia." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Enggak, dan ini penting: hasil Unicode di sini adalah bahan referensi, bukan desain yang siap ditinta. Fungsinya buat nentuin arah — kursif, gotik, atau italic — dan nunjukin arah itu dengan jelas ke tattoo artist-mu. Nanti dia yang nyesuaikan lettering-nya ke kulit kamu: ketebalan garis, sambungan antar huruf, lengkungan area badan. Lettering final itu keahliannya dia."
+      }
     },
     {
       "@type": "Question",
       "name": "Berapa ukuran minimal buat tulisan tato yang tipis?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Makin tipis dan detail tulisannya, makin butuh ruang. Garis super tipis dan lengkungan kecil cenderung melebar dan menutup seiring umur tinta — kata dalam script tipis yang tingginya kurang dari satu sentimeter berisiko jadi gak kebaca beberapa tahun kemudian. Aturan simpelnya: mau tato kecil, pilih gaya simpel (italic, mesin tik); mau kursif penuh hiasan, siapkan area yang lega. Tattoo artist-mu bakal kasih ukuran minimal persisnya sesuai posisi di badan." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Makin tipis dan detail tulisannya, makin butuh ruang. Garis super tipis dan lengkungan kecil cenderung melebar dan menutup seiring umur tinta — kata dalam script tipis yang tingginya kurang dari satu sentimeter berisiko jadi gak kebaca beberapa tahun kemudian. Aturan simpelnya: mau tato kecil, pilih gaya simpel (italic, mesin tik); mau kursif penuh hiasan, siapkan area yang lega. Tattoo artist-mu bakal kasih ukuran minimal persisnya sesuai posisi di badan."
+      }
     },
     {
       "@type": "Question",
       "name": "Gimana cara nunjukin gaya tulisannya ke tattoo artist?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Ketik kata kamu yang sebenarnya (bukan kata contoh) di atas halaman ini, screenshot dua-tiga hasil favoritmu, dan bawa pas konsultasi. Jelasin apa yang kamu suka dari masing-masing — «sambungan hurufnya yang kursif», «ketebalan yang gotik» — daripada minta ditiru persis piksel demi piksel. Artist yang bagus bakal gambar ulang lettering-nya dengan tangan, disesuaikan sama kulit dan posisi tatomu." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ketik kata kamu yang sebenarnya (bukan kata contoh) di atas halaman ini, screenshot dua-tiga hasil favoritmu, dan bawa pas konsultasi. Jelasin apa yang kamu suka dari masing-masing — «sambungan hurufnya yang kursif», «ketebalan yang gotik» — daripada minta ditiru persis piksel demi piksel. Artist yang bagus bakal gambar ulang lettering-nya dengan tangan, disesuaikan sama kulit dan posisi tatomu."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Gimana cara nulis tanggal dalam angka romawi buat tato?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Konversi tiap bagian tanggalnya secara terpisah — tanggal, bulan, tahun — lalu gabungkan pakai pemisah: 12 Juni 2020 jadi XII·VI·MMXX. Mode Tanggal → Romawi di halaman ini ngelakuin konversinya buat kamu dan bisa dipakai buat ngebandingin pemisah (titik, strip, garis, baris bertumpuk) dan urutan (tanggal-bulan-tahun atau bulan-tanggal-tahun). Cek ulang angka romawinya sama tattoo artist-mu sebelum hari-H: tanggal yang salah konversi itu penyesalan paling umum di tato tulisan."
+      }
     }
   ]
 }
@@ -127,26 +168,18 @@
   <div class="hero-inner">
     <div class="hero-card">
       <h1 class="hero-headline">Font tulisan tato</h1>
-      <p class="hero-tagline">Ketik kata, nama, atau tanggal buat ide tatomu dan langsung bandingkan gayanya — kursif, gotik, italic, mesin tik. Screenshot hasil yang kamu suka dan tunjukin ke tattoo artist: dia yang bakal gambar lettering finalnya, halaman ini bantu kamu nentuin arahnya dulu.</p>
-      <div class="input-wrapper">
-        <textarea class="main-input" id="mainInput" placeholder="Ketik tulisanmu di sini..." maxlength="500" autofocus=""></textarea>
+      <p class="hero-tagline">Semua kebutuhan tato tulisan di satu tempat: bandingkan font tato di nama atau kata kamu yang sebenarnya, ubah tanggal jadi angka romawi, bikin monogram huruf, atau pilih simbol kecil yang bermakna. Screenshot yang kamu suka dan tunjukin ke tattoo artist-mu — dia yang bakal gambar lettering finalnya, halaman ini bantu kamu nentuin arahnya.</p>
+      <div class="tattoo-mode-tabs" id="tattooModeTabs"></div>
+      <div class="input-wrapper" id="tattooTextWrap">
+        <textarea class="main-input" id="mainInput" placeholder="Ketik nama, kata, atau kutipanmu..." maxlength="500" autofocus=""></textarea>
         <span class="char-count"><span id="charCount">0</span>/500</span>
       </div>
-      <div class="decoration-section">
-        <div class="decoration-label">Tambahin dekorasi ke hasil</div>
-        <div class="decoration-tabs">
-          <button class="decoration-tab active" data-deco-tab="symbols">Simbol</button>
-          <button class="decoration-tab" data-deco-tab="frames">Bingkai</button>
-          <button class="decoration-tab" data-deco-tab="minimal">Minimal</button>
-        </div>
-        <div class="decoration-grid" id="decorationGrid"></div>
-      </div>
+      <div id="tattooControlPanel"></div>
     </div>
   </div>
 </section>
 
 <main class="container">
-  <div class="category-section"><div class="category-tabs" id="categoryTabs"></div></div>
   <div class="results-grid" id="resultsGrid"></div>
 
   <!-- Preview sebelum jarum -->
@@ -242,6 +275,8 @@
     <div class="faq-item"><button class="faq-question" type="button">Font di halaman ini bisa langsung dipakai buat tato?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Enggak, dan ini penting: hasil Unicode di sini adalah bahan referensi, bukan desain yang siap ditinta. Fungsinya buat nentuin arah — kursif, gotik, atau italic — dan nunjukin arah itu dengan jelas ke tattoo artist-mu. Nanti dia yang nyesuaikan lettering-nya ke kulit kamu: ketebalan garis, sambungan antar huruf, lengkungan area badan. Lettering final itu keahliannya dia.</div></div>
     <div class="faq-item"><button class="faq-question" type="button">Berapa ukuran minimal buat tulisan tato yang tipis?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Makin tipis dan detail tulisannya, makin butuh ruang. Garis super tipis dan lengkungan kecil cenderung melebar dan menutup seiring umur tinta — kata dalam script tipis yang tingginya kurang dari satu sentimeter berisiko jadi gak kebaca beberapa tahun kemudian. Aturan simpelnya: mau tato kecil, pilih gaya simpel (italic, mesin tik); mau kursif penuh hiasan, siapkan area yang lega. Tattoo artist-mu bakal kasih ukuran minimal persisnya sesuai posisi di badan.</div></div>
     <div class="faq-item"><button class="faq-question" type="button">Gimana cara nunjukin gaya tulisannya ke tattoo artist?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Ketik kata kamu yang sebenarnya (bukan kata contoh) di atas halaman ini, screenshot dua-tiga hasil favoritmu, dan bawa pas konsultasi. Jelasin apa yang kamu suka dari masing-masing — «sambungan hurufnya yang kursif», «ketebalan yang gotik» — daripada minta ditiru persis piksel demi piksel. Artist yang bagus bakal gambar ulang lettering-nya dengan tangan, disesuaikan sama kulit dan posisi tatomu.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Gimana cara nulis tanggal dalam angka romawi buat tato?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Konversi tiap bagian tanggalnya secara terpisah — tanggal, bulan, tahun — lalu gabungkan pakai pemisah: 12 Juni 2020 jadi XII·VI·MMXX. Mode Tanggal → Romawi di halaman ini ngelakuin konversinya buat kamu dan bisa dipakai buat ngebandingin pemisah (titik, strip, garis, baris bertumpuk) dan urutan (tanggal-bulan-tahun atau bulan-tanggal-tahun). Cek ulang angka romawinya sama tattoo artist-mu sebelum hari-H: tanggal yang salah konversi itu penyesalan paling umum di tato tulisan.</div></div>
+
 
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="Pilih bahasa">
@@ -262,9 +297,234 @@
 <div class="copy-toast" id="copyToast">Tersalin!</div>
 <div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
 
+<!-- Page configuration: tattoo mode flag + i18n -->
+<script>
+window.UTG_TATTOO_MODE = true;
+window.tattooI18n = {
+  "sampleName": "Aulia",
+  "modeNamesLabel": "Nama & kata",
+  "modeNamesHint": "Ketik nama, kata, atau kutipan",
+  "modeDateLabel": "Tanggal → Romawi",
+  "modeDateHint": "Ubah tanggal atau angka jadi angka romawi",
+  "modeLettersLabel": "Huruf & inisial",
+  "modeLettersHint": "Huruf tunggal dan monogram",
+  "modeSymbolsLabel": "Simbol",
+  "modeSymbolsHint": "Simbol kecil yang bermakna",
+  "sizeClose": "Dari dekat",
+  "sizeArm": "Sejauh lengan",
+  "sizeRoom": "Seberang ruangan",
+  "inkTest": "Tes tinta",
+  "yourDate": "Tanggal kamu",
+  "day": "Tanggal",
+  "month": "Bulan",
+  "yearOrNumber": "Tahun atau angka",
+  "order": "Urutan",
+  "separator": "Pemisah",
+  "yourLetter": "Huruf kamu",
+  "secondInitial": "Inisial kedua",
+  "secondNone": "Tanpa — satu huruf",
+  "joinedBy": "Digabung pakai",
+  "symbolsNote": "Ketuk simbol mana pun buat nyalin — padukan sama nama atau tanggal, atau pakai sendirian.",
+  "sampleHintName": "Menampilkan “{text}” — ketik nama, kata, atau kutipanmu di atas.",
+  "sampleHintDate": "Menampilkan tanggal contoh (12 · 6 · 2020) — masukkan tanggal atau angkamu di atas.",
+  "romanRange": "Angka romawi cuma mencakup 1–3999 — cek lagi nilainya di atas.",
+  "headingRoman": "Angka romawi",
+  "headingFigures": "Angka biasa",
+  "badgeSafe": "awet di ukuran kecil",
+  "badgeRoomy": "butuh ruang",
+  "copy": "Salin",
+  "copyAria": "Salin {name}",
+  "families": {
+    "Script": "Script",
+    "Gothic": "Gotik",
+    "Italic": "Italic",
+    "Minimal": "Minimal",
+    "Roman": "Romawi",
+    "Figures": "Angka"
+  },
+  "orders": {
+    "dmy": "Tanggal · Bulan · Tahun",
+    "mdy": "Bulan · Tanggal · Tahun",
+    "y": "Tahun aja"
+  },
+  "seps": {
+    "space": "spasi",
+    "stack": "bertumpuk"
+  },
+  "joiners": {
+    "none": "Tanpa"
+  },
+  "lettering": {
+    "Ultra Script Bold": {
+      "label": "Script Tebal",
+      "note": "Klasiknya tato nama — nyambung dan hangat, bentuknya tetap kebaca di ukuran kecil."
+    },
+    "Ultra Script": {
+      "label": "Script Tipis",
+      "note": "Halus dan ringan — cantik di ukuran sedang; lengkungan tipisnya butuh ruang biar awet dimakan umur."
+    },
+    "Ultra Chicano Script": {
+      "label": "Nameplate Chicano",
+      "note": "Script tebal di dalam banner berornamen — framing nameplate yang klasik."
+    },
+    "Ultra Gothic": {
+      "label": "Blackletter Gotik",
+      "note": "Blackletter Fraktur — padat dan tegas, lahir buat ngangkat satu kata yang kuat."
+    },
+    "Ultra Gothic Bold": {
+      "label": "Old English Tebal",
+      "note": "Gaya Old English yang berat — andalan lettering old school dan Chicano."
+    },
+    "Ultra Old English Banner": {
+      "label": "Banner Old English",
+      "note": "Blackletter berat di dalam banner — nameplate dengan kehadiran maksimal."
+    },
+    "Ultra Italic": {
+      "label": "Italic Tipis",
+      "note": "Miring yang kalem — ngalir halus di sepanjang rusuk, pergelangan tangan, atau tulang selangka."
+    },
+    "Ultra Italic Serif": {
+      "label": "Italic Serif",
+      "note": "Serif italic bergaya buku — kesannya kayak satu kalimat yang diambil dari novel."
+    },
+    "Ultra Typewriter Document": {
+      "label": "Mesin Tik",
+      "note": "Monospace mentah dan literer — pas banget buat tanggal atau kalimat pendek."
+    },
+    "Ultra Small Caps": {
+      "label": "Kapital Kecil",
+      "note": "Huruf kapital mungil yang rata — pilihannya para minimalis fine line."
+    }
+  },
+  "roman": {
+    "Classic": {
+      "label": "Klasik",
+      "note": "Kapital polos — yang paling sering ditinta para artist."
+    },
+    "Serif Italic": {
+      "label": "Serif Italic",
+      "note": "Kesan ukiran monumen, versi miring."
+    },
+    "Script": {
+      "label": "Script",
+      "note": "Angka romawi dalam script yang ngalir."
+    },
+    "Blackletter": {
+      "label": "Blackletter",
+      "note": "Angka Fraktur — gelap dan penuh ornamen."
+    },
+    "Heavy Old English": {
+      "label": "Old English Tebal",
+      "note": "Angka blackletter dengan bobot maksimal."
+    },
+    "Typewriter": {
+      "label": "Mesin Tik",
+      "note": "Angka monospace — bersih dan dokumenter."
+    }
+  },
+  "digits": {
+    "Typewriter": {
+      "label": "Mesin Tik",
+      "note": "Angka monospace — tampilan tanggal yang klasik."
+    },
+    "Bold Serif": {
+      "label": "Serif Tebal",
+      "note": "Angka gaya buku yang berat — pas dipadukan sama blackletter."
+    },
+    "Bold Sans": {
+      "label": "Sans Tebal",
+      "note": "Angka tebal modern — pas sama script tebal."
+    },
+    "Fine Sans": {
+      "label": "Sans Tipis",
+      "note": "Angka ringan — pas sama script tipis dan italic."
+    },
+    "Double-Struck": {
+      "label": "Garis Ganda",
+      "note": "Angka outline — pilihan fine line yang gak terduga."
+    },
+    "Wide Spaced": {
+      "label": "Lebar Renggang",
+      "note": "Angka fullwidth — lega, spasi ala editorial."
+    },
+    "Tiny": {
+      "label": "Mungil",
+      "note": "Angka mini — skala belakang telinga."
+    }
+  },
+  "groups": {
+    "minimal": "Fine line & minimal",
+    "celestial": "Benda langit",
+    "love": "Cinta & kenangan",
+    "faith": "Iman & perlindungan",
+    "journey": "Kekuatan & perjalanan",
+    "music": "Musik & seni",
+    "zodiac": "Zodiak"
+  },
+  "symbols": {
+    ";": "Titik koma — ceritanya berlanjut",
+    "∞": "Tak hingga — tanpa akhir",
+    "·": "Titik tunggal — sebuah jeda",
+    "—": "Garis panjang — sebuah garis, sebuah jalan",
+    "~": "Ombak — tenang, mengalir",
+    "✕": "Tanda silang — titik persimpangan",
+    "°": "Lingkaran kecil — keutuhan",
+    "⋮": "Tiga titik — mi vida loca / belum selesai",
+    "☾": "Bulan sabit — perubahan, siklus",
+    "☽": "Bulan sabit muda — pertumbuhan",
+    "☼": "Matahari — vitalitas",
+    "✦": "Bintang empat sudut — penunjuk arah",
+    "✧": "Bintang terbuka — harapan",
+    "⋆": "Bintang kecil — percikan yang sunyi",
+    "★": "Bintang penuh — ambisi",
+    "✵": "Bintang bersinar — energi",
+    "♡": "Hati terbuka — cinta yang ringan",
+    "❥": "Hati miring — pengabdian",
+    "❦": "Hati floral — kenangan",
+    "➳": "Panah — terpanah cinta",
+    "✿": "Bunga — sedang mekar",
+    "❀": "Bunga mekar — kenangan akan seseorang",
+    "✝": "Salib Latin — iman",
+    "†": "Salib belati — pengorbanan",
+    "☦": "Salib Ortodoks",
+    "☯": "Yin yang — keseimbangan",
+    "ॐ": "Om — suara pertama",
+    "✡": "Bintang Daud",
+    "☪": "Bintang dan bulan sabit",
+    "ᛉ": "Rune Algiz — perlindungan",
+    "⚓": "Jangkar — tetap teguh",
+    "✈": "Pesawat — pergi, pulang",
+    "➵": "Panah — terus maju",
+    "→": "Panah kanan — terus melangkah",
+    "⚔": "Pedang bersilang — terus berjuang",
+    "♆": "Trisula — lautan",
+    "Δ": "Delta — perubahan",
+    "Ω": "Omega — akhir, ketahanan",
+    "♪": "Not seperdelapan",
+    "♫": "Not ganda tersambung",
+    "♬": "Not ganda berpalang",
+    "𝄞": "Kunci G",
+    "✎": "Pensil — tanda sang pembuat",
+    "♈": "Aries",
+    "♉": "Taurus",
+    "♊": "Gemini",
+    "♋": "Cancer",
+    "♌": "Leo",
+    "♍": "Virgo",
+    "♎": "Libra",
+    "♏": "Scorpio",
+    "♐": "Sagitarius",
+    "♑": "Capricorn",
+    "♒": "Aquarius",
+    "♓": "Pisces"
+  }
+};
+</script>
 <script src="/styles.js" defer></script>
 <script src="/renderer.js" defer></script>
-<script src="/script.js" defer=""></script>
+<script src="/js/tattoo/tattooData.js" defer></script>
+<script src="/script.js" defer></script>
+<script src="/js/tattoo/tattooPageController.js" defer></script>
 <script src="/symbol-explorer.js"></script>
 <script src="/footer.js" defer></script>
 </body></html>

--- a/it/usecase/font-tatuaggi/index.html
+++ b/it/usecase/font-tatuaggi/index.html
@@ -11,7 +11,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Font Tatuaggi — Scritte e Caratteri per il tuo Tattoo | UltraTextGen</title>
-  <meta name="description" content="Font tatuaggi: scrivi il tuo nome, una parola o una data e confronta scritte corsive, gotiche e italiche prima dell'ago. Screenshot e mostralo al tatuatore.">
+  <meta name="description" content="Font tatuaggi: confronta corsivo, gotico e script sul tuo nome, trasforma una data in numeri romani, prova iniziali e simboli — gratis, prima dell'ago.">
   <link rel="canonical" href="https://ultratextgen.com/it/usecase/font-tatuaggi/">
 
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/usecase/tattoo-fonts/">
@@ -49,13 +49,30 @@
   "@context": "https://schema.org",
   "@type": "WebApplication",
   "name": "Font per Tatuaggi",
-  "alternateName": ["Font Tatuaggi", "Scritte Tatuaggi", "Lettere Tatuaggi", "Caratteri Tatuaggi", "Generatore Scritte Tatuaggi"],
+  "alternateName": [
+    "Font Tatuaggi",
+    "Scritte Tatuaggi",
+    "Lettere Tatuaggi",
+    "Caratteri Tatuaggi",
+    "Generatore Scritte Tatuaggi"
+  ],
   "url": "https://ultratextgen.com/it/usecase/font-tatuaggi/",
   "inLanguage": "it",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Any",
-  "description": "Prova i font per tatuaggi sulla tua idea: scrivi una parola, un nome o una data e confronta le scritte in corsivo, gotico, italico e macchina da scrivere — poi mostra lo screenshot al tatuatore. Gratis, senza app.",
-  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "EUR" }
+  "description": "Prova il lettering del tatuaggio prima dell'ago: confronta scritte in corsivo, gotico, italico fine e macchina da scrivere sul tuo nome esatto, converti una data in numeri romani, crea monogrammi di lettere e sfoglia i simboli per tatuaggi con i loro significati — poi fai uno screenshot dei tuoi preferiti e mostralo al tatuatore. Gratis, senza app.",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "EUR"
+  },
+  "featureList": [
+    "Confronta 10 stili di lettering per tatuaggi sul tuo nome o sulla tua parola",
+    "Convertitore da data e numero a numeri romani con formati da tatuaggio",
+    "Generatore di lettere singole e monogrammi a due iniziali",
+    "Libreria di simboli per tatuaggi con i significati",
+    "Test inchiostro — anteprima del lettering alle distanze reali di lettura"
+  ]
 }
 </script>
 
@@ -68,27 +85,50 @@
     {
       "@type": "Question",
       "name": "Come scelgo il font giusto per un tatuaggio?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Parti dal significato, non dall'estetica. Un nome o una dedica → corsivo, caldo e senza tempo. Una parola forte, un motto → gotico, denso e deciso. Una citazione breve → italico fine, discreto ed elegante. Una data → numeri romani o stile macchina da scrivere. Scrivi il tuo testo in cima alla pagina, confronta le scritte una accanto all'altra e tieni le due o tre che ti convincono di più — a decidere ti aiuterà il tatuatore." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Parti dal significato, non dall'estetica. Un nome o una dedica → corsivo, caldo e senza tempo. Una parola forte, un motto → gotico, denso e deciso. Una citazione breve → italico fine, discreto ed elegante. Una data → numeri romani o stile macchina da scrivere. Scrivi il tuo testo in cima alla pagina, confronta le scritte una accanto all'altra e tieni le due o tre che ti convincono di più — a decidere ti aiuterà il tatuatore."
+      }
     },
     {
       "@type": "Question",
       "name": "Quali lettere per un nome tatuato?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Il corsivo resta il grande classico del nome tatuato: le lettere legate danno un effetto scritto a mano, personale, che invecchia bene. Uno script pieno (𝓖𝓲𝓾𝓵𝓲𝓪) ha più presenza, uno script sottile (𝒢𝒾𝓊𝓁𝒾𝒶) più delicatezza. Se il nome è corto e vuoi più carattere, prova anche il gotico — molto usato nello stile chicano. Confrontali su questa pagina prima di decidere." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Il corsivo resta il grande classico del nome tatuato: le lettere legate danno un effetto scritto a mano, personale, che invecchia bene. Uno script pieno (𝓖𝓲𝓾𝓵𝓲𝓪) ha più presenza, uno script sottile (𝒢𝒾𝓊𝓁𝒾𝒶) più delicatezza. Se il nome è corto e vuoi più carattere, prova anche il gotico — molto usato nello stile chicano. Confrontali su questa pagina prima di decidere."
+      }
     },
     {
       "@type": "Question",
       "name": "Posso usare questi font così come sono per il tatuaggio?",
-      "acceptedAnswer": { "@type": "Answer", "text": "No, ed è giusto dirlo chiaramente: queste scritte Unicode sono una base di lavoro, non un disegno pronto da tatuare. Ti servono per scegliere una direzione — corsivo, gotico, italico — e mostrarla in modo chiaro al tatuatore. Sarà lui ad adattare il lettering alla tua pelle: spessore dei tratti, legature tra le lettere, curva della zona scelta. Il lettering finale è il suo mestiere." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No, ed è giusto dirlo chiaramente: queste scritte Unicode sono una base di lavoro, non un disegno pronto da tatuare. Ti servono per scegliere una direzione — corsivo, gotico, italico — e mostrarla in modo chiaro al tatuatore. Sarà lui ad adattare il lettering alla tua pelle: spessore dei tratti, legature tra le lettere, curva della zona scelta. Il lettering finale è il suo mestiere."
+      }
     },
     {
       "@type": "Question",
       "name": "Qual è la dimensione minima per una scritta fine?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Più la scritta è fine e dettagliata, più spazio le serve. I tratti sottilissimi e i piccoli occhielli tendono a ispessirsi e a chiudersi con gli anni — una parola in script fine alta meno di un centimetro rischia di diventare illeggibile. Regola semplice: se la vuoi piccola, scegli uno stile semplice (italico, macchina da scrivere); se vuoi un corsivo elaborato, prevedi spazio. La misura minima esatta te la darà il tatuatore in base alla zona del corpo." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Più la scritta è fine e dettagliata, più spazio le serve. I tratti sottilissimi e i piccoli occhielli tendono a ispessirsi e a chiudersi con gli anni — una parola in script fine alta meno di un centimetro rischia di diventare illeggibile. Regola semplice: se la vuoi piccola, scegli uno stile semplice (italico, macchina da scrivere); se vuoi un corsivo elaborato, prevedi spazio. La misura minima esatta te la darà il tatuatore in base alla zona del corpo."
+      }
     },
     {
       "@type": "Question",
       "name": "Come mostro il font al mio tatuatore?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Scrivi la tua parola esatta (non una parola di prova) in cima alla pagina, fai uno screenshot delle due o tre scritte che preferisci e portale all'appuntamento. Spiega cosa ti piace di ciascuna — «le legature del corsivo», «lo spessore del gotico» — invece di chiedere una copia identica. Occhio agli accenti: è, à o ù nelle scritte Unicode restano spesso lettere normali, ma il tatuatore li disegnerà senza problemi nel lettering finale." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Scrivi la tua parola esatta (non una parola di prova) in cima alla pagina, fai uno screenshot delle due o tre scritte che preferisci e portale all'appuntamento. Spiega cosa ti piace di ciascuna — «le legature del corsivo», «lo spessore del gotico» — invece di chiedere una copia identica. Occhio agli accenti: è, à o ù nelle scritte Unicode restano spesso lettere normali, ma il tatuatore li disegnerà senza problemi nel lettering finale."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Come si scrive una data in numeri romani per un tatuaggio?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Converti ogni parte della data separatamente — giorno, mese, anno — e uniscile con un separatore: 12 giugno 2020 diventa XII·VI·MMXX. La modalità Data → Romani di questa pagina fa la conversione per te e ti lascia confrontare separatori (punti, trattini, barre, righe in colonna) e ordini (giorno-mese-anno o mese-giorno-anno). Ricontrolla i numeri con il tatuatore prima dell'appuntamento: una data convertita male è il rimpianto più comune dei tatuaggi scritti."
+      }
     }
   ]
 }
@@ -128,9 +168,10 @@
   <div class="hero-inner">
     <div class="hero-card">
       <h1 class="hero-headline">Font per tatuaggi</h1>
-      <p class="hero-tagline">Scrivi la parola, il nome o la data della tua idea di tatuaggio e confronta subito le scritte — corsivo, gotico, italico, macchina da scrivere. Fai uno screenshot dei caratteri che ti piacciono e mostralo al tatuatore: il lettering finale lo disegnerà lui, questa pagina ti aiuta solo a scegliere la direzione.</p>
-      <div class="input-wrapper">
-        <textarea class="main-input" id="mainInput" placeholder="Digita il tuo testo qui…" maxlength="500" autofocus=""></textarea>
+      <p class="hero-tagline">Tutto quello che serve a un tatuaggio scritto, in un posto solo: confronta i font per tatuaggi sul tuo nome o sulla tua parola esatta, trasforma una data in numeri romani, crea un monogramma di lettere o scegli un piccolo simbolo con un significato. Fai uno screenshot di quello che ti piace e mostralo al tatuatore: il lettering finale lo disegnerà lui, questa pagina ti aiuta a scegliere la direzione.</p>
+      <div class="tattoo-mode-tabs" id="tattooModeTabs"></div>
+      <div class="input-wrapper" id="tattooTextWrap">
+        <textarea class="main-input" id="mainInput" placeholder="Digita il tuo nome, una parola o una citazione..." maxlength="500" autofocus=""></textarea>
         <span class="char-count"><span id="charCount">0</span>/500</span>
       </div>
       <div class="accent-notice" id="accentNotice" role="note" hidden>
@@ -138,21 +179,12 @@
         <span class="accent-notice-text">Il tuo testo contiene accenti. La maggior parte degli stili lascia <b>è</b>, <b>à</b> o <b>ù</b> come lettere normali — gli stili <b>barrato, sottolineato e cornici</b> li mantengono. <a href="/guide/fancy-fonts-and-accents/">Quali stili mantengono gli accenti →</a></span>
         <button type="button" class="accent-notice-close" id="accentNoticeClose" aria-label="Chiudi">✕</button>
       </div>
-      <div class="decoration-section">
-        <div class="decoration-label">Aggiungi qualche decorazione intorno al risultato</div>
-        <div class="decoration-tabs">
-          <button class="decoration-tab active" data-deco-tab="symbols">Simboli</button>
-          <button class="decoration-tab" data-deco-tab="frames">Cornici</button>
-          <button class="decoration-tab" data-deco-tab="minimal">Minimal</button>
-        </div>
-        <div class="decoration-grid" id="decorationGrid"></div>
-      </div>
+      <div id="tattooControlPanel"></div>
     </div>
   </div>
 </section>
 
 <main class="container">
-  <div class="category-section"><div class="category-tabs" id="categoryTabs"></div></div>
   <div class="results-grid" id="resultsGrid"></div>
 
   <!-- Anteprima prima dell'ago -->
@@ -248,6 +280,8 @@
     <div class="faq-item"><button class="faq-question" type="button">Posso usare questi font così come sono per il tatuaggio?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">No, ed è giusto dirlo chiaramente: queste scritte Unicode sono una base di lavoro, non un disegno pronto da tatuare. Ti servono per scegliere una direzione — corsivo, gotico, italico — e mostrarla in modo chiaro al tatuatore. Sarà lui ad adattare il lettering alla tua pelle: spessore dei tratti, legature tra le lettere, curva della zona scelta. Il lettering finale è il suo mestiere.</div></div>
     <div class="faq-item"><button class="faq-question" type="button">Qual è la dimensione minima per una scritta fine?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Più la scritta è fine e dettagliata, più spazio le serve. I tratti sottilissimi e i piccoli occhielli tendono a ispessirsi e a chiudersi con gli anni — una parola in script fine alta meno di un centimetro rischia di diventare illeggibile. Regola semplice: se la vuoi piccola, scegli uno stile semplice (italico, macchina da scrivere); se vuoi un corsivo elaborato, prevedi spazio. La misura minima esatta te la darà il tatuatore in base alla zona del corpo.</div></div>
     <div class="faq-item"><button class="faq-question" type="button">Come mostro il font al mio tatuatore?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Scrivi la tua parola esatta (non una parola di prova) in cima alla pagina, fai uno screenshot delle due o tre scritte che preferisci e portale all'appuntamento. Spiega cosa ti piace di ciascuna — «le legature del corsivo», «lo spessore del gotico» — invece di chiedere una copia identica. Occhio agli accenti: è, à o ù nelle scritte Unicode restano spesso lettere normali, ma il tatuatore li disegnerà senza problemi nel lettering finale.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Come si scrive una data in numeri romani per un tatuaggio?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Converti ogni parte della data separatamente — giorno, mese, anno — e uniscile con un separatore: 12 giugno 2020 diventa XII·VI·MMXX. La modalità Data → Romani di questa pagina fa la conversione per te e ti lascia confrontare separatori (punti, trattini, barre, righe in colonna) e ordini (giorno-mese-anno o mese-giorno-anno). Ricontrolla i numeri con il tatuatore prima dell'appuntamento: una data convertita male è il rimpianto più comune dei tatuaggi scritti.</div></div>
+
 
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="Selettore lingua">
@@ -268,9 +302,234 @@
 <div class="copy-toast" id="copyToast">Copiato!</div>
 <div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
 
-<script src="/styles.js"></script>
-<script src="/renderer.js"></script>
-<script src="/script.js" defer=""></script>
+<!-- Page configuration: tattoo mode flag + i18n -->
+<script>
+window.UTG_TATTOO_MODE = true;
+window.tattooI18n = {
+  "sampleName": "Giulia",
+  "modeNamesLabel": "Nomi e parole",
+  "modeNamesHint": "Digita un nome, una parola o una citazione",
+  "modeDateLabel": "Data → Romani",
+  "modeDateHint": "Trasforma una data o un numero in numeri romani",
+  "modeLettersLabel": "Lettere e iniziali",
+  "modeLettersHint": "Lettere singole e monogrammi",
+  "modeSymbolsLabel": "Simboli",
+  "modeSymbolsHint": "Piccoli simboli con un significato",
+  "sizeClose": "Da vicino",
+  "sizeArm": "A un braccio",
+  "sizeRoom": "Da lontano",
+  "inkTest": "Test inchiostro",
+  "yourDate": "La tua data",
+  "day": "Giorno",
+  "month": "Mese",
+  "yearOrNumber": "Anno o numero",
+  "order": "Ordine",
+  "separator": "Separatore",
+  "yourLetter": "La tua lettera",
+  "secondInitial": "Seconda iniziale",
+  "secondNone": "Nessuna — lettera singola",
+  "joinedBy": "Unite da",
+  "symbolsNote": "Tocca un simbolo per copiarlo — abbinalo a un nome o a una data, oppure portalo da solo.",
+  "sampleHintName": "Stai vedendo “{text}” — digita il tuo nome, la tua parola o la tua citazione qui sopra.",
+  "sampleHintDate": "Stai vedendo una data di esempio (12 · 6 · 2020) — inserisci la tua data o il tuo numero qui sopra.",
+  "romanRange": "I numeri romani coprono l'intervallo 1–3999 — controlla i valori qui sopra.",
+  "headingRoman": "Numeri romani",
+  "headingFigures": "Cifre normali",
+  "badgeSafe": "regge in piccolo",
+  "badgeRoomy": "serve spazio",
+  "copy": "Copia",
+  "copyAria": "Copia {name}",
+  "families": {
+    "Script": "Script",
+    "Gothic": "Gotico",
+    "Italic": "Italico",
+    "Minimal": "Minimal",
+    "Roman": "Romani",
+    "Figures": "Cifre"
+  },
+  "orders": {
+    "dmy": "Giorno · Mese · Anno",
+    "mdy": "Mese · Giorno · Anno",
+    "y": "Solo anno"
+  },
+  "seps": {
+    "space": "spazio",
+    "stack": "in colonna"
+  },
+  "joiners": {
+    "none": "Nessuno"
+  },
+  "lettering": {
+    "Ultra Script Bold": {
+      "label": "Script Pieno",
+      "note": "Il classico del nome tatuato — legato e caldo, tiene la forma anche in piccolo."
+    },
+    "Ultra Script": {
+      "label": "Script Sottile",
+      "note": "Delicato e arioso — bellissimo a media grandezza; gli occhielli sottili hanno bisogno di spazio per invecchiare bene."
+    },
+    "Ultra Chicano Script": {
+      "label": "Nameplate Chicano",
+      "note": "Script pieno dentro un banner ornamentale — la classica cornice del nameplate."
+    },
+    "Ultra Gothic": {
+      "label": "Gotico Blackletter",
+      "note": "Blackletter in stile Fraktur — denso e deciso, fatto per portare una parola forte."
+    },
+    "Ultra Gothic Bold": {
+      "label": "Old English Pesante",
+      "note": "Il look Old English pesante — un classico del lettering old school e chicano."
+    },
+    "Ultra Old English Banner": {
+      "label": "Banner Old English",
+      "note": "Blackletter pesante dentro un banner — un nameplate con la massima presenza."
+    },
+    "Ultra Italic": {
+      "label": "Italico Fine",
+      "note": "Inclinazione discreta — scivola silenziosa lungo una costola, un polso o una clavicola."
+    },
+    "Ultra Italic Serif": {
+      "label": "Italico Serif",
+      "note": "Italico con grazie dal sapore letterario — sembra una riga presa da un romanzo."
+    },
+    "Ultra Typewriter Document": {
+      "label": "Macchina da Scrivere",
+      "note": "Monospazio crudo e letterario — perfetto per una data o una frase breve."
+    },
+    "Ultra Small Caps": {
+      "label": "Maiuscoletto",
+      "note": "Piccole maiuscole regolari — la scelta minimalista fine line."
+    }
+  },
+  "roman": {
+    "Classic": {
+      "label": "Classico",
+      "note": "Maiuscole semplici — quello che tatua la maggior parte degli artisti."
+    },
+    "Serif Italic": {
+      "label": "Serif Italico",
+      "note": "Il look del monumento inciso, in versione inclinata."
+    },
+    "Script": {
+      "label": "Script",
+      "note": "Numeri romani in corsivo fluido."
+    },
+    "Blackletter": {
+      "label": "Blackletter",
+      "note": "Numeri in stile Fraktur — scuri e ornati."
+    },
+    "Heavy Old English": {
+      "label": "Old English Pesante",
+      "note": "Numeri blackletter dal peso massimo."
+    },
+    "Typewriter": {
+      "label": "Macchina da Scrivere",
+      "note": "Numeri monospazio — puliti e documentari."
+    }
+  },
+  "digits": {
+    "Typewriter": {
+      "label": "Macchina da Scrivere",
+      "note": "Cifre monospazio — il classico look della data."
+    },
+    "Bold Serif": {
+      "label": "Serif Pieno",
+      "note": "Cifre pesanti da carattere di libro — si abbinano al blackletter."
+    },
+    "Bold Sans": {
+      "label": "Sans Pieno",
+      "note": "Cifre moderne e pesanti — si abbinano allo script pieno."
+    },
+    "Fine Sans": {
+      "label": "Sans Sottile",
+      "note": "Cifre leggere — si abbinano allo script sottile e all'italico."
+    },
+    "Double-Struck": {
+      "label": "Doppio Tratto",
+      "note": "Cifre a contorno — una scelta fine line inaspettata."
+    },
+    "Wide Spaced": {
+      "label": "Spaziato",
+      "note": "Cifre a larghezza piena — spaziatura ariosa, editoriale."
+    },
+    "Tiny": {
+      "label": "Mini",
+      "note": "Cifre in miniatura — scala da dietro l'orecchio."
+    }
+  },
+  "groups": {
+    "minimal": "Fine line e minimal",
+    "celestial": "Cielo e astri",
+    "love": "Amore e ricordo",
+    "faith": "Fede e protezione",
+    "journey": "Forza e cammino",
+    "music": "Musica e arte",
+    "zodiac": "Zodiaco"
+  },
+  "symbols": {
+    ";": "Punto e virgola — la storia continua",
+    "∞": "Infinito — senza fine",
+    "·": "Punto singolo — una pausa",
+    "—": "Trattino — una linea, un cammino",
+    "~": "Onda — calma, flusso",
+    "✕": "Croce a X — un punto d'incrocio",
+    "°": "Piccolo cerchio — completezza",
+    "⋮": "Tre punti — mi vida loca / incompiuto",
+    "☾": "Falce di luna — cambiamento, cicli",
+    "☽": "Luna crescente — crescita",
+    "☼": "Sole — vitalità",
+    "✦": "Stella a quattro punte — guida",
+    "✧": "Stella vuota — speranza",
+    "⋆": "Stellina — una scintilla discreta",
+    "★": "Stella piena — ambizione",
+    "✵": "Stella raggiata — energia",
+    "♡": "Cuore vuoto — amore, con leggerezza",
+    "❥": "Cuore inclinato — devozione",
+    "❦": "Cuore floreale — ricordo",
+    "➳": "Freccia — colpito dall'amore",
+    "✿": "Fiore — che sboccia",
+    "❀": "Fiore aperto — il ricordo di qualcuno",
+    "✝": "Croce latina — fede",
+    "†": "Croce a pugnale — sacrificio",
+    "☦": "Croce ortodossa",
+    "☯": "Yin e yang — equilibrio",
+    "ॐ": "Om — il primo suono",
+    "✡": "Stella di David",
+    "☪": "Stella e mezzaluna",
+    "ᛉ": "Runa Algiz — protezione",
+    "⚓": "Ancora — tieni duro",
+    "✈": "Aereo — partire, tornare",
+    "➵": "Freccia — solo avanti",
+    "→": "Freccia a destra — sempre avanti",
+    "⚔": "Spade incrociate — continua a lottare",
+    "♆": "Tridente — il mare",
+    "Δ": "Delta — cambiamento",
+    "Ω": "Omega — la fine, la resistenza",
+    "♪": "Croma",
+    "♫": "Note unite",
+    "♬": "Doppie note unite",
+    "𝄞": "Chiave di violino",
+    "✎": "Matita — il segno di chi crea",
+    "♈": "Ariete",
+    "♉": "Toro",
+    "♊": "Gemelli",
+    "♋": "Cancro",
+    "♌": "Leone",
+    "♍": "Vergine",
+    "♎": "Bilancia",
+    "♏": "Scorpione",
+    "♐": "Sagittario",
+    "♑": "Capricorno",
+    "♒": "Acquario",
+    "♓": "Pesci"
+  }
+};
+</script>
+<script src="/styles.js" defer></script>
+<script src="/renderer.js" defer></script>
+<script src="/js/tattoo/tattooData.js" defer></script>
+<script src="/script.js" defer></script>
+<script src="/js/tattoo/tattooPageController.js" defer></script>
 <script src="/symbol-explorer.js"></script>
 <script src="/accent-notice.js" defer></script>
 <script src="/footer.js"></script>

--- a/js/tattoo/tattooPageController.js
+++ b/js/tattoo/tattooPageController.js
@@ -9,6 +9,10 @@
      date    — date or number → roman numerals + plain-figure fonts
      letters — single letters and two-initial monograms
      symbols — copyable tattoo symbols with their meanings
+
+   Localized pages define window.tattooI18n before this script loads (same
+   pattern as window.verticalI18n / window.zalgoI18n). Missing keys fall
+   back to the built-in English strings.
    ========================================================================== */
 
 (function () {
@@ -19,20 +23,40 @@
   const DATA = window.UTG_TATTOO_DATA;
   if (!Render || !DATA) return;
 
-  const SAMPLE_TEXT = 'Sofia';
+  const I18N = window.tattooI18n || {};
+  function t(key, fallback) {
+    return I18N[key] != null ? I18N[key] : fallback;
+  }
+  /* Lookup in a nested i18n table (e.g. I18N.symbols['∞']). */
+  function pick(table, id, fallback) {
+    const sec = I18N[table];
+    return (sec && sec[id] != null) ? sec[id] : fallback;
+  }
+  /* Lookup a field of a nested i18n record (e.g. I18N.lettering[key].note). */
+  function pickField(table, id, field, fallback) {
+    const sec = I18N[table];
+    const item = sec && sec[id];
+    return (item && item[field] != null) ? item[field] : fallback;
+  }
+
+  const SAMPLE_TEXT = t('sampleName', 'Sofia');
   const SAMPLE_DATE = { d: 12, m: 6, y: 2020 };
 
   const MODES = [
-    { id: 'names',   label: 'Names & words',   hint: 'Type a name, word or quote' },
-    { id: 'date',    label: 'Date → Roman',    hint: 'Turn a date or number into roman numerals' },
-    { id: 'letters', label: 'Letters & initials', hint: 'Single letters and monograms' },
-    { id: 'symbols', label: 'Symbols',         hint: 'Small symbols with meaning' }
+    { id: 'names',   label: t('modeNamesLabel', 'Names & words'),
+      hint: t('modeNamesHint', 'Type a name, word or quote') },
+    { id: 'date',    label: t('modeDateLabel', 'Date → Roman'),
+      hint: t('modeDateHint', 'Turn a date or number into roman numerals') },
+    { id: 'letters', label: t('modeLettersLabel', 'Letters & initials'),
+      hint: t('modeLettersHint', 'Single letters and monograms') },
+    { id: 'symbols', label: t('modeSymbolsLabel', 'Symbols'),
+      hint: t('modeSymbolsHint', 'Small symbols with meaning') }
   ];
 
   const SIZE_VIEWS = [
-    { id: 'close', label: 'Close-up' },
-    { id: 'arm',   label: 'At arm’s length' },
-    { id: 'room',  label: 'Across the room' }
+    { id: 'close', label: t('sizeClose', 'Close-up') },
+    { id: 'arm',   label: t('sizeArm', 'At arm’s length') },
+    { id: 'room',  label: t('sizeRoom', 'Across the room') }
   ];
 
   /* ---- State ---- */
@@ -95,10 +119,10 @@
     const info = el('div', 'style-info');
     const nameRow = el('div', 'style-name');
     nameRow.appendChild(el('span', null, opts.label));
-    if (opts.family) nameRow.appendChild(el('span', 'style-tag', opts.family));
+    if (opts.family) nameRow.appendChild(el('span', 'style-tag', pick('families', opts.family, opts.family)));
     if (opts.hold) {
       nameRow.appendChild(el('span', 'tattoo-badge ' + (opts.hold === 'safe' ? 'is-safe' : 'is-roomy'),
-        opts.hold === 'safe' ? 'holds up small' : 'needs room'));
+        opts.hold === 'safe' ? t('badgeSafe', 'holds up small') : t('badgeRoomy', 'needs room')));
     }
     info.appendChild(nameRow);
 
@@ -109,7 +133,7 @@
     info.appendChild(preview);
     card.appendChild(info);
 
-    const btn = el('button', 'copy-btn', 'Copy');
+    const btn = el('button', 'copy-btn', t('copy', 'Copy'));
     btn.type = 'button';
     btn.dataset.text = opts.text;
     if (opts.styleKey) btn.dataset.style = opts.styleKey;
@@ -133,15 +157,19 @@
     const input = $('#mainInput');
     const raw = input ? input.value.trim() : '';
     const text = raw || SAMPLE_TEXT;
-    if (!raw) grid.appendChild(sampleHint('Showing “' + SAMPLE_TEXT + '” — type your name, word or quote above.'));
+    if (!raw) {
+      grid.appendChild(sampleHint(
+        t('sampleHintName', 'Showing “{text}” — type your name, word or quote above.')
+          .replace('{text}', SAMPLE_TEXT)));
+    }
 
     DATA.LETTERING.forEach(function (entry) {
       if (!styleFor(entry.key)) return;
       grid.appendChild(buildCard({
-        label: entry.label,
+        label: pickField('lettering', entry.key, 'label', entry.label),
         family: entry.family,
         hold: entry.hold,
-        note: entry.note,
+        note: pickField('lettering', entry.key, 'note', entry.note),
         text: applyStyle(text, entry.key),
         styleKey: entry.key,
         sample: !raw
@@ -182,30 +210,31 @@
     const state = dateParts();
     const sep = currentSeparator();
     if (state.sample) {
-      grid.appendChild(sampleHint('Showing a sample date (12 · 6 · 2020) — enter your date or number above.'));
+      grid.appendChild(sampleHint(
+        t('sampleHintDate', 'Showing a sample date (12 · 6 · 2020) — enter your date or number above.')));
     }
 
     const romanParts = state.parts.map(toRoman);
     if (romanParts.some(function (p) { return p === null; })) {
-      grid.appendChild(sampleHint('Roman numerals cover 1–3999 — check the values above.'));
+      grid.appendChild(sampleHint(t('romanRange', 'Roman numerals cover 1–3999 — check the values above.')));
       return;
     }
 
-    grid.appendChild(gridHeading('Roman numerals'));
+    grid.appendChild(gridHeading(t('headingRoman', 'Roman numerals')));
     const romanPlain = romanParts.join(sep.ch);
     DATA.ROMAN_STYLES.forEach(function (entry) {
       if (entry.key && !styleFor(entry.key)) return;
       grid.appendChild(buildCard({
-        label: entry.label,
+        label: pickField('roman', entry.label, 'label', entry.label),
         family: 'Roman',
-        note: entry.note,
+        note: pickField('roman', entry.label, 'note', entry.note),
         text: entry.key ? applyStyle(romanPlain, entry.key) : romanPlain,
         styleKey: entry.key || '',
         sample: state.sample
       }));
     });
 
-    grid.appendChild(gridHeading('Plain figures'));
+    grid.appendChild(gridHeading(t('headingFigures', 'Plain figures')));
     const digitsPlain = state.parts
       .map(function (n, i) {
         // Two-digit day/month (12.06.2020) — the standard tattoo date format.
@@ -217,9 +246,9 @@
         return Array.from(font.digits)[Number(dch)] || dch;
       });
       grid.appendChild(buildCard({
-        label: font.label,
+        label: pickField('digits', font.label, 'label', font.label),
         family: 'Figures',
-        note: font.note,
+        note: pickField('digits', font.label, 'note', font.note),
         text: text,
         sample: state.sample
       }));
@@ -244,7 +273,7 @@
       const plain = monoSecond ? monoFirst + joiner.ch + monoSecond : monoFirst;
       const text = applyStyle(plain, entry.key);
       grid.appendChild(buildCard({
-        label: entry.label,
+        label: pickField('lettering', entry.key, 'label', entry.label),
         family: entry.family,
         hold: entry.hold,
         text: text,
@@ -258,15 +287,16 @@
      -------------------------------------------------------------------------- */
   function renderSymbols(grid) {
     DATA.SYMBOL_GROUPS.forEach(function (group) {
-      grid.appendChild(gridHeading(group.label));
+      grid.appendChild(gridHeading(pick('groups', group.id, group.label)));
       const wrap = el('div', 'tattoo-symbol-grid');
       group.items.forEach(function (item) {
+        const name = pick('symbols', item.ch, item.name);
         const tile = el('button', 'glyph-copy tattoo-symbol-tile');
         tile.type = 'button';
         tile.dataset.text = item.ch;
-        tile.setAttribute('aria-label', 'Copy ' + item.name);
+        tile.setAttribute('aria-label', t('copyAria', 'Copy {name}').replace('{name}', name));
         tile.appendChild(el('span', 'tattoo-symbol-glyph', item.ch));
-        tile.appendChild(el('span', 'tattoo-symbol-name', item.name));
+        tile.appendChild(el('span', 'tattoo-symbol-name', name));
         wrap.appendChild(tile);
       });
       grid.appendChild(wrap);
@@ -314,8 +344,8 @@
 
   function setMode(next) {
     mode = next;
-    $$('.tattoo-mode-tab').forEach(function (t) {
-      t.classList.toggle('active', t.dataset.mode === mode);
+    $$('.tattoo-mode-tab').forEach(function (t2) {
+      t2.classList.toggle('active', t2.dataset.mode === mode);
     });
     const textWrap = $('#tattooTextWrap');
     if (textWrap) textWrap.classList.toggle('u-hidden', mode !== 'names');
@@ -359,7 +389,7 @@
     // The ink test applies to names + letters — the "will it stay readable?" check.
     const panel = el('div', 'tattoo-control-group');
     panel.dataset.tattooSize = '1';
-    panel.appendChild(chipRow('Ink test', SIZE_VIEWS,
+    panel.appendChild(chipRow(t('inkTest', 'Ink test'), SIZE_VIEWS,
       function (chip) { return chip.id === sizeView; },
       function (chip) { sizeView = chip.id; }));
     host.appendChild(panel);
@@ -370,7 +400,7 @@
     panel.dataset.tattooPanel = 'date';
 
     const inputRow = el('div', 'vertical-control-row');
-    inputRow.appendChild(el('span', 'vertical-control-label', 'Your date'));
+    inputRow.appendChild(el('span', 'vertical-control-label', t('yourDate', 'Your date')));
     const fields = el('div', 'tattoo-date-fields');
 
     function numField(id, placeholder, label, max) {
@@ -388,17 +418,23 @@
       return wrap;
     }
 
-    fields.appendChild(numField('tattooDay', '12', 'Day', 31));
-    fields.appendChild(numField('tattooMonth', '6', 'Month', 12));
-    fields.appendChild(numField('tattooYear', '2020', 'Year or number', 3999));
+    fields.appendChild(numField('tattooDay', '12', t('day', 'Day'), 31));
+    fields.appendChild(numField('tattooMonth', '6', t('month', 'Month'), 12));
+    fields.appendChild(numField('tattooYear', '2020', t('yearOrNumber', 'Year or number'), 3999));
     inputRow.appendChild(fields);
     panel.appendChild(inputRow);
 
-    panel.appendChild(chipRow('Order', DATA.DATE_ORDERS,
+    panel.appendChild(chipRow(t('order', 'Order'),
+      DATA.DATE_ORDERS.map(function (o) {
+        return { id: o.id, label: pick('orders', o.id, o.label) };
+      }),
       function (chip) { return chip.id === dateOrder; },
       function (chip) { dateOrder = chip.id; }));
 
-    panel.appendChild(chipRow('Separator', DATA.DATE_SEPARATORS,
+    panel.appendChild(chipRow(t('separator', 'Separator'),
+      DATA.DATE_SEPARATORS.map(function (s) {
+        return { id: s.id, label: pick('seps', s.id, s.label) };
+      }),
       function (chip) { return chip.id === dateSep; },
       function (chip) { dateSep = chip.id; }));
 
@@ -412,7 +448,7 @@
     const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
 
     const firstRow = el('div', 'vertical-control-row');
-    firstRow.appendChild(el('span', 'vertical-control-label', 'Your letter'));
+    firstRow.appendChild(el('span', 'vertical-control-label', t('yourLetter', 'Your letter')));
     const letterGrid = el('div', 'tattoo-letter-grid');
     alphabet.forEach(function (letter) {
       const btn = el('button', 'tattoo-letter-btn' + (letter === monoFirst ? ' active' : ''), letter);
@@ -430,14 +466,14 @@
     panel.appendChild(firstRow);
 
     const secondRow = el('div', 'vertical-control-row');
-    secondRow.appendChild(el('span', 'vertical-control-label', 'Second initial'));
+    secondRow.appendChild(el('span', 'vertical-control-label', t('secondInitial', 'Second initial')));
     const secondWrap = el('div', 'vertical-mode-chips');
     const select = document.createElement('select');
     select.className = 'vertical-layout-select tattoo-second-select';
-    select.setAttribute('aria-label', 'Second initial');
+    select.setAttribute('aria-label', t('secondInitial', 'Second initial'));
     const noneOpt = document.createElement('option');
     noneOpt.value = '';
-    noneOpt.textContent = 'None — single letter';
+    noneOpt.textContent = t('secondNone', 'None — single letter');
     select.appendChild(noneOpt);
     alphabet.forEach(function (letter) {
       const opt = document.createElement('option');
@@ -454,7 +490,10 @@
     secondRow.appendChild(secondWrap);
     panel.appendChild(secondRow);
 
-    const joinerRow = chipRow('Joined by', DATA.JOINERS,
+    const joinerRow = chipRow(t('joinedBy', 'Joined by'),
+      DATA.JOINERS.map(function (j) {
+        return { id: j.id, label: pick('joiners', j.id, j.label), ch: j.ch };
+      }),
       function (chip) { return chip.id === monoJoiner; },
       function (chip) { monoJoiner = chip.id; });
     joinerRow.classList.add('vertical-divider-row', 'disabled-row');
@@ -467,7 +506,7 @@
     const panel = el('div', 'tattoo-control-group u-hidden');
     panel.dataset.tattooPanel = 'symbols';
     panel.appendChild(el('p', 'tattoo-panel-note',
-      'Tap any symbol to copy it — pair one with a name or date, or wear it alone.'));
+      t('symbolsNote', 'Tap any symbol to copy it — pair one with a name or date, or wear it alone.')));
     host.appendChild(panel);
   }
 

--- a/nl/usecase/tattoo-letters/index.html
+++ b/nl/usecase/tattoo-letters/index.html
@@ -11,7 +11,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Tattoo Letters — Lettertypes voor je Tattoo testen | UltraTextGen</title>
-  <meta name="description" content="Tattoo lettertype kiezen? Typ je woord, naam of datum en vergelijk tattoo letters — sierlijk, gothic, italic, typemachine. Screenshot en laat het je artiest zien.">
+  <meta name="description" content="Tattoo lettertypes: vergelijk sierlijk, gothic en typemachine op je eigen naam, zet een datum om in Romeinse cijfers en test initialen en symbolen — gratis.">
   <link rel="canonical" href="https://ultratextgen.com/nl/usecase/tattoo-letters/">
 
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/usecase/tattoo-fonts/">
@@ -49,13 +49,30 @@
   "@context": "https://schema.org",
   "@type": "WebApplication",
   "name": "Tattoo Lettertype Generator",
-  "alternateName": ["Tattoo Letters", "Tattoo Lettertypes", "Tattoo Tekst Generator", "Letters voor een Tattoo", "Tattoo Letters Voorbeelden"],
+  "alternateName": [
+    "Tattoo Letters",
+    "Tattoo Lettertypes",
+    "Tattoo Tekst Generator",
+    "Letters voor een Tattoo",
+    "Tattoo Letters Voorbeelden"
+  ],
   "url": "https://ultratextgen.com/nl/usecase/tattoo-letters/",
   "inLanguage": "nl",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Any",
-  "description": "Bekijk je tattoo tekst vooraf in verschillende lettertypes: typ een woord, naam of datum en vergelijk sierlijke letters, gothic, italic en typemachine — screenshot je favoriet en laat hem aan je tattoo-artiest zien. Gratis, zonder app.",
-  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "EUR" }
+  "description": "Bekijk je tattoo letterwerk voordat de naald begint: vergelijk sierlijke, gothic, dun italic en typemachine tattoo lettertypes op je eigen naam, zet een datum om in Romeinse cijfers, bouw monogrammen van initialen en blader door tattoo-symbolen met hun betekenis — screenshot je favorieten en laat ze aan je tattoo-artiest zien. Gratis, zonder app.",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "EUR"
+  },
+  "featureList": [
+    "Vergelijk 10 tattoo letterstijlen op je eigen naam of woord",
+    "Datum- en getalconverter naar Romeinse cijfers met tattoo-formaten",
+    "Monogram-generator voor losse letters en twee initialen",
+    "Tattoo-symbolenbibliotheek met betekenissen",
+    "Inkttest — bekijk letterwerk op realistische kijkafstanden"
+  ]
 }
 </script>
 
@@ -68,27 +85,50 @@
     {
       "@type": "Question",
       "name": "Hoe kies ik een tattoo lettertype?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Begin bij de betekenis, niet bij het uiterlijk. Een naam of liefdesverklaring → sierlijk schrift, warm en tijdloos. Een krachtig woord of motto → gothic, zwaar en uitgesproken. Een korte quote → dunne italic, ingetogen en elegant. Een datum → Romeinse cijfers of typemachine-stijl. Typ je tekst bovenaan de pagina, vergelijk de stijlen naast elkaar en hou de twee of drie over die iets met je doen — je tattoo-artiest helpt je daarna kiezen." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Begin bij de betekenis, niet bij het uiterlijk. Een naam of liefdesverklaring → sierlijk schrift, warm en tijdloos. Een krachtig woord of motto → gothic, zwaar en uitgesproken. Een korte quote → dunne italic, ingetogen en elegant. Een datum → Romeinse cijfers of typemachine-stijl. Typ je tekst bovenaan de pagina, vergelijk de stijlen naast elkaar en hou de twee of drie over die iets met je doen — je tattoo-artiest helpt je daarna kiezen."
+      }
     },
     {
       "@type": "Question",
       "name": "Welke letters voor een naam tattoo?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Sierlijk schrift is dé klassieker voor een naam tattoo: de verbonden letters ogen handgeschreven en persoonlijk, en ze verouderen mooi. Een volle variant (𝓢𝓪𝓷𝓷𝓮) heeft meer aanwezigheid, een dunne variant (𝒮𝒶𝓃𝓃𝑒) is verfijnder. Is de naam kort en wil je karakter? Probeer dan ook gothic — heel gebruikelijk in de chicano-stijl. Vergelijk ze allebei op deze pagina voordat je beslist." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Sierlijk schrift is dé klassieker voor een naam tattoo: de verbonden letters ogen handgeschreven en persoonlijk, en ze verouderen mooi. Een volle variant (𝓢𝓪𝓷𝓷𝓮) heeft meer aanwezigheid, een dunne variant (𝒮𝒶𝓃𝓃𝑒) is verfijnder. Is de naam kort en wil je karakter? Probeer dan ook gothic — heel gebruikelijk in de chicano-stijl. Vergelijk ze allebei op deze pagina voordat je beslist."
+      }
     },
     {
       "@type": "Question",
       "name": "Kan ik deze lettertypes zo laten tatoeëren?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Nee, en dat zeggen we er eerlijk bij: deze Unicode-letters zijn een werkbasis, geen kant-en-klaar tattoo-ontwerp. Ze helpen je een richting te kiezen — sierlijk, gothic, italic — en die duidelijk aan je tattoo-artiest te laten zien. Die past het letterwerk daarna aan op jouw huid: lijndikte, verbindingen tussen letters, de kromming van de plek. Het uiteindelijke letterwerk is zijn of haar vak." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Nee, en dat zeggen we er eerlijk bij: deze Unicode-letters zijn een werkbasis, geen kant-en-klaar tattoo-ontwerp. Ze helpen je een richting te kiezen — sierlijk, gothic, italic — en die duidelijk aan je tattoo-artiest te laten zien. Die past het letterwerk daarna aan op jouw huid: lijndikte, verbindingen tussen letters, de kromming van de plek. Het uiteindelijke letterwerk is zijn of haar vak."
+      }
     },
     {
       "@type": "Question",
       "name": "Hoe klein kunnen dunne tattoo letters?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Hoe fijner de letters, hoe meer ruimte ze nodig hebben. Heel dunne lijnen en kleine lusjes worden met de jaren dikker en lopen dicht — een woord in dun sierschrift van minder dan een centimeter hoog wordt op den duur onleesbaar. Simpele vuistregel: wil je klein, kies dan een strakke stijl (italic, typemachine); wil je sierlijke krullen, reserveer dan ruimte. Je tattoo-artiest vertelt je de exacte minimale grootte voor de gekozen plek." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Hoe fijner de letters, hoe meer ruimte ze nodig hebben. Heel dunne lijnen en kleine lusjes worden met de jaren dikker en lopen dicht — een woord in dun sierschrift van minder dan een centimeter hoog wordt op den duur onleesbaar. Simpele vuistregel: wil je klein, kies dan een strakke stijl (italic, typemachine); wil je sierlijke krullen, reserveer dan ruimte. Je tattoo-artiest vertelt je de exacte minimale grootte voor de gekozen plek."
+      }
     },
     {
       "@type": "Question",
       "name": "Hoe laat ik het lettertype aan mijn tattoo-artiest zien?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Typ je exacte woord (niet een voorbeeldwoord) bovenaan de pagina, screenshot de twee of drie stijlen die je het mooist vindt en neem ze mee naar de afspraak. Benoem wat je in elke stijl aanspreekt — «de verbindingen van het sierschrift», «de dikte van de gothic» — in plaats van een pixel-perfecte kopie te vragen. Let op letters met accenten of een trema: ë, é of ï blijven in Unicode-stijlen vaak gewone letters, maar je artiest tekent ze in het definitieve ontwerp zonder problemen mee." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Typ je exacte woord (niet een voorbeeldwoord) bovenaan de pagina, screenshot de twee of drie stijlen die je het mooist vindt en neem ze mee naar de afspraak. Benoem wat je in elke stijl aanspreekt — «de verbindingen van het sierschrift», «de dikte van de gothic» — in plaats van een pixel-perfecte kopie te vragen. Let op letters met accenten of een trema: ë, é of ï blijven in Unicode-stijlen vaak gewone letters, maar je artiest tekent ze in het definitieve ontwerp zonder problemen mee."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Hoe schrijf ik een datum in Romeinse cijfers voor een tattoo?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Zet elk deel van de datum apart om — dag, maand, jaar — en verbind ze met een scheidingsteken: 12 juni 2020 wordt XII·VI·MMXX. De modus Datum → Romeins op deze pagina doet de omzetting voor je en laat je scheidingstekens (punten, streepjes, balken, gestapelde regels) en volgordes (dag-maand-jaar of maand-dag-jaar) vergelijken. Controleer de cijfers samen met je tattoo-artiest vóór de afspraak: een fout omgezette datum is dé meest voorkomende spijt bij letter-tattoos."
+      }
     }
   ]
 }
@@ -125,9 +165,10 @@
   <div class="hero-inner">
     <div class="hero-card">
       <h1 class="hero-headline">Tattoo lettertype generator</h1>
-      <p class="hero-tagline">Typ het woord, de naam of de datum van je tattoo-idee en vergelijk meteen de lettertypes — sierlijk, gothic, italic, typemachine. Screenshot de stijlen die je mooi vindt en laat ze aan je tattoo-artiest zien: die tekent het uiteindelijke letterwerk, deze pagina helpt je alleen de richting te kiezen.</p>
-      <div class="input-wrapper">
-        <textarea class="main-input" id="mainInput" placeholder="Typ hier je tekst…" maxlength="500" autofocus=""></textarea>
+      <p class="hero-tagline">Alles wat een letter-tattoo nodig heeft, op één plek: vergelijk tattoo lettertypes op je eigen naam of woord, zet een datum om in Romeinse cijfers, bouw een monogram van initialen of kies een klein symbool met betekenis. Screenshot wat je mooi vindt en laat het aan je tattoo-artiest zien — die tekent het uiteindelijke letterwerk, deze pagina helpt je de richting te kiezen.</p>
+      <div class="tattoo-mode-tabs" id="tattooModeTabs"></div>
+      <div class="input-wrapper" id="tattooTextWrap">
+        <textarea class="main-input" id="mainInput" placeholder="Typ je naam, woord of quote..." maxlength="500" autofocus=""></textarea>
         <span class="char-count"><span id="charCount">0</span>/500</span>
       </div>
       <div class="accent-notice" id="accentNotice" role="note" hidden>
@@ -135,21 +176,12 @@
         <span class="accent-notice-text">Je tekst bevat accenten of een trema. De meeste stijlen laten <b>ë</b>, <b>é</b> of <b>ï</b> als gewone letter staan — de stijlen <b>doorgestreept, onderstreept en kaders</b> houden ze wel. <a href="/guide/fancy-fonts-and-accents/">Welke stijlen accenten houden →</a></span>
         <button type="button" class="accent-notice-close" id="accentNoticeClose" aria-label="Sluiten">✕</button>
       </div>
-      <div class="decoration-section">
-        <div class="decoration-label">Zet er wat decoratie omheen</div>
-        <div class="decoration-tabs">
-          <button class="decoration-tab active" data-deco-tab="symbols">Symbolen</button>
-          <button class="decoration-tab" data-deco-tab="frames">Kaders</button>
-          <button class="decoration-tab" data-deco-tab="minimal">Minimalistisch</button>
-        </div>
-        <div class="decoration-grid" id="decorationGrid"></div>
-      </div>
+      <div id="tattooControlPanel"></div>
     </div>
   </div>
 </section>
 
 <main class="container">
-  <div class="category-section"><div class="category-tabs" id="categoryTabs"></div></div>
   <div class="results-grid" id="resultsGrid"></div>
 
   <!-- Zien voor de naald -->
@@ -245,6 +277,8 @@
     <div class="faq-item"><button class="faq-question" type="button">Kan ik deze lettertypes zo laten tatoeëren?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Nee, en dat zeggen we er eerlijk bij: deze Unicode-letters zijn een werkbasis, geen kant-en-klaar tattoo-ontwerp. Ze helpen je een richting te kiezen — sierlijk, gothic, italic — en die duidelijk aan je tattoo-artiest te laten zien. Die past het letterwerk daarna aan op jouw huid: lijndikte, verbindingen tussen letters, de kromming van de plek. Het uiteindelijke letterwerk is zijn of haar vak.</div></div>
     <div class="faq-item"><button class="faq-question" type="button">Hoe klein kunnen dunne tattoo letters?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Hoe fijner de letters, hoe meer ruimte ze nodig hebben. Heel dunne lijnen en kleine lusjes worden met de jaren dikker en lopen dicht — een woord in dun sierschrift van minder dan een centimeter hoog wordt op den duur onleesbaar. Simpele vuistregel: wil je klein, kies dan een strakke stijl (italic, typemachine); wil je sierlijke krullen, reserveer dan ruimte. Je tattoo-artiest vertelt je de exacte minimale grootte voor de gekozen plek.</div></div>
     <div class="faq-item"><button class="faq-question" type="button">Hoe laat ik het lettertype aan mijn tattoo-artiest zien?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Typ je exacte woord (niet een voorbeeldwoord) bovenaan de pagina, screenshot de twee of drie stijlen die je het mooist vindt en neem ze mee naar de afspraak. Benoem wat je in elke stijl aanspreekt — «de verbindingen van het sierschrift», «de dikte van de gothic» — in plaats van een pixel-perfecte kopie te vragen. Let op letters met accenten of een trema: ë, é of ï blijven in Unicode-stijlen vaak gewone letters, maar je artiest tekent ze in het definitieve ontwerp zonder problemen mee.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Hoe schrijf ik een datum in Romeinse cijfers voor een tattoo?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Zet elk deel van de datum apart om — dag, maand, jaar — en verbind ze met een scheidingsteken: 12 juni 2020 wordt XII·VI·MMXX. De modus Datum → Romeins op deze pagina doet de omzetting voor je en laat je scheidingstekens (punten, streepjes, balken, gestapelde regels) en volgordes (dag-maand-jaar of maand-dag-jaar) vergelijken. Controleer de cijfers samen met je tattoo-artiest vóór de afspraak: een fout omgezette datum is dé meest voorkomende spijt bij letter-tattoos.</div></div>
+
 
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="Taalkeuze">
@@ -265,9 +299,234 @@
 <div class="copy-toast" id="copyToast">Gekopieerd!</div>
 <div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
 
-<script src="/styles.js"></script>
-<script src="/renderer.js"></script>
-<script src="/script.js" defer=""></script>
+<!-- Page configuration: tattoo mode flag + i18n -->
+<script>
+window.UTG_TATTOO_MODE = true;
+window.tattooI18n = {
+  "sampleName": "Sanne",
+  "modeNamesLabel": "Namen & woorden",
+  "modeNamesHint": "Typ een naam, woord of quote",
+  "modeDateLabel": "Datum → Romeins",
+  "modeDateHint": "Zet een datum of getal om in Romeinse cijfers",
+  "modeLettersLabel": "Letters & initialen",
+  "modeLettersHint": "Losse letters en monogrammen",
+  "modeSymbolsLabel": "Symbolen",
+  "modeSymbolsHint": "Kleine symbolen met betekenis",
+  "sizeClose": "Close-up",
+  "sizeArm": "Op armlengte",
+  "sizeRoom": "Van veraf",
+  "inkTest": "Inkttest",
+  "yourDate": "Jouw datum",
+  "day": "Dag",
+  "month": "Maand",
+  "yearOrNumber": "Jaar of getal",
+  "order": "Volgorde",
+  "separator": "Scheidingsteken",
+  "yourLetter": "Jouw letter",
+  "secondInitial": "Tweede initiaal",
+  "secondNone": "Geen — losse letter",
+  "joinedBy": "Verbonden door",
+  "symbolsNote": "Tik op een symbool om het te kopiëren — combineer het met een naam of datum, of draag het los.",
+  "sampleHintName": "Je ziet “{text}” — typ hierboven je naam, woord of quote.",
+  "sampleHintDate": "Je ziet een voorbeelddatum (12 · 6 · 2020) — vul hierboven je eigen datum of getal in.",
+  "romanRange": "Romeinse cijfers gaan van 1 tot 3999 — check de waarden hierboven.",
+  "headingRoman": "Romeinse cijfers",
+  "headingFigures": "Gewone cijfers",
+  "badgeSafe": "blijft klein leesbaar",
+  "badgeRoomy": "heeft ruimte nodig",
+  "copy": "Kopieer",
+  "copyAria": "Kopieer {name}",
+  "families": {
+    "Script": "Sierlijk",
+    "Gothic": "Gothic",
+    "Italic": "Italic",
+    "Minimal": "Minimalistisch",
+    "Roman": "Romeins",
+    "Figures": "Cijfers"
+  },
+  "orders": {
+    "dmy": "Dag · Maand · Jaar",
+    "mdy": "Maand · Dag · Jaar",
+    "y": "Alleen jaar"
+  },
+  "seps": {
+    "space": "spatie",
+    "stack": "gestapeld"
+  },
+  "joiners": {
+    "none": "Geen"
+  },
+  "lettering": {
+    "Ultra Script Bold": {
+      "label": "Vol Sierschrift",
+      "note": "Dé klassieker voor een naam tattoo — verbonden en warm, houdt zijn vorm op klein formaat."
+    },
+    "Ultra Script": {
+      "label": "Dun Sierschrift",
+      "note": "Fijn en luchtig — prachtig op middelgroot formaat; de dunne lusjes hebben ruimte nodig om mooi te verouderen."
+    },
+    "Ultra Chicano Script": {
+      "label": "Chicano Nameplate",
+      "note": "Vol sierschrift in een sierlijke banner — de klassieke nameplate-omlijsting."
+    },
+    "Ultra Gothic": {
+      "label": "Gothic Blackletter",
+      "note": "Fraktur blackletter — compact en uitgesproken, gemaakt om een krachtig woord te dragen."
+    },
+    "Ultra Gothic Bold": {
+      "label": "Zware Old English",
+      "note": "De zware Old English look — een vaste waarde in old school en chicano letterwerk."
+    },
+    "Ultra Old English Banner": {
+      "label": "Old English Banner",
+      "note": "Zwaar blackletter in een banner — een nameplate met maximale aanwezigheid."
+    },
+    "Ultra Italic": {
+      "label": "Dunne Italic",
+      "note": "Ingetogen schuinschrift — glijdt onopvallend langs een rib, pols of sleutelbeen."
+    },
+    "Ultra Italic Serif": {
+      "label": "Italic Serif",
+      "note": "Boekachtige serif italic — leest als een regel uit een roman."
+    },
+    "Ultra Typewriter Document": {
+      "label": "Typemachine",
+      "note": "Rauw, literair monospace — perfect voor een datum of korte zin."
+    },
+    "Ultra Small Caps": {
+      "label": "Kleinkapitalen",
+      "note": "Kleine gelijkmatige kapitalen — de minimalistische fine-line keuze."
+    }
+  },
+  "roman": {
+    "Classic": {
+      "label": "Klassiek",
+      "note": "Gewone kapitalen — wat de meeste tattoo-artiesten zetten."
+    },
+    "Serif Italic": {
+      "label": "Serif Italic",
+      "note": "De look van een gegraveerd monument, schuin gezet."
+    },
+    "Script": {
+      "label": "Sierschrift",
+      "note": "Romeinse cijfers in vloeiend sierschrift."
+    },
+    "Blackletter": {
+      "label": "Blackletter",
+      "note": "Fraktur-cijfers — donker en rijk versierd."
+    },
+    "Heavy Old English": {
+      "label": "Zware Old English",
+      "note": "Blackletter-cijfers in maximaal gewicht."
+    },
+    "Typewriter": {
+      "label": "Typemachine",
+      "note": "Monospace cijfers — strak en documentair."
+    }
+  },
+  "digits": {
+    "Typewriter": {
+      "label": "Typemachine",
+      "note": "Monospace cijfers — de klassieke datum-look."
+    },
+    "Bold Serif": {
+      "label": "Vette Serif",
+      "note": "Zware boekcijfers — mooi bij blackletter."
+    },
+    "Bold Sans": {
+      "label": "Vette Sans",
+      "note": "Moderne zware cijfers — mooi bij vol sierschrift."
+    },
+    "Fine Sans": {
+      "label": "Dunne Sans",
+      "note": "Lichte cijfers — mooi bij dun sierschrift en italic."
+    },
+    "Double-Struck": {
+      "label": "Contour",
+      "note": "Cijfers met open contouren — een verrassende fine-line keuze."
+    },
+    "Wide Spaced": {
+      "label": "Breed Gespatieerd",
+      "note": "Extra brede cijfers — luchtig en redactioneel gespatieerd."
+    },
+    "Tiny": {
+      "label": "Mini",
+      "note": "Miniatuurcijfers — op achter-het-oor formaat."
+    }
+  },
+  "groups": {
+    "minimal": "Fine line & minimalistisch",
+    "celestial": "Hemels",
+    "love": "Liefde & herinnering",
+    "faith": "Geloof & bescherming",
+    "journey": "Kracht & reis",
+    "music": "Muziek & kunst",
+    "zodiac": "Sterrenbeelden"
+  },
+  "symbols": {
+    ";": "Puntkomma — het verhaal gaat verder",
+    "∞": "Oneindig — zonder einde",
+    "·": "Enkele punt — een rustmoment",
+    "—": "Streep — een lijn, een pad",
+    "~": "Golf — kalmte, flow",
+    "✕": "Kruisje — een kruispunt",
+    "°": "Klein rondje — heelheid",
+    "⋮": "Drie puntjes — mi vida loca / onaf",
+    "☾": "Maansikkel — verandering, cycli",
+    "☽": "Wassende maan — groei",
+    "☼": "Zon — levenskracht",
+    "✦": "Vierpuntige ster — richting",
+    "✧": "Open ster — hoop",
+    "⋆": "Kleine ster — een stille vonk",
+    "★": "Gevulde ster — ambitie",
+    "✵": "Stralende ster — energie",
+    "♡": "Open hart — liefde, licht gedragen",
+    "❥": "Gekanteld hart — toewijding",
+    "❦": "Bloemenhart — herinnering",
+    "➳": "Pijl — geraakt door de liefde",
+    "✿": "Bloem — in bloei",
+    "❀": "Bloesem — herinnering aan iemand",
+    "✝": "Latijns kruis — geloof",
+    "†": "Dolkkruis — opoffering",
+    "☦": "Orthodox kruis",
+    "☯": "Yin yang — balans",
+    "ॐ": "Om — de eerste klank",
+    "✡": "Davidster",
+    "☪": "Ster en halve maan",
+    "ᛉ": "Algiz-rune — bescherming",
+    "⚓": "Anker — hou stand",
+    "✈": "Vliegtuig — vertrekken, terugkeren",
+    "➵": "Pijl — alleen vooruit",
+    "→": "Pijl naar rechts — voorwaarts",
+    "⚔": "Gekruiste zwaarden — blijf vechten",
+    "♆": "Drietand — de zee",
+    "Δ": "Delta — verandering",
+    "Ω": "Omega — het einde, volharding",
+    "♪": "Achtste noot",
+    "♫": "Verbonden noten",
+    "♬": "Dubbel verbonden noten",
+    "𝄞": "Vioolsleutel",
+    "✎": "Potlood — teken van de maker",
+    "♈": "Ram",
+    "♉": "Stier",
+    "♊": "Tweelingen",
+    "♋": "Kreeft",
+    "♌": "Leeuw",
+    "♍": "Maagd",
+    "♎": "Weegschaal",
+    "♏": "Schorpioen",
+    "♐": "Boogschutter",
+    "♑": "Steenbok",
+    "♒": "Waterman",
+    "♓": "Vissen"
+  }
+};
+</script>
+<script src="/styles.js" defer></script>
+<script src="/renderer.js" defer></script>
+<script src="/js/tattoo/tattooData.js" defer></script>
+<script src="/script.js" defer></script>
+<script src="/js/tattoo/tattooPageController.js" defer></script>
 <script src="/symbol-explorer.js"></script>
 <script src="/accent-notice.js" defer></script>
 <script src="/footer.js"></script>

--- a/pl/usecase/czcionki-tatuaze/index.html
+++ b/pl/usecase/czcionki-tatuaze/index.html
@@ -11,7 +11,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Czcionki na Tatuaż — Napisy i Litery do Tatuażu | UltraTextGen</title>
-  <meta name="description" content="Czcionki na tatuaż: wpisz słowo, imię lub datę i porównaj napisy — pismo odręczne, gotyk, kursywę — zanim pójdziesz pod igłę. Zrób screena i pokaż tatuażyście.">
+  <meta name="description" content="Czcionki na tatuaż: porównaj pismo odręczne, gotyk i kursywę na swoim imieniu, zamień datę na cyfry rzymskie i sprawdź inicjały — za darmo, przed igłą.">
   <link rel="canonical" href="https://ultratextgen.com/pl/usecase/czcionki-tatuaze/">
 
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/usecase/tattoo-fonts/">
@@ -49,13 +49,30 @@
   "@context": "https://schema.org",
   "@type": "WebApplication",
   "name": "Czcionki na Tatuaż",
-  "alternateName": ["Czcionki Tatuaże", "Napisy na Tatuaż", "Czcionki do Tatuażu", "Wzory Liter na Tatuaż", "Litery do Tatuażu"],
+  "alternateName": [
+    "Czcionki Tatuaże",
+    "Napisy na Tatuaż",
+    "Czcionki do Tatuażu",
+    "Wzory Liter na Tatuaż",
+    "Litery do Tatuażu"
+  ],
   "url": "https://ultratextgen.com/pl/usecase/czcionki-tatuaze/",
   "inLanguage": "pl",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Any",
-  "description": "Podejrzyj napis na swój tatuaż, zanim trafi na skórę: wpisz słowo, imię lub datę i porównaj pismo odręczne, gotyk, kursywę i styl maszynowy — a potem pokaż screena tatuażyście. Za darmo, bez aplikacji.",
-  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
+  "description": "Podejrzyj napis na tatuaż, zanim pójdziesz pod igłę: porównaj pismo odręczne, gotyk, delikatną kursywę i styl maszynowy na swoim dokładnym imieniu, zamień datę na cyfry rzymskie, złóż monogram z inicjałów i przeglądaj symbole na tatuaż z ich znaczeniami — a potem zrób screena ulubionych i pokaż tatuażyście. Za darmo, bez aplikacji.",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "featureList": [
+    "Porównaj 10 stylów liternictwa na swoim dokładnym imieniu lub słowie",
+    "Konwerter dat i liczb na cyfry rzymskie z tatuażowymi formatami",
+    "Generator monogramów z jednej litery lub dwóch inicjałów",
+    "Biblioteka symboli na tatuaż ze znaczeniami",
+    "Test tuszu — podgląd napisu w rozmiarach, w jakich naprawdę się go ogląda"
+  ]
 }
 </script>
 
@@ -68,27 +85,50 @@
     {
       "@type": "Question",
       "name": "Jak wybrać czcionkę na tatuaż?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Zacznij od znaczenia, nie od wyglądu. Imię albo wyznanie → pismo odręczne, ciepłe i ponadczasowe. Mocne słowo, dewiza → gotyk, gęsty i zdecydowany. Krótki cytat → delikatna kursywa, dyskretna i elegancka. Data → cyfry rzymskie albo styl maszynowy. Wpisz swój tekst na górze strony, porównaj style obok siebie i zostaw dwa–trzy, które do ciebie przemawiają — tatuażysta pomoże ci wybrać ostatecznie." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Zacznij od znaczenia, nie od wyglądu. Imię albo wyznanie → pismo odręczne, ciepłe i ponadczasowe. Mocne słowo, dewiza → gotyk, gęsty i zdecydowany. Krótki cytat → delikatna kursywa, dyskretna i elegancka. Data → cyfry rzymskie albo styl maszynowy. Wpisz swój tekst na górze strony, porównaj style obok siebie i zostaw dwa–trzy, które do ciebie przemawiają — tatuażysta pomoże ci wybrać ostatecznie."
+      }
     },
     {
       "@type": "Question",
       "name": "Jakie litery na tatuaż z imieniem?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Pismo odręczne to klasyka tatuowanego imienia: połączone litery dają wrażenie osobistego, ręcznego zapisu, który dobrze się starzeje. Gruby wariant (𝓜𝓪𝓻𝓽𝓪) ma więcej charakteru, cienki (𝓂𝒶𝓇𝓉𝒶) więcej delikatności. Jeśli imię jest krótkie i chcesz mocniejszego efektu, wypróbuj też gotyk — bardzo popularny w stylu chicano. Porównaj oba na tej stronie, zanim zdecydujesz." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Pismo odręczne to klasyka tatuowanego imienia: połączone litery dają wrażenie osobistego, ręcznego zapisu, który dobrze się starzeje. Gruby wariant (𝓜𝓪𝓻𝓽𝓪) ma więcej charakteru, cienki (𝓂𝒶𝓇𝓉𝒶) więcej delikatności. Jeśli imię jest krótkie i chcesz mocniejszego efektu, wypróbuj też gotyk — bardzo popularny w stylu chicano. Porównaj oba na tej stronie, zanim zdecydujesz."
+      }
     },
     {
       "@type": "Question",
       "name": "Czy te czcionki można wykorzystać jeden do jednego jako tatuaż?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Nie — i warto to powiedzieć wprost: te znaki Unicode to punkt wyjścia, a nie gotowy projekt do wbicia. Służą do wybrania kierunku — pismo odręczne, gotyk, kursywa — i pokazania go tatuażyście w czytelny sposób. To on dopasuje liternictwo do twojej skóry: grubość kresek, połączenia między literami, krzywiznę miejsca na ciele. Ostateczny napis to jego rzemiosło." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Nie — i warto to powiedzieć wprost: te znaki Unicode to punkt wyjścia, a nie gotowy projekt do wbicia. Służą do wybrania kierunku — pismo odręczne, gotyk, kursywa — i pokazania go tatuażyście w czytelny sposób. To on dopasuje liternictwo do twojej skóry: grubość kresek, połączenia między literami, krzywiznę miejsca na ciele. Ostateczny napis to jego rzemiosło."
+      }
     },
     {
       "@type": "Question",
       "name": "Jaki jest minimalny rozmiar cienkiego napisu?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Im cieńszy i bardziej zdobiony napis, tym więcej potrzebuje miejsca. Bardzo cienkie kreski i małe pętelki z latami grubieją i się zlewają — słowo cienkim pismem odręcznym poniżej centymetra wysokości może z czasem stać się nieczytelne. Prosta zasada: jeśli ma być mało, wybierz prosty styl (kursywa, maszynowy); jeśli chcesz zdobionego pisma odręcznego, zaplanuj więcej miejsca. Dokładny minimalny rozmiar dla wybranego miejsca poda ci tatuażysta." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Im cieńszy i bardziej zdobiony napis, tym więcej potrzebuje miejsca. Bardzo cienkie kreski i małe pętelki z latami grubieją i się zlewają — słowo cienkim pismem odręcznym poniżej centymetra wysokości może z czasem stać się nieczytelne. Prosta zasada: jeśli ma być mało, wybierz prosty styl (kursywa, maszynowy); jeśli chcesz zdobionego pisma odręcznego, zaplanuj więcej miejsca. Dokładny minimalny rozmiar dla wybranego miejsca poda ci tatuażysta."
+      }
     },
     {
       "@type": "Question",
       "name": "Jak pokazać styl tatuażyście?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Wpisz swoje dokładne słowo (nie przykładowe) na górze strony, zrób screena dwóch–trzech stylów, które podobają ci się najbardziej, i zabierz je na wizytę. Powiedz, co ci się w każdym podoba — «połączenia liter w piśmie odręcznym», «grubość gotyku» — zamiast prosić o kopię piksel w piksel. Uwaga na polskie znaki: ł, ś, ą czy ę w podglądzie Unicode zwykle zostają zwykłymi literami (przetestuj też wersję bez ogonków, np. «milosc»), ale tatuażysta narysuje je w finalnym napisie bez problemu." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Wpisz swoje dokładne słowo (nie przykładowe) na górze strony, zrób screena dwóch–trzech stylów, które podobają ci się najbardziej, i zabierz je na wizytę. Powiedz, co ci się w każdym podoba — «połączenia liter w piśmie odręcznym», «grubość gotyku» — zamiast prosić o kopię piksel w piksel. Uwaga na polskie znaki: ł, ś, ą czy ę w podglądzie Unicode zwykle zostają zwykłymi literami (przetestuj też wersję bez ogonków, np. «milosc»), ale tatuażysta narysuje je w finalnym napisie bez problemu."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Jak zapisać datę cyframi rzymskimi na tatuaż?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Przelicz każdą część daty osobno — dzień, miesiąc, rok — i połącz je separatorem: 12 czerwca 2020 to XII·VI·MMXX. Tryb «Data → rzymskie» na tej stronie zrobi to za ciebie i pozwoli porównać separatory (kropki, myślniki, kreski, zapis w pionie) oraz kolejności (dzień-miesiąc-rok albo miesiąc-dzień-rok). Przed wizytą sprawdź cyfry jeszcze raz z tatuażystą: źle przeliczona data to najczęstszy powód żalu po tatuażu z napisem."
+      }
     }
   ]
 }
@@ -126,9 +166,10 @@
   <div class="hero-inner">
     <div class="hero-card">
       <h1 class="hero-headline">Czcionki na tatuaż</h1>
-      <p class="hero-tagline">Wpisz słowo, imię lub datę z twojego pomysłu na tatuaż i od razu porównaj style napisów — pismo odręczne, gotyk, kursywę, styl maszynowy. Zrób screena tych, które ci się podobają, i pokaż je tatuażyście: to on narysuje ostateczny napis, a ta strona pomoże ci tylko wybrać kierunek.</p>
-      <div class="input-wrapper">
-        <textarea class="main-input" id="mainInput" placeholder="Wpisz swój tekst tutaj…" maxlength="500" autofocus=""></textarea>
+      <p class="hero-tagline">Wszystko, czego potrzebuje tatuaż z napisem, w jednym miejscu: porównaj czcionki na tatuaż na swoim dokładnym imieniu lub słowie, zamień datę na cyfry rzymskie, złóż monogram z liter albo wybierz mały symbol ze znaczeniem. Zrób screena tego, co ci się podoba, i pokaż tatuażyście — to on narysuje ostateczny napis, a ta strona pomoże ci wybrać kierunek.</p>
+      <div class="tattoo-mode-tabs" id="tattooModeTabs"></div>
+      <div class="input-wrapper" id="tattooTextWrap">
+        <textarea class="main-input" id="mainInput" placeholder="Wpisz imię, słowo lub cytat..." maxlength="500" autofocus=""></textarea>
         <span class="char-count"><span id="charCount">0</span>/500</span>
       </div>
       <div class="accent-notice" id="accentNotice" role="note" hidden>
@@ -136,21 +177,12 @@
         <span class="accent-notice-text">Twój tekst zawiera polskie znaki. Większość stylów zostawia <b>ą</b>, <b>ę</b> czy <b>ś</b> jako zwykłe litery — zachowują je style <b>przekreślony, podkreślony i ramki</b>. <a href="/guide/fancy-fonts-and-accents/">Które style zachowują znaki diakrytyczne →</a></span>
         <button type="button" class="accent-notice-close" id="accentNoticeClose" aria-label="Zamknij">✕</button>
       </div>
-      <div class="decoration-section">
-        <div class="decoration-label">Dodaj trochę ozdób wokół wyniku</div>
-        <div class="decoration-tabs">
-          <button class="decoration-tab active" data-deco-tab="symbols">Symbole</button>
-          <button class="decoration-tab" data-deco-tab="frames">Ramki</button>
-          <button class="decoration-tab" data-deco-tab="minimal">Minimalistyczne</button>
-        </div>
-        <div class="decoration-grid" id="decorationGrid"></div>
-      </div>
+      <div id="tattooControlPanel"></div>
     </div>
   </div>
 </section>
 
 <main class="container">
-  <div class="category-section"><div class="category-tabs" id="categoryTabs"></div></div>
   <div class="results-grid" id="resultsGrid"></div>
 
   <!-- Podgląd przed igłą -->
@@ -259,6 +291,8 @@
     <div class="faq-item"><button class="faq-question" type="button">Czy te czcionki można wykorzystać jeden do jednego jako tatuaż?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Nie — i warto to powiedzieć wprost: te znaki Unicode to punkt wyjścia, a nie gotowy projekt do wbicia. Służą do wybrania kierunku — pismo odręczne, gotyk, kursywa — i pokazania go tatuażyście w czytelny sposób. To on dopasuje liternictwo do twojej skóry: grubość kresek, połączenia między literami, krzywiznę miejsca na ciele. Ostateczny napis to jego rzemiosło.</div></div>
     <div class="faq-item"><button class="faq-question" type="button">Jaki jest minimalny rozmiar cienkiego napisu?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Im cieńszy i bardziej zdobiony napis, tym więcej potrzebuje miejsca. Bardzo cienkie kreski i małe pętelki z latami grubieją i się zlewają — słowo cienkim pismem odręcznym poniżej centymetra wysokości może z czasem stać się nieczytelne. Prosta zasada: jeśli ma być mało, wybierz prosty styl (kursywa, maszynowy); jeśli chcesz zdobionego pisma odręcznego, zaplanuj więcej miejsca. Dokładny minimalny rozmiar dla wybranego miejsca poda ci tatuażysta.</div></div>
     <div class="faq-item"><button class="faq-question" type="button">Jak pokazać styl tatuażyście?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Wpisz swoje dokładne słowo (nie przykładowe) na górze strony, zrób screena dwóch–trzech stylów, które podobają ci się najbardziej, i zabierz je na wizytę. Powiedz, co ci się w każdym podoba — «połączenia liter w piśmie odręcznym», «grubość gotyku» — zamiast prosić o kopię piksel w piksel. Uwaga na polskie znaki: ł, ś, ą czy ę w podglądzie Unicode zwykle zostają zwykłymi literami (przetestuj też wersję bez ogonków, np. «milosc»), ale tatuażysta narysuje je w finalnym napisie bez problemu.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Jak zapisać datę cyframi rzymskimi na tatuaż?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Przelicz każdą część daty osobno — dzień, miesiąc, rok — i połącz je separatorem: 12 czerwca 2020 to XII·VI·MMXX. Tryb «Data → rzymskie» na tej stronie zrobi to za ciebie i pozwoli porównać separatory (kropki, myślniki, kreski, zapis w pionie) oraz kolejności (dzień-miesiąc-rok albo miesiąc-dzień-rok). Przed wizytą sprawdź cyfry jeszcze raz z tatuażystą: źle przeliczona data to najczęstszy powód żalu po tatuażu z napisem.</div></div>
+
 
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="Wybór języka">
@@ -279,9 +313,234 @@
 <div class="copy-toast" id="copyToast">Skopiowano!</div>
 <div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
 
-<script src="/styles.js"></script>
-<script src="/renderer.js"></script>
-<script src="/script.js" defer=""></script>
+<!-- Page configuration: tattoo mode flag + i18n -->
+<script>
+window.UTG_TATTOO_MODE = true;
+window.tattooI18n = {
+  "sampleName": "Marta",
+  "modeNamesLabel": "Imiona i słowa",
+  "modeNamesHint": "Wpisz imię, słowo lub cytat",
+  "modeDateLabel": "Data → rzymskie",
+  "modeDateHint": "Zamień datę lub liczbę na cyfry rzymskie",
+  "modeLettersLabel": "Litery i inicjały",
+  "modeLettersHint": "Pojedyncze litery i monogramy",
+  "modeSymbolsLabel": "Symbole",
+  "modeSymbolsHint": "Małe symbole ze znaczeniem",
+  "sizeClose": "Z bliska",
+  "sizeArm": "Na wyciągnięcie ręki",
+  "sizeRoom": "Z drugiego końca pokoju",
+  "inkTest": "Test tuszu",
+  "yourDate": "Twoja data",
+  "day": "Dzień",
+  "month": "Miesiąc",
+  "yearOrNumber": "Rok lub liczba",
+  "order": "Kolejność",
+  "separator": "Separator",
+  "yourLetter": "Twoja litera",
+  "secondInitial": "Drugi inicjał",
+  "secondNone": "Brak — jedna litera",
+  "joinedBy": "Łącznik",
+  "symbolsNote": "Kliknij symbol, aby go skopiować — połącz go z imieniem lub datą albo noś solo.",
+  "sampleHintName": "Pokazujemy «{text}» — wpisz swoje imię, słowo lub cytat powyżej.",
+  "sampleHintDate": "Pokazujemy przykładową datę (12 · 6 · 2020) — wpisz swoją datę lub liczbę powyżej.",
+  "romanRange": "Cyfry rzymskie obejmują zakres 1–3999 — sprawdź wartości powyżej.",
+  "headingRoman": "Cyfry rzymskie",
+  "headingFigures": "Zwykłe cyfry",
+  "badgeSafe": "czytelny w małym",
+  "badgeRoomy": "potrzebuje miejsca",
+  "copy": "Kopiuj",
+  "copyAria": "Kopiuj {name}",
+  "families": {
+    "Script": "Odręczne",
+    "Gothic": "Gotyk",
+    "Italic": "Kursywa",
+    "Minimal": "Minimal",
+    "Roman": "Rzymskie",
+    "Figures": "Cyfry"
+  },
+  "orders": {
+    "dmy": "Dzień · Miesiąc · Rok",
+    "mdy": "Miesiąc · Dzień · Rok",
+    "y": "Tylko rok"
+  },
+  "seps": {
+    "space": "spacja",
+    "stack": "w pionie"
+  },
+  "joiners": {
+    "none": "Brak"
+  },
+  "lettering": {
+    "Ultra Script Bold": {
+      "label": "Grube odręczne",
+      "note": "Klasyka tatuażu z imieniem — połączone i ciepłe litery, trzymają kształt w małych rozmiarach."
+    },
+    "Ultra Script": {
+      "label": "Cienkie odręczne",
+      "note": "Delikatne i lekkie — piękne w średnim rozmiarze; cienkie pętelki potrzebują miejsca, żeby dobrze się starzeć."
+    },
+    "Ultra Chicano Script": {
+      "label": "Chicano z banerem",
+      "note": "Grube pismo odręczne w ozdobnym banerze — klasyczna oprawa tatuowanego imienia."
+    },
+    "Ultra Gothic": {
+      "label": "Gotycka fraktura",
+      "note": "Fraktura — gęsta i zdecydowana, stworzona, żeby unieść mocne słowo."
+    },
+    "Ultra Gothic Bold": {
+      "label": "Ciężki Old English",
+      "note": "Ciężki styl Old English — filar old schoolu i liternictwa chicano."
+    },
+    "Ultra Old English Banner": {
+      "label": "Old English w banerze",
+      "note": "Ciężka fraktura w banerze — imię z maksymalną obecnością."
+    },
+    "Ultra Italic": {
+      "label": "Delikatna kursywa",
+      "note": "Dyskretny pochył — cicho sunie wzdłuż żebra, nadgarstka albo obojczyka."
+    },
+    "Ultra Italic Serif": {
+      "label": "Kursywa szeryfowa",
+      "note": "Książkowa kursywa z szeryfami — czyta się jak linijka wyjęta z powieści."
+    },
+    "Ultra Typewriter Document": {
+      "label": "Maszynowy",
+      "note": "Surowy, literacki styl maszyny do pisania — idealny do daty albo krótkiej linijki."
+    },
+    "Ultra Small Caps": {
+      "label": "Kapitaliki",
+      "note": "Drobne, równe wersaliki — wybór minimalistów od fine line."
+    }
+  },
+  "roman": {
+    "Classic": {
+      "label": "Klasyczne",
+      "note": "Zwykłe wersaliki — tak najczęściej tatuują artyści."
+    },
+    "Serif Italic": {
+      "label": "Szeryfowa kursywa",
+      "note": "Wygląd wygrawerowanego monumentu, z pochyleniem."
+    },
+    "Script": {
+      "label": "Odręczne",
+      "note": "Cyfry rzymskie płynnym pismem odręcznym."
+    },
+    "Blackletter": {
+      "label": "Fraktura",
+      "note": "Cyfry we frakturze — mroczne i ozdobne."
+    },
+    "Heavy Old English": {
+      "label": "Ciężki Old English",
+      "note": "Gotyckie cyfry o maksymalnej grubości."
+    },
+    "Typewriter": {
+      "label": "Maszynowe",
+      "note": "Cyfry o stałej szerokości — czyste i dokumentalne."
+    }
+  },
+  "digits": {
+    "Typewriter": {
+      "label": "Maszynowe",
+      "note": "Cyfry maszynowe — klasyczny wygląd daty."
+    },
+    "Bold Serif": {
+      "label": "Grube szeryfowe",
+      "note": "Ciężkie, książkowe cyfry — pasują do fraktury."
+    },
+    "Bold Sans": {
+      "label": "Grube bezszeryfowe",
+      "note": "Nowoczesne, ciężkie cyfry — pasują do grubego pisma odręcznego."
+    },
+    "Fine Sans": {
+      "label": "Cienkie bezszeryfowe",
+      "note": "Lekkie cyfry — pasują do cienkiego odręcznego i kursywy."
+    },
+    "Double-Struck": {
+      "label": "Konturowe",
+      "note": "Cyfry z podwójną kreską — nieoczywisty wybór w stylu fine line."
+    },
+    "Wide Spaced": {
+      "label": "Szerokie",
+      "note": "Cyfry pełnej szerokości — lekkie, redakcyjne odstępy."
+    },
+    "Tiny": {
+      "label": "Miniaturowe",
+      "note": "Malutkie cyfry — skala za uchem."
+    }
+  },
+  "groups": {
+    "minimal": "Fine line i minimal",
+    "celestial": "Niebo i gwiazdy",
+    "love": "Miłość i pamięć",
+    "faith": "Wiara i ochrona",
+    "journey": "Siła i droga",
+    "music": "Muzyka i sztuka",
+    "zodiac": "Zodiak"
+  },
+  "symbols": {
+    ";": "Średnik — historia trwa dalej",
+    "∞": "Nieskończoność — bez końca",
+    "·": "Pojedyncza kropka — pauza",
+    "—": "Myślnik — linia, droga",
+    "~": "Fala — spokój, przepływ",
+    "✕": "Krzyżyk — punkt przecięcia",
+    "°": "Małe kółko — pełnia",
+    "⋮": "Trzy kropki — mi vida loca / niedokończone",
+    "☾": "Półksiężyc — zmiana, cykle",
+    "☽": "Księżyc rosnący — wzrost",
+    "☼": "Słońce — witalność",
+    "✦": "Gwiazda czteroramienna — drogowskaz",
+    "✧": "Gwiazda konturowa — nadzieja",
+    "⋆": "Mała gwiazdka — cicha iskra",
+    "★": "Pełna gwiazda — ambicja",
+    "✵": "Gwiazda z promieniami — energia",
+    "♡": "Serce konturowe — miłość, lekko trzymana",
+    "❥": "Serce przechylone — oddanie",
+    "❦": "Serce kwiatowe — pamięć",
+    "➳": "Strzała — trafiony przez miłość",
+    "✿": "Kwiat — w rozkwicie",
+    "❀": "Kwiat — pamięć o kimś",
+    "✝": "Krzyż łaciński — wiara",
+    "†": "Krzyż-sztylet — poświęcenie",
+    "☦": "Krzyż prawosławny",
+    "☯": "Yin yang — równowaga",
+    "ॐ": "Om — pierwszy dźwięk",
+    "✡": "Gwiazda Dawida",
+    "☪": "Gwiazda i półksiężyc",
+    "ᛉ": "Runa Algiz — ochrona",
+    "⚓": "Kotwica — trzymaj się mocno",
+    "✈": "Samolot — odloty i powroty",
+    "➵": "Strzała — tylko naprzód",
+    "→": "Strzałka w prawo — dalej",
+    "⚔": "Skrzyżowane miecze — walcz dalej",
+    "♆": "Trójząb — morze",
+    "Δ": "Delta — zmiana",
+    "Ω": "Omega — koniec, wytrwałość",
+    "♪": "Ósemka",
+    "♫": "Nuty z belką",
+    "♬": "Podwójne nuty z belką",
+    "𝄞": "Klucz wiolinowy",
+    "✎": "Ołówek — znak twórcy",
+    "♈": "Baran",
+    "♉": "Byk",
+    "♊": "Bliźnięta",
+    "♋": "Rak",
+    "♌": "Lew",
+    "♍": "Panna",
+    "♎": "Waga",
+    "♏": "Skorpion",
+    "♐": "Strzelec",
+    "♑": "Koziorożec",
+    "♒": "Wodnik",
+    "♓": "Ryby"
+  }
+};
+</script>
+<script src="/styles.js" defer></script>
+<script src="/renderer.js" defer></script>
+<script src="/js/tattoo/tattooData.js" defer></script>
+<script src="/script.js" defer></script>
+<script src="/js/tattoo/tattooPageController.js" defer></script>
 <script src="/symbol-explorer.js"></script>
 <script src="/accent-notice.js" defer></script>
 <script src="/footer.js" defer></script>

--- a/pt/usecase/letras-para-tatuagem/index.html
+++ b/pt/usecase/letras-para-tatuagem/index.html
@@ -11,7 +11,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Letras para Tatuagem — Fontes para testar seu Tattoo | UltraTextGen</title>
-  <meta name="description" content="Letras para tatuagem: digite a palavra, o nome ou a data e compare fontes para tatuagem — cursiva, gótica, itálica — antes de agulhar. Grátis, sem app.">
+  <meta name="description" content="Fontes de tatuagem: compare cursiva, gótica e script no seu nome exato, vire datas em números romanos e teste iniciais e símbolos — grátis, antes da agulha.">
   <link rel="canonical" href="https://ultratextgen.com/pt/usecase/letras-para-tatuagem/">
 
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/usecase/tattoo-fonts/">
@@ -49,13 +49,30 @@
   "@context": "https://schema.org",
   "@type": "WebApplication",
   "name": "Letras para Tatuagem",
-  "alternateName": ["Fontes para Tatuagem", "Fonte Tatuagem", "Letras de Tatuagem", "Tipos de Letras para Tatuagem", "Fonte para Tattoo Online"],
+  "alternateName": [
+    "Fontes para Tatuagem",
+    "Fonte Tatuagem",
+    "Letras de Tatuagem",
+    "Tipos de Letras para Tatuagem",
+    "Fonte para Tattoo Online"
+  ],
   "url": "https://ultratextgen.com/pt/usecase/letras-para-tatuagem/",
   "inLanguage": "pt-BR",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Any",
-  "description": "Teste letras para tatuagem antes de agulhar: digite a palavra, o nome ou a data e compare os tipos de letra — cursiva, gótica, itálica e máquina de escrever — pra levar de referência pro tatuador. Grátis, sem app.",
-  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "BRL" }
+  "description": "Teste letras para tatuagem antes da agulha: compare cursiva, gótica, itálica fina e máquina de escrever no seu nome exato, converta uma data em números romanos, monte monogramas de iniciais e explore símbolos de tatuagem com seus significados — depois printa seus favoritos e mostra pro tatuador. Grátis, sem app.",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "BRL"
+  },
+  "featureList": [
+    "Compare 10 estilos de letras para tatuagem no seu nome ou palavra exata",
+    "Conversor de data e número em números romanos com formatos de tatuagem",
+    "Gerador de letra única e monograma de duas iniciais",
+    "Biblioteca de símbolos de tatuagem com significados",
+    "Teste de tinta — veja o letreiro em tamanhos reais de visualização"
+  ]
 }
 </script>
 
@@ -68,27 +85,50 @@
     {
       "@type": "Question",
       "name": "Como escolher o tipo de letra para tatuagem?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Começa pelo sentido, não pelo visual. Nome ou homenagem → cursiva, emendada e atemporal. Palavra forte, lema → gótica, densa e marcante. Frase curta → itálica fina, discreta e elegante. Data → números romanos ou estilo máquina de escrever. Digita seu texto na caixa lá em cima, compara os resultados lado a lado e separa os dois ou três que te tocaram — o tatuador ajuda a bater o martelo." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Começa pelo sentido, não pelo visual. Nome ou homenagem → cursiva, emendada e atemporal. Palavra forte, lema → gótica, densa e marcante. Frase curta → itálica fina, discreta e elegante. Data → números romanos ou estilo máquina de escrever. Digita seu texto na caixa lá em cima, compara os resultados lado a lado e separa os dois ou três que te tocaram — o tatuador ajuda a bater o martelo."
+      }
     },
     {
       "@type": "Question",
       "name": "Qual letra usar para tatuar um nome?",
-      "acceptedAnswer": { "@type": "Answer", "text": "A cursiva é o clássico do nome tatuado: as letras emendadas dão aquele ar manuscrito, pessoal, que envelhece bem. A cursiva bold (𝓜𝓪𝓻𝓲𝓪) tem mais presença; a fina (ℳ𝒶𝓇𝒾𝒶) é mais delicada. Se o nome for curto e você quiser mais atitude, testa também a gótica — muito usada no estilo chicano. Compara as duas nesta página antes de decidir." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "A cursiva é o clássico do nome tatuado: as letras emendadas dão aquele ar manuscrito, pessoal, que envelhece bem. A cursiva bold (𝓜𝓪𝓻𝓲𝓪) tem mais presença; a fina (ℳ𝒶𝓇𝒾𝒶) é mais delicada. Se o nome for curto e você quiser mais atitude, testa também a gótica — muito usada no estilo chicano. Compara as duas nesta página antes de decidir."
+      }
     },
     {
       "@type": "Question",
       "name": "Dá pra usar essas fontes direto na tatuagem?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Não, e é importante ser honesto: esses resultados em Unicode são uma base de trabalho, não um desenho pronto pra agulhar. Eles servem pra você escolher uma direção — cursiva, gótica, itálica — e mostrar de forma clara pro tatuador. É ele quem adapta o letreiro pra sua pele: espessura do traço, emendas entre as letras, curva do lugar do corpo. O lettering final é o ofício dele." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Não, e é importante ser honesto: esses resultados em Unicode são uma base de trabalho, não um desenho pronto pra agulhar. Eles servem pra você escolher uma direção — cursiva, gótica, itálica — e mostrar de forma clara pro tatuador. É ele quem adapta o letreiro pra sua pele: espessura do traço, emendas entre as letras, curva do lugar do corpo. O lettering final é o ofício dele."
+      }
     },
     {
       "@type": "Question",
       "name": "Qual o tamanho mínimo pra uma letra fina?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Quanto mais fina e detalhada a letra, mais espaço ela pede. Traço muito fino e voltinha pequena tendem a engrossar e fechar com os anos — uma palavra em cursiva fina com menos de um centímetro de altura corre o risco de virar um borrão ilegível. Regra prática: quer pequeno, escolhe um estilo simples (itálica, máquina de escrever); quer cursiva cheia de ornamento, reserva espaço. O tatuador te passa o tamanho mínimo exato conforme o lugar do corpo." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Quanto mais fina e detalhada a letra, mais espaço ela pede. Traço muito fino e voltinha pequena tendem a engrossar e fechar com os anos — uma palavra em cursiva fina com menos de um centímetro de altura corre o risco de virar um borrão ilegível. Regra prática: quer pequeno, escolhe um estilo simples (itálica, máquina de escrever); quer cursiva cheia de ornamento, reserva espaço. O tatuador te passa o tamanho mínimo exato conforme o lugar do corpo."
+      }
     },
     {
       "@type": "Question",
       "name": "Como mostrar o estilo pro tatuador?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Digita a sua palavra exata (não uma palavra de exemplo) na caixa lá em cima, printa os dois ou três resultados que você mais curtiu e leva no dia da consulta. Explica o que te agrada em cada um — «as emendas da cursiva», «o peso da gótica» — em vez de pedir uma cópia idêntica. Atenção aos acentos: ã, é e ç costumam sair como letra normal nos estilos Unicode, mas o tatuador desenha eles sem problema no letreiro final." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Digita a sua palavra exata (não uma palavra de exemplo) na caixa lá em cima, printa os dois ou três resultados que você mais curtiu e leva no dia da consulta. Explica o que te agrada em cada um — «as emendas da cursiva», «o peso da gótica» — em vez de pedir uma cópia idêntica. Atenção aos acentos: ã, é e ç costumam sair como letra normal nos estilos Unicode, mas o tatuador desenha eles sem problema no letreiro final."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Como escrever uma data em números romanos para tatuagem?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Converta cada parte da data separadamente — dia, mês, ano — e junte tudo com um separador: 12 de junho de 2020 vira XII·VI·MMXX. O modo Data → Romanos desta página faz a conversão pra você e deixa comparar separadores (pontos, traços, barras, linhas empilhadas) e ordens (dia-mês-ano ou mês-dia-ano). Confere os números com o tatuador antes da sessão: uma data convertida errado é o arrependimento mais comum das tatuagens escritas."
+      }
     }
   ]
 }
@@ -125,26 +165,18 @@
   <div class="hero-inner">
     <div class="hero-card">
       <h1 class="hero-headline">Letras para tatuagem</h1>
-      <p class="hero-tagline">Digita a palavra, o nome ou a data da sua ideia de tattoo e compara na hora os tipos de letra — cursiva, gótica, itálica, máquina de escrever. Printa os resultados que você curtiu e mostra pro tatuador: é ele quem desenha o letreiro final, esta página só te ajuda a escolher a direção.</p>
-      <div class="input-wrapper">
-        <textarea class="main-input" id="mainInput" placeholder="Digite seu texto aqui..." maxlength="500" autofocus=""></textarea>
+      <p class="hero-tagline">Tudo que uma tattoo escrita precisa, num lugar só: compara fontes de tatuagem no seu nome ou palavra exata, transforma uma data em números romanos, monta um monograma de iniciais ou escolhe um símbolo pequeno com significado. Printa o que você curtiu e mostra pro tatuador — é ele quem desenha o letreiro final, esta página te ajuda a escolher a direção.</p>
+      <div class="tattoo-mode-tabs" id="tattooModeTabs"></div>
+      <div class="input-wrapper" id="tattooTextWrap">
+        <textarea class="main-input" id="mainInput" placeholder="Digite seu nome, palavra ou frase..." maxlength="500" autofocus=""></textarea>
         <span class="char-count"><span id="charCount">0</span>/500</span>
       </div>
-      <div class="decoration-section">
-        <div class="decoration-label">Adicionar enfeites ao resultado</div>
-        <div class="decoration-tabs">
-          <button class="decoration-tab active" data-deco-tab="symbols">Símbolos</button>
-          <button class="decoration-tab" data-deco-tab="frames">Molduras</button>
-          <button class="decoration-tab" data-deco-tab="minimal">Minimalista</button>
-        </div>
-        <div class="decoration-grid" id="decorationGrid"></div>
-      </div>
+      <div id="tattooControlPanel"></div>
     </div>
   </div>
 </section>
 
 <main class="container">
-  <div class="category-section"><div class="category-tabs" id="categoryTabs"></div></div>
   <div class="results-grid" id="resultsGrid"></div>
 
   <!-- Visualize antes da agulha -->
@@ -240,6 +272,8 @@
     <div class="faq-item"><button class="faq-question" type="button">Dá pra usar essas fontes direto na tatuagem?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Não, e é importante ser honesto: esses resultados em Unicode são uma base de trabalho, não um desenho pronto pra agulhar. Eles servem pra você escolher uma direção — cursiva, gótica, itálica — e mostrar de forma clara pro tatuador. É ele quem adapta o letreiro pra sua pele: espessura do traço, emendas entre as letras, curva do lugar do corpo. O lettering final é o ofício dele.</div></div>
     <div class="faq-item"><button class="faq-question" type="button">Qual o tamanho mínimo pra uma letra fina?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Quanto mais fina e detalhada a letra, mais espaço ela pede. Traço muito fino e voltinha pequena tendem a engrossar e fechar com os anos — uma palavra em cursiva fina com menos de um centímetro de altura corre o risco de virar um borrão ilegível. Regra prática: quer pequeno, escolhe um estilo simples (itálica, máquina de escrever); quer cursiva cheia de ornamento, reserva espaço. O tatuador te passa o tamanho mínimo exato conforme o lugar do corpo.</div></div>
     <div class="faq-item"><button class="faq-question" type="button">Como mostrar o estilo pro tatuador?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Digita a sua palavra exata (não uma palavra de exemplo) na caixa lá em cima, printa os dois ou três resultados que você mais curtiu e leva no dia da consulta. Explica o que te agrada em cada um — «as emendas da cursiva», «o peso da gótica» — em vez de pedir uma cópia idêntica. Atenção aos acentos: ã, é e ç costumam sair como letra normal nos estilos Unicode, mas o tatuador desenha eles sem problema no letreiro final.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Como escrever uma data em números romanos para tatuagem?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Converta cada parte da data separadamente — dia, mês, ano — e junte tudo com um separador: 12 de junho de 2020 vira XII·VI·MMXX. O modo Data → Romanos desta página faz a conversão pra você e deixa comparar separadores (pontos, traços, barras, linhas empilhadas) e ordens (dia-mês-ano ou mês-dia-ano). Confere os números com o tatuador antes da sessão: uma data convertida errado é o arrependimento mais comum das tatuagens escritas.</div></div>
+
 
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="Language switcher">
@@ -260,9 +294,234 @@
 <div class="copy-toast" id="copyToast">Copiado!</div>
 <div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
 
-<script src="/styles.js"></script>
-<script src="/renderer.js"></script>
-<script src="/script.js" defer=""></script>
+<!-- Page configuration: tattoo mode flag + i18n -->
+<script>
+window.UTG_TATTOO_MODE = true;
+window.tattooI18n = {
+  "sampleName": "Maria",
+  "modeNamesLabel": "Nomes e palavras",
+  "modeNamesHint": "Digita um nome, palavra ou frase",
+  "modeDateLabel": "Data → Romanos",
+  "modeDateHint": "Transforma uma data ou número em números romanos",
+  "modeLettersLabel": "Letras e iniciais",
+  "modeLettersHint": "Letras únicas e monogramas",
+  "modeSymbolsLabel": "Símbolos",
+  "modeSymbolsHint": "Símbolos pequenos com significado",
+  "sizeClose": "De perto",
+  "sizeArm": "Braço esticado",
+  "sizeRoom": "De longe",
+  "inkTest": "Teste de tinta",
+  "yourDate": "Sua data",
+  "day": "Dia",
+  "month": "Mês",
+  "yearOrNumber": "Ano ou número",
+  "order": "Ordem",
+  "separator": "Separador",
+  "yourLetter": "Sua letra",
+  "secondInitial": "Segunda inicial",
+  "secondNone": "Nenhuma — letra única",
+  "joinedBy": "Unidas por",
+  "symbolsNote": "Toca num símbolo pra copiar — combina com um nome ou data, ou usa ele sozinho.",
+  "sampleHintName": "Mostrando “{text}” — digita seu nome, palavra ou frase lá em cima.",
+  "sampleHintDate": "Mostrando uma data de exemplo (12 · 6 · 2020) — coloca sua data ou número lá em cima.",
+  "romanRange": "Os números romanos vão de 1 a 3999 — confere os valores lá em cima.",
+  "headingRoman": "Números romanos",
+  "headingFigures": "Algarismos comuns",
+  "badgeSafe": "aguenta pequeno",
+  "badgeRoomy": "pede espaço",
+  "copy": "Copiar",
+  "copyAria": "Copiar {name}",
+  "families": {
+    "Script": "Cursiva",
+    "Gothic": "Gótica",
+    "Italic": "Itálica",
+    "Minimal": "Minimalista",
+    "Roman": "Romanos",
+    "Figures": "Algarismos"
+  },
+  "orders": {
+    "dmy": "Dia · Mês · Ano",
+    "mdy": "Mês · Dia · Ano",
+    "y": "Só o ano"
+  },
+  "seps": {
+    "space": "espaço",
+    "stack": "empilhado"
+  },
+  "joiners": {
+    "none": "Nenhum"
+  },
+  "lettering": {
+    "Ultra Script Bold": {
+      "label": "Cursiva Bold",
+      "note": "O clássico do nome tatuado — emendada e afetiva, segura a forma em tamanho pequeno."
+    },
+    "Ultra Script": {
+      "label": "Cursiva Fina",
+      "note": "Delicada e leve — linda em tamanho médio; as voltinhas finas pedem espaço pra envelhecer bem."
+    },
+    "Ultra Chicano Script": {
+      "label": "Letreiro Chicano",
+      "note": "Cursiva bold dentro de uma faixa ornamental — a moldura clássica do nome tatuado."
+    },
+    "Ultra Gothic": {
+      "label": "Gótica Blackletter",
+      "note": "Blackletter Fraktur — densa e marcante, feita pra carregar uma palavra forte."
+    },
+    "Ultra Gothic Bold": {
+      "label": "Old English Pesada",
+      "note": "O visual Old English pesado — clássico do old school e do lettering chicano."
+    },
+    "Ultra Old English Banner": {
+      "label": "Faixa Old English",
+      "note": "Blackletter pesada numa faixa — um letreiro com presença máxima."
+    },
+    "Ultra Italic": {
+      "label": "Itálica Fina",
+      "note": "Inclinação discreta — desliza de mansinho pela costela, pelo pulso ou pela clavícula."
+    },
+    "Ultra Italic Serif": {
+      "label": "Itálica Serifada",
+      "note": "Itálica com serifa e ar de livro — parece uma linha tirada de um romance."
+    },
+    "Ultra Typewriter Document": {
+      "label": "Máquina de Escrever",
+      "note": "Monoespaçada, crua e literária — perfeita pra uma data ou frase curta."
+    },
+    "Ultra Small Caps": {
+      "label": "Versaletes",
+      "note": "Maiúsculas miúdas e uniformes — a escolha minimalista do fine line."
+    }
+  },
+  "roman": {
+    "Classic": {
+      "label": "Clássico",
+      "note": "Capitais simples — o que a maioria dos tatuadores agulha."
+    },
+    "Serif Italic": {
+      "label": "Itálica Serifada",
+      "note": "O visual de monumento gravado, inclinado."
+    },
+    "Script": {
+      "label": "Cursiva",
+      "note": "Números romanos em cursiva fluida."
+    },
+    "Blackletter": {
+      "label": "Blackletter",
+      "note": "Números em Fraktur — escuros e ornamentados."
+    },
+    "Heavy Old English": {
+      "label": "Old English Pesada",
+      "note": "Números blackletter no peso máximo."
+    },
+    "Typewriter": {
+      "label": "Máquina de Escrever",
+      "note": "Números monoespaçados — limpos e documentais."
+    }
+  },
+  "digits": {
+    "Typewriter": {
+      "label": "Máquina de Escrever",
+      "note": "Algarismos monoespaçados — o visual clássico de data."
+    },
+    "Bold Serif": {
+      "label": "Serifa Bold",
+      "note": "Algarismos pesados de livro — combinam com blackletter."
+    },
+    "Bold Sans": {
+      "label": "Sans Bold",
+      "note": "Algarismos pesados e modernos — combinam com cursiva bold."
+    },
+    "Fine Sans": {
+      "label": "Sans Fina",
+      "note": "Algarismos leves — combinam com cursiva fina e itálica."
+    },
+    "Double-Struck": {
+      "label": "Contorno Duplo",
+      "note": "Algarismos vazados — uma escolha fine line inesperada."
+    },
+    "Wide Spaced": {
+      "label": "Espaçado Largo",
+      "note": "Algarismos em largura total — espaçamento leve, editorial."
+    },
+    "Tiny": {
+      "label": "Miniatura",
+      "note": "Algarismos em miniatura — escala de atrás da orelha."
+    }
+  },
+  "groups": {
+    "minimal": "Fine line e minimal",
+    "celestial": "Celestial",
+    "love": "Amor e memória",
+    "faith": "Fé e proteção",
+    "journey": "Força e jornada",
+    "music": "Música e arte",
+    "zodiac": "Zodíaco"
+  },
+  "symbols": {
+    ";": "Ponto e vírgula — a história continua",
+    "∞": "Infinito — sem fim",
+    "·": "Ponto único — uma pausa",
+    "—": "Travessão — uma linha, um caminho",
+    "~": "Onda — calma, fluidez",
+    "✕": "Xis — um ponto de cruzamento",
+    "°": "Círculo pequeno — plenitude",
+    "⋮": "Três pontos — mi vida loca / inacabado",
+    "☾": "Meia-lua — mudança, ciclos",
+    "☽": "Lua crescente — crescimento",
+    "☼": "Sol — vitalidade",
+    "✦": "Estrela de quatro pontas — orientação",
+    "✧": "Estrela vazada — esperança",
+    "⋆": "Estrela pequena — uma faísca discreta",
+    "★": "Estrela cheia — ambição",
+    "✵": "Estrela raiada — energia",
+    "♡": "Coração vazado — amor, de leve",
+    "❥": "Coração inclinado — devoção",
+    "❦": "Coração floral — memória de alguém",
+    "➳": "Flecha — flechado pelo amor",
+    "✿": "Flor — desabrochando",
+    "❀": "Flor aberta — lembrança de alguém",
+    "✝": "Cruz latina — fé",
+    "†": "Cruz adaga — sacrifício",
+    "☦": "Cruz ortodoxa",
+    "☯": "Yin yang — equilíbrio",
+    "ॐ": "Om — o primeiro som",
+    "✡": "Estrela de Davi",
+    "☪": "Estrela e crescente",
+    "ᛉ": "Runa Algiz — proteção",
+    "⚓": "Âncora — firmeza",
+    "✈": "Avião — partir, voltar",
+    "➵": "Flecha — só pra frente",
+    "→": "Seta pra direita — em frente",
+    "⚔": "Espadas cruzadas — segue lutando",
+    "♆": "Tridente — o mar",
+    "Δ": "Delta — mudança",
+    "Ω": "Ômega — o fim, a resistência",
+    "♪": "Colcheia",
+    "♫": "Colcheias ligadas",
+    "♬": "Semicolcheias ligadas",
+    "𝄞": "Clave de sol",
+    "✎": "Lápis — marca de quem cria",
+    "♈": "Áries",
+    "♉": "Touro",
+    "♊": "Gêmeos",
+    "♋": "Câncer",
+    "♌": "Leão",
+    "♍": "Virgem",
+    "♎": "Libra",
+    "♏": "Escorpião",
+    "♐": "Sagitário",
+    "♑": "Capricórnio",
+    "♒": "Aquário",
+    "♓": "Peixes"
+  }
+};
+</script>
+<script src="/styles.js" defer></script>
+<script src="/renderer.js" defer></script>
+<script src="/js/tattoo/tattooData.js" defer></script>
+<script src="/script.js" defer></script>
+<script src="/js/tattoo/tattooPageController.js" defer></script>
 <script src="/symbol-explorer.js"></script>
 <script src="/footer.js"></script>
 </body></html>

--- a/tr/usecase/dovme-yazi-fontlari/index.html
+++ b/tr/usecase/dovme-yazi-fontlari/index.html
@@ -11,7 +11,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Dövme Yazı Fontları — Dövmeni Mürekkepten Önce Test Et | UltraTextGen</title>
-  <meta name="description" content="Dövme yazı fontları: kelimeni, ismini veya tarihini yaz; el yazısı, gotik ve italik dövme yazılarını iğneden önce karşılaştır. Ekran görüntüsünü dövmecine göster.">
+  <meta name="description" content="Dövme yazı fontları: el yazısı, gotik ve script stillerini kendi isminde karşılaştır, tarihi Roma rakamına çevir, sembolleri iğneden önce ücretsiz önizle.">
   <link rel="canonical" href="https://ultratextgen.com/tr/usecase/dovme-yazi-fontlari/">
 
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/usecase/tattoo-fonts/">
@@ -49,13 +49,30 @@
   "@context": "https://schema.org",
   "@type": "WebApplication",
   "name": "Dövme Yazı Fontları",
-  "alternateName": ["Dövme Yazıları", "Dövme Fontları", "Dövme Yazı Tipleri", "Dövme Yazısı Oluşturucu", "Dövme Yazı Stilleri"],
+  "alternateName": [
+    "Dövme Yazıları",
+    "Dövme Fontları",
+    "Dövme Yazı Tipleri",
+    "Dövme Yazısı Oluşturucu",
+    "Dövme Yazı Stilleri"
+  ],
   "url": "https://ultratextgen.com/tr/usecase/dovme-yazi-fontlari/",
   "inLanguage": "tr",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Any",
-  "description": "Dövme fikrindeki yazıyı iğneden önce önizle: kelimeni, ismini veya tarihini yaz; el yazısı, gotik, italik ve daktilo dövme yazı fontlarını karşılaştır — ekran görüntüsünü dövme sanatçına göster. Ücretsiz, uygulamasız.",
-  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "TRY" }
+  "description": "Dövme yazını iğneden önce önizle: el yazısı, gotik, ince italik ve daktilo dövme yazı fontlarını kendi isminde karşılaştır, tarihi Roma rakamlarına çevir, harf monogramları kur ve anlamlarıyla birlikte dövme sembollerine göz at — sonra en beğendiklerinin ekran görüntüsünü al ve dövme sanatçına göster. Ücretsiz, uygulamasız.",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "TRY"
+  },
+  "featureList": [
+    "10 dövme yazı stilini kendi isminde veya kelimende karşılaştır",
+    "Dövme formatlarıyla tarih ve sayıdan Roma rakamına çevirici",
+    "Tek harf ve çift baş harfli monogram oluşturucu",
+    "Anlamlarıyla birlikte dövme sembol kütüphanesi",
+    "Mürekkep testi — yazıyı gerçek bakış mesafelerinde önizle"
+  ]
 }
 </script>
 
@@ -68,27 +85,50 @@
     {
       "@type": "Question",
       "name": "Dövme yazı fontu nasıl seçilir?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Görünüşten değil, anlamdan yola çık. İsim veya sevgi sözü → el yazısı: sıcak ve zamansız. Güçlü tek kelime, motto → gotik: yoğun ve iddialı. Kısa bir söz → ince italik: sade ve zarif. Tarih → Roma rakamları veya daktilo stili. Metnini sayfanın en üstüne yaz, stilleri yan yana karşılaştır ve içine en çok işleyen iki üç tanesini ayır — son kararı dövme sanatçınla birlikte verirsin." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Görünüşten değil, anlamdan yola çık. İsim veya sevgi sözü → el yazısı: sıcak ve zamansız. Güçlü tek kelime, motto → gotik: yoğun ve iddialı. Kısa bir söz → ince italik: sade ve zarif. Tarih → Roma rakamları veya daktilo stili. Metnini sayfanın en üstüne yaz, stilleri yan yana karşılaştır ve içine en çok işleyen iki üç tanesini ayır — son kararı dövme sanatçınla birlikte verirsin."
+      }
     },
     {
       "@type": "Question",
       "name": "İsim dövmesi için hangi yazı tipi kullanılır?",
-      "acceptedAnswer": { "@type": "Answer", "text": "İsim dövmesinin klasiği el yazısıdır: birbirine bağlanan harfler kişisel, elle yazılmış bir hava verir ve yıllar içinde iyi yaşlanır. Kalın bir script (𝓓𝓮𝓯𝓷𝓮) daha güçlü durur, ince bir script (𝒟𝑒𝒻𝓃𝑒) daha narin. İsim kısaysa ve karakter istiyorsan gotiği de dene — chicano tarzında çok yaygındır. Karar vermeden önce ikisini de bu sayfada kendi isminle karşılaştır." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "İsim dövmesinin klasiği el yazısıdır: birbirine bağlanan harfler kişisel, elle yazılmış bir hava verir ve yıllar içinde iyi yaşlanır. Kalın bir script (𝓓𝓮𝓯𝓷𝓮) daha güçlü durur, ince bir script (𝒟𝑒𝒻𝓃𝑒) daha narin. İsim kısaysa ve karakter istiyorsan gotiği de dene — chicano tarzında çok yaygındır. Karar vermeden önce ikisini de bu sayfada kendi isminle karşılaştır."
+      }
     },
     {
       "@type": "Question",
       "name": "Bu fontlar dövmede olduğu gibi kullanılabilir mi?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Hayır — ve bunu açıkça söylemek gerekiyor: bu Unicode stiller bir çalışma tabanıdır, mürekkebe hazır bir çizim değil. Sana yön seçtirir — el yazısı mı, gotik mi, italik mi — ve bu yönü dövmecine net biçimde gösterme imkânı verir. Sonrasını sanatçı devralır: çizgi kalınlığını, harf bağlantılarını ve yerleştirilecek bölgenin kavisini tenine göre yeniden çizer. Son harf tasarımı onun zanaatıdır." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Hayır — ve bunu açıkça söylemek gerekiyor: bu Unicode stiller bir çalışma tabanıdır, mürekkebe hazır bir çizim değil. Sana yön seçtirir — el yazısı mı, gotik mi, italik mi — ve bu yönü dövmecine net biçimde gösterme imkânı verir. Sonrasını sanatçı devralır: çizgi kalınlığını, harf bağlantılarını ve yerleştirilecek bölgenin kavisini tenine göre yeniden çizer. Son harf tasarımı onun zanaatıdır."
+      }
     },
     {
       "@type": "Question",
       "name": "İnce yazılı dövme için minimum boyut ne olmalı?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Yazı inceldikçe ihtiyaç duyduğu alan büyür. Çok ince çizgiler ve küçük kıvrımlar yıllar içinde kalınlaşıp kapanma eğilimindedir — bir santimden alçak ince script bir kelime zamanla okunmaz hâle gelebilir. Basit kural: küçük istiyorsan sade bir stil seç (italik, daktilo); süslü el yazısı istiyorsan yer ayır. Kesin minimum boyutu, seçtiğin bölgeye göre dövme sanatçın söyler." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yazı inceldikçe ihtiyaç duyduğu alan büyür. Çok ince çizgiler ve küçük kıvrımlar yıllar içinde kalınlaşıp kapanma eğilimindedir — bir santimden alçak ince script bir kelime zamanla okunmaz hâle gelebilir. Basit kural: küçük istiyorsan sade bir stil seç (italik, daktilo); süslü el yazısı istiyorsan yer ayır. Kesin minimum boyutu, seçtiğin bölgeye göre dövme sanatçın söyler."
+      }
     },
     {
       "@type": "Question",
       "name": "Seçtiğim stili dövmecime nasıl gösteririm?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Sayfanın üstüne tam kelimeni yaz (örnek bir kelime değil — harfler her şeyi değiştirir), en beğendiğin iki üç stilin ekran görüntüsünü al ve randevuya götür. Her birinde neyi sevdiğini söyle — «el yazısındaki bağlantılar», «gotiğin kalınlığı» — birebir kopya istemek yerine. Türkçe karakterlere dikkat: ş, ı ve ğ Unicode stillerde çoğunlukla normal harf olarak kalır; dövmecine belirt, son çizimde bunları sorunsuz işler." }
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Sayfanın üstüne tam kelimeni yaz (örnek bir kelime değil — harfler her şeyi değiştirir), en beğendiğin iki üç stilin ekran görüntüsünü al ve randevuya götür. Her birinde neyi sevdiğini söyle — «el yazısındaki bağlantılar», «gotiğin kalınlığı» — birebir kopya istemek yerine. Türkçe karakterlere dikkat: ş, ı ve ğ Unicode stillerde çoğunlukla normal harf olarak kalır; dövmecine belirt, son çizimde bunları sorunsuz işler."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Dövme için tarih Roma rakamlarıyla nasıl yazılır?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Tarihin her parçasını — gün, ay, yıl — ayrı ayrı çevir ve bir ayraçla birleştir: 12 Haziran 2020, XII·VI·MMXX olur. Bu sayfadaki Tarih → Romen modu çevirmeyi senin yerine yapar; ayraçları (nokta, tire, çizgi, alt alta satırlar) ve sıralamaları (gün-ay-yıl veya ay-gün-yıl) karşılaştırmanı sağlar. Randevudan önce rakamları dövme sanatçınla bir kez daha kontrol et: yanlış çevrilmiş tarih, yazı dövmelerinde en sık görülen pişmanlıktır."
+      }
     }
   ]
 }
@@ -125,26 +165,18 @@
   <div class="hero-inner">
     <div class="hero-card">
       <h1 class="hero-headline">Dövme yazı fontları</h1>
-      <p class="hero-tagline">Dövme fikrindeki kelimeyi, ismi veya tarihi yaz; stilleri anında karşılaştır — el yazısı, gotik, italik, daktilo. Beğendiğin dövme yazılarının ekran görüntüsünü al ve dövmecine göster: son harf çizimini o yapar, bu sayfa sana yönü seçtirir.</p>
-      <div class="input-wrapper">
-        <textarea class="main-input" id="mainInput" placeholder="Metnini buraya yaz..." maxlength="500" autofocus=""></textarea>
+      <p class="hero-tagline">Yazı dövmesinin ihtiyacı olan her şey tek yerde: dövme yazı fontlarını kendi isminde veya kelimende karşılaştır, tarihi Roma rakamına çevir, harflerden monogram kur ya da anlamı olan küçük bir sembol seç. Beğendiklerinin ekran görüntüsünü al ve dövme sanatçına göster — son harf çizimini o yapar, bu sayfa sana yönü seçtirir.</p>
+      <div class="tattoo-mode-tabs" id="tattooModeTabs"></div>
+      <div class="input-wrapper" id="tattooTextWrap">
+        <textarea class="main-input" id="mainInput" placeholder="İsmini, kelimeni veya sözünü yaz..." maxlength="500" autofocus=""></textarea>
         <span class="char-count"><span id="charCount">0</span>/500</span>
       </div>
-      <div class="decoration-section">
-        <div class="decoration-label">Sonuca süsleme ekle</div>
-        <div class="decoration-tabs">
-          <button class="decoration-tab active" data-deco-tab="symbols">Semboller</button>
-          <button class="decoration-tab" data-deco-tab="frames">Çerçeveler</button>
-          <button class="decoration-tab" data-deco-tab="minimal">Minimal</button>
-        </div>
-        <div class="decoration-grid" id="decorationGrid"></div>
-      </div>
+      <div id="tattooControlPanel"></div>
     </div>
   </div>
 </section>
 
 <main class="container">
-  <div class="category-section"><div class="category-tabs" id="categoryTabs"></div></div>
   <div class="results-grid" id="resultsGrid"></div>
 
   <!-- İğneden önce önizle -->
@@ -240,6 +272,8 @@
     <div class="faq-item"><button class="faq-question" type="button">Bu fontlar dövmede olduğu gibi kullanılabilir mi?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Hayır — ve bunu açıkça söylemek gerekiyor: bu Unicode stiller bir çalışma tabanıdır, mürekkebe hazır bir çizim değil. Sana yön seçtirir — el yazısı mı, gotik mi, italik mi — ve bu yönü dövmecine net biçimde gösterme imkânı verir. Sonrasını sanatçı devralır: çizgi kalınlığını, harf bağlantılarını ve yerleştirilecek bölgenin kavisini tenine göre yeniden çizer. Son harf tasarımı onun zanaatıdır.</div></div>
     <div class="faq-item"><button class="faq-question" type="button">İnce yazılı dövme için minimum boyut ne olmalı?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Yazı inceldikçe ihtiyaç duyduğu alan büyür. Çok ince çizgiler ve küçük kıvrımlar yıllar içinde kalınlaşıp kapanma eğilimindedir — bir santimden alçak ince script bir kelime zamanla okunmaz hâle gelebilir. Basit kural: küçük istiyorsan sade bir stil seç (italik, daktilo); süslü el yazısı istiyorsan yer ayır. Kesin minimum boyutu, seçtiğin bölgeye göre dövme sanatçın söyler.</div></div>
     <div class="faq-item"><button class="faq-question" type="button">Seçtiğim stili dövmecime nasıl gösteririm?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Sayfanın üstüne tam kelimeni yaz (örnek bir kelime değil — harfler her şeyi değiştirir), en beğendiğin iki üç stilin ekran görüntüsünü al ve randevuya götür. Her birinde neyi sevdiğini söyle — «el yazısındaki bağlantılar», «gotiğin kalınlığı» — birebir kopya istemek yerine. Türkçe karakterlere dikkat: ş, ı ve ğ Unicode stillerde çoğunlukla normal harf olarak kalır; dövmecine belirt, son çizimde bunları sorunsuz işler.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Dövme için tarih Roma rakamlarıyla nasıl yazılır?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Tarihin her parçasını — gün, ay, yıl — ayrı ayrı çevir ve bir ayraçla birleştir: 12 Haziran 2020, XII·VI·MMXX olur. Bu sayfadaki Tarih → Romen modu çevirmeyi senin yerine yapar; ayraçları (nokta, tire, çizgi, alt alta satırlar) ve sıralamaları (gün-ay-yıl veya ay-gün-yıl) karşılaştırmanı sağlar. Randevudan önce rakamları dövme sanatçınla bir kez daha kontrol et: yanlış çevrilmiş tarih, yazı dövmelerinde en sık görülen pişmanlıktır.</div></div>
+
 
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="Language switcher">
@@ -259,9 +293,234 @@
 
 <div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
 
-<script src="/styles.js"></script>
-<script src="/renderer.js"></script>
-<script src="/script.js" defer=""></script>
+<!-- Page configuration: tattoo mode flag + i18n -->
+<script>
+window.UTG_TATTOO_MODE = true;
+window.tattooI18n = {
+  "sampleName": "Defne",
+  "modeNamesLabel": "İsimler & kelimeler",
+  "modeNamesHint": "Bir isim, kelime veya söz yaz",
+  "modeDateLabel": "Tarih → Romen",
+  "modeDateHint": "Tarihi veya sayıyı Roma rakamına çevir",
+  "modeLettersLabel": "Harfler & baş harfler",
+  "modeLettersHint": "Tek harfler ve monogramlar",
+  "modeSymbolsLabel": "Semboller",
+  "modeSymbolsHint": "Anlamı olan küçük semboller",
+  "sizeClose": "Yakından",
+  "sizeArm": "Kol mesafesinden",
+  "sizeRoom": "Odanın öbür ucundan",
+  "inkTest": "Mürekkep testi",
+  "yourDate": "Tarihin",
+  "day": "Gün",
+  "month": "Ay",
+  "yearOrNumber": "Yıl veya sayı",
+  "order": "Sıralama",
+  "separator": "Ayraç",
+  "yourLetter": "Harfin",
+  "secondInitial": "İkinci baş harf",
+  "secondNone": "Yok — tek harf",
+  "joinedBy": "Birleştirici",
+  "symbolsNote": "Kopyalamak için bir sembole dokun — bir isim ya da tarihle eşleştir veya tek başına taşı.",
+  "sampleHintName": "“{text}” gösteriliyor — yukarıya kendi ismini, kelimeni veya sözünü yaz.",
+  "sampleHintDate": "Örnek bir tarih gösteriliyor (12 · 6 · 2020) — yukarıya kendi tarihini veya sayını gir.",
+  "romanRange": "Roma rakamları 1–3999 aralığını kapsar — yukarıdaki değerleri kontrol et.",
+  "headingRoman": "Roma rakamları",
+  "headingFigures": "Düz rakamlar",
+  "badgeSafe": "küçükte dayanır",
+  "badgeRoomy": "yer ister",
+  "copy": "Kopyala",
+  "copyAria": "{name} stilini kopyala",
+  "families": {
+    "Script": "El Yazısı",
+    "Gothic": "Gotik",
+    "Italic": "İtalik",
+    "Minimal": "Minimal",
+    "Roman": "Romen",
+    "Figures": "Rakamlar"
+  },
+  "orders": {
+    "dmy": "Gün · Ay · Yıl",
+    "mdy": "Ay · Gün · Yıl",
+    "y": "Sadece yıl"
+  },
+  "seps": {
+    "space": "boşluk",
+    "stack": "alt alta"
+  },
+  "joiners": {
+    "none": "Yok"
+  },
+  "lettering": {
+    "Ultra Script Bold": {
+      "label": "Kalın El Yazısı",
+      "note": "İsim dövmesinin klasiği — bağlantılı ve sıcak, küçük boyutta bile formunu korur."
+    },
+    "Ultra Script": {
+      "label": "İnce El Yazısı",
+      "note": "Narin ve havadar — orta boyutta çok güzel; ince kıvrımların iyi yaşlanmak için yere ihtiyacı var."
+    },
+    "Ultra Chicano Script": {
+      "label": "Chicano İsim Plakası",
+      "note": "Süslü bir bandın içinde kalın el yazısı — klasik isim plakası çerçevesi."
+    },
+    "Ultra Gothic": {
+      "label": "Gotik Blackletter",
+      "note": "Fraktur blackletter — yoğun ve iddialı, güçlü bir kelimeyi taşımak için yapılmış."
+    },
+    "Ultra Gothic Bold": {
+      "label": "Ağır Old English",
+      "note": "Ağır Old English görünümü — old school ve Chicano yazı geleneğinin demirbaşı."
+    },
+    "Ultra Old English Banner": {
+      "label": "Old English Bantlı",
+      "note": "Bant içinde ağır blackletter — sahnedeki en güçlü isim plakası."
+    },
+    "Ultra Italic": {
+      "label": "İnce İtalik",
+      "note": "Gösterişsiz bir eğim — kaburga, bilek veya köprücük kemiği boyunca sessizce süzülür."
+    },
+    "Ultra Italic Serif": {
+      "label": "Serifli İtalik",
+      "note": "Kitap havalı serifli italik — bir romandan alınmış satır gibi okunur."
+    },
+    "Ultra Typewriter Document": {
+      "label": "Daktilo",
+      "note": "Ham, edebi monospace — bir tarih ya da kısa bir satır için biçilmiş kaftan."
+    },
+    "Ultra Small Caps": {
+      "label": "Küçük Kapital",
+      "note": "Minik, eşit büyük harfler — ince çizgi minimalistlerin tercihi."
+    }
+  },
+  "roman": {
+    "Classic": {
+      "label": "Klasik",
+      "note": "Düz büyük harfler — çoğu sanatçının işlediği hâli."
+    },
+    "Serif Italic": {
+      "label": "Serifli İtalik",
+      "note": "Anıt kazıması görünümü, eğik hâliyle."
+    },
+    "Script": {
+      "label": "El Yazısı",
+      "note": "Akıcı el yazısıyla Roma rakamları."
+    },
+    "Blackletter": {
+      "label": "Blackletter",
+      "note": "Fraktur rakamlar — koyu ve süslü."
+    },
+    "Heavy Old English": {
+      "label": "Ağır Old English",
+      "note": "En ağır blackletter rakamlar."
+    },
+    "Typewriter": {
+      "label": "Daktilo",
+      "note": "Monospace rakamlar — temiz ve belge havasında."
+    }
+  },
+  "digits": {
+    "Typewriter": {
+      "label": "Daktilo",
+      "note": "Monospace rakamlar — klasik tarih görünümü."
+    },
+    "Bold Serif": {
+      "label": "Kalın Serif",
+      "note": "Ağır kitap rakamları — blackletter ile eşleşir."
+    },
+    "Bold Sans": {
+      "label": "Kalın Sans",
+      "note": "Modern ağır rakamlar — kalın el yazısıyla eşleşir."
+    },
+    "Fine Sans": {
+      "label": "İnce Sans",
+      "note": "Hafif rakamlar — ince el yazısı ve italikle eşleşir."
+    },
+    "Double-Struck": {
+      "label": "Çift Çizgili",
+      "note": "Kontur rakamlar — ince çizgi için beklenmedik bir seçim."
+    },
+    "Wide Spaced": {
+      "label": "Geniş Aralıklı",
+      "note": "Tam genişlik rakamlar — havadar, editoryal aralık."
+    },
+    "Tiny": {
+      "label": "Minik",
+      "note": "Minyatür rakamlar — kulak arkası ölçeği."
+    }
+  },
+  "groups": {
+    "minimal": "İnce çizgi & minimal",
+    "celestial": "Gökyüzü",
+    "love": "Aşk & anma",
+    "faith": "İnanç & koruma",
+    "journey": "Güç & yolculuk",
+    "music": "Müzik & sanat",
+    "zodiac": "Burçlar"
+  },
+  "symbols": {
+    ";": "Noktalı virgül — hikâye devam ediyor",
+    "∞": "Sonsuzluk — sonu olmayan",
+    "·": "Tek nokta — bir duraklama",
+    "—": "Tire — bir çizgi, bir yol",
+    "~": "Dalga — dinginlik, akış",
+    "✕": "Çarpı — bir kesişme noktası",
+    "°": "Küçük daire — bütünlük",
+    "⋮": "Üç nokta — mi vida loca / tamamlanmamış",
+    "☾": "Hilal — değişim, döngüler",
+    "☽": "Büyüyen ay — büyüme",
+    "☼": "Güneş — yaşam gücü",
+    "✦": "Dört köşeli yıldız — rehberlik",
+    "✧": "Kontur yıldız — umut",
+    "⋆": "Küçük yıldız — sessiz bir kıvılcım",
+    "★": "Dolu yıldız — hırs",
+    "✵": "Işınlı yıldız — enerji",
+    "♡": "Kontur kalp — hafifçe taşınan aşk",
+    "❥": "Yatık kalp — bağlılık",
+    "❦": "Çiçekli kalp — anma",
+    "➳": "Ok — aşka tutulmuş",
+    "✿": "Çiçek — açmakta",
+    "❀": "Açan çiçek — birinin anısı",
+    "✝": "Latin haçı — inanç",
+    "†": "Hançer haç — fedakârlık",
+    "☦": "Ortodoks haçı",
+    "☯": "Yin yang — denge",
+    "ॐ": "Om — ilk ses",
+    "✡": "Davut Yıldızı",
+    "☪": "Ay yıldız",
+    "ᛉ": "Algiz rünü — koruma",
+    "⚓": "Çapa — sağlam dur",
+    "✈": "Uçak — gidişler, dönüşler",
+    "➵": "Ok — yalnızca ileri",
+    "→": "Sağ ok — hep ileri",
+    "⚔": "Çapraz kılıçlar — savaşmaya devam",
+    "♆": "Üç dişli mızrak — deniz",
+    "Δ": "Delta — değişim",
+    "Ω": "Omega — son, dayanıklılık",
+    "♪": "Sekizlik nota",
+    "♫": "Bağlı notalar",
+    "♬": "Çift bağlı notalar",
+    "𝄞": "Sol anahtarı",
+    "✎": "Kalem — yaratanın imzası",
+    "♈": "Koç",
+    "♉": "Boğa",
+    "♊": "İkizler",
+    "♋": "Yengeç",
+    "♌": "Aslan",
+    "♍": "Başak",
+    "♎": "Terazi",
+    "♏": "Akrep",
+    "♐": "Yay",
+    "♑": "Oğlak",
+    "♒": "Kova",
+    "♓": "Balık"
+  }
+};
+</script>
+<script src="/styles.js" defer></script>
+<script src="/renderer.js" defer></script>
+<script src="/js/tattoo/tattooData.js" defer></script>
+<script src="/script.js" defer></script>
+<script src="/js/tattoo/tattooPageController.js" defer></script>
 <script src="/symbol-explorer.js"></script>
 <script src="/footer.js"></script>
 </body></html>


### PR DESCRIPTION
## Summary

Follow-up to #403: the de/es/fr/id/it/nl/pl/pt/tr tattoo pages were still running the old generic-generator template. This PR replaces them with the four-mode tattoo lettering studio (Names & words · Date → Roman · Letters & initials · Symbols), fully localized.

## What changed

- **`js/tattoo/tattooPageController.js`** now routes every user-facing string through `window.tattooI18n` with English fallbacks — the same pattern as `verticalI18n`/`zalgoI18n`. The EN page needs no i18n block and is unaffected.
- **Each of the 9 localized pages** gets:
  - the studio hero (mode tabs + control panel mount) replacing the decoration section and category tabs, with `UTG_TATTOO_MODE` set and `tattooData.js` + the controller in the script load order
  - a complete inline `tattooI18n` pack: mode tabs, controls, aging badges, all 10 lettering labels/notes, roman/digit font notes, symbol group labels, and all 55 symbol meanings — matching each page's established tone and terminology (du/tú/tutoiement registers; local sample names already used in each page's editorial: Mia, Lucía, Manon, Giulia, Sanne, Marta, Maria, Defne, Aulia)
  - localized hero tagline, textarea placeholder, and meta description
  - `WebApplication` JSON-LD gains `description` + `featureList`; `FAQPage` JSON-LD and the footer FAQ gain the roman-numeral date question
- Structural changes were applied by one deterministic patch script, so all 9 pages received identical markup changes; every translation pack was validated key-by-key against the EN template before patching.

## Testing

- Chromium smoke test on all 9 pages × all 4 modes: 10 lettering cards, localized roman numerals/headings, 55 symbol tiles, localized copy buttons, zero JS errors.
- EN page (`/usecase/tattoo-fonts/`) regression-tested after the controller i18n refactor: identical behavior.
- No URL, hreflang, sitemap, or redirect changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DCPGnGu32zuLvDCTKau1s2

---
_Generated by [Claude Code](https://claude.ai/code/session_01DCPGnGu32zuLvDCTKau1s2)_