### PR TITLE
docs: expand product vision to in-browser visual/printable output + govern the new lane

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,13 @@ This file provides context for AI assistants working in this repository. Read it
 
 ## Project Overview
 
-**UltraTextGen** is a fast, zero-framework Unicode text generator. It converts plain text into stylized Unicode fonts that work across social platforms (LinkedIn, Instagram, Discord, etc.). The tool runs entirely in the browser with no backend, no build step, and no runtime dependencies.
+**UltraTextGen** is a fast, zero-framework text-expression tool. Its core is a Unicode text generator that converts plain text into stylized fonts that work across social platforms (LinkedIn, Instagram, Discord, etc.). It has since grown a **second output mode: in-browser visual & printable asset generation** — printable bubble-letter and cursive practice/coloring sheets (per-letter and full A–Z), and the curved/arc text tool (`/curved-text/`) — rendered client-side as **SVG/PNG** that users copy, download, or print.
 
-**Core philosophy**: Fast > Fancy, Clean > Clever, Useful > Impressive.
+Copy-paste Unicode is still the front door and satisfies the job fastest. Visual assets are the on-brand, higher-intent **follow-up** for jobs plain characters can't do (trace, color, print, logo/sticker art) — added where real demand exists, never as a default.
+
+**Scope note (updated):** the earlier "text-only, no image generator" boundary has been intentionally lifted. UltraTextGen now *does* generate images — but only **client-side, on demand, as SVG/PNG built with native Canvas/SVG**. This is not a reversal of the philosophy; it's the same philosophy applied to a new job.
+
+**Core philosophy**: Fast > Fancy, Clean > Clever, Useful > Impressive. **Client-side only is a hard line:** visual generation must use native SVG/Canvas in the browser — never a server-side renderer, an image-processing library, or bundled font binaries.
 
 ---
 
@@ -317,6 +321,11 @@ Do not add a test framework unless explicitly requested.
 
 - Do not add npm packages that run in the browser
 - Do not introduce a JavaScript framework or bundler
+- Do not generate images server-side or with an image-processing library. Visual/printable
+  output (bubble/cursive sheets, curved text, etc.) is **client-side SVG/Canvas → SVG/PNG only**,
+  built with native browser APIs, and must not bundle `.ttf`/`.otf` font binaries.
+- Do not make a visual/printable feature the *default* answer for a query that copy-paste
+  Unicode already serves — visual assets are the higher-intent follow-up, gated on real demand
 - Do not edit `sitemap.xml` directly
 - Do not add `var` declarations — use `const`/`let`
 - Do not use `import`/`export` ES module syntax in frontend scripts

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,6 +55,7 @@ These run across page types rather than producing a type.
 | Pinterest pins (+ new boards) | `generate-pinterest.py`, `generate-id-pins.py`, `generate-vertical-text-pins.py` (skin: `generate-site-art.py`); CSV: `pinterest_csv.py` + `build_pinterest_upload.py` | [`pinterest-pin-generation.md`](./pinterest-pin-generation.md) (board conventions) + [`pinterest-csv-format.md`](./pinterest-csv-format.md) | per batch |
 | Schema / alternateName SEO | `validate-alternatenames.py`, `inject-faq-jsonld.js`, `alternatename-seo-report.md` | ⚠️ none | per batch |
 | Image backlinks (embeddable images / widgets) | `/embed/` widget pages (no generator yet) | [`image-backlink-strategy.md`](./image-backlink-strategy.md) (decision doc) | ad hoc |
+| **Visual & printable assets** (in-browser SVG/PNG output mode) | `js/curved/curvedText.js` + `curvedTextController.js` (curved/arc tool → `/curved-text/`); `js/bubble/bubbleExplorer.js` (printable bubble letters, per-letter + A–Z); `js/cursive/cursivePageController.js` + `cursiveData.js` (cursive practice sheets) | [`jtbd-principles.md`](./jtbd-principles.md) §10 (output modes) + `CLAUDE.md` scope note | per feature (demand-gated) |
 | Collection-copy audit | `audit_library_opportunities.py` (+ explorer, see workflow §5) | ⚠️ workflow §5; [`emoji-combination-taxonomy.md`](./emoji-combination-taxonomy.md) for combo taxonomy | per batch |
 | i18n / localization | `prerender-i18n.js` (+ `de/`, `es/`, `fr/`, `id/`, `it/`, `nl/`, `pl/`, `pt/`, `tl/`, `tr/`, `vi/`, `locales/`, `README.*.md`) | ❌ none | as needed |
 | CSS audit | `audit-css.js` | ❌ none (CI-only) | CI (`css-audit.yml`) |
@@ -134,6 +135,17 @@ here so they aren't lost. Update as they're closed or new ones appear.
    week) never resolve to a lane — the digest classifier has no rule for it,
    and inventing one (e.g. folding it into "Docs" or "Core JS") would misrepresent
    what changed. Needs a decision: its own row, or explicit non-lane status.
+8. **Visual/printable output mode has principles but no pipeline.** The second
+   output mode ([`jtbd-principles.md`](./jtbd-principles.md) §10) is live across
+   three surfaces — the curved/arc tool (`/curved-text/`), printable bubble
+   letters (`/category/bubble-fonts/`), and cursive practice sheets
+   (`/category/cursive-fonts/`) — but each was hand-built with its own module.
+   There is **no shared SVG/PNG export helper, no generator/validator, and no
+   dedicated governing doc** (it's governed only by §10 + the `CLAUDE.md` scope
+   note). The `/curved-text/` top-level namespace is also not in the page-type
+   table and has no `LANE_RULES` entry in `scripts/weekly_pr_digest.py`, so PRs
+   touching it won't classify. Decide: promote to a full lane (shared export
+   util + a governing doc) or keep it a principle-governed cross-cutting track.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -142,10 +142,12 @@ here so they aren't lost. Update as they're closed or new ones appear.
    (`/category/cursive-fonts/`) — but each was hand-built with its own module.
    There is **no shared SVG/PNG export helper, no generator/validator, and no
    dedicated governing doc** (it's governed only by §10 + the `CLAUDE.md` scope
-   note). The `/curved-text/` top-level namespace is also not in the page-type
-   table and has no `LANE_RULES` entry in `scripts/weekly_pr_digest.py`, so PRs
-   touching it won't classify. Decide: promote to a full lane (shared export
-   util + a governing doc) or keep it a principle-governed cross-cutting track.
+   note). PRs touching it now classify — `scripts/weekly_pr_digest.py` has
+   `LANE_RULES` entries for `curved-text/` and `js/curved|bubble|cursive/` → the
+   "Visual & printable assets" lane — but the `/curved-text/` top-level namespace
+   is still absent from the page-type table. Decide: promote to a full lane
+   (shared export util + a governing doc) or keep it a principle-governed
+   cross-cutting track.
 
 ---
 

--- a/docs/jtbd-principles.md
+++ b/docs/jtbd-principles.md
@@ -9,10 +9,14 @@ mechanical companion — *does this become a page or a section?* — is
 production pipeline that enforces demand gating is
 [`unicode-library-workflow.md`](./unicode-library-workflow.md).
 
-> **The job:** *"Help me express this feeling / thing / identity in text —
-> easily, and more expressively than plain words."* People hire UltraTextGen
-> to make their writing more expressive and effortless. Everything below
-> follows from that one sentence.
+> **The job:** *"Help me express this feeling / thing / identity — easily, and
+> more expressively than plain words."* Usually that means **stylized text they
+> can copy and paste**; increasingly it also means a **downloadable or printable
+> visual asset** (a bubble-letter coloring sheet, a cursive practice page,
+> curved/arc text for a logo or sticker) for jobs plain characters can't do.
+> People hire UltraTextGen to make their expression more expressive and
+> effortless — **in text first, and as a visual asset where the job demands it.**
+> Everything below follows from that one sentence.
 
 ---
 
@@ -169,6 +173,44 @@ owner page for the job; they never spawn a thin page of their own.
 
 ---
 
+## 10. Two output modes — copy-paste text first, visual asset as the follow-up
+
+The product now ships in **two output modes**, and the order matters:
+
+1. **Copy-paste Unicode text** — the front door. Fastest path to the job, works
+   inline everywhere, zero-click. This is still the primary answer for almost
+   every query.
+2. **Downloadable / printable visual asset** — the higher-intent follow-up for
+   jobs plain characters *cannot* do: tracing, coloring, printing, classroom
+   handouts, logo / sticker / signage art. Shipped examples: the printable
+   bubble-letter sheets (per-letter + A–Z) on `/category/bubble-fonts/`, the
+   cursive practice sheets on `/category/cursive-fonts/`, and the curved/arc
+   text tool at `/curved-text/`.
+
+**Rules for the visual mode:**
+
+- **Text mode leads; visual mode follows.** On a page that serves a copy-paste
+  intent, the Unicode styles come first; the printable/visual affordance is a
+  section *below* (hub-and-spoke, §5), not the H1. Don't turn a copy-paste page
+  into an image tool.
+- **Demand gates it too (§6).** A visual asset earns its place the same way a
+  page does — real, evidenced demand for *that* job (e.g. "printable bubble
+  letters to color," "cursive practice sheet"). It is not a free add-on to
+  sprinkle on every generator.
+- **Client-side, SVG/PNG, native APIs only.** Generated in the browser with
+  SVG/Canvas, exported as SVG/PNG. **No** server-side rendering, image-processing
+  library, or bundled font binary. (Mirrors the hard line in `CLAUDE.md`.)
+- **Honesty carries over (§9).** A curve or a printable outline is a *visual
+  layout*, not a Unicode property — say so. Curved/printable output is an image
+  and cannot be pasted as characters; the page must set that expectation instead
+  of implying copy-paste.
+
+> **Rule:** Visual/printable output is a real second output mode, not a
+> reversal of "text-first." Lead with copy-paste text, add a visual asset only
+> where a distinct, evidenced job needs one, and build it client-side as SVG/PNG.
+
+---
+
 ## Decision checklist (apply before creating or expanding content)
 
 1. **What job is the user hiring this page for?** State it in their words, as
@@ -187,3 +229,7 @@ owner page for the job; they never spawn a thin page of their own.
 8. **What would make this the best `<thing>` generator?** Run the
    differentiator-discovery pass (§9): list the unsolved frustrations and the
    capabilities that answer them. Ship that list alongside the pages.
+9. **Which output mode does the job need?** (§10) Copy-paste text is the
+   default and leads. Add a downloadable/printable **visual asset** only if a
+   distinct, evidenced job needs one — and build it client-side as SVG/PNG,
+   below the text styles, with honest "this is an image, not characters" framing.

--- a/scripts/weekly_pr_digest.py
+++ b/scripts/weekly_pr_digest.py
@@ -34,6 +34,7 @@ LANE_RULES = [
     ("answers/", "Answer pages"),
     ("usecase/", "Usecase pages"),
     ("guide/", "Guide pages"),
+    ("curved-text/", "Visual & printable assets"),
     ("discord/", "Platform pages"),
     ("facebook/", "Platform pages"),
     ("instagram/", "Platform pages"),
@@ -61,6 +62,10 @@ LANE_RULES = [
     ("script.js", "Core JS"),
     ("header.js", "Core JS"),
     ("fonts.json", "Core JS"),
+    # Visual/printable output modules (must precede the generic "js/" rule).
+    ("js/curved/", "Visual & printable assets"),
+    ("js/bubble/", "Visual & printable assets"),
+    ("js/cursive/", "Visual & printable assets"),
     ("js/", "Core JS"),
     ("package.json", "Scripts / tooling"),
     ("sitemap.xml", "SEO / sitemap"),


### PR DESCRIPTION
## Why

The printable bubble/cursive sheets and the `/curved-text/` SVG tool (shipped in #419) moved UltraTextGen past "copy-paste Unicode only." This PR updates the vision docs to reflect that second output mode and formally governs it in the infra map — so future work is placed, not improvised.

Docs-only + one classifier tweak. No product/runtime code changes.

## Changes

**1. Vision — `CLAUDE.md` + `docs/jtbd-principles.md`** (kept consistent)
- `CLAUDE.md` Project Overview now names the second output mode (client-side **SVG/PNG** visual & printable assets), adds a **"Scope note (updated)"** that intentionally lifts the old "text-only, no image generator" boundary, and hardens the guardrail (native SVG/Canvas only — no server render, no image lib, no bundled fonts). Two new **"What NOT to Do"** bullets.
- `jtbd-principles.md`: broadened the JTBD job to "in text first, and as a visual asset where the job demands it"; added **principle §10** (copy-paste text leads, visual asset is the demand-gated follow-up) + a matching decision-checklist step.

**2. Infra map — `docs/README.md`**
- New **Operational tracks** row: *Visual & printable assets (in-browser SVG/PNG)*, listing the implementing modules (`js/curved/*`, `js/bubble/bubbleExplorer.js`, `js/cursive/*`) and its governing rules (§10 + CLAUDE.md scope note).
- New **Known gap #8**: the mode is principle-governed but has no shared SVG/PNG export helper, no generator/validator, and no dedicated doc; `/curved-text/` is still absent from the page-type table — flagged for the weekly infra review to decide *lane vs track*.

**3. PR digest classifier — `scripts/weekly_pr_digest.py`**
- Added `LANE_RULES` entries so PRs touching the mode classify as **"Visual & printable assets"** instead of Unclassified/Core JS: `curved-text/`, and `js/curved|bubble|cursive/` (placed **before** the generic `js/` rule so first-match-wins routes them correctly).

## Verification
- Classifier verified in a harness: the new paths route to the visual lane; generic `js/` still → Core JS, and `category/bubble-fonts/` still → Category pages (unchanged). Python parses.
- Markdown tables column-count checked.

## Note
The `docs: expand product vision…` commit was previously pushed to this branch but is **not in `main`** — so it's bundled here rather than being a separate merged change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114wUCakRUNVvd1yromruAq

---
_Generated by [Claude Code](https://claude.ai/code/session_0114wUCakRUNVvd1yromruAq)_