### PR TITLE
feat: roll out the new cursive experience to 9 international pages

### DIFF
--- a/category/cursive-fonts/index.html
+++ b/category/cursive-fonts/index.html
@@ -16,11 +16,13 @@
 
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/category/cursive-fonts/">
   <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/letra-cursiva/">
-  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/ecriture-cursive/">
-  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/tulisan-sambung/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/letra-cursiva/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/ecriture-cursive/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/schreibschrift/">
+  <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/lettere-in-corsivo/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/el-yazisi-fontu/">
-  <link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/sierlijke-letters/">
+  <link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/cursieve-letters/">
+  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/tulisan-sambung/">
   <link rel="alternate" hreflang="no" href="https://ultratextgen.com/no/kursiv-tekst/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/category/cursive-fonts/">
 
@@ -888,6 +890,20 @@
 </div>
 
 </div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Language switcher">
+      <a class="lang-option active" href="/category/cursive-fonts/" hreflang="en">EN</a>
+      <a class="lang-option" href="/es/letra-cursiva/" hreflang="es">ES</a>
+      <a class="lang-option" href="/pt/letra-cursiva/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/fr/ecriture-cursive/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/de/schreibschrift/" hreflang="de">DE</a>
+      <a class="lang-option" href="/it/lettere-in-corsivo/" hreflang="it">IT</a>
+      <a class="lang-option" href="/tr/el-yazisi-fontu/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/nl/cursieve-letters/" hreflang="nl">NL</a>
+      <a class="lang-option" href="/id/tulisan-sambung/" hreflang="id">ID</a>
+      <a class="lang-option" href="/no/kursiv-tekst/" hreflang="no">NO</a>
+    </div>
 
     </div>
   </footer>

--- a/de/schreibschrift/index.html
+++ b/de/schreibschrift/index.html
@@ -1,0 +1,848 @@
+<!DOCTYPE html><html lang="de"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZGVh");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Schreibschrift Generator — 𝓢𝓬𝓱𝓻𝓮𝓲𝓫𝓼𝓬𝓱𝓻𝓲𝓯𝓽 zum Kopieren, Alphabet A–Z &amp; Namen | UltraTextGen</title>
+  <meta name="description" content="Kostenloser Schreibschrift Generator — schöne Schrift zum Kopieren und Einfügen, jeder Buchstabe A–Z, das ganze Schreibschrift-Alphabet, beliebte Wörter und Namen als Signatur.">
+  <link rel="canonical" href="https://ultratextgen.com/de/schreibschrift/">
+
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/category/cursive-fonts/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/letra-cursiva/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/letra-cursiva/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/ecriture-cursive/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/schreibschrift/">
+  <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/lettere-in-corsivo/">
+  <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/el-yazisi-fontu/">
+  <link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/cursieve-letters/">
+  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/tulisan-sambung/">
+  <link rel="alternate" hreflang="no" href="https://ultratextgen.com/no/kursiv-tekst/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/category/cursive-fonts/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Schreibschrift Generator — 𝓢𝓬𝓱𝓻𝓮𝓲𝓫𝓼𝓬𝓱𝓻𝓲𝓯𝓽 zum Kopieren, Alphabet A–Z &amp; Namen | UltraTextGen">
+  <meta property="og:description" content="Kostenloser Schreibschrift Generator — schöne Schrift und schöne Buchstaben zum Kopieren, das ganze Alphabet A–Z und Namens-Signaturen. Sofort, ohne Anmeldung.">
+  <meta property="og:url" content="https://ultratextgen.com/de/schreibschrift/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category-cursive-fonts.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Schreibschrift Generator — 𝓢𝓬𝓱𝓻𝓮𝓲𝓫𝓼𝓬𝓱𝓻𝓲𝓯𝓽 zum Kopieren, Alphabet A–Z &amp; Namen | UltraTextGen">
+  <meta name="twitter:description" content="Kostenloser Schreibschrift Generator — schöne Schrift zum Kopieren, jeder Buchstabe A–Z, das ganze Schreibschrift-Alphabet und Namens-Signaturen.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category-cursive-fonts.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "de",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Was ist ein Schreibschrift Generator und wie funktioniert er?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Er wandelt die Buchstaben, die du tippst, in Unicode-Script-Zeichen um — besondere Symbole, die wie handgeschriebene, schöne Schrift aussehen, sich aber wie normaler Text verhalten. Weil es echte Zeichen sind (keine Schriftart und kein Bild), kannst du sie kopieren und in Bios, Bildunterschriften, Kommentare und Nachrichten einfügen, wo sie ihren Schreibschrift-Look behalten. Mehr dazu in unserem <a href=\"/guide/how-unicode-fonts-work/\">Leitfaden, wie Unicode-Schriften funktionieren</a>."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Wie kopiere ich Schreibschrift und füge sie ein?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Tippe oder füge deinen Text oben in das Feld ein und drücke bei deinem Lieblingsstil auf <strong>Kopieren</strong>. Die Schreibschrift-Version liegt jetzt in der Zwischenablage — füge sie überall ein, wo Text erlaubt ist: Instagram, TikTok, WhatsApp, Discord, Dokumente und mehr."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Funktioniert die Schreibschrift auf Instagram, WhatsApp und TikTok?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ja. Bildunterschriften, Kommentare, Chat-Nachrichten und der Bio-Bereich akzeptieren die Zeichen zuverlässig. Ein Hinweis: Manche <strong>Benutzernamen-Felder</strong> filtern Script-Zeichen heraus — für den @-Handle bleibt normaler Text nötig, für die Bio selbst funktioniert die schöne Schrift bestens."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Kann ich Umlaute (ä, ö, ü) und ß in Schreibschrift schreiben?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Unicode-Schreibschrift deckt nur A–Z ab, deshalb haben ä, ö, ü und ß keine eigene Script-Form und bleiben stehen. Für ein durchgehend schönes Ergebnis schreibst du sie am besten als <strong>ae, oe, ue und ss</strong> (etwa „Woerter“ oder „gruesse“). Dann verwandeln sich alle Buchstaben in saubere Schreibschrift."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Ist der Schreibschrift Generator kostenlos?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ja, komplett kostenlos und ohne Anmeldung. Tippe, kopiere und füge so oft du möchtest ein — es gibt keine Grenze und keine versteckten Kosten."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Sind das echte Buchstaben oder ein Bild?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Es sind echte Textzeichen aus dem Unicode-Standard, kein Bild. Deshalb lassen sie sich markieren, kopieren, durchsuchen und in nahezu jedes Textfeld einfügen — deine schöne Schrift bleibt überall Text."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Wie schreibe ich meinen Namen in Schreibschrift?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Gib deinen Namen in das Namens-Studio ein, wähle einen Stil und einen Schnörkel und kopiere ihn oder lade ihn als PNG herunter. Für einen makellosen Look lässt du Umlaute weg oder ersetzt sie durch ae, oe, ue — so werden alle Buchstaben in schöne Schrift umgewandelt."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Warum erscheinen manche Buchstaben als leere Kästchen?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ein leeres Kästchen (▯) bedeutet, dass das Gerät für dieses Script-Zeichen keine passende Glyphe hat. Das betrifft meist ältere Systeme. Wähle einen schlichteren Stil oder vermeide Sonderzeichen — mehr dazu unter <a href=\"/guide/why-fonts-show-as-boxes/\">warum Schriften als Kästchen erscheinen</a>."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Startseite", "item": "https://ultratextgen.com/de/" },
+    { "@type": "ListItem", "position": 2, "name": "Schreibschrift", "item": "https://ultratextgen.com/de/schreibschrift/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Schreibschrift Generator",
+  "alternateName": ["Schreibschrift zum Kopieren","Schöne Schrift Generator","Schreibschrift Alphabet A–Z","Schreibschrift-Alphabet","Schöne Buchstaben","Namen in Schreibschrift","Signatur Generator","Kursivschrift Generator"],
+  "url": "https://ultratextgen.com/de/schreibschrift/",
+  "inLanguage": "de",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "EUR"
+  },
+  "description": "Kostenloser Schreibschrift Generator: schöne Schrift zum Kopieren und Einfügen, jeder Buchstabe A–Z, das ganze Schreibschrift-Alphabet, beliebte Wörter und Namen als Signatur.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers.",
+  "featureList": ["Schreibschrift Generator mit Schnörkel-Vorlagen","Buchstaben A–Z Explorer (groß und klein)","Ganzes Schreibschrift-Alphabet mit einem Klick kopieren","Druckbares Übungsblatt für schöne Schrift","Namen- und Signatur-Studio","Galerie mit Wörtern in Schreibschrift (Liebe, Geburtstag, Monate)"]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/de/">Startseite</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Schreibschrift</span>
+</nav>
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/category-cursive-fonts.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+  <!-- Hero: the cursive-first generator -->
+  <section class="hero">
+    <div class="hero-inner">
+      <div class="hero-card">
+        <h1 class="hero-headline">Schreibschrift Generator</h1>
+        <p class="hero-tagline">Verwandle jeden Text in 𝓢𝓬𝓱𝓻𝓮𝓲𝓫𝓼𝓬𝓱𝓻𝓲𝓯𝓽 zum Kopieren und Einfügen — fließende, schöne Schrift,
+          jeder Buchstabe A–Z, das ganze Alphabet und Namens-Signaturen. Kostenlos, sofort, ohne Anmeldung.</p>
+        <div class="input-wrapper">
+          <textarea class="main-input" id="mainInput" placeholder="Text, Wort oder Namen eingeben…" maxlength="500" autofocus></textarea>
+          <span class="char-count"><span id="charCount">0</span>/500</span>
+        </div>
+        <div class="cursive-quick-row" id="cursiveQuickRow" aria-label="Schnelle Beispiele"></div>
+        <div class="vertical-fit-row" id="cursiveFitRow" hidden></div>
+      </div>
+    </div>
+  </section>
+
+  <nav class="cursive-section-nav" aria-label="Auf dieser Seite">
+    <a href="#cursive-styles">Stile</a>
+    <a href="#cursive-letters">Buchstaben A–Z</a>
+    <a href="#cursive-alphabet">Alphabet</a>
+    <a href="#cursive-words">Wörter</a>
+    <a href="#cursive-names">Namen &amp; Signaturen</a>
+    <a href="#cursive-faq">FAQ</a>
+  </nav>
+
+  <main class="container">
+
+    <!-- 1. Generator output -->
+    <section id="cursive-styles" aria-labelledby="cursiveStylesHeading">
+      <h2 class="bubble-az-heading" id="cursiveStylesHeading">Schreibschrift zum Kopieren und Einfügen</h2>
+      <p class="bubble-az-intro">Jeder Stil unten aktualisiert sich live beim Tippen: klassische und fette Schreibschrift,
+        elegante Varianten, gotische Schrift, Chicano-Namenszüge und Vorlagen mit Herzen,
+        Funkeln und Pfeilen. Auf Kopieren tippen und überall einfügen — deine schöne Schrift ist sofort einsatzbereit.</p>
+      <div class="results-grid" id="resultsGrid"></div>
+    </section>
+
+    <!-- 2. Cursive letters A–Z -->
+    <section class="bubble-az" id="cursive-letters" aria-labelledby="cursiveLettersHeading">
+      <h2 class="bubble-az-heading" id="cursiveLettersHeading">Buchstaben A–Z in Schreibschrift — groß &amp; klein</h2>
+      <p class="bubble-az-intro">Suchst du einen einzelnen Buchstaben — ein S in Schreibschrift, ein großes G, ein kleines f?
+        Tippe auf einen Buchstaben, um ihn in jedem Stil zu sehen, kopiere die genaue schöne Glyphe oder lade sie als PNG herunter.</p>
+  <div class="cursive-letter-grid" role="tablist" aria-label="Wähle einen Buchstaben">
+    <button type="button" class="cursive-letter-cell" id="cursive-a" data-char="A" aria-label="A in Schreibschrift — groß und klein">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒜 𝒶</span>
+      <span class="cursive-letter-name">A in Schreibschrift</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-b" data-char="B" aria-label="B in Schreibschrift — groß und klein">
+      <span class="cursive-letter-pair" aria-hidden="true">ℬ 𝒷</span>
+      <span class="cursive-letter-name">B in Schreibschrift</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-c" data-char="C" aria-label="C in Schreibschrift — groß und klein">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒞 𝒸</span>
+      <span class="cursive-letter-name">C in Schreibschrift</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-d" data-char="D" aria-label="D in Schreibschrift — groß und klein">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒟 𝒹</span>
+      <span class="cursive-letter-name">D in Schreibschrift</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-e" data-char="E" aria-label="E in Schreibschrift — groß und klein">
+      <span class="cursive-letter-pair" aria-hidden="true">ℰ ℯ</span>
+      <span class="cursive-letter-name">E in Schreibschrift</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-f" data-char="F" aria-label="F in Schreibschrift — groß und klein">
+      <span class="cursive-letter-pair" aria-hidden="true">ℱ 𝒻</span>
+      <span class="cursive-letter-name">F in Schreibschrift</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-g" data-char="G" aria-label="G in Schreibschrift — groß und klein">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒢 ℊ</span>
+      <span class="cursive-letter-name">G in Schreibschrift</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-h" data-char="H" aria-label="H in Schreibschrift — groß und klein">
+      <span class="cursive-letter-pair" aria-hidden="true">ℋ 𝒽</span>
+      <span class="cursive-letter-name">H in Schreibschrift</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-i" data-char="I" aria-label="I in Schreibschrift — groß und klein">
+      <span class="cursive-letter-pair" aria-hidden="true">ℐ 𝒾</span>
+      <span class="cursive-letter-name">I in Schreibschrift</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-j" data-char="J" aria-label="J in Schreibschrift — groß und klein">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒥 𝒿</span>
+      <span class="cursive-letter-name">J in Schreibschrift</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-k" data-char="K" aria-label="K in Schreibschrift — groß und klein">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒦 𝓀</span>
+      <span class="cursive-letter-name">K in Schreibschrift</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-l" data-char="L" aria-label="L in Schreibschrift — groß und klein">
+      <span class="cursive-letter-pair" aria-hidden="true">ℒ 𝓁</span>
+      <span class="cursive-letter-name">L in Schreibschrift</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-m" data-char="M" aria-label="M in Schreibschrift — groß und klein">
+      <span class="cursive-letter-pair" aria-hidden="true">ℳ 𝓂</span>
+      <span class="cursive-letter-name">M in Schreibschrift</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-n" data-char="N" aria-label="N in Schreibschrift — groß und klein">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒩 𝓃</span>
+      <span class="cursive-letter-name">N in Schreibschrift</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-o" data-char="O" aria-label="O in Schreibschrift — groß und klein">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒪 ℴ</span>
+      <span class="cursive-letter-name">O in Schreibschrift</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-p" data-char="P" aria-label="P in Schreibschrift — groß und klein">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒫 𝓅</span>
+      <span class="cursive-letter-name">P in Schreibschrift</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-q" data-char="Q" aria-label="Q in Schreibschrift — groß und klein">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒬 𝓆</span>
+      <span class="cursive-letter-name">Q in Schreibschrift</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-r" data-char="R" aria-label="R in Schreibschrift — groß und klein">
+      <span class="cursive-letter-pair" aria-hidden="true">ℛ 𝓇</span>
+      <span class="cursive-letter-name">R in Schreibschrift</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-s" data-char="S" aria-label="S in Schreibschrift — groß und klein">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒮 𝓈</span>
+      <span class="cursive-letter-name">S in Schreibschrift</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-t" data-char="T" aria-label="T in Schreibschrift — groß und klein">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒯 𝓉</span>
+      <span class="cursive-letter-name">T in Schreibschrift</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-u" data-char="U" aria-label="U in Schreibschrift — groß und klein">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒰 𝓊</span>
+      <span class="cursive-letter-name">U in Schreibschrift</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-v" data-char="V" aria-label="V in Schreibschrift — groß und klein">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒱 𝓋</span>
+      <span class="cursive-letter-name">V in Schreibschrift</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-w" data-char="W" aria-label="W in Schreibschrift — groß und klein">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒲 𝓌</span>
+      <span class="cursive-letter-name">W in Schreibschrift</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-x" data-char="X" aria-label="X in Schreibschrift — groß und klein">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒳 𝓍</span>
+      <span class="cursive-letter-name">X in Schreibschrift</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-y" data-char="Y" aria-label="Y in Schreibschrift — groß und klein">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒴 𝓎</span>
+      <span class="cursive-letter-name">Y in Schreibschrift</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-z" data-char="Z" aria-label="Z in Schreibschrift — groß und klein">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒵 𝓏</span>
+      <span class="cursive-letter-name">Z in Schreibschrift</span>
+    </button>
+  </div>
+      <div class="cursive-letter-panel" id="cursiveLetterPanel" aria-live="polite"></div>
+    </section>
+
+    <!-- 3. The cursive alphabet -->
+    <section id="cursive-alphabet" aria-labelledby="cursiveAlphabetHeading">
+      <div class="cursive-chart-toolbar">
+        <h2 class="bubble-az-heading" id="cursiveAlphabetHeading">Das Schreibschrift-Alphabet (A–Z, 0–9)</h2>
+        <button type="button" class="bubble-btn bubble-btn-primary" id="cursivePrintSheet">Übungsblatt drucken</button>
+      </div>
+      <p class="bubble-az-intro">Das ganze Schreibschrift-Alphabet (A–Z) mit einem Klick kopieren — Groß-, Kleinbuchstaben und Ziffern —
+        oder ein Übungsblatt mit Musterbuchstaben zum Nachfahren drucken. Unicode kennt keine echten Schreibschrift-Ziffern, daher
+        kombiniert jeder Stil seine Script-Buchstaben mit passenden stilisierten Zahlen.</p>
+    <div class="cursive-chart">
+      <div class="cursive-chart-head">
+        <h3>Klassisches Schreibschrift-Alphabet (Ultra Script)</h3>
+        <button type="button" class="copy-btn" data-text="𝒜 ℬ 𝒞 𝒟 ℰ ℱ 𝒢 ℋ ℐ 𝒥 𝒦 ℒ ℳ 𝒩 𝒪 𝒫 𝒬 ℛ 𝒮 𝒯 𝒰 𝒱 𝒲 𝒳 𝒴 𝒵&#10;𝒶 𝒷 𝒸 𝒹 ℯ 𝒻 ℊ 𝒽 𝒾 𝒿 𝓀 𝓁 𝓂 𝓃 ℴ 𝓅 𝓆 𝓇 𝓈 𝓉 𝓊 𝓋 𝓌 𝓍 𝓎 𝓏&#10;𝟢 𝟣 𝟤 𝟥 𝟦 𝟧 𝟨 𝟩 𝟪 𝟫" data-style="Ultra Script">Alphabet kopieren</button>
+      </div>
+      <p class="cursive-alphabet-row">𝒜 ℬ 𝒞 𝒟 ℰ ℱ 𝒢 ℋ ℐ 𝒥 𝒦 ℒ ℳ 𝒩 𝒪 𝒫 𝒬 ℛ 𝒮 𝒯 𝒰 𝒱 𝒲 𝒳 𝒴 𝒵</p>
+      <p class="cursive-alphabet-row">𝒶 𝒷 𝒸 𝒹 ℯ 𝒻 ℊ 𝒽 𝒾 𝒿 𝓀 𝓁 𝓂 𝓃 ℴ 𝓅 𝓆 𝓇 𝓈 𝓉 𝓊 𝓋 𝓌 𝓍 𝓎 𝓏</p>
+      <p class="cursive-alphabet-row">𝟢 𝟣 𝟤 𝟥 𝟦 𝟧 𝟨 𝟩 𝟪 𝟫</p>
+    </div>
+    <div class="cursive-chart">
+      <div class="cursive-chart-head">
+        <h3>Fettes Schreibschrift-Alphabet (Ultra Script Bold)</h3>
+        <button type="button" class="copy-btn" data-text="𝓐 𝓑 𝓒 𝓓 𝓔 𝓕 𝓖 𝓗 𝓘 𝓙 𝓚 𝓛 𝓜 𝓝 𝓞 𝓟 𝓠 𝓡 𝓢 𝓣 𝓤 𝓥 𝓦 𝓧 𝓨 𝓩&#10;𝓪 𝓫 𝓬 𝓭 𝓮 𝓯 𝓰 𝓱 𝓲 𝓳 𝓴 𝓵 𝓶 𝓷 𝓸 𝓹 𝓺 𝓻 𝓼 𝓽 𝓾 𝓿 𝔀 𝔁 𝔂 𝔃&#10;𝟬 𝟭 𝟮 𝟯 𝟰 𝟱 𝟲 𝟳 𝟴 𝟵" data-style="Ultra Script Bold">Alphabet kopieren</button>
+      </div>
+      <p class="cursive-alphabet-row">𝓐 𝓑 𝓒 𝓓 𝓔 𝓕 𝓖 𝓗 𝓘 𝓙 𝓚 𝓛 𝓜 𝓝 𝓞 𝓟 𝓠 𝓡 𝓢 𝓣 𝓤 𝓥 𝓦 𝓧 𝓨 𝓩</p>
+      <p class="cursive-alphabet-row">𝓪 𝓫 𝓬 𝓭 𝓮 𝓯 𝓰 𝓱 𝓲 𝓳 𝓴 𝓵 𝓶 𝓷 𝓸 𝓹 𝓺 𝓻 𝓼 𝓽 𝓾 𝓿 𝔀 𝔁 𝔂 𝔃</p>
+      <p class="cursive-alphabet-row">𝟬 𝟭 𝟮 𝟯 𝟰 𝟱 𝟲 𝟳 𝟴 𝟵</p>
+    </div>
+    <div class="cursive-chart">
+      <div class="cursive-chart-head">
+        <h3>Gotisches Schreibschrift-Alphabet (Ultra Gothic Script)</h3>
+        <button type="button" class="copy-btn" data-text="𝕬 𝕭 𝕮 𝕯 𝕰 𝕱 𝕲 𝕳 𝕴 𝕵 𝕶 𝕷 𝕸 𝕹 𝕺 𝕻 𝕼 𝕽 𝕾 𝕿 𝖀 𝖁 𝖂 𝖃 𝖄 𝖅&#10;𝖆 𝖇 𝖈 𝖉 𝖊 𝖋 𝖌 𝖍 𝖎 𝖏 𝖐 𝖑 𝖒 𝖓 𝖔 𝖕 𝖖 𝖗 𝖘 𝖙 𝖚 𝖛 𝖜 𝖝 𝖞 𝖟" data-style="Ultra Gothic Script">Alphabet kopieren</button>
+      </div>
+      <p class="cursive-alphabet-row">𝕬 𝕭 𝕮 𝕯 𝕰 𝕱 𝕲 𝕳 𝕴 𝕵 𝕶 𝕷 𝕸 𝕹 𝕺 𝕻 𝕼 𝕽 𝕾 𝕿 𝖀 𝖁 𝖂 𝖃 𝖄 𝖅</p>
+      <p class="cursive-alphabet-row">𝖆 𝖇 𝖈 𝖉 𝖊 𝖋 𝖌 𝖍 𝖎 𝖏 𝖐 𝖑 𝖒 𝖓 𝖔 𝖕 𝖖 𝖗 𝖘 𝖙 𝖚 𝖛 𝖜 𝖝 𝖞 𝖟</p>
+    </div>
+    </section>
+
+    <!-- 4. Words in cursive -->
+    <section id="cursive-words" aria-labelledby="cursiveWordsHeading">
+      <h2 class="bubble-az-heading" id="cursiveWordsHeading">Wörter in Schreibschrift — sofort zum Kopieren</h2>
+      <p class="bubble-az-intro">Die beliebtesten Wörter, schon fertig in schöner Schrift. Brauchst du ein anderes?
+        Tippe es in den <a href="#mainInput">Generator oben</a> und jeder Stil rendert es sofort.</p>
+    <h3>Liebe &amp; Familie</h3>
+    <div class="cursive-word-grid">
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">ℒ𝒾ℯ𝒷ℯ</span>
+        <span class="cursive-word-label">Liebe in Schreibschrift</span>
+        <button type="button" class="copy-btn" data-text="ℒ𝒾ℯ𝒷ℯ" data-style="Ultra Script">Kopieren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓛𝓲𝓮𝓫𝓮</span>
+        <span class="cursive-word-label">Liebe (fett) in Schreibschrift</span>
+        <button type="button" class="copy-btn" data-text="𝓛𝓲𝓮𝓫𝓮" data-style="Ultra Script Bold">Kopieren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒾𝒸𝒽 𝓁𝒾ℯ𝒷ℯ 𝒹𝒾𝒸𝒽</span>
+        <span class="cursive-word-label">ich liebe dich in Schreibschrift</span>
+        <button type="button" class="copy-btn" data-text="𝒾𝒸𝒽 𝓁𝒾ℯ𝒷ℯ 𝒹𝒾𝒸𝒽" data-style="Ultra Script">Kopieren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">ℱ𝒶𝓂𝒾𝓁𝒾ℯ</span>
+        <span class="cursive-word-label">Familie in Schreibschrift</span>
+        <button type="button" class="copy-btn" data-text="ℱ𝒶𝓂𝒾𝓁𝒾ℯ" data-style="Ultra Script">Kopieren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">ℳ𝒶𝓂𝒶</span>
+        <span class="cursive-word-label">Mama in Schreibschrift</span>
+        <button type="button" class="copy-btn" data-text="ℳ𝒶𝓂𝒶" data-style="Ultra Script">Kopieren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒫𝒶𝓅𝒶</span>
+        <span class="cursive-word-label">Papa in Schreibschrift</span>
+        <button type="button" class="copy-btn" data-text="𝒫𝒶𝓅𝒶" data-style="Ultra Script">Kopieren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒻𝓊ℯ𝓇 𝒾𝓂𝓂ℯ𝓇</span>
+        <span class="cursive-word-label">für immer in Schreibschrift</span>
+        <button type="button" class="copy-btn" data-text="𝒻𝓊ℯ𝓇 𝒾𝓂𝓂ℯ𝓇" data-style="Ultra Script">Kopieren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒯𝓇𝒶𝓊𝓂</span>
+        <span class="cursive-word-label">Traum in Schreibschrift</span>
+        <button type="button" class="copy-btn" data-text="𝒯𝓇𝒶𝓊𝓂" data-style="Ultra Script">Kopieren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">ℊℯ𝓈ℯℊ𝓃ℯ𝓉</span>
+        <span class="cursive-word-label">gesegnet in Schreibschrift</span>
+        <button type="button" class="copy-btn" data-text="ℊℯ𝓈ℯℊ𝓃ℯ𝓉" data-style="Ultra Script">Kopieren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒢𝓁𝓊ℯ𝒸𝓀</span>
+        <span class="cursive-word-label">Glück in Schreibschrift</span>
+        <button type="button" class="copy-btn" data-text="𝒢𝓁𝓊ℯ𝒸𝓀" data-style="Ultra Script">Kopieren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒮ℯℊℯ𝓃</span>
+        <span class="cursive-word-label">Segen in Schreibschrift</span>
+        <button type="button" class="copy-btn" data-text="𝒮ℯℊℯ𝓃" data-style="Ultra Script">Kopieren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">ℱ𝓇ℯ𝓊𝓃𝒹𝓈𝒸𝒽𝒶𝒻𝓉</span>
+        <span class="cursive-word-label">Freundschaft in Schreibschrift</span>
+        <button type="button" class="copy-btn" data-text="ℱ𝓇ℯ𝓊𝓃𝒹𝓈𝒸𝒽𝒶𝒻𝓉" data-style="Ultra Script">Kopieren</button>
+      </div>
+    </div>
+    <h3>Grüße &amp; Anlässe</h3>
+    <div class="cursive-word-grid">
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒶𝓁𝓁ℯ𝓈 𝒢𝓊𝓉ℯ 𝓏𝓊𝓂 𝒢ℯ𝒷𝓊𝓇𝓉𝓈𝓉𝒶ℊ</span>
+        <span class="cursive-word-label">alles Gute zum Geburtstag in Schreibschrift</span>
+        <button type="button" class="copy-btn" data-text="𝒶𝓁𝓁ℯ𝓈 𝒢𝓊𝓉ℯ 𝓏𝓊𝓂 𝒢ℯ𝒷𝓊𝓇𝓉𝓈𝓉𝒶ℊ" data-style="Ultra Script">Kopieren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒹𝒶𝓃𝓀ℯ</span>
+        <span class="cursive-word-label">danke in Schreibschrift</span>
+        <button type="button" class="copy-btn" data-text="𝒹𝒶𝓃𝓀ℯ" data-style="Ultra Script">Kopieren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒽ℯ𝓇𝓏𝓁𝒾𝒸𝒽ℯ𝓃 𝒢𝓁𝓊ℯ𝒸𝓀𝓌𝓊𝓃𝓈𝒸𝒽</span>
+        <span class="cursive-word-label">herzlichen Glückwunsch in Schreibschrift</span>
+        <button type="button" class="copy-btn" data-text="𝒽ℯ𝓇𝓏𝓁𝒾𝒸𝒽ℯ𝓃 𝒢𝓁𝓊ℯ𝒸𝓀𝓌𝓊𝓃𝓈𝒸𝒽" data-style="Ultra Script">Kopieren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓌𝒾𝓁𝓁𝓀ℴ𝓂𝓂ℯ𝓃</span>
+        <span class="cursive-word-label">willkommen in Schreibschrift</span>
+        <button type="button" class="copy-btn" data-text="𝓌𝒾𝓁𝓁𝓀ℴ𝓂𝓂ℯ𝓃" data-style="Ultra Script">Kopieren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒽𝒶𝓁𝓁ℴ</span>
+        <span class="cursive-word-label">hallo in Schreibschrift</span>
+        <button type="button" class="copy-btn" data-text="𝒽𝒶𝓁𝓁ℴ" data-style="Ultra Script">Kopieren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒻𝓇ℴ𝒽ℯ 𝒲ℯ𝒾𝒽𝓃𝒶𝒸𝒽𝓉ℯ𝓃</span>
+        <span class="cursive-word-label">frohe Weihnachten in Schreibschrift</span>
+        <button type="button" class="copy-btn" data-text="𝒻𝓇ℴ𝒽ℯ 𝒲ℯ𝒾𝒽𝓃𝒶𝒸𝒽𝓉ℯ𝓃" data-style="Ultra Script">Kopieren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒶𝓁𝓁ℯ𝓈 ℒ𝒾ℯ𝒷ℯ</span>
+        <span class="cursive-word-label">alles Liebe in Schreibschrift</span>
+        <button type="button" class="copy-btn" data-text="𝒶𝓁𝓁ℯ𝓈 ℒ𝒾ℯ𝒷ℯ" data-style="Ultra Script">Kopieren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓋𝒾ℯ𝓁 ℰ𝓇𝒻ℴ𝓁ℊ</span>
+        <span class="cursive-word-label">viel Erfolg in Schreibschrift</span>
+        <button type="button" class="copy-btn" data-text="𝓋𝒾ℯ𝓁 ℰ𝓇𝒻ℴ𝓁ℊ" data-style="Ultra Script">Kopieren</button>
+      </div>
+    </div>
+    <h3>Monate in Schreibschrift</h3>
+    <div class="cursive-word-grid">
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒥𝒶𝓃𝓊𝒶𝓇</span>
+        <span class="cursive-word-label">Januar in Schreibschrift</span>
+        <button type="button" class="copy-btn" data-text="𝒥𝒶𝓃𝓊𝒶𝓇" data-style="Ultra Script">Kopieren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">ℱℯ𝒷𝓇𝓊𝒶𝓇</span>
+        <span class="cursive-word-label">Februar in Schreibschrift</span>
+        <button type="button" class="copy-btn" data-text="ℱℯ𝒷𝓇𝓊𝒶𝓇" data-style="Ultra Script">Kopieren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">ℳ𝒶ℯ𝓇𝓏</span>
+        <span class="cursive-word-label">März in Schreibschrift</span>
+        <button type="button" class="copy-btn" data-text="ℳ𝒶ℯ𝓇𝓏" data-style="Ultra Script">Kopieren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒜𝓅𝓇𝒾𝓁</span>
+        <span class="cursive-word-label">April in Schreibschrift</span>
+        <button type="button" class="copy-btn" data-text="𝒜𝓅𝓇𝒾𝓁" data-style="Ultra Script">Kopieren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">ℳ𝒶𝒾</span>
+        <span class="cursive-word-label">Mai in Schreibschrift</span>
+        <button type="button" class="copy-btn" data-text="ℳ𝒶𝒾" data-style="Ultra Script">Kopieren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒥𝓊𝓃𝒾</span>
+        <span class="cursive-word-label">Juni in Schreibschrift</span>
+        <button type="button" class="copy-btn" data-text="𝒥𝓊𝓃𝒾" data-style="Ultra Script">Kopieren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒥𝓊𝓁𝒾</span>
+        <span class="cursive-word-label">Juli in Schreibschrift</span>
+        <button type="button" class="copy-btn" data-text="𝒥𝓊𝓁𝒾" data-style="Ultra Script">Kopieren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒜𝓊ℊ𝓊𝓈𝓉</span>
+        <span class="cursive-word-label">August in Schreibschrift</span>
+        <button type="button" class="copy-btn" data-text="𝒜𝓊ℊ𝓊𝓈𝓉" data-style="Ultra Script">Kopieren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒮ℯ𝓅𝓉ℯ𝓂𝒷ℯ𝓇</span>
+        <span class="cursive-word-label">September in Schreibschrift</span>
+        <button type="button" class="copy-btn" data-text="𝒮ℯ𝓅𝓉ℯ𝓂𝒷ℯ𝓇" data-style="Ultra Script">Kopieren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒪𝓀𝓉ℴ𝒷ℯ𝓇</span>
+        <span class="cursive-word-label">Oktober in Schreibschrift</span>
+        <button type="button" class="copy-btn" data-text="𝒪𝓀𝓉ℴ𝒷ℯ𝓇" data-style="Ultra Script">Kopieren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒩ℴ𝓋ℯ𝓂𝒷ℯ𝓇</span>
+        <span class="cursive-word-label">November in Schreibschrift</span>
+        <button type="button" class="copy-btn" data-text="𝒩ℴ𝓋ℯ𝓂𝒷ℯ𝓇" data-style="Ultra Script">Kopieren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒟ℯ𝓏ℯ𝓂𝒷ℯ𝓇</span>
+        <span class="cursive-word-label">Dezember in Schreibschrift</span>
+        <button type="button" class="copy-btn" data-text="𝒟ℯ𝓏ℯ𝓂𝒷ℯ𝓇" data-style="Ultra Script">Kopieren</button>
+      </div>
+    </div>
+    </section>
+
+    <!-- 5. Names & signatures -->
+    <section id="cursive-names" aria-labelledby="cursiveNamesHeading">
+      <h2 class="bubble-az-heading" id="cursiveNamesHeading">Namen- &amp; Signatur-Generator in Schreibschrift</h2>
+      <p class="bubble-az-intro">Gib einen Vornamen — oder einen vollständigen Namen — ein und gestalte deine Signatur in Schreibschrift:
+        wähle einen Schnörkel, lege fest, wie die Monogramm-Initialen verbunden werden, und kopiere den Text oder lade ihn als PNG
+        für E-Mail-Signaturen, Wasserzeichen und Dokumente herunter.</p>
+      <div class="cursive-name-tool">
+        <div class="input-wrapper">
+          <input type="text" class="main-input cursive-name-input" id="cursiveNameInput" placeholder="Namen eingeben… z. B. Emma Marie" maxlength="60">
+        </div>
+        <div class="cursive-sig-controls" id="cursiveSignatureControls"></div>
+        <div class="results-grid" id="cursiveNameResults"></div>
+      </div>
+    <h3>Beliebte Namen in Schreibschrift</h3>
+    <p class="bubble-az-intro">Tippe auf einen Namen, um ihn ins Studio oben zu laden und mit Schnörkeln neu zu gestalten.</p>
+    <div class="cursive-word-grid">
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Mia ins Signatur-Studio laden" data-name="Mia">
+        <span class="cursive-word-render">𝓜𝓲𝓪</span>
+        <span class="cursive-word-label">Mia in Schreibschrift</span>
+        <button type="button" class="copy-btn" data-text="𝓜𝓲𝓪" data-style="Ultra Script Bold">Kopieren</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Emma ins Signatur-Studio laden" data-name="Emma">
+        <span class="cursive-word-render">𝓔𝓶𝓶𝓪</span>
+        <span class="cursive-word-label">Emma in Schreibschrift</span>
+        <button type="button" class="copy-btn" data-text="𝓔𝓶𝓶𝓪" data-style="Ultra Script Bold">Kopieren</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Hannah ins Signatur-Studio laden" data-name="Hannah">
+        <span class="cursive-word-render">𝓗𝓪𝓷𝓷𝓪𝓱</span>
+        <span class="cursive-word-label">Hannah in Schreibschrift</span>
+        <button type="button" class="copy-btn" data-text="𝓗𝓪𝓷𝓷𝓪𝓱" data-style="Ultra Script Bold">Kopieren</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Emilia ins Signatur-Studio laden" data-name="Emilia">
+        <span class="cursive-word-render">𝓔𝓶𝓲𝓵𝓲𝓪</span>
+        <span class="cursive-word-label">Emilia in Schreibschrift</span>
+        <button type="button" class="copy-btn" data-text="𝓔𝓶𝓲𝓵𝓲𝓪" data-style="Ultra Script Bold">Kopieren</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Lina ins Signatur-Studio laden" data-name="Lina">
+        <span class="cursive-word-render">𝓛𝓲𝓷𝓪</span>
+        <span class="cursive-word-label">Lina in Schreibschrift</span>
+        <button type="button" class="copy-btn" data-text="𝓛𝓲𝓷𝓪" data-style="Ultra Script Bold">Kopieren</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Marie ins Signatur-Studio laden" data-name="Marie">
+        <span class="cursive-word-render">𝓜𝓪𝓻𝓲𝓮</span>
+        <span class="cursive-word-label">Marie in Schreibschrift</span>
+        <button type="button" class="copy-btn" data-text="𝓜𝓪𝓻𝓲𝓮" data-style="Ultra Script Bold">Kopieren</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Ben ins Signatur-Studio laden" data-name="Ben">
+        <span class="cursive-word-render">𝓑𝓮𝓷</span>
+        <span class="cursive-word-label">Ben in Schreibschrift</span>
+        <button type="button" class="copy-btn" data-text="𝓑𝓮𝓷" data-style="Ultra Script Bold">Kopieren</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Paul ins Signatur-Studio laden" data-name="Paul">
+        <span class="cursive-word-render">𝓟𝓪𝓾𝓵</span>
+        <span class="cursive-word-label">Paul in Schreibschrift</span>
+        <button type="button" class="copy-btn" data-text="𝓟𝓪𝓾𝓵" data-style="Ultra Script Bold">Kopieren</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Leon ins Signatur-Studio laden" data-name="Leon">
+        <span class="cursive-word-render">𝓛𝓮𝓸𝓷</span>
+        <span class="cursive-word-label">Leon in Schreibschrift</span>
+        <button type="button" class="copy-btn" data-text="𝓛𝓮𝓸𝓷" data-style="Ultra Script Bold">Kopieren</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Noah ins Signatur-Studio laden" data-name="Noah">
+        <span class="cursive-word-render">𝓝𝓸𝓪𝓱</span>
+        <span class="cursive-word-label">Noah in Schreibschrift</span>
+        <button type="button" class="copy-btn" data-text="𝓝𝓸𝓪𝓱" data-style="Ultra Script Bold">Kopieren</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Luca ins Signatur-Studio laden" data-name="Luca">
+        <span class="cursive-word-render">𝓛𝓾𝓬𝓪</span>
+        <span class="cursive-word-label">Luca in Schreibschrift</span>
+        <button type="button" class="copy-btn" data-text="𝓛𝓾𝓬𝓪" data-style="Ultra Script Bold">Kopieren</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Elias ins Signatur-Studio laden" data-name="Elias">
+        <span class="cursive-word-render">𝓔𝓵𝓲𝓪𝓼</span>
+        <span class="cursive-word-label">Elias in Schreibschrift</span>
+        <button type="button" class="copy-btn" data-text="𝓔𝓵𝓲𝓪𝓼" data-style="Ultra Script Bold">Kopieren</button>
+      </div>
+    </div>
+    </section>
+
+    <!-- Editorial -->
+    <section class="editorial-section cursive-editorial">
+      <h2>So funktioniert dieser Schreibschrift Generator</h2>
+      <p>Die Schreibschrift, die du hier siehst, ist keine Schriftart — es sind <strong>Unicode-Script-Zeichen</strong>, derselbe Standard, den dein Gerät für jeden Buchstaben und jedes Emoji nutzt. Deshalb übersteht die schöne Schrift das Kopieren und Einfügen: Apps behandeln 𝓢𝓬𝓱𝓻𝓲𝓯𝓽 genau wie normalen Text. Darum funktioniert sie auch dort, wo du nie eine Schriftart installieren könntest — in Instagram-Bios, TikTok-Untertiteln, Discord-Namen und YouTube-Kommentaren. Neugierig auf die Technik? Lies <a href="/guide/how-unicode-fonts-work/">wie Unicode-Schriften funktionieren</a>.</p>
+
+      <h3>Wo Schreibschrift funktioniert (und wo nicht)</h3>
+      <ul class="compat-list">
+        <li><span class="ts-pill-safe">Funktioniert</span> Instagram-Bios &amp; Bildunterschriften, TikTok-Captions, Discord, WhatsApp, Facebook, X, YouTube-Kommentare und die meisten Dokumente.</li>
+        <li><span class="ts-pill-risk">Eingeschränkt</span> Benutzernamen- und Anzeigename-Felder (Instagram, viele Spiele) entfernen oft Script-Zeichen — halte Handles in normalem Text.</li>
+        <li><span class="ts-pill-risk">Eingeschränkt</span> Einige ältere Geräte zeigen leere Kästchen (▯). Falls das passiert, nimm einen schlichteren Stil oder weniger Sonderzeichen — siehe <a href="/guide/why-fonts-show-as-boxes/">warum Schriften als Kästchen erscheinen</a>.</li>
+      </ul>
+
+      <h3>Unicode-Schreibschrift vs. echte Schreibschrift-Fonts</h3>
+      <p>Nutze Unicode-Schreibschrift, wenn du schöne Schrift <em>innerhalb von Textfeldern</em> brauchst — Social-Profile, Chats, Videotitel. Nutze eine echte Schreibschrift-Schriftart (in Word, Canva oder deinem Design-Tool), wenn du das Dokument selbst kontrollierst und Druckqualität mit sauberem Kerning brauchst. Beides hat seinen Platz; dieses Tool erledigt den ersten Job.</p>
+
+      <h3>Umlaute, ß &amp; Sonderzeichen in Schreibschrift</h3>
+      <p>Unicode-Script-Buchstaben gibt es nur für das lateinische Grundalphabet A–Z. Deutsche Umlaute (ä, ö, ü) und das ß haben keine eigene Script-Form und bleiben deshalb unverändert stehen. Für einen durchgehend schönen Look schreibst du Namen und Wörter am besten mit den Grundbuchstaben — <strong>ae, oe, ue und ss</strong> (z. B. „Mueller“ statt „Müller“, „gruesse“ statt „Grüße“). So verwandelt sich jeder Buchstabe in saubere Schreibschrift. Cyrillische, griechische oder arabische Zeichen werden ebenfalls unverändert durchgereicht.</p>
+
+      <h3>Schreibschrift lernen und üben</h3>
+      <p>Generatoren sind für digitalen Text gedacht, taugen aber auch als Vorlagen-Charts. Drucke das <a href="#cursive-alphabet">Übungsblatt</a> zum Nachfahren, studiere im <a href="#cursive-letters">Buchstaben-Explorer</a>, wie jeder Großbuchstabe verbunden wird, und behalte grundlegende Barrierefreiheit im Blick — kurze Zierzeilen, den Rest in normalem Text (<a href="/guide/fancy-fonts-accessibility-guide/">Leitfaden zur Barrierefreiheit</a>).</p>
+
+      <h3>Schreibschrift für Tattoos</h3>
+      <p>Schreibschrift ist der meistgefragte Tattoo-Stil. Sieh dir dein Wort hier in großer Größe an und nutze dann den speziellen <a href="/de/usecase/tattoo-schrift/">Tattoo-Schrift-Generator</a> — er ergänzt Schrift-Familien, Daten in römischen Zahlen, Initialen und einen Lesbarkeitstest für die Tinten-Größe.</p>
+    </section>
+
+    <div class="cta-card">
+      <h3>Bring deine ganze Bio zum Fließen</h3>
+      <p>Kombiniere eine Überschrift in schöner Schrift mit klarem Fließtext — die Mischung, die auffällt und gut lesbar bleibt. Erstelle deine <strong>Schreibschrift zum Kopieren</strong> im vollständigen Generator.</p>
+      <a class="cta-btn" href="/de/">Zum Schreibschrift Generator →</a>
+    </div>
+  </main>
+
+  <!-- Footer + FAQ -->
+  <footer class="footer">
+    <div class="footer-inner">
+<div class="faq-section" id="cursive-faq">
+
+<h2 class="faq-category">Schreibschrift Generator — FAQ</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Was ist ein Schreibschrift Generator und wie funktioniert er?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Er wandelt die Buchstaben, die du tippst, in Unicode-Script-Zeichen um — besondere Symbole, die wie handgeschriebene, schöne Schrift aussehen, sich aber wie normaler Text verhalten. Weil es echte Zeichen sind (keine Schriftart und kein Bild), kannst du sie kopieren und in Bios, Bildunterschriften, Kommentare und Nachrichten einfügen, wo sie ihren Schreibschrift-Look behalten. Mehr dazu in unserem <a href="/guide/how-unicode-fonts-work/">Leitfaden, wie Unicode-Schriften funktionieren</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Wie kopiere ich Schreibschrift und füge sie ein?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Tippe oder füge deinen Text oben in das Feld ein und drücke bei deinem Lieblingsstil auf <strong>Kopieren</strong>. Die Schreibschrift-Version liegt jetzt in der Zwischenablage — füge sie überall ein, wo Text erlaubt ist: Instagram, TikTok, WhatsApp, Discord, Dokumente und mehr.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Funktioniert die Schreibschrift auf Instagram, WhatsApp und TikTok?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Ja. Bildunterschriften, Kommentare, Chat-Nachrichten und der Bio-Bereich akzeptieren die Zeichen zuverlässig. Ein Hinweis: Manche <strong>Benutzernamen-Felder</strong> filtern Script-Zeichen heraus — für den @-Handle bleibt normaler Text nötig, für die Bio selbst funktioniert die schöne Schrift bestens.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Kann ich Umlaute (ä, ö, ü) und ß in Schreibschrift schreiben?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Unicode-Schreibschrift deckt nur A–Z ab, deshalb haben ä, ö, ü und ß keine eigene Script-Form und bleiben stehen. Für ein durchgehend schönes Ergebnis schreibst du sie am besten als <strong>ae, oe, ue und ss</strong> (etwa „Woerter“ oder „gruesse“). Dann verwandeln sich alle Buchstaben in saubere Schreibschrift.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Ist der Schreibschrift Generator kostenlos?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Ja, komplett kostenlos und ohne Anmeldung. Tippe, kopiere und füge so oft du möchtest ein — es gibt keine Grenze und keine versteckten Kosten.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Sind das echte Buchstaben oder ein Bild?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Es sind echte Textzeichen aus dem Unicode-Standard, kein Bild. Deshalb lassen sie sich markieren, kopieren, durchsuchen und in nahezu jedes Textfeld einfügen — deine schöne Schrift bleibt überall Text.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Wie schreibe ich meinen Namen in Schreibschrift?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Gib deinen Namen in das Namens-Studio ein, wähle einen Stil und einen Schnörkel und kopiere ihn oder lade ihn als PNG herunter. Für einen makellosen Look lässt du Umlaute weg oder ersetzt sie durch ae, oe, ue — so werden alle Buchstaben in schöne Schrift umgewandelt.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Warum erscheinen manche Buchstaben als leere Kästchen?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Ein leeres Kästchen (▯) bedeutet, dass das Gerät für dieses Script-Zeichen keine passende Glyphe hat. Das betrifft meist ältere Systeme. Wähle einen schlichteren Stil oder vermeide Sonderzeichen — mehr dazu unter <a href="/guide/why-fonts-show-as-boxes/">warum Schriften als Kästchen erscheinen</a>.
+  </div>
+</div>
+
+</div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Language switcher">
+      <a class="lang-option" href="/category/cursive-fonts/" hreflang="en">EN</a>
+      <a class="lang-option" href="/es/letra-cursiva/" hreflang="es">ES</a>
+      <a class="lang-option" href="/pt/letra-cursiva/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/fr/ecriture-cursive/" hreflang="fr">FR</a>
+      <a class="lang-option active" href="/de/schreibschrift/" hreflang="de">DE</a>
+      <a class="lang-option" href="/it/lettere-in-corsivo/" hreflang="it">IT</a>
+      <a class="lang-option" href="/tr/el-yazisi-fontu/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/nl/cursieve-letters/" hreflang="nl">NL</a>
+      <a class="lang-option" href="/id/tulisan-sambung/" hreflang="id">ID</a>
+      <a class="lang-option" href="/no/kursiv-tekst/" hreflang="no">NO</a>
+    </div>
+
+    </div>
+  </footer>
+
+  <div id="cursivePrintRoot" aria-hidden="true"></div>
+  <div class="copy-toast" id="copyToast">Kopiert!</div>
+
+  <script>
+    window.UTG_CURSIVE_MODE = true;
+    window.UTG_FAMILY = "cursive";
+    window.cursiveI18n = {
+  "demoText": "Hallo",
+  "demoName": "Mia",
+  "copy": "Kopieren",
+  "typeFirst": "Gib zuerst oben deinen Text ein",
+  "downloadPngTitle": "Als PNG-Bild herunterladen",
+  "downloadPng": "PNG herunterladen",
+  "characters": "Zeichen",
+  "caseUpper": "Großbuchstaben",
+  "caseLower": "Kleinbuchstaben",
+  "caseBoth": "Beide",
+  "labelUpper": "Großes {ch} in Schreibschrift",
+  "labelLower": "Kleines {ch} in Schreibschrift",
+  "labelBoth": "Großes und kleines {ch} in Schreibschrift",
+  "copyBoth": "Beide kopieren",
+  "everyStyle": "{ch} in Schreibschrift — jeder Stil, zum Kopieren anklicken",
+  "suffixCapital": " — groß",
+  "suffixLowercase": " — klein",
+  "accentLabel": "{name}-Akzent",
+  "practiceTitle": "Schreibschrift-Alphabet Übungsblatt — ultratextgen.com",
+  "flourishLabel": "Schnörkel",
+  "monogramLabel": "Monogramm-Verbinder",
+  "copiedToast": "Kopiert!",
+  "quickWords": [
+    "Liebe",
+    "danke",
+    "Familie",
+    "Traum",
+    "Glueck",
+    "Segen"
+  ],
+  "styles": {
+    "Ultra Script": "klassische Schreibschrift",
+    "Ultra Script Bold": "fette Schreibschrift",
+    "Ultra Script Elegant": "elegante Schreibschrift",
+    "Ultra Script Bold Elegant": "fette elegante Schreibschrift",
+    "Ultra Gothic Script": "gotische Schreibschrift",
+    "Ultra Chicano Script": "Chicano-Namenszug",
+    "Ultra Script Sparkle": "funkelnde Schreibschrift"
+  },
+  "presets": {
+    "Script Hearts": "Schreibschrift Herzen",
+    "Script Arrow Bio": "Schreibschrift Pfeil-Bio",
+    "Bold Script Stars": "fette Schreibschrift Sterne",
+    "Script Vintage": "Schreibschrift Vintage",
+    "Script Soft Dots": "Schreibschrift zarte Punkte",
+    "Bold Script Ribbon": "fette Schreibschrift Band",
+    "Script Underline": "Schreibschrift Unterstrich",
+    "Bold Script Crown": "fette Schreibschrift Krone"
+  },
+  "signatures": {
+    "Classic Signature": "klassische Unterschrift",
+    "Bold Signature": "fette Unterschrift",
+    "Signed Underline": "Unterschrift mit Unterstrich",
+    "Sparkle Signature": "funkelnde Unterschrift",
+    "Ornate Nameplate": "verzierter Namenszug",
+    "Autograph Star": "Autogramm mit Stern",
+    "Monogram Initials": "Monogramm-Initialen",
+    "Gothic Signature": "gotische Unterschrift"
+  },
+  "decorators": {
+    "None": "Keine",
+    "Underline": "Unterstrich",
+    "Sparkle": "Funkeln",
+    "Hearts": "Herzen",
+    "Ornate": "Verziert",
+    "Soft dots": "Zarte Punkte"
+  },
+  "accents": {
+    "Sparkle": "Funkeln",
+    "Hearts": "Herzen",
+    "Wings": "Flügel",
+    "Ornate": "Verziert"
+  },
+  "platformLimits": {
+    "Instagram bio": "Instagram-Bio",
+    "TikTok bio": "TikTok-Bio",
+    "X bio": "X-Bio"
+  }
+};
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/js/cursive/cursiveData.js" defer></script>
+  <script src="/script.js" defer></script>
+  <script src="/js/cursive/cursivePageController.js" defer></script>
+  <script src="/footer.js" defer></script>
+</body></html>

--- a/es/letra-cursiva/index.html
+++ b/es/letra-cursiva/index.html
@@ -1,86 +1,848 @@
-<!DOCTYPE html>
-<html lang="es">
-<head>
+<!DOCTYPE html><html lang="es"><head>
   <!-- Google Tag Manager -->
-  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
   <!-- End Google Tag Manager -->
-  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZGVh");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
   <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Letras cursivas para copiar y pegar — generador y abecedario | UltraTextGen</title>
-  <meta name="description" content="Generador de letras cursivas Unicode con abecedario A-Z para copiar: escribe tu texto y copia letras cursivas, script y caligrafía para Instagram, WhatsApp, TikTok y nombres.">
+  <title>Letra Cursiva — 𝓵𝓮𝓽𝓻𝓪𝓼 𝓬𝓾𝓻𝓼𝓲𝓿𝓪𝓼 para copiar y pegar, abecedario y nombres | UltraTextGen</title>
+  <meta name="description" content="Generador de letra cursiva gratis: copia y pega letras cursivas, el abecedario en cursiva completo, cada letra A–Z, palabras en cursiva y firmas con tu nombre.">
   <link rel="canonical" href="https://ultratextgen.com/es/letra-cursiva/">
-  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/letra-cursiva/">
+
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/category/cursive-fonts/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/letra-cursiva/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/letra-cursiva/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/ecriture-cursive/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/schreibschrift/">
+  <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/lettere-in-corsivo/">
+  <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/el-yazisi-fontu/">
+  <link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/cursieve-letters/">
+  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/tulisan-sambung/">
+  <link rel="alternate" hreflang="no" href="https://ultratextgen.com/no/kursiv-tekst/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/category/cursive-fonts/">
-  <meta property="og:title" content="Letras cursivas para copiar y pegar">
-  <meta property="og:description" content="Convierte texto normal en letra cursiva Unicode y copia el resultado al instante.">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Letra Cursiva — 𝓵𝓮𝓽𝓻𝓪𝓼 𝓬𝓾𝓻𝓼𝓲𝓿𝓪𝓼 para copiar y pegar, abecedario y nombres | UltraTextGen">
+  <meta property="og:description" content="Generador de letra cursiva gratis: copia y pega letras cursivas, el abecedario en cursiva completo, cada letra A–Z, palabras en cursiva y firmas con tu nombre.">
   <meta property="og:url" content="https://ultratextgen.com/es/letra-cursiva/">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://ultratextgen.com/assets/og/category-cursive-fonts.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Letras cursivas para copiar y pegar">
-  <meta name="twitter:description" content="Generador de letras cursivas Unicode para redes sociales.">
+  <meta name="twitter:title" content="Letra Cursiva — 𝓵𝓮𝓽𝓻𝓪𝓼 𝓬𝓾𝓻𝓼𝓲𝓿𝓪𝓼 para copiar y pegar, abecedario y nombres | UltraTextGen">
+  <meta name="twitter:description" content="Generador de letra cursiva gratis: copia y pega letras cursivas, el abecedario en cursiva, cada letra A–Z, palabras en cursiva y firmas con tu nombre.">
   <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category-cursive-fonts.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/style.css">
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebApplication","name":"Generador de letras cursivas","alternateName":["Letra cursiva","Abecedario en cursiva","Letra manuscrita","Letras bonitas cursivas"],"url":"https://ultratextgen.com/es/letra-cursiva/","inLanguage":"es","applicationCategory":"UtilitiesApplication","operatingSystem":"All","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"},"description":"Generador de letra cursiva Unicode para copiar y pegar."}</script>
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Inicio","item":"https://ultratextgen.com/es/"},{"@type":"ListItem","position":2,"name":"Fuentes de letras","item":"https://ultratextgen.com/es/fuentes-de-letras/"},{"@type":"ListItem","position":3,"name":"Letra cursiva","item":"https://ultratextgen.com/es/letra-cursiva/"}]}</script>
-  <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"¿La letra cursiva es una fuente real?","acceptedAnswer":{"@type":"Answer","text":"No es un archivo de fuente. El resultado usa caracteres Unicode que ya se ven como cursiva o script, por eso puedes copiarlos y pegarlos como texto."}},{"@type":"Question","name":"¿Funciona la cursiva en Instagram y WhatsApp?","acceptedAnswer":{"@type":"Answer","text":"Sí, en la mayoría de campos de texto modernos. Si alguna variante no se ve bien en un teléfono antiguo, prueba una cursiva más simple o una negrita Unicode."}},{"@type":"Question","name":"¿Puedo generar una sola letra en cursiva?","acceptedAnswer":{"@type":"Answer","text":"Sí. Escribe una letra, una palabra o una frase completa. El generador muestra las variantes cursivas disponibles para copiar. También puedes tomar cualquier letra suelta —la f, la j, la r o la que necesites— directamente del abecedario en cursiva de esta página."}},{"@type":"Question","name":"¿Dónde encuentro el abecedario completo en cursiva?","acceptedAnswer":{"@type":"Answer","text":"En la sección «Abecedario en cursiva» de esta página tienes las mayúsculas A-Z, las minúsculas a-z y los números en cursiva simple, elegante, gruesa y negrita. Selecciona las letras que quieras y cópialas como texto normal."}}]}</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "es",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "¿Qué es un generador de letra cursiva y cómo funciona?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Convierte las letras que escribes en caracteres script de Unicode — símbolos especiales que parecen letra cursiva a mano pero se comportan como texto normal. Como son caracteres reales (no una fuente ni una imagen), puedes copiarlos y pegarlos en biografías, descripciones, comentarios y mensajes, y conservan su aspecto cursivo. Lee más en nuestra <a href=\"/guide/how-unicode-fonts-work/\">guía sobre cómo funcionan las fuentes Unicode</a>."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Cómo copio y pego letra cursiva?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Escribe o pega tu texto en el recuadro de arriba y toca Copiar en el estilo que te guste. La versión en cursiva queda en tu portapapeles: pégala donde aceptes texto — Instagram, TikTok, WhatsApp, Discord, documentos y más."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Funciona la letra cursiva en Instagram, WhatsApp y TikTok?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Sí. Las letras cursivas funcionan perfecto en biografías y descripciones de Instagram, en los mensajes y estados de WhatsApp y en los subtítulos de TikTok, porque son caracteres Unicode reales. La única excepción común son los campos de <strong>nombre de usuario</strong>, que a veces eliminan los caracteres especiales."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Es gratis el generador de letras cursivas?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Sí, es 100% gratis y sin registro. Escribe, copia y pega todas las veces que quieras. No hay límites ni marcas de agua en el texto."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Puedo escribir mi nombre en cursiva para una firma?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Claro. Escribe tu nombre en el <a href=\"#mainInput\">estudio de firmas</a>, elige un adorno y copia el resultado o descárgalo como PNG para tu firma de correo, marcas de agua o documentos."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Por qué mi nombre con acento o ñ se ve roto en cursiva?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Unicode solo tiene letras script para el alfabeto latino básico A–Z. Los acentos (á, é, í, ó, ú), la <strong>ñ</strong> y la ü no se transforman y quedan como texto normal en medio de la palabra. Para un look completamente cursivo, escribe el nombre sin acentos — por ejemplo <em>Sofia</em> o <em>Sebastian</em>."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Puedo copiar el abecedario en cursiva completo?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Sí. En la sección del <a href=\"#cursive-alphabet\">abecedario en cursiva</a> puedes copiar todas las mayúsculas, minúsculas y números de cada estilo con un solo clic, o imprimir una hoja de práctica para calcar el alfabeto cursivo."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Sirve la letra cursiva para tatuajes?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "El lettering en cursiva es el estilo de tatuaje más popular. Previsualiza tu palabra aquí a gran tamaño y luego pásala al <a href=\"/es/usecase/letras-para-tatuajes/\">generador de letras para tatuajes</a> para ver familias de lettering, fechas en números romanos e iniciales."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Inicio", "item": "https://ultratextgen.com/es/" },
+    { "@type": "ListItem", "position": 2, "name": "Letra Cursiva", "item": "https://ultratextgen.com/es/letra-cursiva/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Generador de Letra Cursiva",
+  "alternateName": ["Generador de Letras Cursivas","Letra Cursiva para Copiar","Abecedario en Cursiva","Alfabeto Cursivo","Letras Cursivas A–Z","Generador de Nombres en Cursiva","Generador de Firmas en Cursiva","Copiar y Pegar Cursiva"],
+  "url": "https://ultratextgen.com/es/letra-cursiva/",
+  "inLanguage": "es",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "MXN"
+  },
+  "description": "Generador de letra cursiva gratis: copia y pega letras cursivas, el abecedario en cursiva completo, cada letra A–Z, palabras en cursiva y firmas con tu nombre.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers.",
+  "featureList": ["Generador de letra cursiva con adornos y presets","Explorador de letras cursivas A–Z (mayúscula y minúscula)","Copia el abecedario en cursiva completo con un clic","Hoja de práctica del alfabeto cursivo para imprimir","Estudio de nombres y firmas en cursiva","Galería de palabras en cursiva (amor, feliz cumpleaños, meses)"]
+}
+</script>
 </head>
 <body>
   <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
-  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-  <div id="shared-header"></div><script src="/header.js" defer></script>
-  <nav class="breadcrumbs" aria-label="Breadcrumb"><a href="/es/">Inicio</a><span class="breadcrumb-separator">›</span><a href="/es/fuentes-de-letras/">Fuentes de letras</a><span class="breadcrumb-separator">›</span><span class="breadcrumb-current">Letra cursiva</span></nav>
-  <figure class="page-hero-figure" data-uthero aria-hidden="true"><img src="/assets/hero/category-cursive-fonts.svg" width="1200" height="340" loading="lazy" alt=""></figure>
-  <section class="hero"><div class="hero-inner"><div class="hero-card"><h1 class="hero-headline">Letras cursivas</h1><p class="hero-sub">Crea texto cursivo, script y estilo caligrafía con caracteres Unicode. Abajo tienes el abecedario en cursiva completo.</p><div class="input-wrapper"><textarea class="main-input" id="mainInput" placeholder="Escribe tu texto en cursiva..." maxlength="500"></textarea><span class="char-count"><span id="charCount">0</span>/500</span></div><div class="decoration-section"><div class="decoration-label">Añade símbolos al resultado</div><div class="decoration-tabs"><button class="decoration-tab active" data-deco-tab="symbols">Símbolos</button><button class="decoration-tab" data-deco-tab="frames">Marcos</button><button class="decoration-tab" data-deco-tab="minimal">Minimal</button><button class="decoration-tab" data-deco-tab="emojis">Emojis</button></div><div class="decoration-grid" id="decorationGrid"></div></div></div></div></section>
-  <main class="container"><section class="editorial-section"><span class="article-section-label">Cursiva Unicode</span><h2>Letras cursivas listas para copiar</h2><p>Estas variantes funcionan mejor para nombres, bios, frases cortas y títulos. Para textos largos, usa solo una palabra o la primera línea en cursiva y deja el resto en texto normal para mantener legibilidad.</p></section><div class="category-section"><div class="category-tabs" id="categoryTabs"></div></div><div class="results-grid" id="resultsGrid"></div>
-  <section class="editorial-section abc-section" id="abecedario" aria-label="Abecedario en cursiva para copiar y pegar">
-    <h2>Abecedario en cursiva</h2>
-    <p>Aquí tienes el abecedario en cursiva completo —mayúsculas (A–Z), minúsculas (a–z) y números— en las cuatro variantes más usadas. ¿Buscas una sola letra en cursiva, como la f, la j o la r? Selecciónala directamente de la tabla y cópiala: es texto Unicode normal, así que la puedes pegar en cualquier app.</p>
-    <div class="abc-list">
-      <div class="abc-row">
-        <span class="abc-name">Cursiva</span>
-        <div class="abc-lines">
-          <span class="abc-line">𝘈𝘉𝘊𝘋𝘌𝘍𝘎𝘏𝘐𝘑𝘒𝘓𝘔𝘕𝘖𝘗𝘘𝘙𝘚𝘛𝘜𝘝𝘞𝘟𝘠𝘡</span>
-          <span class="abc-line">𝘢𝘣𝘤𝘥𝘦𝘧𝘨𝘩𝘪𝘫𝘬𝘭𝘮𝘯𝘰𝘱𝘲𝘳𝘴𝘵𝘶𝘷𝘸𝘹𝘺𝘻</span>
-          <span class="abc-line">0123456789</span>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/es/">Inicio</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Letra Cursiva</span>
+</nav>
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/category-cursive-fonts.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+  <!-- Hero: the cursive-first generator -->
+  <section class="hero">
+    <div class="hero-inner">
+      <div class="hero-card">
+        <h1 class="hero-headline">Generador de Letra Cursiva</h1>
+        <p class="hero-tagline">Convierte cualquier texto en 𝓵𝓮𝓽𝓻𝓪 𝓬𝓾𝓻𝓼𝓲𝓿𝓪 que puedes copiar y pegar — letras cursivas elegantes,
+          cada letra A–Z, el abecedario completo y firmas con tu nombre. Gratis, al instante y sin registro.</p>
+        <div class="input-wrapper">
+          <textarea class="main-input" id="mainInput" placeholder="Escribe tu texto, palabra o nombre…" maxlength="500" autofocus></textarea>
+          <span class="char-count"><span id="charCount">0</span>/500</span>
         </div>
-      </div>
-      <div class="abc-row">
-        <span class="abc-name">Cursiva elegante</span>
-        <div class="abc-lines">
-          <span class="abc-line">𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵</span>
-          <span class="abc-line">𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏</span>
-          <span class="abc-line">0123456789</span>
-        </div>
-      </div>
-      <div class="abc-row">
-        <span class="abc-name">Cursiva gruesa</span>
-        <div class="abc-lines">
-          <span class="abc-line">𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩</span>
-          <span class="abc-line">𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃</span>
-          <span class="abc-line">0123456789</span>
-        </div>
-      </div>
-      <div class="abc-row">
-        <span class="abc-name">Cursiva negrita</span>
-        <div class="abc-lines">
-          <span class="abc-line">𝘼𝘽𝘾𝘿𝙀𝙁𝙂𝙃𝙄𝙅𝙆𝙇𝙈𝙉𝙊𝙋𝙌𝙍𝙎𝙏𝙐𝙑𝙒𝙓𝙔𝙕</span>
-          <span class="abc-line">𝙖𝙗𝙘𝙙𝙚𝙛𝙜𝙝𝙞𝙟𝙠𝙡𝙢𝙣𝙤𝙥𝙦𝙧𝙨𝙩𝙪𝙫𝙬𝙭𝙮𝙯</span>
-          <span class="abc-line">0123456789</span>
-        </div>
+        <div class="cursive-quick-row" id="cursiveQuickRow" aria-label="Ejemplos rápidos"></div>
+        <div class="vertical-fit-row" id="cursiveFitRow" hidden></div>
       </div>
     </div>
-    <p>Ojo con la ñ y los acentos: la mayoría de estilos cursivos Unicode no tienen versión de la ñ ni de las vocales con tilde, así que esas letras se quedan en su forma normal. Para nombres y frases en español suele verse mejor mezclar la palabra en cursiva con los acentos en texto normal.</p>
   </section>
-  <section class="editorial-section"><span class="article-section-label">Relacionado</span><p>También puedes probar <a href="/es/letras-goticas/">letras góticas</a>, <a href="/es/letras-negritas/">letras negritas</a>, <a href="/es/letras-aesthetic/">letras aesthetic</a>, <a href="/es/texto-pequeno/">texto pequeño</a> o <a href="/es/fuentes-para-instagram/">fuentes para Instagram</a>. Para nicks de juegos, mira <a href="/es/usecase/nombres-para-free-fire/">nombres para Free Fire</a>.</p></section></main>
-  <div class="copy-toast" id="copyToast">Copiado</div>
-  <script>window.UTG_FAMILY="cursive";window.UTG_DEMO_TEXT="hola mundo\nletra cursiva";</script>
-  <script src="/styles.js" defer></script><script src="/renderer.js" defer></script><script src="/script.js" defer></script><script src="/footer.js" defer></script>
-</body>
-</html>
+
+  <nav class="cursive-section-nav" aria-label="En esta página">
+    <a href="#cursive-styles">Estilos</a>
+    <a href="#cursive-letters">Letras A–Z</a>
+    <a href="#cursive-alphabet">Abecedario</a>
+    <a href="#cursive-words">Palabras</a>
+    <a href="#cursive-names">Nombres y firmas</a>
+    <a href="#cursive-faq">Preguntas</a>
+  </nav>
+
+  <main class="container">
+
+    <!-- 1. Generator output -->
+    <section id="cursive-styles" aria-labelledby="cursiveStylesHeading">
+      <h2 class="bubble-az-heading" id="cursiveStylesHeading">Letras cursivas para copiar y pegar</h2>
+      <p class="bubble-az-intro">Cada estilo de letra cursiva se actualiza en vivo mientras escribes: cursiva clásica y en negrita,
+        variantes elegantes y espaciadas, cursiva gótica, placas estilo chicano y presets con adornos, corazones,
+        brillos y flechas. Toca Copiar y pégala donde quieras.</p>
+      <div class="results-grid" id="resultsGrid"></div>
+    </section>
+
+    <!-- 2. Cursive letters A–Z -->
+    <section class="bubble-az" id="cursive-letters" aria-labelledby="cursiveLettersHeading">
+      <h2 class="bubble-az-heading" id="cursiveLettersHeading">Letras cursivas A–Z — mayúscula y minúscula</h2>
+      <p class="bubble-az-intro">¿Buscas una sola letra — una S cursiva, una G mayúscula en cursiva, una f minúscula?
+        Toca cualquier letra para verla en cada estilo de letra cursiva, copiar el glifo exacto o descargarlo como PNG.</p>
+  <div class="cursive-letter-grid" role="tablist" aria-label="Elige una letra cursiva">
+    <button type="button" class="cursive-letter-cell" id="cursive-a" data-char="A" aria-label="A en cursiva — mayúscula y minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒜 𝒶</span>
+      <span class="cursive-letter-name">A cursiva</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-b" data-char="B" aria-label="B en cursiva — mayúscula y minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">ℬ 𝒷</span>
+      <span class="cursive-letter-name">B cursiva</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-c" data-char="C" aria-label="C en cursiva — mayúscula y minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒞 𝒸</span>
+      <span class="cursive-letter-name">C cursiva</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-d" data-char="D" aria-label="D en cursiva — mayúscula y minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒟 𝒹</span>
+      <span class="cursive-letter-name">D cursiva</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-e" data-char="E" aria-label="E en cursiva — mayúscula y minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">ℰ ℯ</span>
+      <span class="cursive-letter-name">E cursiva</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-f" data-char="F" aria-label="F en cursiva — mayúscula y minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">ℱ 𝒻</span>
+      <span class="cursive-letter-name">F cursiva</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-g" data-char="G" aria-label="G en cursiva — mayúscula y minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒢 ℊ</span>
+      <span class="cursive-letter-name">G cursiva</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-h" data-char="H" aria-label="H en cursiva — mayúscula y minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">ℋ 𝒽</span>
+      <span class="cursive-letter-name">H cursiva</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-i" data-char="I" aria-label="I en cursiva — mayúscula y minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">ℐ 𝒾</span>
+      <span class="cursive-letter-name">I cursiva</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-j" data-char="J" aria-label="J en cursiva — mayúscula y minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒥 𝒿</span>
+      <span class="cursive-letter-name">J cursiva</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-k" data-char="K" aria-label="K en cursiva — mayúscula y minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒦 𝓀</span>
+      <span class="cursive-letter-name">K cursiva</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-l" data-char="L" aria-label="L en cursiva — mayúscula y minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">ℒ 𝓁</span>
+      <span class="cursive-letter-name">L cursiva</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-m" data-char="M" aria-label="M en cursiva — mayúscula y minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">ℳ 𝓂</span>
+      <span class="cursive-letter-name">M cursiva</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-n" data-char="N" aria-label="N en cursiva — mayúscula y minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒩 𝓃</span>
+      <span class="cursive-letter-name">N cursiva</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-o" data-char="O" aria-label="O en cursiva — mayúscula y minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒪 ℴ</span>
+      <span class="cursive-letter-name">O cursiva</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-p" data-char="P" aria-label="P en cursiva — mayúscula y minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒫 𝓅</span>
+      <span class="cursive-letter-name">P cursiva</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-q" data-char="Q" aria-label="Q en cursiva — mayúscula y minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒬 𝓆</span>
+      <span class="cursive-letter-name">Q cursiva</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-r" data-char="R" aria-label="R en cursiva — mayúscula y minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">ℛ 𝓇</span>
+      <span class="cursive-letter-name">R cursiva</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-s" data-char="S" aria-label="S en cursiva — mayúscula y minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒮 𝓈</span>
+      <span class="cursive-letter-name">S cursiva</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-t" data-char="T" aria-label="T en cursiva — mayúscula y minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒯 𝓉</span>
+      <span class="cursive-letter-name">T cursiva</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-u" data-char="U" aria-label="U en cursiva — mayúscula y minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒰 𝓊</span>
+      <span class="cursive-letter-name">U cursiva</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-v" data-char="V" aria-label="V en cursiva — mayúscula y minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒱 𝓋</span>
+      <span class="cursive-letter-name">V cursiva</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-w" data-char="W" aria-label="W en cursiva — mayúscula y minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒲 𝓌</span>
+      <span class="cursive-letter-name">W cursiva</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-x" data-char="X" aria-label="X en cursiva — mayúscula y minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒳 𝓍</span>
+      <span class="cursive-letter-name">X cursiva</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-y" data-char="Y" aria-label="Y en cursiva — mayúscula y minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒴 𝓎</span>
+      <span class="cursive-letter-name">Y cursiva</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-z" data-char="Z" aria-label="Z en cursiva — mayúscula y minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒵 𝓏</span>
+      <span class="cursive-letter-name">Z cursiva</span>
+    </button>
+  </div>
+      <div class="cursive-letter-panel" id="cursiveLetterPanel" aria-live="polite"></div>
+    </section>
+
+    <!-- 3. The cursive alphabet -->
+    <section id="cursive-alphabet" aria-labelledby="cursiveAlphabetHeading">
+      <div class="cursive-chart-toolbar">
+        <h2 class="bubble-az-heading" id="cursiveAlphabetHeading">El abecedario en cursiva (A–Z, 0–9)</h2>
+        <button type="button" class="bubble-btn bubble-btn-primary" id="cursivePrintSheet">Imprimir hoja de práctica</button>
+      </div>
+      <p class="bubble-az-intro">Copia el abecedario en cursiva completo con un solo clic — mayúsculas, minúsculas y números —
+        o imprime una hoja de práctica con letras modelo y espacio para calcar. Unicode no tiene dígitos cursivos reales, así que
+        cada estilo combina sus letras cursivas con números estilizados que hacen juego.</p>
+    <div class="cursive-chart">
+      <div class="cursive-chart-head">
+        <h3>Abecedario cursivo clásico (Ultra Script)</h3>
+        <button type="button" class="copy-btn" data-text="𝒜 ℬ 𝒞 𝒟 ℰ ℱ 𝒢 ℋ ℐ 𝒥 𝒦 ℒ ℳ 𝒩 𝒪 𝒫 𝒬 ℛ 𝒮 𝒯 𝒰 𝒱 𝒲 𝒳 𝒴 𝒵&#10;𝒶 𝒷 𝒸 𝒹 ℯ 𝒻 ℊ 𝒽 𝒾 𝒿 𝓀 𝓁 𝓂 𝓃 ℴ 𝓅 𝓆 𝓇 𝓈 𝓉 𝓊 𝓋 𝓌 𝓍 𝓎 𝓏&#10;𝟢 𝟣 𝟤 𝟥 𝟦 𝟧 𝟨 𝟩 𝟪 𝟫" data-style="Ultra Script">Copiar abecedario</button>
+      </div>
+      <p class="cursive-alphabet-row">𝒜 ℬ 𝒞 𝒟 ℰ ℱ 𝒢 ℋ ℐ 𝒥 𝒦 ℒ ℳ 𝒩 𝒪 𝒫 𝒬 ℛ 𝒮 𝒯 𝒰 𝒱 𝒲 𝒳 𝒴 𝒵</p>
+      <p class="cursive-alphabet-row">𝒶 𝒷 𝒸 𝒹 ℯ 𝒻 ℊ 𝒽 𝒾 𝒿 𝓀 𝓁 𝓂 𝓃 ℴ 𝓅 𝓆 𝓇 𝓈 𝓉 𝓊 𝓋 𝓌 𝓍 𝓎 𝓏</p>
+      <p class="cursive-alphabet-row">𝟢 𝟣 𝟤 𝟥 𝟦 𝟧 𝟨 𝟩 𝟪 𝟫</p>
+    </div>
+    <div class="cursive-chart">
+      <div class="cursive-chart-head">
+        <h3>Abecedario cursivo en negrita (Ultra Script Bold)</h3>
+        <button type="button" class="copy-btn" data-text="𝓐 𝓑 𝓒 𝓓 𝓔 𝓕 𝓖 𝓗 𝓘 𝓙 𝓚 𝓛 𝓜 𝓝 𝓞 𝓟 𝓠 𝓡 𝓢 𝓣 𝓤 𝓥 𝓦 𝓧 𝓨 𝓩&#10;𝓪 𝓫 𝓬 𝓭 𝓮 𝓯 𝓰 𝓱 𝓲 𝓳 𝓴 𝓵 𝓶 𝓷 𝓸 𝓹 𝓺 𝓻 𝓼 𝓽 𝓾 𝓿 𝔀 𝔁 𝔂 𝔃&#10;𝟬 𝟭 𝟮 𝟯 𝟰 𝟱 𝟲 𝟳 𝟴 𝟵" data-style="Ultra Script Bold">Copiar abecedario</button>
+      </div>
+      <p class="cursive-alphabet-row">𝓐 𝓑 𝓒 𝓓 𝓔 𝓕 𝓖 𝓗 𝓘 𝓙 𝓚 𝓛 𝓜 𝓝 𝓞 𝓟 𝓠 𝓡 𝓢 𝓣 𝓤 𝓥 𝓦 𝓧 𝓨 𝓩</p>
+      <p class="cursive-alphabet-row">𝓪 𝓫 𝓬 𝓭 𝓮 𝓯 𝓰 𝓱 𝓲 𝓳 𝓴 𝓵 𝓶 𝓷 𝓸 𝓹 𝓺 𝓻 𝓼 𝓽 𝓾 𝓿 𝔀 𝔁 𝔂 𝔃</p>
+      <p class="cursive-alphabet-row">𝟬 𝟭 𝟮 𝟯 𝟰 𝟱 𝟲 𝟳 𝟴 𝟵</p>
+    </div>
+    <div class="cursive-chart">
+      <div class="cursive-chart-head">
+        <h3>Abecedario cursivo gótico (Ultra Gothic Script)</h3>
+        <button type="button" class="copy-btn" data-text="𝕬 𝕭 𝕮 𝕯 𝕰 𝕱 𝕲 𝕳 𝕴 𝕵 𝕶 𝕷 𝕸 𝕹 𝕺 𝕻 𝕼 𝕽 𝕾 𝕿 𝖀 𝖁 𝖂 𝖃 𝖄 𝖅&#10;𝖆 𝖇 𝖈 𝖉 𝖊 𝖋 𝖌 𝖍 𝖎 𝖏 𝖐 𝖑 𝖒 𝖓 𝖔 𝖕 𝖖 𝖗 𝖘 𝖙 𝖚 𝖛 𝖜 𝖝 𝖞 𝖟" data-style="Ultra Gothic Script">Copiar abecedario</button>
+      </div>
+      <p class="cursive-alphabet-row">𝕬 𝕭 𝕮 𝕯 𝕰 𝕱 𝕲 𝕳 𝕴 𝕵 𝕶 𝕷 𝕸 𝕹 𝕺 𝕻 𝕼 𝕽 𝕾 𝕿 𝖀 𝖁 𝖂 𝖃 𝖄 𝖅</p>
+      <p class="cursive-alphabet-row">𝖆 𝖇 𝖈 𝖉 𝖊 𝖋 𝖌 𝖍 𝖎 𝖏 𝖐 𝖑 𝖒 𝖓 𝖔 𝖕 𝖖 𝖗 𝖘 𝖙 𝖚 𝖛 𝖜 𝖝 𝖞 𝖟</p>
+    </div>
+    </section>
+
+    <!-- 4. Words in cursive -->
+    <section id="cursive-words" aria-labelledby="cursiveWordsHeading">
+      <h2 class="bubble-az-heading" id="cursiveWordsHeading">Palabras en cursiva — listas para copiar</h2>
+      <p class="bubble-az-intro">Las palabras más buscadas, ya renderizadas en letra cursiva. ¿Necesitas otra?
+        Escríbela en el <a href="#mainInput">generador de arriba</a> y cada estilo la convierte al instante.</p>
+    <h3>Amor y familia</h3>
+    <div class="cursive-word-grid">
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒶𝓂ℴ𝓇</span>
+        <span class="cursive-word-label">amor en cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝒶𝓂ℴ𝓇" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓪𝓶𝓸𝓻</span>
+        <span class="cursive-word-label">amor (negrita) en cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓪𝓶𝓸𝓻" data-style="Ultra Script Bold">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓉ℯ 𝒶𝓂ℴ</span>
+        <span class="cursive-word-label">te amo en cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓉ℯ 𝒶𝓂ℴ" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓂𝒶𝓂𝒶</span>
+        <span class="cursive-word-label">mamá en cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓂𝒶𝓂𝒶" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓅𝒶𝓅𝒶</span>
+        <span class="cursive-word-label">papá en cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓅𝒶𝓅𝒶" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒻𝒶𝓂𝒾𝓁𝒾𝒶</span>
+        <span class="cursive-word-label">familia en cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝒻𝒶𝓂𝒾𝓁𝒾𝒶" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓅𝒶𝓇𝒶 𝓈𝒾ℯ𝓂𝓅𝓇ℯ</span>
+        <span class="cursive-word-label">para siempre en cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓅𝒶𝓇𝒶 𝓈𝒾ℯ𝓂𝓅𝓇ℯ" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒷ℯ𝓃𝒹ℯ𝒸𝒾𝒹ℴ</span>
+        <span class="cursive-word-label">bendecido en cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝒷ℯ𝓃𝒹ℯ𝒸𝒾𝒹ℴ" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒻ℯ</span>
+        <span class="cursive-word-label">fe en cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝒻ℯ" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">ℯ𝓈𝓅ℯ𝓇𝒶𝓃𝓏𝒶</span>
+        <span class="cursive-word-label">esperanza en cursiva</span>
+        <button type="button" class="copy-btn" data-text="ℯ𝓈𝓅ℯ𝓇𝒶𝓃𝓏𝒶" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒶𝓃ℊℯ𝓁</span>
+        <span class="cursive-word-label">ángel en cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝒶𝓃ℊℯ𝓁" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒸ℴ𝓇𝒶𝓏ℴ𝓃</span>
+        <span class="cursive-word-label">corazón en cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝒸ℴ𝓇𝒶𝓏ℴ𝓃" data-style="Ultra Script">Copiar</button>
+      </div>
+    </div>
+    <h3>Saludos y ocasiones</h3>
+    <div class="cursive-word-grid">
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒻ℯ𝓁𝒾𝓏 𝒸𝓊𝓂𝓅𝓁ℯ𝒶𝓃ℴ𝓈</span>
+        <span class="cursive-word-label">feliz cumpleaños en cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝒻ℯ𝓁𝒾𝓏 𝒸𝓊𝓂𝓅𝓁ℯ𝒶𝓃ℴ𝓈" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">ℊ𝓇𝒶𝒸𝒾𝒶𝓈</span>
+        <span class="cursive-word-label">gracias en cursiva</span>
+        <button type="button" class="copy-btn" data-text="ℊ𝓇𝒶𝒸𝒾𝒶𝓈" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒻ℯ𝓁𝒾𝒸𝒾𝒹𝒶𝒹ℯ𝓈</span>
+        <span class="cursive-word-label">felicidades en cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝒻ℯ𝓁𝒾𝒸𝒾𝒹𝒶𝒹ℯ𝓈" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒷𝒾ℯ𝓃𝓋ℯ𝓃𝒾𝒹ℴ</span>
+        <span class="cursive-word-label">bienvenido en cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝒷𝒾ℯ𝓃𝓋ℯ𝓃𝒾𝒹ℴ" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒽ℴ𝓁𝒶</span>
+        <span class="cursive-word-label">hola en cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝒽ℴ𝓁𝒶" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒻ℯ𝓁𝒾𝓏 𝓃𝒶𝓋𝒾𝒹𝒶𝒹</span>
+        <span class="cursive-word-label">feliz navidad en cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝒻ℯ𝓁𝒾𝓏 𝓃𝒶𝓋𝒾𝒹𝒶𝒹" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒻ℯ𝓁𝒾𝓏 𝒶𝓃𝒾𝓋ℯ𝓇𝓈𝒶𝓇𝒾ℴ</span>
+        <span class="cursive-word-label">feliz aniversario en cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝒻ℯ𝓁𝒾𝓏 𝒶𝓃𝒾𝓋ℯ𝓇𝓈𝒶𝓇𝒾ℴ" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓂𝒾𝓈 𝓂ℯ𝒿ℴ𝓇ℯ𝓈 𝒹ℯ𝓈ℯℴ𝓈</span>
+        <span class="cursive-word-label">mis mejores deseos en cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓂𝒾𝓈 𝓂ℯ𝒿ℴ𝓇ℯ𝓈 𝒹ℯ𝓈ℯℴ𝓈" data-style="Ultra Script">Copiar</button>
+      </div>
+    </div>
+    <h3>Meses en cursiva</h3>
+    <div class="cursive-word-grid">
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">ℯ𝓃ℯ𝓇ℴ</span>
+        <span class="cursive-word-label">enero en cursiva</span>
+        <button type="button" class="copy-btn" data-text="ℯ𝓃ℯ𝓇ℴ" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒻ℯ𝒷𝓇ℯ𝓇ℴ</span>
+        <span class="cursive-word-label">febrero en cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝒻ℯ𝒷𝓇ℯ𝓇ℴ" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓂𝒶𝓇𝓏ℴ</span>
+        <span class="cursive-word-label">marzo en cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓂𝒶𝓇𝓏ℴ" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒶𝒷𝓇𝒾𝓁</span>
+        <span class="cursive-word-label">abril en cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝒶𝒷𝓇𝒾𝓁" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓂𝒶𝓎ℴ</span>
+        <span class="cursive-word-label">mayo en cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓂𝒶𝓎ℴ" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒿𝓊𝓃𝒾ℴ</span>
+        <span class="cursive-word-label">junio en cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝒿𝓊𝓃𝒾ℴ" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒿𝓊𝓁𝒾ℴ</span>
+        <span class="cursive-word-label">julio en cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝒿𝓊𝓁𝒾ℴ" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒶ℊℴ𝓈𝓉ℴ</span>
+        <span class="cursive-word-label">agosto en cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝒶ℊℴ𝓈𝓉ℴ" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓈ℯ𝓅𝓉𝒾ℯ𝓂𝒷𝓇ℯ</span>
+        <span class="cursive-word-label">septiembre en cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓈ℯ𝓅𝓉𝒾ℯ𝓂𝒷𝓇ℯ" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">ℴ𝒸𝓉𝓊𝒷𝓇ℯ</span>
+        <span class="cursive-word-label">octubre en cursiva</span>
+        <button type="button" class="copy-btn" data-text="ℴ𝒸𝓉𝓊𝒷𝓇ℯ" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓃ℴ𝓋𝒾ℯ𝓂𝒷𝓇ℯ</span>
+        <span class="cursive-word-label">noviembre en cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓃ℴ𝓋𝒾ℯ𝓂𝒷𝓇ℯ" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒹𝒾𝒸𝒾ℯ𝓂𝒷𝓇ℯ</span>
+        <span class="cursive-word-label">diciembre en cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝒹𝒾𝒸𝒾ℯ𝓂𝒷𝓇ℯ" data-style="Ultra Script">Copiar</button>
+      </div>
+    </div>
+    </section>
+
+    <!-- 5. Names & signatures -->
+    <section id="cursive-names" aria-labelledby="cursiveNamesHeading">
+      <h2 class="bubble-az-heading" id="cursiveNamesHeading">Generador de nombres y firmas en cursiva</h2>
+      <p class="bubble-az-intro">Escribe un nombre — o un nombre completo — y diseña tu firma en letra cursiva:
+        elige un adorno, decide cómo se unen las iniciales del monograma y luego copia el texto o descárgalo como PNG
+        para firmas de correo, marcas de agua y documentos.</p>
+      <div class="cursive-name-tool">
+        <div class="input-wrapper">
+          <input type="text" class="main-input cursive-name-input" id="cursiveNameInput" placeholder="Escribe un nombre… p. ej. Valentina" maxlength="60">
+        </div>
+        <div class="cursive-sig-controls" id="cursiveSignatureControls"></div>
+        <div class="results-grid" id="cursiveNameResults"></div>
+      </div>
+    <h3>Nombres populares en cursiva</h3>
+    <p class="bubble-az-intro">Toca cualquier nombre para cargarlo en el estudio de arriba y darle estilo con adornos.</p>
+    <div class="cursive-word-grid">
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Cargar Sofia en el estudio de firmas" data-name="Sofia">
+        <span class="cursive-word-render">𝓢𝓸𝓯𝓲𝓪</span>
+        <span class="cursive-word-label">Sofía en cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓢𝓸𝓯𝓲𝓪" data-style="Ultra Script Bold">Copiar</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Cargar Valentina en el estudio de firmas" data-name="Valentina">
+        <span class="cursive-word-render">𝓥𝓪𝓵𝓮𝓷𝓽𝓲𝓷𝓪</span>
+        <span class="cursive-word-label">Valentina en cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓥𝓪𝓵𝓮𝓷𝓽𝓲𝓷𝓪" data-style="Ultra Script Bold">Copiar</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Cargar Isabella en el estudio de firmas" data-name="Isabella">
+        <span class="cursive-word-render">𝓘𝓼𝓪𝓫𝓮𝓵𝓵𝓪</span>
+        <span class="cursive-word-label">Isabella en cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓘𝓼𝓪𝓫𝓮𝓵𝓵𝓪" data-style="Ultra Script Bold">Copiar</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Cargar Camila en el estudio de firmas" data-name="Camila">
+        <span class="cursive-word-render">𝓒𝓪𝓶𝓲𝓵𝓪</span>
+        <span class="cursive-word-label">Camila en cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓒𝓪𝓶𝓲𝓵𝓪" data-style="Ultra Script Bold">Copiar</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Cargar Mariana en el estudio de firmas" data-name="Mariana">
+        <span class="cursive-word-render">𝓜𝓪𝓻𝓲𝓪𝓷𝓪</span>
+        <span class="cursive-word-label">Mariana en cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓜𝓪𝓻𝓲𝓪𝓷𝓪" data-style="Ultra Script Bold">Copiar</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Cargar Regina en el estudio de firmas" data-name="Regina">
+        <span class="cursive-word-render">𝓡𝓮𝓰𝓲𝓷𝓪</span>
+        <span class="cursive-word-label">Regina en cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓡𝓮𝓰𝓲𝓷𝓪" data-style="Ultra Script Bold">Copiar</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Cargar Ximena en el estudio de firmas" data-name="Ximena">
+        <span class="cursive-word-render">𝓧𝓲𝓶𝓮𝓷𝓪</span>
+        <span class="cursive-word-label">Ximena en cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓧𝓲𝓶𝓮𝓷𝓪" data-style="Ultra Script Bold">Copiar</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Cargar Mateo en el estudio de firmas" data-name="Mateo">
+        <span class="cursive-word-render">𝓜𝓪𝓽𝓮𝓸</span>
+        <span class="cursive-word-label">Mateo en cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓜𝓪𝓽𝓮𝓸" data-style="Ultra Script Bold">Copiar</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Cargar Santiago en el estudio de firmas" data-name="Santiago">
+        <span class="cursive-word-render">𝓢𝓪𝓷𝓽𝓲𝓪𝓰𝓸</span>
+        <span class="cursive-word-label">Santiago en cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓢𝓪𝓷𝓽𝓲𝓪𝓰𝓸" data-style="Ultra Script Bold">Copiar</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Cargar Sebastian en el estudio de firmas" data-name="Sebastian">
+        <span class="cursive-word-render">𝓢𝓮𝓫𝓪𝓼𝓽𝓲𝓪𝓷</span>
+        <span class="cursive-word-label">Sebastián en cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓢𝓮𝓫𝓪𝓼𝓽𝓲𝓪𝓷" data-style="Ultra Script Bold">Copiar</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Cargar Daniel en el estudio de firmas" data-name="Daniel">
+        <span class="cursive-word-render">𝓓𝓪𝓷𝓲𝓮𝓵</span>
+        <span class="cursive-word-label">Daniel en cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓓𝓪𝓷𝓲𝓮𝓵" data-style="Ultra Script Bold">Copiar</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Cargar Diego en el estudio de firmas" data-name="Diego">
+        <span class="cursive-word-render">𝓓𝓲𝓮𝓰𝓸</span>
+        <span class="cursive-word-label">Diego en cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓓𝓲𝓮𝓰𝓸" data-style="Ultra Script Bold">Copiar</button>
+      </div>
+    </div>
+    </section>
+
+    <!-- Editorial -->
+    <section class="editorial-section cursive-editorial">
+      <h2>Cómo funciona este generador de letra cursiva</h2>
+      <p>La letra cursiva que ves aquí no es una fuente: son <strong>caracteres script de Unicode</strong>, el mismo estándar que tu dispositivo usa para cada letra y emoji. Por eso sobrevive al copiar y pegar: las apps tratan 𝒸𝓊𝓇𝓈𝒾𝓋𝒶 igual que texto normal. También por eso funciona donde nunca podrías instalar una fuente — biografías de Instagram, subtítulos de TikTok, nombres en Discord, comentarios de YouTube. ¿Quieres entender el mecanismo? Lee <a href="/guide/how-unicode-fonts-work/">cómo funcionan las fuentes Unicode</a>.</p>
+
+      <h3>Dónde funcionan las letras cursivas (y dónde se rompen)</h3>
+      <ul class="compat-list">
+        <li><span class="ts-pill-safe">Funciona</span> Biografías y descripciones de Instagram, subtítulos de TikTok, Discord, WhatsApp, Facebook, X, comentarios de YouTube y la mayoría de los documentos.</li>
+        <li><span class="ts-pill-risk">Limitado</span> Los campos de usuario y nombre visible (Instagram, la mayoría de los juegos) suelen eliminar los caracteres script — deja tu usuario en texto normal.</li>
+        <li><span class="ts-pill-risk">Limitado</span> Algunos dispositivos antiguos muestran cuadros de glifo faltante (▯). Si pasa, usa un estilo más simple — mira <a href="/guide/why-fonts-show-as-boxes/">por qué las fuentes aparecen como cuadros</a>.</li>
+      </ul>
+
+      <h3>Cursiva de Unicode vs. fuentes cursivas reales</h3>
+      <p>Usa la letra cursiva de Unicode cuando necesites cursiva <em>dentro de campos de texto</em> — perfiles sociales, chats, títulos de video. Usa una tipografía cursiva real (en Word, Canva o tu herramienta de diseño) cuando controles el documento y necesites un interletraje de calidad de impresión. Ambas tienen su lugar; esta herramienta cubre la primera.</p>
+
+      <h3>Acentos, la ñ y letras especiales</h3>
+      <p>Las letras script de Unicode solo existen para el alfabeto latino básico A–Z, así que los acentos (á, é, í, ó, ú), la <strong>ñ</strong> y la ü pasan sin transformarse y pueden verse rotos dentro de una palabra cursiva. Para un look totalmente cursivo, escribe los nombres y palabras sin acento — por ejemplo <em>Sofia</em> en lugar de Sofía, o <em>mama</em> en lugar de mamá. En las tarjetas de arriba mostramos la ortografía correcta en la etiqueta, pero renderizamos la versión sin acentos para que cada letra se vea perfecta.</p>
+
+      <h3>Aprender caligrafía en cursiva</h3>
+      <p>Los generadores son para texto digital, pero también sirven como láminas de referencia. Imprime la <a href="#cursive-alphabet">hoja de práctica</a> para calcar el abecedario en cursiva, estudia cómo se une cada mayúscula en el <a href="#cursive-letters">explorador de letras</a> y mantén hábitos de accesibilidad — líneas decorativas cortas y texto normal para lo demás (<a href="/guide/fancy-fonts-accessibility-guide/">guía de accesibilidad</a>).</p>
+
+      <h3>Letra cursiva para tatuajes</h3>
+      <p>El lettering script es el estilo de tatuaje más pedido. Previsualiza tu palabra aquí a gran tamaño y luego usa el <a href="/es/usecase/letras-para-tatuajes/">generador de letras para tatuajes</a> — añade familias de lettering, fechas en números romanos, iniciales y una prueba de legibilidad para el tamaño de la tinta.</p>
+    </section>
+
+    <div class="cta-card">
+      <h3>Haz que toda tu biografía fluya</h3>
+      <p>Combina un titular en <strong>letra cursiva</strong> con un texto de cuerpo limpio — la combinación que destaca y sigue siendo legible.</p>
+      <a class="cta-btn" href="/es/">Abrir el generador completo →</a>
+    </div>
+  </main>
+
+  <!-- Footer + FAQ -->
+  <footer class="footer">
+    <div class="footer-inner">
+<div class="faq-section" id="cursive-faq">
+
+<h2 class="faq-category">Generador de Letra Cursiva — Preguntas frecuentes</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    ¿Qué es un generador de letra cursiva y cómo funciona?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Convierte las letras que escribes en caracteres script de Unicode — símbolos especiales que parecen letra cursiva a mano pero se comportan como texto normal. Como son caracteres reales (no una fuente ni una imagen), puedes copiarlos y pegarlos en biografías, descripciones, comentarios y mensajes, y conservan su aspecto cursivo. Lee más en nuestra <a href="/guide/how-unicode-fonts-work/">guía sobre cómo funcionan las fuentes Unicode</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    ¿Cómo copio y pego letra cursiva?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Escribe o pega tu texto en el recuadro de arriba y toca Copiar en el estilo que te guste. La versión en cursiva queda en tu portapapeles: pégala donde aceptes texto — Instagram, TikTok, WhatsApp, Discord, documentos y más.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    ¿Funciona la letra cursiva en Instagram, WhatsApp y TikTok?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Sí. Las letras cursivas funcionan perfecto en biografías y descripciones de Instagram, en los mensajes y estados de WhatsApp y en los subtítulos de TikTok, porque son caracteres Unicode reales. La única excepción común son los campos de <strong>nombre de usuario</strong>, que a veces eliminan los caracteres especiales.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    ¿Es gratis el generador de letras cursivas?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Sí, es 100% gratis y sin registro. Escribe, copia y pega todas las veces que quieras. No hay límites ni marcas de agua en el texto.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    ¿Puedo escribir mi nombre en cursiva para una firma?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Claro. Escribe tu nombre en el <a href="#mainInput">estudio de firmas</a>, elige un adorno y copia el resultado o descárgalo como PNG para tu firma de correo, marcas de agua o documentos.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    ¿Por qué mi nombre con acento o ñ se ve roto en cursiva?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Unicode solo tiene letras script para el alfabeto latino básico A–Z. Los acentos (á, é, í, ó, ú), la <strong>ñ</strong> y la ü no se transforman y quedan como texto normal en medio de la palabra. Para un look completamente cursivo, escribe el nombre sin acentos — por ejemplo <em>Sofia</em> o <em>Sebastian</em>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    ¿Puedo copiar el abecedario en cursiva completo?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Sí. En la sección del <a href="#cursive-alphabet">abecedario en cursiva</a> puedes copiar todas las mayúsculas, minúsculas y números de cada estilo con un solo clic, o imprimir una hoja de práctica para calcar el alfabeto cursivo.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    ¿Sirve la letra cursiva para tatuajes?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    El lettering en cursiva es el estilo de tatuaje más popular. Previsualiza tu palabra aquí a gran tamaño y luego pásala al <a href="/es/usecase/letras-para-tatuajes/">generador de letras para tatuajes</a> para ver familias de lettering, fechas en números romanos e iniciales.
+  </div>
+</div>
+
+</div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Language switcher">
+      <a class="lang-option" href="/category/cursive-fonts/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/es/letra-cursiva/" hreflang="es">ES</a>
+      <a class="lang-option" href="/pt/letra-cursiva/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/fr/ecriture-cursive/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/de/schreibschrift/" hreflang="de">DE</a>
+      <a class="lang-option" href="/it/lettere-in-corsivo/" hreflang="it">IT</a>
+      <a class="lang-option" href="/tr/el-yazisi-fontu/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/nl/cursieve-letters/" hreflang="nl">NL</a>
+      <a class="lang-option" href="/id/tulisan-sambung/" hreflang="id">ID</a>
+      <a class="lang-option" href="/no/kursiv-tekst/" hreflang="no">NO</a>
+    </div>
+
+    </div>
+  </footer>
+
+  <div id="cursivePrintRoot" aria-hidden="true"></div>
+  <div class="copy-toast" id="copyToast">¡Copiado!</div>
+
+  <script>
+    window.UTG_CURSIVE_MODE = true;
+    window.UTG_FAMILY = "cursive";
+    window.cursiveI18n = {
+  "demoText": "Hola",
+  "demoName": "Valentina",
+  "copy": "Copiar",
+  "typeFirst": "Primero escribe tu texto arriba",
+  "downloadPngTitle": "Descargar como imagen PNG",
+  "downloadPng": "Descargar PNG",
+  "characters": "caracteres",
+  "caseUpper": "Mayúscula",
+  "caseLower": "Minúscula",
+  "caseBoth": "Ambas",
+  "labelUpper": "{ch} mayúscula en cursiva",
+  "labelLower": "{ch} minúscula en cursiva",
+  "labelBoth": "{ch} mayúscula y minúscula en cursiva",
+  "copyBoth": "Copiar ambas",
+  "everyStyle": "{ch} en cursiva — cada estilo, clic para copiar",
+  "suffixCapital": " — mayúscula",
+  "suffixLowercase": " — minúscula",
+  "accentLabel": "Adorno {name}",
+  "practiceTitle": "Hoja de práctica del alfabeto cursivo — ultratextgen.com",
+  "flourishLabel": "Adorno",
+  "monogramLabel": "Unión de monograma",
+  "copiedToast": "¡Copiado!",
+  "quickWords": [
+    "amor",
+    "gracias",
+    "familia",
+    "feliz",
+    "siempre",
+    "bendecido"
+  ],
+  "styles": {
+    "Ultra Script": "cursiva clásica",
+    "Ultra Script Bold": "cursiva en negrita",
+    "Ultra Script Elegant": "cursiva elegante",
+    "Ultra Script Bold Elegant": "cursiva elegante en negrita",
+    "Ultra Gothic Script": "cursiva gótica",
+    "Ultra Chicano Script": "placa estilo chicano",
+    "Ultra Script Sparkle": "cursiva con brillos"
+  },
+  "presets": {
+    "Script Hearts": "Cursiva con corazones",
+    "Script Arrow Bio": "Cursiva con flechas para bio",
+    "Bold Script Stars": "Cursiva negrita con estrellas",
+    "Script Vintage": "Cursiva vintage",
+    "Script Soft Dots": "Cursiva con puntos suaves",
+    "Bold Script Ribbon": "Cursiva negrita con listón",
+    "Script Underline": "Cursiva subrayada",
+    "Bold Script Crown": "Cursiva negrita con corona"
+  },
+  "signatures": {
+    "Classic Signature": "Firma clásica",
+    "Bold Signature": "Firma en negrita",
+    "Signed Underline": "Firma subrayada",
+    "Sparkle Signature": "Firma con brillos",
+    "Ornate Nameplate": "Placa ornamentada",
+    "Autograph Star": "Autógrafo con estrella",
+    "Monogram Initials": "Iniciales de monograma",
+    "Gothic Signature": "Firma gótica"
+  },
+  "decorators": {
+    "None": "Ninguno",
+    "Underline": "Subrayado",
+    "Sparkle": "Brillos",
+    "Hearts": "Corazones",
+    "Ornate": "Ornamentado",
+    "Soft dots": "Puntos suaves"
+  },
+  "accents": {
+    "Sparkle": "Brillos",
+    "Hearts": "Corazones",
+    "Wings": "Alas",
+    "Ornate": "Ornamentado"
+  },
+  "platformLimits": {
+    "Instagram bio": "Bio de Instagram",
+    "TikTok bio": "Bio de TikTok",
+    "X bio": "Bio de X"
+  }
+};
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/js/cursive/cursiveData.js" defer></script>
+  <script src="/script.js" defer></script>
+  <script src="/js/cursive/cursivePageController.js" defer></script>
+  <script src="/footer.js" defer></script>
+</body></html>

--- a/fr/ecriture-cursive/index.html
+++ b/fr/ecriture-cursive/index.html
@@ -6,27 +6,30 @@
   'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
   })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
   <!-- End Google Tag Manager -->
-  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZGVh");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
   <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Écriture Cursive &amp; Calligraphie à Copier-Coller — Alphabet 𝓒𝓾𝓻𝓼𝓲𝓿𝓮 | UltraTextGen</title>
-  <meta name="description" content="Écriture cursive et calligraphie en ligne : alphabet en calligraphie A–Z, lettres script et écriture manuscrite à copier-coller. Majuscules calligraphiées une par une — gratuit, sans appli.">
+  <title>Générateur d'Écriture Cursive — Polices Cursives 𝓪̀ 𝓬𝓸𝓹𝓲𝓮𝓻, Lettres A–Z &amp; Prénoms | UltraTextGen</title>
+  <meta name="description" content="Générateur d'écriture cursive gratuit — copie-colle des polices cursives, chaque lettre cursive A–Z, l'alphabet cursive complet, des mots en cursive et des signatures de prénoms en lettres attachées.">
   <link rel="canonical" href="https://ultratextgen.com/fr/ecriture-cursive/">
 
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/category/cursive-fonts/">
-  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/ecriture-cursive/">
-  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/tulisan-sambung/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/letra-cursiva/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/letra-cursiva/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/ecriture-cursive/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/schreibschrift/">
+  <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/lettere-in-corsivo/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/el-yazisi-fontu/">
-  <link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/sierlijke-letters/">
+  <link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/cursieve-letters/">
+  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/tulisan-sambung/">
   <link rel="alternate" hreflang="no" href="https://ultratextgen.com/no/kursiv-tekst/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/category/cursive-fonts/">
 
   <meta name="robots" content="index, follow">
   <meta property="og:site_name" content="UltraTextGen">
-  <meta property="og:title" content="Écriture Cursive &amp; Calligraphie à Copier-Coller — Alphabet 𝓒𝓾𝓻𝓼𝓲𝓿𝓮">
-  <meta property="og:description" content="Transforme ton texte en calligraphie : cursive légère, cursive pleine et italique. Alphabet complet et majuscules calligraphiées à copier.">
+  <meta property="og:title" content="Générateur d'Écriture Cursive — Polices Cursives à copier-coller, Lettres A–Z &amp; Prénoms | UltraTextGen">
+  <meta property="og:description" content="Générateur d'écriture cursive gratuit — copie-colle des polices cursives, chaque lettre cursive A–Z, l'alphabet cursive complet, des mots en cursive et des signatures de prénoms.">
   <meta property="og:url" content="https://ultratextgen.com/fr/ecriture-cursive/">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://ultratextgen.com/assets/og/fr-ecriture-cursive.png">
@@ -34,27 +37,13 @@
   <meta property="og:image:height" content="630">
   <meta property="og:image:type" content="image/png">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Écriture Cursive &amp; Calligraphie à Copier-Coller — Alphabet 𝓒𝓾𝓻𝓼𝓲𝓿𝓮">
-  <meta name="twitter:description" content="Calligraphie et écriture cursive à copier-coller — tape, copie, colle. Gratuit.">
+  <meta name="twitter:title" content="Générateur d'Écriture Cursive — Polices Cursives à copier-coller, Lettres A–Z &amp; Prénoms | UltraTextGen">
+  <meta name="twitter:description" content="Générateur d'écriture cursive gratuit — copie-colle des polices cursives, l'alphabet cursive complet, des mots en cursive et des signatures de prénoms en lettres attachées.">
   <meta name="twitter:image" content="https://ultratextgen.com/assets/og/fr-ecriture-cursive.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/style.css">
-  <link rel="stylesheet" href="/symbol-explorer.css">
-
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "WebApplication",
-  "name": "Générateur d'Écriture Cursive",
-  "alternateName": ["Écriture Cursive", "Alphabet en Calligraphie", "Écriture Script", "Écriture Manuscrite", "Calligraphie en Ligne"],
-  "url": "https://ultratextgen.com/fr/ecriture-cursive/",
-  "inLanguage": "fr",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "description": "Générateur d'écriture cursive et de calligraphie : convertit ton texte en lettres script, cursives et manuscrites Unicode — alphabet en calligraphie à copier-coller pour bio, prénom et pseudo.",
-  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "EUR" }
-}
-</script>
 
 <script type="application/ld+json">
 {
@@ -64,28 +53,67 @@
   "mainEntity": [
     {
       "@type": "Question",
-      "name": "Comment écrire en calligraphie sur un clavier ?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Pas besoin de plume : tape ton texte dans le générateur en haut de la page, et il ressort aussitôt en calligraphie Unicode — cursive légère (𝒸𝓊𝓇𝓈𝒾𝓋𝑒), cursive pleine (𝓬𝓾𝓻𝓼𝓲𝓿𝓮) et italique. Copie la version qui te plaît et colle-la dans ta bio, un message ou un pseudo. Ça fonctionne sur téléphone comme sur ordinateur." }
+      "name": "Qu'est-ce qu'un générateur d'écriture cursive et comment ça marche ?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Il convertit les lettres que tu tapes en caractères script Unicode — des symboles spéciaux qui ressemblent à de l'écriture cursive manuscrite mais se comportent comme du texte normal. Comme ce sont de vrais caractères (pas une police ni une image), tu peux les copier et les coller dans tes bios, légendes, commentaires et messages, et ils gardent leur look cursif. Plus de détails dans notre <a href=\"/guide/how-unicode-fonts-work/\">guide sur le fonctionnement des polices Unicode</a> (en anglais)."
+      }
     },
     {
       "@type": "Question",
-      "name": "Quelle différence entre cursive, script et manuscrite ?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Dans l'usage courant, les trois mots désignent des lettres au tracé fluide, inspiré de l'écriture à la main. La «cursive» évoque les lettres attachées apprises à l'école, le «script» est le terme typographique pour ces polices fluides, et la «manuscrite» insiste sur l'effet écrit-à-la-main. Côté Unicode, tout passe par les mêmes jeux de caractères script — cette page les regroupe tous." }
+      "name": "Comment copier-coller de l'écriture cursive ?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Tape ou colle ton texte dans le champ en haut, puis appuie sur Copier sur le style qui te plaît. La version cursive est maintenant dans ton presse-papiers : colle-la partout où le texte est accepté — Instagram, TikTok, WhatsApp, Discord, documents, et plus encore."
+      }
     },
     {
       "@type": "Question",
-      "name": "Comment avoir une belle majuscule en calligraphie ?",
-      "acceptedAnswer": { "@type": "Answer", "text": "La section «Majuscules calligraphiées» de cette page liste les 26 lettres capitales une par une — clique sur une lettre pour la copier seule. Pratique pour une initiale décorée, un monogramme ou la première lettre d'un prénom : 𝓔 pour Emma, 𝓛 pour Lucas, 𝓜 pour Manon." }
+      "name": "L'écriture cursive marche-t-elle sur Instagram, WhatsApp et TikTok ?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Oui. Les bios et légendes Instagram, les statuts et messages WhatsApp et les légendes TikTok acceptent les caractères script Unicode, donc ta <strong>police cursive</strong> reste intacte. Seule exception fréquente : les champs de pseudo/nom d'utilisateur, qui filtrent souvent ces caractères — garde-les en texte simple."
+      }
     },
     {
       "@type": "Question",
-      "name": "L'écriture cursive marche-t-elle sur Instagram et WhatsApp ?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Oui. Les lettres cursives de cette page sont des caractères Unicode : elles s'affichent dans une bio Instagram, un statut ou un nom WhatsApp, une légende TikTok, un pseudo Discord — partout où on peut coller du texte. Aucune application ni police à installer." }
+      "name": "Les accents (é, à, ç) fonctionnent-ils en cursive ?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Non. Unicode ne propose des lettres script que pour l'alphabet latin de base A–Z, donc les lettres accentuées passent sans être converties et cassent le mot. Pour un rendu entièrement en lettres attachées, écris tes prénoms et mots sans accents : <strong>Chloé → Chloe</strong>, <strong>Léa → Lea</strong>, <strong>béni → beni</strong>."
+      }
     },
     {
       "@type": "Question",
-      "name": "Les accents français passent-ils en cursive ?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Partiellement. Les jeux cursifs d'Unicode couvrent l'alphabet latin de base : é, è, à ou ç restent en lettres droites au milieu du mot. Pour un prénom 100 % calligraphié, écris-le sans accents : «Chloé» → Chloe → 𝓒𝓱𝓵𝓸𝓮. Avec accents, le reste du mot est calligraphié et le prénom reste très lisible." }
+      "name": "Le générateur d'écriture cursive est-il gratuit ?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Oui, à 100 %. Aucun compte, aucune inscription, aucune limite : tape, copie et colle autant de <strong>lettres cursives</strong> que tu veux, gratuitement."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Puis-je créer une signature avec mon prénom en cursive ?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Oui. Tape ton prénom ou ton nom complet dans le <a href=\"#mainInput\">studio de prénoms</a>, choisis une fioriture, ajuste la liaison des initiales du monogramme, puis copie le texte ou télécharge-le en PNG pour tes signatures d'e-mail, filigranes et documents."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Puis-je obtenir une seule lettre cursive, comme un S ou un G majuscule ?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Oui. Ouvre l'<a href=\"#cursive-letters\">explorateur de lettres A–Z</a>, touche la lettre voulue et vois-la dans chaque style, en majuscule et en minuscule. Copie le glyphe exact ou télécharge-le en PNG."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "L'écriture cursive convient-elle à un tatouage ?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Le lettrage script est le style de tatouage le plus demandé. Prévisualise ton mot ici, puis affine-le avec le <a href=\"/fr/usecase/ecriture-tatouage/\">générateur d'écriture pour tatouage</a>, qui ajoute des familles de lettrage, les dates en chiffres romains et un test de lisibilité."
+      }
     }
   ]
 }
@@ -101,228 +129,720 @@
   ]
 }
 </script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Générateur d'Écriture Cursive",
+  "alternateName": ["Générateur de Cursive","Générateur de Police Cursive","Lettres Cursives A–Z","Alphabet Cursive","Générateur de Prénom en Cursive","Générateur de Signature Cursive","Cursive à Copier-Coller"],
+  "url": "https://ultratextgen.com/fr/ecriture-cursive/",
+  "inLanguage": "fr",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "EUR"
+  },
+  "description": "Générateur d'écriture cursive gratuit : copie-colle des polices cursives, chaque lettre cursive A–Z, l'alphabet cursive complet, des mots en cursive et des signatures de prénoms en lettres attachées.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers.",
+  "featureList": ["Générateur de police cursive avec fioritures","Explorateur de lettres cursives A–Z (majuscules et minuscules)","Copie en un clic de l'alphabet cursive complet","Fiche d'écriture cursive à imprimer","Studio de prénom et de signature en cursive","Galerie de mots en cursive (amour, joyeux anniversaire, mois)"]
+}
+</script>
 </head>
 <body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
   <!-- Google Tag Manager (noscript) -->
-  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <!-- End Google Tag Manager (noscript) -->
-<script src="/header.js"></script>
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
 
-<nav class="breadcrumbs" aria-label="Fil d'Ariane">
+<nav class="breadcrumbs" aria-label="Breadcrumb">
   <a href="/fr/">Accueil</a>
   <span class="breadcrumb-separator">›</span>
   <span class="breadcrumb-current">Écriture Cursive</span>
 </nav>
 
 <figure class="page-hero-figure" data-uthero aria-hidden="true">
-  <img src="/assets/hero/fr-ecriture-cursive.svg" width="1200" height="340" loading="lazy" alt="">
+  <img src="/assets/hero/fr-ecriture-cursive.svg" width="1200" height="340"
+       loading="lazy" alt="">
 </figure>
 
-<section class="hero">
-  <div class="hero-inner">
-    <div class="hero-card">
-      <h1 class="hero-headline">Écriture cursive &amp; calligraphie à copier-coller</h1>
-      <p class="hero-tagline">Tape ton texte, il ressort aussitôt en calligraphie — cursive légère, cursive pleine, script et italique. Copie et colle dans ta bio, un prénom décoré, une invitation ou un pseudo : le style suit le texte partout.</p>
-      <div class="input-wrapper">
-        <textarea class="main-input" id="mainInput" placeholder="Tape ton prénom ou ton texte ici…" maxlength="500" autofocus=""></textarea>
-        <span class="char-count"><span id="charCount">0</span>/500</span>
-      </div>
-      <div class="accent-notice" id="accentNotice" role="note" hidden>
-        <span class="accent-notice-icon" aria-hidden="true">◌́</span>
-        <span class="accent-notice-text">Ton texte contient des accents. La plupart des styles laissent <b>é</b>, <b>à</b> ou <b>ç</b> en lettres normales — les styles <b>barré, souligné et cadres</b> les gardent. <a href="/guide/fancy-fonts-and-accents/">Quels styles gardent les accents →</a></span>
-        <button type="button" class="accent-notice-close" id="accentNoticeClose" aria-label="Fermer">✕</button>
-      </div>
-      <div class="decoration-section">
-        <div class="decoration-label">Ajoute un peu de déco autour du résultat</div>
-        <div class="decoration-tabs">
-          <button class="decoration-tab active" data-deco-tab="symbols">Symboles</button>
-          <button class="decoration-tab" data-deco-tab="frames">Cadres</button>
-          <button class="decoration-tab" data-deco-tab="minimal">Minimaliste</button>
+  <!-- Hero: the cursive-first generator -->
+  <section class="hero">
+    <div class="hero-inner">
+      <div class="hero-card">
+        <h1 class="hero-headline">Générateur d'Écriture Cursive</h1>
+        <p class="hero-tagline">Transforme n'importe quel texte en 𝓬𝓾𝓻𝓼𝓲𝓿𝓮 à copier-coller — polices script fluides,
+          chaque lettre cursive A–Z, l'alphabet complet et des signatures de prénoms en lettres attachées. Gratuit, instantané, sans inscription.</p>
+        <div class="input-wrapper">
+          <textarea class="main-input" id="mainInput" placeholder="Tape ton texte, un mot ou un prénom…" maxlength="500" autofocus></textarea>
+          <span class="char-count"><span id="charCount">0</span>/500</span>
         </div>
-        <div class="decoration-grid" id="decorationGrid"></div>
+        <div class="cursive-quick-row" id="cursiveQuickRow" aria-label="Exemples rapides"></div>
+        <div class="vertical-fit-row" id="cursiveFitRow" hidden></div>
       </div>
     </div>
+  </section>
+
+  <nav class="cursive-section-nav" aria-label="Sur cette page">
+    <a href="#cursive-styles">Styles</a>
+    <a href="#cursive-letters">Lettres A–Z</a>
+    <a href="#cursive-alphabet">Alphabet</a>
+    <a href="#cursive-words">Mots</a>
+    <a href="#cursive-names">Prénoms &amp; Signatures</a>
+    <a href="#cursive-faq">FAQ</a>
+  </nav>
+
+  <main class="container">
+
+    <!-- 1. Generator output -->
+    <section id="cursive-styles" aria-labelledby="cursiveStylesHeading">
+      <h2 class="bubble-az-heading" id="cursiveStylesHeading">Polices cursives — à copier-coller</h2>
+      <p class="bubble-az-intro">Chaque style ci-dessous se met à jour en direct pendant que tu écris : cursive classique et cursive pleine,
+        variantes élégantes espacées, cursive gothique, plaques Chicano et présélections avec cœurs,
+        étincelles et flèches. Appuie sur Copier et colle ta police cursive où tu veux.</p>
+      <div class="results-grid" id="resultsGrid"></div>
+    </section>
+
+    <!-- 2. Cursive letters A–Z -->
+    <section class="bubble-az" id="cursive-letters" aria-labelledby="cursiveLettersHeading">
+      <h2 class="bubble-az-heading" id="cursiveLettersHeading">Lettres cursives A–Z — majuscules &amp; minuscules</h2>
+      <p class="bubble-az-intro">Tu cherches une seule lettre cursive — un S en cursive, un G majuscule cursive, un f minuscule ?
+        Touche n'importe quelle lettre cursive pour la voir dans tous les styles, copier le glyphe exact ou le télécharger en PNG.</p>
+  <div class="cursive-letter-grid" role="tablist" aria-label="Choisis une lettre cursive">
+    <button type="button" class="cursive-letter-cell" id="cursive-a" data-char="A" aria-label="A en cursive — majuscule et minuscule">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒜 𝒶</span>
+      <span class="cursive-letter-name">A cursive</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-b" data-char="B" aria-label="B en cursive — majuscule et minuscule">
+      <span class="cursive-letter-pair" aria-hidden="true">ℬ 𝒷</span>
+      <span class="cursive-letter-name">B cursive</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-c" data-char="C" aria-label="C en cursive — majuscule et minuscule">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒞 𝒸</span>
+      <span class="cursive-letter-name">C cursive</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-d" data-char="D" aria-label="D en cursive — majuscule et minuscule">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒟 𝒹</span>
+      <span class="cursive-letter-name">D cursive</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-e" data-char="E" aria-label="E en cursive — majuscule et minuscule">
+      <span class="cursive-letter-pair" aria-hidden="true">ℰ ℯ</span>
+      <span class="cursive-letter-name">E cursive</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-f" data-char="F" aria-label="F en cursive — majuscule et minuscule">
+      <span class="cursive-letter-pair" aria-hidden="true">ℱ 𝒻</span>
+      <span class="cursive-letter-name">F cursive</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-g" data-char="G" aria-label="G en cursive — majuscule et minuscule">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒢 ℊ</span>
+      <span class="cursive-letter-name">G cursive</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-h" data-char="H" aria-label="H en cursive — majuscule et minuscule">
+      <span class="cursive-letter-pair" aria-hidden="true">ℋ 𝒽</span>
+      <span class="cursive-letter-name">H cursive</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-i" data-char="I" aria-label="I en cursive — majuscule et minuscule">
+      <span class="cursive-letter-pair" aria-hidden="true">ℐ 𝒾</span>
+      <span class="cursive-letter-name">I cursive</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-j" data-char="J" aria-label="J en cursive — majuscule et minuscule">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒥 𝒿</span>
+      <span class="cursive-letter-name">J cursive</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-k" data-char="K" aria-label="K en cursive — majuscule et minuscule">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒦 𝓀</span>
+      <span class="cursive-letter-name">K cursive</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-l" data-char="L" aria-label="L en cursive — majuscule et minuscule">
+      <span class="cursive-letter-pair" aria-hidden="true">ℒ 𝓁</span>
+      <span class="cursive-letter-name">L cursive</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-m" data-char="M" aria-label="M en cursive — majuscule et minuscule">
+      <span class="cursive-letter-pair" aria-hidden="true">ℳ 𝓂</span>
+      <span class="cursive-letter-name">M cursive</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-n" data-char="N" aria-label="N en cursive — majuscule et minuscule">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒩 𝓃</span>
+      <span class="cursive-letter-name">N cursive</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-o" data-char="O" aria-label="O en cursive — majuscule et minuscule">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒪 ℴ</span>
+      <span class="cursive-letter-name">O cursive</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-p" data-char="P" aria-label="P en cursive — majuscule et minuscule">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒫 𝓅</span>
+      <span class="cursive-letter-name">P cursive</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-q" data-char="Q" aria-label="Q en cursive — majuscule et minuscule">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒬 𝓆</span>
+      <span class="cursive-letter-name">Q cursive</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-r" data-char="R" aria-label="R en cursive — majuscule et minuscule">
+      <span class="cursive-letter-pair" aria-hidden="true">ℛ 𝓇</span>
+      <span class="cursive-letter-name">R cursive</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-s" data-char="S" aria-label="S en cursive — majuscule et minuscule">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒮 𝓈</span>
+      <span class="cursive-letter-name">S cursive</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-t" data-char="T" aria-label="T en cursive — majuscule et minuscule">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒯 𝓉</span>
+      <span class="cursive-letter-name">T cursive</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-u" data-char="U" aria-label="U en cursive — majuscule et minuscule">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒰 𝓊</span>
+      <span class="cursive-letter-name">U cursive</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-v" data-char="V" aria-label="V en cursive — majuscule et minuscule">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒱 𝓋</span>
+      <span class="cursive-letter-name">V cursive</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-w" data-char="W" aria-label="W en cursive — majuscule et minuscule">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒲 𝓌</span>
+      <span class="cursive-letter-name">W cursive</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-x" data-char="X" aria-label="X en cursive — majuscule et minuscule">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒳 𝓍</span>
+      <span class="cursive-letter-name">X cursive</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-y" data-char="Y" aria-label="Y en cursive — majuscule et minuscule">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒴 𝓎</span>
+      <span class="cursive-letter-name">Y cursive</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-z" data-char="Z" aria-label="Z en cursive — majuscule et minuscule">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒵 𝓏</span>
+      <span class="cursive-letter-name">Z cursive</span>
+    </button>
   </div>
-</section>
+      <div class="cursive-letter-panel" id="cursiveLetterPanel" aria-live="polite"></div>
+    </section>
 
-<main class="container">
-  <div class="category-section"><div class="category-tabs" id="categoryTabs"></div></div>
-  <div class="results-grid" id="resultsGrid"></div>
-
-  <!-- Cursive, script, manuscrite -->
-  <section class="editorial-section">
-    <h2>Cursive, script, manuscrite : la calligraphie sans plume</h2>
-    <p class="editorial-intro">L'<strong>écriture cursive</strong> de cette page, c'est de la calligraphie en caractères Unicode : des lettres au tracé fluide, dessinées comme à la main, mais que tu peux copier-coller comme du texte normal. Qu'on parle d'<strong>écriture script</strong>, de <strong>lettres attachées</strong> ou d'<strong>écriture manuscrite</strong>, tout se retrouve dans les mêmes jeux de caractères — et ils sont tous ici.</p>
-    <div class="block-example">
-      <strong>Exemple :</strong> «bonjour» → 𝒷𝑜𝓃𝒿𝑜𝓊𝓇 (cursive légère), 𝓫𝓸𝓷𝓳𝓸𝓾𝓻 (cursive pleine), 𝘣𝘰𝘯𝘫𝘰𝘶𝘳 (italique)
-    </div>
-    <p>Contrairement à une police installée dans Word, ces lettres gardent leur style une fois collées dans une bio Instagram, une invitation numérique ou un pseudo. Pour un penché plus sobre et typographique, regarde l'<a href="/fr/ecriture-italique/">écriture italique</a>.</p>
-  </section>
-
-  <!-- Alphabet en calligraphie -->
-  <section class="editorial-section glyph-section">
-    <h2>Alphabet en calligraphie (A–Z) — à copier d'un clic</h2>
-    <p class="editorial-intro">L'alphabet complet en calligraphie, majuscules et minuscules. Clique sur une ligne pour copier tout le jeu, ou tape ton mot en haut pour l'obtenir directement.</p>
-    <div class="alpha-list">
-      <div class="alpha-row">
-        <span class="alpha-label">Cursive Légère</span>
-        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵 𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏" aria-label="Copier l'alphabet cursive légère">𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵 · 𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏</button>
+    <!-- 3. The cursive alphabet -->
+    <section id="cursive-alphabet" aria-labelledby="cursiveAlphabetHeading">
+      <div class="cursive-chart-toolbar">
+        <h2 class="bubble-az-heading" id="cursiveAlphabetHeading">L'alphabet cursive (A–Z, 0–9)</h2>
+        <button type="button" class="bubble-btn bubble-btn-primary" id="cursivePrintSheet">Imprimer la fiche d'écriture</button>
       </div>
-      <div class="alpha-row">
-        <span class="alpha-label">Cursive Pleine</span>
-        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩 𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃" aria-label="Copier l'alphabet cursive pleine">𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩 · 𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃</button>
+      <p class="bubble-az-intro">Copie l'alphabet cursive complet en un clic — majuscules, minuscules et chiffres —
+        ou imprime une fiche d'écriture avec des lettres modèles et de la place pour t'entraîner. Unicode n'a pas de vrais chiffres cursifs, donc chaque
+        style associe ses lettres script à des chiffres stylisés assortis.</p>
+    <div class="cursive-chart">
+      <div class="cursive-chart-head">
+        <h3>Alphabet cursive classique (Ultra Script)</h3>
+        <button type="button" class="copy-btn" data-text="𝒜 ℬ 𝒞 𝒟 ℰ ℱ 𝒢 ℋ ℐ 𝒥 𝒦 ℒ ℳ 𝒩 𝒪 𝒫 𝒬 ℛ 𝒮 𝒯 𝒰 𝒱 𝒲 𝒳 𝒴 𝒵&#10;𝒶 𝒷 𝒸 𝒹 ℯ 𝒻 ℊ 𝒽 𝒾 𝒿 𝓀 𝓁 𝓂 𝓃 ℴ 𝓅 𝓆 𝓇 𝓈 𝓉 𝓊 𝓋 𝓌 𝓍 𝓎 𝓏&#10;𝟢 𝟣 𝟤 𝟥 𝟦 𝟧 𝟨 𝟩 𝟪 𝟫" data-style="Ultra Script">Copier l'alphabet</button>
       </div>
-      <div class="alpha-row">
-        <span class="alpha-label">Italique Serif</span>
-        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝐴𝐵𝐶𝐷𝐸𝐹𝐺𝐻𝐼𝐽𝐾𝐿𝑀𝑁𝑂𝑃𝑄𝑅𝑆𝑇𝑈𝑉𝑊𝑋𝑌𝑍 𝑎𝑏𝑐𝑑𝑒𝑓𝑔ℎ𝑖𝑗𝑘𝑙𝑚𝑛𝑜𝑝𝑞𝑟𝑠𝑡𝑢𝑣𝑤𝑥𝑦𝑧" aria-label="Copier l'alphabet italique serif">𝐴𝐵𝐶𝐷𝐸𝐹𝐺𝐻𝐼𝐽𝐾𝐿𝑀𝑁𝑂𝑃𝑄𝑅𝑆𝑇𝑈𝑉𝑊𝑋𝑌𝑍 · 𝑎𝑏𝑐𝑑𝑒𝑓𝑔ℎ𝑖𝑗𝑘𝑙𝑚𝑛𝑜𝑝𝑞𝑟𝑠𝑡𝑢𝑣𝑤𝑥𝑦𝑧</button>
+      <p class="cursive-alphabet-row">𝒜 ℬ 𝒞 𝒟 ℰ ℱ 𝒢 ℋ ℐ 𝒥 𝒦 ℒ ℳ 𝒩 𝒪 𝒫 𝒬 ℛ 𝒮 𝒯 𝒰 𝒱 𝒲 𝒳 𝒴 𝒵</p>
+      <p class="cursive-alphabet-row">𝒶 𝒷 𝒸 𝒹 ℯ 𝒻 ℊ 𝒽 𝒾 𝒿 𝓀 𝓁 𝓂 𝓃 ℴ 𝓅 𝓆 𝓇 𝓈 𝓉 𝓊 𝓋 𝓌 𝓍 𝓎 𝓏</p>
+      <p class="cursive-alphabet-row">𝟢 𝟣 𝟤 𝟥 𝟦 𝟧 𝟨 𝟩 𝟪 𝟫</p>
+    </div>
+    <div class="cursive-chart">
+      <div class="cursive-chart-head">
+        <h3>Alphabet cursive plein (Ultra Script Bold)</h3>
+        <button type="button" class="copy-btn" data-text="𝓐 𝓑 𝓒 𝓓 𝓔 𝓕 𝓖 𝓗 𝓘 𝓙 𝓚 𝓛 𝓜 𝓝 𝓞 𝓟 𝓠 𝓡 𝓢 𝓣 𝓤 𝓥 𝓦 𝓧 𝓨 𝓩&#10;𝓪 𝓫 𝓬 𝓭 𝓮 𝓯 𝓰 𝓱 𝓲 𝓳 𝓴 𝓵 𝓶 𝓷 𝓸 𝓹 𝓺 𝓻 𝓼 𝓽 𝓾 𝓿 𝔀 𝔁 𝔂 𝔃&#10;𝟬 𝟭 𝟮 𝟯 𝟰 𝟱 𝟲 𝟳 𝟴 𝟵" data-style="Ultra Script Bold">Copier l'alphabet</button>
+      </div>
+      <p class="cursive-alphabet-row">𝓐 𝓑 𝓒 𝓓 𝓔 𝓕 𝓖 𝓗 𝓘 𝓙 𝓚 𝓛 𝓜 𝓝 𝓞 𝓟 𝓠 𝓡 𝓢 𝓣 𝓤 𝓥 𝓦 𝓧 𝓨 𝓩</p>
+      <p class="cursive-alphabet-row">𝓪 𝓫 𝓬 𝓭 𝓮 𝓯 𝓰 𝓱 𝓲 𝓳 𝓴 𝓵 𝓶 𝓷 𝓸 𝓹 𝓺 𝓻 𝓼 𝓽 𝓾 𝓿 𝔀 𝔁 𝔂 𝔃</p>
+      <p class="cursive-alphabet-row">𝟬 𝟭 𝟮 𝟯 𝟰 𝟱 𝟲 𝟳 𝟴 𝟵</p>
+    </div>
+    <div class="cursive-chart">
+      <div class="cursive-chart-head">
+        <h3>Alphabet cursive gothique (Ultra Gothic Script)</h3>
+        <button type="button" class="copy-btn" data-text="𝕬 𝕭 𝕮 𝕯 𝕰 𝕱 𝕲 𝕳 𝕴 𝕵 𝕶 𝕷 𝕸 𝕹 𝕺 𝕻 𝕼 𝕽 𝕾 𝕿 𝖀 𝖁 𝖂 𝖃 𝖄 𝖅&#10;𝖆 𝖇 𝖈 𝖉 𝖊 𝖋 𝖌 𝖍 𝖎 𝖏 𝖐 𝖑 𝖒 𝖓 𝖔 𝖕 𝖖 𝖗 𝖘 𝖙 𝖚 𝖛 𝖜 𝖝 𝖞 𝖟" data-style="Ultra Gothic Script">Copier l'alphabet</button>
+      </div>
+      <p class="cursive-alphabet-row">𝕬 𝕭 𝕮 𝕯 𝕰 𝕱 𝕲 𝕳 𝕴 𝕵 𝕶 𝕷 𝕸 𝕹 𝕺 𝕻 𝕼 𝕽 𝕾 𝕿 𝖀 𝖁 𝖂 𝖃 𝖄 𝖅</p>
+      <p class="cursive-alphabet-row">𝖆 𝖇 𝖈 𝖉 𝖊 𝖋 𝖌 𝖍 𝖎 𝖏 𝖐 𝖑 𝖒 𝖓 𝖔 𝖕 𝖖 𝖗 𝖘 𝖙 𝖚 𝖛 𝖜 𝖝 𝖞 𝖟</p>
+    </div>
+    </section>
+
+    <!-- 4. Words in cursive -->
+    <section id="cursive-words" aria-labelledby="cursiveWordsHeading">
+      <h2 class="bubble-az-heading" id="cursiveWordsHeading">Mots en cursive — prêts à copier</h2>
+      <p class="bubble-az-intro">Les mots les plus demandés, déjà rendus en écriture cursive. Tu en veux un autre ?
+        Tape-le dans le <a href="#mainInput">générateur ci-dessus</a> et chaque style le convertit instantanément.</p>
+    <h3>Amour &amp; famille</h3>
+    <div class="cursive-word-grid">
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒶𝓂ℴ𝓊𝓇</span>
+        <span class="cursive-word-label">amour en cursive</span>
+        <button type="button" class="copy-btn" data-text="𝒶𝓂ℴ𝓊𝓇" data-style="Ultra Script">Copier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓪𝓶𝓸𝓾𝓻</span>
+        <span class="cursive-word-label">amour (plein) en cursive</span>
+        <button type="button" class="copy-btn" data-text="𝓪𝓶𝓸𝓾𝓻" data-style="Ultra Script Bold">Copier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒿ℯ 𝓉𝒶𝒾𝓂ℯ</span>
+        <span class="cursive-word-label">je t'aime en cursive</span>
+        <button type="button" class="copy-btn" data-text="𝒿ℯ 𝓉𝒶𝒾𝓂ℯ" data-style="Ultra Script">Copier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓂𝒶𝓂𝒶𝓃</span>
+        <span class="cursive-word-label">maman en cursive</span>
+        <button type="button" class="copy-btn" data-text="𝓂𝒶𝓂𝒶𝓃" data-style="Ultra Script">Copier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓅𝒶𝓅𝒶</span>
+        <span class="cursive-word-label">papa en cursive</span>
+        <button type="button" class="copy-btn" data-text="𝓅𝒶𝓅𝒶" data-style="Ultra Script">Copier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒻𝒶𝓂𝒾𝓁𝓁ℯ</span>
+        <span class="cursive-word-label">famille en cursive</span>
+        <button type="button" class="copy-btn" data-text="𝒻𝒶𝓂𝒾𝓁𝓁ℯ" data-style="Ultra Script">Copier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓅ℴ𝓊𝓇 𝓉ℴ𝓊𝒿ℴ𝓊𝓇𝓈</span>
+        <span class="cursive-word-label">pour toujours en cursive</span>
+        <button type="button" class="copy-btn" data-text="𝓅ℴ𝓊𝓇 𝓉ℴ𝓊𝒿ℴ𝓊𝓇𝓈" data-style="Ultra Script">Copier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒷ℴ𝓃𝒽ℯ𝓊𝓇</span>
+        <span class="cursive-word-label">bonheur en cursive</span>
+        <button type="button" class="copy-btn" data-text="𝒷ℴ𝓃𝒽ℯ𝓊𝓇" data-style="Ultra Script">Copier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">ℯ𝓈𝓅ℴ𝒾𝓇</span>
+        <span class="cursive-word-label">espoir en cursive</span>
+        <button type="button" class="copy-btn" data-text="ℯ𝓈𝓅ℴ𝒾𝓇" data-style="Ultra Script">Copier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒷ℯ𝓃𝒾</span>
+        <span class="cursive-word-label">béni en cursive</span>
+        <button type="button" class="copy-btn" data-text="𝒷ℯ𝓃𝒾" data-style="Ultra Script">Copier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒶𝓃ℊℯ</span>
+        <span class="cursive-word-label">ange en cursive</span>
+        <button type="button" class="copy-btn" data-text="𝒶𝓃ℊℯ" data-style="Ultra Script">Copier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒷𝒾𝓈ℴ𝓊𝓈</span>
+        <span class="cursive-word-label">bisous en cursive</span>
+        <button type="button" class="copy-btn" data-text="𝒷𝒾𝓈ℴ𝓊𝓈" data-style="Ultra Script">Copier</button>
       </div>
     </div>
-    <p class="u-mt-15">La <strong>cursive légère</strong> (𝒶𝒷𝒸) est fine et aérienne — élégante dans une bio. La <strong>cursive pleine</strong> (𝓪𝓫𝓬) est plus épaisse et se lit mieux en petit — le bon choix pour un pseudo. L'<strong>italique serif</strong> (𝑎𝑏𝑐) donne un rendu manuscrit posé, presque littéraire.</p>
-  </section>
-
-  <!-- Majuscules calligraphiées -->
-  <section class="editorial-section glyph-section">
-    <h2>Majuscules calligraphiées, une par une</h2>
-    <p class="editorial-intro">Une initiale pour un monogramme, la première lettre d'un prénom, une lettre décorée pour un titre : clique sur une majuscule en calligraphie pour la copier seule.</p>
-    <div class="glyph-group">
-      <h3>Cursive pleine</h3>
-      <div class="glyph-grid">
-        <button class="glyph-copy" type="button" data-text="𝓐">𝓐</button>
-        <button class="glyph-copy" type="button" data-text="𝓑">𝓑</button>
-        <button class="glyph-copy" type="button" data-text="𝓒">𝓒</button>
-        <button class="glyph-copy" type="button" data-text="𝓓">𝓓</button>
-        <button class="glyph-copy" type="button" data-text="𝓔">𝓔</button>
-        <button class="glyph-copy" type="button" data-text="𝓕">𝓕</button>
-        <button class="glyph-copy" type="button" data-text="𝓖">𝓖</button>
-        <button class="glyph-copy" type="button" data-text="𝓗">𝓗</button>
-        <button class="glyph-copy" type="button" data-text="𝓘">𝓘</button>
-        <button class="glyph-copy" type="button" data-text="𝓙">𝓙</button>
-        <button class="glyph-copy" type="button" data-text="𝓚">𝓚</button>
-        <button class="glyph-copy" type="button" data-text="𝓛">𝓛</button>
-        <button class="glyph-copy" type="button" data-text="𝓜">𝓜</button>
-        <button class="glyph-copy" type="button" data-text="𝓝">𝓝</button>
-        <button class="glyph-copy" type="button" data-text="𝓞">𝓞</button>
-        <button class="glyph-copy" type="button" data-text="𝓟">𝓟</button>
-        <button class="glyph-copy" type="button" data-text="𝓠">𝓠</button>
-        <button class="glyph-copy" type="button" data-text="𝓡">𝓡</button>
-        <button class="glyph-copy" type="button" data-text="𝓢">𝓢</button>
-        <button class="glyph-copy" type="button" data-text="𝓣">𝓣</button>
-        <button class="glyph-copy" type="button" data-text="𝓤">𝓤</button>
-        <button class="glyph-copy" type="button" data-text="𝓥">𝓥</button>
-        <button class="glyph-copy" type="button" data-text="𝓦">𝓦</button>
-        <button class="glyph-copy" type="button" data-text="𝓧">𝓧</button>
-        <button class="glyph-copy" type="button" data-text="𝓨">𝓨</button>
-        <button class="glyph-copy" type="button" data-text="𝓩">𝓩</button>
+    <h3>Vœux &amp; occasions</h3>
+    <div class="cursive-word-grid">
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒿ℴ𝓎ℯ𝓊𝓍 𝒶𝓃𝓃𝒾𝓋ℯ𝓇𝓈𝒶𝒾𝓇ℯ</span>
+        <span class="cursive-word-label">joyeux anniversaire en cursive</span>
+        <button type="button" class="copy-btn" data-text="𝒿ℴ𝓎ℯ𝓊𝓍 𝒶𝓃𝓃𝒾𝓋ℯ𝓇𝓈𝒶𝒾𝓇ℯ" data-style="Ultra Script">Copier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓂ℯ𝓇𝒸𝒾</span>
+        <span class="cursive-word-label">merci en cursive</span>
+        <button type="button" class="copy-btn" data-text="𝓂ℯ𝓇𝒸𝒾" data-style="Ultra Script">Copier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒷𝒾ℯ𝓃𝓋ℯ𝓃𝓊ℯ</span>
+        <span class="cursive-word-label">bienvenue en cursive</span>
+        <button type="button" class="copy-btn" data-text="𝒷𝒾ℯ𝓃𝓋ℯ𝓃𝓊ℯ" data-style="Ultra Script">Copier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒷ℴ𝓃𝒿ℴ𝓊𝓇</span>
+        <span class="cursive-word-label">bonjour en cursive</span>
+        <button type="button" class="copy-btn" data-text="𝒷ℴ𝓃𝒿ℴ𝓊𝓇" data-style="Ultra Script">Copier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒻ℯ𝓁𝒾𝒸𝒾𝓉𝒶𝓉𝒾ℴ𝓃𝓈</span>
+        <span class="cursive-word-label">félicitations en cursive</span>
+        <button type="button" class="copy-btn" data-text="𝒻ℯ𝓁𝒾𝒸𝒾𝓉𝒶𝓉𝒾ℴ𝓃𝓈" data-style="Ultra Script">Copier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒿ℴ𝓎ℯ𝓊𝓍 𝓃ℴℯ𝓁</span>
+        <span class="cursive-word-label">joyeux noël en cursive</span>
+        <button type="button" class="copy-btn" data-text="𝒿ℴ𝓎ℯ𝓊𝓍 𝓃ℴℯ𝓁" data-style="Ultra Script">Copier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒷ℴ𝓃𝓃ℯ 𝒶𝓃𝓃ℯℯ</span>
+        <span class="cursive-word-label">bonne année en cursive</span>
+        <button type="button" class="copy-btn" data-text="𝒷ℴ𝓃𝓃ℯ 𝒶𝓃𝓃ℯℯ" data-style="Ultra Script">Copier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓂ℯ𝒾𝓁𝓁ℯ𝓊𝓇𝓈 𝓋ℴℯ𝓊𝓍</span>
+        <span class="cursive-word-label">meilleurs vœux en cursive</span>
+        <button type="button" class="copy-btn" data-text="𝓂ℯ𝒾𝓁𝓁ℯ𝓊𝓇𝓈 𝓋ℴℯ𝓊𝓍" data-style="Ultra Script">Copier</button>
       </div>
     </div>
-    <div class="glyph-group">
-      <h3>Cursive légère</h3>
-      <div class="glyph-grid">
-        <button class="glyph-copy" type="button" data-text="𝒜">𝒜</button>
-        <button class="glyph-copy" type="button" data-text="ℬ">ℬ</button>
-        <button class="glyph-copy" type="button" data-text="𝒞">𝒞</button>
-        <button class="glyph-copy" type="button" data-text="𝒟">𝒟</button>
-        <button class="glyph-copy" type="button" data-text="ℰ">ℰ</button>
-        <button class="glyph-copy" type="button" data-text="ℱ">ℱ</button>
-        <button class="glyph-copy" type="button" data-text="𝒢">𝒢</button>
-        <button class="glyph-copy" type="button" data-text="ℋ">ℋ</button>
-        <button class="glyph-copy" type="button" data-text="ℐ">ℐ</button>
-        <button class="glyph-copy" type="button" data-text="𝒥">𝒥</button>
-        <button class="glyph-copy" type="button" data-text="𝒦">𝒦</button>
-        <button class="glyph-copy" type="button" data-text="ℒ">ℒ</button>
-        <button class="glyph-copy" type="button" data-text="ℳ">ℳ</button>
-        <button class="glyph-copy" type="button" data-text="𝒩">𝒩</button>
-        <button class="glyph-copy" type="button" data-text="𝒪">𝒪</button>
-        <button class="glyph-copy" type="button" data-text="𝒫">𝒫</button>
-        <button class="glyph-copy" type="button" data-text="𝒬">𝒬</button>
-        <button class="glyph-copy" type="button" data-text="ℛ">ℛ</button>
-        <button class="glyph-copy" type="button" data-text="𝒮">𝒮</button>
-        <button class="glyph-copy" type="button" data-text="𝒯">𝒯</button>
-        <button class="glyph-copy" type="button" data-text="𝒰">𝒰</button>
-        <button class="glyph-copy" type="button" data-text="𝒱">𝒱</button>
-        <button class="glyph-copy" type="button" data-text="𝒲">𝒲</button>
-        <button class="glyph-copy" type="button" data-text="𝒳">𝒳</button>
-        <button class="glyph-copy" type="button" data-text="𝒴">𝒴</button>
-        <button class="glyph-copy" type="button" data-text="𝒵">𝒵</button>
+    <h3>Les mois en cursive</h3>
+    <div class="cursive-word-grid">
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒿𝒶𝓃𝓋𝒾ℯ𝓇</span>
+        <span class="cursive-word-label">janvier en cursive</span>
+        <button type="button" class="copy-btn" data-text="𝒿𝒶𝓃𝓋𝒾ℯ𝓇" data-style="Ultra Script">Copier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒻ℯ𝓋𝓇𝒾ℯ𝓇</span>
+        <span class="cursive-word-label">février en cursive</span>
+        <button type="button" class="copy-btn" data-text="𝒻ℯ𝓋𝓇𝒾ℯ𝓇" data-style="Ultra Script">Copier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓂𝒶𝓇𝓈</span>
+        <span class="cursive-word-label">mars en cursive</span>
+        <button type="button" class="copy-btn" data-text="𝓂𝒶𝓇𝓈" data-style="Ultra Script">Copier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒶𝓋𝓇𝒾𝓁</span>
+        <span class="cursive-word-label">avril en cursive</span>
+        <button type="button" class="copy-btn" data-text="𝒶𝓋𝓇𝒾𝓁" data-style="Ultra Script">Copier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓂𝒶𝒾</span>
+        <span class="cursive-word-label">mai en cursive</span>
+        <button type="button" class="copy-btn" data-text="𝓂𝒶𝒾" data-style="Ultra Script">Copier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒿𝓊𝒾𝓃</span>
+        <span class="cursive-word-label">juin en cursive</span>
+        <button type="button" class="copy-btn" data-text="𝒿𝓊𝒾𝓃" data-style="Ultra Script">Copier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒿𝓊𝒾𝓁𝓁ℯ𝓉</span>
+        <span class="cursive-word-label">juillet en cursive</span>
+        <button type="button" class="copy-btn" data-text="𝒿𝓊𝒾𝓁𝓁ℯ𝓉" data-style="Ultra Script">Copier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒶ℴ𝓊𝓉</span>
+        <span class="cursive-word-label">août en cursive</span>
+        <button type="button" class="copy-btn" data-text="𝒶ℴ𝓊𝓉" data-style="Ultra Script">Copier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓈ℯ𝓅𝓉ℯ𝓂𝒷𝓇ℯ</span>
+        <span class="cursive-word-label">septembre en cursive</span>
+        <button type="button" class="copy-btn" data-text="𝓈ℯ𝓅𝓉ℯ𝓂𝒷𝓇ℯ" data-style="Ultra Script">Copier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">ℴ𝒸𝓉ℴ𝒷𝓇ℯ</span>
+        <span class="cursive-word-label">octobre en cursive</span>
+        <button type="button" class="copy-btn" data-text="ℴ𝒸𝓉ℴ𝒷𝓇ℯ" data-style="Ultra Script">Copier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓃ℴ𝓋ℯ𝓂𝒷𝓇ℯ</span>
+        <span class="cursive-word-label">novembre en cursive</span>
+        <button type="button" class="copy-btn" data-text="𝓃ℴ𝓋ℯ𝓂𝒷𝓇ℯ" data-style="Ultra Script">Copier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒹ℯ𝒸ℯ𝓂𝒷𝓇ℯ</span>
+        <span class="cursive-word-label">décembre en cursive</span>
+        <button type="button" class="copy-btn" data-text="𝒹ℯ𝒸ℯ𝓂𝒷𝓇ℯ" data-style="Ultra Script">Copier</button>
       </div>
     </div>
-    <p class="u-mt-15">Astuce monogramme : combine deux initiales calligraphiées avec un séparateur discret — 𝓐·𝓜 ou ℰ ⋆ 𝒥 — et colle le résultat en nom de profil ou en signature.</p>
-  </section>
+    </section>
 
-  <!-- Prénom en calligraphie -->
-  <section class="editorial-section">
-    <h2>Un prénom en calligraphie, en trois secondes</h2>
-    <p class="editorial-intro">Le cas d'usage préféré de cette page : <strong>calligraphier un prénom</strong> pour une bio, un cadeau personnalisé, une story d'anniversaire ou un pseudo. Tape le prénom en haut, choisis la cursive qui lui va, ajoute une touche de déco.</p>
-    <div class="block-example">
-      <strong>Exemples :</strong> Emma → ✧ 𝓔𝓶𝓶𝓪 ✧ &nbsp;·&nbsp; Lucas → 𝓛𝓾𝓬𝓪𝓼 ࿐ &nbsp;·&nbsp; Manon → ♡ 𝓜𝓪𝓷𝓸𝓷 ♡ &nbsp;·&nbsp; Chloé → 𝒞𝒽𝓁ℴ𝑒 ⋆
+    <!-- 5. Names & signatures -->
+    <section id="cursive-names" aria-labelledby="cursiveNamesHeading">
+      <h2 class="bubble-az-heading" id="cursiveNamesHeading">Générateur de prénom &amp; signature en cursive</h2>
+      <p class="bubble-az-intro">Tape un prénom — ou un nom complet — et conçois ta signature en cursive :
+        choisis une fioriture, décide comment les initiales du monogramme se relient, puis copie le texte ou télécharge-le en PNG
+        pour tes signatures d'e-mail, filigranes et documents.</p>
+      <div class="cursive-name-tool">
+        <div class="input-wrapper">
+          <input type="text" class="main-input cursive-name-input" id="cursiveNameInput" placeholder="Tape un prénom… ex. Louise Marie" maxlength="60">
+        </div>
+        <div class="cursive-sig-controls" id="cursiveSignatureControls"></div>
+        <div class="results-grid" id="cursiveNameResults"></div>
+      </div>
+    <h3>Prénoms populaires en cursive</h3>
+    <p class="bubble-az-intro">Touche un prénom pour le charger dans le studio ci-dessus et le restyler avec des fioritures.</p>
+    <div class="cursive-word-grid">
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Charger Emma dans le studio de signature" data-name="Emma">
+        <span class="cursive-word-render">𝓔𝓶𝓶𝓪</span>
+        <span class="cursive-word-label">Emma en cursive</span>
+        <button type="button" class="copy-btn" data-text="𝓔𝓶𝓶𝓪" data-style="Ultra Script Bold">Copier</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Charger Louise dans le studio de signature" data-name="Louise">
+        <span class="cursive-word-render">𝓛𝓸𝓾𝓲𝓼𝓮</span>
+        <span class="cursive-word-label">Louise en cursive</span>
+        <button type="button" class="copy-btn" data-text="𝓛𝓸𝓾𝓲𝓼𝓮" data-style="Ultra Script Bold">Copier</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Charger Jade dans le studio de signature" data-name="Jade">
+        <span class="cursive-word-render">𝓙𝓪𝓭𝓮</span>
+        <span class="cursive-word-label">Jade en cursive</span>
+        <button type="button" class="copy-btn" data-text="𝓙𝓪𝓭𝓮" data-style="Ultra Script Bold">Copier</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Charger Alice dans le studio de signature" data-name="Alice">
+        <span class="cursive-word-render">𝓐𝓵𝓲𝓬𝓮</span>
+        <span class="cursive-word-label">Alice en cursive</span>
+        <button type="button" class="copy-btn" data-text="𝓐𝓵𝓲𝓬𝓮" data-style="Ultra Script Bold">Copier</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Charger Chloe dans le studio de signature" data-name="Chloe">
+        <span class="cursive-word-render">𝓒𝓱𝓵𝓸𝓮</span>
+        <span class="cursive-word-label">Chloé en cursive</span>
+        <button type="button" class="copy-btn" data-text="𝓒𝓱𝓵𝓸𝓮" data-style="Ultra Script Bold">Copier</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Charger Lea dans le studio de signature" data-name="Lea">
+        <span class="cursive-word-render">𝓛𝓮𝓪</span>
+        <span class="cursive-word-label">Léa en cursive</span>
+        <button type="button" class="copy-btn" data-text="𝓛𝓮𝓪" data-style="Ultra Script Bold">Copier</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Charger Gabriel dans le studio de signature" data-name="Gabriel">
+        <span class="cursive-word-render">𝓖𝓪𝓫𝓻𝓲𝓮𝓵</span>
+        <span class="cursive-word-label">Gabriel en cursive</span>
+        <button type="button" class="copy-btn" data-text="𝓖𝓪𝓫𝓻𝓲𝓮𝓵" data-style="Ultra Script Bold">Copier</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Charger Louis dans le studio de signature" data-name="Louis">
+        <span class="cursive-word-render">𝓛𝓸𝓾𝓲𝓼</span>
+        <span class="cursive-word-label">Louis en cursive</span>
+        <button type="button" class="copy-btn" data-text="𝓛𝓸𝓾𝓲𝓼" data-style="Ultra Script Bold">Copier</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Charger Raphael dans le studio de signature" data-name="Raphael">
+        <span class="cursive-word-render">𝓡𝓪𝓹𝓱𝓪𝓮𝓵</span>
+        <span class="cursive-word-label">Raphaël en cursive</span>
+        <button type="button" class="copy-btn" data-text="𝓡𝓪𝓹𝓱𝓪𝓮𝓵" data-style="Ultra Script Bold">Copier</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Charger Arthur dans le studio de signature" data-name="Arthur">
+        <span class="cursive-word-render">𝓐𝓻𝓽𝓱𝓾𝓻</span>
+        <span class="cursive-word-label">Arthur en cursive</span>
+        <button type="button" class="copy-btn" data-text="𝓐𝓻𝓽𝓱𝓾𝓻" data-style="Ultra Script Bold">Copier</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Charger Jules dans le studio de signature" data-name="Jules">
+        <span class="cursive-word-render">𝓙𝓾𝓵𝓮𝓼</span>
+        <span class="cursive-word-label">Jules en cursive</span>
+        <button type="button" class="copy-btn" data-text="𝓙𝓾𝓵𝓮𝓼" data-style="Ultra Script Bold">Copier</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Charger Adam dans le studio de signature" data-name="Adam">
+        <span class="cursive-word-render">𝓐𝓭𝓪𝓶</span>
+        <span class="cursive-word-label">Adam en cursive</span>
+        <button type="button" class="copy-btn" data-text="𝓐𝓭𝓪𝓶" data-style="Ultra Script Bold">Copier</button>
+      </div>
     </div>
-    <p>Pour les prénoms accentués (Chloé, Éva, Noé…), écris-les sans accent si tu veux que chaque lettre soit calligraphiée — sinon l'accent reste en lettre droite au milieu du mot. Et pour entourer le prénom de cœurs, d'étoiles ou de cadres, pioche dans les <a href="/fr/library/symboles/">symboles à copier-coller</a>.</p>
-  </section>
+    </section>
 
-  <!-- Related -->
-  <section class="editorial-section">
-    <h2>Écriture cursive pour un tatouage</h2>
-    <p class="editorial-intro">La cursive est le style le plus demandé pour les prénoms et les citations tatoués — fluide, intemporelle, lisible même en petit. Tape ton prénom en haut de la page, compare la cursive fine et la cursive grasse, et fais une capture pour ton tatoueur.</p>
-    <p>Pour comparer la cursive avec le gothique, l'italique et la machine à écrire côte à côte, va sur la page <a href="/fr/usecase/ecriture-tatouage/">style d'écriture tatouage</a> — elle est faite exactement pour ça.</p>
-  </section>
+    <!-- Editorial -->
+    <section class="editorial-section cursive-editorial">
+      <h2>Comment fonctionne ce générateur d'écriture cursive</h2>
+      <p>L'écriture cursive que tu vois ici n'est pas une police — ce sont des <strong>caractères script Unicode</strong>, la même norme que ton appareil utilise pour chaque lettre et chaque emoji. C'est pour ça qu'elle survit au copier-coller : les applis traitent 𝒸𝓊𝓇𝓈𝒾𝓋ℯ exactement comme du texte normal. C'est aussi pour ça qu'elle marche là où tu ne pourrais jamais installer de police — bios Instagram, légendes TikTok, pseudos Discord, commentaires YouTube. Envie de comprendre les coulisses ? Lis <a href="/guide/how-unicode-fonts-work/">comment fonctionnent les polices Unicode</a> (en anglais).</p>
 
-  <section class="editorial-section">
-    <h2>D'autres styles à copier</h2>
-    <div class="compare-grid">
-      <a href="/fr/calligraphie/" class="compare-card variant-muted u-no-underline">
-        <h4>Calligraphie en Ligne</h4>
-        <p>La calligraphie sans plume ni encre — alphabet complet et lettres seules.</p>
-      </a>
-      <a href="/fr/belle-ecriture/" class="compare-card variant-muted u-no-underline">
-        <h4>Belle Écriture</h4>
-        <p>Les plus jolies écritures à copier-coller, pour Insta et au-delà.</p>
-      </a>
-      <a href="/fr/ecriture-italique/" class="compare-card variant-muted u-no-underline">
-        <h4>Écriture Italique</h4>
-        <p>Le penché typographique, sobre et lisible.</p>
-      </a>
-      <a href="/fr/police-d-ecriture/" class="compare-card variant-muted u-no-underline">
-        <h4>Police d'Écriture</h4>
-        <p>Tous les styles sur une seule page — gras, gothique, bubble…</p>
-      </a>
-      <a href="/fr/police-instagram/" class="compare-card variant-muted u-no-underline">
-        <h4>Police Instagram</h4>
-        <p>Les cursives qui rendent le mieux dans une bio Insta.</p>
-      </a>
+      <h3>Où l'écriture cursive marche (et où elle casse)</h3>
+      <ul class="compat-list">
+        <li><span class="ts-pill-safe">Marche</span> Bios &amp; légendes Instagram, légendes TikTok, Discord, WhatsApp, Facebook, X, commentaires YouTube et la plupart des documents.</li>
+        <li><span class="ts-pill-risk">Limité</span> Les champs de nom d'utilisateur et de pseudo (Instagram, la plupart des jeux) suppriment souvent les caractères script — garde tes identifiants en texte simple.</li>
+        <li><span class="ts-pill-risk">Limité</span> Quelques vieux appareils affichent des carrés vides (▯). Si ça arrive, utilise un style plus simple ou moins d'accents — vois <a href="/guide/why-fonts-show-as-boxes/">pourquoi les polices s'affichent en carrés</a> (en anglais).</li>
+      </ul>
+
+      <h3>Cursive Unicode ou vraie police cursive</h3>
+      <p>Utilise la cursive Unicode quand tu as besoin de lettres cursives <em>dans un champ de texte</em> — profils sociaux, discussions, titres de vidéos. Utilise une vraie police cursive (dans Word, Canva ou ton outil de design) quand tu contrôles le document et qu'il te faut un crénage de qualité impression. Les deux ont leur place ; cet outil couvre le premier besoin.</p>
+
+      <h3>Accents français &amp;amp; caractères spéciaux</h3>
+      <p>Les lettres script Unicode n'existent que pour l'alphabet latin de base A–Z. Les caractères accentués — é, è, à, ç, ê, ù, ë — n'ont pas d'équivalent cursif et passent sans être transformés, ce qui casse le mot. Pour un rendu 100 % en lettres attachées, écris tes prénoms et tes mots sans accents (Chloé → Chloe, Léa → Lea, béni → beni) : la version cursive reste fluide et lisible. Notre <a href="#cursive-alphabet">fiche d'écriture à imprimer</a> couvre justement l'alphabet A–Z.</p>
+
+      <h3>Apprendre l'écriture cursive à la main</h3>
+      <p>Les générateurs servent au texte numérique, mais ils font aussi de bonnes fiches de référence. Imprime la <a href="#cursive-alphabet">fiche d'écriture</a> pour t'entraîner à tracer, observe comment chaque majuscule cursive se relie dans l'<a href="#cursive-letters">explorateur de lettres</a>, et garde en tête les bons réflexes d'accessibilité — de courtes touches décoratives, du texte simple pour le reste (<a href="/guide/fancy-fonts-accessibility-guide/">guide d'accessibilité</a>, en anglais).</p>
+
+      <h3>L'écriture cursive pour les tatouages</h3>
+      <p>Le lettrage script est le style de tatouage le plus demandé. Prévisualise ton mot ici en grand, puis passe au <a href="/fr/usecase/ecriture-tatouage/">générateur d'écriture pour tatouage</a> dédié — il ajoute des familles de lettrage, les dates en chiffres romains, les initiales et un test de lisibilité à la taille de l'encre.</p>
+    </section>
+
+    <div class="cta-card">
+      <h3>Fais couler toute ta bio</h3>
+      <p>Associe un titre en écriture cursive à un texte de corps net — la combinaison qui attire l'œil tout en restant lisible.</p>
+      <a class="cta-btn" href="/fr/">Ouvrir le générateur complet →</a>
     </div>
-  </section>
-</main>
+  </main>
 
-<footer class="footer">
-  <div class="footer-inner">
-    <h2 class="faq-category">Questions sur l'écriture cursive</h2>
-    <div class="faq-item"><button class="faq-question" type="button">Comment écrire en calligraphie sur un clavier ?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Pas besoin de plume : tape ton texte dans le générateur en haut de la page, et il ressort aussitôt en calligraphie Unicode — cursive légère (𝒸𝓊𝓇𝓈𝒾𝓋𝑒), cursive pleine (𝓬𝓾𝓻𝓼𝓲𝓿𝓮) et italique. Copie la version qui te plaît et colle-la dans ta bio, un message ou un pseudo. Ça fonctionne sur téléphone comme sur ordinateur.</div></div>
-    <div class="faq-item"><button class="faq-question" type="button">Quelle différence entre cursive, script et manuscrite ?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Dans l'usage courant, les trois mots désignent des lettres au tracé fluide, inspiré de l'écriture à la main. La «cursive» évoque les lettres attachées apprises à l'école, le «script» est le terme typographique pour ces polices fluides, et la «manuscrite» insiste sur l'effet écrit-à-la-main. Côté Unicode, tout passe par les mêmes jeux de caractères script — cette page les regroupe tous.</div></div>
-    <div class="faq-item"><button class="faq-question" type="button">Comment avoir une belle majuscule en calligraphie ?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">La section «Majuscules calligraphiées» de cette page liste les 26 lettres capitales une par une — clique sur une lettre pour la copier seule. Pratique pour une initiale décorée, un monogramme ou la première lettre d'un prénom : 𝓔 pour Emma, 𝓛 pour Lucas, 𝓜 pour Manon.</div></div>
-    <div class="faq-item"><button class="faq-question" type="button">L'écriture cursive marche-t-elle sur Instagram et WhatsApp ?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Oui. Les lettres cursives de cette page sont des caractères Unicode : elles s'affichent dans une bio Instagram, un statut ou un nom WhatsApp, une légende TikTok, un pseudo Discord — partout où on peut coller du texte. Aucune application ni police à installer.</div></div>
-    <div class="faq-item"><button class="faq-question" type="button">Les accents français passent-ils en cursive ?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Partiellement. Les jeux cursifs d'Unicode couvrent l'alphabet latin de base : é, è, à ou ç restent en lettres droites au milieu du mot. Pour un prénom 100 % calligraphié, écris-le sans accents : «Chloé» → Chloe → 𝓒𝓱𝓵𝓸𝓮. Avec accents, le reste du mot est calligraphié et le prénom reste très lisible.</div></div>
+  <!-- Footer + FAQ -->
+  <footer class="footer">
+    <div class="footer-inner">
+<div class="faq-section" id="cursive-faq">
+
+<h2 class="faq-category">Générateur d'Écriture Cursive — FAQ</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Qu'est-ce qu'un générateur d'écriture cursive et comment ça marche ?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Il convertit les lettres que tu tapes en caractères script Unicode — des symboles spéciaux qui ressemblent à de l'écriture cursive manuscrite mais se comportent comme du texte normal. Comme ce sont de vrais caractères (pas une police ni une image), tu peux les copier et les coller dans tes bios, légendes, commentaires et messages, et ils gardent leur look cursif. Plus de détails dans notre <a href="/guide/how-unicode-fonts-work/">guide sur le fonctionnement des polices Unicode</a> (en anglais).
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Comment copier-coller de l'écriture cursive ?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Tape ou colle ton texte dans le champ en haut, puis appuie sur Copier sur le style qui te plaît. La version cursive est maintenant dans ton presse-papiers : colle-la partout où le texte est accepté — Instagram, TikTok, WhatsApp, Discord, documents, et plus encore.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    L'écriture cursive marche-t-elle sur Instagram, WhatsApp et TikTok ?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Oui. Les bios et légendes Instagram, les statuts et messages WhatsApp et les légendes TikTok acceptent les caractères script Unicode, donc ta <strong>police cursive</strong> reste intacte. Seule exception fréquente : les champs de pseudo/nom d'utilisateur, qui filtrent souvent ces caractères — garde-les en texte simple.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Les accents (é, à, ç) fonctionnent-ils en cursive ?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Non. Unicode ne propose des lettres script que pour l'alphabet latin de base A–Z, donc les lettres accentuées passent sans être converties et cassent le mot. Pour un rendu entièrement en lettres attachées, écris tes prénoms et mots sans accents : <strong>Chloé → Chloe</strong>, <strong>Léa → Lea</strong>, <strong>béni → beni</strong>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Le générateur d'écriture cursive est-il gratuit ?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Oui, à 100 %. Aucun compte, aucune inscription, aucune limite : tape, copie et colle autant de <strong>lettres cursives</strong> que tu veux, gratuitement.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Puis-je créer une signature avec mon prénom en cursive ?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Oui. Tape ton prénom ou ton nom complet dans le <a href="#mainInput">studio de prénoms</a>, choisis une fioriture, ajuste la liaison des initiales du monogramme, puis copie le texte ou télécharge-le en PNG pour tes signatures d'e-mail, filigranes et documents.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Puis-je obtenir une seule lettre cursive, comme un S ou un G majuscule ?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Oui. Ouvre l'<a href="#cursive-letters">explorateur de lettres A–Z</a>, touche la lettre voulue et vois-la dans chaque style, en majuscule et en minuscule. Copie le glyphe exact ou télécharge-le en PNG.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    L'écriture cursive convient-elle à un tatouage ?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Le lettrage script est le style de tatouage le plus demandé. Prévisualise ton mot ici, puis affine-le avec le <a href="/fr/usecase/ecriture-tatouage/">générateur d'écriture pour tatouage</a>, qui ajoute des familles de lettrage, les dates en chiffres romains et un test de lisibilité.
+  </div>
+</div>
+
+</div>
 
     <!-- Language Switcher -->
-    <div class="lang-switcher" role="navigation" aria-label="Sélecteur de langue">
+    <div class="lang-switcher" role="navigation" aria-label="Language switcher">
       <a class="lang-option" href="/category/cursive-fonts/" hreflang="en">EN</a>
-      <a class="lang-option active" href="/fr/ecriture-cursive/" hreflang="fr">FR</a>
-      <a class="lang-option" href="/id/tulisan-sambung/" hreflang="id">ID</a>
-      <a class="lang-option" href="/nl/sierlijke-letters/" hreflang="nl">NL</a>
+      <a class="lang-option" href="/es/letra-cursiva/" hreflang="es">ES</a>
       <a class="lang-option" href="/pt/letra-cursiva/" hreflang="pt">PT</a>
+      <a class="lang-option active" href="/fr/ecriture-cursive/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/de/schreibschrift/" hreflang="de">DE</a>
+      <a class="lang-option" href="/it/lettere-in-corsivo/" hreflang="it">IT</a>
       <a class="lang-option" href="/tr/el-yazisi-fontu/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/nl/cursieve-letters/" hreflang="nl">NL</a>
+      <a class="lang-option" href="/id/tulisan-sambung/" hreflang="id">ID</a>
       <a class="lang-option" href="/no/kursiv-tekst/" hreflang="no">NO</a>
     </div>
-  </div>
-</footer>
 
-<div class="copy-toast" id="copyToast">Copié !</div>
-<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+    </div>
+  </footer>
 
-<script>window.UTG_FAMILY = "cursive";</script>
-<script src="/styles.js"></script>
-<script src="/renderer.js"></script>
-<script src="/script.js" defer=""></script>
-<script src="/symbol-explorer.js"></script>
-<script src="/accent-notice.js" defer></script>
-<script src="/footer.js"></script>
+  <div id="cursivePrintRoot" aria-hidden="true"></div>
+  <div class="copy-toast" id="copyToast">Copié !</div>
+
+  <script>
+    window.UTG_CURSIVE_MODE = true;
+    window.UTG_FAMILY = "cursive";
+    window.cursiveI18n = {
+  "demoText": "Bonjour",
+  "demoName": "Louise",
+  "copy": "Copier",
+  "typeFirst": "Tape d'abord ton texte ci-dessus",
+  "downloadPngTitle": "Télécharger en image PNG",
+  "downloadPng": "Télécharger le PNG",
+  "characters": "caractères",
+  "caseUpper": "Majuscule",
+  "caseLower": "Minuscule",
+  "caseBoth": "Les deux",
+  "labelUpper": "{ch} majuscule en cursive",
+  "labelLower": "{ch} minuscule en cursive",
+  "labelBoth": "{ch} majuscule et minuscule en cursive",
+  "copyBoth": "Copier les deux",
+  "everyStyle": "{ch} en cursive — tous les styles, clique pour copier",
+  "suffixCapital": " — majuscule",
+  "suffixLowercase": " — minuscule",
+  "accentLabel": "Accent {name}",
+  "practiceTitle": "Fiche d'écriture cursive — ultratextgen.com",
+  "flourishLabel": "Fioriture",
+  "monogramLabel": "Liaison de monogramme",
+  "copiedToast": "Copié !",
+  "quickWords": [
+    "amour",
+    "famille",
+    "merci",
+    "toujours",
+    "bonheur",
+    "bisous"
+  ],
+  "styles": {
+    "Ultra Script": "cursive classique",
+    "Ultra Script Bold": "cursive pleine",
+    "Ultra Script Elegant": "cursive élégante",
+    "Ultra Script Bold Elegant": "cursive pleine élégante",
+    "Ultra Gothic Script": "cursive gothique",
+    "Ultra Chicano Script": "plaque Chicano",
+    "Ultra Script Sparkle": "cursive étincelante"
+  },
+  "presets": {
+    "Script Hearts": "Cursive cœurs",
+    "Script Arrow Bio": "Cursive bio flèche",
+    "Bold Script Stars": "Cursive pleine étoiles",
+    "Script Vintage": "Cursive vintage",
+    "Script Soft Dots": "Cursive points doux",
+    "Bold Script Ribbon": "Cursive pleine ruban",
+    "Script Underline": "Cursive soulignée",
+    "Bold Script Crown": "Cursive pleine couronne"
+  },
+  "signatures": {
+    "Classic Signature": "Signature classique",
+    "Bold Signature": "Signature pleine",
+    "Signed Underline": "Signature soulignée",
+    "Sparkle Signature": "Signature étincelante",
+    "Ornate Nameplate": "Plaque ornée",
+    "Autograph Star": "Autographe étoile",
+    "Monogram Initials": "Initiales monogramme",
+    "Gothic Signature": "Signature gothique"
+  },
+  "decorators": {
+    "None": "Aucun",
+    "Underline": "Souligné",
+    "Sparkle": "Étincelles",
+    "Hearts": "Cœurs",
+    "Ornate": "Orné",
+    "Soft dots": "Points doux"
+  },
+  "accents": {
+    "Sparkle": "Étincelles",
+    "Hearts": "Cœurs",
+    "Wings": "Ailes",
+    "Ornate": "Orné"
+  },
+  "platformLimits": {
+    "Instagram bio": "Bio Instagram",
+    "TikTok bio": "Bio TikTok",
+    "X bio": "Bio X"
+  }
+};
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/js/cursive/cursiveData.js" defer></script>
+  <script src="/script.js" defer></script>
+  <script src="/js/cursive/cursivePageController.js" defer></script>
+  <script src="/footer.js" defer></script>
 </body></html>

--- a/id/tulisan-sambung/index.html
+++ b/id/tulisan-sambung/index.html
@@ -6,27 +6,30 @@
   'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
   })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
   <!-- End Google Tag Manager -->
-  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZGVh");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
   <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Tulisan Sambung &amp; Tulisan Latin (𝒞𝓊𝓇𝓈𝒾𝓋𝑒) — Generator Copy Paste | UltraTextGen</title>
-  <meta name="description" content="Bikin tulisan sambung, tulisan latin, huruf sambung, dan font sambung (𝓬𝓾𝓻𝓼𝓲𝓿𝓮) buat undangan, bio IG, status WA, &amp; caption. Ketik, salin, tempel — gratis, tanpa aplikasi.">
+  <title>Generator Tulisan Sambung — 𝓬𝓸𝓹𝔂 𝓹𝓪𝓼𝓽𝓮 Font Tulisan, Huruf A–Z &amp; Nama | UltraTextGen</title>
+  <meta name="description" content="Generator tulisan sambung gratis — copy paste font tulisan latin, semua huruf sambung A–Z, alfabet lengkap, kata-kata populer, dan tanda tangan nama dalam tulisan keren.">
   <link rel="canonical" href="https://ultratextgen.com/id/tulisan-sambung/">
 
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/category/cursive-fonts/">
-  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/ecriture-cursive/">
-  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/tulisan-sambung/">
-  <link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/sierlijke-letters/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/letra-cursiva/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/letra-cursiva/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/ecriture-cursive/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/schreibschrift/">
+  <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/lettere-in-corsivo/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/el-yazisi-fontu/">
+  <link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/cursieve-letters/">
+  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/tulisan-sambung/">
   <link rel="alternate" hreflang="no" href="https://ultratextgen.com/no/kursiv-tekst/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/category/cursive-fonts/">
 
   <meta name="robots" content="index, follow">
   <meta property="og:site_name" content="UltraTextGen">
-  <meta property="og:title" content="Tulisan Sambung &amp; Tulisan Latin (𝒞𝓊𝓇𝓈𝒾𝓋𝑒) — Generator Copy Paste">
-  <meta property="og:description" content="Bikin tulisan sambung, tulisan latin, dan huruf sambung buat undangan, bio IG, &amp; status WA. Salin-tempel, gratis.">
+  <meta property="og:title" content="Generator Tulisan Sambung — 𝓬𝓸𝓹𝔂 𝓹𝓪𝓼𝓽𝓮 Font Tulisan, Huruf A–Z &amp; Nama | UltraTextGen">
+  <meta property="og:description" content="Generator tulisan sambung gratis — copy paste font tulisan latin, semua huruf sambung A–Z, alfabet lengkap, kata populer, dan tanda tangan nama dalam tulisan keren.">
   <meta property="og:url" content="https://ultratextgen.com/id/tulisan-sambung/">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://ultratextgen.com/assets/og/category-cursive-fonts.png">
@@ -34,8 +37,8 @@
   <meta property="og:image:height" content="630">
   <meta property="og:image:type" content="image/png">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Tulisan Sambung &amp; Tulisan Latin (𝒞𝓊𝓇𝓈𝒾𝓋𝑒) — Copy Paste">
-  <meta name="twitter:description" content="Salin tulisan sambung &amp; tulisan latin dalam sekali klik.">
+  <meta name="twitter:title" content="Generator Tulisan Sambung — 𝓬𝓸𝓹𝔂 𝓹𝓪𝓼𝓽𝓮 Font Tulisan, Huruf A–Z &amp; Nama | UltraTextGen">
+  <meta name="twitter:description" content="Generator tulisan sambung gratis — copy paste font tulisan latin, huruf sambung A–Z, alfabet lengkap, dan tanda tangan nama dalam tulisan keren.">
   <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category-cursive-fonts.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -45,48 +48,72 @@
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
-  "@type": "WebApplication",
-  "name": "Generator Tulisan Sambung",
-  "alternateName": ["Generator Tulisan Sambung", "Generator Tulisan Latin", "Huruf Sambung Copy Paste", "Font Sambung", "Cursive Text Generator"],
-  "url": "https://ultratextgen.com/id/tulisan-sambung/",
-  "inLanguage": "id",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "description": "Generator tulisan sambung, tulisan latin, dan huruf sambung (cursive Unicode) yang siap copy paste ke undangan digital, bio, caption, dan status.",
-  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
-}
-</script>
-
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
   "@type": "FAQPage",
   "inLanguage": "id",
   "mainEntity": [
     {
       "@type": "Question",
-      "name": "Apa itu tulisan sambung dan tulisan latin?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Di internet, tulisan sambung atau tulisan latin biasanya merujuk ke huruf gaya kaligrafi versi Unicode — misalnya 𝓪𝓫𝓬 (script tebal) atau 𝒶𝒷𝒸 (script ringan). Tiap hurufnya adalah karakter tersendiri yang memang digambar menyambung, jadi gayanya ikut kebawa waktu kamu salin-tempel ke bio, undangan digital, caption, atau status — beda sama font yang cuma ke-install di Word." }
+      "name": "Apa itu generator tulisan sambung dan bagaimana cara kerjanya?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Alat ini mengubah huruf yang kamu ketik jadi karakter script Unicode — simbol khusus yang tampak seperti tulisan tangan menyambung tapi berperilaku seperti teks biasa. Karena benar-benar karakter (bukan font atau gambar), kamu bisa menyalin dan menempelnya ke bio, caption, komentar, dan pesan, dan gaya sambungnya tetap terjaga. Selengkapnya di <a href=\"/guide/how-unicode-fonts-work/\">panduan cara kerja font Unicode</a>."
+      }
     },
     {
       "@type": "Question",
-      "name": "Font sambung bisa dipakai di mana aja?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Hampir di semua tempat yang nerima teks: bio dan nama tampilan IG, status dan nama profil WA, caption TikTok, undangan digital, Telegram, Facebook, sampai nickname game. Yang gak bisa cuma kolom username (@) karena cuma nerima huruf biasa, angka, titik, dan garis bawah." }
+      "name": "Bagaimana cara copy paste tulisan sambung?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ketik atau tempel teksmu di kotak paling atas, lalu tekan Salin pada gaya yang kamu suka. Versi tulisan sambungnya kini ada di clipboard — tempel di mana saja yang menerima teks: Instagram, TikTok, WhatsApp, Discord, dokumen, dan lainnya."
+      }
     },
     {
       "@type": "Question",
-      "name": "Apa bedanya sama huruf tegak bersambung yang di sekolah?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Huruf tegak bersambung adalah cara menulis tangan yang diajarkan di SD — dilatih pakai buku halus, bukan di-copy paste. Halaman ini beda: ini generator font sambung digital, buat bikin teks bergaya kaligrafi yang bisa langsung disalin ke bio, undangan, dan caption. Jadi kalau kamu nyari materi latihan menulis halus, ini bukan tempatnya — tapi kalau mau nama atau kata terlihat menyambung indah di layar, ini dia." }
+      "name": "Apakah tulisan sambung berfungsi di Instagram, WhatsApp, dan TikTok?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ya. Tulisan sambung berfungsi di bio dan caption Instagram, status dan nama profil WhatsApp, serta caption dan bio TikTok. Cukup salin di sini lalu tempel. Satu-satunya tempat yang menolak adalah kolom username (@), yang hanya menerima huruf biasa, angka, titik, dan garis bawah."
+      }
     },
     {
       "@type": "Question",
-      "name": "Kenapa huruf sambungnya kadang jadi kotak-kotak?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Beberapa perangkat lama belum punya font sistem yang lengkap, jadi karakter langka bisa muncul sebagai kotak (□). Gaya paling aman adalah script tebal (𝓪𝓫𝓬) karena setnya lengkap dan didukung hampir semua HP. Script ringan (𝒶𝒷𝒸) sedikit lebih riskan karena beberapa hurufnya (ℯ, ℊ, ℴ) diambil dari blok Unicode yang lebih tua." }
+      "name": "Apakah generator tulisan sambung ini gratis?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Gratis sepenuhnya, tanpa daftar dan tanpa aplikasi. Ketik, salin, tempel sebanyak yang kamu mau langsung di browser."
+      }
     },
     {
       "@type": "Question",
-      "name": "Gratis dan tanpa aplikasi?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Gratis 100%, jalan langsung di browser, tanpa daftar dan tanpa install aplikasi. Tinggal ketik, pilih gaya tulisan sambung, salin, tempel." }
+      "name": "Apa beda tulisan sambung ini dengan huruf tegak bersambung di sekolah?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Huruf tegak bersambung adalah cara menulis tangan yang dilatih di SD pakai buku halus. Halaman ini adalah generator <strong>font tulisan sambung digital</strong>: bikin teks bergaya menyambung yang langsung bisa disalin ke bio, undangan, dan caption. Kalau kamu cari materi latihan menulis, ini bukan tempatnya — tapi kalau mau nama atau kata tampak menyambung indah di layar, ini pas."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Kenapa nama dengan karakter khusus terlihat rusak?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Karakter script Unicode hanya mencakup A–Z, a–z, dan 0–9. Bahasa Indonesia hampir seluruhnya ASCII jadi umumnya aman, tapi jika kamu menyisipkan simbol asing, aksen, atau tanda khusus, karakter itu tidak ikut berubah dan bisa terlihat janggal. Tulis nama pakai huruf biasa saja agar seluruhnya tampil menyambung sempurna."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Bisakah saya membuat tanda tangan nama dalam tulisan sambung?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Bisa. Ketik nama depan atau nama lengkap di studio tanda tangan, pilih hiasan, atur inisial monogram, lalu salin teksnya atau unduh sebagai PNG untuk footer email, watermark, dan dokumen."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Apakah tulisan sambung cocok untuk desain tato?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Sangat cocok — lettering script adalah gaya tato paling populer. Pratinjau katamu di sini, lalu buka <a href=\"/id/usecase/font-tato/\">generator font tato</a> untuk keluarga lettering, tanggal angka Romawi, dan uji keterbacaan ukuran tinta."
+      }
     }
   ]
 }
@@ -97,127 +124,725 @@
   "@context": "https://schema.org",
   "@type": "BreadcrumbList",
   "itemListElement": [
-    { "@type": "ListItem", "position": 1, "name": "Tulisan Aesthetic", "item": "https://ultratextgen.com/id/" },
+    { "@type": "ListItem", "position": 1, "name": "Beranda", "item": "https://ultratextgen.com/id/" },
     { "@type": "ListItem", "position": 2, "name": "Tulisan Sambung", "item": "https://ultratextgen.com/id/tulisan-sambung/" }
   ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Generator Tulisan Sambung",
+  "alternateName": ["Generator Tulisan Latin","Generator Font Tulisan","Huruf Sambung A–Z","Alfabet Tulisan Sambung","Generator Nama Tulisan Sambung","Generator Tanda Tangan","Tulisan Sambung Copy Paste"],
+  "url": "https://ultratextgen.com/id/tulisan-sambung/",
+  "inLanguage": "id",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "IDR"
+  },
+  "description": "Generator tulisan sambung gratis: copy paste font tulisan latin, semua huruf sambung A–Z, alfabet lengkap, kata-kata populer dalam tulisan keren, dan tanda tangan nama.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers.",
+  "featureList": ["Generator font tulisan sambung dengan preset hiasan","Penjelajah huruf sambung A–Z (kapital dan kecil)","Salin seluruh alfabet tulisan sambung sekali klik","Lembar latihan tulisan sambung siap cetak","Studio nama dan tanda tangan tulisan sambung","Galeri kata dalam tulisan sambung (cinta, ulang tahun, bulan)"]
 }
 </script>
 </head>
 <body>
   <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
   <!-- Google Tag Manager (noscript) -->
-  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <!-- End Google Tag Manager (noscript) -->
   <div id="shared-header"></div>
 <script src="/header.js" defer></script>
 
 <nav class="breadcrumbs" aria-label="Breadcrumb">
-  <a href="/id/">Tulisan Aesthetic</a>
+  <a href="/id/">Beranda</a>
   <span class="breadcrumb-separator">›</span>
   <span class="breadcrumb-current">Tulisan Sambung</span>
 </nav>
 
-<section class="hero">
-  <div class="hero-inner">
-    <div class="hero-card">
-      <h1 class="hero-headline">Generator Tulisan Sambung &amp; Tulisan Latin (𝓒𝓾𝓻𝓼𝓲𝓿𝓮)</h1>
-      <p class="hero-tagline">Ubah teks biasa jadi tulisan sambung, tulisan latin, dan font sambung Unicode yang siap copy paste ke undangan digital, bio IG, status WA, sampai caption TikTok — tanpa aplikasi.</p>
-      <div class="input-wrapper">
-        <textarea class="main-input" id="mainInput" placeholder="Ketik tulisanmu di sini..." maxlength="500" autofocus=""></textarea>
-        <span class="char-count"><span id="charCount">0</span>/500</span>
-      </div>
-      <div class="decoration-section">
-        <div class="decoration-label">Tambahin dekorasi ke hasil</div>
-        <div class="decoration-tabs">
-          <button class="decoration-tab active" data-deco-tab="symbols">Simbol</button>
-          <button class="decoration-tab" data-deco-tab="frames">Bingkai</button>
-          <button class="decoration-tab" data-deco-tab="minimal">Minimal</button>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/category-cursive-fonts.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+  <!-- Hero: the cursive-first generator -->
+  <section class="hero">
+    <div class="hero-inner">
+      <div class="hero-card">
+        <h1 class="hero-headline">Generator Tulisan Sambung</h1>
+        <p class="hero-tagline">Ubah teks apa pun jadi 𝓽𝓾𝓵𝓲𝓼𝓪𝓷 𝓼𝓪𝓶𝓫𝓾𝓷𝓰 yang bisa langsung copy paste — font tulisan latin mengalir,
+          semua huruf sambung A–Z, alfabet lengkap, dan tanda tangan nama. Gratis, instan, tanpa daftar.</p>
+        <div class="input-wrapper">
+          <textarea class="main-input" id="mainInput" placeholder="Ketik teks, kata, atau nama…" maxlength="500" autofocus></textarea>
+          <span class="char-count"><span id="charCount">0</span>/500</span>
         </div>
-        <div class="decoration-grid" id="decorationGrid"></div>
+        <div class="cursive-quick-row" id="cursiveQuickRow" aria-label="Contoh cepat"></div>
+        <div class="vertical-fit-row" id="cursiveFitRow" hidden></div>
       </div>
     </div>
+  </section>
+
+  <nav class="cursive-section-nav" aria-label="Di halaman ini">
+    <a href="#cursive-styles">Gaya</a>
+    <a href="#cursive-letters">Huruf A–Z</a>
+    <a href="#cursive-alphabet">Alfabet</a>
+    <a href="#cursive-words">Kata</a>
+    <a href="#cursive-names">Nama &amp; Tanda Tangan</a>
+    <a href="#cursive-faq">FAQ</a>
+  </nav>
+
+  <main class="container">
+
+    <!-- 1. Generator output -->
+    <section id="cursive-styles" aria-labelledby="cursiveStylesHeading">
+      <h2 class="bubble-az-heading" id="cursiveStylesHeading">Font tulisan sambung — copy paste</h2>
+      <p class="bubble-az-intro">Setiap gaya tulisan sambung di bawah berubah langsung saat kamu mengetik: script klasik dan tebal,
+        varian elegan berspasi, gothic-sambung, nameplate Chicano, dan preset hiasan dengan hati,
+        kilau, serta panah. Ketuk Salin lalu tempel di mana saja.</p>
+      <div class="results-grid" id="resultsGrid"></div>
+    </section>
+
+    <!-- 2. Cursive letters A–Z -->
+    <section class="bubble-az" id="cursive-letters" aria-labelledby="cursiveLettersHeading">
+      <h2 class="bubble-az-heading" id="cursiveLettersHeading">Huruf sambung A–Z — kapital &amp; kecil</h2>
+      <p class="bubble-az-intro">Cari satu huruf saja — huruf S sambung, huruf G kapital tulisan sambung, atau huruf f kecil?
+        Ketuk huruf mana pun untuk melihatnya di setiap gaya tulisan sambung, salin glif persisnya, atau unduh sebagai PNG.</p>
+  <div class="cursive-letter-grid" role="tablist" aria-label="Pilih huruf tulisan sambung">
+    <button type="button" class="cursive-letter-cell" id="cursive-a" data-char="A" aria-label="A dalam tulisan sambung — kapital dan kecil">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒜 𝒶</span>
+      <span class="cursive-letter-name">Sambung A</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-b" data-char="B" aria-label="B dalam tulisan sambung — kapital dan kecil">
+      <span class="cursive-letter-pair" aria-hidden="true">ℬ 𝒷</span>
+      <span class="cursive-letter-name">Sambung B</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-c" data-char="C" aria-label="C dalam tulisan sambung — kapital dan kecil">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒞 𝒸</span>
+      <span class="cursive-letter-name">Sambung C</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-d" data-char="D" aria-label="D dalam tulisan sambung — kapital dan kecil">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒟 𝒹</span>
+      <span class="cursive-letter-name">Sambung D</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-e" data-char="E" aria-label="E dalam tulisan sambung — kapital dan kecil">
+      <span class="cursive-letter-pair" aria-hidden="true">ℰ ℯ</span>
+      <span class="cursive-letter-name">Sambung E</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-f" data-char="F" aria-label="F dalam tulisan sambung — kapital dan kecil">
+      <span class="cursive-letter-pair" aria-hidden="true">ℱ 𝒻</span>
+      <span class="cursive-letter-name">Sambung F</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-g" data-char="G" aria-label="G dalam tulisan sambung — kapital dan kecil">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒢 ℊ</span>
+      <span class="cursive-letter-name">Sambung G</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-h" data-char="H" aria-label="H dalam tulisan sambung — kapital dan kecil">
+      <span class="cursive-letter-pair" aria-hidden="true">ℋ 𝒽</span>
+      <span class="cursive-letter-name">Sambung H</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-i" data-char="I" aria-label="I dalam tulisan sambung — kapital dan kecil">
+      <span class="cursive-letter-pair" aria-hidden="true">ℐ 𝒾</span>
+      <span class="cursive-letter-name">Sambung I</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-j" data-char="J" aria-label="J dalam tulisan sambung — kapital dan kecil">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒥 𝒿</span>
+      <span class="cursive-letter-name">Sambung J</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-k" data-char="K" aria-label="K dalam tulisan sambung — kapital dan kecil">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒦 𝓀</span>
+      <span class="cursive-letter-name">Sambung K</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-l" data-char="L" aria-label="L dalam tulisan sambung — kapital dan kecil">
+      <span class="cursive-letter-pair" aria-hidden="true">ℒ 𝓁</span>
+      <span class="cursive-letter-name">Sambung L</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-m" data-char="M" aria-label="M dalam tulisan sambung — kapital dan kecil">
+      <span class="cursive-letter-pair" aria-hidden="true">ℳ 𝓂</span>
+      <span class="cursive-letter-name">Sambung M</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-n" data-char="N" aria-label="N dalam tulisan sambung — kapital dan kecil">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒩 𝓃</span>
+      <span class="cursive-letter-name">Sambung N</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-o" data-char="O" aria-label="O dalam tulisan sambung — kapital dan kecil">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒪 ℴ</span>
+      <span class="cursive-letter-name">Sambung O</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-p" data-char="P" aria-label="P dalam tulisan sambung — kapital dan kecil">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒫 𝓅</span>
+      <span class="cursive-letter-name">Sambung P</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-q" data-char="Q" aria-label="Q dalam tulisan sambung — kapital dan kecil">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒬 𝓆</span>
+      <span class="cursive-letter-name">Sambung Q</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-r" data-char="R" aria-label="R dalam tulisan sambung — kapital dan kecil">
+      <span class="cursive-letter-pair" aria-hidden="true">ℛ 𝓇</span>
+      <span class="cursive-letter-name">Sambung R</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-s" data-char="S" aria-label="S dalam tulisan sambung — kapital dan kecil">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒮 𝓈</span>
+      <span class="cursive-letter-name">Sambung S</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-t" data-char="T" aria-label="T dalam tulisan sambung — kapital dan kecil">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒯 𝓉</span>
+      <span class="cursive-letter-name">Sambung T</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-u" data-char="U" aria-label="U dalam tulisan sambung — kapital dan kecil">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒰 𝓊</span>
+      <span class="cursive-letter-name">Sambung U</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-v" data-char="V" aria-label="V dalam tulisan sambung — kapital dan kecil">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒱 𝓋</span>
+      <span class="cursive-letter-name">Sambung V</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-w" data-char="W" aria-label="W dalam tulisan sambung — kapital dan kecil">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒲 𝓌</span>
+      <span class="cursive-letter-name">Sambung W</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-x" data-char="X" aria-label="X dalam tulisan sambung — kapital dan kecil">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒳 𝓍</span>
+      <span class="cursive-letter-name">Sambung X</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-y" data-char="Y" aria-label="Y dalam tulisan sambung — kapital dan kecil">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒴 𝓎</span>
+      <span class="cursive-letter-name">Sambung Y</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-z" data-char="Z" aria-label="Z dalam tulisan sambung — kapital dan kecil">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒵 𝓏</span>
+      <span class="cursive-letter-name">Sambung Z</span>
+    </button>
   </div>
-</section>
+      <div class="cursive-letter-panel" id="cursiveLetterPanel" aria-live="polite"></div>
+    </section>
 
-<main class="container">
-  <div class="category-section"><div class="category-tabs" id="categoryTabs"></div></div>
-  <div class="results-grid" id="resultsGrid"></div>
-
-  <!-- Apa itu tulisan sambung -->
-  <section class="editorial-section">
-    <h2>Tulisan Sambung Unicode: Kaligrafi yang Bisa Di-copy Paste</h2>
-    <p class="editorial-intro">Font kaligrafi yang kamu install di Word cuma kelihatan di komputermu sendiri — begitu teksnya dikirim ke orang lain, gayanya hilang. Tulisan sambung di halaman ini beda: tiap huruf adalah <strong>karakter Unicode tersendiri</strong> yang memang digambar menyambung, jadi ke mana pun kamu tempel, tetap 𝓶𝓮𝓷𝔂𝓪𝓶𝓫𝓾𝓷𝓰 𝓲𝓷𝓭𝓪𝓱.</p>
-    <p>Gaya font sambung yang paling sering dipakai:</p>
-    <ul class="u-mt-15">
-      <li><strong>Script tebal</strong> — kaligrafi penuh dan tegas: 𝓱𝓪𝓵𝓸 𝓭𝓾𝓷𝓲𝓪. Paling aman dan paling gampang dibaca di ukuran kecil.</li>
-      <li><strong>Script ringan</strong> — kaligrafi tipis dan anggun: 𝒽𝒶𝓁ℴ 𝒹𝓊𝓃𝒾𝒶. Cantik buat bio dan undangan.</li>
-      <li><strong>Italic serif</strong> — miring bergaya tulisan tangan rapi: ℎ𝑎𝑙𝑜 𝑑𝑢𝑛𝑖𝑎. Buat kesan literer yang kalem.</li>
-    </ul>
-  </section>
-
-  <!-- Huruf sambung A-Z -->
-  <section class="editorial-section glyph-section">
-    <h2>Huruf Sambung A–Z (Script Tebal &amp; Script Ringan)</h2>
-    <p class="editorial-intro">Butuh huruf latin satu-satu buat inisial, monogram, atau hiasan? Ini abjad lengkapnya dalam dua gaya sambung paling populer. Klik satu baris buat nyalin seluruh alfabetnya sekaligus.</p>
-    <div class="alpha-list">
-      <div class="alpha-row">
-        <span class="alpha-label">Script Tebal</span>
-        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩 𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃" aria-label="Salin huruf sambung gaya Script Tebal">𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩 · 𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃</button>
+    <!-- 3. The cursive alphabet -->
+    <section id="cursive-alphabet" aria-labelledby="cursiveAlphabetHeading">
+      <div class="cursive-chart-toolbar">
+        <h2 class="bubble-az-heading" id="cursiveAlphabetHeading">Alfabet tulisan sambung (A–Z, 0–9)</h2>
+        <button type="button" class="bubble-btn bubble-btn-primary" id="cursivePrintSheet">Cetak lembar latihan</button>
       </div>
-      <div class="alpha-row">
-        <span class="alpha-label">Script Ringan</span>
-        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵 𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏" aria-label="Salin huruf sambung gaya Script Ringan">𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵 · 𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏</button>
+      <p class="bubble-az-intro">Salin seluruh alfabet tulisan sambung dalam sekali klik — huruf besar, kecil, dan angka —
+        atau cetak lembar latihan berisi huruf contoh dan ruang untuk menjiplak. Unicode tidak punya angka sambung asli, jadi setiap
+        gaya memasangkan huruf script-nya dengan angka berhias yang serasi.</p>
+    <div class="cursive-chart">
+      <div class="cursive-chart-head">
+        <h3>Alfabet tulisan sambung klasik (Ultra Script)</h3>
+        <button type="button" class="copy-btn" data-text="𝒜 ℬ 𝒞 𝒟 ℰ ℱ 𝒢 ℋ ℐ 𝒥 𝒦 ℒ ℳ 𝒩 𝒪 𝒫 𝒬 ℛ 𝒮 𝒯 𝒰 𝒱 𝒲 𝒳 𝒴 𝒵&#10;𝒶 𝒷 𝒸 𝒹 ℯ 𝒻 ℊ 𝒽 𝒾 𝒿 𝓀 𝓁 𝓂 𝓃 ℴ 𝓅 𝓆 𝓇 𝓈 𝓉 𝓊 𝓋 𝓌 𝓍 𝓎 𝓏&#10;𝟢 𝟣 𝟤 𝟥 𝟦 𝟧 𝟨 𝟩 𝟪 𝟫" data-style="Ultra Script">Salin alfabet</button>
+      </div>
+      <p class="cursive-alphabet-row">𝒜 ℬ 𝒞 𝒟 ℰ ℱ 𝒢 ℋ ℐ 𝒥 𝒦 ℒ ℳ 𝒩 𝒪 𝒫 𝒬 ℛ 𝒮 𝒯 𝒰 𝒱 𝒲 𝒳 𝒴 𝒵</p>
+      <p class="cursive-alphabet-row">𝒶 𝒷 𝒸 𝒹 ℯ 𝒻 ℊ 𝒽 𝒾 𝒿 𝓀 𝓁 𝓂 𝓃 ℴ 𝓅 𝓆 𝓇 𝓈 𝓉 𝓊 𝓋 𝓌 𝓍 𝓎 𝓏</p>
+      <p class="cursive-alphabet-row">𝟢 𝟣 𝟤 𝟥 𝟦 𝟧 𝟨 𝟩 𝟪 𝟫</p>
+    </div>
+    <div class="cursive-chart">
+      <div class="cursive-chart-head">
+        <h3>Alfabet tulisan sambung tebal (Ultra Script Bold)</h3>
+        <button type="button" class="copy-btn" data-text="𝓐 𝓑 𝓒 𝓓 𝓔 𝓕 𝓖 𝓗 𝓘 𝓙 𝓚 𝓛 𝓜 𝓝 𝓞 𝓟 𝓠 𝓡 𝓢 𝓣 𝓤 𝓥 𝓦 𝓧 𝓨 𝓩&#10;𝓪 𝓫 𝓬 𝓭 𝓮 𝓯 𝓰 𝓱 𝓲 𝓳 𝓴 𝓵 𝓶 𝓷 𝓸 𝓹 𝓺 𝓻 𝓼 𝓽 𝓾 𝓿 𝔀 𝔁 𝔂 𝔃&#10;𝟬 𝟭 𝟮 𝟯 𝟰 𝟱 𝟲 𝟳 𝟴 𝟵" data-style="Ultra Script Bold">Salin alfabet</button>
+      </div>
+      <p class="cursive-alphabet-row">𝓐 𝓑 𝓒 𝓓 𝓔 𝓕 𝓖 𝓗 𝓘 𝓙 𝓚 𝓛 𝓜 𝓝 𝓞 𝓟 𝓠 𝓡 𝓢 𝓣 𝓤 𝓥 𝓦 𝓧 𝓨 𝓩</p>
+      <p class="cursive-alphabet-row">𝓪 𝓫 𝓬 𝓭 𝓮 𝓯 𝓰 𝓱 𝓲 𝓳 𝓴 𝓵 𝓶 𝓷 𝓸 𝓹 𝓺 𝓻 𝓼 𝓽 𝓾 𝓿 𝔀 𝔁 𝔂 𝔃</p>
+      <p class="cursive-alphabet-row">𝟬 𝟭 𝟮 𝟯 𝟰 𝟱 𝟲 𝟳 𝟴 𝟵</p>
+    </div>
+    <div class="cursive-chart">
+      <div class="cursive-chart-head">
+        <h3>Alfabet tulisan sambung gothic (Ultra Gothic Script)</h3>
+        <button type="button" class="copy-btn" data-text="𝕬 𝕭 𝕮 𝕯 𝕰 𝕱 𝕲 𝕳 𝕴 𝕵 𝕶 𝕷 𝕸 𝕹 𝕺 𝕻 𝕼 𝕽 𝕾 𝕿 𝖀 𝖁 𝖂 𝖃 𝖄 𝖅&#10;𝖆 𝖇 𝖈 𝖉 𝖊 𝖋 𝖌 𝖍 𝖎 𝖏 𝖐 𝖑 𝖒 𝖓 𝖔 𝖕 𝖖 𝖗 𝖘 𝖙 𝖚 𝖛 𝖜 𝖝 𝖞 𝖟" data-style="Ultra Gothic Script">Salin alfabet</button>
+      </div>
+      <p class="cursive-alphabet-row">𝕬 𝕭 𝕮 𝕯 𝕰 𝕱 𝕲 𝕳 𝕴 𝕵 𝕶 𝕷 𝕸 𝕹 𝕺 𝕻 𝕼 𝕽 𝕾 𝕿 𝖀 𝖁 𝖂 𝖃 𝖄 𝖅</p>
+      <p class="cursive-alphabet-row">𝖆 𝖇 𝖈 𝖉 𝖊 𝖋 𝖌 𝖍 𝖎 𝖏 𝖐 𝖑 𝖒 𝖓 𝖔 𝖕 𝖖 𝖗 𝖘 𝖙 𝖚 𝖛 𝖜 𝖝 𝖞 𝖟</p>
+    </div>
+    </section>
+
+    <!-- 4. Words in cursive -->
+    <section id="cursive-words" aria-labelledby="cursiveWordsHeading">
+      <h2 class="bubble-az-heading" id="cursiveWordsHeading">Kata dalam tulisan sambung — siap disalin</h2>
+      <p class="bubble-az-intro">Kata-kata paling dicari, sudah dirender jadi tulisan sambung. Butuh kata lain?
+        Ketik di <a href="#mainInput">generator di atas</a> dan setiap gaya langsung merendernya.</p>
+    <h3>Cinta &amp; keluarga</h3>
+    <div class="cursive-word-grid">
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒸𝒾𝓃𝓉𝒶</span>
+        <span class="cursive-word-label">cinta dalam tulisan sambung</span>
+        <button type="button" class="copy-btn" data-text="𝒸𝒾𝓃𝓉𝒶" data-style="Ultra Script">Salin</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓬𝓲𝓷𝓽𝓪</span>
+        <span class="cursive-word-label">cinta (tebal) dalam tulisan sambung</span>
+        <button type="button" class="copy-btn" data-text="𝓬𝓲𝓷𝓽𝓪" data-style="Ultra Script Bold">Salin</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒶𝓀𝓊 𝒸𝒾𝓃𝓉𝒶 𝓀𝒶𝓂𝓊</span>
+        <span class="cursive-word-label">aku cinta kamu dalam tulisan sambung</span>
+        <button type="button" class="copy-btn" data-text="𝒶𝓀𝓊 𝒸𝒾𝓃𝓉𝒶 𝓀𝒶𝓂𝓊" data-style="Ultra Script">Salin</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓀ℯ𝓁𝓊𝒶𝓇ℊ𝒶</span>
+        <span class="cursive-word-label">keluarga dalam tulisan sambung</span>
+        <button type="button" class="copy-btn" data-text="𝓀ℯ𝓁𝓊𝒶𝓇ℊ𝒶" data-style="Ultra Script">Salin</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒾𝒷𝓊</span>
+        <span class="cursive-word-label">ibu dalam tulisan sambung</span>
+        <button type="button" class="copy-btn" data-text="𝒾𝒷𝓊" data-style="Ultra Script">Salin</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒶𝓎𝒶𝒽</span>
+        <span class="cursive-word-label">ayah dalam tulisan sambung</span>
+        <button type="button" class="copy-btn" data-text="𝒶𝓎𝒶𝒽" data-style="Ultra Script">Salin</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓈ℯ𝓁𝒶𝓂𝒶𝓃𝓎𝒶</span>
+        <span class="cursive-word-label">selamanya dalam tulisan sambung</span>
+        <button type="button" class="copy-btn" data-text="𝓈ℯ𝓁𝒶𝓂𝒶𝓃𝓎𝒶" data-style="Ultra Script">Salin</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓈𝒶𝒽𝒶𝒷𝒶𝓉</span>
+        <span class="cursive-word-label">sahabat dalam tulisan sambung</span>
+        <button type="button" class="copy-btn" data-text="𝓈𝒶𝒽𝒶𝒷𝒶𝓉" data-style="Ultra Script">Salin</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒸𝒾𝓃𝓉𝒶 𝓈ℯ𝒿𝒶𝓉𝒾</span>
+        <span class="cursive-word-label">cinta sejati dalam tulisan sambung</span>
+        <button type="button" class="copy-btn" data-text="𝒸𝒾𝓃𝓉𝒶 𝓈ℯ𝒿𝒶𝓉𝒾" data-style="Ultra Script">Salin</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓈𝒶𝓎𝒶𝓃ℊ</span>
+        <span class="cursive-word-label">sayang dalam tulisan sambung</span>
+        <button type="button" class="copy-btn" data-text="𝓈𝒶𝓎𝒶𝓃ℊ" data-style="Ultra Script">Salin</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓇𝒾𝓃𝒹𝓊</span>
+        <span class="cursive-word-label">rindu dalam tulisan sambung</span>
+        <button type="button" class="copy-btn" data-text="𝓇𝒾𝓃𝒹𝓊" data-style="Ultra Script">Salin</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒷𝒶𝒽𝒶ℊ𝒾𝒶</span>
+        <span class="cursive-word-label">bahagia dalam tulisan sambung</span>
+        <button type="button" class="copy-btn" data-text="𝒷𝒶𝒽𝒶ℊ𝒾𝒶" data-style="Ultra Script">Salin</button>
       </div>
     </div>
-    <p class="u-mt-15">Catatan kecil: angka gak punya versi sambung di Unicode, jadi 0–9 tetap tampil biasa di tengah tulisan latinmu. Dan di gaya script ringan, huruf ℯ, ℊ, dan ℴ diambil dari blok Unicode lain — itu memang bentuk resminya, bukan salah ketik.</p>
-  </section>
-
-  <!-- Undangan & bio -->
-  <section class="editorial-section">
-    <h2>Tulisan Latin buat Undangan &amp; Bio</h2>
-    <p class="editorial-intro">Tulisan sambung font paling sering dipakai buat momen yang butuh sentuhan elegan:</p>
-    <div class="block-example">
-      — <strong>Undangan digital</strong>: nama pengantin atau ulang tahun, misal 𝓡𝓪𝓴𝓪 &amp; 𝓓𝓮𝔀𝓲 ✿<br>
-      — <strong>Bio IG &amp; TikTok</strong>: satu baris kaligrafi biar profil terlihat soft, misal ⋆ 𝓈𝒶𝒷𝒶𝓇 𝒾𝓉𝓊 𝒾𝓃𝒹𝒶𝒽 ⋆<br>
-      — <strong>Status &amp; nama profil WA</strong>: 𝓼𝓮𝓵𝓪𝓵𝓾 𝓫𝓮𝓻𝓼𝔂𝓾𝓴𝓾𝓻 ☾ yang beda dari yang lain<br>
-      — <strong>Monogram inisial</strong>: gabung dua inisial dengan pemisah halus — 𝓐·𝓜 atau ℰ ⋆ 𝒥
+    <h3>Ucapan &amp; momen</h3>
+    <div class="cursive-word-grid">
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓈ℯ𝓁𝒶𝓂𝒶𝓉 𝓊𝓁𝒶𝓃ℊ 𝓉𝒶𝒽𝓊𝓃</span>
+        <span class="cursive-word-label">selamat ulang tahun dalam tulisan sambung</span>
+        <button type="button" class="copy-btn" data-text="𝓈ℯ𝓁𝒶𝓂𝒶𝓉 𝓊𝓁𝒶𝓃ℊ 𝓉𝒶𝒽𝓊𝓃" data-style="Ultra Script">Salin</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓉ℯ𝓇𝒾𝓂𝒶 𝓀𝒶𝓈𝒾𝒽</span>
+        <span class="cursive-word-label">terima kasih dalam tulisan sambung</span>
+        <button type="button" class="copy-btn" data-text="𝓉ℯ𝓇𝒾𝓂𝒶 𝓀𝒶𝓈𝒾𝒽" data-style="Ultra Script">Salin</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓈ℯ𝓁𝒶𝓂𝒶𝓉</span>
+        <span class="cursive-word-label">selamat dalam tulisan sambung</span>
+        <button type="button" class="copy-btn" data-text="𝓈ℯ𝓁𝒶𝓂𝒶𝓉" data-style="Ultra Script">Salin</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓈ℯ𝓁𝒶𝓂𝒶𝓉 𝒹𝒶𝓉𝒶𝓃ℊ</span>
+        <span class="cursive-word-label">selamat datang dalam tulisan sambung</span>
+        <button type="button" class="copy-btn" data-text="𝓈ℯ𝓁𝒶𝓂𝒶𝓉 𝒹𝒶𝓉𝒶𝓃ℊ" data-style="Ultra Script">Salin</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓈ℯ𝓁𝒶𝓂𝒶𝓉 𝓂ℯ𝓃𝒾𝓀𝒶𝒽</span>
+        <span class="cursive-word-label">selamat menikah dalam tulisan sambung</span>
+        <button type="button" class="copy-btn" data-text="𝓈ℯ𝓁𝒶𝓂𝒶𝓉 𝓂ℯ𝓃𝒾𝓀𝒶𝒽" data-style="Ultra Script">Salin</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓈ℯ𝓂ℴℊ𝒶 𝓈𝓊𝓀𝓈ℯ𝓈</span>
+        <span class="cursive-word-label">semoga sukses dalam tulisan sambung</span>
+        <button type="button" class="copy-btn" data-text="𝓈ℯ𝓂ℴℊ𝒶 𝓈𝓊𝓀𝓈ℯ𝓈" data-style="Ultra Script">Salin</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓈ℯ𝓁𝒶𝓂𝒶𝓉 𝒽𝒶𝓇𝒾 𝓇𝒶𝓎𝒶</span>
+        <span class="cursive-word-label">selamat hari raya dalam tulisan sambung</span>
+        <button type="button" class="copy-btn" data-text="𝓈ℯ𝓁𝒶𝓂𝒶𝓉 𝒽𝒶𝓇𝒾 𝓇𝒶𝓎𝒶" data-style="Ultra Script">Salin</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓈𝒶𝓁𝒶𝓂 𝒽𝒶𝓃ℊ𝒶𝓉</span>
+        <span class="cursive-word-label">salam hangat dalam tulisan sambung</span>
+        <button type="button" class="copy-btn" data-text="𝓈𝒶𝓁𝒶𝓂 𝒽𝒶𝓃ℊ𝒶𝓉" data-style="Ultra Script">Salin</button>
+      </div>
     </div>
-    <p>Tips: kaligrafi paling cantik dipakai <em>hemat</em> — satu nama, satu kutipan pendek, atau satu kata penting. Buat kontras, pasangkan sama <a href="/id/tulisan-kecil/">tulisan kecil</a> di baris keterangan, atau <a href="/id/tulisan-tebal/">tulisan tebal</a> buat judulnya.</p>
-  </section>
+    <h3>Bulan dalam tulisan sambung</h3>
+    <div class="cursive-word-grid">
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒥𝒶𝓃𝓊𝒶𝓇𝒾</span>
+        <span class="cursive-word-label">Januari dalam tulisan sambung</span>
+        <button type="button" class="copy-btn" data-text="𝒥𝒶𝓃𝓊𝒶𝓇𝒾" data-style="Ultra Script">Salin</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">ℱℯ𝒷𝓇𝓊𝒶𝓇𝒾</span>
+        <span class="cursive-word-label">Februari dalam tulisan sambung</span>
+        <button type="button" class="copy-btn" data-text="ℱℯ𝒷𝓇𝓊𝒶𝓇𝒾" data-style="Ultra Script">Salin</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">ℳ𝒶𝓇ℯ𝓉</span>
+        <span class="cursive-word-label">Maret dalam tulisan sambung</span>
+        <button type="button" class="copy-btn" data-text="ℳ𝒶𝓇ℯ𝓉" data-style="Ultra Script">Salin</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒜𝓅𝓇𝒾𝓁</span>
+        <span class="cursive-word-label">April dalam tulisan sambung</span>
+        <button type="button" class="copy-btn" data-text="𝒜𝓅𝓇𝒾𝓁" data-style="Ultra Script">Salin</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">ℳℯ𝒾</span>
+        <span class="cursive-word-label">Mei dalam tulisan sambung</span>
+        <button type="button" class="copy-btn" data-text="ℳℯ𝒾" data-style="Ultra Script">Salin</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒥𝓊𝓃𝒾</span>
+        <span class="cursive-word-label">Juni dalam tulisan sambung</span>
+        <button type="button" class="copy-btn" data-text="𝒥𝓊𝓃𝒾" data-style="Ultra Script">Salin</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒥𝓊𝓁𝒾</span>
+        <span class="cursive-word-label">Juli dalam tulisan sambung</span>
+        <button type="button" class="copy-btn" data-text="𝒥𝓊𝓁𝒾" data-style="Ultra Script">Salin</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒜ℊ𝓊𝓈𝓉𝓊𝓈</span>
+        <span class="cursive-word-label">Agustus dalam tulisan sambung</span>
+        <button type="button" class="copy-btn" data-text="𝒜ℊ𝓊𝓈𝓉𝓊𝓈" data-style="Ultra Script">Salin</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒮ℯ𝓅𝓉ℯ𝓂𝒷ℯ𝓇</span>
+        <span class="cursive-word-label">September dalam tulisan sambung</span>
+        <button type="button" class="copy-btn" data-text="𝒮ℯ𝓅𝓉ℯ𝓂𝒷ℯ𝓇" data-style="Ultra Script">Salin</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒪𝓀𝓉ℴ𝒷ℯ𝓇</span>
+        <span class="cursive-word-label">Oktober dalam tulisan sambung</span>
+        <button type="button" class="copy-btn" data-text="𝒪𝓀𝓉ℴ𝒷ℯ𝓇" data-style="Ultra Script">Salin</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒩ℴ𝓋ℯ𝓂𝒷ℯ𝓇</span>
+        <span class="cursive-word-label">November dalam tulisan sambung</span>
+        <button type="button" class="copy-btn" data-text="𝒩ℴ𝓋ℯ𝓂𝒷ℯ𝓇" data-style="Ultra Script">Salin</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒟ℯ𝓈ℯ𝓂𝒷ℯ𝓇</span>
+        <span class="cursive-word-label">Desember dalam tulisan sambung</span>
+        <button type="button" class="copy-btn" data-text="𝒟ℯ𝓈ℯ𝓂𝒷ℯ𝓇" data-style="Ultra Script">Salin</button>
+      </div>
+    </div>
+    </section>
 
-  <!-- Bukan huruf tegak bersambung sekolah -->
-  <section class="editorial-section">
-    <h2>Beda sama Huruf Tegak Bersambung di Sekolah</h2>
-    <p class="editorial-intro">Kalau kamu nyari <strong>huruf tegak bersambung</strong> buat latihan menulis halus anak SD, itu soal tulisan tangan — dilatih pakai buku bergaris, bukan di-copy paste. Halaman ini fokusnya beda: <strong>generator font sambung digital</strong> yang bikin teks bergaya kaligrafi langsung jadi, siap ditempel ke bio, undangan, caption, dan chat.</p>
-    <p>Jadi anggap ini versi instannya: gak perlu bisa nulis indah, tinggal ketik dan salin. Mau eksplor gaya lain kayak bold, kecil, atau coret? Semua ada di <a href="/id/">generator tulisan aesthetic lengkap</a>.</p>
-  </section>
-</main>
+    <!-- 5. Names & signatures -->
+    <section id="cursive-names" aria-labelledby="cursiveNamesHeading">
+      <h2 class="bubble-az-heading" id="cursiveNamesHeading">Generator nama &amp; tanda tangan tulisan sambung</h2>
+      <p class="bubble-az-intro">Ketik nama depan — atau nama lengkap — lalu rancang tanda tangan tulisan sambungmu:
+        pilih hiasan, atur cara inisial monogram menyatu, lalu salin teksnya atau unduh sebagai PNG
+        untuk footer email, watermark, dan dokumen.</p>
+      <div class="cursive-name-tool">
+        <div class="input-wrapper">
+          <input type="text" class="main-input cursive-name-input" id="cursiveNameInput" placeholder="Ketik nama… misalnya Aisyah Putri" maxlength="60">
+        </div>
+        <div class="cursive-sig-controls" id="cursiveSignatureControls"></div>
+        <div class="results-grid" id="cursiveNameResults"></div>
+      </div>
+    <h3>Nama populer dalam tulisan sambung</h3>
+    <p class="bubble-az-intro">Ketuk nama mana pun untuk memuatnya ke studio di atas dan menghiasnya ulang dengan ornamen.</p>
+    <div class="cursive-word-grid">
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Muat Aisyah ke studio tanda tangan" data-name="Aisyah">
+        <span class="cursive-word-render">𝓐𝓲𝓼𝔂𝓪𝓱</span>
+        <span class="cursive-word-label">Aisyah dalam tulisan sambung</span>
+        <button type="button" class="copy-btn" data-text="𝓐𝓲𝓼𝔂𝓪𝓱" data-style="Ultra Script Bold">Salin</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Muat Siti ke studio tanda tangan" data-name="Siti">
+        <span class="cursive-word-render">𝓢𝓲𝓽𝓲</span>
+        <span class="cursive-word-label">Siti dalam tulisan sambung</span>
+        <button type="button" class="copy-btn" data-text="𝓢𝓲𝓽𝓲" data-style="Ultra Script Bold">Salin</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Muat Putri ke studio tanda tangan" data-name="Putri">
+        <span class="cursive-word-render">𝓟𝓾𝓽𝓻𝓲</span>
+        <span class="cursive-word-label">Putri dalam tulisan sambung</span>
+        <button type="button" class="copy-btn" data-text="𝓟𝓾𝓽𝓻𝓲" data-style="Ultra Script Bold">Salin</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Muat Dewi ke studio tanda tangan" data-name="Dewi">
+        <span class="cursive-word-render">𝓓𝓮𝔀𝓲</span>
+        <span class="cursive-word-label">Dewi dalam tulisan sambung</span>
+        <button type="button" class="copy-btn" data-text="𝓓𝓮𝔀𝓲" data-style="Ultra Script Bold">Salin</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Muat Nabila ke studio tanda tangan" data-name="Nabila">
+        <span class="cursive-word-render">𝓝𝓪𝓫𝓲𝓵𝓪</span>
+        <span class="cursive-word-label">Nabila dalam tulisan sambung</span>
+        <button type="button" class="copy-btn" data-text="𝓝𝓪𝓫𝓲𝓵𝓪" data-style="Ultra Script Bold">Salin</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Muat Alya ke studio tanda tangan" data-name="Alya">
+        <span class="cursive-word-render">𝓐𝓵𝔂𝓪</span>
+        <span class="cursive-word-label">Alya dalam tulisan sambung</span>
+        <button type="button" class="copy-btn" data-text="𝓐𝓵𝔂𝓪" data-style="Ultra Script Bold">Salin</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Muat Budi ke studio tanda tangan" data-name="Budi">
+        <span class="cursive-word-render">𝓑𝓾𝓭𝓲</span>
+        <span class="cursive-word-label">Budi dalam tulisan sambung</span>
+        <button type="button" class="copy-btn" data-text="𝓑𝓾𝓭𝓲" data-style="Ultra Script Bold">Salin</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Muat Rizki ke studio tanda tangan" data-name="Rizki">
+        <span class="cursive-word-render">𝓡𝓲𝔃𝓴𝓲</span>
+        <span class="cursive-word-label">Rizki dalam tulisan sambung</span>
+        <button type="button" class="copy-btn" data-text="𝓡𝓲𝔃𝓴𝓲" data-style="Ultra Script Bold">Salin</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Muat Fajar ke studio tanda tangan" data-name="Fajar">
+        <span class="cursive-word-render">𝓕𝓪𝓳𝓪𝓻</span>
+        <span class="cursive-word-label">Fajar dalam tulisan sambung</span>
+        <button type="button" class="copy-btn" data-text="𝓕𝓪𝓳𝓪𝓻" data-style="Ultra Script Bold">Salin</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Muat Andi ke studio tanda tangan" data-name="Andi">
+        <span class="cursive-word-render">𝓐𝓷𝓭𝓲</span>
+        <span class="cursive-word-label">Andi dalam tulisan sambung</span>
+        <button type="button" class="copy-btn" data-text="𝓐𝓷𝓭𝓲" data-style="Ultra Script Bold">Salin</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Muat Bagus ke studio tanda tangan" data-name="Bagus">
+        <span class="cursive-word-render">𝓑𝓪𝓰𝓾𝓼</span>
+        <span class="cursive-word-label">Bagus dalam tulisan sambung</span>
+        <button type="button" class="copy-btn" data-text="𝓑𝓪𝓰𝓾𝓼" data-style="Ultra Script Bold">Salin</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Muat Dimas ke studio tanda tangan" data-name="Dimas">
+        <span class="cursive-word-render">𝓓𝓲𝓶𝓪𝓼</span>
+        <span class="cursive-word-label">Dimas dalam tulisan sambung</span>
+        <button type="button" class="copy-btn" data-text="𝓓𝓲𝓶𝓪𝓼" data-style="Ultra Script Bold">Salin</button>
+      </div>
+    </div>
+    </section>
 
-<footer class="footer">
-  <div class="footer-inner">
-    <h2 class="faq-category">Panduan Tulisan Sambung &amp; Tulisan Latin</h2>
-    <div class="faq-item"><button class="faq-question" type="button">Apa itu tulisan sambung dan tulisan latin?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Di internet, tulisan sambung atau tulisan latin biasanya merujuk ke huruf gaya kaligrafi versi Unicode — misalnya 𝓪𝓫𝓬 (script tebal) atau 𝒶𝒷𝒸 (script ringan). Tiap hurufnya adalah karakter tersendiri yang memang digambar menyambung, jadi gayanya ikut kebawa waktu kamu salin-tempel ke bio, undangan digital, caption, atau status — beda sama font yang cuma ke-install di Word.</div></div>
-    <div class="faq-item"><button class="faq-question" type="button">Font sambung bisa dipakai di mana aja?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Hampir di semua tempat yang nerima teks: bio dan nama tampilan IG, status dan nama profil WA, caption TikTok, undangan digital, Telegram, Facebook, sampai nickname game. Yang gak bisa cuma kolom username (@) karena cuma nerima huruf biasa, angka, titik, dan garis bawah.</div></div>
-    <div class="faq-item"><button class="faq-question" type="button">Apa bedanya sama huruf tegak bersambung yang di sekolah?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Huruf tegak bersambung adalah cara menulis tangan yang diajarkan di SD — dilatih pakai buku halus, bukan di-copy paste. Halaman ini beda: ini generator font sambung digital, buat bikin teks bergaya kaligrafi yang bisa langsung disalin ke bio, undangan, dan caption. Jadi kalau kamu nyari materi latihan menulis halus, ini bukan tempatnya — tapi kalau mau nama atau kata terlihat menyambung indah di layar, ini dia.</div></div>
-    <div class="faq-item"><button class="faq-question" type="button">Kenapa huruf sambungnya kadang jadi kotak-kotak?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Beberapa perangkat lama belum punya font sistem yang lengkap, jadi karakter langka bisa muncul sebagai kotak (□). Gaya paling aman adalah script tebal (𝓪𝓫𝓬) karena setnya lengkap dan didukung hampir semua HP. Script ringan (𝒶𝒷𝒸) sedikit lebih riskan karena beberapa hurufnya (ℯ, ℊ, ℴ) diambil dari blok Unicode yang lebih tua.</div></div>
-    <div class="faq-item"><button class="faq-question" type="button">Gratis dan tanpa aplikasi?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Gratis 100%, jalan langsung di browser, tanpa daftar dan tanpa install aplikasi. Tinggal ketik, pilih gaya tulisan sambung, salin, tempel.</div></div>
+    <!-- Editorial -->
+    <section class="editorial-section cursive-editorial">
+      <h2>Cara kerja generator tulisan sambung ini</h2>
+      <p>Tulisan sambung yang kamu lihat di sini bukan font — ini <strong>karakter script Unicode</strong>, standar yang sama dipakai perangkatmu untuk setiap huruf dan emoji. Itulah kenapa gayanya tetap terbawa saat copy paste: aplikasi memperlakukan 𝒸𝓊𝓇𝓈𝒾𝓋ℯ persis seperti teks biasa. Karena itu pula ia bisa dipakai di tempat yang tak bisa kamu instal font — bio Instagram, caption TikTok, nama Discord, komentar YouTube. Penasaran cara kerjanya? Baca <a href="/guide/how-unicode-fonts-work/">cara kerja font Unicode</a>.</p>
+
+      <h3>Di mana tulisan sambung berfungsi (dan di mana tidak)</h3>
+      <ul class="compat-list">
+        <li><span class="ts-pill-safe">Berfungsi</span> Bio &amp; caption Instagram, caption TikTok, Discord, WhatsApp, Facebook, X, komentar YouTube, dan hampir semua dokumen.</li>
+        <li><span class="ts-pill-risk">Terbatas</span> Kolom username dan nama pengguna (Instagram, kebanyakan game) sering menghapus karakter script — pakai teks biasa untuk username.</li>
+        <li><span class="ts-pill-risk">Terbatas</span> Beberapa perangkat lama menampilkan kotak glif kosong (▯). Kalau itu terjadi, pakai gaya yang lebih sederhana — lihat <a href="/guide/why-fonts-show-as-boxes/">kenapa font muncul sebagai kotak</a>.</li>
+      </ul>
+
+      <h3>Tulisan sambung Unicode vs font tulisan asli</h3>
+      <p>Pakai tulisan sambung Unicode saat kamu butuh gaya sambung <em>di dalam kolom teks</em> — profil sosial, chat, judul video. Pakai tipografi tulisan asli (di Word, Canva, atau alat desainmu) saat kamu mengendalikan dokumen dan butuh kerning kualitas cetak. Keduanya punya tempatnya; alat ini menangani tugas pertama.</p>
+
+      <h3>Huruf sambung, aksen, dan alfabet lain</h3>
+      <p>Huruf script Unicode hanya ada untuk alfabet Latin, jadi Arab, Sirilik, dan aksara lain akan lewat tanpa berubah gaya. Bahasa Indonesia hampir seluruhnya ASCII sehingga aman, tapi tetap hindari karakter khusus atau simbol asing di dalam kata — ganti dengan huruf biasa agar seluruh kata benar-benar menyambung. <a href="#cursive-alphabet">Lembar latihan siap cetak</a> mencakup padanan Latin A–Z.</p>
+
+      <h3>Belajar menulis huruf sambung</h3>
+      <p>Generator ini untuk teks digital, tapi bisa dipakai jadi kartu referensi. Cetak <a href="#cursive-alphabet">lembar latihan</a> untuk menjiplak, pelajari cara setiap huruf kapital menyambung di <a href="#cursive-letters">penjelajah huruf</a>, dan ingat kebiasaan aksesibilitas penting — garis hias singkat, sisanya teks biasa (<a href="/guide/fancy-fonts-accessibility-guide/">panduan aksesibilitas</a>).</p>
+
+      <h3>Tulisan sambung untuk tato</h3>
+      <p>Lettering script adalah gaya tato yang paling banyak diminta. Pratinjau katamu di sini dalam ukuran besar, lalu pakai <a href="/id/usecase/font-tato/">generator font tato</a> khusus — lengkap dengan keluarga lettering, tanggal dalam angka Romawi, inisial, dan uji keterbacaan ukuran tinta.</p>
+    </section>
+
+    <div class="cta-card">
+      <h3>Bikin seluruh bio-mu mengalir</h3>
+      <p>Padukan judul tulisan sambung dengan teks isi yang bersih — kombinasi yang mencolok namun tetap terbaca.</p>
+      <a class="cta-btn" href="/id/">Buka generator tulisan sambung →</a>
+    </div>
+  </main>
+
+  <!-- Footer + FAQ -->
+  <footer class="footer">
+    <div class="footer-inner">
+<div class="faq-section" id="cursive-faq">
+
+<h2 class="faq-category">Generator Tulisan Sambung — FAQ</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Apa itu generator tulisan sambung dan bagaimana cara kerjanya?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Alat ini mengubah huruf yang kamu ketik jadi karakter script Unicode — simbol khusus yang tampak seperti tulisan tangan menyambung tapi berperilaku seperti teks biasa. Karena benar-benar karakter (bukan font atau gambar), kamu bisa menyalin dan menempelnya ke bio, caption, komentar, dan pesan, dan gaya sambungnya tetap terjaga. Selengkapnya di <a href="/guide/how-unicode-fonts-work/">panduan cara kerja font Unicode</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Bagaimana cara copy paste tulisan sambung?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Ketik atau tempel teksmu di kotak paling atas, lalu tekan Salin pada gaya yang kamu suka. Versi tulisan sambungnya kini ada di clipboard — tempel di mana saja yang menerima teks: Instagram, TikTok, WhatsApp, Discord, dokumen, dan lainnya.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Apakah tulisan sambung berfungsi di Instagram, WhatsApp, dan TikTok?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Ya. Tulisan sambung berfungsi di bio dan caption Instagram, status dan nama profil WhatsApp, serta caption dan bio TikTok. Cukup salin di sini lalu tempel. Satu-satunya tempat yang menolak adalah kolom username (@), yang hanya menerima huruf biasa, angka, titik, dan garis bawah.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Apakah generator tulisan sambung ini gratis?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Gratis sepenuhnya, tanpa daftar dan tanpa aplikasi. Ketik, salin, tempel sebanyak yang kamu mau langsung di browser.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Apa beda tulisan sambung ini dengan huruf tegak bersambung di sekolah?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Huruf tegak bersambung adalah cara menulis tangan yang dilatih di SD pakai buku halus. Halaman ini adalah generator <strong>font tulisan sambung digital</strong>: bikin teks bergaya menyambung yang langsung bisa disalin ke bio, undangan, dan caption. Kalau kamu cari materi latihan menulis, ini bukan tempatnya — tapi kalau mau nama atau kata tampak menyambung indah di layar, ini pas.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Kenapa nama dengan karakter khusus terlihat rusak?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Karakter script Unicode hanya mencakup A–Z, a–z, dan 0–9. Bahasa Indonesia hampir seluruhnya ASCII jadi umumnya aman, tapi jika kamu menyisipkan simbol asing, aksen, atau tanda khusus, karakter itu tidak ikut berubah dan bisa terlihat janggal. Tulis nama pakai huruf biasa saja agar seluruhnya tampil menyambung sempurna.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Bisakah saya membuat tanda tangan nama dalam tulisan sambung?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Bisa. Ketik nama depan atau nama lengkap di studio tanda tangan, pilih hiasan, atur inisial monogram, lalu salin teksnya atau unduh sebagai PNG untuk footer email, watermark, dan dokumen.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Apakah tulisan sambung cocok untuk desain tato?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Sangat cocok — lettering script adalah gaya tato paling populer. Pratinjau katamu di sini, lalu buka <a href="/id/usecase/font-tato/">generator font tato</a> untuk keluarga lettering, tanggal angka Romawi, dan uji keterbacaan ukuran tinta.
+  </div>
+</div>
+
+</div>
 
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="Language switcher">
       <a class="lang-option" href="/category/cursive-fonts/" hreflang="en">EN</a>
-      <a class="lang-option" href="/fr/ecriture-cursive/" hreflang="fr">FR</a>
-      <a class="lang-option active" href="/id/tulisan-sambung/" hreflang="id">ID</a>
-      <a class="lang-option" href="/nl/sierlijke-letters/" hreflang="nl">NL</a>
+      <a class="lang-option" href="/es/letra-cursiva/" hreflang="es">ES</a>
       <a class="lang-option" href="/pt/letra-cursiva/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/fr/ecriture-cursive/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/de/schreibschrift/" hreflang="de">DE</a>
+      <a class="lang-option" href="/it/lettere-in-corsivo/" hreflang="it">IT</a>
       <a class="lang-option" href="/tr/el-yazisi-fontu/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/nl/cursieve-letters/" hreflang="nl">NL</a>
+      <a class="lang-option active" href="/id/tulisan-sambung/" hreflang="id">ID</a>
       <a class="lang-option" href="/no/kursiv-tekst/" hreflang="no">NO</a>
     </div>
-  </div>
-</footer>
 
-<script>window.UTG_FAMILY = "cursive";</script>
-<script src="/styles.js" defer></script>
-<script src="/renderer.js" defer></script>
-<script src="/script.js" defer=""></script>
-<script src="/footer.js" defer></script>
+    </div>
+  </footer>
+
+  <div id="cursivePrintRoot" aria-hidden="true"></div>
+  <div class="copy-toast" id="copyToast">Tersalin!</div>
+
+  <script>
+    window.UTG_CURSIVE_MODE = true;
+    window.UTG_FAMILY = "cursive";
+    window.cursiveI18n = {
+  "demoText": "Halo",
+  "demoName": "Aisyah",
+  "copy": "Salin",
+  "typeFirst": "Ketik teksmu di atas dulu",
+  "downloadPngTitle": "Unduh sebagai gambar PNG",
+  "downloadPng": "Unduh PNG",
+  "characters": "karakter",
+  "caseUpper": "Kapital",
+  "caseLower": "Huruf kecil",
+  "caseBoth": "Keduanya",
+  "labelUpper": "Kapital {ch} dalam tulisan sambung",
+  "labelLower": "Huruf kecil {ch} dalam tulisan sambung",
+  "labelBoth": "Kapital dan huruf kecil {ch} dalam tulisan sambung",
+  "copyBoth": "Salin keduanya",
+  "everyStyle": "{ch} dalam tulisan sambung — semua gaya, klik untuk menyalin",
+  "suffixCapital": " — kapital",
+  "suffixLowercase": " — huruf kecil",
+  "accentLabel": "Aksen {name}",
+  "practiceTitle": "Lembar latihan alfabet tulisan sambung — ultratextgen.com",
+  "flourishLabel": "Hiasan",
+  "monogramLabel": "Penyambung monogram",
+  "copiedToast": "Tersalin!",
+  "quickWords": [
+    "cinta",
+    "bahagia",
+    "terimakasih",
+    "keluarga",
+    "selamanya",
+    "berkah"
+  ],
+  "styles": {
+    "Ultra Script": "script klasik",
+    "Ultra Script Bold": "script tebal",
+    "Ultra Script Elegant": "script elegan",
+    "Ultra Script Bold Elegant": "script tebal elegan",
+    "Ultra Gothic Script": "script gothic",
+    "Ultra Chicano Script": "nameplate Chicano",
+    "Ultra Script Sparkle": "script berkilau"
+  },
+  "presets": {
+    "Script Hearts": "Script hati",
+    "Script Arrow Bio": "Bio script panah",
+    "Bold Script Stars": "Script tebal bintang",
+    "Script Vintage": "Script vintage",
+    "Script Soft Dots": "Script titik lembut",
+    "Bold Script Ribbon": "Script tebal pita",
+    "Script Underline": "Script garis bawah",
+    "Bold Script Crown": "Script tebal mahkota"
+  },
+  "signatures": {
+    "Classic Signature": "Tanda tangan klasik",
+    "Bold Signature": "Tanda tangan tebal",
+    "Signed Underline": "Tanda tangan bergaris bawah",
+    "Sparkle Signature": "Tanda tangan berkilau",
+    "Ornate Nameplate": "Nameplate berhias",
+    "Autograph Star": "Autograf bintang",
+    "Monogram Initials": "Inisial monogram",
+    "Gothic Signature": "Tanda tangan gothic"
+  },
+  "decorators": {
+    "None": "Tanpa hiasan",
+    "Underline": "Garis bawah",
+    "Sparkle": "Kilau",
+    "Hearts": "Hati",
+    "Ornate": "Berhias",
+    "Soft dots": "Titik lembut"
+  },
+  "accents": {
+    "Sparkle": "Kilau",
+    "Hearts": "Hati",
+    "Wings": "Sayap",
+    "Ornate": "Berhias"
+  },
+  "platformLimits": {
+    "Instagram bio": "Bio Instagram",
+    "TikTok bio": "Bio TikTok",
+    "X bio": "Bio X"
+  }
+};
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/js/cursive/cursiveData.js" defer></script>
+  <script src="/script.js" defer></script>
+  <script src="/js/cursive/cursivePageController.js" defer></script>
+  <script src="/footer.js" defer></script>
 </body></html>

--- a/it/lettere-in-corsivo/index.html
+++ b/it/lettere-in-corsivo/index.html
@@ -1,0 +1,868 @@
+<!DOCTYPE html><html lang="it"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZGVh");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Generatore di Corsivo — 𝓵𝓮𝓽𝓽𝓮𝓻𝓮 𝓲𝓷 𝓬𝓸𝓻𝓼𝓲𝓿𝓸 da copiare e incollare, alfabeto A–Z e nomi | UltraTextGen</title>
+  <meta name="description" content="Generatore di lettere in corsivo gratis — copia e incolla scritte in corsivo, ogni lettera dalla A alla Z, l'alfabeto corsivo completo, parole in corsivo e firme con il tuo nome. Corsivo maiuscolo e minuscolo.">
+  <link rel="canonical" href="https://ultratextgen.com/it/lettere-in-corsivo/">
+
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/category/cursive-fonts/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/letra-cursiva/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/letra-cursiva/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/ecriture-cursive/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/schreibschrift/">
+  <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/lettere-in-corsivo/">
+  <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/el-yazisi-fontu/">
+  <link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/cursieve-letters/">
+  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/tulisan-sambung/">
+  <link rel="alternate" hreflang="no" href="https://ultratextgen.com/no/kursiv-tekst/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/category/cursive-fonts/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Generatore di Corsivo — 𝓵𝓮𝓽𝓽𝓮𝓻𝓮 𝓲𝓷 𝓬𝓸𝓻𝓼𝓲𝓿𝓸 da copiare e incollare, alfabeto A–Z e nomi | UltraTextGen">
+  <meta property="og:description" content="Generatore di lettere in corsivo gratis — copia e incolla scritte in corsivo, ogni lettera dalla A alla Z, l'alfabeto corsivo completo, parole in corsivo e firme con il tuo nome.">
+  <meta property="og:url" content="https://ultratextgen.com/it/lettere-in-corsivo/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category-cursive-fonts.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Generatore di Corsivo — 𝓵𝓮𝓽𝓽𝓮𝓻𝓮 𝓲𝓷 𝓬𝓸𝓻𝓼𝓲𝓿𝓸 da copiare e incollare, alfabeto A–Z e nomi | UltraTextGen">
+  <meta name="twitter:description" content="Generatore di lettere in corsivo gratis — copia e incolla corsivo maiuscolo e minuscolo, l'alfabeto corsivo completo, parole in corsivo e firme.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category-cursive-fonts.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "it",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Cos'è un generatore di corsivo e come funziona?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Converte le lettere che scrivi in caratteri script di Unicode — simboli speciali che sembrano scrittura corsiva ma si comportano come testo normale. Poiché sono veri caratteri (non un font né un'immagine), puoi copiarli e incollarli in biografie, didascalie, commenti e messaggi, mantenendo l'aspetto in corsivo. Scopri di più nella nostra <a href=\"/guide/how-unicode-fonts-work/\">guida su come funzionano i font Unicode</a>."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Come si copiano e incollano le lettere in corsivo?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Scrivi o incolla il testo nel riquadro in alto, poi tocca Copia sullo stile che preferisci. La versione in corsivo è ora nei tuoi appunti: incollala ovunque accetti testo — Instagram, TikTok, WhatsApp, Discord, documenti e altro."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Il corsivo funziona su Instagram, WhatsApp e TikTok?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Sì — il corsivo Unicode si incolla senza problemi nelle biografie e didascalie di Instagram, su TikTok, X, Facebook, WhatsApp, Discord e YouTube. Tieni però nomi utente e handle in testo semplice: molti campi username eliminano o rifiutano i caratteri speciali. Consulta la nostra pagina sui <a href=\"/instagram/\">font per Instagram</a> per consigli specifici."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Come ottengo una singola lettera in corsivo, come una S o una G maiuscola?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Usa la sezione Lettere in corsivo A–Z di questa pagina. Tocca una lettera per vederne la forma maiuscola e minuscola in ogni stile di corsivo, copia solo quella che ti serve o scaricala come PNG. Puoi anche collegarti direttamente a una lettera — per esempio <strong>#cursive-s</strong>."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Posso copiare tutto l'alfabeto corsivo insieme?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Sì. La sezione dell'alfabeto corsivo ha tabelle complete dalla A alla Z (maiuscole, minuscole e numeri) per gli stili classico, grassetto e gotico, ciascuna con un pulsante Copia alfabeto con un clic."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Posso scrivere il mio nome in corsivo o creare una firma?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Sì. Lo studio dei nomi e delle firme trasforma qualsiasi nome in corsivo stile firma: script classico, grassetto, autografo sottolineato, targa ornata e iniziali monogramma. È un modo rapido per vedere come scorre il tuo nome in corsivo prima di usarlo in una bio, in una firma email o in un progetto grafico."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Le lettere accentate (à, è, é, ì, ò, ù) diventano corsive?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. I caratteri script di Unicode esistono solo per le lettere A–Z senza accento, quindi le vocali accentate restano invariate. Per una parola o un nome completamente in corsivo, scrivili senza accento — ad esempio <strong>papa</strong> al posto di <em>papà</em> o <strong>perche</strong> al posto di <em>perché</em>."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Questo generatore di corsivo è gratuito?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Completamente gratuito — senza registrazione, senza filigrane, senza limiti. Tutto funziona direttamente nel tuo browser."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Posso fare numeri in corsivo?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Unicode non ha vere cifre corsive, perciò gli stili di corsivo abbinano alle lettere script dei numeri stilizzati coordinati — numeri leggeri per Ultra Script e più marcati per Ultra Script Bold. Scrivi le cifre insieme al testo e vengono stilizzate per intonarsi."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ultratextgen.com/it/" },
+    { "@type": "ListItem", "position": 2, "name": "Lettere in Corsivo", "item": "https://ultratextgen.com/it/lettere-in-corsivo/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Generatore di Lettere in Corsivo",
+  "alternateName": ["Generatore di Corsivo","Font Corsivo","Lettere in Corsivo A–Z","Alfabeto Corsivo","Corsivo Maiuscolo e Minuscolo","Generatore di Nomi in Corsivo","Generatore di Firme in Corsivo","Corsivo da Copiare e Incollare"],
+  "url": "https://ultratextgen.com/it/lettere-in-corsivo/",
+  "inLanguage": "it",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "EUR"
+  },
+  "description": "Generatore di lettere in corsivo gratuito: copia e incolla scritte in corsivo, ogni lettera dalla A alla Z, l'alfabeto corsivo completo, parole in corsivo e firme con il tuo nome.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers.",
+  "featureList": ["Generatore di corsivo con svolazzi e decorazioni","Esploratore delle lettere in corsivo A–Z (maiuscole e minuscole)","Copia dell'intero alfabeto corsivo con un clic","Foglio di pratica per l'alfabeto corsivo da stampare","Studio per nomi e firme in corsivo","Galleria di parole in corsivo (amore, buon compleanno, mesi)"]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/it/">Home</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Lettere in Corsivo</span>
+</nav>
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/category-cursive-fonts.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+  <!-- Hero: the cursive-first generator -->
+  <section class="hero">
+    <div class="hero-inner">
+      <div class="hero-card">
+        <h1 class="hero-headline">Generatore di Lettere in Corsivo</h1>
+        <p class="hero-tagline">Trasforma qualsiasi testo in 𝓬𝓸𝓻𝓼𝓲𝓿𝓸 da copiare e incollare — una vera scrittura corsiva
+          tipo scrittura a mano, ogni lettera dalla A alla Z, l'alfabeto completo e firme con il nome.
+          Attenzione: qui non intendiamo il testo in <em>corsivo</em> (italico), ma il corsivo calligrafico. Gratis, immediato, senza registrazione.</p>
+        <div class="input-wrapper">
+          <textarea class="main-input" id="mainInput" placeholder="Scrivi il tuo testo, una parola o un nome…" maxlength="500" autofocus></textarea>
+          <span class="char-count"><span id="charCount">0</span>/500</span>
+        </div>
+        <div class="cursive-quick-row" id="cursiveQuickRow" aria-label="Esempi rapidi"></div>
+        <div class="vertical-fit-row" id="cursiveFitRow" hidden></div>
+      </div>
+    </div>
+  </section>
+
+  <nav class="cursive-section-nav" aria-label="In questa pagina">
+    <a href="#cursive-styles">Stili</a>
+    <a href="#cursive-letters">Lettere A–Z</a>
+    <a href="#cursive-alphabet">Alfabeto</a>
+    <a href="#cursive-words">Parole</a>
+    <a href="#cursive-names">Nomi e firme</a>
+    <a href="#cursive-faq">FAQ</a>
+  </nav>
+
+  <main class="container">
+
+    <!-- 1. Generator output -->
+    <section id="cursive-styles" aria-labelledby="cursiveStylesHeading">
+      <h2 class="bubble-az-heading" id="cursiveStylesHeading">Font in corsivo — copia e incolla</h2>
+      <p class="bubble-az-intro">Ogni stile qui sotto si aggiorna in tempo reale mentre scrivi: corsivo classico e in grassetto,
+        varianti eleganti e spaziate, corsivo gotico, targhe stile Chicano e preset con svolazzi, cuori,
+        stelline e frecce. Tocca Copia e incolla il tuo corsivo dove vuoi.</p>
+      <div class="results-grid" id="resultsGrid"></div>
+    </section>
+
+    <!-- 2. Cursive letters A–Z -->
+    <section class="bubble-az" id="cursive-letters" aria-labelledby="cursiveLettersHeading">
+      <h2 class="bubble-az-heading" id="cursiveLettersHeading">Lettere in corsivo A–Z — maiuscole e minuscole</h2>
+      <p class="bubble-az-intro">Cerchi una singola lettera — una S in corsivo, una G maiuscola in corsivo, una f minuscola?
+        Questo esploratore mostra il <strong>corsivo maiuscolo e minuscolo</strong> di ogni lettera: tocca una lettera
+        per vederla in tutti gli stili, copia esattamente il glifo che ti serve o scaricalo come immagine PNG.</p>
+  <div class="cursive-letter-grid" role="tablist" aria-label="Scegli una lettera in corsivo">
+    <button type="button" class="cursive-letter-cell" id="cursive-a" data-char="A" aria-label="A in corsivo — maiuscola e minuscola">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒜 𝒶</span>
+      <span class="cursive-letter-name">A in corsivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-b" data-char="B" aria-label="B in corsivo — maiuscola e minuscola">
+      <span class="cursive-letter-pair" aria-hidden="true">ℬ 𝒷</span>
+      <span class="cursive-letter-name">B in corsivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-c" data-char="C" aria-label="C in corsivo — maiuscola e minuscola">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒞 𝒸</span>
+      <span class="cursive-letter-name">C in corsivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-d" data-char="D" aria-label="D in corsivo — maiuscola e minuscola">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒟 𝒹</span>
+      <span class="cursive-letter-name">D in corsivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-e" data-char="E" aria-label="E in corsivo — maiuscola e minuscola">
+      <span class="cursive-letter-pair" aria-hidden="true">ℰ ℯ</span>
+      <span class="cursive-letter-name">E in corsivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-f" data-char="F" aria-label="F in corsivo — maiuscola e minuscola">
+      <span class="cursive-letter-pair" aria-hidden="true">ℱ 𝒻</span>
+      <span class="cursive-letter-name">F in corsivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-g" data-char="G" aria-label="G in corsivo — maiuscola e minuscola">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒢 ℊ</span>
+      <span class="cursive-letter-name">G in corsivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-h" data-char="H" aria-label="H in corsivo — maiuscola e minuscola">
+      <span class="cursive-letter-pair" aria-hidden="true">ℋ 𝒽</span>
+      <span class="cursive-letter-name">H in corsivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-i" data-char="I" aria-label="I in corsivo — maiuscola e minuscola">
+      <span class="cursive-letter-pair" aria-hidden="true">ℐ 𝒾</span>
+      <span class="cursive-letter-name">I in corsivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-j" data-char="J" aria-label="J in corsivo — maiuscola e minuscola">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒥 𝒿</span>
+      <span class="cursive-letter-name">J in corsivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-k" data-char="K" aria-label="K in corsivo — maiuscola e minuscola">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒦 𝓀</span>
+      <span class="cursive-letter-name">K in corsivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-l" data-char="L" aria-label="L in corsivo — maiuscola e minuscola">
+      <span class="cursive-letter-pair" aria-hidden="true">ℒ 𝓁</span>
+      <span class="cursive-letter-name">L in corsivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-m" data-char="M" aria-label="M in corsivo — maiuscola e minuscola">
+      <span class="cursive-letter-pair" aria-hidden="true">ℳ 𝓂</span>
+      <span class="cursive-letter-name">M in corsivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-n" data-char="N" aria-label="N in corsivo — maiuscola e minuscola">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒩 𝓃</span>
+      <span class="cursive-letter-name">N in corsivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-o" data-char="O" aria-label="O in corsivo — maiuscola e minuscola">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒪 ℴ</span>
+      <span class="cursive-letter-name">O in corsivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-p" data-char="P" aria-label="P in corsivo — maiuscola e minuscola">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒫 𝓅</span>
+      <span class="cursive-letter-name">P in corsivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-q" data-char="Q" aria-label="Q in corsivo — maiuscola e minuscola">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒬 𝓆</span>
+      <span class="cursive-letter-name">Q in corsivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-r" data-char="R" aria-label="R in corsivo — maiuscola e minuscola">
+      <span class="cursive-letter-pair" aria-hidden="true">ℛ 𝓇</span>
+      <span class="cursive-letter-name">R in corsivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-s" data-char="S" aria-label="S in corsivo — maiuscola e minuscola">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒮 𝓈</span>
+      <span class="cursive-letter-name">S in corsivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-t" data-char="T" aria-label="T in corsivo — maiuscola e minuscola">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒯 𝓉</span>
+      <span class="cursive-letter-name">T in corsivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-u" data-char="U" aria-label="U in corsivo — maiuscola e minuscola">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒰 𝓊</span>
+      <span class="cursive-letter-name">U in corsivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-v" data-char="V" aria-label="V in corsivo — maiuscola e minuscola">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒱 𝓋</span>
+      <span class="cursive-letter-name">V in corsivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-w" data-char="W" aria-label="W in corsivo — maiuscola e minuscola">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒲 𝓌</span>
+      <span class="cursive-letter-name">W in corsivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-x" data-char="X" aria-label="X in corsivo — maiuscola e minuscola">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒳 𝓍</span>
+      <span class="cursive-letter-name">X in corsivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-y" data-char="Y" aria-label="Y in corsivo — maiuscola e minuscola">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒴 𝓎</span>
+      <span class="cursive-letter-name">Y in corsivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-z" data-char="Z" aria-label="Z in corsivo — maiuscola e minuscola">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒵 𝓏</span>
+      <span class="cursive-letter-name">Z in corsivo</span>
+    </button>
+  </div>
+      <div class="cursive-letter-panel" id="cursiveLetterPanel" aria-live="polite"></div>
+    </section>
+
+    <!-- 3. The cursive alphabet -->
+    <section id="cursive-alphabet" aria-labelledby="cursiveAlphabetHeading">
+      <div class="cursive-chart-toolbar">
+        <h2 class="bubble-az-heading" id="cursiveAlphabetHeading">L'alfabeto corsivo (A–Z, 0–9)</h2>
+        <button type="button" class="bubble-btn bubble-btn-primary" id="cursivePrintSheet">Stampa foglio di pratica</button>
+      </div>
+      <p class="bubble-az-intro">Copia l'intero alfabeto corsivo con un solo clic — maiuscole, minuscole e numeri —
+        oppure stampa un foglio di pratica con le lettere modello e lo spazio per ricalcarle. Unicode non prevede
+        cifre corsive vere e proprie, perciò ogni stile abbina alle lettere corsive dei numeri stilizzati coordinati.</p>
+    <div class="cursive-chart">
+      <div class="cursive-chart-head">
+        <h3>Alfabeto corsivo classico (Ultra Script)</h3>
+        <button type="button" class="copy-btn" data-text="𝒜 ℬ 𝒞 𝒟 ℰ ℱ 𝒢 ℋ ℐ 𝒥 𝒦 ℒ ℳ 𝒩 𝒪 𝒫 𝒬 ℛ 𝒮 𝒯 𝒰 𝒱 𝒲 𝒳 𝒴 𝒵&#10;𝒶 𝒷 𝒸 𝒹 ℯ 𝒻 ℊ 𝒽 𝒾 𝒿 𝓀 𝓁 𝓂 𝓃 ℴ 𝓅 𝓆 𝓇 𝓈 𝓉 𝓊 𝓋 𝓌 𝓍 𝓎 𝓏&#10;𝟢 𝟣 𝟤 𝟥 𝟦 𝟧 𝟨 𝟩 𝟪 𝟫" data-style="Ultra Script">Copia alfabeto</button>
+      </div>
+      <p class="cursive-alphabet-row">𝒜 ℬ 𝒞 𝒟 ℰ ℱ 𝒢 ℋ ℐ 𝒥 𝒦 ℒ ℳ 𝒩 𝒪 𝒫 𝒬 ℛ 𝒮 𝒯 𝒰 𝒱 𝒲 𝒳 𝒴 𝒵</p>
+      <p class="cursive-alphabet-row">𝒶 𝒷 𝒸 𝒹 ℯ 𝒻 ℊ 𝒽 𝒾 𝒿 𝓀 𝓁 𝓂 𝓃 ℴ 𝓅 𝓆 𝓇 𝓈 𝓉 𝓊 𝓋 𝓌 𝓍 𝓎 𝓏</p>
+      <p class="cursive-alphabet-row">𝟢 𝟣 𝟤 𝟥 𝟦 𝟧 𝟨 𝟩 𝟪 𝟫</p>
+    </div>
+    <div class="cursive-chart">
+      <div class="cursive-chart-head">
+        <h3>Alfabeto corsivo in grassetto (Ultra Script Bold)</h3>
+        <button type="button" class="copy-btn" data-text="𝓐 𝓑 𝓒 𝓓 𝓔 𝓕 𝓖 𝓗 𝓘 𝓙 𝓚 𝓛 𝓜 𝓝 𝓞 𝓟 𝓠 𝓡 𝓢 𝓣 𝓤 𝓥 𝓦 𝓧 𝓨 𝓩&#10;𝓪 𝓫 𝓬 𝓭 𝓮 𝓯 𝓰 𝓱 𝓲 𝓳 𝓴 𝓵 𝓶 𝓷 𝓸 𝓹 𝓺 𝓻 𝓼 𝓽 𝓾 𝓿 𝔀 𝔁 𝔂 𝔃&#10;𝟬 𝟭 𝟮 𝟯 𝟰 𝟱 𝟲 𝟳 𝟴 𝟵" data-style="Ultra Script Bold">Copia alfabeto</button>
+      </div>
+      <p class="cursive-alphabet-row">𝓐 𝓑 𝓒 𝓓 𝓔 𝓕 𝓖 𝓗 𝓘 𝓙 𝓚 𝓛 𝓜 𝓝 𝓞 𝓟 𝓠 𝓡 𝓢 𝓣 𝓤 𝓥 𝓦 𝓧 𝓨 𝓩</p>
+      <p class="cursive-alphabet-row">𝓪 𝓫 𝓬 𝓭 𝓮 𝓯 𝓰 𝓱 𝓲 𝓳 𝓴 𝓵 𝓶 𝓷 𝓸 𝓹 𝓺 𝓻 𝓼 𝓽 𝓾 𝓿 𝔀 𝔁 𝔂 𝔃</p>
+      <p class="cursive-alphabet-row">𝟬 𝟭 𝟮 𝟯 𝟰 𝟱 𝟲 𝟳 𝟴 𝟵</p>
+    </div>
+    <div class="cursive-chart">
+      <div class="cursive-chart-head">
+        <h3>Alfabeto corsivo gotico (Ultra Gothic Script)</h3>
+        <button type="button" class="copy-btn" data-text="𝕬 𝕭 𝕮 𝕯 𝕰 𝕱 𝕲 𝕳 𝕴 𝕵 𝕶 𝕷 𝕸 𝕹 𝕺 𝕻 𝕼 𝕽 𝕾 𝕿 𝖀 𝖁 𝖂 𝖃 𝖄 𝖅&#10;𝖆 𝖇 𝖈 𝖉 𝖊 𝖋 𝖌 𝖍 𝖎 𝖏 𝖐 𝖑 𝖒 𝖓 𝖔 𝖕 𝖖 𝖗 𝖘 𝖙 𝖚 𝖛 𝖜 𝖝 𝖞 𝖟" data-style="Ultra Gothic Script">Copia alfabeto</button>
+      </div>
+      <p class="cursive-alphabet-row">𝕬 𝕭 𝕮 𝕯 𝕰 𝕱 𝕲 𝕳 𝕴 𝕵 𝕶 𝕷 𝕸 𝕹 𝕺 𝕻 𝕼 𝕽 𝕾 𝕿 𝖀 𝖁 𝖂 𝖃 𝖄 𝖅</p>
+      <p class="cursive-alphabet-row">𝖆 𝖇 𝖈 𝖉 𝖊 𝖋 𝖌 𝖍 𝖎 𝖏 𝖐 𝖑 𝖒 𝖓 𝖔 𝖕 𝖖 𝖗 𝖘 𝖙 𝖚 𝖛 𝖜 𝖝 𝖞 𝖟</p>
+    </div>
+    </section>
+
+    <!-- 4. Words in cursive -->
+    <section id="cursive-words" aria-labelledby="cursiveWordsHeading">
+      <h2 class="bubble-az-heading" id="cursiveWordsHeading">Parole in corsivo — pronte da copiare</h2>
+      <p class="bubble-az-intro">Le parole più richieste, già pronte in corsivo. Ne cerchi un'altra?
+        Scrivila nel <a href="#mainInput">generatore qui sopra</a> e ogni stile la renderà all'istante in corsivo.</p>
+    <h3>Amore e famiglia</h3>
+    <div class="cursive-word-grid">
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒶𝓂ℴ𝓇ℯ</span>
+        <span class="cursive-word-label">amore in corsivo</span>
+        <button type="button" class="copy-btn" data-text="𝒶𝓂ℴ𝓇ℯ" data-style="Ultra Script">Copia</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓪𝓶𝓸𝓻𝓮</span>
+        <span class="cursive-word-label">amore (grassetto) in corsivo</span>
+        <button type="button" class="copy-btn" data-text="𝓪𝓶𝓸𝓻𝓮" data-style="Ultra Script Bold">Copia</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓉𝒾 𝒶𝓂ℴ</span>
+        <span class="cursive-word-label">ti amo in corsivo</span>
+        <button type="button" class="copy-btn" data-text="𝓉𝒾 𝒶𝓂ℴ" data-style="Ultra Script">Copia</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓂𝒶𝓂𝓂𝒶</span>
+        <span class="cursive-word-label">mamma in corsivo</span>
+        <button type="button" class="copy-btn" data-text="𝓂𝒶𝓂𝓂𝒶" data-style="Ultra Script">Copia</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓅𝒶𝓅𝒶</span>
+        <span class="cursive-word-label">papà in corsivo</span>
+        <button type="button" class="copy-btn" data-text="𝓅𝒶𝓅𝒶" data-style="Ultra Script">Copia</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒻𝒶𝓂𝒾ℊ𝓁𝒾𝒶</span>
+        <span class="cursive-word-label">famiglia in corsivo</span>
+        <button type="button" class="copy-btn" data-text="𝒻𝒶𝓂𝒾ℊ𝓁𝒾𝒶" data-style="Ultra Script">Copia</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓅ℯ𝓇 𝓈ℯ𝓂𝓅𝓇ℯ</span>
+        <span class="cursive-word-label">per sempre in corsivo</span>
+        <button type="button" class="copy-btn" data-text="𝓅ℯ𝓇 𝓈ℯ𝓂𝓅𝓇ℯ" data-style="Ultra Script">Copia</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒶𝓂ℴ𝓇ℯ 𝓂𝒾ℴ</span>
+        <span class="cursive-word-label">amore mio in corsivo</span>
+        <button type="button" class="copy-btn" data-text="𝒶𝓂ℴ𝓇ℯ 𝓂𝒾ℴ" data-style="Ultra Script">Copia</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒸𝓊ℴ𝓇ℯ</span>
+        <span class="cursive-word-label">cuore in corsivo</span>
+        <button type="button" class="copy-btn" data-text="𝒸𝓊ℴ𝓇ℯ" data-style="Ultra Script">Copia</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓋𝒾𝓉𝒶</span>
+        <span class="cursive-word-label">vita in corsivo</span>
+        <button type="button" class="copy-btn" data-text="𝓋𝒾𝓉𝒶" data-style="Ultra Script">Copia</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒻ℯ𝓁𝒾𝒸𝒾𝓉𝒶</span>
+        <span class="cursive-word-label">felicità in corsivo</span>
+        <button type="button" class="copy-btn" data-text="𝒻ℯ𝓁𝒾𝒸𝒾𝓉𝒶" data-style="Ultra Script">Copia</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒾𝓃𝓈𝒾ℯ𝓂ℯ</span>
+        <span class="cursive-word-label">insieme in corsivo</span>
+        <button type="button" class="copy-btn" data-text="𝒾𝓃𝓈𝒾ℯ𝓂ℯ" data-style="Ultra Script">Copia</button>
+      </div>
+    </div>
+    <h3>Auguri e occasioni</h3>
+    <div class="cursive-word-grid">
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒷𝓊ℴ𝓃 𝒸ℴ𝓂𝓅𝓁ℯ𝒶𝓃𝓃ℴ</span>
+        <span class="cursive-word-label">buon compleanno in corsivo</span>
+        <button type="button" class="copy-btn" data-text="𝒷𝓊ℴ𝓃 𝒸ℴ𝓂𝓅𝓁ℯ𝒶𝓃𝓃ℴ" data-style="Ultra Script">Copia</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒶𝓊ℊ𝓊𝓇𝒾</span>
+        <span class="cursive-word-label">auguri in corsivo</span>
+        <button type="button" class="copy-btn" data-text="𝒶𝓊ℊ𝓊𝓇𝒾" data-style="Ultra Script">Copia</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">ℊ𝓇𝒶𝓏𝒾ℯ</span>
+        <span class="cursive-word-label">grazie in corsivo</span>
+        <button type="button" class="copy-btn" data-text="ℊ𝓇𝒶𝓏𝒾ℯ" data-style="Ultra Script">Copia</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒷𝓊ℴ𝓃 𝓃𝒶𝓉𝒶𝓁ℯ</span>
+        <span class="cursive-word-label">buon natale in corsivo</span>
+        <button type="button" class="copy-btn" data-text="𝒷𝓊ℴ𝓃 𝓃𝒶𝓉𝒶𝓁ℯ" data-style="Ultra Script">Copia</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒷𝓊ℴ𝓃 𝒶𝓃𝓃ℴ</span>
+        <span class="cursive-word-label">buon anno in corsivo</span>
+        <button type="button" class="copy-btn" data-text="𝒷𝓊ℴ𝓃 𝒶𝓃𝓃ℴ" data-style="Ultra Script">Copia</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒸ℴ𝓃ℊ𝓇𝒶𝓉𝓊𝓁𝒶𝓏𝒾ℴ𝓃𝒾</span>
+        <span class="cursive-word-label">congratulazioni in corsivo</span>
+        <button type="button" class="copy-btn" data-text="𝒸ℴ𝓃ℊ𝓇𝒶𝓉𝓊𝓁𝒶𝓏𝒾ℴ𝓃𝒾" data-style="Ultra Script">Copia</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒷ℯ𝓃𝓋ℯ𝓃𝓊𝓉ℴ</span>
+        <span class="cursive-word-label">benvenuto in corsivo</span>
+        <button type="button" class="copy-btn" data-text="𝒷ℯ𝓃𝓋ℯ𝓃𝓊𝓉ℴ" data-style="Ultra Script">Copia</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒸𝒾𝒶ℴ</span>
+        <span class="cursive-word-label">ciao in corsivo</span>
+        <button type="button" class="copy-btn" data-text="𝒸𝒾𝒶ℴ" data-style="Ultra Script">Copia</button>
+      </div>
+    </div>
+    <h3>Mesi in corsivo</h3>
+    <div class="cursive-word-grid">
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">ℊℯ𝓃𝓃𝒶𝒾ℴ</span>
+        <span class="cursive-word-label">gennaio in corsivo</span>
+        <button type="button" class="copy-btn" data-text="ℊℯ𝓃𝓃𝒶𝒾ℴ" data-style="Ultra Script">Copia</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒻ℯ𝒷𝒷𝓇𝒶𝒾ℴ</span>
+        <span class="cursive-word-label">febbraio in corsivo</span>
+        <button type="button" class="copy-btn" data-text="𝒻ℯ𝒷𝒷𝓇𝒶𝒾ℴ" data-style="Ultra Script">Copia</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓂𝒶𝓇𝓏ℴ</span>
+        <span class="cursive-word-label">marzo in corsivo</span>
+        <button type="button" class="copy-btn" data-text="𝓂𝒶𝓇𝓏ℴ" data-style="Ultra Script">Copia</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒶𝓅𝓇𝒾𝓁ℯ</span>
+        <span class="cursive-word-label">aprile in corsivo</span>
+        <button type="button" class="copy-btn" data-text="𝒶𝓅𝓇𝒾𝓁ℯ" data-style="Ultra Script">Copia</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓂𝒶ℊℊ𝒾ℴ</span>
+        <span class="cursive-word-label">maggio in corsivo</span>
+        <button type="button" class="copy-btn" data-text="𝓂𝒶ℊℊ𝒾ℴ" data-style="Ultra Script">Copia</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">ℊ𝒾𝓊ℊ𝓃ℴ</span>
+        <span class="cursive-word-label">giugno in corsivo</span>
+        <button type="button" class="copy-btn" data-text="ℊ𝒾𝓊ℊ𝓃ℴ" data-style="Ultra Script">Copia</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓁𝓊ℊ𝓁𝒾ℴ</span>
+        <span class="cursive-word-label">luglio in corsivo</span>
+        <button type="button" class="copy-btn" data-text="𝓁𝓊ℊ𝓁𝒾ℴ" data-style="Ultra Script">Copia</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒶ℊℴ𝓈𝓉ℴ</span>
+        <span class="cursive-word-label">agosto in corsivo</span>
+        <button type="button" class="copy-btn" data-text="𝒶ℊℴ𝓈𝓉ℴ" data-style="Ultra Script">Copia</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓈ℯ𝓉𝓉ℯ𝓂𝒷𝓇ℯ</span>
+        <span class="cursive-word-label">settembre in corsivo</span>
+        <button type="button" class="copy-btn" data-text="𝓈ℯ𝓉𝓉ℯ𝓂𝒷𝓇ℯ" data-style="Ultra Script">Copia</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">ℴ𝓉𝓉ℴ𝒷𝓇ℯ</span>
+        <span class="cursive-word-label">ottobre in corsivo</span>
+        <button type="button" class="copy-btn" data-text="ℴ𝓉𝓉ℴ𝒷𝓇ℯ" data-style="Ultra Script">Copia</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓃ℴ𝓋ℯ𝓂𝒷𝓇ℯ</span>
+        <span class="cursive-word-label">novembre in corsivo</span>
+        <button type="button" class="copy-btn" data-text="𝓃ℴ𝓋ℯ𝓂𝒷𝓇ℯ" data-style="Ultra Script">Copia</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒹𝒾𝒸ℯ𝓂𝒷𝓇ℯ</span>
+        <span class="cursive-word-label">dicembre in corsivo</span>
+        <button type="button" class="copy-btn" data-text="𝒹𝒾𝒸ℯ𝓂𝒷𝓇ℯ" data-style="Ultra Script">Copia</button>
+      </div>
+    </div>
+    </section>
+
+    <!-- 5. Names & signatures -->
+    <section id="cursive-names" aria-labelledby="cursiveNamesHeading">
+      <h2 class="bubble-az-heading" id="cursiveNamesHeading">Generatore di nomi e firme in corsivo</h2>
+      <p class="bubble-az-intro">Scrivi un nome — o un nome e cognome — e crea la tua firma in corsivo:
+        scegli uno svolazzo, decidi come unire le iniziali del monogramma, poi copia il testo o scaricalo come PNG
+        per firme email, filigrane e documenti.</p>
+      <div class="cursive-name-tool">
+        <div class="input-wrapper">
+          <input type="text" class="main-input cursive-name-input" id="cursiveNameInput" placeholder="Scrivi un nome… es. Giulia Rossi" maxlength="60">
+        </div>
+        <div class="cursive-sig-controls" id="cursiveSignatureControls"></div>
+        <div class="results-grid" id="cursiveNameResults"></div>
+      </div>
+    <h3>Nomi popolari in corsivo</h3>
+    <p class="bubble-az-intro">Tocca un nome per caricarlo nello studio qui sopra e reimpostarne lo stile con svolazzi e decorazioni.</p>
+    <div class="cursive-word-grid">
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Carica Sofia nello studio delle firme" data-name="Sofia">
+        <span class="cursive-word-render">𝓢𝓸𝓯𝓲𝓪</span>
+        <span class="cursive-word-label">Sofia in corsivo</span>
+        <button type="button" class="copy-btn" data-text="𝓢𝓸𝓯𝓲𝓪" data-style="Ultra Script Bold">Copia</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Carica Giulia nello studio delle firme" data-name="Giulia">
+        <span class="cursive-word-render">𝓖𝓲𝓾𝓵𝓲𝓪</span>
+        <span class="cursive-word-label">Giulia in corsivo</span>
+        <button type="button" class="copy-btn" data-text="𝓖𝓲𝓾𝓵𝓲𝓪" data-style="Ultra Script Bold">Copia</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Carica Aurora nello studio delle firme" data-name="Aurora">
+        <span class="cursive-word-render">𝓐𝓾𝓻𝓸𝓻𝓪</span>
+        <span class="cursive-word-label">Aurora in corsivo</span>
+        <button type="button" class="copy-btn" data-text="𝓐𝓾𝓻𝓸𝓻𝓪" data-style="Ultra Script Bold">Copia</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Carica Alice nello studio delle firme" data-name="Alice">
+        <span class="cursive-word-render">𝓐𝓵𝓲𝓬𝓮</span>
+        <span class="cursive-word-label">Alice in corsivo</span>
+        <button type="button" class="copy-btn" data-text="𝓐𝓵𝓲𝓬𝓮" data-style="Ultra Script Bold">Copia</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Carica Ginevra nello studio delle firme" data-name="Ginevra">
+        <span class="cursive-word-render">𝓖𝓲𝓷𝓮𝓿𝓻𝓪</span>
+        <span class="cursive-word-label">Ginevra in corsivo</span>
+        <button type="button" class="copy-btn" data-text="𝓖𝓲𝓷𝓮𝓿𝓻𝓪" data-style="Ultra Script Bold">Copia</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Carica Emma nello studio delle firme" data-name="Emma">
+        <span class="cursive-word-render">𝓔𝓶𝓶𝓪</span>
+        <span class="cursive-word-label">Emma in corsivo</span>
+        <button type="button" class="copy-btn" data-text="𝓔𝓶𝓶𝓪" data-style="Ultra Script Bold">Copia</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Carica Leonardo nello studio delle firme" data-name="Leonardo">
+        <span class="cursive-word-render">𝓛𝓮𝓸𝓷𝓪𝓻𝓭𝓸</span>
+        <span class="cursive-word-label">Leonardo in corsivo</span>
+        <button type="button" class="copy-btn" data-text="𝓛𝓮𝓸𝓷𝓪𝓻𝓭𝓸" data-style="Ultra Script Bold">Copia</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Carica Francesco nello studio delle firme" data-name="Francesco">
+        <span class="cursive-word-render">𝓕𝓻𝓪𝓷𝓬𝓮𝓼𝓬𝓸</span>
+        <span class="cursive-word-label">Francesco in corsivo</span>
+        <button type="button" class="copy-btn" data-text="𝓕𝓻𝓪𝓷𝓬𝓮𝓼𝓬𝓸" data-style="Ultra Script Bold">Copia</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Carica Alessandro nello studio delle firme" data-name="Alessandro">
+        <span class="cursive-word-render">𝓐𝓵𝓮𝓼𝓼𝓪𝓷𝓭𝓻𝓸</span>
+        <span class="cursive-word-label">Alessandro in corsivo</span>
+        <button type="button" class="copy-btn" data-text="𝓐𝓵𝓮𝓼𝓼𝓪𝓷𝓭𝓻𝓸" data-style="Ultra Script Bold">Copia</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Carica Lorenzo nello studio delle firme" data-name="Lorenzo">
+        <span class="cursive-word-render">𝓛𝓸𝓻𝓮𝓷𝔃𝓸</span>
+        <span class="cursive-word-label">Lorenzo in corsivo</span>
+        <button type="button" class="copy-btn" data-text="𝓛𝓸𝓻𝓮𝓷𝔃𝓸" data-style="Ultra Script Bold">Copia</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Carica Tommaso nello studio delle firme" data-name="Tommaso">
+        <span class="cursive-word-render">𝓣𝓸𝓶𝓶𝓪𝓼𝓸</span>
+        <span class="cursive-word-label">Tommaso in corsivo</span>
+        <button type="button" class="copy-btn" data-text="𝓣𝓸𝓶𝓶𝓪𝓼𝓸" data-style="Ultra Script Bold">Copia</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Carica Riccardo nello studio delle firme" data-name="Riccardo">
+        <span class="cursive-word-render">𝓡𝓲𝓬𝓬𝓪𝓻𝓭𝓸</span>
+        <span class="cursive-word-label">Riccardo in corsivo</span>
+        <button type="button" class="copy-btn" data-text="𝓡𝓲𝓬𝓬𝓪𝓻𝓭𝓸" data-style="Ultra Script Bold">Copia</button>
+      </div>
+    </div>
+    </section>
+
+    <!-- Editorial -->
+    <section class="editorial-section cursive-editorial">
+      <h2>Come funziona questo generatore di corsivo</h2>
+      <p>Il corsivo che vedi qui non è un font: sono <strong>caratteri script di Unicode</strong>, lo stesso standard che il tuo dispositivo usa per ogni lettera ed emoji. Ecco perché resiste al copia e incolla: le app trattano 𝒸𝑜𝓇𝓈𝒾𝓋𝑜 esattamente come testo normale. È anche il motivo per cui funziona dove non potresti mai installare un font — biografie di Instagram, didascalie di TikTok, nomi su Discord, commenti su YouTube. Vuoi capire il meccanismo? Leggi <a href="/guide/how-unicode-fonts-work/">come funzionano i font Unicode</a>.</p>
+
+      <h3>Dove funzionano le lettere in corsivo (e dove no)</h3>
+      <ul class="compat-list">
+        <li><span class="ts-pill-safe">Funziona</span> Biografie e didascalie di Instagram, didascalie di TikTok, Discord, WhatsApp, Facebook, X, commenti di YouTube e la maggior parte dei documenti.</li>
+        <li><span class="ts-pill-risk">Limitato</span> I campi nome utente e nome visualizzato (Instagram, molti giochi) spesso eliminano i caratteri script — tieni gli username in testo semplice.</li>
+        <li><span class="ts-pill-risk">Limitato</span> Alcuni dispositivi datati mostrano quadratini di glifo mancante (▯). Se succede, usa uno stile più semplice o meno accenti — vedi <a href="/guide/why-fonts-show-as-boxes/">perché i font appaiono come quadratini</a>.</li>
+      </ul>
+
+      <h3>Corsivo Unicode vs corsivo tipografico vero</h3>
+      <p>Usa il corsivo Unicode quando ti serve il corsivo <em>dentro i campi di testo</em> — profili social, chat, titoli dei video. Usa invece un vero carattere corsivo (in Word, Canva o nel tuo programma di grafica) quando controlli il documento e ti serve una crenatura di qualità da stampa. E ricorda: in italiano "corsivo" indica anche l'<em>italico</em>, ma questo strumento crea il corsivo calligrafico, quello tipo scrittura a mano. Entrambi hanno il loro posto; qui ci occupiamo del primo.</p>
+
+      <h3>Accenti, lettere accentate e altri alfabeti</h3>
+      <p>I caratteri script di Unicode esistono solo per l'alfabeto latino A–Z, quindi le lettere accentate italiane (à, è, é, ì, ò, ù) non vengono trasformate e restano invariate, così come il cirillico, il greco e l'arabo. Per ottenere una parola o un nome interamente in corsivo, scrivili senza accento — per esempio <strong>papa</strong> invece di <em>papà</em> o <strong>felicita</strong> invece di <em>felicità</em>. Per esercitarti con la scrittura a mano, il nostro <a href="#cursive-alphabet">foglio di pratica da stampare</a> copre l'alfabeto latino dalla A alla Z.</p>
+
+      <h3>Imparare la scrittura corsiva</h3>
+      <p>I generatori servono per il testo digitale, ma funzionano anche come tabelle di riferimento. Stampa il <a href="#cursive-alphabet">foglio di pratica</a> per ricalcare le lettere, studia come ogni maiuscola si collega nell'<a href="#cursive-letters">esploratore delle lettere</a> e tieni presente qualche buona abitudine di accessibilità — linee decorative brevi e testo semplice per il resto (<a href="/guide/fancy-fonts-accessibility-guide/">guida all'accessibilità</a>).</p>
+
+      <h3>Corsivo per i tatuaggi</h3>
+      <p>Il lettering in corsivo è lo stile di tatuaggio più richiesto. Visualizza qui la tua parola in grande, poi usa il <a href="/it/usecase/font-tatuaggi/">generatore di font per tatuaggi</a> dedicato — aggiunge famiglie di lettering, date in numeri romani, iniziali e un test di leggibilità alla dimensione dell'inchiostro.</p>
+    </section>
+
+    <div class="cta-card">
+      <h3>Dai un tocco corsivo a tutta la tua bio</h3>
+      <p>Abbina un titolo in corsivo a un testo pulito — la combinazione che spicca e resta leggibile. Apri il generatore completo e prova ogni stile in tempo reale.</p>
+      <a class="cta-btn" href="/it/">Apri il generatore completo →</a>
+    </div>
+  </main>
+
+  <!-- Footer + FAQ -->
+  <footer class="footer">
+    <div class="footer-inner">
+<div class="faq-section" id="cursive-faq">
+
+<h2 class="faq-category">Generatore di Lettere in Corsivo — Domande frequenti</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Cos'è un generatore di corsivo e come funziona?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Converte le lettere che scrivi in caratteri script di Unicode — simboli speciali che sembrano scrittura corsiva ma si comportano come testo normale. Poiché sono veri caratteri (non un font né un'immagine), puoi copiarli e incollarli in biografie, didascalie, commenti e messaggi, mantenendo l'aspetto in corsivo. Scopri di più nella nostra <a href="/guide/how-unicode-fonts-work/">guida su come funzionano i font Unicode</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Come si copiano e incollano le lettere in corsivo?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Scrivi o incolla il testo nel riquadro in alto, poi tocca Copia sullo stile che preferisci. La versione in corsivo è ora nei tuoi appunti: incollala ovunque accetti testo — Instagram, TikTok, WhatsApp, Discord, documenti e altro.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Il corsivo funziona su Instagram, WhatsApp e TikTok?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Sì — il corsivo Unicode si incolla senza problemi nelle biografie e didascalie di Instagram, su TikTok, X, Facebook, WhatsApp, Discord e YouTube. Tieni però nomi utente e handle in testo semplice: molti campi username eliminano o rifiutano i caratteri speciali. Consulta la nostra pagina sui <a href="/instagram/">font per Instagram</a> per consigli specifici.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Come ottengo una singola lettera in corsivo, come una S o una G maiuscola?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Usa la sezione Lettere in corsivo A–Z di questa pagina. Tocca una lettera per vederne la forma maiuscola e minuscola in ogni stile di corsivo, copia solo quella che ti serve o scaricala come PNG. Puoi anche collegarti direttamente a una lettera — per esempio <strong>#cursive-s</strong>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Posso copiare tutto l'alfabeto corsivo insieme?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Sì. La sezione dell'alfabeto corsivo ha tabelle complete dalla A alla Z (maiuscole, minuscole e numeri) per gli stili classico, grassetto e gotico, ciascuna con un pulsante Copia alfabeto con un clic.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Posso scrivere il mio nome in corsivo o creare una firma?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Sì. Lo studio dei nomi e delle firme trasforma qualsiasi nome in corsivo stile firma: script classico, grassetto, autografo sottolineato, targa ornata e iniziali monogramma. È un modo rapido per vedere come scorre il tuo nome in corsivo prima di usarlo in una bio, in una firma email o in un progetto grafico.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Le lettere accentate (à, è, é, ì, ò, ù) diventano corsive?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    No. I caratteri script di Unicode esistono solo per le lettere A–Z senza accento, quindi le vocali accentate restano invariate. Per una parola o un nome completamente in corsivo, scrivili senza accento — ad esempio <strong>papa</strong> al posto di <em>papà</em> o <strong>perche</strong> al posto di <em>perché</em>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Questo generatore di corsivo è gratuito?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Completamente gratuito — senza registrazione, senza filigrane, senza limiti. Tutto funziona direttamente nel tuo browser.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Posso fare numeri in corsivo?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Unicode non ha vere cifre corsive, perciò gli stili di corsivo abbinano alle lettere script dei numeri stilizzati coordinati — numeri leggeri per Ultra Script e più marcati per Ultra Script Bold. Scrivi le cifre insieme al testo e vengono stilizzate per intonarsi.
+  </div>
+</div>
+
+</div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Language switcher">
+      <a class="lang-option" href="/category/cursive-fonts/" hreflang="en">EN</a>
+      <a class="lang-option" href="/es/letra-cursiva/" hreflang="es">ES</a>
+      <a class="lang-option" href="/pt/letra-cursiva/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/fr/ecriture-cursive/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/de/schreibschrift/" hreflang="de">DE</a>
+      <a class="lang-option active" href="/it/lettere-in-corsivo/" hreflang="it">IT</a>
+      <a class="lang-option" href="/tr/el-yazisi-fontu/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/nl/cursieve-letters/" hreflang="nl">NL</a>
+      <a class="lang-option" href="/id/tulisan-sambung/" hreflang="id">ID</a>
+      <a class="lang-option" href="/no/kursiv-tekst/" hreflang="no">NO</a>
+    </div>
+
+    </div>
+  </footer>
+
+  <div id="cursivePrintRoot" aria-hidden="true"></div>
+  <div class="copy-toast" id="copyToast">Copiato!</div>
+
+  <script>
+    window.UTG_CURSIVE_MODE = true;
+    window.UTG_FAMILY = "cursive";
+    window.cursiveI18n = {
+  "demoText": "Ciao",
+  "demoName": "Giulia",
+  "copy": "Copia",
+  "typeFirst": "Scrivi prima il tuo testo qui sopra",
+  "downloadPngTitle": "Scarica come immagine PNG",
+  "downloadPng": "Scarica PNG",
+  "characters": "caratteri",
+  "caseUpper": "Maiuscola",
+  "caseLower": "Minuscola",
+  "caseBoth": "Entrambe",
+  "labelUpper": "{ch} maiuscola in corsivo",
+  "labelLower": "{ch} minuscola in corsivo",
+  "labelBoth": "{ch} maiuscola e minuscola in corsivo",
+  "copyBoth": "Copia entrambe",
+  "everyStyle": "{ch} in corsivo — tutti gli stili, clicca per copiare",
+  "suffixCapital": " — maiuscola",
+  "suffixLowercase": " — minuscola",
+  "accentLabel": "Decorazione {name}",
+  "practiceTitle": "Foglio di pratica per l'alfabeto corsivo — ultratextgen.com",
+  "flourishLabel": "Svolazzo",
+  "monogramLabel": "Unione monogramma",
+  "copiedToast": "Copiato!",
+  "quickWords": [
+    "amore",
+    "auguri",
+    "grazie",
+    "famiglia",
+    "sempre",
+    "benedetta"
+  ],
+  "styles": {
+    "Ultra Script": "corsivo classico",
+    "Ultra Script Bold": "corsivo in grassetto",
+    "Ultra Script Elegant": "corsivo elegante",
+    "Ultra Script Bold Elegant": "corsivo grassetto elegante",
+    "Ultra Gothic Script": "corsivo gotico",
+    "Ultra Chicano Script": "targa stile Chicano",
+    "Ultra Script Sparkle": "corsivo scintillante"
+  },
+  "presets": {
+    "Script Hearts": "Corsivo con cuori",
+    "Script Arrow Bio": "Corsivo con frecce per bio",
+    "Bold Script Stars": "Corsivo grassetto con stelle",
+    "Script Vintage": "Corsivo vintage",
+    "Script Soft Dots": "Corsivo con puntini",
+    "Bold Script Ribbon": "Corsivo grassetto con nastro",
+    "Script Underline": "Corsivo sottolineato",
+    "Bold Script Crown": "Corsivo grassetto con corona"
+  },
+  "signatures": {
+    "Classic Signature": "Firma classica",
+    "Bold Signature": "Firma in grassetto",
+    "Signed Underline": "Firma sottolineata",
+    "Sparkle Signature": "Firma scintillante",
+    "Ornate Nameplate": "Targa ornata",
+    "Autograph Star": "Autografo con stella",
+    "Monogram Initials": "Iniziali monogramma",
+    "Gothic Signature": "Firma gotica"
+  },
+  "decorators": {
+    "None": "Nessuna",
+    "Underline": "Sottolineatura",
+    "Sparkle": "Scintillii",
+    "Hearts": "Cuori",
+    "Ornate": "Ornata",
+    "Soft dots": "Puntini"
+  },
+  "accents": {
+    "Sparkle": "Scintillii",
+    "Hearts": "Cuori",
+    "Wings": "Ali",
+    "Ornate": "Ornata"
+  },
+  "platformLimits": {
+    "Instagram bio": "Bio di Instagram",
+    "TikTok bio": "Bio di TikTok",
+    "X bio": "Bio di X"
+  }
+};
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/js/cursive/cursiveData.js" defer></script>
+  <script src="/script.js" defer></script>
+  <script src="/js/cursive/cursivePageController.js" defer></script>
+  <script src="/footer.js" defer></script>
+</body></html>

--- a/js/cursive/cursivePageController.js
+++ b/js/cursive/cursivePageController.js
@@ -16,9 +16,29 @@
   const $$ = (sel, root) => Array.from((root || document).querySelectorAll(sel));
 
   const D = window.UTG_CURSIVE_DATA || {};
+
+  // Optional per-page localization table (see the translated cursive pages).
+  // Every user-facing string falls back to English, so the English page needs
+  // no cursiveI18n at all and behaves exactly as before.
+  const I18N = window.cursiveI18n || {};
+  function t(key, fallback) {
+    return I18N[key] != null ? I18N[key] : fallback;
+  }
+  // Look up a localized value in a nested table (e.g. I18N.presets['Script Hearts']).
+  function pick(table, id, fallback) {
+    const sec = I18N[table];
+    return (sec && sec[id] != null) ? sec[id] : fallback;
+  }
+  // Fill {placeholders} in a template string.
+  function fmt(str, map) {
+    return String(str).replace(/\{(\w+)\}/g, (m, k) => (map[k] != null ? map[k] : m));
+  }
+  // Display label for a registry style key ("Ultra Script" → localized name).
+  function styleLabel(name) { return pick("styles", name, name); }
+
   const LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("");
   const GLYPH_FONT = "'Plus Jakarta Sans', 'Segoe UI Symbol', 'Noto Sans Symbols 2', sans-serif";
-  const DEMO_TEXT = "Hello";
+  const DEMO_TEXT = t("demoText", "Hello");
 
   const el = {
     input: $("#mainInput"),
@@ -106,10 +126,10 @@
     const btn = document.createElement("button");
     btn.type = "button";
     btn.className = "copy-btn";
-    btn.textContent = "Copy";
+    btn.textContent = t("copy", "Copy");
     if (o.demo || !text) {
       btn.disabled = true;
-      btn.title = "Type your text above first";
+      btn.title = t("typeFirst", "Type your text above first");
     } else {
       btn.dataset.text = text;
       btn.dataset.style = o.styleName || name;
@@ -121,7 +141,7 @@
       png.type = "button";
       png.className = "cursive-png-btn";
       png.textContent = "PNG";
-      png.title = "Download as PNG image";
+      png.title = t("downloadPngTitle", "Download as PNG image");
       png.addEventListener("click", () => downloadTextPNG(text, o.pngName || name));
       actions.appendChild(png);
     }
@@ -147,14 +167,14 @@
       const out = renderWith(text, name);
       if (!out || seen[out]) return;
       seen[out] = true;
-      frag.appendChild(buildCard(name, out, { demo: isDemo, styleName: name }));
+      frag.appendChild(buildCard(styleLabel(name), out, { demo: isDemo, styleName: name }));
     });
 
     (D.presets || []).forEach((preset) => {
       const out = renderPreset(text, preset);
       if (!out || seen[out]) return;
       seen[out] = true;
-      frag.appendChild(buildCard(preset.name, out, { demo: isDemo, styleName: preset.name }));
+      frag.appendChild(buildCard(pick("presets", preset.name, preset.name), out, { demo: isDemo, styleName: preset.name }));
     });
 
     el.resultsGrid.innerHTML = "";
@@ -171,21 +191,22 @@
     const count = [...rendered].length;
     const note = document.createElement("span");
     note.className = "vertical-fit-count";
-    note.textContent = count + " characters";
+    note.textContent = count + " " + t("characters", "characters");
     el.fitRow.appendChild(note);
 
     (D.platformLimits || []).forEach((p) => {
       const ok = count <= p.limit;
       const badge = document.createElement("span");
       badge.className = "vertical-fit-badge " + (ok ? "fit" : "no-fit");
-      badge.textContent = (ok ? "✓ " : "✗ ") + p.label + " (" + p.limit + ")";
+      badge.textContent = (ok ? "✓ " : "✗ ") + pick("platformLimits", p.label, p.label) + " (" + p.limit + ")";
       el.fitRow.appendChild(badge);
     });
   }
 
   function buildQuickRow() {
     if (!el.quickRow || !el.input) return;
-    (D.quickWords || []).forEach((word) => {
+    const words = Array.isArray(I18N.quickWords) ? I18N.quickWords : (D.quickWords || []);
+    words.forEach((word) => {
       const chip = document.createElement("button");
       chip.type = "button";
       chip.className = "vertical-chip cursive-quick-chip";
@@ -281,9 +302,9 @@
   // are what most "cursive s" searches want, but the pair is the default view.
   let letterCase = "both";
   const CASES = [
-    { id: "upper", label: "Capital" },
-    { id: "lower", label: "Lowercase" },
-    { id: "both",  label: "Both" }
+    { id: "upper", label: t("caseUpper", "Capital") },
+    { id: "lower", label: t("caseLower", "Lowercase") },
+    { id: "both",  label: t("caseBoth", "Both") }
   ];
 
   function caseGlyph(primary, ch) {
@@ -293,9 +314,9 @@
   }
 
   function caseLabel(ch) {
-    if (letterCase === "upper") return "Capital " + ch + " in cursive";
-    if (letterCase === "lower") return "Lowercase " + ch.toLowerCase() + " in cursive";
-    return "Capital and lowercase " + ch + " in cursive";
+    if (letterCase === "upper") return fmt(t("labelUpper", "Capital {ch} in cursive"), { ch: ch });
+    if (letterCase === "lower") return fmt(t("labelLower", "Lowercase {ch} in cursive"), { ch: ch.toLowerCase() });
+    return fmt(t("labelBoth", "Capital and lowercase {ch} in cursive"), { ch: ch });
   }
 
   function selectLetter(ch, opts) {
@@ -345,14 +366,14 @@
     const copyBtn = document.createElement("button");
     copyBtn.type = "button";
     copyBtn.className = "bubble-btn bubble-btn-primary copy-btn";
-    copyBtn.textContent = letterCase === "both" ? "Copy both" : "Copy " + (letterCase === "upper" ? primary.upper : primary.lower);
+    copyBtn.textContent = letterCase === "both" ? t("copyBoth", "Copy both") : t("copy", "Copy") + " " + (letterCase === "upper" ? primary.upper : primary.lower);
     copyBtn.dataset.text = caseGlyph(primary, ch);
     copyBtn.dataset.style = primary.name;
     actions.appendChild(copyBtn);
     const dl = document.createElement("button");
     dl.type = "button";
     dl.className = "bubble-btn";
-    dl.textContent = "Download PNG";
+    dl.textContent = t("downloadPng", "Download PNG");
     dl.addEventListener("click", () => downloadLetterPNG(ch, caseGlyph(primary, ch)));
     actions.appendChild(dl);
     figure.appendChild(actions);
@@ -362,7 +383,7 @@
     detail.className = "bubble-detail";
     const title = document.createElement("h3");
     title.className = "bubble-detail-title";
-    title.textContent = ch + " in cursive — every style, click to copy";
+    title.textContent = fmt(t("everyStyle", "{ch} in cursive — every style, click to copy"), { ch: ch });
     detail.appendChild(title);
 
     const list = document.createElement("div");
@@ -378,10 +399,10 @@
         glyph.textContent = v[kind];
         const meta = document.createElement("span");
         meta.className = "bubble-variant-name";
-        meta.textContent = v.name.replace(/^Ultra /, "") + (kind === "upper" ? " — capital" : " — lowercase");
+        meta.textContent = pick("styles", v.name, v.name.replace(/^Ultra /, "")) + (kind === "upper" ? t("suffixCapital", " — capital") : t("suffixLowercase", " — lowercase"));
         const cta = document.createElement("span");
         cta.className = "bubble-variant-copy";
-        cta.textContent = "Copy";
+        cta.textContent = t("copy", "Copy");
         row.appendChild(glyph); row.appendChild(meta); row.appendChild(cta);
         list.appendChild(row);
       });
@@ -399,10 +420,10 @@
       glyph.textContent = glyphText;
       const meta = document.createElement("span");
       meta.className = "bubble-variant-name";
-      meta.textContent = acc.name + " accent";
+      meta.textContent = fmt(t("accentLabel", "{name} accent"), { name: pick("accents", acc.name, acc.name) });
       const cta = document.createElement("span");
       cta.className = "bubble-variant-copy";
-      cta.textContent = "Copy";
+      cta.textContent = t("copy", "Copy");
       row.appendChild(glyph); row.appendChild(meta); row.appendChild(cta);
       list.appendChild(row);
     });
@@ -437,7 +458,7 @@
     wrap.className = "bubble-print-wrap";
     const h = document.createElement("h2");
     h.className = "bubble-print-title";
-    h.textContent = "Cursive alphabet practice sheet — ultratextgen.com";
+    h.textContent = t("practiceTitle", "Cursive alphabet practice sheet — ultratextgen.com");
     wrap.appendChild(h);
 
     const sheet = document.createElement("div");
@@ -475,7 +496,7 @@
   function renderNames() {
     if (!el.nameResults) return;
     const raw = el.nameInput ? el.nameInput.value : "";
-    const name = raw.trim() ? raw.trim() : "Olivia";
+    const name = raw.trim() ? raw.trim() : t("demoName", "Olivia");
     const isDemo = !raw.trim();
 
     const frag = document.createDocumentFragment();
@@ -490,7 +511,7 @@
       const out = renderPreset(source, preset, preset.initials ? null : activeDecorator);
       if (!out || seen[out]) return;
       seen[out] = true;
-      frag.appendChild(buildCard(preset.name, out, { demo: isDemo, styleName: preset.name, png: true, pngName: preset.name }));
+      frag.appendChild(buildCard(pick("signatures", preset.name, preset.name), out, { demo: isDemo, styleName: preset.name, png: true, pngName: preset.name }));
     });
 
     el.nameResults.innerHTML = "";
@@ -527,13 +548,13 @@
     if (!el.sigControls) return;
     const decos = D.signatureDecorators || [];
     el.sigControls.appendChild(chipRow(
-      "Flourish",
-      decos.map((d) => ({ label: d.name, value: d })),
+      t("flourishLabel", "Flourish"),
+      decos.map((d) => ({ label: pick("decorators", d.name, d.name), value: d })),
       (chip) => (activeDecorator ? activeDecorator.name : "None") === chip.value.name,
       (chip) => { activeDecorator = chip.value.name === "None" ? null : chip.value; }
     ));
     el.sigControls.appendChild(chipRow(
-      "Monogram joiner",
+      t("monogramLabel", "Monogram joiner"),
       (D.monogramJoiners || ["."]).map((j) => ({ label: "O" + j + "G", value: j })),
       (chip) => chip.value === activeJoiner,
       (chip) => { activeJoiner = chip.value; }

--- a/nl/cursieve-letters/index.html
+++ b/nl/cursieve-letters/index.html
@@ -6,24 +6,30 @@
   'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
   })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
   <!-- End Google Tag Manager -->
-  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZGVh");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
   <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Cursieve Letters — Schuine Tekst om te Kopiëren en Plakken (𝘊𝘶𝘳𝘴𝘪𝘦𝘧) | UltraTextGen</title>
-  <meta name="description" content="Cursieve letters om te kopiëren en plakken: maak je tekst 𝘴𝘤𝘩𝘶𝘪𝘯 in drie stijlen — cursief, serif cursief en vet cursief. Voor Instagram, WhatsApp, Facebook en overal waar geen cursief-knop is.">
+  <title>Cursieve Letters Generator — 𝓴𝓸𝓹𝓲𝓮𝓮𝓻 𝓮𝓷 𝓹𝓵𝓪𝓴 sierlijke letters A–Z &amp; namen | UltraTextGen</title>
+  <meta name="description" content="Gratis generator voor cursieve letters — kopieer en plak een cursief lettertype, elke sierlijke letter A–Z, het complete cursieve alfabet, populaire woorden in cursief schrift en cursieve naamhandtekeningen.">
   <link rel="canonical" href="https://ultratextgen.com/nl/cursieve-letters/">
 
-  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/category/italic-fonts/">
-  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/ecriture-italique/">
-  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/tulisan-miring/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/category/cursive-fonts/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/letra-cursiva/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/letra-cursiva/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/ecriture-cursive/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/schreibschrift/">
+  <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/lettere-in-corsivo/">
+  <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/el-yazisi-fontu/">
   <link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/cursieve-letters/">
-  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/category/italic-fonts/">
+  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/tulisan-sambung/">
+  <link rel="alternate" hreflang="no" href="https://ultratextgen.com/no/kursiv-tekst/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/category/cursive-fonts/">
 
   <meta name="robots" content="index, follow">
   <meta property="og:site_name" content="UltraTextGen">
-  <meta property="og:title" content="Cursieve Letters — Schuine Tekst om te Kopiëren en Plakken (𝘊𝘶𝘳𝘴𝘪𝘦𝘧)">
-  <meta property="og:description" content="Maak je tekst schuin in drie cursieve stijlen. Kopieer en plak in je bio, status of post — de schuine letters blijven staan.">
+  <meta property="og:title" content="Cursieve Letters Generator — 𝓴𝓸𝓹𝓲𝓮𝓮𝓻 𝓮𝓷 𝓹𝓵𝓪𝓴 sierlijke letters A–Z &amp; namen | UltraTextGen">
+  <meta property="og:description" content="Gratis generator voor cursieve letters — kopieer en plak een cursief lettertype, elke sierlijke letter A–Z, het complete cursieve alfabet, populaire woorden in cursief schrift en cursieve namen.">
   <meta property="og:url" content="https://ultratextgen.com/nl/cursieve-letters/">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://ultratextgen.com/assets/og/nl-cursieve-letters.png">
@@ -31,27 +37,13 @@
   <meta property="og:image:height" content="630">
   <meta property="og:image:type" content="image/png">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Cursieve Letters — Schuine Tekst om te Kopiëren en Plakken (𝘊𝘶𝘳𝘴𝘪𝘦𝘧)">
-  <meta name="twitter:description" content="Alle cursieve stijlen op één pagina — typ, kopieer, plak. Gratis.">
+  <meta name="twitter:title" content="Cursieve Letters Generator — 𝓴𝓸𝓹𝓲𝓮𝓮𝓻 𝓮𝓷 𝓹𝓵𝓪𝓴 sierlijke letters A–Z &amp; namen | UltraTextGen">
+  <meta name="twitter:description" content="Gratis generator voor cursieve letters — kopieer en plak een cursief lettertype, elke sierlijke letter A–Z, het volledige cursieve alfabet en cursieve naamhandtekeningen.">
   <meta name="twitter:image" content="https://ultratextgen.com/assets/og/nl-cursieve-letters.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/style.css">
-  <link rel="stylesheet" href="/symbol-explorer.css">
-
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "WebApplication",
-  "name": "Cursieve Letters Generator",
-  "alternateName": ["Cursieve Letters", "Schuine Tekst", "Cursief Lettertype", "Schuine Letters", "Tekst Cursief Maken"],
-  "url": "https://ultratextgen.com/nl/cursieve-letters/",
-  "inLanguage": "nl",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "description": "Cursieve letters generator: zet je tekst om in schuine Unicode-letters — cursief, serif cursief en vet cursief — om te kopiëren en plakken in je Instagram bio, WhatsApp-status, Facebook-post of e-mail.",
-  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "EUR" }
-}
-</script>
 
 <script type="application/ld+json">
 {
@@ -61,28 +53,67 @@
   "mainEntity": [
     {
       "@type": "Question",
-      "name": "Hoe maak ik tekst cursief?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Typ je tekst in het vak bovenaan — de schuine versies (𝘤𝘶𝘳𝘴𝘪𝘦𝘧, 𝑠𝑒𝑟𝑖𝑓 𝑐𝑢𝑟𝑠𝑖𝑒𝑓 en 𝙫𝙚𝙩 𝙘𝙪𝙧𝙨𝙞𝙚𝙛) verschijnen meteen. Klik op «Kopieer» en plak de tekst waar je wilt. Omdat elke letter zelf al schuin is, blijft de tekst cursief — ook in velden zonder cursief-knop." }
+      "name": "Wat is een generator voor cursieve letters en hoe werkt hij?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Hij zet de letters die je typt om in Unicode-scripttekens — speciale symbolen die eruitzien als cursief handschrift maar zich gedragen als gewone tekst. Omdat het echte tekens zijn (geen lettertype of afbeelding), kun je ze kopiëren en plakken in bio's, bijschriften, reacties en berichten, waarbij ze hun cursieve uiterlijk behouden. Lees meer in onze <a href=\"/guide/how-unicode-fonts-work/\">gids over hoe Unicode-lettertypes werken</a>."
+      }
     },
     {
       "@type": "Question",
-      "name": "Is cursief hetzelfde als sierlijke letters?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Nee — en dit is in het Nederlands verwarrend. Cursief betekent schuingedrukt: rechte letters die schuin hellen, zoals de I-knop in Word. Sierlijke letters (sierletters) zijn krullende kalligrafie-letters. Deze pagina maakt schuine tekst; voor de krullen ga je naar de pagina sierlijke letters." }
+      "name": "Hoe kopieer en plak ik cursieve tekst?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Typ of plak je tekst in het vak bovenaan en tik op Kopiëren bij de stijl die je mooi vindt. De cursieve versie staat nu op je klembord — plak hem overal waar tekst kan: Instagram, TikTok, WhatsApp, Discord, documenten en meer."
+      }
     },
     {
       "@type": "Question",
-      "name": "Hoe maak ik tekst cursief op Instagram of Facebook?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Instagram en Facebook hebben geen cursief-knop in posts, bio's en reacties. Typ je tekst hier, kopieer de cursieve versie en plak hem waar je wilt — de schuine letters blijven staan, want ze zíjn schuin. In WhatsApp-berichten kan cursief ook met _liggende streepjes_, maar dat werkt alleen in berichten en verdwijnt bij kopiëren." }
+      "name": "Werken cursieve letters op Instagram, WhatsApp en TikTok?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ja. Cursieve letters werken in je Instagram-<strong>bio</strong> en bijschriften, je WhatsApp-status en -berichten, en TikTok-bijschriften. Let op: velden voor je gebruikersnaam of weergavenaam filteren soms speciale tekens weg — voor je @handle blijf je bij gewone letters."
+      }
     },
     {
       "@type": "Question",
-      "name": "Waarvoor gebruik je cursieve tekst?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Voor subtiele nadruk: een citaat in je bio, een boektitel, een gedachte tussen gewone tekst, of een zachte ondertitel onder een vette kop. Cursief is de meest ingetogen van alle tekststijlen — het valt op zonder te schreeuwen. Combineer het met vetgedrukte letters voor een kop-en-subkop-effect." }
+      "name": "Is het gratis en moet ik een account maken?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Volledig gratis, zonder account en zonder installatie. Alles draait in je browser: typen, kopiëren, plakken. Er wordt niets opgeslagen op een server."
+      }
     },
     {
       "@type": "Question",
-      "name": "Blijven ë en é staan in cursieve tekst?",
-      "acceptedAnswer": { "@type": "Answer", "text": "De letters met trema of accent hebben geen cursieve Unicode-variant, dus die blijven gewoon recht tussen de schuine letters staan — «café» wordt 𝘤𝘢𝘧é. Dat leest prima. De ij doet wel volledig mee: «vrij» wordt 𝘷𝘳𝘪𝘫." }
+      "name": "Waarom veranderen mijn accenten en trema's niet mee?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Unicode-scriptletters bestaan alleen voor A–Z. Letters met accenten of trema's (é, ë, ï, ö, ç) hebben geen cursieve tegenhanger en blijven daarom in gewone tekst staan. Wil je alles volledig cursief? Schrijf het woord of de naam dan zonder accenten."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Kan ik één losse cursieve letter kopiëren?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ja. Gebruik de <a href=\"#cursive-letters\">letterverkenner A–Z</a>: tik op een letter om elke cursieve stijl te zien, kopieer de exacte hoofdletter of kleine letter, of download hem als PNG-afbeelding."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Waarom zie ik lege vakjes in plaats van sierlijke letters?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Een leeg vakje (▯) betekent dat het apparaat of de app dat teken niet kan tonen. Dat komt bijna alleen voor op oudere systemen. Kies dan een eenvoudigere stijl of houd de tekst korter. Meer uitleg staat in <a href=\"/guide/why-fonts-show-as-boxes/\">waarom lettertypes als vakjes verschijnen</a>."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Kan ik cursieve letters gebruiken voor een tattoo?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Zeker. Bekijk je woord hier op groot formaat en ga daarna naar de <a href=\"/nl/usecase/tattoo-letters/\">generator voor tattoo-letters</a> voor letterfamilies, datums in Romeinse cijfers en een leesbaarheidstest."
+      }
     }
   ]
 }
@@ -98,145 +129,720 @@
   ]
 }
 </script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Cursieve Letters Generator",
+  "alternateName": ["Cursief Generator","Sierlijke Letters Generator","Cursieve Letters A–Z","Cursief Alfabet","Cursieve Namen Generator","Cursieve Handtekening Generator","Schuine Letters Kopiëren en Plakken"],
+  "url": "https://ultratextgen.com/nl/cursieve-letters/",
+  "inLanguage": "nl",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "EUR"
+  },
+  "description": "Gratis generator voor cursieve letters: kopieer en plak een cursief lettertype, elke sierlijke letter A–Z, het complete cursieve alfabet, populaire woorden in cursief schrift en cursieve naamhandtekeningen.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers.",
+  "featureList": ["Generator voor cursieve letters met sierlijke presets","Verkenner voor cursieve letters A–Z (hoofd- en kleine letters)","Het hele cursieve alfabet met één klik kopiëren","Printbaar oefenblad voor het cursieve alfabet","Studio voor cursieve namen en handtekeningen","Galerij met woorden in cursief schrift (liefde, fijne verjaardag, maanden)"]
+}
+</script>
 </head>
 <body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
   <!-- Google Tag Manager (noscript) -->
-  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <!-- End Google Tag Manager (noscript) -->
-<script src="/header.js"></script>
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
 
-<nav class="breadcrumbs" aria-label="Kruimelpad">
+<nav class="breadcrumbs" aria-label="Breadcrumb">
   <a href="/nl/">Home</a>
   <span class="breadcrumb-separator">›</span>
   <span class="breadcrumb-current">Cursieve Letters</span>
 </nav>
 
 <figure class="page-hero-figure" data-uthero aria-hidden="true">
-  <img src="/assets/hero/nl-cursieve-letters.svg" width="1200" height="340" loading="lazy" alt="">
+  <img src="/assets/hero/nl-cursieve-letters.svg" width="1200" height="340"
+       loading="lazy" alt="">
 </figure>
 
-<section class="hero">
-  <div class="hero-inner">
-    <div class="hero-card">
-      <h1 class="hero-headline">Cursieve letters om te kopiëren en plakken</h1>
-      <p class="hero-tagline">Typ je tekst en hij wordt meteen schuin — als strak 𝘤𝘶𝘳𝘴𝘪𝘦𝘧, klassiek 𝑠𝑒𝑟𝑖𝑓 𝑐𝑢𝑟𝑠𝑖𝑒𝑓 of stevig 𝙫𝙚𝙩 𝙘𝙪𝙧𝙨𝙞𝙚𝙛. Plak hem in je bio, status of post: de schuine letters blijven overal staan.</p>
-      <div class="input-wrapper">
-        <textarea class="main-input" id="mainInput" placeholder="Typ hier je tekst…" maxlength="500" autofocus=""></textarea>
-        <span class="char-count"><span id="charCount">0</span>/500</span>
-      </div>
-      <div class="accent-notice" id="accentNotice" role="note" hidden>
-        <span class="accent-notice-icon" aria-hidden="true">◌̈</span>
-        <span class="accent-notice-text">Je tekst bevat accenten of een trema. De meeste stijlen laten <b>ë</b>, <b>é</b> of <b>ï</b> als gewone letter staan — de stijlen <b>doorgestreept, onderstreept en kaders</b> houden ze wel. <a href="/guide/fancy-fonts-and-accents/">Welke stijlen accenten houden →</a></span>
-        <button type="button" class="accent-notice-close" id="accentNoticeClose" aria-label="Sluiten">✕</button>
-      </div>
-      <div class="decoration-section">
-        <div class="decoration-label">Zet er wat decoratie omheen</div>
-        <div class="decoration-tabs">
-          <button class="decoration-tab active" data-deco-tab="symbols">Symbolen</button>
-          <button class="decoration-tab" data-deco-tab="frames">Kaders</button>
-          <button class="decoration-tab" data-deco-tab="minimal">Minimalistisch</button>
+  <!-- Hero: the cursive-first generator -->
+  <section class="hero">
+    <div class="hero-inner">
+      <div class="hero-card">
+        <h1 class="hero-headline">Cursieve Letters Generator</h1>
+        <p class="hero-tagline">Zet elke tekst om in 𝓼𝓲𝓮𝓻𝓵𝓲𝓳𝓴𝓮 cursieve letters die je kunt kopiëren en plakken —
+          vloeiende schuine letters, elke cursieve letter A–Z, het complete alfabet en naamhandtekeningen. Gratis, meteen, zonder account.</p>
+        <div class="input-wrapper">
+          <textarea class="main-input" id="mainInput" placeholder="Typ je tekst, woord of naam…" maxlength="500" autofocus></textarea>
+          <span class="char-count"><span id="charCount">0</span>/500</span>
         </div>
-        <div class="decoration-grid" id="decorationGrid"></div>
+        <div class="cursive-quick-row" id="cursiveQuickRow" aria-label="Snelle voorbeelden"></div>
+        <div class="vertical-fit-row" id="cursiveFitRow" hidden></div>
       </div>
     </div>
+  </section>
+
+  <nav class="cursive-section-nav" aria-label="Op deze pagina">
+    <a href="#cursive-styles">Stijlen</a>
+    <a href="#cursive-letters">Letters A–Z</a>
+    <a href="#cursive-alphabet">Alfabet</a>
+    <a href="#cursive-words">Woorden</a>
+    <a href="#cursive-names">Namen &amp; Handtekeningen</a>
+    <a href="#cursive-faq">FAQ</a>
+  </nav>
+
+  <main class="container">
+
+    <!-- 1. Generator output -->
+    <section id="cursive-styles" aria-labelledby="cursiveStylesHeading">
+      <h2 class="bubble-az-heading" id="cursiveStylesHeading">Cursieve lettertypes — kopiëren en plakken</h2>
+      <p class="bubble-az-intro">Elke stijl hieronder werkt live bij terwijl je typt: klassieke en vette cursieve letters,
+        elegante versies met ruimte, gothic cursief, Chicano-naamplaten en sierlijke presets met hartjes,
+        sterretjes en pijltjes. Tik op Kopiëren en plak het overal.</p>
+      <div class="results-grid" id="resultsGrid"></div>
+    </section>
+
+    <!-- 2. Cursive letters A–Z -->
+    <section class="bubble-az" id="cursive-letters" aria-labelledby="cursiveLettersHeading">
+      <h2 class="bubble-az-heading" id="cursiveLettersHeading">Cursieve letters A–Z — hoofdletters &amp; kleine letters</h2>
+      <p class="bubble-az-intro">Zoek je één sierlijke letter — een cursieve S, een hoofdletter G in cursief, een kleine f?
+        Tik op een letter om hem in elke cursieve stijl te zien, kopieer de exacte letter of download hem als PNG.</p>
+  <div class="cursive-letter-grid" role="tablist" aria-label="Kies een cursieve letter">
+    <button type="button" class="cursive-letter-cell" id="cursive-a" data-char="A" aria-label="A in cursief — hoofdletter en kleine letter">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒜 𝒶</span>
+      <span class="cursive-letter-name">Cursieve A</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-b" data-char="B" aria-label="B in cursief — hoofdletter en kleine letter">
+      <span class="cursive-letter-pair" aria-hidden="true">ℬ 𝒷</span>
+      <span class="cursive-letter-name">Cursieve B</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-c" data-char="C" aria-label="C in cursief — hoofdletter en kleine letter">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒞 𝒸</span>
+      <span class="cursive-letter-name">Cursieve C</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-d" data-char="D" aria-label="D in cursief — hoofdletter en kleine letter">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒟 𝒹</span>
+      <span class="cursive-letter-name">Cursieve D</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-e" data-char="E" aria-label="E in cursief — hoofdletter en kleine letter">
+      <span class="cursive-letter-pair" aria-hidden="true">ℰ ℯ</span>
+      <span class="cursive-letter-name">Cursieve E</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-f" data-char="F" aria-label="F in cursief — hoofdletter en kleine letter">
+      <span class="cursive-letter-pair" aria-hidden="true">ℱ 𝒻</span>
+      <span class="cursive-letter-name">Cursieve F</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-g" data-char="G" aria-label="G in cursief — hoofdletter en kleine letter">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒢 ℊ</span>
+      <span class="cursive-letter-name">Cursieve G</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-h" data-char="H" aria-label="H in cursief — hoofdletter en kleine letter">
+      <span class="cursive-letter-pair" aria-hidden="true">ℋ 𝒽</span>
+      <span class="cursive-letter-name">Cursieve H</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-i" data-char="I" aria-label="I in cursief — hoofdletter en kleine letter">
+      <span class="cursive-letter-pair" aria-hidden="true">ℐ 𝒾</span>
+      <span class="cursive-letter-name">Cursieve I</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-j" data-char="J" aria-label="J in cursief — hoofdletter en kleine letter">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒥 𝒿</span>
+      <span class="cursive-letter-name">Cursieve J</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-k" data-char="K" aria-label="K in cursief — hoofdletter en kleine letter">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒦 𝓀</span>
+      <span class="cursive-letter-name">Cursieve K</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-l" data-char="L" aria-label="L in cursief — hoofdletter en kleine letter">
+      <span class="cursive-letter-pair" aria-hidden="true">ℒ 𝓁</span>
+      <span class="cursive-letter-name">Cursieve L</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-m" data-char="M" aria-label="M in cursief — hoofdletter en kleine letter">
+      <span class="cursive-letter-pair" aria-hidden="true">ℳ 𝓂</span>
+      <span class="cursive-letter-name">Cursieve M</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-n" data-char="N" aria-label="N in cursief — hoofdletter en kleine letter">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒩 𝓃</span>
+      <span class="cursive-letter-name">Cursieve N</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-o" data-char="O" aria-label="O in cursief — hoofdletter en kleine letter">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒪 ℴ</span>
+      <span class="cursive-letter-name">Cursieve O</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-p" data-char="P" aria-label="P in cursief — hoofdletter en kleine letter">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒫 𝓅</span>
+      <span class="cursive-letter-name">Cursieve P</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-q" data-char="Q" aria-label="Q in cursief — hoofdletter en kleine letter">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒬 𝓆</span>
+      <span class="cursive-letter-name">Cursieve Q</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-r" data-char="R" aria-label="R in cursief — hoofdletter en kleine letter">
+      <span class="cursive-letter-pair" aria-hidden="true">ℛ 𝓇</span>
+      <span class="cursive-letter-name">Cursieve R</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-s" data-char="S" aria-label="S in cursief — hoofdletter en kleine letter">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒮 𝓈</span>
+      <span class="cursive-letter-name">Cursieve S</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-t" data-char="T" aria-label="T in cursief — hoofdletter en kleine letter">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒯 𝓉</span>
+      <span class="cursive-letter-name">Cursieve T</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-u" data-char="U" aria-label="U in cursief — hoofdletter en kleine letter">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒰 𝓊</span>
+      <span class="cursive-letter-name">Cursieve U</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-v" data-char="V" aria-label="V in cursief — hoofdletter en kleine letter">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒱 𝓋</span>
+      <span class="cursive-letter-name">Cursieve V</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-w" data-char="W" aria-label="W in cursief — hoofdletter en kleine letter">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒲 𝓌</span>
+      <span class="cursive-letter-name">Cursieve W</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-x" data-char="X" aria-label="X in cursief — hoofdletter en kleine letter">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒳 𝓍</span>
+      <span class="cursive-letter-name">Cursieve X</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-y" data-char="Y" aria-label="Y in cursief — hoofdletter en kleine letter">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒴 𝓎</span>
+      <span class="cursive-letter-name">Cursieve Y</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-z" data-char="Z" aria-label="Z in cursief — hoofdletter en kleine letter">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒵 𝓏</span>
+      <span class="cursive-letter-name">Cursieve Z</span>
+    </button>
   </div>
-</section>
+      <div class="cursive-letter-panel" id="cursiveLetterPanel" aria-live="polite"></div>
+    </section>
 
-<main class="container">
-  <div class="category-section"><div class="category-tabs" id="categoryTabs"></div></div>
-  <div class="results-grid" id="resultsGrid"></div>
-
-  <!-- Cursief vs sierlijk -->
-  <section class="editorial-section">
-    <h2>Cursief = schuin. Niet hetzelfde als sierlijk.</h2>
-    <p class="editorial-intro">Even het misverstand uit de weg: in het Nederlands betekent <strong>cursief</strong> schuingedrukt — rechte letters die hellen, zoals de <em>I</em>-knop in Word. Zoek je krullende kalligrafie-letters, dan zoek je <a href="/nl/sierlijke-letters/">sierlijke letters</a>. Deze pagina maakt <strong>schuine tekst</strong> die je overal kunt plakken.</p>
-    <div class="block-example">
-      <strong>Voorbeeld:</strong> «hallo» → 𝘩𝘢𝘭𝘭𝘰 (cursief), ℎ𝑎𝑙𝑙𝑜 (serif cursief), 𝙝𝙖𝙡𝙡𝙤 (vet cursief)
-    </div>
-    <p>Net als bij alle stijlen hier zijn dit Unicode-tekens: elke letter is zelf al schuin getekend. Daarom overleeft het cursief elke kopieer-plak-actie — óók naar plekken zonder enige opmaakknop, zoals een Instagram bio of een WhatsApp-status.</p>
-  </section>
-
-  <!-- Alphabet -->
-  <section class="editorial-section glyph-section">
-    <h2>Cursief alfabet (A–Z) — met één klik gekopieerd</h2>
-    <p class="editorial-intro">Het complete alfabet in de drie cursieve stijlen. Klik op een rij om alles te kopiëren.</p>
-    <div class="alpha-list">
-      <div class="alpha-row">
-        <span class="alpha-label">Cursief</span>
-        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝘈𝘉𝘊𝘋𝘌𝘍𝘎𝘏𝘐𝘑𝘒𝘓𝘔𝘕𝘖𝘗𝘘𝘙𝘚𝘛𝘜𝘝𝘞𝘟𝘠𝘡 𝘢𝘣𝘤𝘥𝘦𝘧𝘨𝘩𝘪𝘫𝘬𝘭𝘮𝘯𝘰𝘱𝘲𝘳𝘴𝘵𝘶𝘷𝘸𝘹𝘺𝘻" aria-label="Kopieer het cursieve alfabet">𝘈𝘉𝘊𝘋𝘌𝘍𝘎𝘏𝘐𝘑𝘒𝘓𝘔𝘕𝘖𝘗𝘘𝘙𝘚𝘛𝘜𝘝𝘞𝘟𝘠𝘡 · 𝘢𝘣𝘤𝘥𝘦𝘧𝘨𝘩𝘪𝘫𝘬𝘭𝘮𝘯𝘰𝘱𝘲𝘳𝘴𝘵𝘶𝘷𝘸𝘹𝘺𝘻</button>
+    <!-- 3. The cursive alphabet -->
+    <section id="cursive-alphabet" aria-labelledby="cursiveAlphabetHeading">
+      <div class="cursive-chart-toolbar">
+        <h2 class="bubble-az-heading" id="cursiveAlphabetHeading">Het cursieve alfabet (A–Z, 0–9)</h2>
+        <button type="button" class="bubble-btn bubble-btn-primary" id="cursivePrintSheet">Oefenblad printen</button>
       </div>
-      <div class="alpha-row">
-        <span class="alpha-label">Serif Cursief</span>
-        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝐴𝐵𝐶𝐷𝐸𝐹𝐺𝐻𝐼𝐽𝐾𝐿𝑀𝑁𝑂𝑃𝑄𝑅𝑆𝑇𝑈𝑉𝑊𝑋𝑌𝑍 𝑎𝑏𝑐𝑑𝑒𝑓𝑔ℎ𝑖𝑗𝑘𝑙𝑚𝑛𝑜𝑝𝑞𝑟𝑠𝑡𝑢𝑣𝑤𝑥𝑦𝑧" aria-label="Kopieer het serif-cursieve alfabet">𝐴𝐵𝐶𝐷𝐸𝐹𝐺𝐻𝐼𝐽𝐾𝐿𝑀𝑁𝑂𝑃𝑄𝑅𝑆𝑇𝑈𝑉𝑊𝑋𝑌𝑍 · 𝑎𝑏𝑐𝑑𝑒𝑓𝑔ℎ𝑖𝑗𝑘𝑙𝑚𝑛𝑜𝑝𝑞𝑟𝑠𝑡𝑢𝑣𝑤𝑥𝑦𝑧</button>
+      <p class="bubble-az-intro">Kopieer het complete cursieve alfabet met één klik — hoofdletters, kleine letters en cijfers —
+        of print een oefenblad met voorbeeldletters en ruimte om over te trekken. Unicode kent geen echte cursieve cijfers, dus elke
+        stijl combineert de schuine letters met bijpassende gestileerde cijfers.</p>
+    <div class="cursive-chart">
+      <div class="cursive-chart-head">
+        <h3>Klassiek cursief alfabet (Ultra Script)</h3>
+        <button type="button" class="copy-btn" data-text="𝒜 ℬ 𝒞 𝒟 ℰ ℱ 𝒢 ℋ ℐ 𝒥 𝒦 ℒ ℳ 𝒩 𝒪 𝒫 𝒬 ℛ 𝒮 𝒯 𝒰 𝒱 𝒲 𝒳 𝒴 𝒵&#10;𝒶 𝒷 𝒸 𝒹 ℯ 𝒻 ℊ 𝒽 𝒾 𝒿 𝓀 𝓁 𝓂 𝓃 ℴ 𝓅 𝓆 𝓇 𝓈 𝓉 𝓊 𝓋 𝓌 𝓍 𝓎 𝓏&#10;𝟢 𝟣 𝟤 𝟥 𝟦 𝟧 𝟨 𝟩 𝟪 𝟫" data-style="Ultra Script">Alfabet kopiëren</button>
       </div>
-      <div class="alpha-row">
-        <span class="alpha-label">Vet Cursief</span>
-        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝘼𝘽𝘾𝘿𝙀𝙁𝙂𝙃𝙄𝙅𝙆𝙇𝙈𝙉𝙊𝙋𝙌𝙍𝙎𝙏𝙐𝙑𝙒𝙓𝙔𝙕 𝙖𝙗𝙘𝙙𝙚𝙛𝙜𝙝𝙞𝙟𝙠𝙡𝙢𝙣𝙤𝙥𝙦𝙧𝙨𝙩𝙪𝙫𝙬𝙭𝙮𝙯" aria-label="Kopieer het vet-cursieve alfabet">𝘼𝘽𝘾𝘿𝙀𝙁𝙂𝙃𝙄𝙅𝙆𝙇𝙈𝙉𝙊𝙋𝙌𝙍𝙎𝙏𝙐𝙑𝙒𝙓𝙔𝙕 · 𝙖𝙗𝙘𝙙𝙚𝙛𝙜𝙝𝙞𝙟𝙠𝙡𝙢𝙣𝙤𝙥𝙦𝙧𝙨𝙩𝙪𝙫𝙬𝙭𝙮𝙯</button>
+      <p class="cursive-alphabet-row">𝒜 ℬ 𝒞 𝒟 ℰ ℱ 𝒢 ℋ ℐ 𝒥 𝒦 ℒ ℳ 𝒩 𝒪 𝒫 𝒬 ℛ 𝒮 𝒯 𝒰 𝒱 𝒲 𝒳 𝒴 𝒵</p>
+      <p class="cursive-alphabet-row">𝒶 𝒷 𝒸 𝒹 ℯ 𝒻 ℊ 𝒽 𝒾 𝒿 𝓀 𝓁 𝓂 𝓃 ℴ 𝓅 𝓆 𝓇 𝓈 𝓉 𝓊 𝓋 𝓌 𝓍 𝓎 𝓏</p>
+      <p class="cursive-alphabet-row">𝟢 𝟣 𝟤 𝟥 𝟦 𝟧 𝟨 𝟩 𝟪 𝟫</p>
+    </div>
+    <div class="cursive-chart">
+      <div class="cursive-chart-head">
+        <h3>Vet cursief alfabet (Ultra Script Bold)</h3>
+        <button type="button" class="copy-btn" data-text="𝓐 𝓑 𝓒 𝓓 𝓔 𝓕 𝓖 𝓗 𝓘 𝓙 𝓚 𝓛 𝓜 𝓝 𝓞 𝓟 𝓠 𝓡 𝓢 𝓣 𝓤 𝓥 𝓦 𝓧 𝓨 𝓩&#10;𝓪 𝓫 𝓬 𝓭 𝓮 𝓯 𝓰 𝓱 𝓲 𝓳 𝓴 𝓵 𝓶 𝓷 𝓸 𝓹 𝓺 𝓻 𝓼 𝓽 𝓾 𝓿 𝔀 𝔁 𝔂 𝔃&#10;𝟬 𝟭 𝟮 𝟯 𝟰 𝟱 𝟲 𝟳 𝟴 𝟵" data-style="Ultra Script Bold">Alfabet kopiëren</button>
+      </div>
+      <p class="cursive-alphabet-row">𝓐 𝓑 𝓒 𝓓 𝓔 𝓕 𝓖 𝓗 𝓘 𝓙 𝓚 𝓛 𝓜 𝓝 𝓞 𝓟 𝓠 𝓡 𝓢 𝓣 𝓤 𝓥 𝓦 𝓧 𝓨 𝓩</p>
+      <p class="cursive-alphabet-row">𝓪 𝓫 𝓬 𝓭 𝓮 𝓯 𝓰 𝓱 𝓲 𝓳 𝓴 𝓵 𝓶 𝓷 𝓸 𝓹 𝓺 𝓻 𝓼 𝓽 𝓾 𝓿 𝔀 𝔁 𝔂 𝔃</p>
+      <p class="cursive-alphabet-row">𝟬 𝟭 𝟮 𝟯 𝟰 𝟱 𝟲 𝟳 𝟴 𝟵</p>
+    </div>
+    <div class="cursive-chart">
+      <div class="cursive-chart-head">
+        <h3>Gothic cursief alfabet (Ultra Gothic Script)</h3>
+        <button type="button" class="copy-btn" data-text="𝕬 𝕭 𝕮 𝕯 𝕰 𝕱 𝕲 𝕳 𝕴 𝕵 𝕶 𝕷 𝕸 𝕹 𝕺 𝕻 𝕼 𝕽 𝕾 𝕿 𝖀 𝖁 𝖂 𝖃 𝖄 𝖅&#10;𝖆 𝖇 𝖈 𝖉 𝖊 𝖋 𝖌 𝖍 𝖎 𝖏 𝖐 𝖑 𝖒 𝖓 𝖔 𝖕 𝖖 𝖗 𝖘 𝖙 𝖚 𝖛 𝖜 𝖝 𝖞 𝖟" data-style="Ultra Gothic Script">Alfabet kopiëren</button>
+      </div>
+      <p class="cursive-alphabet-row">𝕬 𝕭 𝕮 𝕯 𝕰 𝕱 𝕲 𝕳 𝕴 𝕵 𝕶 𝕷 𝕸 𝕹 𝕺 𝕻 𝕼 𝕽 𝕾 𝕿 𝖀 𝖁 𝖂 𝖃 𝖄 𝖅</p>
+      <p class="cursive-alphabet-row">𝖆 𝖇 𝖈 𝖉 𝖊 𝖋 𝖌 𝖍 𝖎 𝖏 𝖐 𝖑 𝖒 𝖓 𝖔 𝖕 𝖖 𝖗 𝖘 𝖙 𝖚 𝖛 𝖜 𝖝 𝖞 𝖟</p>
+    </div>
+    </section>
+
+    <!-- 4. Words in cursive -->
+    <section id="cursive-words" aria-labelledby="cursiveWordsHeading">
+      <h2 class="bubble-az-heading" id="cursiveWordsHeading">Woorden in cursief schrift — klaar om te kopiëren</h2>
+      <p class="bubble-az-intro">De meestgevraagde woorden, al klaar in cursieve letters. Heb je een ander woord nodig?
+        Typ het in de <a href="#mainInput">generator hierboven</a> en elke stijl toont het meteen.</p>
+    <h3>Liefde &amp; familie</h3>
+    <div class="cursive-word-grid">
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓁𝒾ℯ𝒻𝒹ℯ</span>
+        <span class="cursive-word-label">liefde in cursief</span>
+        <button type="button" class="copy-btn" data-text="𝓁𝒾ℯ𝒻𝒹ℯ" data-style="Ultra Script">Kopiëren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓵𝓲𝓮𝓯𝓭𝓮</span>
+        <span class="cursive-word-label">liefde (vet) in cursief</span>
+        <button type="button" class="copy-btn" data-text="𝓵𝓲𝓮𝓯𝓭𝓮" data-style="Ultra Script Bold">Kopiëren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒾𝓀 𝒽ℴ𝓊 𝓋𝒶𝓃 𝒿ℴ𝓊</span>
+        <span class="cursive-word-label">ik hou van jou in cursief</span>
+        <button type="button" class="copy-btn" data-text="𝒾𝓀 𝒽ℴ𝓊 𝓋𝒶𝓃 𝒿ℴ𝓊" data-style="Ultra Script">Kopiëren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓂𝒶𝓂𝒶</span>
+        <span class="cursive-word-label">mama in cursief</span>
+        <button type="button" class="copy-btn" data-text="𝓂𝒶𝓂𝒶" data-style="Ultra Script">Kopiëren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓅𝒶𝓅𝒶</span>
+        <span class="cursive-word-label">papa in cursief</span>
+        <button type="button" class="copy-btn" data-text="𝓅𝒶𝓅𝒶" data-style="Ultra Script">Kopiëren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒻𝒶𝓂𝒾𝓁𝒾ℯ</span>
+        <span class="cursive-word-label">familie in cursief</span>
+        <button type="button" class="copy-btn" data-text="𝒻𝒶𝓂𝒾𝓁𝒾ℯ" data-style="Ultra Script">Kopiëren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓋ℴℴ𝓇 𝒶𝓁𝓉𝒾𝒿𝒹</span>
+        <span class="cursive-word-label">voor altijd in cursief</span>
+        <button type="button" class="copy-btn" data-text="𝓋ℴℴ𝓇 𝒶𝓁𝓉𝒾𝒿𝒹" data-style="Ultra Script">Kopiëren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">ℊℯ𝓁ℴℴ𝒻</span>
+        <span class="cursive-word-label">geloof in cursief</span>
+        <button type="button" class="copy-btn" data-text="ℊℯ𝓁ℴℴ𝒻" data-style="Ultra Script">Kopiëren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒽ℴℴ𝓅</span>
+        <span class="cursive-word-label">hoop in cursief</span>
+        <button type="button" class="copy-btn" data-text="𝒽ℴℴ𝓅" data-style="Ultra Script">Kopiëren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">ℊℯ𝓏ℯℊℯ𝓃𝒹</span>
+        <span class="cursive-word-label">gezegend in cursief</span>
+        <button type="button" class="copy-btn" data-text="ℊℯ𝓏ℯℊℯ𝓃𝒹" data-style="Ultra Script">Kopiëren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">ℯ𝓃ℊℯ𝓁</span>
+        <span class="cursive-word-label">engel in cursief</span>
+        <button type="button" class="copy-btn" data-text="ℯ𝓃ℊℯ𝓁" data-style="Ultra Script">Kopiëren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">ℊℯ𝓃𝒶𝒹ℯ</span>
+        <span class="cursive-word-label">genade in cursief</span>
+        <button type="button" class="copy-btn" data-text="ℊℯ𝓃𝒶𝒹ℯ" data-style="Ultra Script">Kopiëren</button>
       </div>
     </div>
-    <p class="u-mt-15">Het strakke <strong>cursief</strong> past bij moderne bio's; <strong>serif cursief</strong> leest als een boekcitaat; <strong>vet cursief</strong> is nadruk mét volume. Let op één ding bij serif cursief: de kleine h is ℎ — een teken uit een ouder Unicode-blok dat er net iets anders uit kan zien.</p>
-  </section>
-
-  <!-- Wanneer cursief -->
-  <section class="editorial-section">
-    <h2>Schuine tekst gebruiken: citaten, nadruk en ondertitels</h2>
-    <p class="editorial-intro">Cursief is de subtielste stijl in de verzameling — zo zet je hem in:</p>
-    <div class="block-example">
-      — <strong>Citaat in je bio</strong>: 𝘭𝘦𝘷𝘦 𝘢𝘭𝘴𝘰𝘧 𝘯𝘪𝘦𝘮𝘢𝘯𝘥 𝘬𝘪𝘫𝘬𝘵<br>
-      — <strong>Ondertitel</strong> onder een vette kop: 𝗡𝗶𝗲𝘂𝘄𝗲 𝗰𝗼𝗹𝗹𝗲𝗰𝘁𝗶𝗲 → 𝘯𝘶 𝘰𝘯𝘭𝘪𝘯𝘦<br>
-      — <strong>Boek- of filmtitel</strong> in een reactie of caption<br>
-      — <strong>Één woord nadruk</strong> midden in een zin — zonder te schreeuwen zoals vet
+    <h3>Groeten &amp; gelegenheden</h3>
+    <div class="cursive-word-grid">
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒻𝒾𝒿𝓃ℯ 𝓋ℯ𝓇𝒿𝒶𝒶𝓇𝒹𝒶ℊ</span>
+        <span class="cursive-word-label">fijne verjaardag in cursief</span>
+        <button type="button" class="copy-btn" data-text="𝒻𝒾𝒿𝓃ℯ 𝓋ℯ𝓇𝒿𝒶𝒶𝓇𝒹𝒶ℊ" data-style="Ultra Script">Kopiëren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒹𝒶𝓃𝓀𝒿ℯ𝓌ℯ𝓁</span>
+        <span class="cursive-word-label">dankjewel in cursief</span>
+        <button type="button" class="copy-btn" data-text="𝒹𝒶𝓃𝓀𝒿ℯ𝓌ℯ𝓁" data-style="Ultra Script">Kopiëren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓌ℯ𝓁𝓀ℴ𝓂</span>
+        <span class="cursive-word-label">welkom in cursief</span>
+        <button type="button" class="copy-btn" data-text="𝓌ℯ𝓁𝓀ℴ𝓂" data-style="Ultra Script">Kopiëren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒽𝒶𝓁𝓁ℴ</span>
+        <span class="cursive-word-label">hallo in cursief</span>
+        <button type="button" class="copy-btn" data-text="𝒽𝒶𝓁𝓁ℴ" data-style="Ultra Script">Kopiëren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">ℊℯ𝒻ℯ𝓁𝒾𝒸𝒾𝓉ℯℯ𝓇𝒹</span>
+        <span class="cursive-word-label">gefeliciteerd in cursief</span>
+        <button type="button" class="copy-btn" data-text="ℊℯ𝒻ℯ𝓁𝒾𝒸𝒾𝓉ℯℯ𝓇𝒹" data-style="Ultra Script">Kopiëren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓋𝓇ℴ𝓁𝒾𝒿𝓀 𝓀ℯ𝓇𝓈𝓉𝒻ℯℯ𝓈𝓉</span>
+        <span class="cursive-word-label">vrolijk kerstfeest in cursief</span>
+        <button type="button" class="copy-btn" data-text="𝓋𝓇ℴ𝓁𝒾𝒿𝓀 𝓀ℯ𝓇𝓈𝓉𝒻ℯℯ𝓈𝓉" data-style="Ultra Script">Kopiëren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">ℊℯ𝓁𝓊𝓀𝓀𝒾ℊ 𝓃𝒾ℯ𝓊𝓌𝒿𝒶𝒶𝓇</span>
+        <span class="cursive-word-label">gelukkig nieuwjaar in cursief</span>
+        <button type="button" class="copy-btn" data-text="ℊℯ𝓁𝓊𝓀𝓀𝒾ℊ 𝓃𝒾ℯ𝓊𝓌𝒿𝒶𝒶𝓇" data-style="Ultra Script">Kopiëren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒽ℯ𝓉 𝒶𝓁𝓁ℯ𝓇𝒷ℯ𝓈𝓉ℯ</span>
+        <span class="cursive-word-label">het allerbeste in cursief</span>
+        <button type="button" class="copy-btn" data-text="𝒽ℯ𝓉 𝒶𝓁𝓁ℯ𝓇𝒷ℯ𝓈𝓉ℯ" data-style="Ultra Script">Kopiëren</button>
+      </div>
     </div>
-    <p>In WhatsApp-berichten kun je cursief ook maken met _liggende streepjes_ — maar dat werkt alleen binnen berichten en verdwijnt zodra je de tekst ergens anders plakt. Geplakt Unicode-cursief blijft overal staan: status, groepsnaam, bio, post.</p>
-  </section>
-
-  <!-- Related -->
-  <section class="editorial-section">
-    <h2>Meer stijlen om te kopiëren</h2>
-    <div class="compare-grid">
-      <a href="/nl/sierlijke-letters/" class="compare-card variant-muted u-no-underline">
-        <h4>Sierlijke Letters</h4>
-        <p>Zoek je krullen in plaats van schuin? Dit zijn de kalligrafie-letters.</p>
-      </a>
-      <a href="/nl/vetgedrukte-letters/" class="compare-card variant-muted u-no-underline">
-        <h4>Vetgedrukte Letters</h4>
-        <p>Meer nadruk nodig? Dik en opvallend, in drie stijlen.</p>
-      </a>
-      <a href="/nl/mooie-letters/" class="compare-card variant-muted u-no-underline">
-        <h4>Mooie Letters</h4>
-        <p>Alle mooie lettertypes op één pagina — de complete verzameling.</p>
-      </a>
+    <h3>Maanden in cursief</h3>
+    <div class="cursive-word-grid">
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒿𝒶𝓃𝓊𝒶𝓇𝒾</span>
+        <span class="cursive-word-label">januari in cursief</span>
+        <button type="button" class="copy-btn" data-text="𝒿𝒶𝓃𝓊𝒶𝓇𝒾" data-style="Ultra Script">Kopiëren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒻ℯ𝒷𝓇𝓊𝒶𝓇𝒾</span>
+        <span class="cursive-word-label">februari in cursief</span>
+        <button type="button" class="copy-btn" data-text="𝒻ℯ𝒷𝓇𝓊𝒶𝓇𝒾" data-style="Ultra Script">Kopiëren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓂𝒶𝒶𝓇𝓉</span>
+        <span class="cursive-word-label">maart in cursief</span>
+        <button type="button" class="copy-btn" data-text="𝓂𝒶𝒶𝓇𝓉" data-style="Ultra Script">Kopiëren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒶𝓅𝓇𝒾𝓁</span>
+        <span class="cursive-word-label">april in cursief</span>
+        <button type="button" class="copy-btn" data-text="𝒶𝓅𝓇𝒾𝓁" data-style="Ultra Script">Kopiëren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓂ℯ𝒾</span>
+        <span class="cursive-word-label">mei in cursief</span>
+        <button type="button" class="copy-btn" data-text="𝓂ℯ𝒾" data-style="Ultra Script">Kopiëren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒿𝓊𝓃𝒾</span>
+        <span class="cursive-word-label">juni in cursief</span>
+        <button type="button" class="copy-btn" data-text="𝒿𝓊𝓃𝒾" data-style="Ultra Script">Kopiëren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒿𝓊𝓁𝒾</span>
+        <span class="cursive-word-label">juli in cursief</span>
+        <button type="button" class="copy-btn" data-text="𝒿𝓊𝓁𝒾" data-style="Ultra Script">Kopiëren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒶𝓊ℊ𝓊𝓈𝓉𝓊𝓈</span>
+        <span class="cursive-word-label">augustus in cursief</span>
+        <button type="button" class="copy-btn" data-text="𝒶𝓊ℊ𝓊𝓈𝓉𝓊𝓈" data-style="Ultra Script">Kopiëren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓈ℯ𝓅𝓉ℯ𝓂𝒷ℯ𝓇</span>
+        <span class="cursive-word-label">september in cursief</span>
+        <button type="button" class="copy-btn" data-text="𝓈ℯ𝓅𝓉ℯ𝓂𝒷ℯ𝓇" data-style="Ultra Script">Kopiëren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">ℴ𝓀𝓉ℴ𝒷ℯ𝓇</span>
+        <span class="cursive-word-label">oktober in cursief</span>
+        <button type="button" class="copy-btn" data-text="ℴ𝓀𝓉ℴ𝒷ℯ𝓇" data-style="Ultra Script">Kopiëren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓃ℴ𝓋ℯ𝓂𝒷ℯ𝓇</span>
+        <span class="cursive-word-label">november in cursief</span>
+        <button type="button" class="copy-btn" data-text="𝓃ℴ𝓋ℯ𝓂𝒷ℯ𝓇" data-style="Ultra Script">Kopiëren</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒹ℯ𝒸ℯ𝓂𝒷ℯ𝓇</span>
+        <span class="cursive-word-label">december in cursief</span>
+        <button type="button" class="copy-btn" data-text="𝒹ℯ𝒸ℯ𝓂𝒷ℯ𝓇" data-style="Ultra Script">Kopiëren</button>
+      </div>
     </div>
-  </section>
-</main>
+    </section>
 
-<footer class="footer">
-  <div class="footer-inner">
-    <h2 class="faq-category">Vragen over cursieve letters</h2>
-    <div class="faq-item"><button class="faq-question" type="button">Hoe maak ik tekst cursief?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Typ je tekst in het vak bovenaan — de schuine versies (𝘤𝘶𝘳𝘴𝘪𝘦𝘧, 𝑠𝑒𝑟𝑖𝑓 𝑐𝑢𝑟𝑠𝑖𝑒𝑓 en 𝙫𝙚𝙩 𝙘𝙪𝙧𝙨𝙞𝙚𝙛) verschijnen meteen. Klik op «Kopieer» en plak de tekst waar je wilt. Omdat elke letter zelf al schuin is, blijft de tekst cursief — ook in velden zonder cursief-knop.</div></div>
-    <div class="faq-item"><button class="faq-question" type="button">Is cursief hetzelfde als sierlijke letters?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Nee — en dit is in het Nederlands verwarrend. Cursief betekent schuingedrukt: rechte letters die schuin hellen, zoals de I-knop in Word. Sierlijke letters (sierletters) zijn krullende kalligrafie-letters. Deze pagina maakt schuine tekst; voor de krullen ga je naar de pagina <a href="/nl/sierlijke-letters/">sierlijke letters</a>.</div></div>
-    <div class="faq-item"><button class="faq-question" type="button">Hoe maak ik tekst cursief op Instagram of Facebook?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Instagram en Facebook hebben geen cursief-knop in posts, bio's en reacties. Typ je tekst hier, kopieer de cursieve versie en plak hem waar je wilt — de schuine letters blijven staan, want ze zíjn schuin. In WhatsApp-berichten kan cursief ook met _liggende streepjes_, maar dat werkt alleen in berichten en verdwijnt bij kopiëren.</div></div>
-    <div class="faq-item"><button class="faq-question" type="button">Waarvoor gebruik je cursieve tekst?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Voor subtiele nadruk: een citaat in je bio, een boektitel, een gedachte tussen gewone tekst, of een zachte ondertitel onder een vette kop. Cursief is de meest ingetogen van alle tekststijlen — het valt op zonder te schreeuwen. Combineer het met <a href="/nl/vetgedrukte-letters/">vetgedrukte letters</a> voor een kop-en-subkop-effect.</div></div>
-    <div class="faq-item"><button class="faq-question" type="button">Blijven ë en é staan in cursieve tekst?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">De letters met trema of accent hebben geen cursieve Unicode-variant, dus die blijven gewoon recht tussen de schuine letters staan — «café» wordt 𝘤𝘢𝘧é. Dat leest prima. De ij doet wel volledig mee: «vrij» wordt 𝘷𝘳𝘪𝘫.</div></div>
+    <!-- 5. Names & signatures -->
+    <section id="cursive-names" aria-labelledby="cursiveNamesHeading">
+      <h2 class="bubble-az-heading" id="cursiveNamesHeading">Generator voor cursieve namen &amp; handtekeningen</h2>
+      <p class="bubble-az-intro">Typ een voornaam — of een volledige naam — en ontwerp je cursieve handtekening:
+        kies een sierlijke krul, bepaal hoe de monogram-initialen aan elkaar vloeien en kopieer de tekst of download hem als PNG
+        voor e-mailhandtekeningen, watermerken en documenten.</p>
+      <div class="cursive-name-tool">
+        <div class="input-wrapper">
+          <input type="text" class="main-input cursive-name-input" id="cursiveNameInput" placeholder="Typ een naam… bijv. Julia Sophie" maxlength="60">
+        </div>
+        <div class="cursive-sig-controls" id="cursiveSignatureControls"></div>
+        <div class="results-grid" id="cursiveNameResults"></div>
+      </div>
+    <h3>Populaire namen in cursief</h3>
+    <p class="bubble-az-intro">Tik op een naam om hem in de studio hierboven te laden en met sierlijke krullen te restylen.</p>
+    <div class="cursive-word-grid">
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Laad Emma in de handtekeningstudio" data-name="Emma">
+        <span class="cursive-word-render">𝓔𝓶𝓶𝓪</span>
+        <span class="cursive-word-label">Emma in cursief</span>
+        <button type="button" class="copy-btn" data-text="𝓔𝓶𝓶𝓪" data-style="Ultra Script Bold">Kopiëren</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Laad Julia in de handtekeningstudio" data-name="Julia">
+        <span class="cursive-word-render">𝓙𝓾𝓵𝓲𝓪</span>
+        <span class="cursive-word-label">Julia in cursief</span>
+        <button type="button" class="copy-btn" data-text="𝓙𝓾𝓵𝓲𝓪" data-style="Ultra Script Bold">Kopiëren</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Laad Mila in de handtekeningstudio" data-name="Mila">
+        <span class="cursive-word-render">𝓜𝓲𝓵𝓪</span>
+        <span class="cursive-word-label">Mila in cursief</span>
+        <button type="button" class="copy-btn" data-text="𝓜𝓲𝓵𝓪" data-style="Ultra Script Bold">Kopiëren</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Laad Tess in de handtekeningstudio" data-name="Tess">
+        <span class="cursive-word-render">𝓣𝓮𝓼𝓼</span>
+        <span class="cursive-word-label">Tess in cursief</span>
+        <button type="button" class="copy-btn" data-text="𝓣𝓮𝓼𝓼" data-style="Ultra Script Bold">Kopiëren</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Laad Sophie in de handtekeningstudio" data-name="Sophie">
+        <span class="cursive-word-render">𝓢𝓸𝓹𝓱𝓲𝓮</span>
+        <span class="cursive-word-label">Sophie in cursief</span>
+        <button type="button" class="copy-btn" data-text="𝓢𝓸𝓹𝓱𝓲𝓮" data-style="Ultra Script Bold">Kopiëren</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Laad Nora in de handtekeningstudio" data-name="Nora">
+        <span class="cursive-word-render">𝓝𝓸𝓻𝓪</span>
+        <span class="cursive-word-label">Nora in cursief</span>
+        <button type="button" class="copy-btn" data-text="𝓝𝓸𝓻𝓪" data-style="Ultra Script Bold">Kopiëren</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Laad Noah in de handtekeningstudio" data-name="Noah">
+        <span class="cursive-word-render">𝓝𝓸𝓪𝓱</span>
+        <span class="cursive-word-label">Noah in cursief</span>
+        <button type="button" class="copy-btn" data-text="𝓝𝓸𝓪𝓱" data-style="Ultra Script Bold">Kopiëren</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Laad Sem in de handtekeningstudio" data-name="Sem">
+        <span class="cursive-word-render">𝓢𝓮𝓶</span>
+        <span class="cursive-word-label">Sem in cursief</span>
+        <button type="button" class="copy-btn" data-text="𝓢𝓮𝓶" data-style="Ultra Script Bold">Kopiëren</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Laad Liam in de handtekeningstudio" data-name="Liam">
+        <span class="cursive-word-render">𝓛𝓲𝓪𝓶</span>
+        <span class="cursive-word-label">Liam in cursief</span>
+        <button type="button" class="copy-btn" data-text="𝓛𝓲𝓪𝓶" data-style="Ultra Script Bold">Kopiëren</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Laad Lucas in de handtekeningstudio" data-name="Lucas">
+        <span class="cursive-word-render">𝓛𝓾𝓬𝓪𝓼</span>
+        <span class="cursive-word-label">Lucas in cursief</span>
+        <button type="button" class="copy-btn" data-text="𝓛𝓾𝓬𝓪𝓼" data-style="Ultra Script Bold">Kopiëren</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Laad Daan in de handtekeningstudio" data-name="Daan">
+        <span class="cursive-word-render">𝓓𝓪𝓪𝓷</span>
+        <span class="cursive-word-label">Daan in cursief</span>
+        <button type="button" class="copy-btn" data-text="𝓓𝓪𝓪𝓷" data-style="Ultra Script Bold">Kopiëren</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Laad Finn in de handtekeningstudio" data-name="Finn">
+        <span class="cursive-word-render">𝓕𝓲𝓷𝓷</span>
+        <span class="cursive-word-label">Finn in cursief</span>
+        <button type="button" class="copy-btn" data-text="𝓕𝓲𝓷𝓷" data-style="Ultra Script Bold">Kopiëren</button>
+      </div>
+    </div>
+    </section>
+
+    <!-- Editorial -->
+    <section class="editorial-section cursive-editorial">
+      <h2>Hoe deze generator voor cursieve letters werkt</h2>
+      <p>De cursieve letters die je hier ziet, zijn geen lettertype — het zijn <strong>Unicode-scripttekens</strong>, dezelfde standaard die je apparaat voor elke letter en emoji gebruikt. Daarom overleven ze kopiëren en plakken: apps behandelen 𝒸𝓊𝓇𝓈𝒾ℯℱ precies als gewone tekst. Daarom werken sierlijke letters ook op plekken waar je nooit een lettertype kunt installeren — Instagram-bio's, TikTok-bijschriften, Discord-namen, YouTube-reacties. Benieuwd naar de techniek? Lees <a href="/guide/how-unicode-fonts-work/">hoe Unicode-lettertypes werken</a>.</p>
+
+      <h3>Waar cursieve tekst werkt (en waar het misgaat)</h3>
+      <ul class="compat-list">
+        <li><span class="ts-pill-safe">Werkt</span> Instagram-bio's &amp; bijschriften, TikTok-bijschriften, Discord, WhatsApp, Facebook, X, YouTube-reacties en de meeste documenten.</li>
+        <li><span class="ts-pill-risk">Beperkt</span> Velden voor gebruikersnaam en weergavenaam (Instagram, de meeste games) verwijderen vaak de scripttekens — houd handles in gewone tekst.</li>
+        <li><span class="ts-pill-risk">Beperkt</span> Een paar oudere apparaten tonen lege vakjes (▯) voor ontbrekende tekens. Gebeurt dat? Kies dan een eenvoudigere stijl — zie <a href="/guide/why-fonts-show-as-boxes/">waarom lettertypes als vakjes verschijnen</a>.</li>
+      </ul>
+
+      <h3>Unicode-cursief versus een echt cursief lettertype</h3>
+      <p>Gebruik Unicode-cursief wanneer je schuine letters <em>binnen tekstvelden</em> nodig hebt — sociale profielen, chats, videotitels. Gebruik een echt cursief lettertype (in Word, Canva of je ontwerpprogramma) wanneer je het document zelf beheert en print-kwaliteit met nette kerning nodig hebt. Beide hebben hun plek; deze tool doet het eerste.</p>
+
+      <h3>Accenten, ç, ë en cursieve letters</h3>
+      <p>Unicode-scriptletters bestaan alleen voor het Latijnse alfabet A–Z, dus letters met accenten en trema's (é, ë, ï, ö, ç) veranderen niet mee en blijven in gewone tekst staan. Wil je een naam of woord volledig in sierlijke letters? Schrijf hem dan zonder accenten (schrijf bijvoorbeeld <strong>cafe</strong> in plaats van café, of <strong>Rene</strong> in plaats van René) — zo blijft alles mooi cursief. Het <a href="#cursive-alphabet">printbare oefenblad</a> dekt de volledige Latijnse A–Z.</p>
+
+      <h3>Cursief schrift leren</h3>
+      <p>Generators zijn voor digitale tekst, maar ze werken ook als voorbeeldkaart. Print het <a href="#cursive-alphabet">oefenblad</a> om over te trekken, bekijk hoe elke hoofdletter verbindt in de <a href="#cursive-letters">letterverkenner</a> en houd rekening met toegankelijkheid — korte sierlijke stukjes, de rest in gewone tekst (<a href="/guide/fancy-fonts-accessibility-guide/">gids over toegankelijkheid</a>).</p>
+
+      <h3>Cursieve letters voor tattoos</h3>
+      <p>Sierlijke schuine letters zijn de meestgevraagde tattoo-stijl. Bekijk je woord hier eerst op groot formaat en gebruik daarna de speciale <a href="/nl/usecase/tattoo-letters/">generator voor tattoo-letters</a> — die voegt letterfamilies toe, datums in Romeinse cijfers, initialen en een leesbaarheidstest voor het formaat van je inkt.</p>
+    </section>
+
+    <div class="cta-card">
+      <h3>Laat je hele bio vloeien</h3>
+      <p>Combineer een cursieve koptekst met nette gewone tekst — de mix die opvalt én leesbaar blijft.</p>
+      <a class="cta-btn" href="/nl/">Open de volledige generator →</a>
+    </div>
+  </main>
+
+  <!-- Footer + FAQ -->
+  <footer class="footer">
+    <div class="footer-inner">
+<div class="faq-section" id="cursive-faq">
+
+<h2 class="faq-category">Cursieve Letters Generator — Veelgestelde vragen</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Wat is een generator voor cursieve letters en hoe werkt hij?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Hij zet de letters die je typt om in Unicode-scripttekens — speciale symbolen die eruitzien als cursief handschrift maar zich gedragen als gewone tekst. Omdat het echte tekens zijn (geen lettertype of afbeelding), kun je ze kopiëren en plakken in bio's, bijschriften, reacties en berichten, waarbij ze hun cursieve uiterlijk behouden. Lees meer in onze <a href="/guide/how-unicode-fonts-work/">gids over hoe Unicode-lettertypes werken</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Hoe kopieer en plak ik cursieve tekst?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Typ of plak je tekst in het vak bovenaan en tik op Kopiëren bij de stijl die je mooi vindt. De cursieve versie staat nu op je klembord — plak hem overal waar tekst kan: Instagram, TikTok, WhatsApp, Discord, documenten en meer.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Werken cursieve letters op Instagram, WhatsApp en TikTok?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Ja. Cursieve letters werken in je Instagram-<strong>bio</strong> en bijschriften, je WhatsApp-status en -berichten, en TikTok-bijschriften. Let op: velden voor je gebruikersnaam of weergavenaam filteren soms speciale tekens weg — voor je @handle blijf je bij gewone letters.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Is het gratis en moet ik een account maken?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Volledig gratis, zonder account en zonder installatie. Alles draait in je browser: typen, kopiëren, plakken. Er wordt niets opgeslagen op een server.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Waarom veranderen mijn accenten en trema's niet mee?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Unicode-scriptletters bestaan alleen voor A–Z. Letters met accenten of trema's (é, ë, ï, ö, ç) hebben geen cursieve tegenhanger en blijven daarom in gewone tekst staan. Wil je alles volledig cursief? Schrijf het woord of de naam dan zonder accenten.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Kan ik één losse cursieve letter kopiëren?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Ja. Gebruik de <a href="#cursive-letters">letterverkenner A–Z</a>: tik op een letter om elke cursieve stijl te zien, kopieer de exacte hoofdletter of kleine letter, of download hem als PNG-afbeelding.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Waarom zie ik lege vakjes in plaats van sierlijke letters?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Een leeg vakje (▯) betekent dat het apparaat of de app dat teken niet kan tonen. Dat komt bijna alleen voor op oudere systemen. Kies dan een eenvoudigere stijl of houd de tekst korter. Meer uitleg staat in <a href="/guide/why-fonts-show-as-boxes/">waarom lettertypes als vakjes verschijnen</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Kan ik cursieve letters gebruiken voor een tattoo?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Zeker. Bekijk je woord hier op groot formaat en ga daarna naar de <a href="/nl/usecase/tattoo-letters/">generator voor tattoo-letters</a> voor letterfamilies, datums in Romeinse cijfers en een leesbaarheidstest.
+  </div>
+</div>
+
+</div>
 
     <!-- Language Switcher -->
-    <div class="lang-switcher" role="navigation" aria-label="Taalkeuze">
-      <a class="lang-option" href="/category/italic-fonts/" hreflang="en">EN</a>
-      <a class="lang-option" href="/fr/ecriture-italique/" hreflang="fr">FR</a>
-      <a class="lang-option" href="/id/tulisan-miring/" hreflang="id">ID</a>
+    <div class="lang-switcher" role="navigation" aria-label="Language switcher">
+      <a class="lang-option" href="/category/cursive-fonts/" hreflang="en">EN</a>
+      <a class="lang-option" href="/es/letra-cursiva/" hreflang="es">ES</a>
+      <a class="lang-option" href="/pt/letra-cursiva/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/fr/ecriture-cursive/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/de/schreibschrift/" hreflang="de">DE</a>
+      <a class="lang-option" href="/it/lettere-in-corsivo/" hreflang="it">IT</a>
+      <a class="lang-option" href="/tr/el-yazisi-fontu/" hreflang="tr">TR</a>
       <a class="lang-option active" href="/nl/cursieve-letters/" hreflang="nl">NL</a>
+      <a class="lang-option" href="/id/tulisan-sambung/" hreflang="id">ID</a>
+      <a class="lang-option" href="/no/kursiv-tekst/" hreflang="no">NO</a>
     </div>
-  </div>
-</footer>
 
-<div class="copy-toast" id="copyToast">Gekopieerd!</div>
-<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+    </div>
+  </footer>
 
-<script>window.UTG_FAMILY = "italic";</script>
-<script src="/styles.js"></script>
-<script src="/renderer.js"></script>
-<script src="/script.js" defer=""></script>
-<script src="/symbol-explorer.js"></script>
-<script src="/accent-notice.js" defer></script>
-<script src="/footer.js"></script>
+  <div id="cursivePrintRoot" aria-hidden="true"></div>
+  <div class="copy-toast" id="copyToast">Gekopieerd!</div>
+
+  <script>
+    window.UTG_CURSIVE_MODE = true;
+    window.UTG_FAMILY = "cursive";
+    window.cursiveI18n = {
+  "demoText": "Hallo",
+  "demoName": "Julia",
+  "copy": "Kopiëren",
+  "typeFirst": "Typ eerst je tekst hierboven",
+  "downloadPngTitle": "Downloaden als PNG-afbeelding",
+  "downloadPng": "PNG downloaden",
+  "characters": "tekens",
+  "caseUpper": "Hoofdletter",
+  "caseLower": "Kleine letter",
+  "caseBoth": "Beide",
+  "labelUpper": "Hoofdletter {ch} in cursief",
+  "labelLower": "Kleine letter {ch} in cursief",
+  "labelBoth": "Hoofdletter en kleine letter {ch} in cursief",
+  "copyBoth": "Beide kopiëren",
+  "everyStyle": "{ch} in cursief — elke stijl, klik om te kopiëren",
+  "suffixCapital": " — hoofdletter",
+  "suffixLowercase": " — kleine letter",
+  "accentLabel": "{name}-accent",
+  "practiceTitle": "Oefenblad cursief alfabet — ultratextgen.com",
+  "flourishLabel": "Krul",
+  "monogramLabel": "Monogram-verbinder",
+  "copiedToast": "Gekopieerd!",
+  "quickWords": [
+    "liefde",
+    "verjaardag",
+    "dankjewel",
+    "familie",
+    "altijd",
+    "gezegend"
+  ],
+  "styles": {
+    "Ultra Script": "klassiek cursief",
+    "Ultra Script Bold": "vet cursief",
+    "Ultra Script Elegant": "elegant cursief",
+    "Ultra Script Bold Elegant": "vet elegant cursief",
+    "Ultra Gothic Script": "gothic cursief",
+    "Ultra Chicano Script": "Chicano-naamplaat",
+    "Ultra Script Sparkle": "cursief met sterretjes"
+  },
+  "presets": {
+    "Script Hearts": "Cursief met hartjes",
+    "Script Arrow Bio": "Cursieve bio met pijl",
+    "Bold Script Stars": "Vet cursief met sterren",
+    "Script Vintage": "Cursief vintage",
+    "Script Soft Dots": "Cursief met zachte stippen",
+    "Bold Script Ribbon": "Vet cursief met lint",
+    "Script Underline": "Cursief onderstreept",
+    "Bold Script Crown": "Vet cursief met kroon"
+  },
+  "signatures": {
+    "Classic Signature": "Klassieke handtekening",
+    "Bold Signature": "Vette handtekening",
+    "Signed Underline": "Handtekening onderstreept",
+    "Sparkle Signature": "Handtekening met sterretjes",
+    "Ornate Nameplate": "Sierlijke naamplaat",
+    "Autograph Star": "Handtekening met ster",
+    "Monogram Initials": "Monogram-initialen",
+    "Gothic Signature": "Gothic handtekening"
+  },
+  "decorators": {
+    "None": "Geen",
+    "Underline": "Onderstreping",
+    "Sparkle": "Sterretjes",
+    "Hearts": "Hartjes",
+    "Ornate": "Sierlijk",
+    "Soft dots": "Zachte stippen"
+  },
+  "accents": {
+    "Sparkle": "Sterretjes",
+    "Hearts": "Hartjes",
+    "Wings": "Vleugels",
+    "Ornate": "Sierlijk"
+  },
+  "platformLimits": {
+    "Instagram bio": "Instagram-bio",
+    "TikTok bio": "TikTok-bio",
+    "X bio": "X-bio"
+  }
+};
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/js/cursive/cursiveData.js" defer></script>
+  <script src="/script.js" defer></script>
+  <script src="/js/cursive/cursivePageController.js" defer></script>
+  <script src="/footer.js" defer></script>
 </body></html>

--- a/no/kursiv-tekst/index.html
+++ b/no/kursiv-tekst/index.html
@@ -6,27 +6,30 @@
   'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
   })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
   <!-- End Google Tag Manager -->
-  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZGVh");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
   <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Kursiv tekst - kopier og lim inn kursiv skrift | UltraTextGen</title>
-  <meta name="description" content="Lag kursiv tekst og kursiv skrift du kan kopiere og lime inn. Skriv teksten din og få Unicode-kursiv, håndskrift og fine bokstaver til Instagram, Facebook, Discord og bio.">
+  <title>Kursiv Tekst Generator — 𝓴𝓸𝓹𝓲𝓮𝓻 𝓸𝓰 𝓵𝓲𝓶 Kursiv Skrift, Bokstaver A–Z og Navn | UltraTextGen</title>
+  <meta name="description" content="Gratis generator for kursiv tekst — kopier kursiv skrift, hver kursiv bokstav A–Z, hele det kursive alfabetet, populære ord i kursiv og navnesignaturer. Fin skrift til Instagram, TikTok og bio.">
   <link rel="canonical" href="https://ultratextgen.com/no/kursiv-tekst/">
 
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/category/cursive-fonts/">
-  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/ecriture-cursive/">
-  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/tulisan-sambung/">
-  <link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/sierlijke-letters/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/letra-cursiva/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/letra-cursiva/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/ecriture-cursive/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/schreibschrift/">
+  <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/lettere-in-corsivo/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/el-yazisi-fontu/">
+  <link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/cursieve-letters/">
+  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/tulisan-sambung/">
   <link rel="alternate" hreflang="no" href="https://ultratextgen.com/no/kursiv-tekst/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/category/cursive-fonts/">
 
   <meta name="robots" content="index, follow">
   <meta property="og:site_name" content="UltraTextGen">
-  <meta property="og:title" content="Kursiv tekst - kopier og lim inn kursiv skrift">
-  <meta property="og:description" content="Skriv vanlig tekst og få kursiv Unicode-tekst, håndskrift og fine bokstaver klare til å kopiere.">
+  <meta property="og:title" content="Kursiv Tekst Generator — 𝓴𝓸𝓹𝓲𝓮𝓻 𝓸𝓰 𝓵𝓲𝓶 Kursiv Skrift, Bokstaver A–Z og Navn | UltraTextGen">
+  <meta property="og:description" content="Gratis generator for kursiv tekst og kursiv skrift — kopier kursiv skrift, kursivt alfabet A–Z, populære ord i kursiv og navnesignaturer.">
   <meta property="og:url" content="https://ultratextgen.com/no/kursiv-tekst/">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://ultratextgen.com/assets/og/category-cursive-fonts.png">
@@ -34,58 +37,83 @@
   <meta property="og:image:height" content="630">
   <meta property="og:image:type" content="image/png">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Kursiv tekst - kopier og lim inn kursiv skrift">
-  <meta name="twitter:description" content="Gratis generator for kursiv tekst, håndskrift og fine bokstaver.">
+  <meta name="twitter:title" content="Kursiv Tekst Generator — 𝓴𝓸𝓹𝓲𝓮𝓻 𝓸𝓰 𝓵𝓲𝓶 Kursiv Skrift, Bokstaver A–Z og Navn | UltraTextGen">
+  <meta name="twitter:description" content="Gratis generator for kursiv tekst og kursiv skrift — kopier kursiv skrift, kursivt alfabet A–Z, ord i kursiv og navnesignaturer.">
   <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category-cursive-fonts.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/style.css">
-  <link rel="stylesheet" href="/symbol-explorer.css">
-
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "WebApplication",
-  "name": "Kursiv tekst generator",
-  "alternateName": ["Kursiv tekst", "Kursiv skrift", "Kursiv font", "Håndskrift generator", "Fine bokstaver"],
-  "url": "https://ultratextgen.com/no/kursiv-tekst/",
-  "inLanguage": "no",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "description": "Gratis generator for kursiv tekst og kursiv skrift i Unicode. Skriv vanlig tekst, velg kursiv eller håndskrift, og kopier resultatet til Instagram, Facebook, Discord, WhatsApp eller bio.",
-  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
-}
-</script>
 
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
   "@type": "FAQPage",
-  "inLanguage": "no",
+  "inLanguage": "nb-NO",
   "mainEntity": [
     {
       "@type": "Question",
-      "name": "Hvordan lager jeg kursiv tekst?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Skriv teksten din i feltet øverst på siden. Resultatene vises automatisk i kursiv, håndskrift og andre Unicode-stiler. Trykk på Kopier ved den varianten du liker, og lim den inn i bio, melding, caption eller dokument." }
+      "name": "Hva er en generator for kursiv tekst, og hvordan fungerer den?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Den gjør bokstavene du skriver om til Unicode-skrifttegn — spesialtegn som ser ut som kursiv håndskrift, men oppfører seg som vanlig tekst. Fordi de er ekte tegn (ikke en skrifttype eller et bilde), kan du kopiere dem og lime dem inn i bio, bildetekster, kommentarer og meldinger, og de beholder det kursive uttrykket. Les mer i <a href=\"/guide/how-unicode-fonts-work/\">guiden om hvordan Unicode-fonter fungerer</a>."
+      }
     },
     {
       "@type": "Question",
-      "name": "Er dette ekte kursiv formatering?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Nei. Dette er Unicode-tegn som ser kursiverte ut. Det betyr at stilen følger med når du kopierer teksten, også på steder som ikke har en kursiv-knapp, for eksempel Instagram-bioer, Discord-navn og Facebook-kommentarer." }
+      "name": "Hvordan kopierer og limer jeg inn kursiv tekst?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Skriv eller lim inn teksten din i feltet øverst, og trykk deretter <strong>Kopier</strong> på stilen du liker. Den kursive versjonen ligger nå på utklippstavlen — lim den inn hvor som helst som tar imot tekst: Instagram, TikTok, WhatsApp, Discord, dokumenter og mer."
+      }
     },
     {
       "@type": "Question",
-      "name": "Fungerer kursiv tekst på Instagram og Facebook?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Ja, i bio, captions, kommentarer, innlegg og visningsnavn fungerer kursiv Unicode vanligvis fint. Brukernavn og @-handles er strengere og godtar ofte bare vanlige bokstaver, tall, punktum og understrek." }
+      "name": "Fungerer kursiv tekst på Instagram, WhatsApp og TikTok?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ja. Kursiv skrift virker i Instagram-bio og bildetekster, i WhatsApp-meldinger og status, og i TikTok-tekster og profilbeskrivelser. Merk at felt for brukernavn ofte fjerner spesialtegn, så hold selve brukernavnet i vanlig tekst."
+      }
     },
     {
       "@type": "Question",
-      "name": "Hva skjer med norske bokstaver som æ, ø og å?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Unicode har ikke alltid egne kursiv-varianter av æ, ø og å. I de stilene blir bokstavene stående som vanlige tegn mens resten av ordet blir kursiv. For helt jevn pyntetekst kan du skrive ae, o eller a, men til vanlig tekst er det best å beholde de norske bokstavene." }
+      "name": "Hvorfor blir ikke æ, ø og å kursive?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Unicode har kursive skriftbokstaver bare for A–Z, så æ, ø og å går uendret gjennom. For et helt gjennomført kursivt utseende skriver du dem om: æ → «ae», ø → «o», å → «a». Da blir for eksempel «kjærlighet» til «kjaerlighet» og gjengis fullt ut i kursiv."
+      }
     },
     {
       "@type": "Question",
-      "name": "Kan jeg bruke kursiv tekst til hele avsnitt?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Det er bedre å bruke det til korte linjer, navn eller ett viktig ord. Lang Unicode-kursiv kan være tyngre å lese og kan gi dårligere tilgjengelighet for skjermlesere." }
+      "name": "Er kursiv tekst gratis å bruke?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ja, helt gratis og uten registrering. Skriv inn <strong>kursiv tekst</strong>, kopier resultatet, og bruk det så mange ganger du vil — også til kommersielle profiler."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Kan jeg lage en kursiv navnesignatur?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ja. Bruk <a href=\"#mainInput\">navne- og signaturstudioet</a> til å skrive fornavnet eller det fulle navnet ditt, velge pynt og monogram-initialer, og kopiere resultatet eller laste det ned som PNG til e-postsignaturer og dokumenter."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Fungerer kursiv tekst i lesehjelpemidler?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Skjermlesere kan lese Unicode-skrifttegn bokstav for bokstav eller hoppe over dem, så bruk kursiv skrift til korte dekorative innslag og hold viktig informasjon i vanlig tekst. Se vår <a href=\"/guide/fancy-fonts-accessibility-guide/\">tilgjengelighetsguide</a> for gode vaner."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Hvorfor vises noen kursive bokstaver som tomme ruter?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "En tom rute (▯) betyr at enheten mangler glyfen for det tegnet. Prøv en enklere stil, oppdater systemet, eller unngå spesialtegn — les <a href=\"/guide/why-fonts-show-as-boxes/\">hvorfor fonter vises som ruter</a>."
+      }
     }
   ]
 }
@@ -96,148 +124,725 @@
   "@context": "https://schema.org",
   "@type": "BreadcrumbList",
   "itemListElement": [
-    { "@type": "ListItem", "position": 1, "name": "Tekstgenerator", "item": "https://ultratextgen.com/no/" },
-    { "@type": "ListItem", "position": 2, "name": "Kursiv tekst", "item": "https://ultratextgen.com/no/kursiv-tekst/" }
+    { "@type": "ListItem", "position": 1, "name": "Hjem", "item": "https://ultratextgen.com/no/" },
+    { "@type": "ListItem", "position": 2, "name": "Kursiv Tekst", "item": "https://ultratextgen.com/no/kursiv-tekst/" }
   ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Kursiv Tekst Generator",
+  "alternateName": ["Kursiv Skrift Generator","Kursiv Font","Kursive Bokstaver A–Z","Kursiv Alfabet","Fin Skrift","Navnesignatur i Kursiv","Kopier Kursiv Tekst"],
+  "url": "https://ultratextgen.com/no/kursiv-tekst/",
+  "inLanguage": "nb-NO",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "NOK"
+  },
+  "description": "Gratis generator for kursiv tekst: kopier kursiv skrift, hver kursiv bokstav A–Z, hele det kursive alfabetet, populære ord i kursiv og navnesignaturer.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers.",
+  "featureList": ["Kursiv skrift generator med pynt og forhåndsvalg","Utforsker for kursive bokstaver A–Z (store og små)","Kopier hele det kursive alfabetet med ett klikk","Utskrivbart øvingsark for kursiv","Studio for navn og signatur i kursiv","Galleri med ord i kursiv (kjærlighet, gratulerer med dagen, måneder)"]
 }
 </script>
 </head>
 <body>
   <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
   <!-- Google Tag Manager (noscript) -->
-  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <!-- End Google Tag Manager (noscript) -->
   <div id="shared-header"></div>
 <script src="/header.js" defer></script>
 
-<nav class="breadcrumbs" aria-label="Brødsmule">
-  <a href="/no/">Tekstgenerator</a>
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/no/">Hjem</a>
   <span class="breadcrumb-separator">›</span>
-  <span class="breadcrumb-current">Kursiv tekst</span>
+  <span class="breadcrumb-current">Kursiv Tekst</span>
 </nav>
 
 <figure class="page-hero-figure" data-uthero aria-hidden="true">
-  <img src="/assets/hero/category-cursive-fonts.svg" width="1200" height="340" loading="lazy" alt="">
+  <img src="/assets/hero/category-cursive-fonts.svg" width="1200" height="340"
+       loading="lazy" alt="">
 </figure>
 
-<section class="hero">
-  <div class="hero-inner">
-    <div class="hero-card">
-      <h1 class="hero-headline">Kursiv tekst - kopier og lim inn</h1>
-      <p class="hero-tagline">Skriv vanlig tekst og få kursiv skrift, håndskrift og fine bokstaver du kan lime inn i Instagram, Facebook, Discord, TikTok, WhatsApp eller en bio.</p>
-      <div class="input-wrapper">
-        <textarea class="main-input" id="mainInput" placeholder="Skriv teksten din her..." maxlength="500" autofocus></textarea>
-        <span class="char-count"><span id="charCount">0</span>/500</span>
-      </div>
-      <div class="accent-notice" id="accentNotice" role="note" hidden>
-        <span class="accent-notice-icon" aria-hidden="true">◌̊</span>
-        <span class="accent-notice-text">Teksten din inneholder æ, ø eller å. Mange Unicode-stiler lar disse bokstavene stå vanlige. Stiler som understrek, gjennomstreking og rammer beholder dem best.</span>
-        <button type="button" class="accent-notice-close" id="accentNoticeClose" aria-label="Lukk">×</button>
-      </div>
-      <div class="decoration-section">
-        <div class="decoration-label">Legg pynt rundt resultatet</div>
-        <div class="decoration-tabs">
-          <button class="decoration-tab active" data-deco-tab="symbols">Symboler</button>
-          <button class="decoration-tab" data-deco-tab="frames">Rammer</button>
-          <button class="decoration-tab" data-deco-tab="minimal">Minimal</button>
+  <!-- Hero: the cursive-first generator -->
+  <section class="hero">
+    <div class="hero-inner">
+      <div class="hero-card">
+        <h1 class="hero-headline">Kursiv Tekst Generator</h1>
+        <p class="hero-tagline">Gjør hvilken som helst tekst om til 𝓴𝓾𝓻𝓼𝓲𝓿 du kan kopiere og lime inn — flytende kursiv skrift,
+          hver kursiv bokstav A–Z, hele alfabetet og navnesignaturer. Gratis, umiddelbart, uten registrering.</p>
+        <div class="input-wrapper">
+          <textarea class="main-input" id="mainInput" placeholder="Skriv teksten, ordet eller navnet ditt…" maxlength="500" autofocus></textarea>
+          <span class="char-count"><span id="charCount">0</span>/500</span>
         </div>
-        <div class="decoration-grid" id="decorationGrid"></div>
+        <div class="cursive-quick-row" id="cursiveQuickRow" aria-label="Raske eksempler"></div>
+        <div class="vertical-fit-row" id="cursiveFitRow" hidden></div>
       </div>
     </div>
+  </section>
+
+  <nav class="cursive-section-nav" aria-label="På denne siden">
+    <a href="#cursive-styles">Stiler</a>
+    <a href="#cursive-letters">Bokstaver A–Z</a>
+    <a href="#cursive-alphabet">Alfabet</a>
+    <a href="#cursive-words">Ord</a>
+    <a href="#cursive-names">Navn og signaturer</a>
+    <a href="#cursive-faq">FAQ</a>
+  </nav>
+
+  <main class="container">
+
+    <!-- 1. Generator output -->
+    <section id="cursive-styles" aria-labelledby="cursiveStylesHeading">
+      <h2 class="bubble-az-heading" id="cursiveStylesHeading">Kursiv skrift — kopier og lim inn</h2>
+      <p class="bubble-az-intro">Hver stil under oppdateres direkte mens du skriver: klassisk og fet kursiv skrift,
+        elegante varianter med luft, gotisk kursiv, chicano-navneskilt og forhåndsvalg med pynt som hjerter,
+        glitter og piler. Trykk Kopier og lim den inn hvor som helst.</p>
+      <div class="results-grid" id="resultsGrid"></div>
+    </section>
+
+    <!-- 2. Cursive letters A–Z -->
+    <section class="bubble-az" id="cursive-letters" aria-labelledby="cursiveLettersHeading">
+      <h2 class="bubble-az-heading" id="cursiveLettersHeading">Kursive bokstaver A–Z — store og små</h2>
+      <p class="bubble-az-intro">Ute etter én bokstav — en kursiv S, en stor G i kursiv, en liten f?
+        Trykk på en bokstav for å se den i hver kursiv stil, kopier akkurat den glyfen, eller last den ned som PNG.</p>
+  <div class="cursive-letter-grid" role="tablist" aria-label="Velg en kursiv bokstav">
+    <button type="button" class="cursive-letter-cell" id="cursive-a" data-char="A" aria-label="A i kursiv — stor og liten">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒜 𝒶</span>
+      <span class="cursive-letter-name">Kursiv A</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-b" data-char="B" aria-label="B i kursiv — stor og liten">
+      <span class="cursive-letter-pair" aria-hidden="true">ℬ 𝒷</span>
+      <span class="cursive-letter-name">Kursiv B</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-c" data-char="C" aria-label="C i kursiv — stor og liten">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒞 𝒸</span>
+      <span class="cursive-letter-name">Kursiv C</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-d" data-char="D" aria-label="D i kursiv — stor og liten">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒟 𝒹</span>
+      <span class="cursive-letter-name">Kursiv D</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-e" data-char="E" aria-label="E i kursiv — stor og liten">
+      <span class="cursive-letter-pair" aria-hidden="true">ℰ ℯ</span>
+      <span class="cursive-letter-name">Kursiv E</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-f" data-char="F" aria-label="F i kursiv — stor og liten">
+      <span class="cursive-letter-pair" aria-hidden="true">ℱ 𝒻</span>
+      <span class="cursive-letter-name">Kursiv F</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-g" data-char="G" aria-label="G i kursiv — stor og liten">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒢 ℊ</span>
+      <span class="cursive-letter-name">Kursiv G</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-h" data-char="H" aria-label="H i kursiv — stor og liten">
+      <span class="cursive-letter-pair" aria-hidden="true">ℋ 𝒽</span>
+      <span class="cursive-letter-name">Kursiv H</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-i" data-char="I" aria-label="I i kursiv — stor og liten">
+      <span class="cursive-letter-pair" aria-hidden="true">ℐ 𝒾</span>
+      <span class="cursive-letter-name">Kursiv I</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-j" data-char="J" aria-label="J i kursiv — stor og liten">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒥 𝒿</span>
+      <span class="cursive-letter-name">Kursiv J</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-k" data-char="K" aria-label="K i kursiv — stor og liten">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒦 𝓀</span>
+      <span class="cursive-letter-name">Kursiv K</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-l" data-char="L" aria-label="L i kursiv — stor og liten">
+      <span class="cursive-letter-pair" aria-hidden="true">ℒ 𝓁</span>
+      <span class="cursive-letter-name">Kursiv L</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-m" data-char="M" aria-label="M i kursiv — stor og liten">
+      <span class="cursive-letter-pair" aria-hidden="true">ℳ 𝓂</span>
+      <span class="cursive-letter-name">Kursiv M</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-n" data-char="N" aria-label="N i kursiv — stor og liten">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒩 𝓃</span>
+      <span class="cursive-letter-name">Kursiv N</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-o" data-char="O" aria-label="O i kursiv — stor og liten">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒪 ℴ</span>
+      <span class="cursive-letter-name">Kursiv O</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-p" data-char="P" aria-label="P i kursiv — stor og liten">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒫 𝓅</span>
+      <span class="cursive-letter-name">Kursiv P</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-q" data-char="Q" aria-label="Q i kursiv — stor og liten">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒬 𝓆</span>
+      <span class="cursive-letter-name">Kursiv Q</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-r" data-char="R" aria-label="R i kursiv — stor og liten">
+      <span class="cursive-letter-pair" aria-hidden="true">ℛ 𝓇</span>
+      <span class="cursive-letter-name">Kursiv R</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-s" data-char="S" aria-label="S i kursiv — stor og liten">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒮 𝓈</span>
+      <span class="cursive-letter-name">Kursiv S</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-t" data-char="T" aria-label="T i kursiv — stor og liten">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒯 𝓉</span>
+      <span class="cursive-letter-name">Kursiv T</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-u" data-char="U" aria-label="U i kursiv — stor og liten">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒰 𝓊</span>
+      <span class="cursive-letter-name">Kursiv U</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-v" data-char="V" aria-label="V i kursiv — stor og liten">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒱 𝓋</span>
+      <span class="cursive-letter-name">Kursiv V</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-w" data-char="W" aria-label="W i kursiv — stor og liten">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒲 𝓌</span>
+      <span class="cursive-letter-name">Kursiv W</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-x" data-char="X" aria-label="X i kursiv — stor og liten">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒳 𝓍</span>
+      <span class="cursive-letter-name">Kursiv X</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-y" data-char="Y" aria-label="Y i kursiv — stor og liten">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒴 𝓎</span>
+      <span class="cursive-letter-name">Kursiv Y</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-z" data-char="Z" aria-label="Z i kursiv — stor og liten">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒵 𝓏</span>
+      <span class="cursive-letter-name">Kursiv Z</span>
+    </button>
   </div>
-</section>
+      <div class="cursive-letter-panel" id="cursiveLetterPanel" aria-live="polite"></div>
+    </section>
 
-<main class="container">
-  <div class="category-section"><div class="category-tabs" id="categoryTabs"></div></div>
-  <div class="results-grid" id="resultsGrid"></div>
-
-  <section class="editorial-section">
-    <h2>Kursiv tekst som faktisk kan kopieres</h2>
-    <p class="editorial-intro"><strong>Kursiv tekst</strong> her betyr ikke vanlig formatering fra Word. Generatoren bytter bokstavene til Unicode-tegn som allerede ser kursiverte eller håndskrevne ut. Derfor beholder teksten stilen når du limer den inn i en bio, kommentar, status eller melding.</p>
-    <div class="block-example">
-      <strong>Eksempel:</strong> "hei Norge" kan bli 𝘩𝘦𝘪 𝘕𝘰𝘳𝘨𝘦, 𝒽ℯ𝒾 𝒩ℴ𝓇ℊℯ eller 𝓱𝓮𝓲 𝓝𝓸𝓻𝓰𝓮.
-    </div>
-    <p>Vil du ha mer trykk enn kursiv? Bruk <a href="/category/bold-fonts/">fet skrift</a>. Vil du ha en roligere stil til navn eller bio, fungerer håndskrift og fine bokstaver ofte bedre enn tung dekorasjon.</p>
-  </section>
-
-  <section class="editorial-section glyph-section">
-    <h2>Kursiv alfabet og håndskrift</h2>
-    <p class="editorial-intro">Her er de vanligste kursiv- og script-variantene. Klikk på en linje for å kopiere hele alfabetet.</p>
-    <div class="alpha-list">
-      <div class="alpha-row">
-        <span class="alpha-label">Kursiv sans</span>
-        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝘈𝘉𝘊𝘋𝘌𝘍𝘎𝘏𝘐𝘑𝘒𝘓𝘔𝘕𝘖𝘗𝘘𝘙𝘚𝘛𝘜𝘝𝘞𝘟𝘠𝘡 𝘢𝘣𝘤𝘥𝘦𝘧𝘨𝘩𝘪𝘫𝘬𝘭𝘮𝘯𝘰𝘱𝘲𝘳𝘴𝘵𝘶𝘷𝘸𝘹𝘺𝘻" aria-label="Kopier kursiv sans alfabet">𝘈𝘉𝘊𝘋𝘌𝘍𝘎𝘏𝘐𝘑𝘒𝘓𝘔𝘕𝘖𝘗𝘘𝘙𝘚𝘛𝘜𝘝𝘞𝘟𝘠𝘡 · 𝘢𝘣𝘤𝘥𝘦𝘧𝘨𝘩𝘪𝘫𝘬𝘭𝘮𝘯𝘰𝘱𝘲𝘳𝘴𝘵𝘶𝘷𝘸𝘹𝘺𝘻</button>
+    <!-- 3. The cursive alphabet -->
+    <section id="cursive-alphabet" aria-labelledby="cursiveAlphabetHeading">
+      <div class="cursive-chart-toolbar">
+        <h2 class="bubble-az-heading" id="cursiveAlphabetHeading">Det kursive alfabetet (A–Z, 0–9)</h2>
+        <button type="button" class="bubble-btn bubble-btn-primary" id="cursivePrintSheet">Skriv ut øvingsark</button>
       </div>
-      <div class="alpha-row">
-        <span class="alpha-label">Håndskrift</span>
-        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵 𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏" aria-label="Kopier håndskrift alfabet">𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵 · 𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏</button>
+      <p class="bubble-az-intro">Kopier hele det kursive alfabetet med ett klikk — store bokstaver, små bokstaver og tall —
+        eller skriv ut et øvingsark med modellbokstaver og plass til å tegne over. Unicode har ingen ekte kursive sifre, så hver
+        stil kombinerer skriftbokstavene med tilpassede stiliserte tall.</p>
+    <div class="cursive-chart">
+      <div class="cursive-chart-head">
+        <h3>Klassisk kursiv alfabet (Ultra Script)</h3>
+        <button type="button" class="copy-btn" data-text="𝒜 ℬ 𝒞 𝒟 ℰ ℱ 𝒢 ℋ ℐ 𝒥 𝒦 ℒ ℳ 𝒩 𝒪 𝒫 𝒬 ℛ 𝒮 𝒯 𝒰 𝒱 𝒲 𝒳 𝒴 𝒵&#10;𝒶 𝒷 𝒸 𝒹 ℯ 𝒻 ℊ 𝒽 𝒾 𝒿 𝓀 𝓁 𝓂 𝓃 ℴ 𝓅 𝓆 𝓇 𝓈 𝓉 𝓊 𝓋 𝓌 𝓍 𝓎 𝓏&#10;𝟢 𝟣 𝟤 𝟥 𝟦 𝟧 𝟨 𝟩 𝟪 𝟫" data-style="Ultra Script">Kopier alfabet</button>
       </div>
-      <div class="alpha-row">
-        <span class="alpha-label">Fet håndskrift</span>
-        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩 𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃" aria-label="Kopier fet håndskrift alfabet">𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩 · 𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃</button>
+      <p class="cursive-alphabet-row">𝒜 ℬ 𝒞 𝒟 ℰ ℱ 𝒢 ℋ ℐ 𝒥 𝒦 ℒ ℳ 𝒩 𝒪 𝒫 𝒬 ℛ 𝒮 𝒯 𝒰 𝒱 𝒲 𝒳 𝒴 𝒵</p>
+      <p class="cursive-alphabet-row">𝒶 𝒷 𝒸 𝒹 ℯ 𝒻 ℊ 𝒽 𝒾 𝒿 𝓀 𝓁 𝓂 𝓃 ℴ 𝓅 𝓆 𝓇 𝓈 𝓉 𝓊 𝓋 𝓌 𝓍 𝓎 𝓏</p>
+      <p class="cursive-alphabet-row">𝟢 𝟣 𝟤 𝟥 𝟦 𝟧 𝟨 𝟩 𝟪 𝟫</p>
+    </div>
+    <div class="cursive-chart">
+      <div class="cursive-chart-head">
+        <h3>Fet kursiv alfabet (Ultra Script Bold)</h3>
+        <button type="button" class="copy-btn" data-text="𝓐 𝓑 𝓒 𝓓 𝓔 𝓕 𝓖 𝓗 𝓘 𝓙 𝓚 𝓛 𝓜 𝓝 𝓞 𝓟 𝓠 𝓡 𝓢 𝓣 𝓤 𝓥 𝓦 𝓧 𝓨 𝓩&#10;𝓪 𝓫 𝓬 𝓭 𝓮 𝓯 𝓰 𝓱 𝓲 𝓳 𝓴 𝓵 𝓶 𝓷 𝓸 𝓹 𝓺 𝓻 𝓼 𝓽 𝓾 𝓿 𝔀 𝔁 𝔂 𝔃&#10;𝟬 𝟭 𝟮 𝟯 𝟰 𝟱 𝟲 𝟳 𝟴 𝟵" data-style="Ultra Script Bold">Kopier alfabet</button>
+      </div>
+      <p class="cursive-alphabet-row">𝓐 𝓑 𝓒 𝓓 𝓔 𝓕 𝓖 𝓗 𝓘 𝓙 𝓚 𝓛 𝓜 𝓝 𝓞 𝓟 𝓠 𝓡 𝓢 𝓣 𝓤 𝓥 𝓦 𝓧 𝓨 𝓩</p>
+      <p class="cursive-alphabet-row">𝓪 𝓫 𝓬 𝓭 𝓮 𝓯 𝓰 𝓱 𝓲 𝓳 𝓴 𝓵 𝓶 𝓷 𝓸 𝓹 𝓺 𝓻 𝓼 𝓽 𝓾 𝓿 𝔀 𝔁 𝔂 𝔃</p>
+      <p class="cursive-alphabet-row">𝟬 𝟭 𝟮 𝟯 𝟰 𝟱 𝟲 𝟳 𝟴 𝟵</p>
+    </div>
+    <div class="cursive-chart">
+      <div class="cursive-chart-head">
+        <h3>Gotisk kursiv alfabet (Ultra Gothic Script)</h3>
+        <button type="button" class="copy-btn" data-text="𝕬 𝕭 𝕮 𝕯 𝕰 𝕱 𝕲 𝕳 𝕴 𝕵 𝕶 𝕷 𝕸 𝕹 𝕺 𝕻 𝕼 𝕽 𝕾 𝕿 𝖀 𝖁 𝖂 𝖃 𝖄 𝖅&#10;𝖆 𝖇 𝖈 𝖉 𝖊 𝖋 𝖌 𝖍 𝖎 𝖏 𝖐 𝖑 𝖒 𝖓 𝖔 𝖕 𝖖 𝖗 𝖘 𝖙 𝖚 𝖛 𝖜 𝖝 𝖞 𝖟" data-style="Ultra Gothic Script">Kopier alfabet</button>
+      </div>
+      <p class="cursive-alphabet-row">𝕬 𝕭 𝕮 𝕯 𝕰 𝕱 𝕲 𝕳 𝕴 𝕵 𝕶 𝕷 𝕸 𝕹 𝕺 𝕻 𝕼 𝕽 𝕾 𝕿 𝖀 𝖁 𝖂 𝖃 𝖄 𝖅</p>
+      <p class="cursive-alphabet-row">𝖆 𝖇 𝖈 𝖉 𝖊 𝖋 𝖌 𝖍 𝖎 𝖏 𝖐 𝖑 𝖒 𝖓 𝖔 𝖕 𝖖 𝖗 𝖘 𝖙 𝖚 𝖛 𝖜 𝖝 𝖞 𝖟</p>
+    </div>
+    </section>
+
+    <!-- 4. Words in cursive -->
+    <section id="cursive-words" aria-labelledby="cursiveWordsHeading">
+      <h2 class="bubble-az-heading" id="cursiveWordsHeading">Ord i kursiv — klare til å kopiere</h2>
+      <p class="bubble-az-intro">De mest etterspurte ordene, ferdig gjengitt i kursiv skrift. Trenger du et annet?
+        Skriv det i <a href="#mainInput">generatoren over</a>, så gjengir hver stil det umiddelbart.</p>
+    <h3>Kjærlighet og familie</h3>
+    <div class="cursive-word-grid">
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓀𝒿𝒶ℯ𝓇𝓁𝒾ℊ𝒽ℯ𝓉</span>
+        <span class="cursive-word-label">kjærlighet i kursiv</span>
+        <button type="button" class="copy-btn" data-text="𝓀𝒿𝒶ℯ𝓇𝓁𝒾ℊ𝒽ℯ𝓉" data-style="Ultra Script">Kopier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓴𝓳𝓪𝓮𝓻𝓵𝓲𝓰𝓱𝓮𝓽</span>
+        <span class="cursive-word-label">kjærlighet (fet) i kursiv</span>
+        <button type="button" class="copy-btn" data-text="𝓴𝓳𝓪𝓮𝓻𝓵𝓲𝓰𝓱𝓮𝓽" data-style="Ultra Script Bold">Kopier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒿ℯℊ ℯ𝓁𝓈𝓀ℯ𝓇 𝒹ℯℊ</span>
+        <span class="cursive-word-label">jeg elsker deg i kursiv</span>
+        <button type="button" class="copy-btn" data-text="𝒿ℯℊ ℯ𝓁𝓈𝓀ℯ𝓇 𝒹ℯℊ" data-style="Ultra Script">Kopier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓂𝒶𝓂𝓂𝒶</span>
+        <span class="cursive-word-label">mamma i kursiv</span>
+        <button type="button" class="copy-btn" data-text="𝓂𝒶𝓂𝓂𝒶" data-style="Ultra Script">Kopier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓅𝒶𝓅𝓅𝒶</span>
+        <span class="cursive-word-label">pappa i kursiv</span>
+        <button type="button" class="copy-btn" data-text="𝓅𝒶𝓅𝓅𝒶" data-style="Ultra Script">Kopier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒻𝒶𝓂𝒾𝓁𝒾ℯ</span>
+        <span class="cursive-word-label">familie i kursiv</span>
+        <button type="button" class="copy-btn" data-text="𝒻𝒶𝓂𝒾𝓁𝒾ℯ" data-style="Ultra Script">Kopier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒻ℴ𝓇 𝒶𝓁𝓁𝓉𝒾𝒹</span>
+        <span class="cursive-word-label">for alltid i kursiv</span>
+        <button type="button" class="copy-btn" data-text="𝒻ℴ𝓇 𝒶𝓁𝓁𝓉𝒾𝒹" data-style="Ultra Script">Kopier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓉𝓇ℴ</span>
+        <span class="cursive-word-label">tro i kursiv</span>
+        <button type="button" class="copy-btn" data-text="𝓉𝓇ℴ" data-style="Ultra Script">Kopier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒽𝒶𝓅</span>
+        <span class="cursive-word-label">håp i kursiv</span>
+        <button type="button" class="copy-btn" data-text="𝒽𝒶𝓅" data-style="Ultra Script">Kopier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓋ℯ𝓁𝓈𝒾ℊ𝓃ℯ𝓉</span>
+        <span class="cursive-word-label">velsignet i kursiv</span>
+        <button type="button" class="copy-btn" data-text="𝓋ℯ𝓁𝓈𝒾ℊ𝓃ℯ𝓉" data-style="Ultra Script">Kopier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">ℯ𝓃ℊℯ𝓁</span>
+        <span class="cursive-word-label">engel i kursiv</span>
+        <button type="button" class="copy-btn" data-text="ℯ𝓃ℊℯ𝓁" data-style="Ultra Script">Kopier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓋ℯ𝓃𝓃</span>
+        <span class="cursive-word-label">venn i kursiv</span>
+        <button type="button" class="copy-btn" data-text="𝓋ℯ𝓃𝓃" data-style="Ultra Script">Kopier</button>
       </div>
     </div>
-    <p class="u-mt-15">Unicode har ikke egne kursiv-varianter for alle tegn. Derfor kan æ, ø og å bli stående vanlige i noen stiler. Det er normalt, og teksten er fortsatt trygg å kopiere.</p>
-  </section>
-
-  <section class="editorial-section">
-    <h2>Hvor fungerer kursiv skrift?</h2>
-    <ul class="compat-list">
-      <li><span class="ts-pill-safe">Fungerer</span> Instagram-bio, Facebook-innlegg, Discord-navn, TikTok-captions, WhatsApp-status, X-innlegg, YouTube-kommentarer og de fleste dokumenter.</li>
-      <li><span class="ts-pill-risk">Begrenset</span> Brukernavn og @-handles. Plattformene kan avvise kursiv Unicode fordi de vil ha enkle bokstaver.</li>
-      <li><span class="ts-pill-risk">Begrenset</span> Lange avsnitt. Kursiv Unicode er best som pynt, ikke som brødtekst.</li>
-    </ul>
-  </section>
-
-  <section class="editorial-section">
-    <h2>Kursiv tekst, fet skrift og fin skrift</h2>
-    <p class="editorial-intro">De norske søkene blander ofte <strong>kursiv tekst</strong>, <strong>fet skrift</strong>, <strong>fin skrift</strong> og <strong>tekst generator</strong>. Du kan lage alt dette fra samme felt øverst: velg kursiv for en mykere linje, fet skrift for mer vekt, eller håndskrift når du vil ha en mer personlig bio.</p>
-    <div class="compare-grid">
-      <a href="/no/" class="compare-card variant-muted u-no-underline">
-        <h4>Tekstgenerator</h4>
-        <p>Alle stilene på norsk: fet, kursiv, håndskrift, bobler, gotisk og mer.</p>
-      </a>
-      <a href="/category/bold-fonts/" class="compare-card variant-muted u-no-underline">
-        <h4>Fet skrift</h4>
-        <p>Når ordet skal få mer tyngde i bio, innlegg eller kommentar.</p>
-      </a>
-      <a href="/instagram/" class="compare-card variant-muted u-no-underline">
-        <h4>Instagram fonts</h4>
-        <p>Stiler som fungerer godt i bio, caption og visningsnavn.</p>
-      </a>
+    <h3>Hilsener og anledninger</h3>
+    <div class="cursive-word-grid">
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">ℊ𝓇𝒶𝓉𝓊𝓁ℯ𝓇ℯ𝓇 𝓂ℯ𝒹 𝒹𝒶ℊℯ𝓃</span>
+        <span class="cursive-word-label">gratulerer med dagen i kursiv</span>
+        <button type="button" class="copy-btn" data-text="ℊ𝓇𝒶𝓉𝓊𝓁ℯ𝓇ℯ𝓇 𝓂ℯ𝒹 𝒹𝒶ℊℯ𝓃" data-style="Ultra Script">Kopier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">ℊ𝓇𝒶𝓉𝓊𝓁ℯ𝓇ℯ𝓇</span>
+        <span class="cursive-word-label">gratulerer i kursiv</span>
+        <button type="button" class="copy-btn" data-text="ℊ𝓇𝒶𝓉𝓊𝓁ℯ𝓇ℯ𝓇" data-style="Ultra Script">Kopier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓉𝒶𝓀𝓀</span>
+        <span class="cursive-word-label">takk i kursiv</span>
+        <button type="button" class="copy-btn" data-text="𝓉𝒶𝓀𝓀" data-style="Ultra Script">Kopier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓋ℯ𝓁𝓀ℴ𝓂𝓂ℯ𝓃</span>
+        <span class="cursive-word-label">velkommen i kursiv</span>
+        <button type="button" class="copy-btn" data-text="𝓋ℯ𝓁𝓀ℴ𝓂𝓂ℯ𝓃" data-style="Ultra Script">Kopier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒽ℯ𝒾</span>
+        <span class="cursive-word-label">hei i kursiv</span>
+        <button type="button" class="copy-btn" data-text="𝒽ℯ𝒾" data-style="Ultra Script">Kopier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">ℊℴ𝒹 𝒿𝓊𝓁</span>
+        <span class="cursive-word-label">god jul i kursiv</span>
+        <button type="button" class="copy-btn" data-text="ℊℴ𝒹 𝒿𝓊𝓁" data-style="Ultra Script">Kopier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">ℊℴ𝒹𝓉 𝓃𝓎𝓉𝓉𝒶𝓇</span>
+        <span class="cursive-word-label">godt nyttår i kursiv</span>
+        <button type="button" class="copy-btn" data-text="ℊℴ𝒹𝓉 𝓃𝓎𝓉𝓉𝒶𝓇" data-style="Ultra Script">Kopier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓁𝓎𝓀𝓀ℯ 𝓉𝒾𝓁</span>
+        <span class="cursive-word-label">lykke til i kursiv</span>
+        <button type="button" class="copy-btn" data-text="𝓁𝓎𝓀𝓀ℯ 𝓉𝒾𝓁" data-style="Ultra Script">Kopier</button>
+      </div>
     </div>
-  </section>
-</main>
+    <h3>Måneder i kursiv</h3>
+    <div class="cursive-word-grid">
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒿𝒶𝓃𝓊𝒶𝓇</span>
+        <span class="cursive-word-label">januar i kursiv</span>
+        <button type="button" class="copy-btn" data-text="𝒿𝒶𝓃𝓊𝒶𝓇" data-style="Ultra Script">Kopier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒻ℯ𝒷𝓇𝓊𝒶𝓇</span>
+        <span class="cursive-word-label">februar i kursiv</span>
+        <button type="button" class="copy-btn" data-text="𝒻ℯ𝒷𝓇𝓊𝒶𝓇" data-style="Ultra Script">Kopier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓂𝒶𝓇𝓈</span>
+        <span class="cursive-word-label">mars i kursiv</span>
+        <button type="button" class="copy-btn" data-text="𝓂𝒶𝓇𝓈" data-style="Ultra Script">Kopier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒶𝓅𝓇𝒾𝓁</span>
+        <span class="cursive-word-label">april i kursiv</span>
+        <button type="button" class="copy-btn" data-text="𝒶𝓅𝓇𝒾𝓁" data-style="Ultra Script">Kopier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓂𝒶𝒾</span>
+        <span class="cursive-word-label">mai i kursiv</span>
+        <button type="button" class="copy-btn" data-text="𝓂𝒶𝒾" data-style="Ultra Script">Kopier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒿𝓊𝓃𝒾</span>
+        <span class="cursive-word-label">juni i kursiv</span>
+        <button type="button" class="copy-btn" data-text="𝒿𝓊𝓃𝒾" data-style="Ultra Script">Kopier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒿𝓊𝓁𝒾</span>
+        <span class="cursive-word-label">juli i kursiv</span>
+        <button type="button" class="copy-btn" data-text="𝒿𝓊𝓁𝒾" data-style="Ultra Script">Kopier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒶𝓊ℊ𝓊𝓈𝓉</span>
+        <span class="cursive-word-label">august i kursiv</span>
+        <button type="button" class="copy-btn" data-text="𝒶𝓊ℊ𝓊𝓈𝓉" data-style="Ultra Script">Kopier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓈ℯ𝓅𝓉ℯ𝓂𝒷ℯ𝓇</span>
+        <span class="cursive-word-label">september i kursiv</span>
+        <button type="button" class="copy-btn" data-text="𝓈ℯ𝓅𝓉ℯ𝓂𝒷ℯ𝓇" data-style="Ultra Script">Kopier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">ℴ𝓀𝓉ℴ𝒷ℯ𝓇</span>
+        <span class="cursive-word-label">oktober i kursiv</span>
+        <button type="button" class="copy-btn" data-text="ℴ𝓀𝓉ℴ𝒷ℯ𝓇" data-style="Ultra Script">Kopier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓃ℴ𝓋ℯ𝓂𝒷ℯ𝓇</span>
+        <span class="cursive-word-label">november i kursiv</span>
+        <button type="button" class="copy-btn" data-text="𝓃ℴ𝓋ℯ𝓂𝒷ℯ𝓇" data-style="Ultra Script">Kopier</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒹ℯ𝓈ℯ𝓂𝒷ℯ𝓇</span>
+        <span class="cursive-word-label">desember i kursiv</span>
+        <button type="button" class="copy-btn" data-text="𝒹ℯ𝓈ℯ𝓂𝒷ℯ𝓇" data-style="Ultra Script">Kopier</button>
+      </div>
+    </div>
+    </section>
 
-<footer class="footer">
-  <div class="footer-inner">
-    <h2 class="faq-category">Spørsmål om kursiv tekst</h2>
-    <div class="faq-item"><button class="faq-question" type="button">Hvordan lager jeg kursiv tekst?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Skriv teksten din i feltet øverst på siden. Resultatene vises automatisk i kursiv, håndskrift og andre Unicode-stiler. Trykk på Kopier ved varianten du liker, og lim den inn der du vil bruke den.</div></div>
-    <div class="faq-item"><button class="faq-question" type="button">Er dette ekte kursiv formatering?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Det er Unicode-tegn som ser kursiverte ut. Fordelen er at de kan kopieres til steder som ikke har formatering, som Instagram-bioer og Discord-navn.</div></div>
-    <div class="faq-item"><button class="faq-question" type="button">Fungerer kursiv tekst på Instagram og Facebook?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Ja, i bio, captions, kommentarer, innlegg og visningsnavn fungerer det vanligvis fint. Brukernavn er strengere og bør holdes vanlige.</div></div>
-    <div class="faq-item"><button class="faq-question" type="button">Hva skjer med æ, ø og å?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Mange Unicode-stiler har ikke egne varianter for æ, ø og å. De blir ofte stående vanlige mens resten av ordet styles. Det er normalt.</div></div>
-    <div class="faq-item"><button class="faq-question" type="button">Kan jeg bruke kursiv tekst til hele avsnitt?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Bruk det helst til korte linjer, navn eller ett viktig ord. Vanlig tekst er bedre for lesbarhet og tilgjengelighet.</div></div>
+    <!-- 5. Names & signatures -->
+    <section id="cursive-names" aria-labelledby="cursiveNamesHeading">
+      <h2 class="bubble-az-heading" id="cursiveNamesHeading">Generator for navn og signatur i kursiv</h2>
+      <p class="bubble-az-intro">Skriv et fornavn — eller et fullt navn — og design din kursive signatur:
+        velg pynt, bestem hvordan monogram-initialene kobles sammen, og kopier teksten eller last den ned som PNG
+        til e-postsignaturer, vannmerker og dokumenter.</p>
+      <div class="cursive-name-tool">
+        <div class="input-wrapper">
+          <input type="text" class="main-input cursive-name-input" id="cursiveNameInput" placeholder="Skriv et navn… f.eks. Emma Sofie" maxlength="60">
+        </div>
+        <div class="cursive-sig-controls" id="cursiveSignatureControls"></div>
+        <div class="results-grid" id="cursiveNameResults"></div>
+      </div>
+    <h3>Populære navn i kursiv</h3>
+    <p class="bubble-az-intro">Trykk på et navn for å laste det inn i studioet over og style det på nytt med pynt.</p>
+    <div class="cursive-word-grid">
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Last Emma inn i signaturstudioet" data-name="Emma">
+        <span class="cursive-word-render">𝓔𝓶𝓶𝓪</span>
+        <span class="cursive-word-label">Emma i kursiv</span>
+        <button type="button" class="copy-btn" data-text="𝓔𝓶𝓶𝓪" data-style="Ultra Script Bold">Kopier</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Last Nora inn i signaturstudioet" data-name="Nora">
+        <span class="cursive-word-render">𝓝𝓸𝓻𝓪</span>
+        <span class="cursive-word-label">Nora i kursiv</span>
+        <button type="button" class="copy-btn" data-text="𝓝𝓸𝓻𝓪" data-style="Ultra Script Bold">Kopier</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Last Ella inn i signaturstudioet" data-name="Ella">
+        <span class="cursive-word-render">𝓔𝓵𝓵𝓪</span>
+        <span class="cursive-word-label">Ella i kursiv</span>
+        <button type="button" class="copy-btn" data-text="𝓔𝓵𝓵𝓪" data-style="Ultra Script Bold">Kopier</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Last Maja inn i signaturstudioet" data-name="Maja">
+        <span class="cursive-word-render">𝓜𝓪𝓳𝓪</span>
+        <span class="cursive-word-label">Maja i kursiv</span>
+        <button type="button" class="copy-btn" data-text="𝓜𝓪𝓳𝓪" data-style="Ultra Script Bold">Kopier</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Last Sofie inn i signaturstudioet" data-name="Sofie">
+        <span class="cursive-word-render">𝓢𝓸𝓯𝓲𝓮</span>
+        <span class="cursive-word-label">Sofie i kursiv</span>
+        <button type="button" class="copy-btn" data-text="𝓢𝓸𝓯𝓲𝓮" data-style="Ultra Script Bold">Kopier</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Last Ingrid inn i signaturstudioet" data-name="Ingrid">
+        <span class="cursive-word-render">𝓘𝓷𝓰𝓻𝓲𝓭</span>
+        <span class="cursive-word-label">Ingrid i kursiv</span>
+        <button type="button" class="copy-btn" data-text="𝓘𝓷𝓰𝓻𝓲𝓭" data-style="Ultra Script Bold">Kopier</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Last Jakob inn i signaturstudioet" data-name="Jakob">
+        <span class="cursive-word-render">𝓙𝓪𝓴𝓸𝓫</span>
+        <span class="cursive-word-label">Jakob i kursiv</span>
+        <button type="button" class="copy-btn" data-text="𝓙𝓪𝓴𝓸𝓫" data-style="Ultra Script Bold">Kopier</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Last Emil inn i signaturstudioet" data-name="Emil">
+        <span class="cursive-word-render">𝓔𝓶𝓲𝓵</span>
+        <span class="cursive-word-label">Emil i kursiv</span>
+        <button type="button" class="copy-btn" data-text="𝓔𝓶𝓲𝓵" data-style="Ultra Script Bold">Kopier</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Last Oskar inn i signaturstudioet" data-name="Oskar">
+        <span class="cursive-word-render">𝓞𝓼𝓴𝓪𝓻</span>
+        <span class="cursive-word-label">Oskar i kursiv</span>
+        <button type="button" class="copy-btn" data-text="𝓞𝓼𝓴𝓪𝓻" data-style="Ultra Script Bold">Kopier</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Last Noah inn i signaturstudioet" data-name="Noah">
+        <span class="cursive-word-render">𝓝𝓸𝓪𝓱</span>
+        <span class="cursive-word-label">Noah i kursiv</span>
+        <button type="button" class="copy-btn" data-text="𝓝𝓸𝓪𝓱" data-style="Ultra Script Bold">Kopier</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Last William inn i signaturstudioet" data-name="William">
+        <span class="cursive-word-render">𝓦𝓲𝓵𝓵𝓲𝓪𝓶</span>
+        <span class="cursive-word-label">William i kursiv</span>
+        <button type="button" class="copy-btn" data-text="𝓦𝓲𝓵𝓵𝓲𝓪𝓶" data-style="Ultra Script Bold">Kopier</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Last Aksel inn i signaturstudioet" data-name="Aksel">
+        <span class="cursive-word-render">𝓐𝓴𝓼𝓮𝓵</span>
+        <span class="cursive-word-label">Aksel i kursiv</span>
+        <button type="button" class="copy-btn" data-text="𝓐𝓴𝓼𝓮𝓵" data-style="Ultra Script Bold">Kopier</button>
+      </div>
+    </div>
+    </section>
 
+    <!-- Editorial -->
+    <section class="editorial-section cursive-editorial">
+      <h2>Slik fungerer denne kursiv-generatoren</h2>
+      <p>Den kursive teksten du ser her er ikke en skrifttype — det er <strong>Unicode-skrifttegn</strong>, samme standard som enheten din bruker for hver bokstav og emoji. Derfor overlever den kopier og lim inn: appene behandler 𝓴𝓾𝓻𝓼𝓲𝓿 nøyaktig som vanlig tekst. Det er også derfor kursiv skrift virker på steder der du aldri kunne installere en skrifttype — Instagram-bio, TikTok-tekster, Discord-navn og YouTube-kommentarer. Nysgjerrig på mekanikken? Les <a href="/guide/how-unicode-fonts-work/">hvordan Unicode-fonter fungerer</a>.</p>
+
+      <h3>Hvor kursiv tekst virker (og hvor den ryker)</h3>
+      <ul class="compat-list">
+        <li><span class="ts-pill-safe">Virker</span> Instagram-bio og bildetekster, TikTok-tekster, Discord, WhatsApp, Facebook, X, YouTube-kommentarer og de fleste dokumenter.</li>
+        <li><span class="ts-pill-risk">Begrenset</span> Felt for brukernavn og visningsnavn (Instagram, de fleste spill) fjerner ofte skrifttegn — hold selve brukernavnet i vanlig tekst.</li>
+        <li><span class="ts-pill-risk">Begrenset</span> Noen eldre enheter viser tomme ruter (▯) for manglende tegn. Skjer det, bruk en enklere stil eller færre spesialtegn — se <a href="/guide/why-fonts-show-as-boxes/">hvorfor fonter vises som ruter</a>.</li>
+      </ul>
+
+      <h3>Unicode-kursiv kontra ekte kursive skrifttyper</h3>
+      <p>Bruk Unicode-kursiv når du trenger kursiv skrift <em>inne i tekstfelt</em> — sosiale profiler, chatter, videotitler. Bruk en ekte kursiv skrifttype (i Word, Canva eller designverktøyet ditt) når du styrer dokumentet selv og trenger utskriftskvalitet og finjustert kerning. Begge har sin plass; dette verktøyet dekker den første jobben.</p>
+
+      <h3>Norske bokstaver: æ, ø og å</h3>
+      <p>Unicode-skriftbokstaver finnes bare for det latinske grunnalfabetet A–Z, så æ, ø og å — og aksenttegn — går uendret gjennom og bryter det kursive uttrykket. For et gjennomført kursivt utseende skriver du dem om: æ blir «ae», ø blir «o» og å blir «a» (for eksempel «kjærlighet» → «kjaerlighet»). Vil du beheholde riktig staving, kan du blande vanlig tekst med kursive ord der det passer. Vårt <a href="#cursive-alphabet">øvingsark</a> dekker den latinske A–Z-varianten.</p>
+
+      <h3>Lære kursiv håndskrift</h3>
+      <p>Generatorer er laget for digital tekst, men de fungerer også som referansekart. Skriv ut <a href="#cursive-alphabet">øvingsarket</a> for å tegne over, studer hvordan hver stor bokstav kobles i <a href="#cursive-letters">bokstavutforskeren</a>, og husk grunnleggende tilgjengelighetsvaner — korte dekorative linjer, vanlig tekst til resten (<a href="/guide/fancy-fonts-accessibility-guide/">tilgjengelighetsguide</a>).</p>
+
+      <h3>Kursiv til tatoveringer</h3>
+      <p>Kursiv skrift er den mest etterspurte tatoveringsstilen. Forhåndsvis ordet ditt her i stor størrelse, og bruk deretter den egne <a href="/usecase/tattoo-fonts/">tatoverings-generatoren</a> — den legger til bokstavfamilier, datoer i romertall, initialer og en lesbarhetstest for hvor lite blekket kan settes.</p>
+    </section>
+
+    <div class="cta-card">
+      <h3>La hele bioen din flyte</h3>
+      <p>Kombiner en kursiv overskrift med ren brødtekst — kombinasjonen som skiller seg ut og forblir lesbar. Åpne generatoren og lag din egen <strong>kursive tekst</strong> på sekunder.</p>
+      <a class="cta-btn" href="/no/">Åpne generatoren →</a>
+    </div>
+  </main>
+
+  <!-- Footer + FAQ -->
+  <footer class="footer">
+    <div class="footer-inner">
+<div class="faq-section" id="cursive-faq">
+
+<h2 class="faq-category">Kursiv Tekst Generator — FAQ</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Hva er en generator for kursiv tekst, og hvordan fungerer den?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Den gjør bokstavene du skriver om til Unicode-skrifttegn — spesialtegn som ser ut som kursiv håndskrift, men oppfører seg som vanlig tekst. Fordi de er ekte tegn (ikke en skrifttype eller et bilde), kan du kopiere dem og lime dem inn i bio, bildetekster, kommentarer og meldinger, og de beholder det kursive uttrykket. Les mer i <a href="/guide/how-unicode-fonts-work/">guiden om hvordan Unicode-fonter fungerer</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Hvordan kopierer og limer jeg inn kursiv tekst?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Skriv eller lim inn teksten din i feltet øverst, og trykk deretter <strong>Kopier</strong> på stilen du liker. Den kursive versjonen ligger nå på utklippstavlen — lim den inn hvor som helst som tar imot tekst: Instagram, TikTok, WhatsApp, Discord, dokumenter og mer.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Fungerer kursiv tekst på Instagram, WhatsApp og TikTok?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Ja. Kursiv skrift virker i Instagram-bio og bildetekster, i WhatsApp-meldinger og status, og i TikTok-tekster og profilbeskrivelser. Merk at felt for brukernavn ofte fjerner spesialtegn, så hold selve brukernavnet i vanlig tekst.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Hvorfor blir ikke æ, ø og å kursive?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Unicode har kursive skriftbokstaver bare for A–Z, så æ, ø og å går uendret gjennom. For et helt gjennomført kursivt utseende skriver du dem om: æ → «ae», ø → «o», å → «a». Da blir for eksempel «kjærlighet» til «kjaerlighet» og gjengis fullt ut i kursiv.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Er kursiv tekst gratis å bruke?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Ja, helt gratis og uten registrering. Skriv inn <strong>kursiv tekst</strong>, kopier resultatet, og bruk det så mange ganger du vil — også til kommersielle profiler.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Kan jeg lage en kursiv navnesignatur?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Ja. Bruk <a href="#mainInput">navne- og signaturstudioet</a> til å skrive fornavnet eller det fulle navnet ditt, velge pynt og monogram-initialer, og kopiere resultatet eller laste det ned som PNG til e-postsignaturer og dokumenter.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Fungerer kursiv tekst i lesehjelpemidler?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Skjermlesere kan lese Unicode-skrifttegn bokstav for bokstav eller hoppe over dem, så bruk kursiv skrift til korte dekorative innslag og hold viktig informasjon i vanlig tekst. Se vår <a href="/guide/fancy-fonts-accessibility-guide/">tilgjengelighetsguide</a> for gode vaner.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Hvorfor vises noen kursive bokstaver som tomme ruter?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    En tom rute (▯) betyr at enheten mangler glyfen for det tegnet. Prøv en enklere stil, oppdater systemet, eller unngå spesialtegn — les <a href="/guide/why-fonts-show-as-boxes/">hvorfor fonter vises som ruter</a>.
+  </div>
+</div>
+
+</div>
+
+    <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="Language switcher">
       <a class="lang-option" href="/category/cursive-fonts/" hreflang="en">EN</a>
-      <a class="lang-option" href="/fr/ecriture-cursive/" hreflang="fr">FR</a>
-      <a class="lang-option" href="/id/tulisan-sambung/" hreflang="id">ID</a>
-      <a class="lang-option" href="/nl/sierlijke-letters/" hreflang="nl">NL</a>
+      <a class="lang-option" href="/es/letra-cursiva/" hreflang="es">ES</a>
       <a class="lang-option" href="/pt/letra-cursiva/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/fr/ecriture-cursive/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/de/schreibschrift/" hreflang="de">DE</a>
+      <a class="lang-option" href="/it/lettere-in-corsivo/" hreflang="it">IT</a>
       <a class="lang-option" href="/tr/el-yazisi-fontu/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/nl/cursieve-letters/" hreflang="nl">NL</a>
+      <a class="lang-option" href="/id/tulisan-sambung/" hreflang="id">ID</a>
       <a class="lang-option active" href="/no/kursiv-tekst/" hreflang="no">NO</a>
     </div>
-  </div>
-</footer>
 
-<div class="copy-toast" id="copyToast">Kopiert!</div>
-<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+    </div>
+  </footer>
 
-<script>window.UTG_FAMILY = "cursive";</script>
-<script src="/styles.js" defer></script>
-<script src="/renderer.js" defer></script>
-<script src="/script.js" defer></script>
-<script src="/symbol-explorer.js" defer></script>
-<script src="/accent-notice.js" defer></script>
-<script src="/footer.js" defer></script>
+  <div id="cursivePrintRoot" aria-hidden="true"></div>
+  <div class="copy-toast" id="copyToast">Kopiert!</div>
+
+  <script>
+    window.UTG_CURSIVE_MODE = true;
+    window.UTG_FAMILY = "cursive";
+    window.cursiveI18n = {
+  "demoText": "Hei",
+  "demoName": "Emma",
+  "copy": "Kopier",
+  "typeFirst": "Skriv teksten din over først",
+  "downloadPngTitle": "Last ned som PNG-bilde",
+  "downloadPng": "Last ned PNG",
+  "characters": "tegn",
+  "caseUpper": "Stor",
+  "caseLower": "Liten",
+  "caseBoth": "Begge",
+  "labelUpper": "Stor {ch} i kursiv",
+  "labelLower": "Liten {ch} i kursiv",
+  "labelBoth": "Stor og liten {ch} i kursiv",
+  "copyBoth": "Kopier begge",
+  "everyStyle": "{ch} i kursiv — alle stiler, klikk for å kopiere",
+  "suffixCapital": " — stor",
+  "suffixLowercase": " — liten",
+  "accentLabel": "{name}-pynt",
+  "practiceTitle": "Øvingsark for kursivt alfabet — ultratextgen.com",
+  "flourishLabel": "Sving",
+  "monogramLabel": "Monogram-kobling",
+  "copiedToast": "Kopiert!",
+  "quickWords": [
+    "elsker",
+    "gratulerer",
+    "takk",
+    "familie",
+    "alltid",
+    "velsignet"
+  ],
+  "styles": {
+    "Ultra Script": "klassisk kursiv",
+    "Ultra Script Bold": "fet kursiv",
+    "Ultra Script Elegant": "elegant kursiv",
+    "Ultra Script Bold Elegant": "fet elegant kursiv",
+    "Ultra Gothic Script": "gotisk kursiv",
+    "Ultra Chicano Script": "chicano-navneskilt",
+    "Ultra Script Sparkle": "glitrende kursiv"
+  },
+  "presets": {
+    "Script Hearts": "kursiv med hjerter",
+    "Script Arrow Bio": "kursiv bio med piler",
+    "Bold Script Stars": "fet kursiv med stjerner",
+    "Script Vintage": "vintage kursiv",
+    "Script Soft Dots": "kursiv med myke prikker",
+    "Bold Script Ribbon": "fet kursiv med bånd",
+    "Script Underline": "kursiv med understrek",
+    "Bold Script Crown": "fet kursiv med krone"
+  },
+  "signatures": {
+    "Classic Signature": "klassisk signatur",
+    "Bold Signature": "fet signatur",
+    "Signed Underline": "signatur med understrek",
+    "Sparkle Signature": "glitrende signatur",
+    "Ornate Nameplate": "utsmykket navneskilt",
+    "Autograph Star": "autograf med stjerne",
+    "Monogram Initials": "monogram-initialer",
+    "Gothic Signature": "gotisk signatur"
+  },
+  "decorators": {
+    "None": "Ingen",
+    "Underline": "Understrek",
+    "Sparkle": "Glitter",
+    "Hearts": "Hjerter",
+    "Ornate": "Utsmykket",
+    "Soft dots": "Myke prikker"
+  },
+  "accents": {
+    "Sparkle": "Glitter",
+    "Hearts": "Hjerter",
+    "Wings": "Vinger",
+    "Ornate": "Utsmykket"
+  },
+  "platformLimits": {
+    "Instagram bio": "Instagram-bio",
+    "TikTok bio": "TikTok-bio",
+    "X bio": "X-bio"
+  }
+};
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/js/cursive/cursiveData.js" defer></script>
+  <script src="/script.js" defer></script>
+  <script src="/js/cursive/cursivePageController.js" defer></script>
+  <script src="/footer.js" defer></script>
 </body></html>

--- a/pt/letra-cursiva/index.html
+++ b/pt/letra-cursiva/index.html
@@ -6,27 +6,30 @@
   'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
   })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
   <!-- End Google Tag Manager -->
-  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZGVh");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
   <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Letra Cursiva para Copiar e Colar — Alfabeto Cursivo A–Z (𝒶𝒷𝒸) | UltraTextGen</title>
-  <meta name="description" content="Letra cursiva para copiar e colar: alfabeto cursivo completo A–Z, maiúsculas, minúsculas, nomes e fonte cursiva pra bio, legenda e tattoo. Grátis, sem app.">
+  <title>Gerador de Letra Cursiva — 𝓬𝓸𝓹𝓲𝓪 𝓮 𝓬𝓸𝓵𝓪 Alfabeto Cursivo A–Z e Nomes | UltraTextGen</title>
+  <meta name="description" content="Gerador de letra cursiva para copiar e colar: alfabeto cursivo completo A–Z, letras maiúsculas e minúsculas, fonte manuscrita, palavras e nomes em letras cursivas bonitas pra bio, legenda e tattoo. Grátis, sem app.">
   <link rel="canonical" href="https://ultratextgen.com/pt/letra-cursiva/">
 
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/category/cursive-fonts/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/letra-cursiva/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/letra-cursiva/">
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/ecriture-cursive/">
-  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/tulisan-sambung/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/schreibschrift/">
+  <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/lettere-in-corsivo/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/el-yazisi-fontu/">
-  <link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/sierlijke-letters/">
+  <link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/cursieve-letters/">
+  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/tulisan-sambung/">
   <link rel="alternate" hreflang="no" href="https://ultratextgen.com/no/kursiv-tekst/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/category/cursive-fonts/">
 
   <meta name="robots" content="index, follow">
   <meta property="og:site_name" content="UltraTextGen">
-  <meta property="og:title" content="Letra Cursiva para Copiar e Colar — Alfabeto Cursivo A–Z (𝒶𝒷𝒸)">
-  <meta property="og:description" content="Alfabeto cursivo completo, letras maiúsculas e minúsculas cursivas, nomes prontos e fonte cursiva pra bio, legenda, convite e tattoo. Copia e cola grátis.">
+  <meta property="og:title" content="Gerador de Letra Cursiva — 𝓬𝓸𝓹𝓲𝓪 𝓮 𝓬𝓸𝓵𝓪 Alfabeto Cursivo A–Z e Nomes">
+  <meta property="og:description" content="Letra cursiva para copiar e colar: alfabeto cursivo completo, letras maiúsculas e minúsculas, fonte manuscrita, palavras e nomes prontos pra bio, legenda, convite e tattoo. Grátis, direto no navegador.">
   <meta property="og:url" content="https://ultratextgen.com/pt/letra-cursiva/">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://ultratextgen.com/assets/og/pt-letra-cursiva.png">
@@ -34,27 +37,13 @@
   <meta property="og:image:height" content="630">
   <meta property="og:image:type" content="image/png">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Letra Cursiva para Copiar e Colar — Alfabeto Cursivo A–Z (𝒶𝒷𝒸)">
-  <meta name="twitter:description" content="Alfabeto cursivo completo e nomes em letra cursiva prontos pra copiar e colar. Grátis, direto no navegador.">
+  <meta name="twitter:title" content="Gerador de Letra Cursiva — 𝓬𝓸𝓹𝓲𝓪 𝓮 𝓬𝓸𝓵𝓪 Alfabeto Cursivo A–Z e Nomes">
+  <meta name="twitter:description" content="Alfabeto cursivo completo, palavras e nomes em letra cursiva prontos pra copiar e colar. Grátis, sem app.">
   <meta name="twitter:image" content="https://ultratextgen.com/assets/og/pt-letra-cursiva.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/style.css">
-  <link rel="stylesheet" href="/symbol-explorer.css">
-
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "WebApplication",
-  "name": "Gerador de Letra Cursiva",
-  "alternateName": ["Letra Cursiva para Copiar e Colar", "Alfabeto Cursivo", "Gerador de Fonte Cursiva", "Fonte Manuscrita Online", "Letras Cursivas Bonitas"],
-  "url": "https://ultratextgen.com/pt/letra-cursiva/",
-  "inLanguage": "pt-BR",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "description": "Gerador de letra cursiva para copiar e colar: alfabeto cursivo completo, letras maiúsculas e minúsculas cursivas, fonte cursiva bold e nomes prontos pra bio, legenda, convite e referência de tatuagem.",
-  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "BRL" }
-}
-</script>
 
 <script type="application/ld+json">
 {
@@ -64,28 +53,67 @@
   "mainEntity": [
     {
       "@type": "Question",
-      "name": "Como copiar a letra cursiva?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Digita seu texto na caixa lá em cima e todas as versões em letra cursiva aparecem na hora. Clica em Copiar no estilo que você gostou e cola onde quiser: bio, legenda, status, convite. Também dá pra clicar em qualquer letra do alfabeto cursivo desta página pra copiar uma letra avulsa, tipo o f cursivo ou o s maiúsculo." }
+      "name": "O que é um gerador de letra cursiva e como funciona?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ele transforma as letras que você digita em caracteres Unicode do tipo script — símbolos especiais que parecem escrita à mão, mas se comportam como texto normal. Como são caracteres de verdade (não uma fonte nem uma imagem), dá pra copiar e colar na bio, na legenda, nos comentários e nas mensagens, e eles mantêm o desenho cursivo. Veja mais no nosso <a href=\"/guide/how-unicode-fonts-work/\">guia de como as fontes Unicode funcionam</a>."
+      }
     },
     {
       "@type": "Question",
-      "name": "Letra cursiva serve para tatuagem?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Serve como referência. Digita a palavra ou o nome, testa a cursiva normal e a cursiva bold e mostra o resultado pro tatuador como base do desenho. O traço final quem define é o artista, mas a prévia em letra cursiva ajuda a decidir o estilo antes de agulhar." }
+      "name": "Como copiar e colar a letra cursiva?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Digita ou cola seu texto na caixa lá em cima e clica em Copiar no estilo que você gostou. A versão em <strong>letra cursiva para copiar e colar</strong> já vai pra área de transferência — cola onde aceitar texto: Instagram, TikTok, WhatsApp, Discord, documentos e mais."
+      }
     },
     {
       "@type": "Question",
-      "name": "Letra cursiva funciona no Instagram e no WhatsApp?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Funciona. Como cada letra é um caractere Unicode de verdade, a cursiva cola na bio e na legenda do Instagram, no status e no recado do WhatsApp, no TikTok, no Discord e em quase todo campo que aceita texto. Só em nome de usuário (@) ela costuma ser bloqueada — nesses campos, mantém o texto normal." }
+      "name": "A letra cursiva funciona no Instagram, no WhatsApp e no TikTok?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Funciona. Como cada letra é um caractere Unicode de verdade, a cursiva cola na bio e na legenda do Instagram, no status e no recado do WhatsApp, na legenda do TikTok, no Discord e em quase todo campo que aceita texto. Só em nome de usuário (@) ela costuma ser bloqueada — nesses campos, deixa o texto normal."
+      }
     },
     {
       "@type": "Question",
-      "name": "Qual a diferença entre letra cursiva e manuscrita?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Na prática, aqui as duas dão no mesmo resultado: caracteres Unicode com desenho de escrita à mão. Cursiva costuma descrever a letra emendada e inclinada; manuscrita (ou letra de mão) é qualquer letra com cara de escrita à mão, emendada ou não. Os estilos script desta página cobrem os dois casos." }
+      "name": "A letra cursiva serve para tatuagem?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Serve como referência. Digita a palavra ou o nome, testa a cursiva normal e a cursiva bold e mostra o resultado pro tatuador como base do desenho. O traço final quem define é o artista, mas a prévia ajuda a decidir o estilo antes de agulhar. Pra ver famílias de lettering e datas em romano, use o <a href=\"/pt/usecase/letras-para-tatuagem/\">gerador de letras para tatuagem</a>."
+      }
     },
     {
       "@type": "Question",
-      "name": "Funciona com acento (ã, é, ç)?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Em parte. O Unicode não tem versão cursiva pras letras acentuadas, então á, ã, ç e companhia saem sem estilo no meio da palavra. Pra um nome 100% cursivo, escreve sem acento: João vira Joao → 𝒥ℴ𝒶ℴ. Fica menos correto na gramática, mas visualmente consistente — bom pra bio e nick." }
+      "name": "Qual a diferença entre letra cursiva, letra de mão e fonte manuscrita?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Na prática, aqui todas dão no mesmo resultado: caracteres Unicode com desenho de escrita à mão. «Cursiva» costuma descrever a letra emendada e inclinada; «letra de mão» e «fonte manuscrita» são qualquer letra com cara de escrita à mão, emendada ou não. Os estilos script desta página cobrem os dois casos."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "A letra cursiva funciona com acento (ã, é, ç)?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Em parte. O Unicode não tem versão cursiva das letras acentuadas, então á, ã, é, ç e companhia saem sem estilo no meio da palavra. Pra um nome 100% cursivo, escreve sem acento: «João» vira Joao → 𝒥ℴ𝒶ℴ. Fica menos correto na gramática, mas visualmente consistente — bom pra bio e nick."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "O alfabeto cursivo tem números?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "O Unicode não tem número cursivo de verdade, então cada estilo combina as letras script com numerais finos que casam com o traço (𝟢 𝟣 𝟤 𝟥). Dá pra copiar o alfabeto cursivo completo — maiúsculas, minúsculas e números — em um clique na seção do <a href=\"#cursive-alphabet\">alfabeto</a>."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "O gerador de letra cursiva é grátis?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "É totalmente grátis, sem cadastro e sem instalar nada. Roda direto no navegador, no celular ou no computador. Digita, copia e cola — quantas vezes quiser."
+      }
     }
   ]
 }
@@ -101,12 +129,36 @@
   ]
 }
 </script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Gerador de Letra Cursiva",
+  "alternateName": ["Letra Cursiva para Copiar e Colar","Alfabeto Cursivo","Gerador de Fonte Cursiva","Letras Cursivas A–Z","Fonte Manuscrita Online","Gerador de Nomes em Cursiva","Letras Cursivas Bonitas"],
+  "url": "https://ultratextgen.com/pt/letra-cursiva/",
+  "inLanguage": "pt-BR",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "BRL"
+  },
+  "description": "Gerador de letra cursiva grátis: copia e cola fonte cursiva, cada letra cursiva de A a Z, o alfabeto cursivo completo, palavras em cursiva e nomes em letra cursiva pra bio, legenda e referência de tatuagem.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers.",
+  "featureList": ["Gerador de fonte cursiva com enfeites prontos","Explorador de letras cursivas A–Z (maiúsculas e minúsculas)","Copiar o alfabeto cursivo completo em um clique","Folha de caligrafia cursiva pra imprimir","Estúdio de nomes e assinaturas em cursiva","Galeria de palavras em cursiva (amor, feliz aniversário, meses)"]
+}
+</script>
 </head>
 <body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
   <!-- Google Tag Manager (noscript) -->
-  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <!-- End Google Tag Manager (noscript) -->
-<script src="/header.js"></script>
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
 
 <nav class="breadcrumbs" aria-label="Breadcrumb">
   <a href="/pt/">Início</a>
@@ -115,217 +167,683 @@
 </nav>
 
 <figure class="page-hero-figure" data-uthero aria-hidden="true">
-  <img src="/assets/hero/pt-letra-cursiva.svg" width="1200" height="340" loading="lazy" alt="">
+  <img src="/assets/hero/pt-letra-cursiva.svg" width="1200" height="340"
+       loading="lazy" alt="">
 </figure>
 
-<section class="hero">
-  <div class="hero-inner">
-    <div class="hero-card">
-      <h1 class="hero-headline">Letra cursiva para copiar e colar</h1>
-      <p class="hero-tagline">Digita qualquer palavra e ela vira letra cursiva na hora — fonte cursiva delicada, cursiva bold e letras cursivas bonitas prontas pra colar na bio, na legenda, no convite ou levar de referência pro tatuador.</p>
-      <div class="input-wrapper">
-        <textarea class="main-input" id="mainInput" placeholder="Digite seu texto aqui..." maxlength="500" autofocus=""></textarea>
-        <span class="char-count"><span id="charCount">0</span>/500</span>
-      </div>
-      <div class="decoration-section">
-        <div class="decoration-label">Adicionar enfeites ao resultado</div>
-        <div class="decoration-tabs">
-          <button class="decoration-tab active" data-deco-tab="symbols">Símbolos</button>
-          <button class="decoration-tab" data-deco-tab="frames">Molduras</button>
-          <button class="decoration-tab" data-deco-tab="minimal">Minimalista</button>
+  <!-- Hero: the cursive-first generator -->
+  <section class="hero">
+    <div class="hero-inner">
+      <div class="hero-card">
+        <h1 class="hero-headline">Gerador de Letra Cursiva</h1>
+        <p class="hero-tagline">Transforme qualquer texto em <strong>letra cursiva para copiar e colar</strong> — fonte manuscrita
+          delicada, cursiva bold e cada letra do alfabeto cursivo A–Z, além de nomes e assinaturas.
+          Grátis, na hora, sem cadastro.</p>
+        <div class="input-wrapper">
+          <textarea class="main-input" id="mainInput" placeholder="Digite seu texto, palavra ou nome…" maxlength="500" autofocus></textarea>
+          <span class="char-count"><span id="charCount">0</span>/500</span>
         </div>
-        <div class="decoration-grid" id="decorationGrid"></div>
+        <div class="cursive-quick-row" id="cursiveQuickRow" aria-label="Exemplos rápidos"></div>
+        <div class="vertical-fit-row" id="cursiveFitRow" hidden></div>
       </div>
     </div>
+  </section>
+
+  <nav class="cursive-section-nav" aria-label="Nesta página">
+    <a href="#cursive-styles">Estilos</a>
+    <a href="#cursive-letters">Letras A–Z</a>
+    <a href="#cursive-alphabet">Alfabeto</a>
+    <a href="#cursive-words">Palavras</a>
+    <a href="#cursive-names">Nomes e Assinaturas</a>
+    <a href="#cursive-faq">Perguntas</a>
+  </nav>
+
+  <main class="container">
+
+    <!-- 1. Generator output -->
+    <section id="cursive-styles" aria-labelledby="cursiveStylesHeading">
+      <h2 class="bubble-az-heading" id="cursiveStylesHeading">Fontes cursivas — copiar e colar</h2>
+      <p class="bubble-az-intro">Cada estilo abaixo atualiza ao vivo enquanto você digita: cursiva clássica e bold,
+        variações elegantes com espaço, cursiva gótica, letreiro chicano e enfeites prontos com corações,
+        brilhos e setas. Toque em Copiar e cole onde quiser.</p>
+      <div class="results-grid" id="resultsGrid"></div>
+    </section>
+
+    <!-- 2. Cursive letters A–Z -->
+    <section class="bubble-az" id="cursive-letters" aria-labelledby="cursiveLettersHeading">
+      <h2 class="bubble-az-heading" id="cursiveLettersHeading">Letras cursivas A–Z — maiúsculas e minúsculas</h2>
+      <p class="bubble-az-intro">Procurando uma letra sozinha — um S cursivo, um G maiúsculo em cursiva, um f minúsculo?
+        Toque em qualquer letra pra ver em todos os estilos cursivos, copiar o caractere exato ou baixar como PNG.</p>
+  <div class="cursive-letter-grid" role="tablist" aria-label="Escolha uma letra cursiva">
+    <button type="button" class="cursive-letter-cell" id="cursive-a" data-char="A" aria-label="A em cursiva — maiúscula e minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒜 𝒶</span>
+      <span class="cursive-letter-name">A cursivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-b" data-char="B" aria-label="B em cursiva — maiúscula e minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">ℬ 𝒷</span>
+      <span class="cursive-letter-name">B cursivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-c" data-char="C" aria-label="C em cursiva — maiúscula e minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒞 𝒸</span>
+      <span class="cursive-letter-name">C cursivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-d" data-char="D" aria-label="D em cursiva — maiúscula e minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒟 𝒹</span>
+      <span class="cursive-letter-name">D cursivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-e" data-char="E" aria-label="E em cursiva — maiúscula e minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">ℰ ℯ</span>
+      <span class="cursive-letter-name">E cursivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-f" data-char="F" aria-label="F em cursiva — maiúscula e minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">ℱ 𝒻</span>
+      <span class="cursive-letter-name">F cursivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-g" data-char="G" aria-label="G em cursiva — maiúscula e minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒢 ℊ</span>
+      <span class="cursive-letter-name">G cursivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-h" data-char="H" aria-label="H em cursiva — maiúscula e minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">ℋ 𝒽</span>
+      <span class="cursive-letter-name">H cursivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-i" data-char="I" aria-label="I em cursiva — maiúscula e minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">ℐ 𝒾</span>
+      <span class="cursive-letter-name">I cursivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-j" data-char="J" aria-label="J em cursiva — maiúscula e minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒥 𝒿</span>
+      <span class="cursive-letter-name">J cursivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-k" data-char="K" aria-label="K em cursiva — maiúscula e minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒦 𝓀</span>
+      <span class="cursive-letter-name">K cursivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-l" data-char="L" aria-label="L em cursiva — maiúscula e minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">ℒ 𝓁</span>
+      <span class="cursive-letter-name">L cursivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-m" data-char="M" aria-label="M em cursiva — maiúscula e minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">ℳ 𝓂</span>
+      <span class="cursive-letter-name">M cursivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-n" data-char="N" aria-label="N em cursiva — maiúscula e minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒩 𝓃</span>
+      <span class="cursive-letter-name">N cursivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-o" data-char="O" aria-label="O em cursiva — maiúscula e minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒪 ℴ</span>
+      <span class="cursive-letter-name">O cursivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-p" data-char="P" aria-label="P em cursiva — maiúscula e minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒫 𝓅</span>
+      <span class="cursive-letter-name">P cursivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-q" data-char="Q" aria-label="Q em cursiva — maiúscula e minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒬 𝓆</span>
+      <span class="cursive-letter-name">Q cursivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-r" data-char="R" aria-label="R em cursiva — maiúscula e minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">ℛ 𝓇</span>
+      <span class="cursive-letter-name">R cursivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-s" data-char="S" aria-label="S em cursiva — maiúscula e minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒮 𝓈</span>
+      <span class="cursive-letter-name">S cursivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-t" data-char="T" aria-label="T em cursiva — maiúscula e minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒯 𝓉</span>
+      <span class="cursive-letter-name">T cursivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-u" data-char="U" aria-label="U em cursiva — maiúscula e minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒰 𝓊</span>
+      <span class="cursive-letter-name">U cursivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-v" data-char="V" aria-label="V em cursiva — maiúscula e minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒱 𝓋</span>
+      <span class="cursive-letter-name">V cursivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-w" data-char="W" aria-label="W em cursiva — maiúscula e minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒲 𝓌</span>
+      <span class="cursive-letter-name">W cursivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-x" data-char="X" aria-label="X em cursiva — maiúscula e minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒳 𝓍</span>
+      <span class="cursive-letter-name">X cursivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-y" data-char="Y" aria-label="Y em cursiva — maiúscula e minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒴 𝓎</span>
+      <span class="cursive-letter-name">Y cursivo</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-z" data-char="Z" aria-label="Z em cursiva — maiúscula e minúscula">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒵 𝓏</span>
+      <span class="cursive-letter-name">Z cursivo</span>
+    </button>
   </div>
-</section>
+      <div class="cursive-letter-panel" id="cursiveLetterPanel" aria-live="polite"></div>
+    </section>
 
-<main class="container">
-  <div class="category-section"><div class="category-tabs" id="categoryTabs"></div></div>
-  <div class="results-grid" id="resultsGrid"></div>
-
-  <!-- Letra cursiva Unicode -->
-  <section class="editorial-section">
-    <h2>Letra cursiva Unicode: copia e cola onde quiser</h2>
-    <p class="editorial-intro">A <strong>letra cursiva</strong> daqui não é fonte instalada nem imagem — cada letra é um caractere Unicode que já vem com o traço emendado e inclinado. Por isso ela cola em qualquer campo de texto sem perder o desenho: bio do Instagram, legenda, status do WhatsApp, nome no Discord, convite de casamento digital e até naquela prévia que você leva pro tatuador.</p>
-    <div class="block-example">
-      <strong>Exemplo:</strong> «amor» → 𝒶𝓂ℴ𝓇 (cursiva) ou 𝓪𝓶𝓸𝓻 (cursiva bold)
-    </div>
-    <p>É diferente da fonte cursiva do Word ou do Canva, que some quando você cola fora do editor. Aqui o estilo viaja junto com o texto. Quer comparar com outros estilos além da cursiva? Dá uma olhada nas <a href="/pt/letras-diferentes/">letras diferentes</a> e na <a href="/pt/fonte-gotica/">fonte gótica</a>, ou volta pro <a href="/pt/">gerador completo</a>.</p>
-  </section>
-
-  <!-- Alfabeto cursivo completo -->
-  <section class="editorial-section glyph-section">
-    <h2>Alfabeto cursivo completo (A–Z) para copiar</h2>
-    <p class="editorial-intro">O <strong>alfabeto cursivo</strong> inteiro nos dois estilos mais usados: letras maiúsculas cursivas, alfabeto minúsculo cursivo e a versão bold. Clica numa linha pra copiar o alfabeto todo daquele estilo de uma vez.</p>
-    <div class="alpha-list">
-      <div class="alpha-row">
-        <span class="alpha-label">Maiúsculas cursivas</span>
-        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵" aria-label="Copiar alfabeto de letras maiúsculas cursivas A a Z">𝒜 ℬ 𝒞 𝒟 ℰ ℱ 𝒢 ℋ ℐ 𝒥 𝒦 ℒ ℳ 𝒩 𝒪 𝒫 𝒬 ℛ 𝒮 𝒯 𝒰 𝒱 𝒲 𝒳 𝒴 𝒵</button>
+    <!-- 3. The cursive alphabet -->
+    <section id="cursive-alphabet" aria-labelledby="cursiveAlphabetHeading">
+      <div class="cursive-chart-toolbar">
+        <h2 class="bubble-az-heading" id="cursiveAlphabetHeading">O alfabeto cursivo (A–Z, 0–9)</h2>
+        <button type="button" class="bubble-btn bubble-btn-primary" id="cursivePrintSheet">Imprimir folha de caligrafia</button>
       </div>
-      <div class="alpha-row">
-        <span class="alpha-label">Minúsculas cursivas</span>
-        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏" aria-label="Copiar alfabeto minúsculo cursivo de a a z">𝒶 𝒷 𝒸 𝒹 ℯ 𝒻 ℊ 𝒽 𝒾 𝒿 𝓀 𝓁 𝓂 𝓃 ℴ 𝓅 𝓆 𝓇 𝓈 𝓉 𝓊 𝓋 𝓌 𝓍 𝓎 𝓏</button>
+      <p class="bubble-az-intro">Copie o alfabeto cursivo completo em um clique — maiúsculas, minúsculas e números —
+        ou imprima uma folha de caligrafia com as letras-modelo e espaço pra treinar o traço. O Unicode não tem
+        número cursivo de verdade, então cada estilo combina as letras script com numerais finos que casam com o traço.</p>
+    <div class="cursive-chart">
+      <div class="cursive-chart-head">
+        <h3>Alfabeto cursivo clássico (Ultra Script)</h3>
+        <button type="button" class="copy-btn" data-text="𝒜 ℬ 𝒞 𝒟 ℰ ℱ 𝒢 ℋ ℐ 𝒥 𝒦 ℒ ℳ 𝒩 𝒪 𝒫 𝒬 ℛ 𝒮 𝒯 𝒰 𝒱 𝒲 𝒳 𝒴 𝒵&#10;𝒶 𝒷 𝒸 𝒹 ℯ 𝒻 ℊ 𝒽 𝒾 𝒿 𝓀 𝓁 𝓂 𝓃 ℴ 𝓅 𝓆 𝓇 𝓈 𝓉 𝓊 𝓋 𝓌 𝓍 𝓎 𝓏&#10;𝟢 𝟣 𝟤 𝟥 𝟦 𝟧 𝟨 𝟩 𝟪 𝟫" data-style="Ultra Script">Copiar alfabeto</button>
       </div>
-      <div class="alpha-row">
-        <span class="alpha-label">Cursiva bold</span>
-        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩 𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃" aria-label="Copiar alfabeto em cursiva bold">𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩 · 𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃</button>
+      <p class="cursive-alphabet-row">𝒜 ℬ 𝒞 𝒟 ℰ ℱ 𝒢 ℋ ℐ 𝒥 𝒦 ℒ ℳ 𝒩 𝒪 𝒫 𝒬 ℛ 𝒮 𝒯 𝒰 𝒱 𝒲 𝒳 𝒴 𝒵</p>
+      <p class="cursive-alphabet-row">𝒶 𝒷 𝒸 𝒹 ℯ 𝒻 ℊ 𝒽 𝒾 𝒿 𝓀 𝓁 𝓂 𝓃 ℴ 𝓅 𝓆 𝓇 𝓈 𝓉 𝓊 𝓋 𝓌 𝓍 𝓎 𝓏</p>
+      <p class="cursive-alphabet-row">𝟢 𝟣 𝟤 𝟥 𝟦 𝟧 𝟨 𝟩 𝟪 𝟫</p>
+    </div>
+    <div class="cursive-chart">
+      <div class="cursive-chart-head">
+        <h3>Alfabeto cursivo bold (Ultra Script Bold)</h3>
+        <button type="button" class="copy-btn" data-text="𝓐 𝓑 𝓒 𝓓 𝓔 𝓕 𝓖 𝓗 𝓘 𝓙 𝓚 𝓛 𝓜 𝓝 𝓞 𝓟 𝓠 𝓡 𝓢 𝓣 𝓤 𝓥 𝓦 𝓧 𝓨 𝓩&#10;𝓪 𝓫 𝓬 𝓭 𝓮 𝓯 𝓰 𝓱 𝓲 𝓳 𝓴 𝓵 𝓶 𝓷 𝓸 𝓹 𝓺 𝓻 𝓼 𝓽 𝓾 𝓿 𝔀 𝔁 𝔂 𝔃&#10;𝟬 𝟭 𝟮 𝟯 𝟰 𝟱 𝟲 𝟳 𝟴 𝟵" data-style="Ultra Script Bold">Copiar alfabeto</button>
       </div>
-      <div class="alpha-row">
-        <span class="alpha-label">Números que combinam</span>
-        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝟢𝟣𝟤𝟥𝟦𝟧𝟨𝟩𝟪𝟫" aria-label="Copiar números que combinam com a letra cursiva">𝟢 𝟣 𝟤 𝟥 𝟦 𝟧 𝟨 𝟩 𝟪 𝟫</button>
+      <p class="cursive-alphabet-row">𝓐 𝓑 𝓒 𝓓 𝓔 𝓕 𝓖 𝓗 𝓘 𝓙 𝓚 𝓛 𝓜 𝓝 𝓞 𝓟 𝓠 𝓡 𝓢 𝓣 𝓤 𝓥 𝓦 𝓧 𝓨 𝓩</p>
+      <p class="cursive-alphabet-row">𝓪 𝓫 𝓬 𝓭 𝓮 𝓯 𝓰 𝓱 𝓲 𝓳 𝓴 𝓵 𝓶 𝓷 𝓸 𝓹 𝓺 𝓻 𝓼 𝓽 𝓾 𝓿 𝔀 𝔁 𝔂 𝔃</p>
+      <p class="cursive-alphabet-row">𝟬 𝟭 𝟮 𝟯 𝟰 𝟱 𝟲 𝟳 𝟴 𝟵</p>
+    </div>
+    <div class="cursive-chart">
+      <div class="cursive-chart-head">
+        <h3>Alfabeto cursivo gótico (Ultra Gothic Script)</h3>
+        <button type="button" class="copy-btn" data-text="𝕬 𝕭 𝕮 𝕯 𝕰 𝕱 𝕲 𝕳 𝕴 𝕵 𝕶 𝕷 𝕸 𝕹 𝕺 𝕻 𝕼 𝕽 𝕾 𝕿 𝖀 𝖁 𝖂 𝖃 𝖄 𝖅&#10;𝖆 𝖇 𝖈 𝖉 𝖊 𝖋 𝖌 𝖍 𝖎 𝖏 𝖐 𝖑 𝖒 𝖓 𝖔 𝖕 𝖖 𝖗 𝖘 𝖙 𝖚 𝖛 𝖜 𝖝 𝖞 𝖟" data-style="Ultra Gothic Script">Copiar alfabeto</button>
+      </div>
+      <p class="cursive-alphabet-row">𝕬 𝕭 𝕮 𝕯 𝕰 𝕱 𝕲 𝕳 𝕴 𝕵 𝕶 𝕷 𝕸 𝕹 𝕺 𝕻 𝕼 𝕽 𝕾 𝕿 𝖀 𝖁 𝖂 𝖃 𝖄 𝖅</p>
+      <p class="cursive-alphabet-row">𝖆 𝖇 𝖈 𝖉 𝖊 𝖋 𝖌 𝖍 𝖎 𝖏 𝖐 𝖑 𝖒 𝖓 𝖔 𝖕 𝖖 𝖗 𝖘 𝖙 𝖚 𝖛 𝖜 𝖝 𝖞 𝖟</p>
+    </div>
+    </section>
+
+    <!-- 4. Words in cursive -->
+    <section id="cursive-words" aria-labelledby="cursiveWordsHeading">
+      <h2 class="bubble-az-heading" id="cursiveWordsHeading">Palavras em cursiva — prontas pra copiar</h2>
+      <p class="bubble-az-intro">As palavras mais pedidas, já prontas em letra cursiva. Precisa de outra?
+        Digita no <a href="#mainInput">gerador lá em cima</a> que todos os estilos renderizam na hora.</p>
+    <h3>Amor e família</h3>
+    <div class="cursive-word-grid">
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒶𝓂ℴ𝓇</span>
+        <span class="cursive-word-label">amor em cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝒶𝓂ℴ𝓇" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓪𝓶𝓸𝓻</span>
+        <span class="cursive-word-label">amor (bold) em cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓪𝓶𝓸𝓻" data-style="Ultra Script Bold">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓉ℯ 𝒶𝓂ℴ</span>
+        <span class="cursive-word-label">te amo em cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓉ℯ 𝒶𝓂ℴ" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒻𝒶𝓂𝒾𝓁𝒾𝒶</span>
+        <span class="cursive-word-label">família em cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝒻𝒶𝓂𝒾𝓁𝒾𝒶" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓂𝒶ℯ</span>
+        <span class="cursive-word-label">mãe em cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓂𝒶ℯ" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓅𝒶𝒾</span>
+        <span class="cursive-word-label">pai em cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓅𝒶𝒾" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓅𝒶𝓇𝒶 𝓈ℯ𝓂𝓅𝓇ℯ</span>
+        <span class="cursive-word-label">para sempre em cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓅𝒶𝓇𝒶 𝓈ℯ𝓂𝓅𝓇ℯ" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓈𝒶𝓊𝒹𝒶𝒹ℯ</span>
+        <span class="cursive-word-label">saudade em cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓈𝒶𝓊𝒹𝒶𝒹ℯ" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒻ℯ</span>
+        <span class="cursive-word-label">fé em cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝒻ℯ" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒶𝒷ℯ𝓃𝒸ℴ𝒶𝒹ℴ</span>
+        <span class="cursive-word-label">abençoado em cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝒶𝒷ℯ𝓃𝒸ℴ𝒶𝒹ℴ" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">ℊ𝓇𝒶𝓉𝒾𝒹𝒶ℴ</span>
+        <span class="cursive-word-label">gratidão em cursiva</span>
+        <button type="button" class="copy-btn" data-text="ℊ𝓇𝒶𝓉𝒾𝒹𝒶ℴ" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒶𝓃𝒿ℴ</span>
+        <span class="cursive-word-label">anjo em cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝒶𝓃𝒿ℴ" data-style="Ultra Script">Copiar</button>
       </div>
     </div>
-    <p class="u-mt-15">O Unicode não tem número cursivo de verdade, então a fonte cursiva usa esses numerais finos que combinam com o traço das letras.</p>
-
-    <div class="glyph-group">
-      <h3>Letras cursivas avulsas — minúsculas (a–z)</h3>
-      <div class="glyph-grid">
-        <button class="glyph-copy" type="button" data-text="𝒶" aria-label="Copiar letra a cursiva">𝒶</button>
-        <button class="glyph-copy" type="button" data-text="𝒷" aria-label="Copiar letra b cursiva">𝒷</button>
-        <button class="glyph-copy" type="button" data-text="𝒸" aria-label="Copiar letra c cursiva">𝒸</button>
-        <button class="glyph-copy" type="button" data-text="𝒹" aria-label="Copiar letra d cursiva">𝒹</button>
-        <button class="glyph-copy" type="button" data-text="ℯ" aria-label="Copiar letra e cursiva">ℯ</button>
-        <button class="glyph-copy" type="button" data-text="𝒻" aria-label="Copiar letra f cursiva">𝒻</button>
-        <button class="glyph-copy" type="button" data-text="ℊ" aria-label="Copiar letra g cursiva">ℊ</button>
-        <button class="glyph-copy" type="button" data-text="𝒽" aria-label="Copiar letra h cursiva">𝒽</button>
-        <button class="glyph-copy" type="button" data-text="𝒾" aria-label="Copiar letra i cursiva">𝒾</button>
-        <button class="glyph-copy" type="button" data-text="𝒿" aria-label="Copiar letra j cursiva">𝒿</button>
-        <button class="glyph-copy" type="button" data-text="𝓀" aria-label="Copiar letra k cursiva">𝓀</button>
-        <button class="glyph-copy" type="button" data-text="𝓁" aria-label="Copiar letra l cursiva">𝓁</button>
-        <button class="glyph-copy" type="button" data-text="𝓂" aria-label="Copiar letra m cursiva">𝓂</button>
-        <button class="glyph-copy" type="button" data-text="𝓃" aria-label="Copiar letra n cursiva">𝓃</button>
-        <button class="glyph-copy" type="button" data-text="ℴ" aria-label="Copiar letra o cursiva">ℴ</button>
-        <button class="glyph-copy" type="button" data-text="𝓅" aria-label="Copiar letra p cursiva">𝓅</button>
-        <button class="glyph-copy" type="button" data-text="𝓆" aria-label="Copiar letra q cursiva">𝓆</button>
-        <button class="glyph-copy" type="button" data-text="𝓇" aria-label="Copiar letra r cursiva">𝓇</button>
-        <button class="glyph-copy" type="button" data-text="𝓈" aria-label="Copiar letra s cursiva">𝓈</button>
-        <button class="glyph-copy" type="button" data-text="𝓉" aria-label="Copiar letra t cursiva">𝓉</button>
-        <button class="glyph-copy" type="button" data-text="𝓊" aria-label="Copiar letra u cursiva">𝓊</button>
-        <button class="glyph-copy" type="button" data-text="𝓋" aria-label="Copiar letra v cursiva">𝓋</button>
-        <button class="glyph-copy" type="button" data-text="𝓌" aria-label="Copiar letra w cursiva">𝓌</button>
-        <button class="glyph-copy" type="button" data-text="𝓍" aria-label="Copiar letra x cursiva">𝓍</button>
-        <button class="glyph-copy" type="button" data-text="𝓎" aria-label="Copiar letra y cursiva">𝓎</button>
-        <button class="glyph-copy" type="button" data-text="𝓏" aria-label="Copiar letra z cursiva">𝓏</button>
+    <h3>Saudações e datas</h3>
+    <div class="cursive-word-grid">
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒻ℯ𝓁𝒾𝓏 𝒶𝓃𝒾𝓋ℯ𝓇𝓈𝒶𝓇𝒾ℴ</span>
+        <span class="cursive-word-label">feliz aniversário em cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝒻ℯ𝓁𝒾𝓏 𝒶𝓃𝒾𝓋ℯ𝓇𝓈𝒶𝓇𝒾ℴ" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓅𝒶𝓇𝒶𝒷ℯ𝓃𝓈</span>
+        <span class="cursive-word-label">parabéns em cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓅𝒶𝓇𝒶𝒷ℯ𝓃𝓈" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">ℴ𝒷𝓇𝒾ℊ𝒶𝒹ℴ</span>
+        <span class="cursive-word-label">obrigado em cursiva</span>
+        <button type="button" class="copy-btn" data-text="ℴ𝒷𝓇𝒾ℊ𝒶𝒹ℴ" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒷ℯ𝓂 𝓋𝒾𝓃𝒹ℴ</span>
+        <span class="cursive-word-label">bem-vindo em cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝒷ℯ𝓂 𝓋𝒾𝓃𝒹ℴ" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒻ℯ𝓁𝒾𝓏 𝓃𝒶𝓉𝒶𝓁</span>
+        <span class="cursive-word-label">feliz natal em cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝒻ℯ𝓁𝒾𝓏 𝓃𝒶𝓉𝒶𝓁" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒻ℯ𝓁𝒾𝓏 𝒶𝓃ℴ 𝓃ℴ𝓋ℴ</span>
+        <span class="cursive-word-label">feliz ano novo em cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝒻ℯ𝓁𝒾𝓏 𝒶𝓃ℴ 𝓃ℴ𝓋ℴ" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒻ℯ𝓁𝒾𝒸𝒾𝒹𝒶𝒹ℯ𝓈</span>
+        <span class="cursive-word-label">felicidades em cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝒻ℯ𝓁𝒾𝒸𝒾𝒹𝒶𝒹ℯ𝓈" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒷ℴ𝓂 𝒹𝒾𝒶</span>
+        <span class="cursive-word-label">bom dia em cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝒷ℴ𝓂 𝒹𝒾𝒶" data-style="Ultra Script">Copiar</button>
       </div>
     </div>
-    <div class="glyph-group">
-      <h3>Letras cursivas avulsas — maiúsculas (A–Z)</h3>
-      <div class="glyph-grid">
-        <button class="glyph-copy" type="button" data-text="𝒜" aria-label="Copiar letra A maiúscula cursiva">𝒜</button>
-        <button class="glyph-copy" type="button" data-text="ℬ" aria-label="Copiar letra B maiúscula cursiva">ℬ</button>
-        <button class="glyph-copy" type="button" data-text="𝒞" aria-label="Copiar letra C maiúscula cursiva">𝒞</button>
-        <button class="glyph-copy" type="button" data-text="𝒟" aria-label="Copiar letra D maiúscula cursiva">𝒟</button>
-        <button class="glyph-copy" type="button" data-text="ℰ" aria-label="Copiar letra E maiúscula cursiva">ℰ</button>
-        <button class="glyph-copy" type="button" data-text="ℱ" aria-label="Copiar letra F maiúscula cursiva">ℱ</button>
-        <button class="glyph-copy" type="button" data-text="𝒢" aria-label="Copiar letra G maiúscula cursiva">𝒢</button>
-        <button class="glyph-copy" type="button" data-text="ℋ" aria-label="Copiar letra H maiúscula cursiva">ℋ</button>
-        <button class="glyph-copy" type="button" data-text="ℐ" aria-label="Copiar letra I maiúscula cursiva">ℐ</button>
-        <button class="glyph-copy" type="button" data-text="𝒥" aria-label="Copiar letra J maiúscula cursiva">𝒥</button>
-        <button class="glyph-copy" type="button" data-text="𝒦" aria-label="Copiar letra K maiúscula cursiva">𝒦</button>
-        <button class="glyph-copy" type="button" data-text="ℒ" aria-label="Copiar letra L maiúscula cursiva">ℒ</button>
-        <button class="glyph-copy" type="button" data-text="ℳ" aria-label="Copiar letra M maiúscula cursiva">ℳ</button>
-        <button class="glyph-copy" type="button" data-text="𝒩" aria-label="Copiar letra N maiúscula cursiva">𝒩</button>
-        <button class="glyph-copy" type="button" data-text="𝒪" aria-label="Copiar letra O maiúscula cursiva">𝒪</button>
-        <button class="glyph-copy" type="button" data-text="𝒫" aria-label="Copiar letra P maiúscula cursiva">𝒫</button>
-        <button class="glyph-copy" type="button" data-text="𝒬" aria-label="Copiar letra Q maiúscula cursiva">𝒬</button>
-        <button class="glyph-copy" type="button" data-text="ℛ" aria-label="Copiar letra R maiúscula cursiva">ℛ</button>
-        <button class="glyph-copy" type="button" data-text="𝒮" aria-label="Copiar letra S maiúscula cursiva">𝒮</button>
-        <button class="glyph-copy" type="button" data-text="𝒯" aria-label="Copiar letra T maiúscula cursiva">𝒯</button>
-        <button class="glyph-copy" type="button" data-text="𝒰" aria-label="Copiar letra U maiúscula cursiva">𝒰</button>
-        <button class="glyph-copy" type="button" data-text="𝒱" aria-label="Copiar letra V maiúscula cursiva">𝒱</button>
-        <button class="glyph-copy" type="button" data-text="𝒲" aria-label="Copiar letra W maiúscula cursiva">𝒲</button>
-        <button class="glyph-copy" type="button" data-text="𝒳" aria-label="Copiar letra X maiúscula cursiva">𝒳</button>
-        <button class="glyph-copy" type="button" data-text="𝒴" aria-label="Copiar letra Y maiúscula cursiva">𝒴</button>
-        <button class="glyph-copy" type="button" data-text="𝒵" aria-label="Copiar letra Z maiúscula cursiva">𝒵</button>
+    <h3>Meses em cursiva</h3>
+    <div class="cursive-word-grid">
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒿𝒶𝓃ℯ𝒾𝓇ℴ</span>
+        <span class="cursive-word-label">janeiro em cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝒿𝒶𝓃ℯ𝒾𝓇ℴ" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒻ℯ𝓋ℯ𝓇ℯ𝒾𝓇ℴ</span>
+        <span class="cursive-word-label">fevereiro em cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝒻ℯ𝓋ℯ𝓇ℯ𝒾𝓇ℴ" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓂𝒶𝓇𝒸ℴ</span>
+        <span class="cursive-word-label">março em cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓂𝒶𝓇𝒸ℴ" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒶𝒷𝓇𝒾𝓁</span>
+        <span class="cursive-word-label">abril em cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝒶𝒷𝓇𝒾𝓁" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓂𝒶𝒾ℴ</span>
+        <span class="cursive-word-label">maio em cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓂𝒶𝒾ℴ" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒿𝓊𝓃𝒽ℴ</span>
+        <span class="cursive-word-label">junho em cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝒿𝓊𝓃𝒽ℴ" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒿𝓊𝓁𝒽ℴ</span>
+        <span class="cursive-word-label">julho em cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝒿𝓊𝓁𝒽ℴ" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒶ℊℴ𝓈𝓉ℴ</span>
+        <span class="cursive-word-label">agosto em cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝒶ℊℴ𝓈𝓉ℴ" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓈ℯ𝓉ℯ𝓂𝒷𝓇ℴ</span>
+        <span class="cursive-word-label">setembro em cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓈ℯ𝓉ℯ𝓂𝒷𝓇ℴ" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">ℴ𝓊𝓉𝓊𝒷𝓇ℴ</span>
+        <span class="cursive-word-label">outubro em cursiva</span>
+        <button type="button" class="copy-btn" data-text="ℴ𝓊𝓉𝓊𝒷𝓇ℴ" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓃ℴ𝓋ℯ𝓂𝒷𝓇ℴ</span>
+        <span class="cursive-word-label">novembro em cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓃ℴ𝓋ℯ𝓂𝒷𝓇ℴ" data-style="Ultra Script">Copiar</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒹ℯ𝓏ℯ𝓂𝒷𝓇ℴ</span>
+        <span class="cursive-word-label">dezembro em cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝒹ℯ𝓏ℯ𝓂𝒷𝓇ℴ" data-style="Ultra Script">Copiar</button>
       </div>
     </div>
-    <p class="u-mt-15">Procurando o <strong>f cursivo</strong>, a <strong>letra g cursiva</strong>, a <strong>letra l cursiva</strong> ou o <strong>s maiúsculo cursivo</strong>? Clica na letra que ela já vai pra área de transferência — pronta pra inicial do nick, monograma ou detalhe da bio. Repara que algumas letras (ℬ ℰ ℱ ℊ ℴ) têm desenho um pouco diferente das vizinhas: o Unicode guarda essas em outro bloco, mas todas colam do mesmo jeito.</p>
-  </section>
+    </section>
 
-  <!-- Letra de mão e manuscrita -->
-  <section class="editorial-section">
-    <h2>Letra de mão e fonte manuscrita</h2>
-    <p class="editorial-intro">Muita gente procura por <strong>letra de mão</strong> ou <strong>fonte manuscrita</strong> — e aqui isso é a mesma família da cursiva: caracteres Unicode do tipo <em>script</em>, desenhados pra imitar escrita à mão. A versão fina (𝓂𝒶𝓃𝓊𝓈𝒸𝓇𝒾𝓉𝒶) tem clima de caneta tinteiro; a bold (𝓶𝓪𝓷𝓾𝓼𝓬𝓻𝓲𝓽𝓪) lembra pincel ou brush lettering.</p>
-    <p>Na prática: quer uma assinatura delicada no fim do texto, um cabeçalho de destaque no story ou aquela frase com cara de bilhete escrito à mão? Digita no gerador lá em cima e escolhe entre a manuscrita fina e a bold. Pra um visual ainda mais clean, combina com as <a href="/pt/letras-aesthetic/">letras aesthetic</a> ou com as <a href="/pt/letras-pequenas/">letras pequenas</a> na linha de baixo.</p>
-  </section>
-
-  <!-- O que é letra cursiva -->
-  <section class="editorial-section">
-    <h2>O que é letra cursiva?</h2>
-    <p class="editorial-intro">Letra cursiva é o estilo de escrita em que as letras saem emendadas umas nas outras, com traço contínuo e inclinado — o jeito de escrever «de mão» que a gente aprende cedo e que passa uma sensação elegante, pessoal e romântica. É o oposto da letra de forma (ou letra bastão), em que cada letra fica separada e reta.</p>
-    <p>No mundo digital, a letra cursiva virou caractere: o Unicode reservou um conjunto de letras <em>script</em> (𝒶, 𝒷, 𝒸…) que reproduzem esse traço emendado em qualquer tela. É isso que este gerador usa — então o «cursivo» que você copia aqui não é uma fonte que precisa estar instalada, é texto de verdade que funciona em bio, legenda, status e mensagem.</p>
-  </section>
-
-  <!-- Nomes em letra cursiva -->
-  <section class="editorial-section" id="nomes-cursiva">
-    <h2>Nomes em letra cursiva prontos pra copiar</h2>
-    <p class="uname-note">Clica no nome que ele já é copiado. Quer o seu? Digita no gerador lá em cima que sai em todas as versões cursivas.</p>
-    <div class="uname-grid">
-      <button class="uname-chip symbol-tile" data-symbol="ℳ𝒶𝓇𝒾𝒶" aria-label="Copiar nome Maria em letra cursiva">ℳ𝒶𝓇𝒾𝒶</button>
-      <button class="uname-chip symbol-tile" data-symbol="♡ 𝒥𝓊𝓁𝒾𝒶 ♡" aria-label="Copiar nome Julia em letra cursiva com corações">♡ 𝒥𝓊𝓁𝒾𝒶 ♡</button>
-      <button class="uname-chip symbol-tile" data-symbol="𝒜𝓃𝒶" aria-label="Copiar nome Ana em letra cursiva">𝒜𝓃𝒶</button>
-      <button class="uname-chip symbol-tile" data-symbol="⋆˚ 𝒮ℴ𝒻𝒾𝒶 ˚⋆" aria-label="Copiar nome Sofia em letra cursiva com estrelas">⋆˚ 𝒮ℴ𝒻𝒾𝒶 ˚⋆</button>
-      <button class="uname-chip symbol-tile" data-symbol="𝒥ℴ𝒶ℴ" aria-label="Copiar nome Joao em letra cursiva">𝒥ℴ𝒶ℴ</button>
-      <button class="uname-chip symbol-tile" data-symbol="𝒫ℯ𝒹𝓇ℴ" aria-label="Copiar nome Pedro em letra cursiva">𝒫ℯ𝒹𝓇ℴ</button>
-      <button class="uname-chip symbol-tile" data-symbol="✧ ℬℯ𝒶𝓉𝓇𝒾𝓏 ✧" aria-label="Copiar nome Beatriz em letra cursiva com brilhos">✧ ℬℯ𝒶𝓉𝓇𝒾𝓏 ✧</button>
-      <button class="uname-chip symbol-tile" data-symbol="𝒢𝒶𝒷𝓇𝒾ℯ𝓁" aria-label="Copiar nome Gabriel em letra cursiva">𝒢𝒶𝒷𝓇𝒾ℯ𝓁</button>
-      <button class="uname-chip symbol-tile" data-symbol="𝓛𝓾𝓲𝔃𝓪" aria-label="Copiar nome Luiza em cursiva bold">𝓛𝓾𝓲𝔃𝓪</button>
-      <button class="uname-chip symbol-tile" data-symbol="❀ 𝓗𝓮𝓵𝓮𝓷𝓪 ❀" aria-label="Copiar nome Helena em cursiva bold com flores">❀ 𝓗𝓮𝓵𝓮𝓷𝓪 ❀</button>
-      <button class="uname-chip symbol-tile" data-symbol="𝓜𝓲𝓰𝓾𝓮𝓵" aria-label="Copiar nome Miguel em cursiva bold">𝓜𝓲𝓰𝓾𝓮𝓵</button>
-      <button class="uname-chip symbol-tile" data-symbol="𝓛𝓪𝓻𝓲𝓼𝓼𝓪" aria-label="Copiar nome Larissa em cursiva bold">𝓛𝓪𝓻𝓲𝓼𝓼𝓪</button>
+    <!-- 5. Names & signatures -->
+    <section id="cursive-names" aria-labelledby="cursiveNamesHeading">
+      <h2 class="bubble-az-heading" id="cursiveNamesHeading">Gerador de nomes e assinatura em cursiva</h2>
+      <p class="bubble-az-intro">Digite um nome — ou o nome completo — e monte sua assinatura em letra cursiva:
+        escolha um enfeite, defina como as iniciais do monograma se emendam e copie o texto ou baixe como PNG
+        pra rodapé de e-mail, marca-d'água e documentos.</p>
+      <div class="cursive-name-tool">
+        <div class="input-wrapper">
+          <input type="text" class="main-input cursive-name-input" id="cursiveNameInput" placeholder="Digite um nome… ex.: Maria Helena" maxlength="60">
+        </div>
+        <div class="cursive-sig-controls" id="cursiveSignatureControls"></div>
+        <div class="results-grid" id="cursiveNameResults"></div>
+      </div>
+    <h3>Nomes populares em cursiva</h3>
+    <p class="bubble-az-intro">Toque em qualquer nome pra carregar no estúdio acima e reestilizar com enfeites. Os nomes com acento aparecem escritos sem acento pra ficarem 100% cursivos.</p>
+    <div class="cursive-word-grid">
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Carregar Maria no estúdio de assinatura" data-name="Maria">
+        <span class="cursive-word-render">𝓜𝓪𝓻𝓲𝓪</span>
+        <span class="cursive-word-label">Maria em cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓜𝓪𝓻𝓲𝓪" data-style="Ultra Script Bold">Copiar</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Carregar Ana no estúdio de assinatura" data-name="Ana">
+        <span class="cursive-word-render">𝓐𝓷𝓪</span>
+        <span class="cursive-word-label">Ana em cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓐𝓷𝓪" data-style="Ultra Script Bold">Copiar</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Carregar Julia no estúdio de assinatura" data-name="Julia">
+        <span class="cursive-word-render">𝓙𝓾𝓵𝓲𝓪</span>
+        <span class="cursive-word-label">Júlia em cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓙𝓾𝓵𝓲𝓪" data-style="Ultra Script Bold">Copiar</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Carregar Sofia no estúdio de assinatura" data-name="Sofia">
+        <span class="cursive-word-render">𝓢𝓸𝓯𝓲𝓪</span>
+        <span class="cursive-word-label">Sofia em cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓢𝓸𝓯𝓲𝓪" data-style="Ultra Script Bold">Copiar</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Carregar Helena no estúdio de assinatura" data-name="Helena">
+        <span class="cursive-word-render">𝓗𝓮𝓵𝓮𝓷𝓪</span>
+        <span class="cursive-word-label">Helena em cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓗𝓮𝓵𝓮𝓷𝓪" data-style="Ultra Script Bold">Copiar</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Carregar Laura no estúdio de assinatura" data-name="Laura">
+        <span class="cursive-word-render">𝓛𝓪𝓾𝓻𝓪</span>
+        <span class="cursive-word-label">Laura em cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓛𝓪𝓾𝓻𝓪" data-style="Ultra Script Bold">Copiar</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Carregar Valentina no estúdio de assinatura" data-name="Valentina">
+        <span class="cursive-word-render">𝓥𝓪𝓵𝓮𝓷𝓽𝓲𝓷𝓪</span>
+        <span class="cursive-word-label">Valentina em cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓥𝓪𝓵𝓮𝓷𝓽𝓲𝓷𝓪" data-style="Ultra Script Bold">Copiar</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Carregar Miguel no estúdio de assinatura" data-name="Miguel">
+        <span class="cursive-word-render">𝓜𝓲𝓰𝓾𝓮𝓵</span>
+        <span class="cursive-word-label">Miguel em cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓜𝓲𝓰𝓾𝓮𝓵" data-style="Ultra Script Bold">Copiar</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Carregar Arthur no estúdio de assinatura" data-name="Arthur">
+        <span class="cursive-word-render">𝓐𝓻𝓽𝓱𝓾𝓻</span>
+        <span class="cursive-word-label">Arthur em cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓐𝓻𝓽𝓱𝓾𝓻" data-style="Ultra Script Bold">Copiar</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Carregar Gabriel no estúdio de assinatura" data-name="Gabriel">
+        <span class="cursive-word-render">𝓖𝓪𝓫𝓻𝓲𝓮𝓵</span>
+        <span class="cursive-word-label">Gabriel em cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓖𝓪𝓫𝓻𝓲𝓮𝓵" data-style="Ultra Script Bold">Copiar</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Carregar Pedro no estúdio de assinatura" data-name="Pedro">
+        <span class="cursive-word-render">𝓟𝓮𝓭𝓻𝓸</span>
+        <span class="cursive-word-label">Pedro em cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓟𝓮𝓭𝓻𝓸" data-style="Ultra Script Bold">Copiar</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Carregar Lucas no estúdio de assinatura" data-name="Lucas">
+        <span class="cursive-word-render">𝓛𝓾𝓬𝓪𝓼</span>
+        <span class="cursive-word-label">Lucas em cursiva</span>
+        <button type="button" class="copy-btn" data-text="𝓛𝓾𝓬𝓪𝓼" data-style="Ultra Script Bold">Copiar</button>
+      </div>
     </div>
-    <p class="u-mt-15">Repara que «João» virou 𝒥ℴ𝒶ℴ e «Júlia» virou 𝒥𝓊𝓁𝒾𝒶: o Unicode não tem versão cursiva das letras com acento (ã, í, ú), então nomes acentuados ficam mais bonitos escritos sem acento. Pra enfeitar ainda mais, pega corações e estrelinhas na página de <a href="/pt/library/simbolos/">símbolos para copiar</a> — e se a ideia é nome estiloso pra jogo, veja o <a href="/pt/usecase/nick-ff/">nick de FF</a>.</p>
-  </section>
+    </section>
 
-  <!-- Related -->
-  <section class="editorial-section">
-    <h2>Mais letras pra copiar e colar</h2>
-    <div class="compare-grid">
-      <a href="/pt/letras-diferentes/" class="compare-card variant-muted u-no-underline">
-        <h4>Letras diferentes</h4>
-        <p>Todos os estilos num lugar só: negrito, gótica, bubble, riscada e mais.</p>
-      </a>
-      <a href="/pt/letras-aesthetic/" class="compare-card variant-muted u-no-underline">
-        <h4>Letras aesthetic</h4>
-        <p>Estilos delicados e símbolos pra bio coquette, clean e minimalista.</p>
-      </a>
-      <a href="/pt/fontes-para-instagram/" class="compare-card variant-muted u-no-underline">
-        <h4>Fontes para Instagram</h4>
-        <p>As fontes que mais combinam com bio, legenda e nome de exibição no Insta.</p>
-      </a>
+    <!-- Editorial -->
+    <section class="editorial-section cursive-editorial">
+      <h2>Como funciona este gerador de letra cursiva</h2>
+      <p>A <strong>letra cursiva</strong> que você vê aqui não é uma fonte — são <strong>caracteres Unicode do tipo script</strong>, o mesmo padrão que seu aparelho usa pra cada letra e emoji. É por isso que ela sobrevive ao copiar e colar: os apps tratam 𝒸𝓊𝓇𝓈𝒾𝓋𝒶 exatamente como texto comum. E é por isso que funciona em lugares onde você jamais instalaria uma fonte — bio do Instagram, legenda do TikTok, nome no Discord, comentário do YouTube. Quer entender o mecanismo? Leia <a href="/guide/how-unicode-fonts-work/">como as fontes Unicode funcionam</a>.</p>
+
+      <h3>Onde a letra cursiva funciona (e onde ela quebra)</h3>
+      <ul class="compat-list">
+        <li><span class="ts-pill-safe">Funciona</span> Bio e legenda do Instagram, legenda do TikTok, Discord, WhatsApp, Facebook, X, comentário do YouTube e na maioria dos documentos.</li>
+        <li><span class="ts-pill-risk">Limitado</span> Campos de nome de usuário (@) e nome de exibição (Instagram, maioria dos jogos) costumam remover os caracteres script — deixa o @ em texto normal.</li>
+        <li><span class="ts-pill-risk">Limitado</span> Alguns aparelhos antigos mostram quadradinhos (▯) no lugar da letra. Se acontecer, use um estilo mais simples ou menos acentos — veja <a href="/guide/why-fonts-show-as-boxes/">por que as fontes aparecem como quadrados</a>.</li>
+      </ul>
+
+      <h3>Cursiva Unicode x fonte cursiva de verdade</h3>
+      <p>Use a cursiva Unicode quando precisar de cursiva <em>dentro de campos de texto</em> — perfis de redes, conversas, títulos de vídeo. Use uma fonte cursiva de verdade (no Word, no Canva ou no seu editor de design) quando você controla o documento e precisa de qualidade de impressão. Cada uma tem seu lugar; esta ferramenta cobre o primeiro caso.</p>
+
+      <h3>Letra de mão, fonte manuscrita e acentos (ã, é, ç)</h3>
+      <p>Muita gente procura por <strong>letra de mão</strong> ou <strong>fonte manuscrita</strong> — e aqui é a mesma família da cursiva: caracteres Unicode <em>script</em>, desenhados pra imitar a escrita à mão. Um detalhe do português: o Unicode só tem letras script pra A–Z sem acento, então á, ã, é, ç e companhia saem sem estilo no meio da palavra. Pra um nome ou frase 100% em cursiva, escreve sem acento — «João» vira Joao → 𝒥ℴ𝒶ℴ e «Júlia» vira Julia → 𝒥𝓊𝓁𝒾𝒶. Fica menos correto na gramática, mas visualmente consistente — ótimo pra bio e nick.</p>
+
+      <h3>Aprendendo a escrever em letra cursiva</h3>
+      <p>Os geradores são pra texto digital, mas servem também como tabela de referência. Imprima a <a href="#cursive-alphabet">folha de caligrafia</a> pra treinar o traço, estude como cada maiúscula se emenda no <a href="#cursive-letters">explorador de letras</a> e mantenha os cuidados essenciais de acessibilidade — linhas decorativas curtas, o resto em texto normal (<a href="/guide/fancy-fonts-accessibility-guide/">guia de acessibilidade</a>).</p>
+
+      <h3>Letra cursiva para tatuagem</h3>
+      <p>O lettering em cursiva é o estilo de tatuagem mais pedido. Veja sua palavra aqui em tamanho grande e depois use o <a href="/pt/usecase/letras-para-tatuagem/">gerador de letras para tatuagem</a> — ele traz famílias de lettering, datas em números romanos, iniciais e um teste de legibilidade pensado no tamanho do traço na pele.</p>
+    </section>
+
+    <div class="cta-card">
+      <h3>Deixe a bio inteira com aquele fluxo</h3>
+      <p>Combine um título em <strong>letra cursiva</strong> com um texto de corpo limpo — a mistura que chama atenção e continua fácil de ler.</p>
+      <a class="cta-btn" href="/pt/">Abrir o gerador completo →</a>
     </div>
-  </section>
-</main>
+  </main>
 
-<footer class="footer">
-  <div class="footer-inner">
-    <h2 class="faq-category">Perguntas sobre letra cursiva</h2>
-    <div class="faq-item"><button class="faq-question" type="button">Como copiar a letra cursiva?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Digita seu texto na caixa lá em cima e todas as versões em letra cursiva aparecem na hora. Clica em «Copiar» no estilo que você gostou e cola onde quiser: bio, legenda, status, convite. Também dá pra clicar em qualquer letra do alfabeto cursivo desta página pra copiar uma letra avulsa, tipo o f cursivo ou o s maiúsculo.</div></div>
-    <div class="faq-item"><button class="faq-question" type="button">Letra cursiva serve para tatuagem?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Serve como referência. Digita a palavra ou o nome, testa a cursiva normal e a cursiva bold e mostra o resultado pro tatuador como base do desenho. O traço final quem define é o artista, mas a prévia em letra cursiva ajuda a decidir o estilo antes de agulhar.</div></div>
-    <div class="faq-item"><button class="faq-question" type="button">Letra cursiva funciona no Instagram e no WhatsApp?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Funciona. Como cada letra é um caractere Unicode de verdade, a cursiva cola na bio e na legenda do Instagram, no status e no recado do WhatsApp, no TikTok, no Discord e em quase todo campo que aceita texto. Só em nome de usuário (@) ela costuma ser bloqueada — nesses campos, mantém o texto normal.</div></div>
-    <div class="faq-item"><button class="faq-question" type="button">Qual a diferença entre letra cursiva e manuscrita?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Na prática, aqui as duas dão no mesmo resultado: caracteres Unicode com desenho de escrita à mão. «Cursiva» costuma descrever a letra emendada e inclinada; «manuscrita» (ou letra de mão) é qualquer letra com cara de escrita à mão, emendada ou não. Os estilos script desta página cobrem os dois casos.</div></div>
-    <div class="faq-item"><button class="faq-question" type="button">Funciona com acento (ã, é, ç)?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Em parte. O Unicode não tem versão cursiva pras letras acentuadas, então á, ã, ç e companhia saem sem estilo no meio da palavra. Pra um nome 100% cursivo, escreve sem acento: «João» vira Joao → 𝒥ℴ𝒶ℴ. Fica menos correto na gramática, mas visualmente consistente — bom pra bio e nick.</div></div>
+  <!-- Footer + FAQ -->
+  <footer class="footer">
+    <div class="footer-inner">
+<div class="faq-section" id="cursive-faq">
+
+<h2 class="faq-category">Gerador de Letra Cursiva — Perguntas frequentes</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    O que é um gerador de letra cursiva e como funciona?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Ele transforma as letras que você digita em caracteres Unicode do tipo script — símbolos especiais que parecem escrita à mão, mas se comportam como texto normal. Como são caracteres de verdade (não uma fonte nem uma imagem), dá pra copiar e colar na bio, na legenda, nos comentários e nas mensagens, e eles mantêm o desenho cursivo. Veja mais no nosso <a href="/guide/how-unicode-fonts-work/">guia de como as fontes Unicode funcionam</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Como copiar e colar a letra cursiva?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Digita ou cola seu texto na caixa lá em cima e clica em Copiar no estilo que você gostou. A versão em <strong>letra cursiva para copiar e colar</strong> já vai pra área de transferência — cola onde aceitar texto: Instagram, TikTok, WhatsApp, Discord, documentos e mais.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    A letra cursiva funciona no Instagram, no WhatsApp e no TikTok?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Funciona. Como cada letra é um caractere Unicode de verdade, a cursiva cola na bio e na legenda do Instagram, no status e no recado do WhatsApp, na legenda do TikTok, no Discord e em quase todo campo que aceita texto. Só em nome de usuário (@) ela costuma ser bloqueada — nesses campos, deixa o texto normal.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    A letra cursiva serve para tatuagem?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Serve como referência. Digita a palavra ou o nome, testa a cursiva normal e a cursiva bold e mostra o resultado pro tatuador como base do desenho. O traço final quem define é o artista, mas a prévia ajuda a decidir o estilo antes de agulhar. Pra ver famílias de lettering e datas em romano, use o <a href="/pt/usecase/letras-para-tatuagem/">gerador de letras para tatuagem</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Qual a diferença entre letra cursiva, letra de mão e fonte manuscrita?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Na prática, aqui todas dão no mesmo resultado: caracteres Unicode com desenho de escrita à mão. «Cursiva» costuma descrever a letra emendada e inclinada; «letra de mão» e «fonte manuscrita» são qualquer letra com cara de escrita à mão, emendada ou não. Os estilos script desta página cobrem os dois casos.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    A letra cursiva funciona com acento (ã, é, ç)?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Em parte. O Unicode não tem versão cursiva das letras acentuadas, então á, ã, é, ç e companhia saem sem estilo no meio da palavra. Pra um nome 100% cursivo, escreve sem acento: «João» vira Joao → 𝒥ℴ𝒶ℴ. Fica menos correto na gramática, mas visualmente consistente — bom pra bio e nick.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    O alfabeto cursivo tem números?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    O Unicode não tem número cursivo de verdade, então cada estilo combina as letras script com numerais finos que casam com o traço (𝟢 𝟣 𝟤 𝟥). Dá pra copiar o alfabeto cursivo completo — maiúsculas, minúsculas e números — em um clique na seção do <a href="#cursive-alphabet">alfabeto</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    O gerador de letra cursiva é grátis?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    É totalmente grátis, sem cadastro e sem instalar nada. Roda direto no navegador, no celular ou no computador. Digita, copia e cola — quantas vezes quiser.
+  </div>
+</div>
+
+</div>
 
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="Language switcher">
       <a class="lang-option" href="/category/cursive-fonts/" hreflang="en">EN</a>
-      <a class="lang-option" href="/fr/ecriture-cursive/" hreflang="fr">FR</a>
-      <a class="lang-option" href="/id/tulisan-sambung/" hreflang="id">ID</a>
-      <a class="lang-option" href="/nl/sierlijke-letters/" hreflang="nl">NL</a>
+      <a class="lang-option" href="/es/letra-cursiva/" hreflang="es">ES</a>
       <a class="lang-option active" href="/pt/letra-cursiva/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/fr/ecriture-cursive/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/de/schreibschrift/" hreflang="de">DE</a>
+      <a class="lang-option" href="/it/lettere-in-corsivo/" hreflang="it">IT</a>
       <a class="lang-option" href="/tr/el-yazisi-fontu/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/nl/cursieve-letters/" hreflang="nl">NL</a>
+      <a class="lang-option" href="/id/tulisan-sambung/" hreflang="id">ID</a>
       <a class="lang-option" href="/no/kursiv-tekst/" hreflang="no">NO</a>
     </div>
-  </div>
-</footer>
 
-<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+    </div>
+  </footer>
 
-<script>window.UTG_FAMILY = "cursive";</script>
-<script src="/styles.js"></script>
-<script src="/renderer.js"></script>
-<script src="/script.js" defer=""></script>
-<script src="/symbol-explorer.js"></script>
-<script src="/footer.js"></script>
+  <div id="cursivePrintRoot" aria-hidden="true"></div>
+  <div class="copy-toast" id="copyToast">Copiado!</div>
+
+  <script>
+    window.UTG_CURSIVE_MODE = true;
+    window.UTG_FAMILY = "cursive";
+    window.cursiveI18n = {
+  "demoText": "Ola",
+  "demoName": "Maria",
+  "copy": "Copiar",
+  "typeFirst": "Digite seu texto acima primeiro",
+  "downloadPngTitle": "Baixar como imagem PNG",
+  "downloadPng": "Baixar PNG",
+  "characters": "caracteres",
+  "caseUpper": "Maiúscula",
+  "caseLower": "Minúscula",
+  "caseBoth": "Ambas",
+  "labelUpper": "{ch} maiúsculo em cursiva",
+  "labelLower": "{ch} minúsculo em cursiva",
+  "labelBoth": "{ch} maiúsculo e minúsculo em cursiva",
+  "copyBoth": "Copiar os dois",
+  "everyStyle": "{ch} em cursiva — todos os estilos, clique pra copiar",
+  "suffixCapital": " — maiúscula",
+  "suffixLowercase": " — minúscula",
+  "accentLabel": "Enfeite {name}",
+  "practiceTitle": "Folha de caligrafia do alfabeto cursivo — ultratextgen.com",
+  "flourishLabel": "Enfeite",
+  "monogramLabel": "União de monograma",
+  "copiedToast": "Copiado!",
+  "quickWords": [
+    "amor",
+    "parabens",
+    "obrigado",
+    "familia",
+    "sempre",
+    "abencoado"
+  ],
+  "styles": {
+    "Ultra Script": "cursiva clássica",
+    "Ultra Script Bold": "cursiva bold",
+    "Ultra Script Elegant": "cursiva elegante",
+    "Ultra Script Bold Elegant": "cursiva bold elegante",
+    "Ultra Gothic Script": "cursiva gótica",
+    "Ultra Chicano Script": "letreiro chicano",
+    "Ultra Script Sparkle": "cursiva com brilho"
+  },
+  "presets": {
+    "Script Hearts": "cursiva com corações",
+    "Script Arrow Bio": "cursiva com setas",
+    "Bold Script Stars": "cursiva bold com estrelas",
+    "Script Vintage": "cursiva vintage",
+    "Script Soft Dots": "cursiva com pontinhos",
+    "Bold Script Ribbon": "cursiva bold com fita",
+    "Script Underline": "cursiva sublinhada",
+    "Bold Script Crown": "cursiva bold com coroa"
+  },
+  "signatures": {
+    "Classic Signature": "assinatura clássica",
+    "Bold Signature": "assinatura bold",
+    "Signed Underline": "assinatura sublinhada",
+    "Sparkle Signature": "assinatura com brilho",
+    "Ornate Nameplate": "placa ornamentada",
+    "Autograph Star": "autógrafo com estrela",
+    "Monogram Initials": "iniciais de monograma",
+    "Gothic Signature": "assinatura gótica"
+  },
+  "decorators": {
+    "None": "Nenhum",
+    "Underline": "Sublinhado",
+    "Sparkle": "Brilho",
+    "Hearts": "Corações",
+    "Ornate": "Ornamentado",
+    "Soft dots": "Pontinhos"
+  },
+  "accents": {
+    "Sparkle": "Brilho",
+    "Hearts": "Corações",
+    "Wings": "Asas",
+    "Ornate": "Ornamentado"
+  },
+  "platformLimits": {
+    "Instagram bio": "bio do Instagram",
+    "TikTok bio": "bio do TikTok",
+    "X bio": "bio do X"
+  }
+};
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/js/cursive/cursiveData.js" defer></script>
+  <script src="/script.js" defer></script>
+  <script src="/js/cursive/cursivePageController.js" defer></script>
+  <script src="/footer.js" defer></script>
 </body></html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -213,7 +213,7 @@
 
   <url>
     <loc>https://ultratextgen.com/category/aesthetic-fonts/</loc>
-    <lastmod>2026-07-06</lastmod>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -255,7 +255,7 @@
 
   <url>
     <loc>https://ultratextgen.com/category/cursive-fonts/</loc>
-    <lastmod>2026-07-06</lastmod>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -332,14 +332,28 @@
 
   <url>
     <loc>https://ultratextgen.com/de/</loc>
-    <lastmod>2026-07-06</lastmod>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
+    <loc>https://ultratextgen.com/de/schreibschrift/</loc>
+    <lastmod>2026-07-07</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
     <loc>https://ultratextgen.com/de/unsichtbares-zeichen/</loc>
     <lastmod>2026-07-03</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/de/usecase/tattoo-schrift/</loc>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -374,7 +388,7 @@
 
   <url>
     <loc>https://ultratextgen.com/es/</loc>
-    <lastmod>2026-07-06</lastmod>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -409,7 +423,7 @@
 
   <url>
     <loc>https://ultratextgen.com/es/letras-aesthetic/</loc>
-    <lastmod>2026-07-04</lastmod>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -464,6 +478,13 @@
   </url>
 
   <url>
+    <loc>https://ultratextgen.com/es/usecase/letras-para-tatuajes/</loc>
+    <lastmod>2026-07-07</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
     <loc>https://ultratextgen.com/es/usecase/nombre-de-usuario/</loc>
     <lastmod>2026-07-06</lastmod>
     <changefreq>monthly</changefreq>
@@ -500,28 +521,63 @@
 
   <url>
     <loc>https://ultratextgen.com/facebook/</loc>
-    <lastmod>2026-07-02</lastmod>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/fr/</loc>
-    <lastmod>2026-07-06</lastmod>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
+    <loc>https://ultratextgen.com/fr/belle-ecriture/</loc>
+    <lastmod>2026-07-07</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/fr/calligraphie/</loc>
+    <lastmod>2026-07-07</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/fr/changeur-de-police/</loc>
+    <lastmod>2026-07-07</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/fr/ecriture-aesthetic/</loc>
+    <lastmod>2026-07-07</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
     <loc>https://ultratextgen.com/fr/ecriture-cursive/</loc>
-    <lastmod>2026-07-06</lastmod>
+    <lastmod>2026-07-07</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/fr/ecriture-facebook/</loc>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/fr/ecriture-gothique/</loc>
-    <lastmod>2026-07-02</lastmod>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -536,6 +592,20 @@
   <url>
     <loc>https://ultratextgen.com/fr/ecriture-speciale/</loc>
     <lastmod>2026-07-02</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/fr/ecriture-style/</loc>
+    <lastmod>2026-07-07</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/fr/generateur-de-texte/</loc>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -556,7 +626,7 @@
 
   <url>
     <loc>https://ultratextgen.com/fr/police-d-ecriture/</loc>
-    <lastmod>2026-07-02</lastmod>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -564,6 +634,13 @@
   <url>
     <loc>https://ultratextgen.com/fr/police-instagram/</loc>
     <lastmod>2026-07-04</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/fr/police-linkedin/</loc>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -577,7 +654,7 @@
 
   <url>
     <loc>https://ultratextgen.com/fr/texte-en-gras/</loc>
-    <lastmod>2026-07-03</lastmod>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -585,6 +662,13 @@
   <url>
     <loc>https://ultratextgen.com/fr/texte-invisible/</loc>
     <lastmod>2026-07-03</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/fr/usecase/ecriture-tatouage/</loc>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -780,7 +864,7 @@
 
   <url>
     <loc>https://ultratextgen.com/id/</loc>
-    <lastmod>2026-07-06</lastmod>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -919,6 +1003,13 @@
   </url>
 
   <url>
+    <loc>https://ultratextgen.com/id/usecase/font-tato/</loc>
+    <lastmod>2026-07-07</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
     <loc>https://ultratextgen.com/id/usecase/nama-ff-keren/</loc>
     <lastmod>2026-07-06</lastmod>
     <changefreq>monthly</changefreq>
@@ -997,14 +1088,28 @@
 
   <url>
     <loc>https://ultratextgen.com/it/</loc>
-    <lastmod>2026-07-06</lastmod>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
+    <loc>https://ultratextgen.com/it/lettere-in-corsivo/</loc>
+    <lastmod>2026-07-07</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
     <loc>https://ultratextgen.com/it/testo-invisibile/</loc>
     <lastmod>2026-07-03</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/it/usecase/font-tatuaggi/</loc>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -2817,14 +2922,14 @@
 
   <url>
     <loc>https://ultratextgen.com/linkedin/</loc>
-    <lastmod>2026-07-02</lastmod>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/nl/</loc>
-    <lastmod>2026-07-06</lastmod>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -2838,7 +2943,7 @@
 
   <url>
     <loc>https://ultratextgen.com/nl/facebook-lettertype/</loc>
-    <lastmod>2026-07-02</lastmod>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -2881,6 +2986,13 @@
   <url>
     <loc>https://ultratextgen.com/nl/sierlijke-letters/</loc>
     <lastmod>2026-07-06</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/nl/usecase/tattoo-letters/</loc>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -2929,7 +3041,7 @@
 
   <url>
     <loc>https://ultratextgen.com/pl/</loc>
-    <lastmod>2026-07-06</lastmod>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -2937,6 +3049,13 @@
   <url>
     <loc>https://ultratextgen.com/pl/niewidzialny-znak/</loc>
     <lastmod>2026-07-03</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/pl/usecase/czcionki-tatuaze/</loc>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -2964,7 +3083,7 @@
 
   <url>
     <loc>https://ultratextgen.com/pt/</loc>
-    <lastmod>2026-07-06</lastmod>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -2985,7 +3104,7 @@
 
   <url>
     <loc>https://ultratextgen.com/pt/letras-aesthetic/</loc>
-    <lastmod>2026-07-02</lastmod>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -3014,6 +3133,13 @@
   <url>
     <loc>https://ultratextgen.com/pt/texto-invisivel/</loc>
     <lastmod>2026-07-03</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/pt/usecase/letras-para-tatuagem/</loc>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -3118,7 +3244,7 @@
 
   <url>
     <loc>https://ultratextgen.com/tr/</loc>
-    <lastmod>2026-07-06</lastmod>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -3187,6 +3313,13 @@
   </url>
 
   <url>
+    <loc>https://ultratextgen.com/tr/usecase/dovme-yazi-fontlari/</loc>
+    <lastmod>2026-07-07</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
     <loc>https://ultratextgen.com/tr/usecase/pubg-nick/</loc>
     <lastmod>2026-07-02</lastmod>
     <changefreq>monthly</changefreq>
@@ -3216,7 +3349,7 @@
 
   <url>
     <loc>https://ultratextgen.com/usecase/</loc>
-    <lastmod>2026-07-03</lastmod>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -3280,6 +3413,13 @@
   <url>
     <loc>https://ultratextgen.com/usecase/nickname-generator/</loc>
     <lastmod>2026-07-06</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/usecase/tattoo-fonts/</loc>
+    <lastmod>2026-07-07</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>

--- a/tr/el-yazisi-fontu/index.html
+++ b/tr/el-yazisi-fontu/index.html
@@ -6,27 +6,30 @@
   'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
   })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
   <!-- End Google Tag Manager -->
-  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZGVh");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
   <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>El Yazısı Fontu — Kopyala Yapıştır El Yazısı Alfabesi (𝒶𝒷𝒸) | UltraTextGen</title>
-  <meta name="description" content="El yazısı fontu kopyala yapıştır: A–Z el yazısı alfabesi, ince ve kalın el yazısı stilleri, italik yazı ve isme özel örnekler. Bio, durum ve nick için — ücretsiz, uygulamasız.">
+  <title>El Yazısı Fontu — 𝓴𝓸𝓹𝔂𝓪𝓵𝓪 𝔂𝓪𝓹𝓲𝓼𝓽𝓲𝓻 El Yazısı Alfabesi, A–Z Harfler ve İsimler | UltraTextGen</title>
+  <meta name="description" content="Ücretsiz el yazısı fontu çevirici — el yazısı kopyala yapıştır, A–Z el yazısı alfabesi, tüm el yazısı karakterleri, popüler kelimeler ve isme özel el yazısı imza örnekleri.">
   <link rel="canonical" href="https://ultratextgen.com/tr/el-yazisi-fontu/">
 
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/category/cursive-fonts/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/letra-cursiva/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/letra-cursiva/">
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/ecriture-cursive/">
-  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/tulisan-sambung/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/schreibschrift/">
+  <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/lettere-in-corsivo/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/el-yazisi-fontu/">
-  <link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/sierlijke-letters/">
+  <link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/cursieve-letters/">
+  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/tulisan-sambung/">
   <link rel="alternate" hreflang="no" href="https://ultratextgen.com/no/kursiv-tekst/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/category/cursive-fonts/">
 
   <meta name="robots" content="index, follow">
   <meta property="og:site_name" content="UltraTextGen">
-  <meta property="og:title" content="El Yazısı Fontu — Kopyala Yapıştır El Yazısı Alfabesi (𝒶𝒷𝒸)">
-  <meta property="og:description" content="A–Z el yazısı alfabesi, ince ve kalın el yazısı stilleri, italik yazı ve hazır isim örnekleri. Kopyala, bio'ya, duruma, nicke yapıştır.">
+  <meta property="og:title" content="El Yazısı Fontu — 𝓴𝓸𝓹𝔂𝓪𝓵𝓪 𝔂𝓪𝓹𝓲𝓼𝓽𝓲𝓻 El Yazısı Alfabesi, A–Z Harfler ve İsimler | UltraTextGen">
+  <meta property="og:description" content="Ücretsiz el yazısı fontu çevirici — el yazısı kopyala yapıştır, A–Z el yazısı alfabesi, tüm el yazısı karakterleri ve isme özel imza örnekleri.">
   <meta property="og:url" content="https://ultratextgen.com/tr/el-yazisi-fontu/">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://ultratextgen.com/assets/og/tr-el-yazisi-fontu.png">
@@ -34,27 +37,13 @@
   <meta property="og:image:height" content="630">
   <meta property="og:image:type" content="image/png">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="El Yazısı Fontu — Kopyala Yapıştır El Yazısı Alfabesi (𝒶𝒷𝒸)">
-  <meta name="twitter:description" content="El yazısı alfabesi ve hazır isimler — kopyala yapıştır, tarayıcıda, ücretsiz.">
+  <meta name="twitter:title" content="El Yazısı Fontu — 𝓴𝓸𝓹𝔂𝓪𝓵𝓪 𝔂𝓪𝓹𝓲𝓼𝓽𝓲𝓻 El Yazısı Alfabesi, A–Z Harfler ve İsimler | UltraTextGen">
+  <meta name="twitter:description" content="Ücretsiz el yazısı fontu çevirici — el yazısı kopyala yapıştır, A–Z el yazısı alfabesi ve isme özel örnekler. Tarayıcıda, ücretsiz.">
   <meta name="twitter:image" content="https://ultratextgen.com/assets/og/tr-el-yazisi-fontu.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/style.css">
-  <link rel="stylesheet" href="/symbol-explorer.css">
-
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "WebApplication",
-  "name": "El Yazısı Fontu Oluşturucu",
-  "alternateName": ["El Yazısı Fontu", "El Yazısı Kopyala Yapıştır", "El Yazısı Stilleri", "İtalik Yazı", "Güzel Yazı Stilleri"],
-  "url": "https://ultratextgen.com/tr/el-yazisi-fontu/",
-  "inLanguage": "tr",
-  "applicationCategory": "UtilitiesApplication",
-  "operatingSystem": "Any",
-  "description": "El yazısı fontu oluşturucu: A–Z el yazısı alfabesi, ince ve kalın el yazısı, italik yazı ve isme özel örnekler — bio, durum, davetiye ve dövme önizlemesi için kopyala yapıştır.",
-  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "TRY" }
-}
-</script>
 
 <script type="application/ld+json">
 {
@@ -64,28 +53,67 @@
   "mainEntity": [
     {
       "@type": "Question",
-      "name": "El yazısı fontu nasıl kopyalanır?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Yukarıdaki kutuya metnini yaz — tüm el yazısı versiyonları anında görünür. Beğendiğin stilin yanındaki Kopyala butonuna dokun ve istediğin yere yapıştır: bio, durum, açıklama, davetiye. Sayfadaki alfabe tablosundan tek harf de kopyalayabilirsin — mesela ismin baş harfini." }
+      "name": "El yazısı fontu çevirici nedir ve nasıl çalışır?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yazdığın harfleri Unicode el yazısı karakterlerine dönüştürür — el yazısı gibi görünen ama normal metin gibi davranan özel sembollere. Bunlar gerçek karakter olduğu için (font ya da görsel değil) kopyalayıp biolara, açıklamalara, yorumlara ve mesajlara yapıştırabilirsin; el yazısı görünümünü korurlar. Ayrıntı için <a href=\"/guide/how-unicode-fonts-work/\">Unicode fontlar nasıl çalışır</a> rehberimize bak."
+      }
     },
     {
       "@type": "Question",
-      "name": "El yazısı fontu Instagram ve WhatsApp'ta çalışır mı?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Çalışır. Her harf gerçek bir Unicode karakteri olduğu için el yazısı Instagram bio'suna ve açıklamalara, WhatsApp durumuna ve mesajlara, TikTok'a, Discord'a ve metin kabul eden hemen her alana yapışır. Yalnızca kullanıcı adı (@) alanları genelde kabul etmez — orada düz yazı kullan." }
+      "name": "El yazısını nasıl kopyalayıp yapıştırırım?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Metnini üstteki kutuya yaz ya da yapıştır, sonra beğendiğin stildeki Kopyala'ya dokun. El yazısı sürüm artık panonda — metin kabul eden her yere yapıştır: Instagram, TikTok, WhatsApp, Discord, belgeler ve daha fazlası. Buna kısaca <strong>el yazısı kopyala</strong> denir."
+      }
     },
     {
       "@type": "Question",
-      "name": "Dövme için el yazısı örneği olarak kullanılır mı?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Referans olarak kullanılır. Kelimeyi ya da ismi yaz, ince ve kalın el yazısını dene, sonucu dövme sanatçına taslak olarak göster. Son çizgiyi sanatçı belirler ama el yazısı önizlemesi, iğneden önce stile karar vermeni kolaylaştırır." }
+      "name": "Instagram, WhatsApp ve TikTok'ta çalışıyor mu?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Evet. El yazısı karakterleri Instagram biolarında ve açıklamalarında, WhatsApp durum ve mesajlarında, TikTok açıklamalarında çalışır. İpucu: kullanıcı adı alanları özel karakterleri bazen temizler, o yüzden el yazısını <strong>bio, durum ve açıklama</strong> metinlerinde kullan."
+      }
     },
     {
       "@type": "Question",
-      "name": "El yazısı ile italik yazı arasındaki fark ne?",
-      "acceptedAnswer": { "@type": "Answer", "text": "İtalik, harflerin sağa yatık halidir (𝘪𝘵𝘢𝘭𝘪𝘬); el yazısı ise harflerin birbirine bağlanıp aktığı süslü stildir (𝓮𝓵 𝔂𝓪𝔃𝓲𝓼𝓲). İkisi de Unicode'dur ve ikisi de bu sayfadaki üreticide var — sade vurgu için italik, zarif ve romantik görünüm için el yazısı seç." }
+      "name": "Türkçe karakterler (ş, ı, ğ, ç, ö, ü) neden el yazısına dönüşmüyor?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Unicode el yazısı harfleri yalnızca A–Z, a–z ve 0–9 için tanımlıdır. ş, ı, ğ, ç, ö, ü ve İ gibi harflerin el yazısı karşılığı yoktur, bu yüzden değişmeden kalırlar. En akıcı görünüm için bu harfleri sadeleştir: <strong>ı→i, İ→I, ş→s, ğ→g, ç→c, ö→o, ü→u</strong>. Örneğin “Şeyma” yerine “Seyma”, “Gökçe” yerine “Gokce” yaz. İsim örneklerimizde etiketler doğru yazımı gösterir, el yazısına yalnızca sadeleştirilmiş biçim dönüşür."
+      }
     },
     {
       "@type": "Question",
-      "name": "Türkçe karakterlerle (ş, ğ, ü) çalışıyor mu?",
-      "acceptedAnswer": { "@type": "Answer", "text": "Kısmen. Unicode'da el yazısı seti yalnızca temel Latin harflerini kapsar; ş, ı, ğ, ö, ü ve ç kelimenin ortasında düz kalır. İsmin tamamen el yazısı görünmesi için Türkçe karakterleri sadeleştir: Gül yerine Gul → 𝒢𝓊𝓁. Yazım eksilir ama görünüm tutarlı olur — bio ve nick için idealdir." }
+      "name": "El yazısı isimler ve imzalar oluşturabilir miyim?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Evet. İsim stüdyosuna bir ad yaz, bir süsleme ve monogram baş harfi birleşimi seç, sonra metni kopyala ya da e-posta imzası ve filigran için PNG olarak indir. Türkçe harf içeren isimlerde daha akıcı bir sonuç için harfleri sadeleştirmeyi dene."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "El yazısı fontu ücretsiz mi ve üyelik gerekiyor mu?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Tamamen ücretsiz ve üyeliksiz. Her şey tarayıcında çalışır — kayıt yok, indirme yok, sınır yok. İstediğin kadar kelime, isim ve alfabe kopyala."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "El yazısı alfabesinin tamamını kopyalayabilir miyim?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Evet. Alfabe bölümünde büyük harf, küçük harf ve rakamların tamamını tek tıkla kopyala ya da üzerinden geçmek için yazdırılabilir bir çalışma sayfası al. Bu, el yazısı karakterlerini bir arada görmenin en hızlı yolu."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Rakamlar (0–9) el yazısıyla yazılabilir mi?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Unicode'da gerçek el yazısı rakam yoktur, bu yüzden her stil el yazısı harfleri uyumlu şık rakamlarla eşleştirir. Böylece tarihler ve yıllar el yazısı metninle görsel olarak uyumlu kalır."
+      }
     }
   ]
 }
@@ -101,12 +129,36 @@
   ]
 }
 </script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "El Yazısı Fontu Çevirici",
+  "alternateName": ["El Yazısı Fontu","El Yazısı Çevirici","El Yazısı Alfabesi","El Yazısı Karakterleri A–Z","El Yazısı Kopyala Yapıştır","El Yazısı İsim Oluşturucu","El Yazısı İmza Oluşturucu"],
+  "url": "https://ultratextgen.com/tr/el-yazisi-fontu/",
+  "inLanguage": "tr",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "TRY"
+  },
+  "description": "Ücretsiz el yazısı fontu çevirici: el yazısı kopyala yapıştır, A–Z el yazısı alfabesi, tüm el yazısı karakterleri, popüler kelimeler ve isme özel el yazısı imza örnekleri.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers.",
+  "featureList": ["Süsleme ön ayarlarıyla el yazısı fontu oluşturucu","A–Z el yazısı karakterleri gezgini (büyük ve küçük harf)","Tüm el yazısı alfabesini tek tıkla kopyalama","Yazdırılabilir el yazısı çalışma sayfası","El yazısı isim ve imza stüdyosu","El yazısı kelime galerisi (aşk, doğum günü, aylar)"]
+}
+</script>
 </head>
 <body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
   <!-- Google Tag Manager (noscript) -->
-  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <!-- End Google Tag Manager (noscript) -->
-<script src="/header.js"></script>
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
 
 <nav class="breadcrumbs" aria-label="Breadcrumb">
   <a href="/tr/">Ana Sayfa</a>
@@ -115,217 +167,684 @@
 </nav>
 
 <figure class="page-hero-figure" data-uthero aria-hidden="true">
-  <img src="/assets/hero/tr-el-yazisi-fontu.svg" width="1200" height="340" loading="lazy" alt="">
+  <img src="/assets/hero/tr-el-yazisi-fontu.svg" width="1200" height="340"
+       loading="lazy" alt="">
 </figure>
 
-<section class="hero">
-  <div class="hero-inner">
-    <div class="hero-card">
-      <h1 class="hero-headline">El yazısı fontu — kopyala yapıştır</h1>
-      <p class="hero-tagline">Herhangi bir kelimeyi yaz, anında el yazısına dönsün — zarif ince el yazısı, kalın el yazısı ve italik stiller; bio'ya, duruma, davetiyeye yapıştırmaya ya da dövmecine referans göstermeye hazır.</p>
-      <div class="input-wrapper">
-        <textarea class="main-input" id="mainInput" placeholder="Metnini buraya yaz..." maxlength="500" autofocus=""></textarea>
-        <span class="char-count"><span id="charCount">0</span>/500</span>
-      </div>
-      <div class="decoration-section">
-        <div class="decoration-label">Sonuca süsleme ekle</div>
-        <div class="decoration-tabs">
-          <button class="decoration-tab active" data-deco-tab="symbols">Semboller</button>
-          <button class="decoration-tab" data-deco-tab="frames">Çerçeveler</button>
-          <button class="decoration-tab" data-deco-tab="minimal">Minimal</button>
+  <!-- Hero: the cursive-first generator -->
+  <section class="hero">
+    <div class="hero-inner">
+      <div class="hero-card">
+        <h1 class="hero-headline">El Yazısı Fontu Çevirici</h1>
+        <p class="hero-tagline">Yazdığın her metni kopyala-yapıştır yapabileceğin 𝓮𝓵 𝔂𝓪𝔃𝓲𝓼𝓲 haline getir — akıcı el yazısı stilleri,
+          A–Z tüm el yazısı karakterleri, eksiksiz alfabe ve isme özel imzalar. Ücretsiz, anında, üyeliksiz.</p>
+        <div class="input-wrapper">
+          <textarea class="main-input" id="mainInput" placeholder="Metnini, kelimeni ya da ismini yaz…" maxlength="500" autofocus></textarea>
+          <span class="char-count"><span id="charCount">0</span>/500</span>
         </div>
-        <div class="decoration-grid" id="decorationGrid"></div>
+        <div class="cursive-quick-row" id="cursiveQuickRow" aria-label="Hızlı örnekler"></div>
+        <div class="vertical-fit-row" id="cursiveFitRow" hidden></div>
       </div>
     </div>
+  </section>
+
+  <nav class="cursive-section-nav" aria-label="Bu sayfada">
+    <a href="#cursive-styles">Stiller</a>
+    <a href="#cursive-letters">A–Z Harfler</a>
+    <a href="#cursive-alphabet">Alfabe</a>
+    <a href="#cursive-words">Kelimeler</a>
+    <a href="#cursive-names">İsimler ve İmzalar</a>
+    <a href="#cursive-faq">SSS</a>
+  </nav>
+
+  <main class="container">
+
+    <!-- 1. Generator output -->
+    <section id="cursive-styles" aria-labelledby="cursiveStylesHeading">
+      <h2 class="bubble-az-heading" id="cursiveStylesHeading">El yazısı fontu — kopyala yapıştır</h2>
+      <p class="bubble-az-intro">Aşağıdaki her stil yazdıkça anında güncellenir: klasik ve kalın el yazısı, zarif aralıklı
+        varyantlar, gotik el yazısı, Chicano isimlik stilleri ve kalpler, parıltılar ve oklarla süslenmiş ön ayarlar.
+        Kopyala'ya dokun ve istediğin yere yapıştır.</p>
+      <div class="results-grid" id="resultsGrid"></div>
+    </section>
+
+    <!-- 2. Cursive letters A–Z -->
+    <section class="bubble-az" id="cursive-letters" aria-labelledby="cursiveLettersHeading">
+      <h2 class="bubble-az-heading" id="cursiveLettersHeading">El yazısı karakterleri A–Z — büyük ve küçük harf</h2>
+      <p class="bubble-az-intro">Tek bir harf mi arıyorsun — el yazısı bir S, el yazısı büyük G, küçük bir f?
+        Herhangi bir harfe dokunarak onu her el yazısı stilinde gör, tam karakteri kopyala ya da PNG olarak indir.</p>
+  <div class="cursive-letter-grid" role="tablist" aria-label="Bir el yazısı harfi seç">
+    <button type="button" class="cursive-letter-cell" id="cursive-a" data-char="A" aria-label="El yazısı A — büyük ve küçük harf">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒜 𝒶</span>
+      <span class="cursive-letter-name">El yazısı A</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-b" data-char="B" aria-label="El yazısı B — büyük ve küçük harf">
+      <span class="cursive-letter-pair" aria-hidden="true">ℬ 𝒷</span>
+      <span class="cursive-letter-name">El yazısı B</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-c" data-char="C" aria-label="El yazısı C — büyük ve küçük harf">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒞 𝒸</span>
+      <span class="cursive-letter-name">El yazısı C</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-d" data-char="D" aria-label="El yazısı D — büyük ve küçük harf">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒟 𝒹</span>
+      <span class="cursive-letter-name">El yazısı D</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-e" data-char="E" aria-label="El yazısı E — büyük ve küçük harf">
+      <span class="cursive-letter-pair" aria-hidden="true">ℰ ℯ</span>
+      <span class="cursive-letter-name">El yazısı E</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-f" data-char="F" aria-label="El yazısı F — büyük ve küçük harf">
+      <span class="cursive-letter-pair" aria-hidden="true">ℱ 𝒻</span>
+      <span class="cursive-letter-name">El yazısı F</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-g" data-char="G" aria-label="El yazısı G — büyük ve küçük harf">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒢 ℊ</span>
+      <span class="cursive-letter-name">El yazısı G</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-h" data-char="H" aria-label="El yazısı H — büyük ve küçük harf">
+      <span class="cursive-letter-pair" aria-hidden="true">ℋ 𝒽</span>
+      <span class="cursive-letter-name">El yazısı H</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-i" data-char="I" aria-label="El yazısı I — büyük ve küçük harf">
+      <span class="cursive-letter-pair" aria-hidden="true">ℐ 𝒾</span>
+      <span class="cursive-letter-name">El yazısı I</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-j" data-char="J" aria-label="El yazısı J — büyük ve küçük harf">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒥 𝒿</span>
+      <span class="cursive-letter-name">El yazısı J</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-k" data-char="K" aria-label="El yazısı K — büyük ve küçük harf">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒦 𝓀</span>
+      <span class="cursive-letter-name">El yazısı K</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-l" data-char="L" aria-label="El yazısı L — büyük ve küçük harf">
+      <span class="cursive-letter-pair" aria-hidden="true">ℒ 𝓁</span>
+      <span class="cursive-letter-name">El yazısı L</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-m" data-char="M" aria-label="El yazısı M — büyük ve küçük harf">
+      <span class="cursive-letter-pair" aria-hidden="true">ℳ 𝓂</span>
+      <span class="cursive-letter-name">El yazısı M</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-n" data-char="N" aria-label="El yazısı N — büyük ve küçük harf">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒩 𝓃</span>
+      <span class="cursive-letter-name">El yazısı N</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-o" data-char="O" aria-label="El yazısı O — büyük ve küçük harf">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒪 ℴ</span>
+      <span class="cursive-letter-name">El yazısı O</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-p" data-char="P" aria-label="El yazısı P — büyük ve küçük harf">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒫 𝓅</span>
+      <span class="cursive-letter-name">El yazısı P</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-q" data-char="Q" aria-label="El yazısı Q — büyük ve küçük harf">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒬 𝓆</span>
+      <span class="cursive-letter-name">El yazısı Q</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-r" data-char="R" aria-label="El yazısı R — büyük ve küçük harf">
+      <span class="cursive-letter-pair" aria-hidden="true">ℛ 𝓇</span>
+      <span class="cursive-letter-name">El yazısı R</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-s" data-char="S" aria-label="El yazısı S — büyük ve küçük harf">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒮 𝓈</span>
+      <span class="cursive-letter-name">El yazısı S</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-t" data-char="T" aria-label="El yazısı T — büyük ve küçük harf">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒯 𝓉</span>
+      <span class="cursive-letter-name">El yazısı T</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-u" data-char="U" aria-label="El yazısı U — büyük ve küçük harf">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒰 𝓊</span>
+      <span class="cursive-letter-name">El yazısı U</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-v" data-char="V" aria-label="El yazısı V — büyük ve küçük harf">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒱 𝓋</span>
+      <span class="cursive-letter-name">El yazısı V</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-w" data-char="W" aria-label="El yazısı W — büyük ve küçük harf">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒲 𝓌</span>
+      <span class="cursive-letter-name">El yazısı W</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-x" data-char="X" aria-label="El yazısı X — büyük ve küçük harf">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒳 𝓍</span>
+      <span class="cursive-letter-name">El yazısı X</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-y" data-char="Y" aria-label="El yazısı Y — büyük ve küçük harf">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒴 𝓎</span>
+      <span class="cursive-letter-name">El yazısı Y</span>
+    </button>
+    <button type="button" class="cursive-letter-cell" id="cursive-z" data-char="Z" aria-label="El yazısı Z — büyük ve küçük harf">
+      <span class="cursive-letter-pair" aria-hidden="true">𝒵 𝓏</span>
+      <span class="cursive-letter-name">El yazısı Z</span>
+    </button>
   </div>
-</section>
+      <div class="cursive-letter-panel" id="cursiveLetterPanel" aria-live="polite"></div>
+    </section>
 
-<main class="container">
-  <div class="category-section"><div class="category-tabs" id="categoryTabs"></div></div>
-  <div class="results-grid" id="resultsGrid"></div>
-
-  <!-- El yazısı Unicode -->
-  <section class="editorial-section">
-    <h2>Unicode el yazısı: istediğin yere kopyala yapıştır</h2>
-    <p class="editorial-intro">Buradaki <strong>el yazısı fontu</strong> yüklenen bir font ya da görsel değil — her harf, bağlantılı ve eğik çizimiyle gelen bir Unicode karakteri. Bu yüzden hangi metin alanına yapıştırırsan yapıştır çizimini korur: Instagram bio'su, açıklama, WhatsApp durumu, Discord'daki adın, dijital davetiye ve dövmecine götürdüğün o önizleme.</p>
-    <div class="block-example">
-      <strong>Örnek:</strong> «sevgi» → 𝓈𝑒𝓋𝑔𝒾 (ince el yazısı) veya 𝓼𝓮𝓿𝓰𝓲 (kalın el yazısı)
-    </div>
-    <p>Word'ün ya da Canva'nın el yazısı fontundan farkı şu: onlar editörün dışına yapıştırınca kaybolur, buradaki stil metinle birlikte taşınır. El yazısı dışındaki stillerle karşılaştırmak istersen <a href="/tr/yazi-stilleri/">yazı stilleri</a> sayfasına bak ya da <a href="/tr/">tam üreticiye</a> dön.</p>
-  </section>
-
-  <!-- Alfabe -->
-  <section class="editorial-section glyph-section">
-    <h2>El yazısı alfabesi (A–Z) — komple kopyala</h2>
-    <p class="editorial-intro">En çok kullanılan iki stilde tam <strong>el yazısı alfabesi</strong>: büyük harfler, küçük harfler ve kalın versiyon. Bir satıra dokun, o stilin alfabesi komple kopyalansın.</p>
-    <div class="alpha-list">
-      <div class="alpha-row">
-        <span class="alpha-label">Büyük el yazısı</span>
-        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵" aria-label="Büyük el yazısı alfabesini A'dan Z'ye kopyala">𝒜 ℬ 𝒞 𝒟 ℰ ℱ 𝒢 ℋ ℐ 𝒥 𝒦 ℒ ℳ 𝒩 𝒪 𝒫 𝒬 ℛ 𝒮 𝒯 𝒰 𝒱 𝒲 𝒳 𝒴 𝒵</button>
+    <!-- 3. The cursive alphabet -->
+    <section id="cursive-alphabet" aria-labelledby="cursiveAlphabetHeading">
+      <div class="cursive-chart-toolbar">
+        <h2 class="bubble-az-heading" id="cursiveAlphabetHeading">El yazısı alfabesi (A–Z, 0–9)</h2>
+        <button type="button" class="bubble-btn bubble-btn-primary" id="cursivePrintSheet">Çalışma sayfasını yazdır</button>
       </div>
-      <div class="alpha-row">
-        <span class="alpha-label">Küçük el yazısı</span>
-        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏" aria-label="Küçük el yazısı alfabesini a'dan z'ye kopyala">𝒶 𝒷 𝒸 𝒹 ℯ 𝒻 ℊ 𝒽 𝒾 𝒿 𝓀 𝓁 𝓂 𝓃 ℴ 𝓅 𝓆 𝓇 𝓈 𝓉 𝓊 𝓋 𝓌 𝓍 𝓎 𝓏</button>
+      <p class="bubble-az-intro">Tüm el yazısı alfabesini tek tıkla kopyala — büyük harf, küçük harf ve rakamlar —
+        ya da model harfler ve üzerinden geçmek için boşluk içeren bir çalışma sayfası yazdır. Unicode'da gerçek el yazısı
+        rakam yoktur, bu yüzden her stil el yazısı harflerini uyumlu şık rakamlarla eşleştirir.</p>
+    <div class="cursive-chart">
+      <div class="cursive-chart-head">
+        <h3>Klasik el yazısı alfabesi (Ultra Script)</h3>
+        <button type="button" class="copy-btn" data-text="𝒜 ℬ 𝒞 𝒟 ℰ ℱ 𝒢 ℋ ℐ 𝒥 𝒦 ℒ ℳ 𝒩 𝒪 𝒫 𝒬 ℛ 𝒮 𝒯 𝒰 𝒱 𝒲 𝒳 𝒴 𝒵&#10;𝒶 𝒷 𝒸 𝒹 ℯ 𝒻 ℊ 𝒽 𝒾 𝒿 𝓀 𝓁 𝓂 𝓃 ℴ 𝓅 𝓆 𝓇 𝓈 𝓉 𝓊 𝓋 𝓌 𝓍 𝓎 𝓏&#10;𝟢 𝟣 𝟤 𝟥 𝟦 𝟧 𝟨 𝟩 𝟪 𝟫" data-style="Ultra Script">Alfabeyi kopyala</button>
       </div>
-      <div class="alpha-row">
-        <span class="alpha-label">Kalın el yazısı</span>
-        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩 𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃" aria-label="Kalın el yazısı alfabesini kopyala">𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩 · 𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃</button>
+      <p class="cursive-alphabet-row">𝒜 ℬ 𝒞 𝒟 ℰ ℱ 𝒢 ℋ ℐ 𝒥 𝒦 ℒ ℳ 𝒩 𝒪 𝒫 𝒬 ℛ 𝒮 𝒯 𝒰 𝒱 𝒲 𝒳 𝒴 𝒵</p>
+      <p class="cursive-alphabet-row">𝒶 𝒷 𝒸 𝒹 ℯ 𝒻 ℊ 𝒽 𝒾 𝒿 𝓀 𝓁 𝓂 𝓃 ℴ 𝓅 𝓆 𝓇 𝓈 𝓉 𝓊 𝓋 𝓌 𝓍 𝓎 𝓏</p>
+      <p class="cursive-alphabet-row">𝟢 𝟣 𝟤 𝟥 𝟦 𝟧 𝟨 𝟩 𝟪 𝟫</p>
+    </div>
+    <div class="cursive-chart">
+      <div class="cursive-chart-head">
+        <h3>Kalın el yazısı alfabesi (Ultra Script Bold)</h3>
+        <button type="button" class="copy-btn" data-text="𝓐 𝓑 𝓒 𝓓 𝓔 𝓕 𝓖 𝓗 𝓘 𝓙 𝓚 𝓛 𝓜 𝓝 𝓞 𝓟 𝓠 𝓡 𝓢 𝓣 𝓤 𝓥 𝓦 𝓧 𝓨 𝓩&#10;𝓪 𝓫 𝓬 𝓭 𝓮 𝓯 𝓰 𝓱 𝓲 𝓳 𝓴 𝓵 𝓶 𝓷 𝓸 𝓹 𝓺 𝓻 𝓼 𝓽 𝓾 𝓿 𝔀 𝔁 𝔂 𝔃&#10;𝟬 𝟭 𝟮 𝟯 𝟰 𝟱 𝟲 𝟳 𝟴 𝟵" data-style="Ultra Script Bold">Alfabeyi kopyala</button>
       </div>
-      <div class="alpha-row">
-        <span class="alpha-label">Uyumlu rakamlar</span>
-        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝟢𝟣𝟤𝟥𝟦𝟧𝟨𝟩𝟪𝟫" aria-label="El yazısıyla uyumlu rakamları kopyala">𝟢 𝟣 𝟤 𝟥 𝟦 𝟧 𝟨 𝟩 𝟪 𝟫</button>
+      <p class="cursive-alphabet-row">𝓐 𝓑 𝓒 𝓓 𝓔 𝓕 𝓖 𝓗 𝓘 𝓙 𝓚 𝓛 𝓜 𝓝 𝓞 𝓟 𝓠 𝓡 𝓢 𝓣 𝓤 𝓥 𝓦 𝓧 𝓨 𝓩</p>
+      <p class="cursive-alphabet-row">𝓪 𝓫 𝓬 𝓭 𝓮 𝓯 𝓰 𝓱 𝓲 𝓳 𝓴 𝓵 𝓶 𝓷 𝓸 𝓹 𝓺 𝓻 𝓼 𝓽 𝓾 𝓿 𝔀 𝔁 𝔂 𝔃</p>
+      <p class="cursive-alphabet-row">𝟬 𝟭 𝟮 𝟯 𝟰 𝟱 𝟲 𝟳 𝟴 𝟵</p>
+    </div>
+    <div class="cursive-chart">
+      <div class="cursive-chart-head">
+        <h3>Gotik el yazısı alfabesi (Ultra Gothic Script)</h3>
+        <button type="button" class="copy-btn" data-text="𝕬 𝕭 𝕮 𝕯 𝕰 𝕱 𝕲 𝕳 𝕴 𝕵 𝕶 𝕷 𝕸 𝕹 𝕺 𝕻 𝕼 𝕽 𝕾 𝕿 𝖀 𝖁 𝖂 𝖃 𝖄 𝖅&#10;𝖆 𝖇 𝖈 𝖉 𝖊 𝖋 𝖌 𝖍 𝖎 𝖏 𝖐 𝖑 𝖒 𝖓 𝖔 𝖕 𝖖 𝖗 𝖘 𝖙 𝖚 𝖛 𝖜 𝖝 𝖞 𝖟" data-style="Ultra Gothic Script">Alfabeyi kopyala</button>
+      </div>
+      <p class="cursive-alphabet-row">𝕬 𝕭 𝕮 𝕯 𝕰 𝕱 𝕲 𝕳 𝕴 𝕵 𝕶 𝕷 𝕸 𝕹 𝕺 𝕻 𝕼 𝕽 𝕾 𝕿 𝖀 𝖁 𝖂 𝖃 𝖄 𝖅</p>
+      <p class="cursive-alphabet-row">𝖆 𝖇 𝖈 𝖉 𝖊 𝖋 𝖌 𝖍 𝖎 𝖏 𝖐 𝖑 𝖒 𝖓 𝖔 𝖕 𝖖 𝖗 𝖘 𝖙 𝖚 𝖛 𝖜 𝖝 𝖞 𝖟</p>
+    </div>
+    </section>
+
+    <!-- 4. Words in cursive -->
+    <section id="cursive-words" aria-labelledby="cursiveWordsHeading">
+      <h2 class="bubble-az-heading" id="cursiveWordsHeading">El yazısı kelimeler — kopyalamaya hazır</h2>
+      <p class="bubble-az-intro">En çok istenen kelimeler, el yazısıyla hazır. Başka bir şey mi lazım?
+        <a href="#mainInput">Yukarıdaki çeviriciye</a> yaz, her stil onu anında el yazısına dönüştürsün.</p>
+    <h3>Aşk ve aile</h3>
+    <div class="cursive-word-grid">
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒶𝓈𝓀</span>
+        <span class="cursive-word-label">aşk el yazısı</span>
+        <button type="button" class="copy-btn" data-text="𝒶𝓈𝓀" data-style="Ultra Script">Kopyala</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓪𝓼𝓴</span>
+        <span class="cursive-word-label">aşk (kalın) el yazısı</span>
+        <button type="button" class="copy-btn" data-text="𝓪𝓼𝓴" data-style="Ultra Script Bold">Kopyala</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓈ℯ𝓃𝒾 𝓈ℯ𝓋𝒾𝓎ℴ𝓇𝓊𝓂</span>
+        <span class="cursive-word-label">seni seviyorum el yazısı</span>
+        <button type="button" class="copy-btn" data-text="𝓈ℯ𝓃𝒾 𝓈ℯ𝓋𝒾𝓎ℴ𝓇𝓊𝓂" data-style="Ultra Script">Kopyala</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒶𝓃𝓃ℯ</span>
+        <span class="cursive-word-label">anne el yazısı</span>
+        <button type="button" class="copy-btn" data-text="𝒶𝓃𝓃ℯ" data-style="Ultra Script">Kopyala</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒷𝒶𝒷𝒶</span>
+        <span class="cursive-word-label">baba el yazısı</span>
+        <button type="button" class="copy-btn" data-text="𝒷𝒶𝒷𝒶" data-style="Ultra Script">Kopyala</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒶𝒾𝓁ℯ</span>
+        <span class="cursive-word-label">aile el yazısı</span>
+        <button type="button" class="copy-btn" data-text="𝒶𝒾𝓁ℯ" data-style="Ultra Script">Kopyala</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓈ℴ𝓃𝓈𝓊𝓏𝒶 𝒹ℯ𝓀</span>
+        <span class="cursive-word-label">sonsuza dek el yazısı</span>
+        <button type="button" class="copy-btn" data-text="𝓈ℴ𝓃𝓈𝓊𝓏𝒶 𝒹ℯ𝓀" data-style="Ultra Script">Kopyala</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓈ℯ𝓋ℊ𝒾</span>
+        <span class="cursive-word-label">sevgi el yazısı</span>
+        <button type="button" class="copy-btn" data-text="𝓈ℯ𝓋ℊ𝒾" data-style="Ultra Script">Kopyala</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓊𝓂𝓊𝓉</span>
+        <span class="cursive-word-label">umut el yazısı</span>
+        <button type="button" class="copy-btn" data-text="𝓊𝓂𝓊𝓉" data-style="Ultra Script">Kopyala</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓂ℯ𝓁ℯ𝓀</span>
+        <span class="cursive-word-label">melek el yazısı</span>
+        <button type="button" class="copy-btn" data-text="𝓂ℯ𝓁ℯ𝓀" data-style="Ultra Script">Kopyala</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒸𝒶𝓃𝒾𝓂</span>
+        <span class="cursive-word-label">canım el yazısı</span>
+        <button type="button" class="copy-btn" data-text="𝒸𝒶𝓃𝒾𝓂" data-style="Ultra Script">Kopyala</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒽𝓊𝓏𝓊𝓇</span>
+        <span class="cursive-word-label">huzur el yazısı</span>
+        <button type="button" class="copy-btn" data-text="𝒽𝓊𝓏𝓊𝓇" data-style="Ultra Script">Kopyala</button>
       </div>
     </div>
-    <p class="u-mt-15">Unicode'da gerçek el yazısı rakamı yok; bu ince numaralar harflerin çizgisiyle en iyi uyuşan set.</p>
-
-    <div class="glyph-group">
-      <h3>Tek tek el yazısı harfler — küçük (a–z)</h3>
-      <div class="glyph-grid">
-        <button class="glyph-copy" type="button" data-text="𝒶" aria-label="El yazısı a harfini kopyala">𝒶</button>
-        <button class="glyph-copy" type="button" data-text="𝒷" aria-label="El yazısı b harfini kopyala">𝒷</button>
-        <button class="glyph-copy" type="button" data-text="𝒸" aria-label="El yazısı c harfini kopyala">𝒸</button>
-        <button class="glyph-copy" type="button" data-text="𝒹" aria-label="El yazısı d harfini kopyala">𝒹</button>
-        <button class="glyph-copy" type="button" data-text="ℯ" aria-label="El yazısı e harfini kopyala">ℯ</button>
-        <button class="glyph-copy" type="button" data-text="𝒻" aria-label="El yazısı f harfini kopyala">𝒻</button>
-        <button class="glyph-copy" type="button" data-text="ℊ" aria-label="El yazısı g harfini kopyala">ℊ</button>
-        <button class="glyph-copy" type="button" data-text="𝒽" aria-label="El yazısı h harfini kopyala">𝒽</button>
-        <button class="glyph-copy" type="button" data-text="𝒾" aria-label="El yazısı i harfini kopyala">𝒾</button>
-        <button class="glyph-copy" type="button" data-text="𝒿" aria-label="El yazısı j harfini kopyala">𝒿</button>
-        <button class="glyph-copy" type="button" data-text="𝓀" aria-label="El yazısı k harfini kopyala">𝓀</button>
-        <button class="glyph-copy" type="button" data-text="𝓁" aria-label="El yazısı l harfini kopyala">𝓁</button>
-        <button class="glyph-copy" type="button" data-text="𝓂" aria-label="El yazısı m harfini kopyala">𝓂</button>
-        <button class="glyph-copy" type="button" data-text="𝓃" aria-label="El yazısı n harfini kopyala">𝓃</button>
-        <button class="glyph-copy" type="button" data-text="ℴ" aria-label="El yazısı o harfini kopyala">ℴ</button>
-        <button class="glyph-copy" type="button" data-text="𝓅" aria-label="El yazısı p harfini kopyala">𝓅</button>
-        <button class="glyph-copy" type="button" data-text="𝓆" aria-label="El yazısı q harfini kopyala">𝓆</button>
-        <button class="glyph-copy" type="button" data-text="𝓇" aria-label="El yazısı r harfini kopyala">𝓇</button>
-        <button class="glyph-copy" type="button" data-text="𝓈" aria-label="El yazısı s harfini kopyala">𝓈</button>
-        <button class="glyph-copy" type="button" data-text="𝓉" aria-label="El yazısı t harfini kopyala">𝓉</button>
-        <button class="glyph-copy" type="button" data-text="𝓊" aria-label="El yazısı u harfini kopyala">𝓊</button>
-        <button class="glyph-copy" type="button" data-text="𝓋" aria-label="El yazısı v harfini kopyala">𝓋</button>
-        <button class="glyph-copy" type="button" data-text="𝓌" aria-label="El yazısı w harfini kopyala">𝓌</button>
-        <button class="glyph-copy" type="button" data-text="𝓍" aria-label="El yazısı x harfini kopyala">𝓍</button>
-        <button class="glyph-copy" type="button" data-text="𝓎" aria-label="El yazısı y harfini kopyala">𝓎</button>
-        <button class="glyph-copy" type="button" data-text="𝓏" aria-label="El yazısı z harfini kopyala">𝓏</button>
+    <h3>Kutlama ve özel günler</h3>
+    <div class="cursive-word-grid">
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒹ℴℊ𝓊𝓂 ℊ𝓊𝓃𝓊𝓃 𝓀𝓊𝓉𝓁𝓊 ℴ𝓁𝓈𝓊𝓃</span>
+        <span class="cursive-word-label">doğum günün kutlu olsun el yazısı</span>
+        <button type="button" class="copy-btn" data-text="𝒹ℴℊ𝓊𝓂 ℊ𝓊𝓃𝓊𝓃 𝓀𝓊𝓉𝓁𝓊 ℴ𝓁𝓈𝓊𝓃" data-style="Ultra Script">Kopyala</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓉ℯ𝓈ℯ𝓀𝓀𝓊𝓇𝓁ℯ𝓇</span>
+        <span class="cursive-word-label">teşekkürler el yazısı</span>
+        <button type="button" class="copy-btn" data-text="𝓉ℯ𝓈ℯ𝓀𝓀𝓊𝓇𝓁ℯ𝓇" data-style="Ultra Script">Kopyala</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓉ℯ𝒷𝓇𝒾𝓀𝓁ℯ𝓇</span>
+        <span class="cursive-word-label">tebrikler el yazısı</span>
+        <button type="button" class="copy-btn" data-text="𝓉ℯ𝒷𝓇𝒾𝓀𝓁ℯ𝓇" data-style="Ultra Script">Kopyala</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒽ℴ𝓈 ℊℯ𝓁𝒹𝒾𝓃</span>
+        <span class="cursive-word-label">hoş geldin el yazısı</span>
+        <button type="button" class="copy-btn" data-text="𝒽ℴ𝓈 ℊℯ𝓁𝒹𝒾𝓃" data-style="Ultra Script">Kopyala</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">ℊ𝓊𝓃𝒶𝓎𝒹𝒾𝓃</span>
+        <span class="cursive-word-label">günaydın el yazısı</span>
+        <button type="button" class="copy-btn" data-text="ℊ𝓊𝓃𝒶𝓎𝒹𝒾𝓃" data-style="Ultra Script">Kopyala</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝓂𝓊𝓉𝓁𝓊 𝓎𝒾𝓁𝓁𝒶𝓇</span>
+        <span class="cursive-word-label">mutlu yıllar el yazısı</span>
+        <button type="button" class="copy-btn" data-text="𝓂𝓊𝓉𝓁𝓊 𝓎𝒾𝓁𝓁𝒶𝓇" data-style="Ultra Script">Kopyala</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒾𝓎𝒾 𝓀𝒾 𝒹ℴℊ𝒹𝓊𝓃</span>
+        <span class="cursive-word-label">iyi ki doğdun el yazısı</span>
+        <button type="button" class="copy-btn" data-text="𝒾𝓎𝒾 𝓀𝒾 𝒹ℴℊ𝒹𝓊𝓃" data-style="Ultra Script">Kopyala</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">ℯ𝓃 𝒾𝓎𝒾 𝒹𝒾𝓁ℯ𝓀𝓁ℯ𝓇𝒾𝓂𝓁ℯ</span>
+        <span class="cursive-word-label">en iyi dileklerimle el yazısı</span>
+        <button type="button" class="copy-btn" data-text="ℯ𝓃 𝒾𝓎𝒾 𝒹𝒾𝓁ℯ𝓀𝓁ℯ𝓇𝒾𝓂𝓁ℯ" data-style="Ultra Script">Kopyala</button>
       </div>
     </div>
-    <div class="glyph-group">
-      <h3>Tek tek el yazısı harfler — büyük (A–Z)</h3>
-      <div class="glyph-grid">
-        <button class="glyph-copy" type="button" data-text="𝒜" aria-label="Büyük el yazısı A harfini kopyala">𝒜</button>
-        <button class="glyph-copy" type="button" data-text="ℬ" aria-label="Büyük el yazısı B harfini kopyala">ℬ</button>
-        <button class="glyph-copy" type="button" data-text="𝒞" aria-label="Büyük el yazısı C harfini kopyala">𝒞</button>
-        <button class="glyph-copy" type="button" data-text="𝒟" aria-label="Büyük el yazısı D harfini kopyala">𝒟</button>
-        <button class="glyph-copy" type="button" data-text="ℰ" aria-label="Büyük el yazısı E harfini kopyala">ℰ</button>
-        <button class="glyph-copy" type="button" data-text="ℱ" aria-label="Büyük el yazısı F harfini kopyala">ℱ</button>
-        <button class="glyph-copy" type="button" data-text="𝒢" aria-label="Büyük el yazısı G harfini kopyala">𝒢</button>
-        <button class="glyph-copy" type="button" data-text="ℋ" aria-label="Büyük el yazısı H harfini kopyala">ℋ</button>
-        <button class="glyph-copy" type="button" data-text="ℐ" aria-label="Büyük el yazısı I harfini kopyala">ℐ</button>
-        <button class="glyph-copy" type="button" data-text="𝒥" aria-label="Büyük el yazısı J harfini kopyala">𝒥</button>
-        <button class="glyph-copy" type="button" data-text="𝒦" aria-label="Büyük el yazısı K harfini kopyala">𝒦</button>
-        <button class="glyph-copy" type="button" data-text="ℒ" aria-label="Büyük el yazısı L harfini kopyala">ℒ</button>
-        <button class="glyph-copy" type="button" data-text="ℳ" aria-label="Büyük el yazısı M harfini kopyala">ℳ</button>
-        <button class="glyph-copy" type="button" data-text="𝒩" aria-label="Büyük el yazısı N harfini kopyala">𝒩</button>
-        <button class="glyph-copy" type="button" data-text="𝒪" aria-label="Büyük el yazısı O harfini kopyala">𝒪</button>
-        <button class="glyph-copy" type="button" data-text="𝒫" aria-label="Büyük el yazısı P harfini kopyala">𝒫</button>
-        <button class="glyph-copy" type="button" data-text="𝒬" aria-label="Büyük el yazısı Q harfini kopyala">𝒬</button>
-        <button class="glyph-copy" type="button" data-text="ℛ" aria-label="Büyük el yazısı R harfini kopyala">ℛ</button>
-        <button class="glyph-copy" type="button" data-text="𝒮" aria-label="Büyük el yazısı S harfini kopyala">𝒮</button>
-        <button class="glyph-copy" type="button" data-text="𝒯" aria-label="Büyük el yazısı T harfini kopyala">𝒯</button>
-        <button class="glyph-copy" type="button" data-text="𝒰" aria-label="Büyük el yazısı U harfini kopyala">𝒰</button>
-        <button class="glyph-copy" type="button" data-text="𝒱" aria-label="Büyük el yazısı V harfini kopyala">𝒱</button>
-        <button class="glyph-copy" type="button" data-text="𝒲" aria-label="Büyük el yazısı W harfini kopyala">𝒲</button>
-        <button class="glyph-copy" type="button" data-text="𝒳" aria-label="Büyük el yazısı X harfini kopyala">𝒳</button>
-        <button class="glyph-copy" type="button" data-text="𝒴" aria-label="Büyük el yazısı Y harfini kopyala">𝒴</button>
-        <button class="glyph-copy" type="button" data-text="𝒵" aria-label="Büyük el yazısı Z harfini kopyala">𝒵</button>
+    <h3>Aylar el yazısıyla</h3>
+    <div class="cursive-word-grid">
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒪𝒸𝒶𝓀</span>
+        <span class="cursive-word-label">Ocak el yazısı</span>
+        <button type="button" class="copy-btn" data-text="𝒪𝒸𝒶𝓀" data-style="Ultra Script">Kopyala</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒮𝓊𝒷𝒶𝓉</span>
+        <span class="cursive-word-label">Şubat el yazısı</span>
+        <button type="button" class="copy-btn" data-text="𝒮𝓊𝒷𝒶𝓉" data-style="Ultra Script">Kopyala</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">ℳ𝒶𝓇𝓉</span>
+        <span class="cursive-word-label">Mart el yazısı</span>
+        <button type="button" class="copy-btn" data-text="ℳ𝒶𝓇𝓉" data-style="Ultra Script">Kopyala</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒩𝒾𝓈𝒶𝓃</span>
+        <span class="cursive-word-label">Nisan el yazısı</span>
+        <button type="button" class="copy-btn" data-text="𝒩𝒾𝓈𝒶𝓃" data-style="Ultra Script">Kopyala</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">ℳ𝒶𝓎𝒾𝓈</span>
+        <span class="cursive-word-label">Mayıs el yazısı</span>
+        <button type="button" class="copy-btn" data-text="ℳ𝒶𝓎𝒾𝓈" data-style="Ultra Script">Kopyala</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">ℋ𝒶𝓏𝒾𝓇𝒶𝓃</span>
+        <span class="cursive-word-label">Haziran el yazısı</span>
+        <button type="button" class="copy-btn" data-text="ℋ𝒶𝓏𝒾𝓇𝒶𝓃" data-style="Ultra Script">Kopyala</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒯ℯ𝓂𝓂𝓊𝓏</span>
+        <span class="cursive-word-label">Temmuz el yazısı</span>
+        <button type="button" class="copy-btn" data-text="𝒯ℯ𝓂𝓂𝓊𝓏" data-style="Ultra Script">Kopyala</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒜ℊ𝓊𝓈𝓉ℴ𝓈</span>
+        <span class="cursive-word-label">Ağustos el yazısı</span>
+        <button type="button" class="copy-btn" data-text="𝒜ℊ𝓊𝓈𝓉ℴ𝓈" data-style="Ultra Script">Kopyala</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">ℰ𝓎𝓁𝓊𝓁</span>
+        <span class="cursive-word-label">Eylül el yazısı</span>
+        <button type="button" class="copy-btn" data-text="ℰ𝓎𝓁𝓊𝓁" data-style="Ultra Script">Kopyala</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">ℰ𝓀𝒾𝓂</span>
+        <span class="cursive-word-label">Ekim el yazısı</span>
+        <button type="button" class="copy-btn" data-text="ℰ𝓀𝒾𝓂" data-style="Ultra Script">Kopyala</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒦𝒶𝓈𝒾𝓂</span>
+        <span class="cursive-word-label">Kasım el yazısı</span>
+        <button type="button" class="copy-btn" data-text="𝒦𝒶𝓈𝒾𝓂" data-style="Ultra Script">Kopyala</button>
+      </div>
+      <div class="cursive-word-card">
+        <span class="cursive-word-render">𝒜𝓇𝒶𝓁𝒾𝓀</span>
+        <span class="cursive-word-label">Aralık el yazısı</span>
+        <button type="button" class="copy-btn" data-text="𝒜𝓇𝒶𝓁𝒾𝓀" data-style="Ultra Script">Kopyala</button>
       </div>
     </div>
-    <p class="u-mt-15">Nickin baş harfi, monogram ya da bio'daki tek şık detay için harfe dokunman yeterli — panoya kopyalanır. Bazı harflerin (ℬ ℰ ℱ ℊ ℴ) çizimi komşularından biraz farklıdır: Unicode bu harfleri başka bir blokta saklar ama hepsi aynı şekilde yapışır.</p>
-  </section>
+    </section>
 
-  <!-- İtalik -->
-  <section class="editorial-section">
-    <h2>İtalik yazı ve güzel yazı stilleri</h2>
-    <p class="editorial-intro">Arayanların bir kısmı <strong>italik yazı</strong> peşinde — o da burada: harflerin sağa yatık hali (𝘪𝘵𝘢𝘭𝘪𝘬), sade vurgu için birebir. El yazısıysa harflerin birbirine bağlandığı süslü stil: ince versiyon (𝓈𝑒𝓋𝑔𝒾) dolma kalem havasında, kalın versiyon (𝓼𝓮𝓿𝓰𝓲) fırça ucu gibi.</p>
-    <p>Pratikte: metnin sonuna zarif bir imza, story'de öne çıkan bir başlık ya da elden çıkmış gibi duran bir söz mü istiyorsun? Yukarıdaki üreticiye yaz, ince ile kalın el yazısı arasında seç. Daha sade bir görünüm için <a href="/tr/kucuk-yazi/">küçük yazı</a>yla, dikkat çekmek içinse <a href="/tr/kalin-yazi/">kalın yazı</a>yla birleştir.</p>
-  </section>
-
-  <!-- El yazısı nedir -->
-  <section class="editorial-section">
-    <h2>El yazısı fontu tam olarak ne?</h2>
-    <p class="editorial-intro">El yazısı, harflerin birbirine bağlanarak aktığı, eğimli ve kesintisiz yazım stilidir — okulda öğrendiğimiz «bitişik eğik yazı»nın dijital hali. Zarif, kişisel ve romantik bir his verir; her harfin ayrı ve dik durduğu düz yazının tam tersi.</p>
-    <p>Dijital dünyada bu stil karaktere dönüştü: Unicode, bu akışkan çizimi her ekranda aynen gösteren bir <em>script</em> harf seti ayırdı (𝒶, 𝒷, 𝒸…). Bu üreticinin kullandığı şey tam olarak o — yani buradan kopyaladığın «el yazısı», yüklenmesi gereken bir font değil; bio'da, durumda ve mesajda çalışan gerçek metin.</p>
-  </section>
-
-  <!-- İsimler -->
-  <section class="editorial-section" id="el-yazisi-isimler">
-    <h2>El yazısıyla hazır isimler — kopyala yapıştır</h2>
-    <p class="uname-note">İsme dokun, kopyalansın. Kendi ismini mi istiyorsun? Yukarıdaki üreticiye yaz, tüm el yazısı versiyonları çıksın.</p>
-    <div class="uname-grid">
-      <button class="uname-chip symbol-tile" data-symbol="ℳ𝑒𝓁𝒾𝓈𝒶" aria-label="Melisa ismini el yazısıyla kopyala">ℳ𝑒𝓁𝒾𝓈𝒶</button>
-      <button class="uname-chip symbol-tile" data-symbol="♡ 𝒵𝑒𝓎𝓃𝑒𝓅 ♡" aria-label="Zeynep ismini kalpli el yazısıyla kopyala">♡ 𝒵𝑒𝓎𝓃𝑒𝓅 ♡</button>
-      <button class="uname-chip symbol-tile" data-symbol="ℰ𝒻ℯ" aria-label="Efe ismini el yazısıyla kopyala">ℰ𝒻ℯ</button>
-      <button class="uname-chip symbol-tile" data-symbol="⋆˚ ℰ𝓁𝒾𝒻 ˚⋆" aria-label="Elif ismini yıldızlı el yazısıyla kopyala">⋆˚ ℰ𝓁𝒾𝒻 ˚⋆</button>
-      <button class="uname-chip symbol-tile" data-symbol="𝒟ℯ𝓃𝒾𝓏" aria-label="Deniz ismini el yazısıyla kopyala">𝒟ℯ𝓃𝒾𝓏</button>
-      <button class="uname-chip symbol-tile" data-symbol="ℰ𝓂𝒾𝓇" aria-label="Emir ismini el yazısıyla kopyala">ℰ𝓂𝒾𝓇</button>
-      <button class="uname-chip symbol-tile" data-symbol="✧ 𝒜𝓏𝓇𝒶 ✧" aria-label="Azra ismini parıltılı el yazısıyla kopyala">✧ 𝒜𝓏𝓇𝒶 ✧</button>
-      <button class="uname-chip symbol-tile" data-symbol="𝒴𝓊𝓈𝓊𝒻" aria-label="Yusuf ismini el yazısıyla kopyala">𝒴𝓊𝓈𝓊𝒻</button>
-      <button class="uname-chip symbol-tile" data-symbol="𝓐𝓼𝓮𝓵" aria-label="Asel ismini kalın el yazısıyla kopyala">𝓐𝓼𝓮𝓵</button>
-      <button class="uname-chip symbol-tile" data-symbol="❀ 𝓔𝓬𝓮 ❀" aria-label="Ece ismini çiçekli kalın el yazısıyla kopyala">❀ 𝓔𝓬𝓮 ❀</button>
-      <button class="uname-chip symbol-tile" data-symbol="𝓜𝓮𝓻𝓽" aria-label="Mert ismini kalın el yazısıyla kopyala">𝓜𝓮𝓻𝓽</button>
-      <button class="uname-chip symbol-tile" data-symbol="𝓑𝓮𝓻𝓮𝓷" aria-label="Beren ismini kalın el yazısıyla kopyala">𝓑𝓮𝓻𝓮𝓷</button>
+    <!-- 5. Names & signatures -->
+    <section id="cursive-names" aria-labelledby="cursiveNamesHeading">
+      <h2 class="bubble-az-heading" id="cursiveNamesHeading">El yazısı isim ve imza oluşturucu</h2>
+      <p class="bubble-az-intro">Bir ad — ya da tam isim — yaz ve el yazısı imzanı tasarla:
+        bir süsleme seç, monogram baş harflerinin nasıl birleşeceğine karar ver, sonra metni kopyala ya da e-posta imzaları,
+        filigranlar ve belgeler için PNG olarak indir. Not: Türkçe özel harfler (ş, ı, ğ, ç, ö, ü) el yazısına dönüşmez —
+        bu harfleri olmadan yazmak en akıcı sonucu verir.</p>
+      <div class="cursive-name-tool">
+        <div class="input-wrapper">
+          <input type="text" class="main-input cursive-name-input" id="cursiveNameInput" placeholder="Bir isim yaz… örn. Elif Deniz" maxlength="60">
+        </div>
+        <div class="cursive-sig-controls" id="cursiveSignatureControls"></div>
+        <div class="results-grid" id="cursiveNameResults"></div>
+      </div>
+    <h3>El yazısıyla popüler isimler</h3>
+    <p class="bubble-az-intro">Herhangi bir isme dokunarak onu yukarıdaki stüdyoya yükle ve süslemelerle yeniden şekillendir.
+        Türkçe harf içeren isimlerde (Ömer, Gökhan…) baş harfleri sadeleştirilmiş yazım daha akıcı görünür.</p>
+    <div class="cursive-word-grid">
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Zeynep ismini imza stüdyosuna yükle" data-name="Zeynep">
+        <span class="cursive-word-render">𝓩𝓮𝔂𝓷𝓮𝓹</span>
+        <span class="cursive-word-label">Zeynep el yazısı</span>
+        <button type="button" class="copy-btn" data-text="𝓩𝓮𝔂𝓷𝓮𝓹" data-style="Ultra Script Bold">Kopyala</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Elif ismini imza stüdyosuna yükle" data-name="Elif">
+        <span class="cursive-word-render">𝓔𝓵𝓲𝓯</span>
+        <span class="cursive-word-label">Elif el yazısı</span>
+        <button type="button" class="copy-btn" data-text="𝓔𝓵𝓲𝓯" data-style="Ultra Script Bold">Kopyala</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Defne ismini imza stüdyosuna yükle" data-name="Defne">
+        <span class="cursive-word-render">𝓓𝓮𝓯𝓷𝓮</span>
+        <span class="cursive-word-label">Defne el yazısı</span>
+        <button type="button" class="copy-btn" data-text="𝓓𝓮𝓯𝓷𝓮" data-style="Ultra Script Bold">Kopyala</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Ecrin ismini imza stüdyosuna yükle" data-name="Ecrin">
+        <span class="cursive-word-render">𝓔𝓬𝓻𝓲𝓷</span>
+        <span class="cursive-word-label">Ecrin el yazısı</span>
+        <button type="button" class="copy-btn" data-text="𝓔𝓬𝓻𝓲𝓷" data-style="Ultra Script Bold">Kopyala</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Azra ismini imza stüdyosuna yükle" data-name="Azra">
+        <span class="cursive-word-render">𝓐𝔃𝓻𝓪</span>
+        <span class="cursive-word-label">Azra el yazısı</span>
+        <button type="button" class="copy-btn" data-text="𝓐𝔃𝓻𝓪" data-style="Ultra Script Bold">Kopyala</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Deniz ismini imza stüdyosuna yükle" data-name="Deniz">
+        <span class="cursive-word-render">𝓓𝓮𝓷𝓲𝔃</span>
+        <span class="cursive-word-label">Deniz el yazısı</span>
+        <button type="button" class="copy-btn" data-text="𝓓𝓮𝓷𝓲𝔃" data-style="Ultra Script Bold">Kopyala</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Yusuf ismini imza stüdyosuna yükle" data-name="Yusuf">
+        <span class="cursive-word-render">𝓨𝓾𝓼𝓾𝓯</span>
+        <span class="cursive-word-label">Yusuf el yazısı</span>
+        <button type="button" class="copy-btn" data-text="𝓨𝓾𝓼𝓾𝓯" data-style="Ultra Script Bold">Kopyala</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Eymen ismini imza stüdyosuna yükle" data-name="Eymen">
+        <span class="cursive-word-render">𝓔𝔂𝓶𝓮𝓷</span>
+        <span class="cursive-word-label">Eymen el yazısı</span>
+        <button type="button" class="copy-btn" data-text="𝓔𝔂𝓶𝓮𝓷" data-style="Ultra Script Bold">Kopyala</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Mustafa ismini imza stüdyosuna yükle" data-name="Mustafa">
+        <span class="cursive-word-render">𝓜𝓾𝓼𝓽𝓪𝓯𝓪</span>
+        <span class="cursive-word-label">Mustafa el yazısı</span>
+        <button type="button" class="copy-btn" data-text="𝓜𝓾𝓼𝓽𝓪𝓯𝓪" data-style="Ultra Script Bold">Kopyala</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Ahmet ismini imza stüdyosuna yükle" data-name="Ahmet">
+        <span class="cursive-word-render">𝓐𝓱𝓶𝓮𝓽</span>
+        <span class="cursive-word-label">Ahmet el yazısı</span>
+        <button type="button" class="copy-btn" data-text="𝓐𝓱𝓶𝓮𝓽" data-style="Ultra Script Bold">Kopyala</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Omer ismini imza stüdyosuna yükle" data-name="Omer">
+        <span class="cursive-word-render">𝓞𝓶𝓮𝓻</span>
+        <span class="cursive-word-label">Ömer el yazısı</span>
+        <button type="button" class="copy-btn" data-text="𝓞𝓶𝓮𝓻" data-style="Ultra Script Bold">Kopyala</button>
+      </div>
+      <div class="cursive-word-card cursive-name-example" role="button" tabindex="0" title="Mert ismini imza stüdyosuna yükle" data-name="Mert">
+        <span class="cursive-word-render">𝓜𝓮𝓻𝓽</span>
+        <span class="cursive-word-label">Mert el yazısı</span>
+        <button type="button" class="copy-btn" data-text="𝓜𝓮𝓻𝓽" data-style="Ultra Script Bold">Kopyala</button>
+      </div>
     </div>
-    <p class="u-mt-15">Dikkat: «Gül» ismi 𝒢𝓊𝓁 oldu — Unicode'da ü, ş, ı gibi Türkçe harflerin el yazısı karşılığı olmadığından, bu harfleri içeren isimler sadeleştirilmiş haliyle daha güzel görünür. Süsü artırmak için kalp ve yıldızları <a href="/tr/library/semboller/">şekilli semboller</a> sayfasından al — oyun için şık isim arıyorsan <a href="/tr/sekilli-nick/">şekilli nick</a> hazır.</p>
-  </section>
+    </section>
 
-  <!-- Related -->
-  <section class="editorial-section">
-    <h2>Kopyalanacak başka stiller</h2>
-    <div class="compare-grid">
-      <a href="/tr/yazi-stilleri/" class="compare-card variant-muted u-no-underline">
-        <h4>Yazı Stilleri</h4>
-        <p>Tüm stiller tek yerde: kalın, gotik, bubble, çizili ve fazlası.</p>
-      </a>
-      <a href="/tr/kalin-yazi/" class="compare-card variant-muted u-no-underline">
-        <h4>Kalın Yazı</h4>
-        <p>Dikkat çeken koyu stiller — başlık ve vurgu için.</p>
-      </a>
-      <a href="/tr/instagram-yazi-tipi/" class="compare-card variant-muted u-no-underline">
-        <h4>Instagram Yazı Tipi</h4>
-        <p>Bio, açıklama ve görünen ad için Instagram'a en uygun fontlar.</p>
-      </a>
+    <!-- Editorial -->
+    <section class="editorial-section cursive-editorial">
+      <h2>Bu el yazısı fontu çevirici nasıl çalışır</h2>
+      <p>Burada gördüğün el yazısı aslında bir font değil — cihazının her harf ve emoji için kullandığı aynı standart olan <strong>Unicode el yazısı karakterleri</strong>. Kopyala-yapıştır yaptığında bozulmamasının nedeni bu: uygulamalar 𝓮𝓵 𝔂𝓪𝔃𝓲𝓼𝓲 metnini tıpkı düz yazı gibi işler. Font kuramayacağın yerlerde bile çalışmasının sebebi de bu — Instagram bioları, TikTok açıklamaları, Discord isimleri, YouTube yorumları. Mekaniğini merak ediyorsan <a href="/guide/how-unicode-fonts-work/">Unicode fontlar nasıl çalışır</a> yazımızı oku.</p>
+
+      <h3>El yazısı nerede çalışır (ve nerede bozulur)</h3>
+      <ul class="compat-list">
+        <li><span class="ts-pill-safe">Çalışır</span> Instagram bio ve açıklamaları, TikTok açıklamaları, Discord, WhatsApp, Facebook, X, YouTube yorumları ve çoğu belge.</li>
+        <li><span class="ts-pill-risk">Sınırlı</span> Kullanıcı adı ve görünen ad alanları (Instagram, çoğu oyun) el yazısı karakterlerini genellikle temizler — kullanıcı adlarını düz metin tut.</li>
+        <li><span class="ts-pill-risk">Sınırlı</span> Bazı eski cihazlar boş kutu (▯) gösterebilir. Böyle olursa daha sade bir stil kullan — <a href="/guide/why-fonts-show-as-boxes/">fontlar neden kutu görünür</a>.</li>
+      </ul>
+
+      <h3>Unicode el yazısı ile gerçek el yazısı fontları</h3>
+      <p>Metin alanlarının <em>içinde</em> el yazısına ihtiyacın olduğunda Unicode el yazısını kullan — sosyal profiller, sohbetler, video başlıkları. Belgeyi sen kontrol ettiğinde ve baskı kalitesinde harf aralığı gerektiğinde gerçek bir el yazısı yazı tipini (Word, Canva ya da tasarım aracında) kullan. İkisinin de yeri var; bu araç birinci işi yapar.</p>
+
+      <h3>Türkçe karakterler ve el yazısı alfabesi</h3>
+      <p>Unicode el yazısı harfleri yalnızca Latin alfabesi için vardır, bu yüzden Türkçeye özgü ş, ı, ğ, ç, ö, ü ve İ harfleri dönüşmeden geçer. Hatta çevirimizin adı olan “el yazısı” bile ı ve ş harflerini içerir — bu yüzden en akıcı sonucu <a href="#cursive-alphabet">A–Z el yazısı alfabesini</a> temel alarak, isimleri bu özel harfler olmadan yazarak alırsın (Şeyma → Seyma, Gökhan → Gokhan). Kart altındaki etiketler doğru Türkçe yazımı korur; el yazısına yalnızca sade harfler dönüşür.</p>
+
+      <h3>El yazısı öğrenmek için</h3>
+      <p>Çeviriciler dijital metin içindir ama referans tablosu olarak da işe yarar. Üzerinden geçmek için <a href="#cursive-alphabet">çalışma sayfasını</a> yazdır, her büyük harfin nasıl bağlandığını <a href="#cursive-letters">harf gezgininde</a> incele ve erişilebilirlik alışkanlıklarını unutma — kısa süslü ifadeler, gerisi düz metin (<a href="/guide/fancy-fonts-accessibility-guide/">erişilebilirlik rehberi</a>).</p>
+
+      <h3>Dövme için el yazısı</h3>
+      <p>El yazısı, en çok istenen dövme yazı stilidir. Kelimeni burada büyük boyutta önizle, sonra özel <a href="/tr/usecase/dovme-yazi-fontlari/">dövme yazı fontları oluşturucusunu</a> kullan — harf aileleri, Roma rakamlarıyla tarihler, baş harfler ve okunabilirlik testi ekler.</p>
+    </section>
+
+    <div class="cta-card">
+      <h3>Tüm bioya akıcı bir hava kat</h3>
+      <p>El yazısı bir başlığı sade gövde metniyle eşleştir — hem dikkat çeken hem okunaklı kalan kombinasyon. Tüm el yazısı fontu çeviriciyi aç ve dene.</p>
+      <a class="cta-btn" href="/tr/">El yazısı çeviriciyi aç →</a>
     </div>
-  </section>
-</main>
+  </main>
 
-<footer class="footer">
-  <div class="footer-inner">
-    <h2 class="faq-category">El yazısı fontu hakkında sorular</h2>
-    <div class="faq-item"><button class="faq-question" type="button">El yazısı fontu nasıl kopyalanır?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Yukarıdaki kutuya metnini yaz — tüm el yazısı versiyonları anında görünür. Beğendiğin stilin yanındaki «Kopyala» butonuna dokun ve istediğin yere yapıştır: bio, durum, açıklama, davetiye. Sayfadaki alfabe tablosundan tek harf de kopyalayabilirsin — mesela ismin baş harfini.</div></div>
-    <div class="faq-item"><button class="faq-question" type="button">El yazısı fontu Instagram ve WhatsApp'ta çalışır mı?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Çalışır. Her harf gerçek bir Unicode karakteri olduğu için el yazısı Instagram bio'suna ve açıklamalara, WhatsApp durumuna ve mesajlara, TikTok'a, Discord'a ve metin kabul eden hemen her alana yapışır. Yalnızca kullanıcı adı (@) alanları genelde kabul etmez — orada düz yazı kullan.</div></div>
-    <div class="faq-item"><button class="faq-question" type="button">Dövme için el yazısı örneği olarak kullanılır mı?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Referans olarak kullanılır. Kelimeyi ya da ismi yaz, ince ve kalın el yazısını dene, sonucu dövme sanatçına taslak olarak göster. Son çizgiyi sanatçı belirler ama el yazısı önizlemesi, iğneden önce stile karar vermeni kolaylaştırır.</div></div>
-    <div class="faq-item"><button class="faq-question" type="button">El yazısı ile italik yazı arasındaki fark ne?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">İtalik, harflerin sağa yatık halidir (𝘪𝘵𝘢𝘭𝘪𝘬); el yazısı ise harflerin birbirine bağlanıp aktığı süslü stildir (𝓮𝓵 𝔂𝓪𝔃𝓲𝓼𝓲). İkisi de Unicode'dur ve ikisi de bu sayfadaki üreticide var — sade vurgu için italik, zarif ve romantik görünüm için el yazısı seç.</div></div>
-    <div class="faq-item"><button class="faq-question" type="button">Türkçe karakterlerle (ş, ğ, ü) çalışıyor mu?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Kısmen. Unicode'da el yazısı seti yalnızca temel Latin harflerini kapsar; ş, ı, ğ, ö, ü ve ç kelimenin ortasında düz kalır. İsmin tamamen el yazısı görünmesi için Türkçe karakterleri sadeleştir: «Gül» yerine Gul → 𝒢𝓊𝓁. Yazım eksilir ama görünüm tutarlı olur — bio ve nick için idealdir.</div></div>
+  <!-- Footer + FAQ -->
+  <footer class="footer">
+    <div class="footer-inner">
+<div class="faq-section" id="cursive-faq">
+
+<h2 class="faq-category">El Yazısı Fontu Çevirici — SSS</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    El yazısı fontu çevirici nedir ve nasıl çalışır?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Yazdığın harfleri Unicode el yazısı karakterlerine dönüştürür — el yazısı gibi görünen ama normal metin gibi davranan özel sembollere. Bunlar gerçek karakter olduğu için (font ya da görsel değil) kopyalayıp biolara, açıklamalara, yorumlara ve mesajlara yapıştırabilirsin; el yazısı görünümünü korurlar. Ayrıntı için <a href="/guide/how-unicode-fonts-work/">Unicode fontlar nasıl çalışır</a> rehberimize bak.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    El yazısını nasıl kopyalayıp yapıştırırım?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Metnini üstteki kutuya yaz ya da yapıştır, sonra beğendiğin stildeki Kopyala'ya dokun. El yazısı sürüm artık panonda — metin kabul eden her yere yapıştır: Instagram, TikTok, WhatsApp, Discord, belgeler ve daha fazlası. Buna kısaca <strong>el yazısı kopyala</strong> denir.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Instagram, WhatsApp ve TikTok'ta çalışıyor mu?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Evet. El yazısı karakterleri Instagram biolarında ve açıklamalarında, WhatsApp durum ve mesajlarında, TikTok açıklamalarında çalışır. İpucu: kullanıcı adı alanları özel karakterleri bazen temizler, o yüzden el yazısını <strong>bio, durum ve açıklama</strong> metinlerinde kullan.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Türkçe karakterler (ş, ı, ğ, ç, ö, ü) neden el yazısına dönüşmüyor?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Unicode el yazısı harfleri yalnızca A–Z, a–z ve 0–9 için tanımlıdır. ş, ı, ğ, ç, ö, ü ve İ gibi harflerin el yazısı karşılığı yoktur, bu yüzden değişmeden kalırlar. En akıcı görünüm için bu harfleri sadeleştir: <strong>ı→i, İ→I, ş→s, ğ→g, ç→c, ö→o, ü→u</strong>. Örneğin “Şeyma” yerine “Seyma”, “Gökçe” yerine “Gokce” yaz. İsim örneklerimizde etiketler doğru yazımı gösterir, el yazısına yalnızca sadeleştirilmiş biçim dönüşür.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    El yazısı isimler ve imzalar oluşturabilir miyim?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Evet. İsim stüdyosuna bir ad yaz, bir süsleme ve monogram baş harfi birleşimi seç, sonra metni kopyala ya da e-posta imzası ve filigran için PNG olarak indir. Türkçe harf içeren isimlerde daha akıcı bir sonuç için harfleri sadeleştirmeyi dene.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    El yazısı fontu ücretsiz mi ve üyelik gerekiyor mu?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Tamamen ücretsiz ve üyeliksiz. Her şey tarayıcında çalışır — kayıt yok, indirme yok, sınır yok. İstediğin kadar kelime, isim ve alfabe kopyala.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    El yazısı alfabesinin tamamını kopyalayabilir miyim?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Evet. Alfabe bölümünde büyük harf, küçük harf ve rakamların tamamını tek tıkla kopyala ya da üzerinden geçmek için yazdırılabilir bir çalışma sayfası al. Bu, el yazısı karakterlerini bir arada görmenin en hızlı yolu.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Rakamlar (0–9) el yazısıyla yazılabilir mi?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Unicode'da gerçek el yazısı rakam yoktur, bu yüzden her stil el yazısı harfleri uyumlu şık rakamlarla eşleştirir. Böylece tarihler ve yıllar el yazısı metninle görsel olarak uyumlu kalır.
+  </div>
+</div>
+
+</div>
 
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="Language switcher">
       <a class="lang-option" href="/category/cursive-fonts/" hreflang="en">EN</a>
-      <a class="lang-option" href="/fr/ecriture-cursive/" hreflang="fr">FR</a>
-      <a class="lang-option" href="/id/tulisan-sambung/" hreflang="id">ID</a>
-      <a class="lang-option" href="/nl/sierlijke-letters/" hreflang="nl">NL</a>
+      <a class="lang-option" href="/es/letra-cursiva/" hreflang="es">ES</a>
       <a class="lang-option" href="/pt/letra-cursiva/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/fr/ecriture-cursive/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/de/schreibschrift/" hreflang="de">DE</a>
+      <a class="lang-option" href="/it/lettere-in-corsivo/" hreflang="it">IT</a>
       <a class="lang-option active" href="/tr/el-yazisi-fontu/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/nl/cursieve-letters/" hreflang="nl">NL</a>
+      <a class="lang-option" href="/id/tulisan-sambung/" hreflang="id">ID</a>
       <a class="lang-option" href="/no/kursiv-tekst/" hreflang="no">NO</a>
     </div>
-  </div>
-</footer>
 
-<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+    </div>
+  </footer>
 
-<script>window.UTG_FAMILY = "cursive";</script>
-<script src="/styles.js"></script>
-<script src="/renderer.js"></script>
-<script src="/script.js" defer=""></script>
-<script src="/symbol-explorer.js"></script>
-<script src="/footer.js"></script>
+  <div id="cursivePrintRoot" aria-hidden="true"></div>
+  <div class="copy-toast" id="copyToast">Kopyalandı!</div>
+
+  <script>
+    window.UTG_CURSIVE_MODE = true;
+    window.UTG_FAMILY = "cursive";
+    window.cursiveI18n = {
+  "demoText": "Merhaba",
+  "demoName": "Deniz",
+  "copy": "Kopyala",
+  "typeFirst": "Önce yukarıya metnini yaz",
+  "downloadPngTitle": "PNG görsel olarak indir",
+  "downloadPng": "PNG indir",
+  "characters": "karakter",
+  "caseUpper": "Büyük harf",
+  "caseLower": "Küçük harf",
+  "caseBoth": "İkisi de",
+  "labelUpper": "El yazısı büyük {ch}",
+  "labelLower": "El yazısı küçük {ch}",
+  "labelBoth": "El yazısı büyük ve küçük {ch}",
+  "copyBoth": "İkisini de kopyala",
+  "everyStyle": "El yazısı {ch} — her stil, kopyalamak için tıkla",
+  "suffixCapital": " — büyük harf",
+  "suffixLowercase": " — küçük harf",
+  "accentLabel": "{name} süslemesi",
+  "practiceTitle": "El yazısı alfabesi çalışma sayfası — ultratextgen.com",
+  "flourishLabel": "Süsleme",
+  "monogramLabel": "Monogram birleştirici",
+  "copiedToast": "Kopyalandı!",
+  "quickWords": [
+    "sevgi",
+    "mutlu",
+    "tebrikler",
+    "aile",
+    "sonsuz",
+    "melek"
+  ],
+  "styles": {
+    "Ultra Script": "klasik el yazısı",
+    "Ultra Script Bold": "kalın el yazısı",
+    "Ultra Script Elegant": "zarif el yazısı",
+    "Ultra Script Bold Elegant": "kalın zarif el yazısı",
+    "Ultra Gothic Script": "gotik el yazısı",
+    "Ultra Chicano Script": "Chicano isimlik",
+    "Ultra Script Sparkle": "parıltılı el yazısı"
+  },
+  "presets": {
+    "Script Hearts": "El Yazısı Kalpler",
+    "Script Arrow Bio": "El Yazısı Ok Bio",
+    "Bold Script Stars": "Kalın El Yazısı Yıldızlar",
+    "Script Vintage": "El Yazısı Vintage",
+    "Script Soft Dots": "El Yazısı Yumuşak Noktalar",
+    "Bold Script Ribbon": "Kalın El Yazısı Kurdele",
+    "Script Underline": "El Yazısı Alt Çizgi",
+    "Bold Script Crown": "Kalın El Yazısı Taç"
+  },
+  "signatures": {
+    "Classic Signature": "Klasik İmza",
+    "Bold Signature": "Kalın İmza",
+    "Signed Underline": "Alt Çizgili İmza",
+    "Sparkle Signature": "Parıltılı İmza",
+    "Ornate Nameplate": "Süslü İsimlik",
+    "Autograph Star": "İmza Yıldızı",
+    "Monogram Initials": "Monogram Baş Harfleri",
+    "Gothic Signature": "Gotik İmza"
+  },
+  "decorators": {
+    "None": "Yok",
+    "Underline": "Alt çizgi",
+    "Sparkle": "Parıltı",
+    "Hearts": "Kalpler",
+    "Ornate": "Süslü",
+    "Soft dots": "Yumuşak noktalar"
+  },
+  "accents": {
+    "Sparkle": "Parıltı",
+    "Hearts": "Kalpler",
+    "Wings": "Kanatlar",
+    "Ornate": "Süslü"
+  },
+  "platformLimits": {
+    "Instagram bio": "Instagram bio",
+    "TikTok bio": "TikTok bio",
+    "X bio": "X bio"
+  }
+};
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/js/cursive/cursiveData.js" defer></script>
+  <script src="/script.js" defer></script>
+  <script src="/js/cursive/cursivePageController.js" defer></script>
+  <script src="/footer.js" defer></script>
 </body></html>


### PR DESCRIPTION
Localizes the rebuilt cursive generator (generator + A–Z letter explorer + alphabet + words + name/signature studio + FAQ) into Spanish, Portuguese, French, German, Italian, Turkish, Dutch, Indonesian and Norwegian.

- Make js/cursive/cursivePageController.js i18n-aware: all UI strings, style/ preset/decorator/accent labels, platform badges and quick-fill words now read from an optional window.cursiveI18n table with English fallbacks, so the English page is unchanged.
- Add 9 fully localized pages with native copy, localized example words/names/ months (glyphs rendered at build time so they stay valid Unicode script), translated FAQ + editorial, JSON-LD (FAQPage, BreadcrumbList, WebApplication), breadcrumbs and a language switcher.
- Tune each page to its keyword volumes: DE leads on "Schreibschrift" + "Schreibschrift Generator/Alphabet"; IT emphasizes "corsivo maiuscolo" and "alfabeto corsivo"; ES/PT lead on the high-volume "letra cursiva"; TR on "el yazısı fontu"; special characters (ä/ö/ü/ß, ı/ş/ğ/ç, æ/ø/å, accents) are ASCII-folded for the rendered glyphs with an explainer FAQ per language.
- New slugs /de/schreibschrift/ and /it/lettere-in-corsivo/; Dutch upgraded at /nl/cursieve-letters/.
- Expand the hreflang cluster (en, es, pt, fr, de, it, tr, nl, id, no + x-default) across every cursive page and the English page; add a language switcher to the English page; regenerate sitemap.xml.


Claude-Session: https://claude.ai/code/session_01NyFuxDzQthfinXesZYdtYX