### PR TITLE
Add printables cluster: unified engine for letter/alphabet/tracing sheets

### DIFF
--- a/category/bubble-fonts/index.html
+++ b/category/bubble-fonts/index.html
@@ -116,30 +116,6 @@
         "@type": "Answer",
         "text": "After generating your bubble text in a style like Ultra Bubble Spaced or Ultra Bubble Filled, click the \"Copy\" button next to the output. Then open your social media app, email, or messaging platform and paste it using Ctrl+V on desktop or the paste option on mobile. <br><br> The Unicode characters retain their bubbly appearance across all devices, operating systems, and websites. No special fonts need to be installed on the recipient's device."
       }
-    },
-    {
-      "@type": "Question",
-      "name": "Can I get printable bubble letters to trace or color?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Yes. In the Bubble Letters A–Z section, pick any letter (A–Z) or number (0–9) to see a large outline version. <br><br> Use <strong>Print this letter</strong> to send just that outline to your printer, or <strong>Download PNG</strong> to save a high-resolution image. You can also print the whole A–Z alphabet at once from the Printable Bubble Letter Alphabet section. <br><br> The outlines are white with a bold rounded border, so they are ready to trace or color in for posters, signs, birthday cards, classroom activities, and bullet journals."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "How do I draw a bubble letter by hand?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Drawing a bubble letter takes three steps. <br><br> <strong>Step 1:</strong> Lightly pencil the plain letter as a thin skeleton.<br> <strong>Step 2:</strong> Draw a rounded, puffy outline about a finger-width around every stroke of the letter.<br> <strong>Step 3:</strong> Round off the corners, erase the pencil skeleton, then ink the outline and color it in. <br><br> A quick way to learn the shape is to print the outline for a letter from the Bubble Letters A–Z section and trace over it a few times until it feels natural."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Where can I see the full bubble letter alphabet?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "The Printable Bubble Letter Alphabet section on this page shows every letter from A to Z as a bubble outline in one grid. <br><br> Tap any letter to jump to its copy-and-paste Unicode styles and its print and download options, or use Print the alphabet to print the entire A–Z sheet for tracing, coloring, or classroom handouts."
-      }
     }
   ]
 }
@@ -269,30 +245,20 @@
     <!-- Results -->
     <div class="results-grid" id="resultsGrid"></div>
 
-    <!-- ===== Bubble Letters A–Z explorer ===== -->
-    <section class="bubble-az" id="bubbleAZ" aria-labelledby="bubbleAZHeading">
-      <h2 class="bubble-az-heading" id="bubbleAZHeading">Bubble Letters A–Z</h2>
+    <!-- ===== Printable version lives under /printables/ (intent split:
+             this page is the copy-paste generator; trace/color/print is its
+             own dedicated page) ===== -->
+    <section class="bubble-alphabet" aria-labelledby="bubblePrintableHeading">
+      <h2 id="bubblePrintableHeading">Printable bubble letters to trace &amp; color</h2>
       <p class="bubble-az-intro">
-        Pick a letter or number to see it as a big printable bubble outline you can
-        trace, color, or print — plus every copy-and-paste Unicode bubble style for that character.
+        Want big bubble outlines to print, trace, color, or download as a PNG — including a whole
+        name in bubble letters? That has its own page, built for paper instead of copy-paste.
       </p>
-
-      <div class="bubble-strip" id="bubbleLetterStrip" role="tablist" aria-label="Choose a bubble letter or number"></div>
-
-      <div class="bubble-letter-panel" id="bubbleLetterPanel" aria-live="polite"></div>
-    </section>
-
-    <!-- ===== Printable bubble alphabet reference ===== -->
-    <section class="bubble-alphabet" aria-labelledby="bubbleAlphabetHeading">
-      <div class="bubble-alphabet-head">
-        <h2 id="bubbleAlphabetHeading">Printable Bubble Letter Alphabet</h2>
-        <button class="bubble-btn bubble-btn-primary" type="button" id="bubblePrintAlphabet">Print the alphabet</button>
+      <div class="cta-card">
+        <h3>Printable Bubble Letters A–Z &amp; 0–9</h3>
+        <p>Large puffy outlines to trace and color, print the full alphabet, or save any letter as a PNG.</p>
+        <a class="cta-btn" href="/printables/bubble-letters/">Open printable bubble letters →</a>
       </div>
-      <p class="bubble-az-intro">
-        The full A–Z bubble alphabet as outline letters. Print the whole sheet to trace or color,
-        or tap any letter to jump to its copy-paste styles and download options.
-      </p>
-      <div class="bubble-alphabet-grid" id="bubbleAlphabetGrid"></div>
     </section>
   </main>
 
@@ -486,58 +452,6 @@
   </div>
 </div>
 
-<!-- Drawing and Printing Bubble Letters -->
-<h2 class="faq-category">Drawing and Printing Bubble Letters</h2>
-
-<div class="faq-item">
-  <button class="faq-question" type="button">
-    Can I get printable bubble letters to trace or color?
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-    </svg>
-  </button>
-  <div class="faq-answer">
-    Yes. In the <strong>Bubble Letters A–Z</strong> section near the top, pick any letter (A–Z) or number (0–9) to see a large outline version.
-    <br><br>
-    Use <strong>Print this letter</strong> to send just that outline to your printer, or <strong>Download PNG</strong> to save a high-resolution image.
-    You can also print the whole A–Z alphabet at once from the Printable Bubble Letter Alphabet section.
-    <br><br>
-    The outlines are white with a bold rounded border, so they are ready to trace or color in for posters, signs, birthday cards, classroom activities, and bullet journals.
-  </div>
-</div>
-
-<div class="faq-item">
-  <button class="faq-question" type="button">
-    How do I draw a bubble letter by hand?
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-    </svg>
-  </button>
-  <div class="faq-answer">
-    Drawing a bubble letter takes three steps.
-    <br><br>
-    <strong>Step 1:</strong> Lightly pencil the plain letter as a thin skeleton.<br>
-    <strong>Step 2:</strong> Draw a rounded, puffy outline about a finger-width around every stroke of the letter.<br>
-    <strong>Step 3:</strong> Round off the corners, erase the pencil skeleton, then ink the outline and color it in.
-    <br><br>
-    A quick way to learn the shape is to print the outline for a letter from the Bubble Letters A–Z section and trace over it a few times until it feels natural.
-  </div>
-</div>
-
-<div class="faq-item">
-  <button class="faq-question" type="button">
-    Where can I see the full bubble letter alphabet?
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-    </svg>
-  </button>
-  <div class="faq-answer">
-    The <strong>Printable Bubble Letter Alphabet</strong> section on this page shows every letter from A to Z as a bubble outline in one grid.
-    <br><br>
-    Tap any letter to jump to its copy-and-paste Unicode styles and its print and download options, or use <strong>Print the alphabet</strong> to print the entire A–Z sheet for tracing, coloring, or classroom handouts.
-  </div>
-</div>
-
 <!-- Device Compatibility and Limitations -->
 <h2 class="faq-category">Device Compatibility and Limitations</h2>
 
@@ -587,13 +501,9 @@
     window.UTG_FAMILY = "bubble";
   </script>
 
-  <!-- Print surface for bubble outlines (hidden on screen) -->
-  <div id="bubblePrintRoot" aria-hidden="true"></div>
-
   <script src="/styles.js" defer></script>
 <script src="/renderer.js" defer></script>
 <script src="/script.js" defer=""></script>
-<script src="/js/bubble/bubbleExplorer.js" defer=""></script>
 
 
 

--- a/category/cursive-fonts/index.html
+++ b/category/cursive-fonts/index.html
@@ -134,7 +134,7 @@
       "name": "Can I print cursive practice sheets or worksheets?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes. In the alphabet section, hit “Print practice sheet” to get a printable A–Z page: each row shows the cursive model letters plus space to trace and repeat them — handy for teachers, parents, and anyone learning cursive."
+        "text": "Yes. Our printable cursive alphabet page has a Print practice sheet button that produces a printable A–Z page: each row shows the cursive model letters plus space to trace and repeat them — handy for teachers, parents, and anyone learning cursive."
       }
     },
     {
@@ -404,11 +404,12 @@
     <section id="cursive-alphabet" aria-labelledby="cursiveAlphabetHeading">
       <div class="cursive-chart-toolbar">
         <h2 class="bubble-az-heading" id="cursiveAlphabetHeading">The cursive alphabet (A–Z, 0–9)</h2>
-        <button type="button" class="bubble-btn bubble-btn-primary" id="cursivePrintSheet">Print practice sheet</button>
+        <a class="bubble-btn bubble-btn-primary" href="/printables/cursive-alphabet/">Printable practice sheets →</a>
       </div>
-      <p class="bubble-az-intro">Copy the full cursive alphabet in one click — uppercase, lowercase, and numerals —
-        or print a practice sheet with model letters and space to trace. Unicode has no true cursive digits, so each
-        style pairs its script letters with matching stylised numerals.</p>
+      <p class="bubble-az-intro">Copy the full cursive alphabet in one click — uppercase, lowercase, and numerals. Want to
+        practice by hand? Our <a href="/printables/cursive-alphabet/">printable cursive practice sheets</a> give model
+        letters plus space to trace. Unicode has no true cursive digits, so each style pairs its script letters with
+        matching stylised numerals.</p>
     <div class="cursive-chart">
       <div class="cursive-chart-head">
         <h3>Classic cursive alphabet (Ultra Script)</h3>
@@ -721,11 +722,11 @@
       <p>Unicode script letters only exist for the Latin alphabet, so Cyrillic (Russian), Greek, and Arabic
         text passes through unstyled. If you're here to learn Russian cursive handwriting, you'll want
         practice sheets for the handwritten forms rather than a Unicode converter — our
-        <a href="#cursive-alphabet">printable practice sheet</a> covers the Latin A–Z equivalent.</p>
+        <a href="/printables/cursive-alphabet/">printable practice sheet</a> covers the Latin A–Z equivalent.</p>
 
       <h3>Learning cursive handwriting</h3>
       <p>Generators are for digital text, but they double as reference charts. Print the
-        <a href="#cursive-alphabet">practice sheet</a> for tracing, study how each capital connects in the
+        <a href="/printables/cursive-alphabet/">practice sheet</a> for tracing, study how each capital connects in the
         <a href="#cursive-letters">letter explorer</a>, and keep essential accessibility habits in mind —
         short decorative lines, plain text for the rest
         (<a href="/guide/fancy-fonts-accessibility-guide/">accessibility guide</a>).</p>
@@ -856,7 +857,7 @@
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
   </button>
   <div class="faq-answer">
-    Yes. In the alphabet section, hit “Print practice sheet” to get a printable A–Z page: each row shows the cursive model letters plus space to trace and repeat them — handy for teachers, parents, and anyone learning cursive.
+    Yes. Our <a href="/printables/cursive-alphabet/">printable cursive alphabet</a> page has a <strong>Print practice sheet</strong> button that produces a printable A–Z page: each row shows the cursive model letters plus space to trace and repeat them — handy for teachers, parents, and anyone learning cursive.
   </div>
 </div>
 
@@ -909,7 +910,6 @@
     </div>
   </footer>
 
-  <div id="cursivePrintRoot" aria-hidden="true"></div>
   <div class="copy-toast" id="copyToast">Copied!</div>
 
   <script>

--- a/footer.js
+++ b/footer.js
@@ -11,6 +11,7 @@
         '<a href="/usecase/" class="footer-link">Use Cases</a>' +
         '<a href="/category/" class="footer-link">Categories</a>' +
         '<a href="/library/" class="footer-link">Library</a>' +
+        '<a href="/printables/" class="footer-link">Printables</a>' +
       '</div>' +
       '<div class="footer-col">' +
         '<span class="footer-col-title">Popular Tools</span>' +

--- a/header.js
+++ b/header.js
@@ -48,6 +48,12 @@
           '</svg>' +
           '<span>Library</span>' +
         '</a>' +
+        '<a class="header-btn" href="/printables/" aria-label="Printables">' +
+          '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">' +
+            '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 9V2h12v7M6 18H4a2 2 0 01-2-2v-5a2 2 0 012-2h16a2 2 0 012 2v5a2 2 0 01-2 2h-2M6 14h12v8H6v-8z" />' +
+          '</svg>' +
+          '<span>Printables</span>' +
+        '</a>' +
         '<button class="header-btn" id="darkModeBtn" aria-label="Toggle dark mode" type="button">' +
           '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">' +
             '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"></path>' +

--- a/js/printables/printablesEngine.js
+++ b/js/printables/printablesEngine.js
@@ -1,0 +1,630 @@
+/*
+ * printablesEngine.js — shared, config-driven controller for /printables/ pages.
+ *
+ * One engine powers every printables page (bubble-letters, cursive-alphabet,
+ * block-letters, name-tracing). A page declares window.UTG_PRINTABLE = {...}
+ * and includes whichever mount points it wants; the engine builds only the
+ * sections whose mounts exist on the page. This generalizes the two original
+ * per-page controllers (js/bubble/bubbleExplorer.js and
+ * js/cursive/cursivePageController.js) into reusable primitives:
+ *   - a letter / number picker strip
+ *   - a selected-character detail panel (big glyph + print + PNG + variants)
+ *   - a printable alphabet grid (print the whole A–Z / 0–9 sheet)
+ *   - a ruled practice sheet (model + trace rows)
+ *   - a personalized name / word tracing worksheet
+ *
+ * Two render modes:
+ *   - "outline": white-fill + rounded dark-stroke shapes (bubble, block) —
+ *     traceable / colorable. Needs no font registry.
+ *   - "glyph":   Unicode style glyphs from the registry (cursive) via
+ *     window.UltraTextGenRender. Copy-paste variants are available in this mode.
+ *
+ * Self-contained IIFE. Document-level .copy-btn / .glyph-copy clipboard
+ * delegation from the shared script.js is reused via the data-text contract;
+ * copy inside the panel uses a local fallback so the engine works standalone.
+ *
+ * Mount points (all optional except the print surface, which is required for
+ * any print action):
+ *   #pt-strip            character picker
+ *   #pt-panel            selected-character detail
+ *   #pt-alphabet-grid    printable alphabet grid   (+ button #pt-alphabet-print)
+ *   #pt-practice-print   button: print ruled practice sheet
+ *   #pt-name-input       name / word field  (+ #pt-name-print, #pt-name-png,
+ *                        #pt-name-preview, #pt-name-rows)
+ *   #pt-print-root       hidden print surface (REQUIRED to print)
+ */
+(function () {
+  "use strict";
+
+  const CFG = window.UTG_PRINTABLE;
+  if (!CFG) return;
+
+  const $ = (sel, root) => (root || document).querySelector(sel);
+  const $$ = (sel, root) => Array.from((root || document).querySelectorAll(sel));
+  const SVGNS = "http://www.w3.org/2000/svg";
+
+  const LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("");
+  const DIGITS = "0123456789".split("");
+  const CHARS = (CFG.charset === "alnum") ? LETTERS.concat(DIGITS) : LETTERS.slice();
+
+  const RENDER = CFG.render || "outline";           // "outline" | "glyph"
+  const FONT = CFG.font || "'Plus Jakarta Sans', 'Segoe UI Symbol', sans-serif";
+  const STROKE = CFG.strokeWidth || 9;
+  const NOUN = CFG.noun || "letter";                // "bubble letter", "block letter"…
+  const PNG_PREFIX = CFG.pngPrefix || "printable";
+  const GLYPH_STYLE = CFG.glyphStyle || "";         // primary registry style (glyph mode)
+  const INK = "#1a1a2e";
+
+  const el = {
+    strip: $("#pt-strip"),
+    panel: $("#pt-panel"),
+    alphaGrid: $("#pt-alphabet-grid"),
+    alphaPrint: $("#pt-alphabet-print"),
+    practicePrint: $("#pt-practice-print"),
+    nameInput: $("#pt-name-input"),
+    namePrint: $("#pt-name-print"),
+    namePng: $("#pt-name-png"),
+    namePreview: $("#pt-name-preview"),
+    nameRows: $("#pt-name-rows"),
+    printRoot: $("#pt-print-root")
+  };
+
+  /* ---------------------------------------------------------------
+     Small helpers
+     --------------------------------------------------------------- */
+
+  function charLabel(ch) { return /[0-9]/.test(ch) ? ("number " + ch) : ("letter " + ch); }
+  function charSlug(ch) { return /[0-9]/.test(ch) ? ("number-" + ch) : ("letter-" + ch.toLowerCase()); }
+  function slugify(s) {
+    return String(s || "").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+  }
+  function primaryFontName() {
+    // "Fredoka, '…', sans-serif" -> "Fredoka" (for document.fonts.load)
+    return (FONT.split(",")[0] || "").replace(/['"]/g, "").trim();
+  }
+  function registry() { return window.textStyles || {}; }
+
+  function renderGlyph(text, styleKey) {
+    const style = registry()[styleKey || GLYPH_STYLE];
+    const R = window.UltraTextGenRender;
+    if (!style || !R || typeof R.renderAny !== "function") return text;
+    try { return R.renderAny(text, style); } catch (e) { return text; }
+  }
+
+  // Copy-paste Unicode variants of a single character, drawn from a familySlug.
+  function familyStyles() {
+    if (!CFG.variantFamily) return [];
+    const reg = registry();
+    const out = [];
+    Object.keys(reg).forEach((name) => {
+      const s = reg[name];
+      if (!s || s.type !== "map") return;
+      const fam = s.familySlug;
+      const inFam = fam === CFG.variantFamily || (Array.isArray(fam) && fam.indexOf(CFG.variantFamily) !== -1);
+      if (inFam) out.push({ name: name, style: s });
+    });
+    return out;
+  }
+
+  function copyText(value, btn) {
+    const done = () => {
+      if (!btn) return;
+      const prev = btn.textContent;
+      btn.classList.add("is-copied");
+      btn.textContent = "Copied!";
+      setTimeout(() => { btn.textContent = prev; btn.classList.remove("is-copied"); }, 1400);
+    };
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(value).then(done).catch(done);
+    } else {
+      const ta = document.createElement("textarea");
+      ta.value = value; document.body.appendChild(ta); ta.select();
+      try { document.execCommand("copy"); } catch (e) { /* noop */ }
+      document.body.removeChild(ta); done();
+    }
+  }
+
+  /* ---------------------------------------------------------------
+     Glyph builders (SVG for outline mode, text for glyph mode)
+     --------------------------------------------------------------- */
+
+  // A single character as a rounded, traceable SVG outline (outline mode).
+  function outlineSVG(ch, opts) {
+    const o = opts || {};
+    const svg = document.createElementNS(SVGNS, "svg");
+    svg.setAttribute("viewBox", "0 0 200 240");
+    svg.setAttribute("class", "bubble-outline" + (o.small ? " is-small" : ""));
+    svg.setAttribute("role", "img");
+    svg.setAttribute("aria-label", NOUN + " " + charLabel(ch));
+    const text = document.createElementNS(SVGNS, "text");
+    text.setAttribute("x", "100");
+    text.setAttribute("y", "128");
+    text.setAttribute("text-anchor", "middle");
+    text.setAttribute("dominant-baseline", "central");
+    text.setAttribute("font-family", FONT);
+    text.setAttribute("font-weight", "700");
+    text.setAttribute("font-size", "210");
+    text.setAttribute("fill", "#ffffff");
+    text.setAttribute("stroke", INK);
+    text.setAttribute("stroke-width", String(o.small ? Math.max(4, STROKE - 2) : STROKE));
+    text.setAttribute("stroke-linejoin", "round");
+    text.setAttribute("paint-order", "stroke");
+    text.textContent = ch;
+    svg.appendChild(text);
+    return svg;
+  }
+
+  // A whole word as one rounded outline SVG (used by the name worksheet in
+  // outline mode). Width scales with the word so long names stay readable.
+  function wordOutlineSVG(word, opts) {
+    const o = opts || {};
+    const chars = [...String(word)];
+    const w = Math.max(200, chars.length * 118 + 80);
+    const svg = document.createElementNS(SVGNS, "svg");
+    svg.setAttribute("viewBox", "0 0 " + w + " 200");
+    svg.setAttribute("class", "pt-word-outline");
+    svg.setAttribute("role", "img");
+    svg.setAttribute("aria-label", word);
+    const text = document.createElementNS(SVGNS, "text");
+    text.setAttribute("x", String(w / 2));
+    text.setAttribute("y", "112");
+    text.setAttribute("text-anchor", "middle");
+    text.setAttribute("dominant-baseline", "central");
+    text.setAttribute("font-family", FONT);
+    text.setAttribute("font-weight", "700");
+    text.setAttribute("font-size", "150");
+    text.setAttribute("fill", o.solid ? INK : "#ffffff");
+    text.setAttribute("stroke", o.solid ? "none" : "#8b93a7");
+    text.setAttribute("stroke-width", o.solid ? "0" : "3");
+    text.setAttribute("stroke-linejoin", "round");
+    text.setAttribute("paint-order", "stroke");
+    text.textContent = word;
+    svg.appendChild(text);
+    return svg;
+  }
+
+  // The big figure for the detail panel: outline SVG or a script-glyph pair.
+  function figureNode(ch) {
+    if (RENDER === "glyph") {
+      const p = document.createElement("p");
+      p.className = "pt-glyph-figure";
+      const u = renderGlyph(ch.toUpperCase());
+      const l = renderGlyph(ch.toLowerCase());
+      p.textContent = /[0-9]/.test(ch) ? u : (u + " " + l);
+      return p;
+    }
+    return outlineSVG(ch);
+  }
+
+  /* ---------------------------------------------------------------
+     PNG export (Canvas)
+     --------------------------------------------------------------- */
+
+  function withFont(cb) {
+    const fam = primaryFontName();
+    if (fam && document.fonts && document.fonts.load) {
+      document.fonts.load("700 200px " + fam).then(cb).catch(cb);
+    } else {
+      cb();
+    }
+  }
+
+  function downloadCanvas(canvas, filename) {
+    canvas.toBlob((blob) => {
+      if (!blob) return;
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a); a.click(); document.body.removeChild(a);
+      setTimeout(() => URL.revokeObjectURL(url), 1000);
+    }, "image/png");
+  }
+
+  // Single character -> square PNG.
+  function letterPNG(ch) {
+    withFont(() => {
+      const size = 1024;
+      const canvas = document.createElement("canvas");
+      canvas.width = size; canvas.height = size;
+      const ctx = canvas.getContext("2d");
+      ctx.fillStyle = "#ffffff";
+      ctx.fillRect(0, 0, size, size);
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
+      ctx.lineJoin = "round";
+      const glyph = RENDER === "glyph"
+        ? (/[0-9]/.test(ch) ? renderGlyph(ch.toUpperCase()) : (renderGlyph(ch.toUpperCase()) + renderGlyph(ch.toLowerCase())))
+        : ch;
+      ctx.font = "700 " + Math.round(size * (RENDER === "glyph" ? 0.4 : 0.74)) + "px " + FONT;
+      if (RENDER === "outline") {
+        ctx.fillStyle = "#ffffff";
+        ctx.fillText(glyph, size / 2, size * 0.54);
+        ctx.lineWidth = Math.round(size * 0.045);
+        ctx.strokeStyle = INK;
+        ctx.strokeText(glyph, size / 2, size * 0.54);
+      } else {
+        ctx.fillStyle = INK;
+        ctx.fillText(glyph, size / 2, size * 0.54);
+      }
+      downloadCanvas(canvas, PNG_PREFIX + "-" + charSlug(ch) + ".png");
+    });
+  }
+
+  // A word / name -> wide PNG.
+  function wordPNG(text) {
+    withFont(() => {
+      const width = 1600, height = 520, pad = 90;
+      const canvas = document.createElement("canvas");
+      canvas.width = width; canvas.height = height;
+      const ctx = canvas.getContext("2d");
+      ctx.fillStyle = "#ffffff";
+      ctx.fillRect(0, 0, width, height);
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
+      ctx.lineJoin = "round";
+      const out = RENDER === "glyph" ? renderGlyph(text) : text;
+      let fontSize = 300;
+      ctx.font = "700 " + fontSize + "px " + FONT;
+      const measured = ctx.measureText(out).width;
+      if (measured > width - pad * 2) {
+        fontSize = Math.max(54, Math.floor(fontSize * (width - pad * 2) / measured));
+        ctx.font = "700 " + fontSize + "px " + FONT;
+      }
+      if (RENDER === "outline") {
+        ctx.fillStyle = "#ffffff";
+        ctx.fillText(out, width / 2, height * 0.52);
+        ctx.lineWidth = Math.max(6, Math.round(fontSize * 0.06));
+        ctx.strokeStyle = INK;
+        ctx.strokeText(out, width / 2, height * 0.52);
+      } else {
+        ctx.fillStyle = INK;
+        ctx.fillText(out, width / 2, height * 0.52);
+      }
+      downloadCanvas(canvas, PNG_PREFIX + "-" + (slugify(text) || "word") + ".png");
+    });
+  }
+
+  /* ---------------------------------------------------------------
+     Print surface
+     --------------------------------------------------------------- */
+
+  function printWrap(titleText, bodyNode) {
+    if (!el.printRoot) { window.print(); return; }
+    el.printRoot.innerHTML = "";
+    const wrap = document.createElement("div");
+    wrap.className = "bubble-print-wrap";
+    const h = document.createElement("h2");
+    h.className = "bubble-print-title";
+    h.textContent = titleText;
+    wrap.appendChild(h);
+    wrap.appendChild(bodyNode);
+    el.printRoot.appendChild(wrap);
+    document.body.classList.add("is-printing");
+    window.print();
+    document.body.classList.remove("is-printing");
+    el.printRoot.innerHTML = "";
+  }
+
+  /* ---------------------------------------------------------------
+     Section: detail panel
+     --------------------------------------------------------------- */
+
+  let activeChar = "A";
+
+  function selectChar(ch, opts) {
+    activeChar = ch;
+    $$(".pt-chip", el.strip).forEach((b) => {
+      const on = b.dataset.char === ch;
+      b.classList.toggle("is-active", on);
+      b.setAttribute("aria-selected", on ? "true" : "false");
+    });
+    if (!el.panel) return;
+
+    el.panel.innerHTML = "";
+    const stage = document.createElement("div");
+    stage.className = "bubble-stage";
+
+    // Left — big figure + print + PNG.
+    const figure = document.createElement("div");
+    figure.className = "bubble-outline-card";
+    figure.appendChild(figureNode(ch));
+
+    const actions = document.createElement("div");
+    actions.className = "bubble-actions";
+    const printBtn = document.createElement("button");
+    printBtn.type = "button";
+    printBtn.className = "bubble-btn bubble-btn-primary";
+    printBtn.textContent = "Print this " + (/[0-9]/.test(ch) ? "number" : "letter");
+    printBtn.addEventListener("click", () => {
+      const holder = document.createElement("div");
+      holder.className = "bubble-print-single";
+      holder.appendChild(RENDER === "glyph" ? bigGlyphForPrint(ch) : outlineSVG(ch));
+      printWrap(cap(NOUN) + " " + charLabel(ch), holder);
+    });
+    const pngBtn = document.createElement("button");
+    pngBtn.type = "button";
+    pngBtn.className = "bubble-btn";
+    pngBtn.textContent = "Download PNG";
+    pngBtn.addEventListener("click", () => letterPNG(ch));
+    actions.appendChild(printBtn);
+    actions.appendChild(pngBtn);
+    figure.appendChild(actions);
+
+    // Right — copy-paste variants (glyph mode) and/or how-to steps.
+    const detail = document.createElement("div");
+    detail.className = "bubble-detail";
+
+    const variants = CFG.variantFamily ? buildVariants(ch) : null;
+    if (variants) {
+      const title = document.createElement("h3");
+      title.className = "bubble-detail-title";
+      title.textContent = "Copy-paste " + NOUN + " " + charLabel(ch);
+      detail.appendChild(title);
+      detail.appendChild(variants);
+    }
+
+    if (CFG.howto && CFG.howto.steps) {
+      const how = document.createElement("div");
+      how.className = "bubble-howto";
+      const ht = document.createElement("h3");
+      ht.className = "bubble-detail-title";
+      ht.textContent = (CFG.howto.title || "How to draw it").replace("{ch}", charLabel(ch));
+      how.appendChild(ht);
+      const ol = document.createElement("ol");
+      ol.className = "bubble-howto-steps";
+      CFG.howto.steps.forEach((s) => {
+        const li = document.createElement("li");
+        li.textContent = s.replace("{ch}", charLabel(ch));
+        ol.appendChild(li);
+      });
+      how.appendChild(ol);
+      if (CFG.howto.tip) {
+        const tip = document.createElement("p");
+        tip.className = "bubble-howto-tip";
+        tip.textContent = CFG.howto.tip;
+        how.appendChild(tip);
+      }
+      detail.appendChild(how);
+    }
+
+    stage.appendChild(figure);
+    if (detail.childNodes.length) stage.appendChild(detail);
+    el.panel.appendChild(stage);
+
+    if ((!opts || !opts.silent) && window.history && window.history.replaceState) {
+      window.history.replaceState(null, "", "#" + charSlug(ch));
+    }
+  }
+
+  function cap(s) { return String(s).charAt(0).toUpperCase() + String(s).slice(1); }
+
+  function bigGlyphForPrint(ch) {
+    const p = document.createElement("p");
+    p.className = "pt-glyph-print";
+    const u = renderGlyph(ch.toUpperCase());
+    const l = renderGlyph(ch.toLowerCase());
+    p.textContent = /[0-9]/.test(ch) ? u : (u + " " + l);
+    return p;
+  }
+
+  function buildVariants(ch) {
+    const list = document.createElement("div");
+    list.className = "bubble-variants";
+    const cases = /[0-9]/.test(ch) ? ["upper"] : ["upper", "lower"];
+    let any = false;
+    familyStyles().forEach(({ name, style }) => {
+      cases.forEach((kind) => {
+        const src = kind === "upper" ? ch.toUpperCase() : ch.toLowerCase();
+        const rendered = renderGlyph(src, name);
+        if (!rendered || rendered === src) return;
+        any = true;
+        const row = document.createElement("button");
+        row.type = "button";
+        row.className = "bubble-variant glyph-copy";
+        row.dataset.text = rendered;
+        row.setAttribute("aria-label", "Copy " + name + " " + NOUN + " " + charLabel(src));
+        const glyph = document.createElement("span");
+        glyph.className = "bubble-variant-glyph";
+        glyph.textContent = rendered;
+        const meta = document.createElement("span");
+        meta.className = "bubble-variant-name";
+        meta.textContent = name.replace(/^Ultra /, "") + (kind === "upper" ? "" : " · lower");
+        const cta = document.createElement("span");
+        cta.className = "bubble-variant-copy";
+        cta.textContent = "Copy";
+        row.appendChild(glyph); row.appendChild(meta); row.appendChild(cta);
+        row.addEventListener("click", () => copyText(rendered, cta));
+        list.appendChild(row);
+      });
+    });
+    return any ? list : null;
+  }
+
+  /* ---------------------------------------------------------------
+     Section: picker strip
+     --------------------------------------------------------------- */
+
+  function buildStrip() {
+    if (!el.strip) return;
+    const make = (ch) => {
+      const b = document.createElement("button");
+      b.type = "button";
+      b.className = "pt-chip bubble-chip";
+      b.dataset.char = ch;
+      b.setAttribute("role", "tab");
+      b.setAttribute("aria-selected", "false");
+      b.setAttribute("aria-label", cap(NOUN) + " " + charLabel(ch));
+      b.textContent = ch;
+      b.addEventListener("click", () => selectChar(ch));
+      return b;
+    };
+    const letterRow = document.createElement("div");
+    letterRow.className = "bubble-strip-row";
+    LETTERS.forEach((ch) => letterRow.appendChild(make(ch)));
+    el.strip.appendChild(letterRow);
+    if (CFG.charset === "alnum") {
+      const digitRow = document.createElement("div");
+      digitRow.className = "bubble-strip-row bubble-strip-digits";
+      DIGITS.forEach((ch) => digitRow.appendChild(make(ch)));
+      el.strip.appendChild(digitRow);
+    }
+  }
+
+  /* ---------------------------------------------------------------
+     Section: printable alphabet grid (outline mode)
+     --------------------------------------------------------------- */
+
+  function buildAlphabetGrid() {
+    if (!el.alphaGrid) return;
+    CHARS.forEach((ch) => {
+      const cell = document.createElement("button");
+      cell.type = "button";
+      cell.className = "bubble-alpha-cell";
+      cell.setAttribute("aria-label", cap(NOUN) + " " + charLabel(ch) + " — open");
+      cell.appendChild(RENDER === "glyph" ? smallGlyphCell(ch) : outlineSVG(ch, { small: true }));
+      cell.addEventListener("click", () => {
+        selectChar(ch);
+        if (el.panel) el.panel.scrollIntoView({ behavior: "smooth", block: "start" });
+      });
+      el.alphaGrid.appendChild(cell);
+    });
+    if (el.alphaPrint) {
+      el.alphaPrint.addEventListener("click", () => {
+        const sheet = document.createElement("div");
+        sheet.className = "bubble-print-sheet";
+        CHARS.forEach((ch) => sheet.appendChild(RENDER === "glyph" ? bigGlyphForPrint(ch) : outlineSVG(ch, { small: true })));
+        printWrap(cap(NOUN) + " alphabet — ultratextgen.com", sheet);
+      });
+    }
+  }
+
+  function smallGlyphCell(ch) {
+    const s = document.createElement("span");
+    s.className = "pt-glyph-cell";
+    s.textContent = renderGlyph(ch.toUpperCase()) + " " + renderGlyph(ch.toLowerCase());
+    return s;
+  }
+
+  /* ---------------------------------------------------------------
+     Section: ruled practice sheet (model + trace + baseline rows)
+     --------------------------------------------------------------- */
+
+  function buildPracticeSheet() {
+    const sheet = document.createElement("div");
+    sheet.className = "cursive-print-sheet";
+    CHARS.forEach((ch) => {
+      const row = document.createElement("div");
+      row.className = "cursive-print-row";
+      const model = document.createElement("span");
+      model.className = "cursive-print-model";
+      const trace = document.createElement("span");
+      trace.className = "cursive-print-trace";
+      if (RENDER === "glyph") {
+        model.textContent = renderGlyph(ch.toUpperCase()) + " " + renderGlyph(ch.toLowerCase());
+        trace.textContent = renderGlyph(ch.toUpperCase()) + " " + renderGlyph(ch.toLowerCase());
+      } else {
+        model.appendChild(outlineSVG(ch, { small: true }));
+        model.classList.add("pt-model-svg");
+        trace.textContent = /[0-9]/.test(ch) ? ch : (ch + " " + ch.toLowerCase());
+      }
+      const line = document.createElement("span");
+      line.className = "cursive-print-line";
+      row.appendChild(model); row.appendChild(trace); row.appendChild(line);
+      sheet.appendChild(row);
+    });
+    printWrap(cap(NOUN) + " practice sheet — ultratextgen.com", sheet);
+  }
+
+  /* ---------------------------------------------------------------
+     Section: personalized name / word worksheet
+     --------------------------------------------------------------- */
+
+  const NAME_DEMO = CFG.nameDemo || "Alex";
+
+  function nameValue() {
+    const raw = el.nameInput ? el.nameInput.value : "";
+    return (raw && raw.trim()) ? raw.trim().slice(0, 40) : NAME_DEMO;
+  }
+
+  function renderNamePreview() {
+    if (!el.namePreview) return;
+    const name = nameValue();
+    el.namePreview.innerHTML = "";
+    if (RENDER === "glyph") {
+      const p = document.createElement("p");
+      p.className = "pt-glyph-figure pt-name-glyph";
+      p.textContent = renderGlyph(name);
+      el.namePreview.appendChild(p);
+    } else {
+      el.namePreview.appendChild(wordOutlineSVG(name, { solid: false }));
+    }
+  }
+
+  function buildNameWorksheet() {
+    const name = nameValue();
+    const rows = document.createElement("div");
+    rows.className = "pt-name-sheet";
+
+    // Solid model row.
+    rows.appendChild(nameRow(name, "model"));
+    // Trace rows (hollow / faded).
+    const traceCount = Math.max(1, Math.min(6, parseInt((el.nameRows && el.nameRows.value) || "3", 10) || 3));
+    for (let i = 0; i < traceCount; i++) rows.appendChild(nameRow(name, "trace"));
+    // Blank ruled rows for free practice.
+    for (let i = 0; i < 2; i++) rows.appendChild(nameRow(name, "blank"));
+
+    printWrap(name + " — tracing worksheet · ultratextgen.com", rows);
+  }
+
+  function nameRow(name, kind) {
+    const row = document.createElement("div");
+    row.className = "pt-name-row pt-name-" + kind;
+    if (kind === "blank") return row;
+    if (RENDER === "glyph") {
+      const span = document.createElement("span");
+      span.className = "pt-name-word" + (kind === "trace" ? " is-trace" : "");
+      span.textContent = renderGlyph(name);
+      row.appendChild(span);
+    } else {
+      row.appendChild(wordOutlineSVG(name, { solid: kind === "model" }));
+    }
+    return row;
+  }
+
+  /* ---------------------------------------------------------------
+     Wiring
+     --------------------------------------------------------------- */
+
+  function init() {
+    buildStrip();
+    buildAlphabetGrid();
+
+    if (el.practicePrint) el.practicePrint.addEventListener("click", buildPracticeSheet);
+
+    if (el.nameInput) {
+      let timer = null;
+      el.nameInput.addEventListener("input", () => {
+        if (timer) clearTimeout(timer);
+        timer = setTimeout(renderNamePreview, 120);
+      });
+      renderNamePreview();
+    }
+    if (el.namePrint) el.namePrint.addEventListener("click", buildNameWorksheet);
+    if (el.namePng) el.namePng.addEventListener("click", () => wordPNG(nameValue()));
+
+    if (el.strip || el.panel) {
+      let initial = CHARS[0];
+      const h = (window.location.hash || "").replace(/^#/, "");
+      const match = CHARS.filter((c) => charSlug(c) === h)[0];
+      if (match) initial = match;
+      selectChar(initial, { silent: true });
+    }
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/js/printables/printablesEngine.js
+++ b/js/printables/printablesEngine.js
@@ -91,10 +91,21 @@
     try { return R.renderAny(text, style); } catch (e) { return text; }
   }
 
-  // Copy-paste Unicode variants of a single character, drawn from a familySlug.
+  // Copy-paste Unicode variants of a single character. A page may supply an
+  // explicit curated list of registry style keys (CFG.variantStyles) — useful
+  // when the set spans more than one familySlug (e.g. calligraphy = blackletter
+  // + elegant script) — otherwise all map styles in CFG.variantFamily are used.
   function familyStyles() {
-    if (!CFG.variantFamily) return [];
     const reg = registry();
+    if (Array.isArray(CFG.variantStyles) && CFG.variantStyles.length) {
+      const out = [];
+      CFG.variantStyles.forEach((name) => {
+        const s = reg[name];
+        if (s && s.type === "map") out.push({ name: name, style: s });
+      });
+      return out;
+    }
+    if (!CFG.variantFamily) return [];
     const out = [];
     Object.keys(reg).forEach((name) => {
       const s = reg[name];
@@ -355,7 +366,7 @@
     const detail = document.createElement("div");
     detail.className = "bubble-detail";
 
-    const variants = CFG.variantFamily ? buildVariants(ch) : null;
+    const variants = (CFG.variantStyles || CFG.variantFamily) ? buildVariants(ch) : null;
     if (variants) {
       const title = document.createElement("h3");
       title.className = "bubble-detail-title";

--- a/printables/block-letters/index.html
+++ b/printables/block-letters/index.html
@@ -10,11 +10,11 @@
   <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Printable Block Letters A–Z &amp; Numbers — Free Stencils to Trace &amp; Cut | UltraTextGen</title>
-  <meta name="description" content="Free printable block letters A–Z and numbers 0–9. Bold hollow letter stencils to print, trace, and cut out for signs, posters, and banners. Download any letter as a PNG.">
+  <title>Printable Block Letters &amp; Letter Stencils A–Z, 0–9 — Free to Trace &amp; Cut | UltraTextGen</title>
+  <meta name="description" content="Free printable block letters and letter stencils A–Z, plus number stencils 0–9. Bold hollow alphabet stencils to print, trace, and cut out for signs, posters, and banners. Download any letter as a PNG.">
   <link rel="canonical" href="https://ultratextgen.com/printables/block-letters/">
-  <meta property="og:title" content="Printable Block Letters A–Z &amp; Numbers — Free Stencils | UltraTextGen">
-  <meta property="og:description" content="Bold hollow block letter and number stencils to print, trace, and cut out for signs, posters, and banners.">
+  <meta property="og:title" content="Printable Block Letters &amp; Stencils A–Z, 0–9 — Free Letter Stencils | UltraTextGen">
+  <meta property="og:description" content="Bold hollow letter stencils, alphabet stencils, and number stencils to print, trace, and cut out for signs, posters, and banners.">
   <meta property="og:url" content="https://ultratextgen.com/printables/block-letters/">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://ultratextgen.com/assets/og/category.png">
@@ -22,8 +22,8 @@
   <meta property="og:image:height" content="630">
   <meta property="og:image:type" content="image/png">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Printable Block Letters A–Z &amp; Numbers — Free Stencils | UltraTextGen">
-  <meta name="twitter:description" content="Bold hollow block letter and number stencils to print, trace, and cut out for signs, posters, and banners.">
+  <meta name="twitter:title" content="Printable Block Letters &amp; Stencils A–Z, 0–9 — Free Letter Stencils | UltraTextGen">
+  <meta name="twitter:description" content="Bold hollow letter stencils, alphabet stencils, and number stencils to print, trace, and cut out for signs, posters, and banners.">
   <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -67,6 +67,14 @@
       "acceptedAnswer": {
         "@type": "Answer",
         "text": "Pick a letter (A–Z) or number (0–9) for a large hollow block outline, then use Print this letter, or print the whole alphabet at once. To make a reusable stencil, print onto cardstock and cut along the border. Use Download PNG to save a high-resolution image you can scale in another program."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Do you have alphabet stencils and number stencils?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. The full A–Z set is a complete alphabet stencil, and the 0–9 set gives you number stencils — print the whole sheet at once, or pick a single letter or number. Every character is a bold hollow outline, so it works as a printable letter stencil to trace or cut out."
       }
     },
     {
@@ -116,10 +124,11 @@
 
   <section class="hero">
     <div class="hero-inner" style="max-width:820px;">
-      <h1 class="hero-headline">Printable Block Letters A–Z &amp; 0–9</h1>
+      <h1 class="hero-headline">Printable Block Letters &amp; Stencils — A–Z &amp; 0–9</h1>
       <p class="hero-tagline">
-        Bold, hollow block letters and numbers to print, trace, and cut out as stencils for
-        signs, posters, banners, and classroom projects. Print any letter or download a PNG. Free.
+        Bold, hollow block letters and numbers to print, trace, and cut out — letter stencils,
+        alphabet stencils, and number stencils for signs, posters, banners, and classroom projects.
+        Print any letter or download a PNG. Free.
       </p>
     </div>
   </section>
@@ -153,10 +162,10 @@
     <!-- Full printable alphabet -->
     <section class="bubble-alphabet" aria-labelledby="ptAlphaHeading">
       <div class="bubble-alphabet-head">
-        <h2 id="ptAlphaHeading">Printable block alphabet</h2>
+        <h2 id="ptAlphaHeading">Printable alphabet &amp; number stencils</h2>
         <button class="bubble-btn bubble-btn-primary" type="button" id="pt-alphabet-print">Print the alphabet</button>
       </div>
-      <p class="bubble-az-intro">The full A–Z and 0–9 block alphabet as hollow outlines. Print the whole sheet for stencils and labels, or tap any letter to open its print and download options.</p>
+      <p class="bubble-az-intro">The full A–Z and 0–9 block alphabet as hollow outlines — a complete set of alphabet stencils and number stencils. Print the whole sheet, or tap any letter to open its print and download options.</p>
       <div class="bubble-alphabet-grid" id="pt-alphabet-grid"></div>
     </section>
 
@@ -188,6 +197,18 @@
           Pick a letter (A–Z) or number (0–9) for a large hollow block outline, then use <strong>Print this letter</strong>, or print
           the whole alphabet at once. To make a reusable stencil, print onto cardstock and cut along the border. Use
           <strong>Download PNG</strong> to save a high-resolution image you can scale in another program.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Do you have alphabet stencils and number stencils?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Yes. The full A–Z set is a complete <strong>alphabet stencil</strong>, and the 0–9 set gives you
+          <strong>number stencils</strong> — print the whole sheet at once, or pick a single letter or number. Every
+          character is a bold hollow outline, so it works as a printable letter stencil to trace or cut out.
         </div>
       </div>
 

--- a/printables/block-letters/index.html
+++ b/printables/block-letters/index.html
@@ -1,0 +1,267 @@
+<!DOCTYPE html><html lang="en"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Printable Block Letters A–Z &amp; Numbers — Free Stencils to Trace &amp; Cut | UltraTextGen</title>
+  <meta name="description" content="Free printable block letters A–Z and numbers 0–9. Bold hollow letter stencils to print, trace, and cut out for signs, posters, and banners. Download any letter as a PNG.">
+  <link rel="canonical" href="https://ultratextgen.com/printables/block-letters/">
+  <meta property="og:title" content="Printable Block Letters A–Z &amp; Numbers — Free Stencils | UltraTextGen">
+  <meta property="og:description" content="Bold hollow block letter and number stencils to print, trace, and cut out for signs, posters, and banners.">
+  <meta property="og:url" content="https://ultratextgen.com/printables/block-letters/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Printable Block Letters A–Z &amp; Numbers — Free Stencils | UltraTextGen">
+  <meta name="twitter:description" content="Bold hollow block letter and number stencils to print, trace, and cut out for signs, posters, and banners.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;family=Archivo+Black&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ultratextgen.com/" },
+    { "@type": "ListItem", "position": 2, "name": "Printables", "item": "https://ultratextgen.com/printables/" },
+    { "@type": "ListItem", "position": 3, "name": "Block Letters", "item": "https://ultratextgen.com/printables/block-letters/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "How to make a block letter stencil",
+  "description": "Turn a printable block letter into a reusable stencil for signs and banners.",
+  "step": [
+    { "@type": "HowToStep", "position": 1, "name": "Print at size", "text": "Print the outline at the size you need — scale it up in your printer dialog for bigger letters." },
+    { "@type": "HowToStep", "position": 2, "name": "Trace or cut", "text": "Trace around the outline onto card, or cut along the border for a reusable stencil." },
+    { "@type": "HowToStep", "position": 3, "name": "Fill it in", "text": "Fill or paint inside the outline; the bold shape keeps edges crisp for signs and banners." }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "How do I print block letter stencils?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Pick a letter (A–Z) or number (0–9) for a large hollow block outline, then use Print this letter, or print the whole alphabet at once. To make a reusable stencil, print onto cardstock and cut along the border. Use Download PNG to save a high-resolution image you can scale in another program."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I print block letters in a bigger size?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Each outline scales cleanly, so use the scale or fit-to-page options in your browser's print dialog to enlarge a single letter across a full page, or tile a letter across several pages for a poster."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I print a whole word or name in block letters?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Type a name or word into the name box and print a sheet of block outlines to trace, color, or cut out — useful for banners, posters, and door signs. You can also download it as a PNG."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the difference between block letters and bubble letters?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Block letters are bold, straight-edged, and geometric — ideal for stencils, signs, and clear labels. Bubble letters are rounded and puffy for a playful look. Both are available as free printable outlines here."
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/">Home</a>
+  <span class="breadcrumb-separator">›</span>
+  <a href="/printables/">Printables</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Block Letters</span>
+</nav>
+
+  <section class="hero">
+    <div class="hero-inner" style="max-width:820px;">
+      <h1 class="hero-headline">Printable Block Letters A–Z &amp; 0–9</h1>
+      <p class="hero-tagline">
+        Bold, hollow block letters and numbers to print, trace, and cut out as stencils for
+        signs, posters, banners, and classroom projects. Print any letter or download a PNG. Free.
+      </p>
+    </div>
+  </section>
+
+  <main class="container">
+
+    <!-- Picker + selected-letter detail -->
+    <section class="bubble-az" aria-labelledby="ptPickHeading">
+      <h2 class="bubble-az-heading" id="ptPickHeading">Pick a block letter</h2>
+      <p class="bubble-az-intro">Tap a letter (A–Z) or number (0–9) to see its large hollow block outline, print it, or download a PNG to scale and reuse.</p>
+      <div class="bubble-strip" id="pt-strip" role="tablist" aria-label="Choose a block letter or number"></div>
+      <div class="bubble-letter-panel" id="pt-panel" aria-live="polite"></div>
+    </section>
+
+    <!-- Name / word worksheet -->
+    <section class="bubble-alphabet" aria-labelledby="ptNameHeading">
+      <h2 id="ptNameHeading">Print a name or word in block letters</h2>
+      <p class="bubble-az-intro">Type a name or short word, then print a sheet of block outlines to trace, color, or cut out — or save it as a PNG.</p>
+      <div class="pt-name-tool">
+        <div class="input-wrapper">
+          <input type="text" class="main-input pt-name-input" id="pt-name-input" placeholder="Type a name or word… e.g. WELCOME" maxlength="40">
+        </div>
+        <div class="pt-name-preview" id="pt-name-preview" aria-live="polite"></div>
+        <div class="bubble-actions pt-name-actions">
+          <button type="button" class="bubble-btn bubble-btn-primary" id="pt-name-print">Print the sheet</button>
+          <button type="button" class="bubble-btn" id="pt-name-png">Download PNG</button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Full printable alphabet -->
+    <section class="bubble-alphabet" aria-labelledby="ptAlphaHeading">
+      <div class="bubble-alphabet-head">
+        <h2 id="ptAlphaHeading">Printable block alphabet</h2>
+        <button class="bubble-btn bubble-btn-primary" type="button" id="pt-alphabet-print">Print the alphabet</button>
+      </div>
+      <p class="bubble-az-intro">The full A–Z and 0–9 block alphabet as hollow outlines. Print the whole sheet for stencils and labels, or tap any letter to open its print and download options.</p>
+      <div class="bubble-alphabet-grid" id="pt-alphabet-grid"></div>
+    </section>
+
+    <!-- Editorial -->
+    <section class="editorial-section">
+      <h2>Ways to use printable block letters</h2>
+      <ul class="compat-list">
+        <li><span class="ts-pill-safe">Stencils</span> Print on cardstock and cut along the border for reusable letter stencils.</li>
+        <li><span class="ts-pill-safe">Signs &amp; banners</span> Enlarge a letter to fill a page, or cut letters out to spell a word across a banner.</li>
+        <li><span class="ts-pill-safe">Labels &amp; learning</span> Clear, straight-edged shapes are easy to trace and read — good for classrooms and organizing.</li>
+      </ul>
+      <h3>Prefer copy-paste text?</h3>
+      <p>These outlines are for paper. For bold text you can paste into a post or bio, try the
+        <a href="/category/bold-fonts/">bold fonts generator</a>. For rounded, playful letters, see the
+        <a href="/printables/bubble-letters/">printable bubble letters</a>.</p>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <h2 class="faq-category">Printable Block Letters — FAQ</h2>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          How do I print block letter stencils?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Pick a letter (A–Z) or number (0–9) for a large hollow block outline, then use <strong>Print this letter</strong>, or print
+          the whole alphabet at once. To make a reusable stencil, print onto cardstock and cut along the border. Use
+          <strong>Download PNG</strong> to save a high-resolution image you can scale in another program.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Can I print block letters in a bigger size?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Yes. Each outline scales cleanly, so use the scale or fit-to-page options in your browser's print dialog to enlarge a single
+          letter across a full page, or tile a letter across several pages for a poster.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Can I print a whole word or name in block letters?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Yes. Type a name or word into the name box and print a sheet of block outlines to trace, color, or cut out — useful for
+          banners, posters, and door signs. You can also download it as a PNG.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          What is the difference between block letters and bubble letters?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Block letters are bold, straight-edged, and geometric — ideal for stencils, signs, and clear labels.
+          <a href="/printables/bubble-letters/">Bubble letters</a> are rounded and puffy for a playful look. Both are available as free
+          printable outlines here.
+        </div>
+      </div>
+
+    </div>
+  </footer>
+
+  <!-- Print surface (hidden on screen, isolated when printing) -->
+  <div id="pt-print-root" aria-hidden="true"></div>
+
+  <script>
+    window.UTG_PRINTABLE = {
+      key: "block-letters",
+      render: "outline",
+      noun: "block",
+      pngPrefix: "block",
+      font: "'Archivo Black', 'Arial Black', 'Plus Jakarta Sans', sans-serif",
+      strokeWidth: 7,
+      charset: "alnum",
+      variantFamily: "",
+      nameDemo: "WELCOME",
+      howto: {
+        title: "How to use a block {ch} stencil",
+        steps: [
+          "Print the outline at the size you need — scale it up in your printer dialog for bigger letters.",
+          "Trace around the outline onto card, or cut along the border for a reusable stencil.",
+          "Fill or paint inside the outline; the bold shape keeps edges crisp for signs and banners."
+        ],
+        tip: "Tip: print onto cardstock for stencils that last."
+      }
+    };
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/js/printables/printablesEngine.js" defer></script>
+
+  <!-- FAQ toggle -->
+  <script>
+    document.querySelectorAll('.faq-question').forEach(function(btn) {
+      btn.addEventListener('click', function() { this.closest('.faq-item').classList.toggle('open'); });
+    });
+  </script>
+<script src="/footer.js" defer></script>
+</body></html>

--- a/printables/bubble-letters/index.html
+++ b/printables/bubble-letters/index.html
@@ -1,0 +1,275 @@
+<!DOCTYPE html><html lang="en"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Printable Bubble Letters A–Z &amp; 0–9 — Trace, Color, Download PNG | UltraTextGen</title>
+  <meta name="description" content="Free printable bubble letters A–Z and numbers 0–9. Large puffy outlines to trace and color, print the whole alphabet, or download any letter as a PNG. No sign-up.">
+  <link rel="canonical" href="https://ultratextgen.com/printables/bubble-letters/">
+  <meta property="og:title" content="Printable Bubble Letters A–Z &amp; 0–9 | UltraTextGen">
+  <meta property="og:description" content="Free printable bubble letters and numbers. Large outlines to trace and color, print the alphabet, or download PNGs.">
+  <meta property="og:url" content="https://ultratextgen.com/printables/bubble-letters/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category-bubble-fonts.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Printable Bubble Letters A–Z &amp; 0–9 | UltraTextGen">
+  <meta name="twitter:description" content="Free printable bubble letters and numbers. Large outlines to trace and color, print the alphabet, or download PNGs.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category-bubble-fonts.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;family=Fredoka:wght@500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ultratextgen.com/" },
+    { "@type": "ListItem", "position": 2, "name": "Printables", "item": "https://ultratextgen.com/printables/" },
+    { "@type": "ListItem", "position": 3, "name": "Bubble Letters", "item": "https://ultratextgen.com/printables/bubble-letters/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "How to draw a bubble letter",
+  "description": "Turn any plain letter into a rounded, puffy bubble letter you can trace and color.",
+  "step": [
+    { "@type": "HowToStep", "position": 1, "name": "Sketch the skeleton", "text": "Lightly pencil the plain letter as a thin skeleton." },
+    { "@type": "HowToStep", "position": 2, "name": "Puff the outline", "text": "Draw a rounded, puffy outline about a finger-width around every stroke of the letter." },
+    { "@type": "HowToStep", "position": 3, "name": "Ink and color", "text": "Round off the corners, erase the skeleton, then ink the outline and color it in." }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "How do I get printable bubble letters to trace or color?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Pick any letter (A–Z) or number (0–9) from the picker to see a large bubble outline. Use Print this letter to send just that outline to your printer, or Download PNG to save a high-resolution image. You can also print the whole A–Z and 0–9 alphabet at once. The outlines are white with a bold rounded border, ready to trace or color for posters, signs, cards, classroom activities, and bullet journals."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How do I draw a bubble letter by hand?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Lightly pencil the plain letter as a thin skeleton, draw a rounded puffy outline about a finger-width around every stroke, then round off the corners, erase the skeleton, and ink and color it in. A quick way to learn the shape is to print the outline for a letter and trace over it a few times until it feels natural."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I print my name in bubble letters?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Type any name or word into the name box and print a sheet of large bubble outlines to trace and color, or download it as a PNG banner for cards, posters, and door signs."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Do you also have copy-paste bubble text for Instagram or TikTok?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. If you want bubble text you can paste into a bio or caption rather than print, use the bubble fonts generator, which turns your text into copy-paste Unicode bubble letters."
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/">Home</a>
+  <span class="breadcrumb-separator">›</span>
+  <a href="/printables/">Printables</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Bubble Letters</span>
+</nav>
+
+  <section class="hero">
+    <div class="hero-inner" style="max-width:820px;">
+      <h1 class="hero-headline">Printable Bubble Letters A–Z &amp; 0–9</h1>
+      <p class="hero-tagline">
+        Pick a letter or number for a big, puffy bubble outline you can trace, color, print,
+        or download as a PNG — or type a name for a whole sheet. Free, no sign-up.
+      </p>
+    </div>
+  </section>
+
+  <main class="container">
+
+    <!-- Picker + selected-letter detail -->
+    <section class="bubble-az" aria-labelledby="ptPickHeading">
+      <h2 class="bubble-az-heading" id="ptPickHeading">Pick a bubble letter</h2>
+      <p class="bubble-az-intro">Tap a letter (A–Z) or number (0–9) to see its large bubble outline, print it, download a PNG, or copy the matching Unicode bubble styles.</p>
+      <div class="bubble-strip" id="pt-strip" role="tablist" aria-label="Choose a bubble letter or number"></div>
+      <div class="bubble-letter-panel" id="pt-panel" aria-live="polite"></div>
+    </section>
+
+    <!-- Name / word worksheet -->
+    <section class="bubble-alphabet" aria-labelledby="ptNameHeading">
+      <h2 id="ptNameHeading">Print a name in bubble letters</h2>
+      <p class="bubble-az-intro">Type a name or short word, then print a sheet of bubble outlines to trace and color, or save it as a PNG banner.</p>
+      <div class="pt-name-tool">
+        <div class="input-wrapper">
+          <input type="text" class="main-input pt-name-input" id="pt-name-input" placeholder="Type a name… e.g. Mia" maxlength="40">
+        </div>
+        <div class="pt-name-preview" id="pt-name-preview" aria-live="polite"></div>
+        <div class="bubble-actions pt-name-actions">
+          <button type="button" class="bubble-btn bubble-btn-primary" id="pt-name-print">Print the sheet</button>
+          <button type="button" class="bubble-btn" id="pt-name-png">Download PNG</button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Full printable alphabet -->
+    <section class="bubble-alphabet" aria-labelledby="ptAlphaHeading">
+      <div class="bubble-alphabet-head">
+        <h2 id="ptAlphaHeading">Printable bubble alphabet</h2>
+        <button class="bubble-btn bubble-btn-primary" type="button" id="pt-alphabet-print">Print the alphabet</button>
+      </div>
+      <p class="bubble-az-intro">The full A–Z and 0–9 bubble alphabet as outlines. Print the whole sheet to trace or color, or tap any letter to open its print and download options.</p>
+      <div class="bubble-alphabet-grid" id="pt-alphabet-grid"></div>
+    </section>
+
+    <!-- Editorial -->
+    <section class="editorial-section">
+      <h2>Ways to use printable bubble letters</h2>
+      <ul class="compat-list">
+        <li><span class="ts-pill-safe">Trace</span> Print an outline and trace over it to learn the puffy shape by hand.</li>
+        <li><span class="ts-pill-safe">Color</span> The white fill is ready for markers, crayons, or paint — great for kids and classrooms.</li>
+        <li><span class="ts-pill-safe">Craft</span> Cut out letters for banners, door signs, birthday cards, scrapbooks, and bullet journals.</li>
+      </ul>
+      <h3>Prefer to copy-paste instead of print?</h3>
+      <p>These outlines are for paper. If you want bubble text you can paste into an Instagram bio, a TikTok caption,
+        or a Discord name, use the <a href="/category/bubble-fonts/">bubble fonts generator</a> — it turns your text
+        into copy-paste Unicode bubble letters that keep their look anywhere.</p>
+    </section>
+
+    <div class="cta-card">
+      <h3>Want bubble text for your bio or caption?</h3>
+      <p>Type once and copy playful Unicode bubble letters that paste anywhere — no image needed.</p>
+      <a class="cta-btn" href="/category/bubble-fonts/">Open the bubble fonts generator →</a>
+    </div>
+  </main>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <h2 class="faq-category">Printable Bubble Letters — FAQ</h2>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          How do I get printable bubble letters to trace or color?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Pick any letter (A–Z) or number (0–9) from the picker to see a large bubble outline. Use <strong>Print this letter</strong>
+          to send just that outline to your printer, or <strong>Download PNG</strong> to save a high-resolution image. You can also
+          print the whole A–Z and 0–9 alphabet at once. The outlines are white with a bold rounded border, ready to trace or color
+          for posters, signs, cards, classroom activities, and bullet journals.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          How do I draw a bubble letter by hand?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Lightly pencil the plain letter as a thin skeleton, draw a rounded puffy outline about a finger-width around every stroke,
+          then round off the corners, erase the skeleton, and ink and color it in. A quick way to learn the shape is to print the
+          outline for a letter and trace over it a few times until it feels natural.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Can I print my name in bubble letters?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Yes. Type any name or word into the name box and print a sheet of large bubble outlines to trace and color, or download it
+          as a PNG banner for cards, posters, and door signs.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Do you also have copy-paste bubble text for Instagram or TikTok?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Yes. If you want bubble text you can paste into a bio or caption rather than print, use the
+          <a href="/category/bubble-fonts/">bubble fonts generator</a>, which turns your text into copy-paste Unicode bubble letters.
+        </div>
+      </div>
+
+    </div>
+  </footer>
+
+  <!-- Print surface (hidden on screen, isolated when printing) -->
+  <div id="pt-print-root" aria-hidden="true"></div>
+
+  <script>
+    window.UTG_PRINTABLE = {
+      key: "bubble-letters",
+      render: "outline",
+      noun: "bubble",
+      pngPrefix: "bubble",
+      font: "Fredoka, 'Plus Jakarta Sans', sans-serif",
+      strokeWidth: 9,
+      charset: "alnum",
+      variantFamily: "bubble",
+      glyphStyle: "Ultra Bubble",
+      nameDemo: "Mia",
+      howto: {
+        title: "How to draw a bubble {ch}",
+        steps: [
+          "Lightly pencil the plain {ch} as a thin skeleton.",
+          "Draw a rounded, puffy outline about a finger-width around every stroke.",
+          "Round off the corners, erase the skeleton, then ink and color it in."
+        ],
+        tip: "Tip: print the outline above and trace it a few times until the shape feels natural."
+      }
+    };
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/js/printables/printablesEngine.js" defer></script>
+
+  <!-- FAQ toggle -->
+  <script>
+    document.querySelectorAll('.faq-question').forEach(function(btn) {
+      btn.addEventListener('click', function() { this.closest('.faq-item').classList.toggle('open'); });
+    });
+  </script>
+<script src="/footer.js" defer></script>
+</body></html>

--- a/printables/calligraphy-alphabet/index.html
+++ b/printables/calligraphy-alphabet/index.html
@@ -1,0 +1,253 @@
+<!DOCTYPE html><html lang="en"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Calligraphy Alphabet A–Z — Free Printable Practice Sheets &amp; Letters | UltraTextGen</title>
+  <meta name="description" content="The calligraphy alphabet A–Z in blackletter and elegant script, with free printable practice sheets to trace, per-letter PNG downloads, and a calligraphy name worksheet. No sign-up.">
+  <link rel="canonical" href="https://ultratextgen.com/printables/calligraphy-alphabet/">
+  <meta property="og:title" content="Calligraphy Alphabet A–Z — Free Printable Practice Sheets | UltraTextGen">
+  <meta property="og:description" content="The calligraphy alphabet A–Z in blackletter and elegant script, with printable practice sheets to trace, per-letter PNG downloads, and a calligraphy name worksheet.">
+  <meta property="og:url" content="https://ultratextgen.com/printables/calligraphy-alphabet/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Calligraphy Alphabet A–Z — Free Printable Practice Sheets | UltraTextGen">
+  <meta name="twitter:description" content="The calligraphy alphabet A–Z in blackletter and elegant script, with printable practice sheets to trace and per-letter PNG downloads.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ultratextgen.com/" },
+    { "@type": "ListItem", "position": 2, "name": "Printables", "item": "https://ultratextgen.com/printables/" },
+    { "@type": "ListItem", "position": 3, "name": "Calligraphy Alphabet", "item": "https://ultratextgen.com/printables/calligraphy-alphabet/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Can I print calligraphy practice sheets?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Click Print practice sheet for a printable A–Z page where each row shows the calligraphy model letters plus space to trace and repeat them — useful for learning blackletter and script hands."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What styles are in the calligraphy alphabet?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The page shows an ornate blackletter (gothic) calligraphy hand as the main model, plus elegant script variants for each letter. Tap a letter to see and copy every style, from bold blackletter to flowing script."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I make a calligraphy name to print?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Type a name into the calligraphy name box and print a worksheet with a model row plus faded rows to trace — a simple way to practice a name or design a decorative nameplate."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is this real dip-pen calligraphy or a font?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The on-screen letters are Unicode characters that serve as clean calligraphy models to trace and copy. For pointed-pen or brush calligraphy you still form the strokes by hand; these sheets give you the letterforms to follow. For copy-paste calligraphy text, use the gothic or cursive font generators."
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/">Home</a>
+  <span class="breadcrumb-separator">›</span>
+  <a href="/printables/">Printables</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Calligraphy Alphabet</span>
+</nav>
+
+  <section class="hero">
+    <div class="hero-inner" style="max-width:820px;">
+      <h1 class="hero-headline">Calligraphy Alphabet — Printable Practice Sheets</h1>
+      <p class="hero-tagline">
+        The calligraphy alphabet A–Z in ornate blackletter and elegant script. Print a practice
+        sheet with model letters to trace, download any letter as a PNG, or make a calligraphy name. Free.
+      </p>
+    </div>
+  </section>
+
+  <main class="container">
+
+    <!-- Practice sheet CTA -->
+    <section class="bubble-alphabet" aria-labelledby="ptPracticeHeading">
+      <div class="bubble-alphabet-head">
+        <h2 id="ptPracticeHeading">Printable calligraphy practice sheet</h2>
+        <button class="bubble-btn bubble-btn-primary" type="button" id="pt-practice-print">Print practice sheet</button>
+      </div>
+      <p class="bubble-az-intro">One click prints an A–Z page where each row shows the calligraphy model letters plus space to trace and repeat them — a simple way to study blackletter and script letterforms.</p>
+    </section>
+
+    <!-- Picker + selected-letter detail -->
+    <section class="bubble-az" aria-labelledby="ptPickHeading">
+      <h2 class="bubble-az-heading" id="ptPickHeading">Calligraphy letters A–Z</h2>
+      <p class="bubble-az-intro">Tap a letter to see it in ornate blackletter and elegant script, print a large single letter, download a PNG, or copy any calligraphy style.</p>
+      <div class="bubble-strip" id="pt-strip" role="tablist" aria-label="Choose a calligraphy letter"></div>
+      <div class="bubble-letter-panel" id="pt-panel" aria-live="polite"></div>
+    </section>
+
+    <!-- Calligraphy name worksheet -->
+    <section class="bubble-alphabet" aria-labelledby="ptNameHeading">
+      <h2 id="ptNameHeading">Calligraphy name sheet</h2>
+      <p class="bubble-az-intro">Type a name to preview it in calligraphy, then print a worksheet with a model row and faded rows to trace — perfect for nameplates, place cards, and practice.</p>
+      <div class="pt-name-tool">
+        <div class="input-wrapper">
+          <input type="text" class="main-input pt-name-input" id="pt-name-input" placeholder="Type a name… e.g. Sofia" maxlength="40">
+        </div>
+        <div class="pt-name-preview" id="pt-name-preview" aria-live="polite"></div>
+        <div class="bubble-actions pt-name-actions">
+          <button type="button" class="bubble-btn bubble-btn-primary" id="pt-name-print">Print the worksheet</button>
+          <button type="button" class="bubble-btn" id="pt-name-png">Download PNG</button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Editorial -->
+    <section class="editorial-section">
+      <h2>Blackletter vs. modern script calligraphy</h2>
+      <p><strong>Blackletter</strong> (also called gothic or Old English) is the dense, angular hand of medieval
+        manuscripts — dramatic capitals and heavy verticals. <strong>Modern script</strong> is lighter and flowing,
+        closer to elegant handwriting. This page gives you both: an ornate blackletter model to trace, plus script
+        variants for every letter.</p>
+      <h3>Printable calligraphy vs. copy-paste text</h3>
+      <p>These sheets are for practicing letterforms on paper. If you want calligraphy-style text you can paste into a
+        bio, caption, or design, use the <a href="/category/gothic-fonts/">gothic font generator</a> for blackletter or
+        the <a href="/category/cursive-fonts/">cursive generator</a> for script. For heritage blackletter names and
+        tattoos, see <a href="/category/old-english-fonts/">Old English fonts</a>. Prefer flowing handwriting practice?
+        Try the <a href="/printables/cursive-alphabet/">cursive practice sheets</a>.</p>
+    </section>
+
+    <div class="cta-card">
+      <h3>Want calligraphy text you can copy and paste?</h3>
+      <p>Type once and copy ornate blackletter or elegant script for bios, titles, and names.</p>
+      <a class="cta-btn" href="/category/gothic-fonts/">Open the gothic font generator →</a>
+    </div>
+  </main>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <h2 class="faq-category">Printable Calligraphy — FAQ</h2>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Can I print calligraphy practice sheets?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Yes. Click <strong>Print practice sheet</strong> for a printable A–Z page where each row shows the calligraphy
+          model letters plus space to trace and repeat them — useful for learning blackletter and script hands.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          What styles are in the calligraphy alphabet?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          An ornate blackletter (gothic) calligraphy hand as the main model, plus elegant script variants for each letter.
+          Tap a letter to see and copy every style, from bold blackletter to flowing script.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Can I make a calligraphy name to print?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Yes. Type a name into the calligraphy name box and print a worksheet with a model row plus faded rows to trace —
+          a simple way to practice a name or design a decorative nameplate.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Is this real dip-pen calligraphy or a font?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          The on-screen letters are Unicode characters that serve as clean calligraphy models to trace and copy. For
+          pointed-pen or brush calligraphy you still form the strokes by hand; these sheets give you the letterforms to
+          follow. For copy-paste calligraphy text, use the <a href="/category/gothic-fonts/">gothic</a> or
+          <a href="/category/cursive-fonts/">cursive</a> font generators.
+        </div>
+      </div>
+
+    </div>
+  </footer>
+
+  <!-- Print surface (hidden on screen, isolated when printing) -->
+  <div id="pt-print-root" aria-hidden="true"></div>
+
+  <script>
+    window.UTG_PRINTABLE = {
+      key: "calligraphy-alphabet",
+      render: "glyph",
+      noun: "calligraphy",
+      pngPrefix: "calligraphy",
+      font: "'Plus Jakarta Sans', 'Segoe UI Symbol', 'Noto Sans Symbols 2', sans-serif",
+      charset: "alpha",
+      glyphStyle: "Ultra Gothic Script",
+      variantStyles: [
+        "Ultra Gothic Script", "Ultra Gothic", "Ultra Gothic Bold",
+        "Ultra Script Elegant", "Ultra Script Bold Elegant", "Ultra Script", "Ultra Script Bold"
+      ],
+      nameDemo: "Sofia"
+    };
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/js/printables/printablesEngine.js" defer></script>
+
+  <!-- FAQ toggle -->
+  <script>
+    document.querySelectorAll('.faq-question').forEach(function(btn) {
+      btn.addEventListener('click', function() { this.closest('.faq-item').classList.toggle('open'); });
+    });
+  </script>
+<script src="/footer.js" defer></script>
+</body></html>

--- a/printables/cursive-alphabet/index.html
+++ b/printables/cursive-alphabet/index.html
@@ -155,7 +155,8 @@
       <p>These sheets are for <em>paper</em> — tracing and handwriting. If you want cursive text you can paste into an
         Instagram bio, a caption, or a document, use the <a href="/category/cursive-fonts/">cursive text generator</a>, which
         turns your words into copy-paste Unicode script. For lettering on skin, the
-        <a href="/usecase/tattoo-fonts/">tattoo font generator</a> adds script families and size tests.</p>
+        <a href="/usecase/tattoo-fonts/">tattoo font generator</a> adds script families and size tests. Prefer ornate
+        blackletter? See the <a href="/printables/calligraphy-alphabet/">calligraphy practice sheets</a>.</p>
     </section>
 
     <div class="cta-card">

--- a/printables/cursive-alphabet/index.html
+++ b/printables/cursive-alphabet/index.html
@@ -1,0 +1,247 @@
+<!DOCTYPE html><html lang="en"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cursive Alphabet A–Z — Free Printable Practice Sheets &amp; Letters | UltraTextGen</title>
+  <meta name="description" content="The cursive alphabet A–Z with free printable practice sheets — model letters plus space to trace — per-letter PNG downloads, and a cursive name worksheet. No sign-up.">
+  <link rel="canonical" href="https://ultratextgen.com/printables/cursive-alphabet/">
+  <meta property="og:title" content="Cursive Alphabet A–Z — Free Printable Practice Sheets | UltraTextGen">
+  <meta property="og:description" content="The cursive alphabet A–Z with printable practice sheets to trace, per-letter PNG downloads, and a cursive name worksheet.">
+  <meta property="og:url" content="https://ultratextgen.com/printables/cursive-alphabet/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category-cursive-fonts.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Cursive Alphabet A–Z — Free Printable Practice Sheets | UltraTextGen">
+  <meta name="twitter:description" content="The cursive alphabet A–Z with printable practice sheets to trace, per-letter PNG downloads, and a cursive name worksheet.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category-cursive-fonts.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ultratextgen.com/" },
+    { "@type": "ListItem", "position": 2, "name": "Printables", "item": "https://ultratextgen.com/printables/" },
+    { "@type": "ListItem", "position": 3, "name": "Cursive Alphabet", "item": "https://ultratextgen.com/printables/cursive-alphabet/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Can I print cursive practice sheets or worksheets?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Hit Print practice sheet to get a printable A–Z page: each row shows the cursive model letters plus space to trace and repeat them — handy for teachers, parents, and anyone learning cursive."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How do I get a single cursive letter to print, like a cursive S or a capital G?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Tap any letter in the picker to see its capital and lowercase cursive form. Use Print this letter for a large single-letter page, or Download PNG to save a high-resolution image you can print or reuse."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I make a cursive name tracing sheet?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Type a name in the cursive name box and print a worksheet with a model row plus faded rows to trace — a simple way to practice writing a name or signature in cursive."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Unicode cursive the same as real cursive handwriting?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The on-screen cursive is Unicode script characters, which double as clean reference models for the letter shapes. Printed practice sheets use them as models to trace. For copy-paste cursive text in bios and captions, use the cursive text generator instead."
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/">Home</a>
+  <span class="breadcrumb-separator">›</span>
+  <a href="/printables/">Printables</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Cursive Alphabet</span>
+</nav>
+
+  <section class="hero">
+    <div class="hero-inner" style="max-width:820px;">
+      <h1 class="hero-headline">Cursive Alphabet — Printable Practice Sheets</h1>
+      <p class="hero-tagline">
+        The full cursive alphabet A–Z. Print a practice sheet with model letters and space to trace,
+        download any letter as a PNG, or make a cursive name worksheet. Free, no sign-up.
+      </p>
+    </div>
+  </section>
+
+  <main class="container">
+
+    <!-- Practice sheet CTA -->
+    <section class="bubble-alphabet" aria-labelledby="ptPracticeHeading">
+      <div class="bubble-alphabet-head">
+        <h2 id="ptPracticeHeading">Printable cursive practice sheet</h2>
+        <button class="bubble-btn bubble-btn-primary" type="button" id="pt-practice-print">Print practice sheet</button>
+      </div>
+      <p class="bubble-az-intro">One click prints an A–Z page where each row shows the cursive model letters plus space to trace and repeat them — ready for the classroom, homeschool, or your own practice.</p>
+    </section>
+
+    <!-- Picker + selected-letter detail -->
+    <section class="bubble-az" aria-labelledby="ptPickHeading">
+      <h2 class="bubble-az-heading" id="ptPickHeading">Cursive letters A–Z</h2>
+      <p class="bubble-az-intro">Tap a letter to see its capital and lowercase cursive form, print a large single letter, download a PNG, or copy the matching Unicode cursive styles.</p>
+      <div class="bubble-strip" id="pt-strip" role="tablist" aria-label="Choose a cursive letter"></div>
+      <div class="bubble-letter-panel" id="pt-panel" aria-live="polite"></div>
+    </section>
+
+    <!-- Cursive name worksheet -->
+    <section class="bubble-alphabet" aria-labelledby="ptNameHeading">
+      <h2 id="ptNameHeading">Cursive name tracing sheet</h2>
+      <p class="bubble-az-intro">Type a name to preview it in cursive, then print a worksheet with a model row and faded rows to trace — great for signatures and name practice.</p>
+      <div class="pt-name-tool">
+        <div class="input-wrapper">
+          <input type="text" class="main-input pt-name-input" id="pt-name-input" placeholder="Type a name… e.g. Olivia" maxlength="40">
+        </div>
+        <div class="pt-name-preview" id="pt-name-preview" aria-live="polite"></div>
+        <div class="bubble-actions pt-name-actions">
+          <button type="button" class="bubble-btn bubble-btn-primary" id="pt-name-print">Print the worksheet</button>
+          <button type="button" class="bubble-btn" id="pt-name-png">Download PNG</button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Editorial -->
+    <section class="editorial-section">
+      <h2>Learning cursive from the practice sheet</h2>
+      <p>Print the <strong>practice sheet</strong> and trace each model letter until the joins feel natural, then move to the
+        blank space to write it freehand. Study how each capital connects, and keep sessions short and frequent — a few
+        letters a day beats one long sitting.</p>
+      <h3>Printable cursive vs. copy-paste cursive</h3>
+      <p>These sheets are for <em>paper</em> — tracing and handwriting. If you want cursive text you can paste into an
+        Instagram bio, a caption, or a document, use the <a href="/category/cursive-fonts/">cursive text generator</a>, which
+        turns your words into copy-paste Unicode script. For lettering on skin, the
+        <a href="/usecase/tattoo-fonts/">tattoo font generator</a> adds script families and size tests.</p>
+    </section>
+
+    <div class="cta-card">
+      <h3>Want cursive you can copy and paste?</h3>
+      <p>Type once and copy flowing Unicode script for bios, captions, names, and signatures.</p>
+      <a class="cta-btn" href="/category/cursive-fonts/">Open the cursive text generator →</a>
+    </div>
+  </main>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <h2 class="faq-category">Printable Cursive — FAQ</h2>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Can I print cursive practice sheets or worksheets?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Yes. Hit <strong>Print practice sheet</strong> to get a printable A–Z page: each row shows the cursive model letters
+          plus space to trace and repeat them — handy for teachers, parents, and anyone learning cursive.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          How do I get a single cursive letter to print, like a cursive S or a capital G?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Tap any letter in the picker to see its capital and lowercase cursive form. Use <strong>Print this letter</strong> for a
+          large single-letter page, or <strong>Download PNG</strong> to save a high-resolution image you can print or reuse.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Can I make a cursive name tracing sheet?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Yes. Type a name in the cursive name box and print a worksheet with a model row plus faded rows to trace — a simple way to
+          practice writing a name or signature in cursive.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Is Unicode cursive the same as real cursive handwriting?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          The on-screen cursive is Unicode script characters, which double as clean reference models for the letter shapes. Printed
+          practice sheets use them as models to trace. For copy-paste cursive text in bios and captions, use the
+          <a href="/category/cursive-fonts/">cursive text generator</a> instead.
+        </div>
+      </div>
+
+    </div>
+  </footer>
+
+  <!-- Print surface (hidden on screen, isolated when printing) -->
+  <div id="pt-print-root" aria-hidden="true"></div>
+
+  <script>
+    window.UTG_PRINTABLE = {
+      key: "cursive-alphabet",
+      render: "glyph",
+      noun: "cursive",
+      pngPrefix: "cursive",
+      font: "'Plus Jakarta Sans', 'Segoe UI Symbol', 'Noto Sans Symbols 2', sans-serif",
+      charset: "alpha",
+      variantFamily: "cursive",
+      glyphStyle: "Ultra Script",
+      nameDemo: "Olivia"
+    };
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/js/printables/printablesEngine.js" defer></script>
+
+  <!-- FAQ toggle -->
+  <script>
+    document.querySelectorAll('.faq-question').forEach(function(btn) {
+      btn.addEventListener('click', function() { this.closest('.faq-item').classList.toggle('open'); });
+    });
+  </script>
+<script src="/footer.js" defer></script>
+</body></html>

--- a/printables/index.html
+++ b/printables/index.html
@@ -1,0 +1,274 @@
+<!DOCTYPE html><html lang="en"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Printable Letters, Alphabets &amp; Tracing Sheets — Free PDF/PNG | UltraTextGen</title>
+  <meta name="description" content="Free printable letters and alphabets: bubble letters, cursive practice sheets, block letter stencils, and name tracing worksheets. Print or download as PNG — no sign-up.">
+  <link rel="canonical" href="https://ultratextgen.com/printables/">
+  <meta property="og:title" content="Printable Letters, Alphabets &amp; Tracing Sheets | UltraTextGen">
+  <meta property="og:description" content="Free printable letters and alphabets: bubble letters, cursive practice sheets, block letter stencils, and name tracing worksheets. Print or download as PNG.">
+  <meta property="og:url" content="https://ultratextgen.com/printables/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Printable Letters, Alphabets &amp; Tracing Sheets | UltraTextGen">
+  <meta name="twitter:description" content="Free printable letters and alphabets: bubble letters, cursive practice sheets, block letter stencils, and name tracing worksheets.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "name": "Printable Letters & Alphabets",
+  "url": "https://ultratextgen.com/printables/",
+  "description": "Free printable letters, alphabets, tracing sheets, and PNG downloads.",
+  "mainEntity": {
+    "@type": "ItemList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Printable Bubble Letters", "url": "https://ultratextgen.com/printables/bubble-letters/" },
+      { "@type": "ListItem", "position": 2, "name": "Cursive Alphabet & Practice Sheets", "url": "https://ultratextgen.com/printables/cursive-alphabet/" },
+      { "@type": "ListItem", "position": 3, "name": "Printable Block Letters", "url": "https://ultratextgen.com/printables/block-letters/" },
+      { "@type": "ListItem", "position": 4, "name": "Name Tracing Worksheets", "url": "https://ultratextgen.com/printables/name-tracing/" }
+    ]
+  }
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ultratextgen.com/" },
+    { "@type": "ListItem", "position": 2, "name": "Printables", "item": "https://ultratextgen.com/printables/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Are these printable letters free?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Every printable on UltraTextGen is completely free with no sign-up, watermark, or usage limit. Pick a letter or type a name, then use the Print button to send it to your printer or Download PNG to save a high-resolution image."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the difference between the printables and the font generators?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The font generators (in Categories) turn text into copy-paste Unicode fonts for bios, captions, and comments. The printables turn letters into large outlines and worksheets you print on paper to trace, color, cut out, or practice handwriting. They are linked, but serve different jobs — one is for screens, one is for paper."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Do I need to download an app or install a font?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. Everything runs in your browser. The outlines and worksheets are generated on the page — click Print to open your browser's print dialog, or Download PNG to save an image you can print or drop into another design."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I make a tracing worksheet with my child's name?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Open Name Tracing Worksheets, type any name, and print a sheet with a solid model row plus faded rows to trace and blank ruled lines for free practice."
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/">Home</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Printables</span>
+</nav>
+
+  <!-- Hero Section -->
+  <section class="hero">
+    <div class="hero-inner" style="max-width:800px;">
+      <h1 class="hero-headline">Printable Letters &amp; Alphabets</h1>
+      <p class="hero-tagline">
+        Free letters and alphabets built for paper, not just screens.<br>
+        Print big outlines to trace and color, practice sheets for handwriting,
+        or a tracing worksheet with any name — then print it or save a PNG.
+      </p>
+    </div>
+  </section>
+
+  <!-- Main Content -->
+  <main class="container" style="max-width:900px;">
+
+    <section class="editorial-section" id="printables">
+      <h2>Choose a printable</h2>
+      <div class="printable-hub-grid">
+
+        <a class="printable-card" href="/printables/bubble-letters/">
+          <span class="printable-card-art" aria-hidden="true">Ⓐ Ⓑ Ⓒ</span>
+          <h3>Printable Bubble Letters</h3>
+          <p>Big, puffy bubble outlines A–Z and 0–9 to trace, color, and print — plus a one-click PNG of any letter for posters, cards, and bullet journals.</p>
+          <span class="printable-card-cta">Open bubble letters →</span>
+        </a>
+
+        <a class="printable-card" href="/printables/cursive-alphabet/">
+          <span class="printable-card-art" aria-hidden="true">𝒜 𝒷 𝒸</span>
+          <h3>Cursive Alphabet &amp; Practice Sheets</h3>
+          <p>The full cursive alphabet with printable practice sheets — model letters plus space to trace — and per-letter PNG downloads for learning cursive.</p>
+          <span class="printable-card-cta">Open cursive alphabet →</span>
+        </a>
+
+        <a class="printable-card" href="/printables/block-letters/">
+          <span class="printable-card-art" aria-hidden="true">A B C</span>
+          <h3>Printable Block Letters</h3>
+          <p>Bold hollow block letters and numbers to print, trace, and cut out as stencils for signs, posters, banners, and classroom projects.</p>
+          <span class="printable-card-cta">Open block letters →</span>
+        </a>
+
+        <a class="printable-card" href="/printables/name-tracing/">
+          <span class="printable-card-art" aria-hidden="true">✎ abc</span>
+          <h3>Name Tracing Worksheets</h3>
+          <p>Type any name and print a handwriting worksheet: a solid model row, faded rows to trace, and blank lines for practice. Great for preschool and kindergarten.</p>
+          <span class="printable-card-cta">Open name tracing →</span>
+        </a>
+
+      </div>
+    </section>
+
+    <section class="editorial-section">
+      <h2>Printables vs. the font generators</h2>
+      <p>UltraTextGen does two different jobs. The <a href="/category/">font generators</a> turn your text into
+        copy-paste Unicode fonts for <a href="/usecase/bio-font/">bios</a>, captions, and comments — styling that
+        travels with your text on screens. These <strong>printables</strong> do the opposite: they turn letters into
+        large outlines and worksheets you put on <em>paper</em> to trace, color, cut out, or practice by hand.</p>
+      <p>They're linked — a bubble-letter poster and a bubble-text caption are cousins — but they answer different
+        searches and belong on different pages. Looking to copy-paste instead of print? Head to
+        <a href="/category/bubble-fonts/">bubble fonts</a> or the <a href="/category/cursive-fonts/">cursive generator</a>.</p>
+    </section>
+
+    <!-- Cross-family Navigation -->
+    <section class="related-pages">
+      <h2>Explore More</h2>
+      <div class="related-pages-grid">
+        <a href="/category/" class="related-page-card">
+          <span class="related-page-label">Categories</span>
+          <h4>Copy-paste font generators</h4>
+        </a>
+        <a href="/category/bubble-fonts/" class="related-page-card">
+          <span class="related-page-label">Generator</span>
+          <h4>Bubble fonts</h4>
+        </a>
+        <a href="/category/cursive-fonts/" class="related-page-card">
+          <span class="related-page-label">Generator</span>
+          <h4>Cursive text</h4>
+        </a>
+        <a href="/guide/" class="related-page-card">
+          <span class="related-page-label">Guides</span>
+          <h4>Typography guides</h4>
+        </a>
+      </div>
+    </section>
+  </main>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-inner">
+      <h2 class="faq-category">Printables FAQ</h2>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Are these printable letters free?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+          </svg>
+        </button>
+        <div class="faq-answer">
+          Yes — completely free, no sign-up, no watermark, no limits. Pick a letter or type a name, then use
+          <strong>Print</strong> to send it to your printer or <strong>Download PNG</strong> to save a high-resolution image.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          What is the difference between the printables and the font generators?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+          </svg>
+        </button>
+        <div class="faq-answer">
+          The <a href="/category/">font generators</a> turn text into copy-paste Unicode fonts for bios, captions, and
+          comments. The printables turn letters into large outlines and worksheets you print on paper to trace, color,
+          cut out, or practice handwriting. They're linked, but one is for screens and one is for paper.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Do I need to download an app or install a font?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+          </svg>
+        </button>
+        <div class="faq-answer">
+          No. Everything runs in your browser. Click <strong>Print</strong> to open your browser's print dialog, or
+          <strong>Download PNG</strong> to save an image you can print or drop into another design.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Can I make a tracing worksheet with my child's name?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+          </svg>
+        </button>
+        <div class="faq-answer">
+          Yes. Open <a href="/printables/name-tracing/">Name Tracing Worksheets</a>, type any name, and print a sheet with
+          a solid model row plus faded rows to trace and blank ruled lines for free practice.
+        </div>
+      </div>
+
+    </div>
+  </footer>
+
+  <!-- FAQ toggle -->
+  <script>
+    document.querySelectorAll('.faq-question').forEach(function(btn) {
+      btn.addEventListener('click', function() {
+        this.closest('.faq-item').classList.toggle('open');
+      });
+    });
+  </script>
+<script src="/footer.js" defer></script>
+</body></html>

--- a/printables/index.html
+++ b/printables/index.html
@@ -42,8 +42,9 @@
     "itemListElement": [
       { "@type": "ListItem", "position": 1, "name": "Printable Bubble Letters", "url": "https://ultratextgen.com/printables/bubble-letters/" },
       { "@type": "ListItem", "position": 2, "name": "Cursive Alphabet & Practice Sheets", "url": "https://ultratextgen.com/printables/cursive-alphabet/" },
-      { "@type": "ListItem", "position": 3, "name": "Printable Block Letters", "url": "https://ultratextgen.com/printables/block-letters/" },
-      { "@type": "ListItem", "position": 4, "name": "Name Tracing Worksheets", "url": "https://ultratextgen.com/printables/name-tracing/" }
+      { "@type": "ListItem", "position": 3, "name": "Calligraphy Alphabet & Practice Sheets", "url": "https://ultratextgen.com/printables/calligraphy-alphabet/" },
+      { "@type": "ListItem", "position": 4, "name": "Printable Block Letters & Stencils", "url": "https://ultratextgen.com/printables/block-letters/" },
+      { "@type": "ListItem", "position": 5, "name": "Name Tracing Worksheets", "url": "https://ultratextgen.com/printables/name-tracing/" }
     ]
   }
 }
@@ -149,10 +150,17 @@
           <span class="printable-card-cta">Open cursive alphabet →</span>
         </a>
 
+        <a class="printable-card" href="/printables/calligraphy-alphabet/">
+          <span class="printable-card-art" aria-hidden="true">𝕬 𝖆 𝔟</span>
+          <h3>Calligraphy Alphabet &amp; Practice Sheets</h3>
+          <p>The calligraphy alphabet in ornate blackletter and elegant script, with printable practice sheets to trace and per-letter PNG downloads.</p>
+          <span class="printable-card-cta">Open calligraphy alphabet →</span>
+        </a>
+
         <a class="printable-card" href="/printables/block-letters/">
           <span class="printable-card-art" aria-hidden="true">A B C</span>
-          <h3>Printable Block Letters</h3>
-          <p>Bold hollow block letters and numbers to print, trace, and cut out as stencils for signs, posters, banners, and classroom projects.</p>
+          <h3>Block Letters &amp; Stencils</h3>
+          <p>Bold hollow block letters and numbers — letter stencils, alphabet stencils, and number stencils to print, trace, and cut out for signs, posters, and banners.</p>
           <span class="printable-card-cta">Open block letters →</span>
         </a>
 

--- a/printables/name-tracing/index.html
+++ b/printables/name-tracing/index.html
@@ -1,0 +1,263 @@
+<!DOCTYPE html><html lang="en"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Name Tracing Worksheets — Free Printable Handwriting Practice | UltraTextGen</title>
+  <meta name="description" content="Type any name to make a free printable name tracing worksheet: a solid model row, faded rows to trace, and blank lines to practice. Plus A–Z and 0–9 letter tracing. No sign-up.">
+  <link rel="canonical" href="https://ultratextgen.com/printables/name-tracing/">
+  <meta property="og:title" content="Name Tracing Worksheets — Free Printable Handwriting Practice | UltraTextGen">
+  <meta property="og:description" content="Type any name to make a free printable tracing worksheet: model row, faded trace rows, and blank practice lines. Plus A–Z and 0–9 letter tracing.">
+  <meta property="og:url" content="https://ultratextgen.com/printables/name-tracing/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Name Tracing Worksheets — Free Printable Handwriting Practice | UltraTextGen">
+  <meta name="twitter:description" content="Type any name to make a free printable tracing worksheet: model row, faded trace rows, and blank practice lines.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;family=Quicksand:wght@500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ultratextgen.com/" },
+    { "@type": "ListItem", "position": 2, "name": "Printables", "item": "https://ultratextgen.com/printables/" },
+    { "@type": "ListItem", "position": 3, "name": "Name Tracing", "item": "https://ultratextgen.com/printables/name-tracing/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "How do I make a name tracing worksheet?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Type a name into the box and click Print the worksheet. The sheet has a solid model row that shows the name, several faded rows to trace over, and blank ruled lines for free practice. You can also download it as a PNG. Choose how many trace rows you want before printing."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Are the name tracing worksheets free?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes — completely free, with no sign-up, watermark, or limit. Make as many worksheets as you like for any name or word."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I make letter and number tracing sheets too?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Use the letter picker to trace a single A–Z letter or 0–9 number, or print the full A–Z and 0–9 practice sheet with model and trace rows. It works for uppercase names, lowercase practice, and number formation."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What age is name tracing good for?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Name tracing suits preschool and kindergarten learners building letter formation and fine-motor control, and anyone practicing neat handwriting. Print several copies and keep sessions short and frequent for the best results."
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/">Home</a>
+  <span class="breadcrumb-separator">›</span>
+  <a href="/printables/">Printables</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Name Tracing</span>
+</nav>
+
+  <section class="hero">
+    <div class="hero-inner" style="max-width:820px;">
+      <h1 class="hero-headline">Name Tracing Worksheets</h1>
+      <p class="hero-tagline">
+        Type any name and print a handwriting worksheet: a solid model row, faded rows to trace,
+        and blank lines to practice. Plus A–Z and 0–9 letter tracing. Free, no sign-up.
+      </p>
+    </div>
+  </section>
+
+  <main class="container">
+
+    <!-- Name worksheet (primary) -->
+    <section class="bubble-alphabet" aria-labelledby="ptNameHeading">
+      <h2 id="ptNameHeading">Make a name tracing worksheet</h2>
+      <p class="bubble-az-intro">Type a name or short word, preview it below, then print — or download a PNG. The worksheet gives a solid model to follow, faded rows to trace, and blank ruled lines for free practice.</p>
+      <div class="pt-name-tool">
+        <div class="input-wrapper">
+          <input type="text" class="main-input pt-name-input" id="pt-name-input" placeholder="Type a name… e.g. Emma" maxlength="40">
+        </div>
+        <div class="pt-name-controls">
+          <label class="pt-name-rows-label" for="pt-name-rows">Trace rows</label>
+          <select id="pt-name-rows" class="pt-name-rows-select">
+            <option value="2">2</option>
+            <option value="3" selected>3</option>
+            <option value="4">4</option>
+            <option value="5">5</option>
+            <option value="6">6</option>
+          </select>
+        </div>
+        <div class="pt-name-preview" id="pt-name-preview" aria-live="polite"></div>
+        <div class="bubble-actions pt-name-actions">
+          <button type="button" class="bubble-btn bubble-btn-primary" id="pt-name-print">Print the worksheet</button>
+          <button type="button" class="bubble-btn" id="pt-name-png">Download PNG</button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Letter / number tracing -->
+    <section class="bubble-az" aria-labelledby="ptPickHeading">
+      <h2 class="bubble-az-heading" id="ptPickHeading">Letter &amp; number tracing A–Z, 0–9</h2>
+      <p class="bubble-az-intro">Tap any letter or number to trace it on its own, print a large single character, or download a PNG.</p>
+      <div class="bubble-strip" id="pt-strip" role="tablist" aria-label="Choose a letter or number to trace"></div>
+      <div class="bubble-letter-panel" id="pt-panel" aria-live="polite"></div>
+    </section>
+
+    <!-- Full practice sheet + alphabet -->
+    <section class="bubble-alphabet" aria-labelledby="ptAlphaHeading">
+      <div class="bubble-alphabet-head">
+        <h2 id="ptAlphaHeading">Printable A–Z &amp; 0–9 tracing sheets</h2>
+        <button class="bubble-btn bubble-btn-primary" type="button" id="pt-practice-print">Print practice sheet</button>
+      </div>
+      <p class="bubble-az-intro">Print a ruled A–Z and 0–9 sheet — a model plus trace space on every row — or print the outline alphabet below to trace whole letters.</p>
+      <div class="bubble-alphabet-grid" id="pt-alphabet-grid"></div>
+      <div class="pt-alpha-print-row">
+        <button class="bubble-btn" type="button" id="pt-alphabet-print">Print the outline alphabet</button>
+      </div>
+    </section>
+
+    <!-- Editorial -->
+    <section class="editorial-section">
+      <h2>Getting the most from name tracing</h2>
+      <ul class="compat-list">
+        <li><span class="ts-pill-safe">Model first</span> Point to the solid top row and say the name before tracing begins.</li>
+        <li><span class="ts-pill-safe">Trace slowly</span> Encourage staying inside the outline — control matters more than speed.</li>
+        <li><span class="ts-pill-safe">Then freehand</span> Finish on the blank lines writing it without the guide.</li>
+      </ul>
+      <p>Print several copies so a name can be practiced across the week. For fancier styles, try the
+        <a href="/printables/cursive-alphabet/">cursive practice sheets</a>, or make a decorative name in
+        <a href="/printables/bubble-letters/">bubble letters</a> to color.</p>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <h2 class="faq-category">Name Tracing — FAQ</h2>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          How do I make a name tracing worksheet?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Type a name into the box and click <strong>Print the worksheet</strong>. The sheet has a solid model row that shows the
+          name, several faded rows to trace over, and blank ruled lines for free practice. You can also download it as a PNG, and
+          choose how many trace rows you want before printing.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Are the name tracing worksheets free?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Yes — completely free, with no sign-up, watermark, or limit. Make as many worksheets as you like for any name or word.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Can I make letter and number tracing sheets too?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Yes. Use the letter picker to trace a single A–Z letter or 0–9 number, or print the full A–Z and 0–9 practice sheet with
+          model and trace rows. It works for uppercase names, lowercase practice, and number formation.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          What age is name tracing good for?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Name tracing suits preschool and kindergarten learners building letter formation and fine-motor control, and anyone
+          practicing neat handwriting. Print several copies and keep sessions short and frequent for the best results.
+        </div>
+      </div>
+
+    </div>
+  </footer>
+
+  <!-- Print surface (hidden on screen, isolated when printing) -->
+  <div id="pt-print-root" aria-hidden="true"></div>
+
+  <script>
+    window.UTG_PRINTABLE = {
+      key: "name-tracing",
+      render: "outline",
+      noun: "tracing",
+      pngPrefix: "tracing",
+      font: "Quicksand, 'Plus Jakarta Sans', sans-serif",
+      strokeWidth: 4,
+      charset: "alnum",
+      variantFamily: "",
+      nameDemo: "Emma",
+      howto: {
+        title: "How to trace the {ch}",
+        steps: [
+          "Start at the top of the gray outline and follow it slowly.",
+          "Keep the pencil inside the lines — go slow for control.",
+          "Trace it a few times, then write it on the blank line freehand."
+        ],
+        tip: "Print several copies so a child can practice all week."
+      }
+    };
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/js/printables/printablesEngine.js" defer></script>
+
+  <!-- FAQ toggle -->
+  <script>
+    document.querySelectorAll('.faq-question').forEach(function(btn) {
+      btn.addEventListener('click', function() { this.closest('.faq-item').classList.toggle('open'); });
+    });
+  </script>
+<script src="/footer.js" defer></script>
+</body></html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -269,7 +269,7 @@
 
   <url>
     <loc>https://ultratextgen.com/category/bubble-fonts/</loc>
-    <lastmod>2026-07-03</lastmod>
+    <lastmod>2026-07-08</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -3363,6 +3363,13 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/bubble-letters/</loc>
+    <lastmod>2026-07-08</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/printables/calligraphy-alphabet/</loc>
     <lastmod>2026-07-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -332,7 +332,7 @@
 
   <url>
     <loc>https://ultratextgen.com/category/strikethrough-text/</loc>
-    <lastmod>2026-07-03</lastmod>
+    <lastmod>2026-07-08</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -346,7 +346,7 @@
 
   <url>
     <loc>https://ultratextgen.com/category/underline-text/</loc>
-    <lastmod>2026-07-02</lastmod>
+    <lastmod>2026-07-08</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -997,7 +997,7 @@
 
   <url>
     <loc>https://ultratextgen.com/id/library/kaomoji/</loc>
-    <lastmod>2026-07-07</lastmod>
+    <lastmod>2026-07-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -1046,7 +1046,7 @@
 
   <url>
     <loc>https://ultratextgen.com/id/tulisan-coret/</loc>
-    <lastmod>2026-07-03</lastmod>
+    <lastmod>2026-07-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -1165,7 +1165,7 @@
 
   <url>
     <loc>https://ultratextgen.com/id/usecase/zalgo-text/</loc>
-    <lastmod>2026-07-03</lastmod>
+    <lastmod>2026-07-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -1347,21 +1347,21 @@
 
   <url>
     <loc>https://ultratextgen.com/ja/library/emoji-combos/</loc>
-    <lastmod>2026-07-07</lastmod>
+    <lastmod>2026-07-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/ja/library/kaomoji/</loc>
-    <lastmod>2026-07-07</lastmod>
+    <lastmod>2026-07-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/ja/library/special-characters/</loc>
-    <lastmod>2026-07-07</lastmod>
+    <lastmod>2026-07-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -3348,6 +3348,41 @@
   </url>
 
   <url>
+    <loc>https://ultratextgen.com/printables/</loc>
+    <lastmod>2026-07-08</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/printables/block-letters/</loc>
+    <lastmod>2026-07-08</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/printables/bubble-letters/</loc>
+    <lastmod>2026-07-08</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/printables/cursive-alphabet/</loc>
+    <lastmod>2026-07-08</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/printables/name-tracing/</loc>
+    <lastmod>2026-07-08</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
     <loc>https://ultratextgen.com/privacy/</loc>
     <lastmod>2026-07-02</lastmod>
     <changefreq>weekly</changefreq>
@@ -3811,7 +3846,7 @@
 
   <url>
     <loc>https://ultratextgen.com/usecase/zalgo-text/</loc>
-    <lastmod>2026-07-03</lastmod>
+    <lastmod>2026-07-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>

--- a/style.css
+++ b/style.css
@@ -3647,9 +3647,10 @@ button.clear-decoration {
 .bubble-print-sheet .bubble-outline { width: 100%; }
 
 @media print {
-  body.is-printing > *:not(#bubblePrintRoot):not(#cursivePrintRoot) { display: none !important; }
+  body.is-printing > *:not(#bubblePrintRoot):not(#cursivePrintRoot):not(#pt-print-root) { display: none !important; }
   body.is-printing #bubblePrintRoot { display: block !important; padding: 1rem; }
   body.is-printing #cursivePrintRoot { display: block !important; padding: 1rem; }
+  body.is-printing #pt-print-root { display: block !important; padding: 1rem; }
 }
 
 /* ===========================================================
@@ -5191,3 +5192,136 @@ html[dir="rtl"] .copy-kbd { direction: ltr; }
 /* Directional affordance: the "→" links in localized copy point at reading
    flow, so flip them for RTL. Authors use .rtl-flip on such inline arrows. */
 html[dir="rtl"] .rtl-flip { display: inline-block; transform: scaleX(-1); }
+
+/* ===========================================================
+   Printables cluster (/printables/) — hub cards + shared engine
+   (js/printables/printablesEngine.js). Reuses the .bubble-* and
+   .cursive-print-* primitives; this block adds only what is new.
+   =========================================================== */
+
+/* Hub grid of printable cards */
+.printable-hub-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+.printable-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1.25rem;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-lg);
+  background: var(--bg-white);
+  box-shadow: var(--shadow-soft);
+  text-decoration: none;
+  color: var(--text-primary);
+  transition: border-color 0.15s ease, transform 0.1s ease;
+}
+.printable-card:hover { border-color: var(--accent-purple); transform: translateY(-2px); }
+.printable-card h3 { margin: 0; font-size: 1.1rem; color: var(--text-primary); }
+.printable-card p { margin: 0; font-size: 0.9rem; line-height: 1.55; color: var(--text-secondary); }
+.printable-card-art {
+  font-size: 1.9rem;
+  letter-spacing: 0.12em;
+  color: var(--accent-purple);
+  opacity: 0.85;
+}
+.printable-card-cta {
+  margin-top: 0.15rem;
+  font-weight: 700;
+  font-size: 0.85rem;
+  color: var(--accent-purple);
+}
+
+/* Selected-character figure in glyph mode (cursive) */
+.pt-glyph-figure {
+  margin: 0;
+  text-align: center;
+  font-size: 4.5rem;
+  line-height: 1.1;
+  color: var(--text-primary);
+}
+.pt-glyph-print {
+  margin: 0;
+  text-align: center;
+  font-size: 6rem;
+  line-height: 1.2;
+  color: #1a1a2e;
+}
+.pt-glyph-cell {
+  display: block;
+  text-align: center;
+  font-size: 1.6rem;
+  color: var(--text-primary);
+}
+
+/* Whole-word outline (name worksheet, outline mode) */
+.pt-word-outline { display: block; width: 100%; height: auto; }
+
+/* Name / word tool */
+.pt-name-tool { margin: 0.5rem 0 0; }
+.pt-name-input { min-height: auto; height: 52px; resize: none; }
+.pt-name-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0.75rem 0 0;
+}
+.pt-name-rows-label { font-size: 0.85rem; color: var(--text-secondary); font-weight: 600; }
+.pt-name-rows-select {
+  padding: 0.4rem 0.6rem;
+  border: 1px solid var(--border-light);
+  border-radius: 8px;
+  background: var(--bg-white);
+  color: var(--text-primary);
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+.pt-name-preview {
+  margin: 1rem 0;
+  padding: 1rem 1.25rem;
+  min-height: 96px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #fff;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+.pt-name-preview .pt-word-outline { max-height: 120px; }
+.pt-name-glyph { color: #1a1a2e; }
+.pt-name-actions { margin-top: 0.25rem; }
+.pt-alpha-print-row { margin-top: 0.9rem; }
+
+/* Practice-sheet model cell that holds an outline SVG (outline mode) */
+.pt-model-svg .bubble-outline { width: 84px; height: auto; }
+
+/* ---- Print surfaces for the shared engine ---- */
+#pt-print-root { display: none; }
+.bubble-print-single { text-align: center; }
+.bubble-print-single .bubble-outline { width: 60%; max-width: 420px; margin: 0 auto; }
+
+/* Name tracing worksheet (print) */
+.pt-name-sheet { display: flex; flex-direction: column; gap: 0.4rem; }
+.pt-name-row {
+  display: flex;
+  align-items: flex-end;
+  min-height: 92px;
+  border-bottom: 1px solid #94a3b8;
+}
+.pt-name-row.pt-name-blank { min-height: 92px; }
+.pt-name-row .pt-word-outline { width: 100%; max-height: 120px; }
+.pt-name-word {
+  font-size: 3.2rem;
+  line-height: 1.1;
+  color: #334155;
+  padding-bottom: 0.15rem;
+}
+.pt-name-word.is-trace { color: #cbd5e1; }
+
+/* Dark-mode: keep print-preview cards light so white-fill outlines stay visible */
+body.dark-mode .pt-name-preview { background: #fff; border-color: var(--border-light); }
+body.dark-mode .printable-card-art { color: var(--accent-blue); }

--- a/styles.js
+++ b/styles.js
@@ -122,10 +122,15 @@ const PRINTABLE_PAGES = {
     title: 'Cursive Alphabet & Practice Sheets',
     description: 'The cursive alphabet A–Z with printable practice sheets to trace and per-letter PNG downloads.'
   },
+  'calligraphy-alphabet': {
+    slug: 'calligraphy-alphabet',
+    title: 'Calligraphy Alphabet & Practice Sheets',
+    description: 'The calligraphy alphabet A–Z — blackletter and elegant script — with printable practice sheets and PNG downloads.'
+  },
   'block-letters': {
     slug: 'block-letters',
-    title: 'Printable Block Letters',
-    description: 'Block letter and number stencils A–Z, 0–9 to print, trace, and cut out.'
+    title: 'Printable Block Letters & Stencils',
+    description: 'Block letter and number stencils A–Z, 0–9 — letter stencils and alphabet stencils to print, trace, and cut out.'
   },
   'name-tracing': {
     slug: 'name-tracing',

--- a/styles.js
+++ b/styles.js
@@ -97,6 +97,40 @@ const SITE_PAGES = {
     slug: 'font',
     title: 'Fonts',
     description: 'Browse individual Unicode font pages.'
+  },
+  printablesRoot: {
+    slug: 'printables',
+    title: 'Printable Letters & Alphabets',
+    description: 'Free printable letters, alphabets, tracing sheets, and PNG downloads.'
+  }
+};
+
+/* -----------------------------
+   PRINTABLE PAGES (Printables cluster)
+   Downloadable / traceable resources (print + PNG), distinct from the
+   copy-paste font generators in CATEGORY_PAGES. Each page is driven by the
+   shared engine at /js/printables/printablesEngine.js via a per-page config.
+------------------------------ */
+const PRINTABLE_PAGES = {
+  'bubble-letters': {
+    slug: 'bubble-letters',
+    title: 'Printable Bubble Letters',
+    description: 'Bubble letters A–Z and 0–9 as large printable outlines to trace, color, and download as PNG.'
+  },
+  'cursive-alphabet': {
+    slug: 'cursive-alphabet',
+    title: 'Cursive Alphabet & Practice Sheets',
+    description: 'The cursive alphabet A–Z with printable practice sheets to trace and per-letter PNG downloads.'
+  },
+  'block-letters': {
+    slug: 'block-letters',
+    title: 'Printable Block Letters',
+    description: 'Block letter and number stencils A–Z, 0–9 to print, trace, and cut out.'
+  },
+  'name-tracing': {
+    slug: 'name-tracing',
+    title: 'Name Tracing Worksheets',
+    description: 'Type any name to build a free printable tracing worksheet with model and trace rows.'
   }
 };
 
@@ -1150,6 +1184,7 @@ function getStylesByFamilyAndGroup(familySlug, groupSlug) {
 ------------------------------ */
 window.SITE_PAGES = SITE_PAGES;
 window.CATEGORY_PAGES = CATEGORY_PAGES;
+window.PRINTABLE_PAGES = PRINTABLE_PAGES;
 window.textStyles = textStyles;
 
 window.StyleRegistry = {


### PR DESCRIPTION
## Summary

Introduces a new **Printables** section (`/printables/`) with four dedicated pages for downloadable, traceable letter resources. All pages are powered by a single, config-driven JavaScript engine (`printablesEngine.js`) that eliminates duplication and scales to new printable types.

## Key Changes

- **New shared engine** (`js/printables/printablesEngine.js`, 630 lines)
  - Single IIFE powers all four printable pages (bubble letters, cursive alphabet, block letters, name tracing)
  - Config-driven via `window.UTG_PRINTABLE` object; pages declare only what they need
  - Supports two render modes: "outline" (SVG, traceable) and "glyph" (Unicode, copy-paste variants)
  - Modular mount points: character picker, detail panel, alphabet grid, practice sheet, name worksheet
  - PNG export via Canvas with font preloading; print surface abstraction for headless testing

- **Four new printable pages**
  - `/printables/` — hub landing page with card grid linking to each printable type
  - `/printables/bubble-letters/` — puffy rounded outlines (outline mode)
  - `/printables/cursive-alphabet/` — Unicode cursive glyphs with practice sheets (glyph mode)
  - `/printables/block-letters/` — bold hollow stencils (outline mode)
  - `/printables/name-tracing/` — personalized name/word tracing worksheets

- **Styling** (`style.css`)
  - Added `.printable-hub-grid` and `.printable-card` for hub layout
  - Glyph figure styles (`.pt-glyph-figure`, `.pt-glyph-print`, `.pt-glyph-cell`)
  - Word outline styles (`.pt-word-outline`)
  - Print media query updated to include `#pt-print-root` alongside legacy print roots
  - ~140 lines of new CSS for printables-specific UI

- **Navigation & routing** (`styles.js`, `header.js`, `footer.js`)
  - Added `PRINTABLE_PAGES` registry mapping slug → config
  - Registered printables hub in `SITE_PAGES`
  - Added "Printables" link to header and footer navigation

- **SEO & metadata**
  - Each page includes BreadcrumbList, FAQPage, and HowTo structured data
  - Canonical URLs, OpenGraph, Twitter Card meta tags
  - Sitemap updated with new URLs

## Implementation Details

- **Config contract**: Each page sets `window.UTG_PRINTABLE = { render, font, charset, noun, ... }` before including the engine
- **Mount points** (all optional except `#pt-print-root`): `#pt-strip`, `#pt-panel`, `#pt-alphabet-grid`, `#pt-practice-print`, `#pt-name-input`, `#pt-name-print`, `#pt-name-png`, `#pt-name-preview`, `#pt-name-rows`, `#pt-print-root`
- **Render modes**:
  - "outline": white-fill + rounded dark-stroke SVG shapes (no font registry needed)
  - "glyph": Unicode glyphs from `window.textStyles` registry via `UltraTextGenRender.renderAny()`
- **Copy fallback**: Local clipboard delegation for standalone operation; reuses shared `script.js` contract via `data-text` attribute
- **PNG export**: Canvas-based with dynamic font loading and size scaling for words
- **Print abstraction**: `printWrap()` function centralizes print surface setup, enabling future headless/PDF integration

## Notes

- Generalizes two legacy per-page controllers (`js/bubble/bubbleExplorer.js`, `js/cursive/cursivePageController.js`) into reusable primitives
- Self-contained IIFE; no external dependencies beyond existing `window.UltraTextGenRender` and `window.textStyles`
- Maintains zero-framework philosophy; pure vanilla JavaScript

https://claude.ai/code/session_019D32u93A2v1d84EGo9opks