### PR TITLE
UX: cursive letter case toggle, signature designer controls, interactive names gallery

### DIFF
--- a/category/cursive-fonts/index.html
+++ b/category/cursive-fonts/index.html
@@ -613,73 +613,75 @@
     <!-- 5. Names & signatures -->
     <section id="cursive-names" aria-labelledby="cursiveNamesHeading">
       <h2 class="bubble-az-heading" id="cursiveNamesHeading">Cursive name &amp; signature generator</h2>
-      <p class="bubble-az-intro">Type a first name — or a full name — and preview it as a cursive signature:
-        classic script, bold autograph, underline flourish, ornate nameplate, and monogram initials.</p>
+      <p class="bubble-az-intro">Type a first name — or a full name — and design your cursive signature:
+        pick a flourish, choose how monogram initials join, then copy the text or download it as a PNG
+        for email footers, watermarks, and documents.</p>
       <div class="cursive-name-tool">
         <div class="input-wrapper">
           <input type="text" class="main-input cursive-name-input" id="cursiveNameInput" placeholder="Type a name… e.g. Olivia Grace" maxlength="60">
         </div>
-        <div class="cursive-quick-row" id="cursiveNameChips" aria-label="Popular names"></div>
+        <div class="cursive-sig-controls" id="cursiveSignatureControls"></div>
         <div class="results-grid" id="cursiveNameResults"></div>
       </div>
     <h3>Popular names in cursive</h3>
+    <p class="bubble-az-intro">Tap any name to load it into the studio above and restyle it with flourishes.</p>
     <div class="cursive-word-grid">
-      <div class="cursive-word-card">
+      <div class="cursive-word-card cursive-name-example" data-name="Olivia" role="button" tabindex="0" title="Load Olivia into the signature studio">
         <span class="cursive-word-render">𝓞𝓵𝓲𝓿𝓲𝓪</span>
         <span class="cursive-word-label">Olivia in cursive</span>
         <button type="button" class="copy-btn" data-text="𝓞𝓵𝓲𝓿𝓲𝓪" data-style="Ultra Script Bold">Copy</button>
       </div>
-      <div class="cursive-word-card">
+      <div class="cursive-word-card cursive-name-example" data-name="Isabella" role="button" tabindex="0" title="Load Isabella into the signature studio">
         <span class="cursive-word-render">𝓘𝓼𝓪𝓫𝓮𝓵𝓵𝓪</span>
         <span class="cursive-word-label">Isabella in cursive</span>
         <button type="button" class="copy-btn" data-text="𝓘𝓼𝓪𝓫𝓮𝓵𝓵𝓪" data-style="Ultra Script Bold">Copy</button>
       </div>
-      <div class="cursive-word-card">
+      <div class="cursive-word-card cursive-name-example" data-name="Emily" role="button" tabindex="0" title="Load Emily into the signature studio">
         <span class="cursive-word-render">𝓔𝓶𝓲𝓵𝔂</span>
         <span class="cursive-word-label">Emily in cursive</span>
         <button type="button" class="copy-btn" data-text="𝓔𝓶𝓲𝓵𝔂" data-style="Ultra Script Bold">Copy</button>
       </div>
-      <div class="cursive-word-card">
+      <div class="cursive-word-card cursive-name-example" data-name="Elizabeth" role="button" tabindex="0" title="Load Elizabeth into the signature studio">
         <span class="cursive-word-render">𝓔𝓵𝓲𝔃𝓪𝓫𝓮𝓽𝓱</span>
         <span class="cursive-word-label">Elizabeth in cursive</span>
         <button type="button" class="copy-btn" data-text="𝓔𝓵𝓲𝔃𝓪𝓫𝓮𝓽𝓱" data-style="Ultra Script Bold">Copy</button>
       </div>
-      <div class="cursive-word-card">
+      <div class="cursive-word-card cursive-name-example" data-name="Emma" role="button" tabindex="0" title="Load Emma into the signature studio">
         <span class="cursive-word-render">𝓔𝓶𝓶𝓪</span>
         <span class="cursive-word-label">Emma in cursive</span>
         <button type="button" class="copy-btn" data-text="𝓔𝓶𝓶𝓪" data-style="Ultra Script Bold">Copy</button>
       </div>
-      <div class="cursive-word-card">
+      <div class="cursive-word-card cursive-name-example" data-name="Sophia" role="button" tabindex="0" title="Load Sophia into the signature studio">
         <span class="cursive-word-render">𝓢𝓸𝓹𝓱𝓲𝓪</span>
         <span class="cursive-word-label">Sophia in cursive</span>
         <button type="button" class="copy-btn" data-text="𝓢𝓸𝓹𝓱𝓲𝓪" data-style="Ultra Script Bold">Copy</button>
       </div>
-      <div class="cursive-word-card">
+      <div class="cursive-word-card cursive-name-example" data-name="Ava" role="button" tabindex="0" title="Load Ava into the signature studio">
         <span class="cursive-word-render">𝓐𝓿𝓪</span>
         <span class="cursive-word-label">Ava in cursive</span>
         <button type="button" class="copy-btn" data-text="𝓐𝓿𝓪" data-style="Ultra Script Bold">Copy</button>
       </div>
-      <div class="cursive-word-card">
+      <div class="cursive-word-card cursive-name-example" data-name="Grace" role="button" tabindex="0" title="Load Grace into the signature studio">
         <span class="cursive-word-render">𝓖𝓻𝓪𝓬𝓮</span>
         <span class="cursive-word-label">Grace in cursive</span>
         <button type="button" class="copy-btn" data-text="𝓖𝓻𝓪𝓬𝓮" data-style="Ultra Script Bold">Copy</button>
       </div>
-      <div class="cursive-word-card">
+      <div class="cursive-word-card cursive-name-example" data-name="Victoria" role="button" tabindex="0" title="Load Victoria into the signature studio">
         <span class="cursive-word-render">𝓥𝓲𝓬𝓽𝓸𝓻𝓲𝓪</span>
         <span class="cursive-word-label">Victoria in cursive</span>
         <button type="button" class="copy-btn" data-text="𝓥𝓲𝓬𝓽𝓸𝓻𝓲𝓪" data-style="Ultra Script Bold">Copy</button>
       </div>
-      <div class="cursive-word-card">
+      <div class="cursive-word-card cursive-name-example" data-name="David" role="button" tabindex="0" title="Load David into the signature studio">
         <span class="cursive-word-render">𝓓𝓪𝓿𝓲𝓭</span>
         <span class="cursive-word-label">David in cursive</span>
         <button type="button" class="copy-btn" data-text="𝓓𝓪𝓿𝓲𝓭" data-style="Ultra Script Bold">Copy</button>
       </div>
-      <div class="cursive-word-card">
+      <div class="cursive-word-card cursive-name-example" data-name="Joseph" role="button" tabindex="0" title="Load Joseph into the signature studio">
         <span class="cursive-word-render">𝓙𝓸𝓼𝓮𝓹𝓱</span>
         <span class="cursive-word-label">Joseph in cursive</span>
         <button type="button" class="copy-btn" data-text="𝓙𝓸𝓼𝓮𝓹𝓱" data-style="Ultra Script Bold">Copy</button>
       </div>
-      <div class="cursive-word-card">
+      <div class="cursive-word-card cursive-name-example" data-name="James" role="button" tabindex="0" title="Load James into the signature studio">
         <span class="cursive-word-render">𝓙𝓪𝓶𝓮𝓼</span>
         <span class="cursive-word-label">James in cursive</span>
         <button type="button" class="copy-btn" data-text="𝓙𝓪𝓶𝓮𝓼" data-style="Ultra Script Bold">Copy</button>

--- a/js/cursive/cursiveData.js
+++ b/js/cursive/cursiveData.js
@@ -49,9 +49,19 @@
     // search for ("love in cursive", "happy birthday in cursive", …).
     quickWords: ["love", "Happy Birthday", "Thank You", "family", "forever", "blessed"],
 
-    // Popular-name chips for the signature studio (top "«name» in cursive"
-    // searches). Kept short; any name can be typed.
-    nameChips: ["Olivia", "Isabella", "Emily", "Elizabeth", "Emma", "Sophia", "Grace", "David", "Joseph", "Alex"],
+    // Flourish decorators for the signature studio — applied to the rendered
+    // name before each preset adds its own wrapper, so they compose cleanly.
+    signatureDecorators: [
+      { name: "None" },
+      { name: "Underline", combining: "̲" },
+      { name: "Sparkle",   pre: "⋆˚ ", post: " ˚⋆" },
+      { name: "Hearts",    pre: "♡ ",  post: " ♡" },
+      { name: "Ornate",    pre: "꧁ ",  post: " ꧂" },
+      { name: "Soft dots", pre: "˚₊· ", post: " ·₊˚" }
+    ],
+
+    // Joiner choices for the monogram-initials preset (O.G. / O·G / O♡G / O&G).
+    monogramJoiners: [".", "·", "♡", "&"],
 
     // Platform bio limits for the will-it-fit badges (counted in code points,
     // matching how the platforms count pasted Unicode).

--- a/js/cursive/cursivePageController.js
+++ b/js/cursive/cursivePageController.js
@@ -28,7 +28,7 @@
     resultsGrid: $("#resultsGrid"),
     letterPanel: $("#cursiveLetterPanel"),
     nameInput: $("#cursiveNameInput"),
-    nameChips: $("#cursiveNameChips"),
+    sigControls: $("#cursiveSignatureControls"),
     nameResults: $("#cursiveNameResults"),
     printRoot: $("#cursivePrintRoot"),
     printBtn: $("#cursivePrintSheet")
@@ -55,14 +55,24 @@
     try { return R.renderAny(text, style); } catch (e) { return text; }
   }
 
-  // Apply a preset: render through its base style, then wrap or add a
-  // combining mark per visible character (the underline-flourish look).
-  function renderPreset(text, preset) {
+  function applyCombining(text, mark) {
+    return [...text].map((c) => (c === " " || c === "\n") ? c : c + mark).join("");
+  }
+
+  function applyWrap(text, wrap) {
+    let out = text;
+    if (wrap.combining) out = applyCombining(out, wrap.combining);
+    return (wrap.pre || "") + out + (wrap.post || "");
+  }
+
+  // Apply a preset: render through its base style, add the preset's combining
+  // mark to the letters only, then let the decorator and the preset's own
+  // pre/post wrap around — so an underlined name keeps its flourish clean.
+  function renderPreset(text, preset, decorator) {
     let out = renderWith(text, preset.base);
     if (!out || !out.trim()) return "";
-    if (preset.combining) {
-      out = [...out].map((c) => (c === " " || c === "\n") ? c : c + preset.combining).join("");
-    }
+    if (preset.combining) out = applyCombining(out, preset.combining);
+    if (decorator && decorator.name !== "None") out = applyWrap(out, decorator);
     return (preset.pre || "") + out + (preset.post || "");
   }
 
@@ -90,6 +100,9 @@
 
     card.appendChild(info);
 
+    const actions = document.createElement("div");
+    actions.className = "cursive-card-actions";
+
     const btn = document.createElement("button");
     btn.type = "button";
     btn.className = "copy-btn";
@@ -101,7 +114,19 @@
       btn.dataset.text = text;
       btn.dataset.style = o.styleName || name;
     }
-    card.appendChild(btn);
+    actions.appendChild(btn);
+
+    if (o.png && text && !o.demo) {
+      const png = document.createElement("button");
+      png.type = "button";
+      png.className = "cursive-png-btn";
+      png.textContent = "PNG";
+      png.title = "Download as PNG image";
+      png.addEventListener("click", () => downloadTextPNG(text, o.pngName || name));
+      actions.appendChild(png);
+    }
+
+    card.appendChild(actions);
     return card;
   }
 
@@ -197,6 +222,38 @@
     return out;
   }
 
+  // Render any text (signature, word) onto a wide canvas, scaling the font
+  // down so long names still fit, and download it as a PNG.
+  function downloadTextPNG(text, label) {
+    const width = 1600, height = 640, pad = 120;
+    const canvas = document.createElement("canvas");
+    canvas.width = width; canvas.height = height;
+    const ctx = canvas.getContext("2d");
+    ctx.fillStyle = "#ffffff";
+    ctx.fillRect(0, 0, width, height);
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    let fontSize = 220;
+    ctx.font = "700 " + fontSize + "px " + GLYPH_FONT;
+    const measured = ctx.measureText(text).width;
+    if (measured > width - pad * 2) {
+      fontSize = Math.max(60, Math.floor(fontSize * (width - pad * 2) / measured));
+      ctx.font = "700 " + fontSize + "px " + GLYPH_FONT;
+    }
+    ctx.fillStyle = "#1a1a2e";
+    ctx.fillText(text, width / 2, height * 0.52);
+    const slug = String(label || "signature").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "signature";
+    canvas.toBlob((blob) => {
+      if (!blob) return;
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "cursive-" + slug + ".png";
+      document.body.appendChild(a); a.click(); document.body.removeChild(a);
+      setTimeout(() => URL.revokeObjectURL(url), 1000);
+    }, "image/png");
+  }
+
   function downloadLetterPNG(ch, glyphPair) {
     const size = 1024;
     const canvas = document.createElement("canvas");
@@ -220,6 +277,27 @@
     }, "image/png");
   }
 
+  // Which case the letter panel's preview/copy/PNG act on: capital letters
+  // are what most "cursive s" searches want, but the pair is the default view.
+  let letterCase = "both";
+  const CASES = [
+    { id: "upper", label: "Capital" },
+    { id: "lower", label: "Lowercase" },
+    { id: "both",  label: "Both" }
+  ];
+
+  function caseGlyph(primary, ch) {
+    if (letterCase === "upper") return primary.upper;
+    if (letterCase === "lower") return primary.lower;
+    return primary.upper + " " + primary.lower;
+  }
+
+  function caseLabel(ch) {
+    if (letterCase === "upper") return "Capital " + ch + " in cursive";
+    if (letterCase === "lower") return "Lowercase " + ch.toLowerCase() + " in cursive";
+    return "Capital and lowercase " + ch + " in cursive";
+  }
+
   function selectLetter(ch, opts) {
     if (!el.letterPanel) return;
     $$(".cursive-letter-cell").forEach((cell) => {
@@ -233,34 +311,49 @@
     const stage = document.createElement("div");
     stage.className = "bubble-stage";
 
-    // Left: the big letter pair + actions.
+    // Left: the big letter + case toggle + actions.
     const figure = document.createElement("div");
     figure.className = "bubble-outline-card cursive-letter-figure";
 
+    const caseRow = document.createElement("div");
+    caseRow.className = "cursive-case-row";
+    CASES.forEach((c) => {
+      const chip = document.createElement("button");
+      chip.type = "button";
+      chip.className = "vertical-chip" + (letterCase === c.id ? " active" : "");
+      chip.textContent = c.label;
+      chip.addEventListener("click", () => {
+        letterCase = c.id;
+        selectLetter(ch, { silent: true });
+      });
+      caseRow.appendChild(chip);
+    });
+    figure.appendChild(caseRow);
+
     const big = document.createElement("p");
     big.className = "cursive-letter-big";
-    big.textContent = primary.upper + " " + primary.lower;
+    big.textContent = caseGlyph(primary, ch);
     figure.appendChild(big);
 
     const tag = document.createElement("p");
     tag.className = "bubble-az-intro";
-    tag.textContent = "Capital and lowercase " + ch + " in cursive";
+    tag.textContent = caseLabel(ch);
     figure.appendChild(tag);
 
     const actions = document.createElement("div");
     actions.className = "bubble-actions";
-    const copyPair = document.createElement("button");
-    copyPair.type = "button";
-    copyPair.className = "bubble-btn bubble-btn-primary copy-btn";
-    copyPair.textContent = "Copy both";
-    copyPair.dataset.text = primary.upper + " " + primary.lower;
-    copyPair.dataset.style = primary.name;
-    actions.appendChild(copyPair);
+    const copyBtn = document.createElement("button");
+    copyBtn.type = "button";
+    copyBtn.className = "bubble-btn bubble-btn-primary copy-btn";
+    copyBtn.textContent = letterCase === "both" ? "Copy both" : "Copy " + (letterCase === "upper" ? primary.upper : primary.lower);
+    copyBtn.dataset.text = caseGlyph(primary, ch);
+    copyBtn.dataset.style = primary.name;
+    actions.appendChild(copyBtn);
     const dl = document.createElement("button");
     dl.type = "button";
     dl.className = "bubble-btn";
     dl.textContent = "Download PNG";
-    dl.addEventListener("click", () => downloadLetterPNG(ch, primary.upper + " " + primary.lower));
+    dl.addEventListener("click", () => downloadLetterPNG(ch, caseGlyph(primary, ch)));
     actions.appendChild(dl);
     figure.appendChild(actions);
 
@@ -376,6 +469,9 @@
      Name & signature studio
      --------------------------------------------------------------- */
 
+  let activeDecorator = null;   // one of D.signatureDecorators, null = None
+  let activeJoiner = ".";       // monogram-initials joiner
+
   function renderNames() {
     if (!el.nameResults) return;
     const raw = el.nameInput ? el.nameInput.value : "";
@@ -385,29 +481,82 @@
     const frag = document.createDocumentFragment();
     const seen = {};
     (D.signatures || []).forEach((preset) => {
-      const source = preset.initials ? initialsOf(name).split(" ").join(preset.joiner || ".") + (preset.joiner || ".") : name;
-      const out = renderPreset(source, preset);
+      // Trailing joiner only for the classic dotted form (O.G.); symbol
+      // joiners read better between initials only (O♡G, O&G).
+      const trail = activeJoiner === "." ? "." : "";
+      const source = preset.initials ? initialsOf(name).split(" ").join(activeJoiner) + trail : name;
+      // The flourish decorator styles the name itself; monogram initials
+      // stay clean so the joiner remains readable.
+      const out = renderPreset(source, preset, preset.initials ? null : activeDecorator);
       if (!out || seen[out]) return;
       seen[out] = true;
-      frag.appendChild(buildCard(preset.name, out, { demo: isDemo, styleName: preset.name }));
+      frag.appendChild(buildCard(preset.name, out, { demo: isDemo, styleName: preset.name, png: true, pngName: preset.name }));
     });
 
     el.nameResults.innerHTML = "";
     el.nameResults.appendChild(frag);
   }
 
-  function buildNameChips() {
-    if (!el.nameChips || !el.nameInput) return;
-    (D.nameChips || []).forEach((name) => {
-      const chip = document.createElement("button");
-      chip.type = "button";
-      chip.className = "vertical-chip cursive-quick-chip";
-      chip.textContent = name;
-      chip.addEventListener("click", () => {
-        el.nameInput.value = name;
+  // Chip-row control (same look as the vertical/tattoo control panels).
+  function chipRow(labelText, chips, isActive, onPick) {
+    const row = document.createElement("div");
+    row.className = "vertical-control-row";
+    const label = document.createElement("span");
+    label.className = "vertical-control-label";
+    label.textContent = labelText;
+    row.appendChild(label);
+    const wrap = document.createElement("div");
+    wrap.className = "vertical-mode-chips";
+    chips.forEach((chip) => {
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = "vertical-chip" + (isActive(chip) ? " active" : "");
+      btn.textContent = chip.label;
+      btn.addEventListener("click", () => {
+        onPick(chip);
+        $$(".vertical-chip", wrap).forEach((b) => b.classList.toggle("active", b === btn));
         renderNames();
       });
-      el.nameChips.appendChild(chip);
+      wrap.appendChild(btn);
+    });
+    row.appendChild(wrap);
+    return row;
+  }
+
+  function buildSignatureControls() {
+    if (!el.sigControls) return;
+    const decos = D.signatureDecorators || [];
+    el.sigControls.appendChild(chipRow(
+      "Flourish",
+      decos.map((d) => ({ label: d.name, value: d })),
+      (chip) => (activeDecorator ? activeDecorator.name : "None") === chip.value.name,
+      (chip) => { activeDecorator = chip.value.name === "None" ? null : chip.value; }
+    ));
+    el.sigControls.appendChild(chipRow(
+      "Monogram joiner",
+      (D.monogramJoiners || ["."]).map((j) => ({ label: "O" + j + "G", value: j })),
+      (chip) => chip.value === activeJoiner,
+      (chip) => { activeJoiner = chip.value; }
+    ));
+  }
+
+  // The popular-names gallery doubles as the studio's example picker.
+  function bindNameExamples() {
+    $$(".cursive-name-example").forEach((card) => {
+      const load = () => {
+        if (!el.nameInput) return;
+        el.nameInput.value = card.dataset.name || "";
+        renderNames();
+        el.nameInput.scrollIntoView({ behavior: "smooth", block: "center" });
+        el.nameInput.focus({ preventScroll: true });
+      };
+      card.addEventListener("click", (e) => {
+        if (e.target.closest(".copy-btn")) return; // copy stays copy
+        load();
+      });
+      card.addEventListener("keydown", (e) => {
+        if (e.key === "Enter" || e.key === " ") { e.preventDefault(); load(); }
+      });
     });
   }
 
@@ -433,7 +582,8 @@
 
     buildQuickRow();
     bindLetterGrid();
-    buildNameChips();
+    buildSignatureControls();
+    bindNameExamples();
 
     if (el.input) {
       const seeded = readUrlText();

--- a/style.css
+++ b/style.css
@@ -2389,6 +2389,12 @@ a:hover {
   color: var(--accent, #6366f1);
 }
 
+/* Keep active chips readable while hovered — the hover rule above would
+   otherwise paint accent text on the accent background. */
+.vertical-chip.active:hover:not(:disabled) {
+  color: #fff;
+}
+
 .vertical-chip.active {
   background: var(--accent, #6366f1);
   border-color: var(--accent, #6366f1);
@@ -5106,4 +5112,46 @@ body.dark-mode .cursive-word-card {
   .cursive-letter-grid { grid-template-columns: repeat(auto-fill, minmax(72px, 1fr)); }
   .cursive-letter-big { font-size: 3.2rem; }
   .cursive-alphabet-row { font-size: 1.15rem; }
+}
+
+/* Cursive signature studio controls, card actions & interactive name cards */
+.cursive-sig-controls { margin: 10px 0 4px; }
+
+.cursive-case-row {
+  display: flex;
+  justify-content: center;
+  gap: 6px;
+  margin-bottom: 10px;
+}
+
+.cursive-card-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.cursive-png-btn {
+  padding: 8px 12px;
+  border: 1px solid var(--border-light);
+  border-radius: 8px;
+  background: var(--bg-white);
+  color: var(--text-secondary);
+  font-family: inherit;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.cursive-png-btn:hover {
+  border-color: var(--accent-purple);
+  color: var(--text-primary);
+}
+
+.cursive-name-example { cursor: pointer; transition: border-color 0.15s ease, transform 0.15s ease; }
+
+.cursive-name-example:hover {
+  border-color: var(--accent-purple);
+  transform: translateY(-2px);
 }


### PR DESCRIPTION
Follow-up UX pass on the rebuilt cursive experience (#405), addressing three review points on `/category/cursive-fonts/`.

## Changes

### a) Letters A–Z panel — case-specific copy
- New **Capital / Lowercase / Both** chip toggle (defaults to Both) in the letter panel.
- The big preview, the primary copy button, and the PNG download all follow the toggle — "Copy 𝒮" copies exactly `𝒮`, nothing else. Serves "capital s in cursive" / "lowercase f in cursive" searchers in one tap.

### b) Signature studio — real controls instead of pre-filled name chips
- **Flourish decorator chips** (None / Underline / Sparkle / Hearts / Ornate / Soft dots) restyle all eight signature cards at once. Flourishes compose *inside* each preset's own wrapper, and combining-mark presets (underline) apply to the name's letters only, keeping flourish glyphs clean.
- **Monogram joiner picker** — `O.G` / `O·G` / `O♡G` / `O&G`; trailing joiner only on the classic dotted form (no `O&G&`).
- **PNG download on every signature card** — renders the signature onto a 1600px canvas with auto font scaling for long names; usable in email footers, watermarks, and documents.

### c) Popular-names gallery becomes the example picker
- Tapping any name card loads it into the studio and re-renders (with hover affordance, `role="button"`, and Enter/Space keyboard support). The crawlable "«name» in cursive" copy is unchanged for SEO; the redundant chips row is removed.

### Bonus fix
- Site-wide `.vertical-chip` contrast bug: an **active** chip lost its white label while hovered (accent text on accent background). Fixed in `style.css`; also repairs the same glitch on the vertical-text page's controls.

## Verification
- Driven end-to-end in Chromium (Playwright): case toggle switches preview/copy/PNG, flourish + joiner combinations render correctly (`꧁ ♡ 𝓞𝓵𝓲𝓿𝓲𝓪 𝓖𝓻𝓪𝓬𝓮 ♡ ꧂`, `𝓞&𝓖`), name-card click loads the studio, PNG download produces `cursive-classic-signature.png`, no console errors.
- `node --check` passes on both `js/cursive/` modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lw1csT8LyfdXdtQ1Gw8wcy

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lw1csT8LyfdXdtQ1Gw8wcy)_