### PR TITLE
Add coloring page maker — type a word to generate a printable sheet

### DIFF
--- a/docs/coloring-sheet-generator-strategy.md
+++ b/docs/coloring-sheet-generator-strategy.md
@@ -1,0 +1,193 @@
+# Coloring / Printable Sheet Generator — Strategy & Build Spec
+
+_Owner brief. Written alongside the first build increment on
+`claude/coloring-sheet-generator-nc7rmu`. Demand figures are Semrush,
+`us` database, pulled 2026-07-09._
+
+---
+
+## 1. Thesis
+
+PR #423 gave us **coloring pages** (pick a letter → print an outline). The next
+job is a **coloring-sheet _generator_**: a tool where a parent or teacher
+_designs_ a finished sheet — a name, a heading, a decoration, a fill — and never
+needs to open Canva or a photo editor.
+
+The good news, established by auditing the engine: **we are ~80% of the way there
+already.** The shared `printablesEngine.js` can render an arbitrary typed word as
+a big colorable outline, it already stamps a heading onto every print, it exports
+PNG, and it has the ruled/trace-row machinery from the name-tracing ("dotted
+line") work. The gap to a real generator is **UI surface + a few native-SVG
+render options** — not a new engine, and with **zero** breach of the client-side
+hard line (no server render, no image library, no font binaries).
+
+The money is in the **"maker / generator" search intent** and **personalization
+(name/word)** — both low-competition, and UTG had **no page for either** until now.
+
+---
+
+## 2. The question the owner asked — "why would someone go to Canva instead of us?"
+
+Every reason someone opens Canva/an editor for a letter-coloring job, and whether
+we can serve it natively:
+
+| Reason to leave for Canva | Can we serve it client-side? | Status |
+|---|---|---|
+| Put a **name / word** on the sheet, not just one letter | Yes — engine already builds a whole-word outline (`wordOutlineSVG`) | **Shipped** |
+| Add a **heading / title** ("Emma's Coloring Page", "Letter of the Week") | Yes — `printWrap` already prints a title; expose it as a field | **Shipped** |
+| Add a **signature / footer** ("Name ___ / Date ___", "Colored by") | Yes — print-surface furniture (SVG text + rule lines) | **Shipped** |
+| Make it **cute / attractive** (stars, hearts, flowers, borders) | Yes — decorative symbol border, reusing our symbol sets | **Shipped** |
+| **Multi-color / fine-line** letters (color many small regions inside a letter) | Yes — SVG `<pattern>` fill (dots / stripes / hearts / stars) painted into the glyph | **Shipped** |
+| A **reference** ("color it like this" / example word) | Yes — solid mini-render + the A–Z example-word data we already have | Phase 2 |
+| **Connect-the-dots / dot-to-dot** version of a letter/name | Yes — sample points along the glyph outline, number them | Phase 2 |
+| **Numbers**, not just letters | Yes — engine supports `charset:"alnum"` | **Shipped** (maker is alnum) |
+| **Occasion themes** (birthday, holidays, welcome-back) | Yes — heading + border + fill presets | Phase 2 |
+| Turn **my photo** into a coloring page | **No** — needs server/AI raster tracing → violates the hard line | **Won't build** (see §5) |
+
+The only common Canva/AI job we deliberately **cannot** serve is photo→coloring.
+That is a feature boundary, not a failure — and it sharpens what we _are_: the
+**typography-native** coloring generator.
+
+---
+
+## 3. Demand — is this real, and where's the volume?
+
+### 3a. The "maker / generator" intent — real, and low-competition
+The exact thing the owner intuited (a *generator*, not just static pages) is a
+distinct, ownable search intent that we had no page for.
+
+| Keyword | Volume /mo | Competition |
+|---|---:|---:|
+| coloring page maker | 1,300 | 0.26 |
+| coloring page generator | 1,300 | 0.10 |
+| coloring page creator | 1,000 | 0.26 |
+| create your own coloring page | 590 | 0.32 |
+| make your own coloring page | 390 | 0.27 |
+| coloring sheet maker | 140 | 0.10 |
+| **maker/generator cluster (approx.)** | **~4,700** | **low (0.10–0.32)** |
+
+Competition on these is **0.10–0.32** — very reachable for a small site.
+
+### 3b. Personalization (name / word) — high intent, low competition
+| Keyword | Volume /mo | Competition |
+|---|---:|---:|
+| name coloring pages | 1,300 | 0.16 |
+| custom coloring pages | 880 | 0.82 |
+| word coloring pages | 480 | 0.12 |
+| personalized coloring pages | 390 | 0.96 |
+| custom name coloring pages | 170 | 0.55 |
+| birthday coloring pages (occasion personalization) | 4,400 | 0.35 |
+
+`name coloring pages` (1,300 @ **0.16**) and `word coloring pages` (480 @ **0.12**)
+are the standout low-competition personalization targets — served perfectly by a
+type-a-word generator.
+
+### 3c. Cheap adjacencies the same engine unlocks
+| Keyword | Volume /mo | Competition | Engine fit |
+|---|---:|---:|---|
+| number coloring pages | 4,400 | 0.25 | `charset:"alnum"` — already on |
+| number tracing worksheets | 4,400 | 0.56 | trace rows exist |
+| handwriting worksheet generator | 1,600 | 0.01 | name-worksheet path |
+| printable name tracing | 1,600 | 0.23 | name-tracing page exists |
+| monogram maker | 8,100 | 0.31 | letter-based; new spoke |
+| dot to dot generator | 480 | ~0 | new render mode |
+| connect the dots maker | 320 | 0.33 | new render mode |
+| stencil maker | 8,100 | 0.88 | block-letters exists |
+
+### 3d. The multi-color / "color-by-number letters" idea
+Direct search is **negligible** (`color by number letters` ≈ 20, `…alphabet` ≈ 10).
+**Conclusion: treat interior pattern-fills as an engagement/quality differentiator,
+not an SEO target.** It is what makes a sheet nicer than a plain outline and what
+brings a teacher back weekly — exactly the owner's "get users who design sheets
+regularly" goal. (The success of the color-by-number app "happy color" — 18,100/mo
+— confirms appetite for structured multi-region coloring even if the *maker* query
+is thin.)
+
+### 3e. Feasibility check (our authority)
+ultratextgen.com: ~**1,200** organic visits/mo, **606** ranking keywords, currently
+strongest on Discord/vertical-text/emoji. The printables cluster is brand-new (no
+rankings yet). Implication: **chase the low-competition long tail** (most targets
+above sit at 0.01–0.35) and lean on engine reuse to keep build cost low. That's the
+whole point of doing this in-engine rather than as a heavy new app.
+
+---
+
+## 4. Engine capability audit (what we're building on)
+
+`js/printables/printablesEngine.js` is one config-driven controller; a page opts
+into sections by including mount points. It already provides:
+
+- **Character picker** (A–Z, optional 0–9) + **detail panel** (big glyph, print,
+  PNG, copy-paste variants, how-to).
+- **`outlineSVG(ch)`** — white-fill + rounded dark-stroke glyph (colorable/traceable).
+- **`wordOutlineSVG(word)`** — an entire typed word as one colorable outline. _This
+  is the key primitive the coloring page never exposed._
+- **Printable alphabet grid** + **ruled practice sheet** (model / trace / blank rows).
+- **`printWrap(title, body)`** — isolated print surface that already renders a heading.
+- **Canvas PNG export** (single char + word), using the page-loaded font via
+  `document.fonts.load`.
+
+Two render modes: **outline** (bubble/block/coloring) and **glyph** (cursive/
+calligraphy Unicode). Sections are mount-gated, so new capability is purely additive.
+
+---
+
+## 5. Guardrails (philosophy compliance)
+
+- **Client-side only.** All generation is native SVG/Canvas in the browser. No
+  server renderer, no image-processing lib, no bundled `.ttf`/`.otf`.
+- **We do not chase photo→coloring / AI-trace demand** (`ai coloring page
+  generator`, `convert picture to colouring page`, ~2,400/mo each). It requires
+  raster tracing we can't do within the hard line. Naming it here so we don't drift.
+- **Copy-paste stays the front door.** The maker is the higher-intent *paper*
+  follow-up, gated on the real demand documented above — not a default answer to a
+  query that Unicode already serves.
+
+---
+
+## 6. What shipped in this increment (Phase 1)
+
+**New page:** `/printables/coloring-page-maker/` — targets the maker/generator/
+creator + name/word coloring keywords (none of which we ranked a page at before).
+
+**Engine additions** (additive, gated on `#pt-design-*` mounts; the 6 existing
+printables pages are untouched):
+
+- **Type a name / word → big colorable outline sheet** (portrait, print-ready).
+- **Editable heading** (optional) rendered on the sheet.
+- **Signature/date footer** toggle ("Name: ___  Date: ___").
+- **Decorative symbol border** — none / stars / hearts / dots / flowers / party mix.
+- **Interior fill for multi-color / fine-line practice** — plain, polka dots,
+  stripes, hearts, stars. Implemented as an SVG `<pattern>` painted as the glyph's
+  own fill (reliable across renderers; avoids the text-as-clipPath trap).
+- **Print** (full richness incl. patterns) and **Download PNG** (clean outline).
+- Reuses the picker + panel + alphabet grid, with **numbers on** (`charset:"alnum"`)
+  → also covers "number coloring pages".
+
+Registered in `PRINTABLE_PAGES`, linked from the printables hub and the
+alphabet-coloring hub, with `WebApplication` + `FAQPage` + `BreadcrumbList` JSON-LD.
+
+Verified in headless Chromium across all fills/borders/footer/heading and
+short/long words (see the build session screenshots).
+
+---
+
+## 7. Roadmap (next, in priority order)
+
+1. **Reference / example-word chip.** Small full-color mini-render + the A–Z
+   example word we already store (`data/printables_alphabet_coloring.json`) —
+   "color it like this." Cheap; raises finish quality.
+2. **Occasion presets.** One click sets heading + border + fill (Birthday, Welcome
+   Back, Valentine, Halloween). Targets `birthday coloring pages` (4,400) etc. and
+   makes the tool feel "designed for me."
+3. **Monogram maker spoke** (`monogram maker` 8,100). 1–3 letters, decorative frames
+   — pure letter art, squarely on-brand.
+4. **Dot-to-dot / connect-the-dots mode** (`dot to dot generator` 480, `connect the
+   dots maker` 320). Sample points along the glyph path, number them — a net-new
+   generator type and keyword set, still native SVG.
+5. **Number & word tracing parity** inside the maker (dashed "trace" fill), folding
+   in `number tracing` (4,400) and `handwriting worksheet generator` (1,600 @ 0.01).
+6. **Multi-line phrases** (2–3 short lines) for signs/welcome sheets.
+
+Each is additive to the same engine, keeps the client-side line, and maps to a
+documented, low-competition demand pocket.

--- a/js/printables/printablesEngine.js
+++ b/js/printables/printablesEngine.js
@@ -66,6 +66,15 @@
     namePng: $("#pt-name-png"),
     namePreview: $("#pt-name-preview"),
     nameRows: $("#pt-name-rows"),
+    // Coloring-sheet designer (optional; gated on its own mounts)
+    designInput: $("#pt-design-input"),
+    designHeading: $("#pt-design-heading"),
+    designFill: $("#pt-design-fill"),
+    designBorder: $("#pt-design-border"),
+    designFooter: $("#pt-design-footer"),
+    designPreview: $("#pt-design-preview"),
+    designPrint: $("#pt-design-print"),
+    designPng: $("#pt-design-png"),
     printRoot: $("#pt-print-root")
   };
 
@@ -305,10 +314,12 @@
     el.printRoot.innerHTML = "";
     const wrap = document.createElement("div");
     wrap.className = "bubble-print-wrap";
-    const h = document.createElement("h2");
-    h.className = "bubble-print-title";
-    h.textContent = titleText;
-    wrap.appendChild(h);
+    if (titleText) {
+      const h = document.createElement("h2");
+      h.className = "bubble-print-title";
+      h.textContent = titleText;
+      wrap.appendChild(h);
+    }
     wrap.appendChild(bodyNode);
     el.printRoot.appendChild(wrap);
     document.body.classList.add("is-printing");
@@ -604,12 +615,261 @@
   }
 
   /* ---------------------------------------------------------------
+     Section: coloring-sheet designer
+     Type a word/name -> a decorated, colorable, print-ready sheet with
+     an optional heading, a signature/date footer, a decorative symbol
+     border, and a multi-color interior fill (dots / stripes / hearts /
+     stars) so a child colors many small regions (fine-motor practice).
+     Everything is one self-contained SVG (native, client-side) so the
+     preview, the print sheet, and the PNG stay in sync. Gated on
+     #pt-design-input + #pt-design-preview so other pages are untouched.
+     --------------------------------------------------------------- */
+
+  const DESIGN = CFG.designer || {};
+  const DESIGN_DEMO = DESIGN.demo || CFG.nameDemo || "Hello";
+  const FILL_KINDS = ["plain", "dots", "stripes", "hearts", "stars"];
+  const BORDER_SETS = Object.assign({
+    none: "",
+    stars: "★",
+    hearts: "♥",
+    dots: "●",
+    flowers: "✿",
+    party: "★ ♥ ✿"
+  }, DESIGN.borders || {});
+
+  let designUid = 0;
+
+  function svgMake(tag, attrs, parent) {
+    const node = document.createElementNS(SVGNS, tag);
+    if (attrs) Object.keys(attrs).forEach((k) => { if (attrs[k] !== "" && attrs[k] != null) node.setAttribute(k, attrs[k]); });
+    if (parent) parent.appendChild(node);
+    return node;
+  }
+
+  function starPath(cx, cy, outer, inner, points) {
+    let d = "";
+    const step = Math.PI / points;
+    for (let i = 0; i < points * 2; i++) {
+      const r = (i % 2 === 0) ? outer : inner;
+      const a = -Math.PI / 2 + i * step;
+      d += (i === 0 ? "M" : "L") + (cx + r * Math.cos(a)).toFixed(1) + " " + (cy + r * Math.sin(a)).toFixed(1);
+    }
+    return d + "Z";
+  }
+  function heartPath(cx, cy, s) {
+    const y = cy - s * 0.55;
+    return "M" + cx + " " + (y + s * 0.35) +
+      " C" + cx + " " + y + " " + (cx - s) + " " + y + " " + (cx - s) + " " + (y + s * 0.5) +
+      " C" + (cx - s) + " " + (y + s * 1.05) + " " + cx + " " + (y + s * 1.35) + " " + cx + " " + (y + s * 1.65) +
+      " C" + cx + " " + (y + s * 1.35) + " " + (cx + s) + " " + (y + s * 1.05) + " " + (cx + s) + " " + (y + s * 0.5) +
+      " C" + (cx + s) + " " + y + " " + cx + " " + y + " " + cx + " " + (y + s * 0.35) + " Z";
+  }
+
+  function designText() {
+    const raw = el.designInput ? el.designInput.value : "";
+    return (raw && raw.trim()) ? raw.trim().slice(0, 24) : DESIGN_DEMO;
+  }
+  function designHeadingText() {
+    return el.designHeading ? el.designHeading.value.trim().slice(0, 48) : "";
+  }
+  function designFillKind() {
+    const v = el.designFill ? el.designFill.value : "plain";
+    return FILL_KINDS.indexOf(v) === -1 ? "plain" : v;
+  }
+  function designBorderSym() {
+    return BORDER_SETS[el.designBorder ? el.designBorder.value : "none"] || "";
+  }
+  function designFooterOn() { return !!(el.designFooter && el.designFooter.checked); }
+
+  // A tiled pattern of small outline shapes. Applied as the glyph's own
+  // fill (fill="url(#pattern)") so it paints only inside the letters —
+  // no clipPath needed (text-as-clip is unreliable across renderers).
+  // Each little shape is a region a child colors -> multi-color / fine-motor.
+  function addFillPattern(defs, kind, uid) {
+    const isStripe = kind === "stripes";
+    const pat = svgMake("pattern", {
+      id: "ptpat" + uid, patternUnits: "userSpaceOnUse",
+      width: isStripe ? 30 : 48, height: isStripe ? 30 : 48,
+      patternTransform: isStripe ? "rotate(45)" : ""
+    }, defs);
+    const col = "#9aa3b2", sw = 3;
+    if (kind === "dots") svgMake("circle", { cx: 24, cy: 24, r: 12, fill: "none", stroke: col, "stroke-width": sw }, pat);
+    else if (kind === "stripes") svgMake("line", { x1: 15, y1: 0, x2: 15, y2: 30, stroke: col, "stroke-width": 6 }, pat);
+    else if (kind === "hearts") svgMake("path", { d: heartPath(24, 24, 13), fill: "none", stroke: col, "stroke-width": sw }, pat);
+    else if (kind === "stars") svgMake("path", { d: starPath(24, 25, 15, 7, 5), fill: "none", stroke: col, "stroke-width": sw }, pat);
+    return "url(#ptpat" + uid + ")";
+  }
+
+  function addBorderRow(svg, symbols, y) {
+    const count = 11, W = 1000, gap = (W - 120) / (count - 1);
+    for (let i = 0; i < count; i++) {
+      const t = svgMake("text", { x: 60 + i * gap, y: y, "text-anchor": "middle", "font-size": 34, fill: "#c8ccd6", "font-family": FONT }, svg);
+      t.textContent = symbols[i % symbols.length];
+    }
+  }
+
+  function addFooter(svg, y) {
+    const field = (x, label, lineEnd) => {
+      const t = svgMake("text", { x: x, y: y, "font-family": FONT, "font-size": 30, "font-weight": 600, fill: INK }, svg);
+      t.textContent = label;
+      svgMake("line", { x1: x + 110, y1: y + 6, x2: lineEnd, y2: y + 6, stroke: "#9aa3b2", "stroke-width": 2 }, svg);
+    };
+    field(90, "Name:", 470);
+    field(560, "Date:", 910);
+  }
+
+  // The whole designed sheet as one portrait SVG (1000x1400).
+  function designSheetSVG() {
+    const text = designText();
+    const heading = designHeadingText();
+    const fill = designFillKind();
+    const borderSym = designBorderSym();
+    const footer = designFooterOn();
+    const uid = ++designUid;
+    const W = 1000, H = 1400, M = 70;
+
+    const svg = svgMake("svg", { viewBox: "0 0 " + W + " " + H, class: "pt-design-sheet-svg", role: "img", "aria-label": (heading || text) + " coloring sheet" });
+    const defs = svgMake("defs", null, svg);
+
+    svgMake("rect", { x: 18, y: 18, width: W - 36, height: H - 36, rx: 26, fill: "#ffffff", stroke: "#e2e6ee", "stroke-width": 3 }, svg);
+
+    if (borderSym) {
+      const strip = borderSym.split(" ").filter(Boolean);
+      addBorderRow(svg, strip, 78);
+      addBorderRow(svg, strip, H - 48);
+    }
+
+    if (heading) {
+      const h = svgMake("text", { x: W / 2, y: 168, "text-anchor": "middle", "font-family": FONT, "font-weight": 700, "font-size": 62, fill: INK }, svg);
+      h.textContent = heading;
+    }
+
+    const availW = W - M * 2;
+    const len = Math.max(1, [...text].length);
+    const fs = Math.max(110, Math.min(360, Math.round(availW * 1.3 / len)));
+    const cy = heading ? 740 : 700;
+    const fontAttrs = {
+      x: W / 2, y: cy, "text-anchor": "middle", "dominant-baseline": "central",
+      "font-family": FONT, "font-weight": 700, "font-size": fs, "stroke-linejoin": "round"
+    };
+    // Guarantee the word fits the width; only compress when it would overflow.
+    if (len * fs * 0.66 > availW) { fontAttrs.textLength = availW; fontAttrs.lengthAdjust = "spacingAndGlyphs"; }
+
+    // Interior: plain white (open to color), or a tiled pattern painted as
+    // the glyph fill. Plain keeps stroke under fill (thin clean edge); a
+    // pattern draws stroke on top so the letter boundary stays crisp.
+    const fillRef = (fill !== "plain") ? addFillPattern(defs, fill, uid) : "#ffffff";
+    const outline = svgMake("text", Object.assign({}, fontAttrs, {
+      fill: fillRef, stroke: INK, "stroke-width": Math.max(4, STROKE),
+      "paint-order": (fill === "plain") ? "stroke" : ""
+    }), svg);
+    outline.textContent = text;
+
+    if (footer) addFooter(svg, H - 150);
+
+    const cred = svgMake("text", { x: W / 2, y: H - 24, "text-anchor": "middle", "font-family": FONT, "font-size": 22, fill: "#aeb4c0" }, svg);
+    cred.textContent = "ultratextgen.com";
+    return svg;
+  }
+
+  function renderDesignPreview() {
+    if (!el.designPreview) return;
+    el.designPreview.innerHTML = "";
+    el.designPreview.appendChild(designSheetSVG());
+  }
+
+  function printDesign() {
+    const holder = document.createElement("div");
+    holder.className = "pt-design-print-holder";
+    holder.appendChild(designSheetSVG());
+    printWrap("", holder);
+  }
+
+  function roundRectPath(ctx, x, y, w, h, r) {
+    ctx.beginPath();
+    ctx.moveTo(x + r, y);
+    ctx.arcTo(x + w, y, x + w, y + h, r);
+    ctx.arcTo(x + w, y + h, x, y + h, r);
+    ctx.arcTo(x, y + h, x, y, r);
+    ctx.arcTo(x, y, x + w, y, r);
+    ctx.closePath();
+  }
+
+  // PNG mirrors the sheet layout via Canvas text (outline + heading +
+  // border + footer). Interior fill patterns are print-only; the PNG
+  // saves the clean outline, which is what most "download" users reuse.
+  function designPNG() {
+    withFont(() => {
+      const W = 1000, H = 1400, scale = 2;
+      const canvas = document.createElement("canvas");
+      canvas.width = W * scale; canvas.height = H * scale;
+      const ctx = canvas.getContext("2d");
+      ctx.scale(scale, scale);
+      ctx.fillStyle = "#ffffff"; ctx.fillRect(0, 0, W, H);
+      ctx.strokeStyle = "#e2e6ee"; ctx.lineWidth = 3;
+      roundRectPath(ctx, 18, 18, W - 36, H - 36, 26); ctx.stroke();
+
+      const text = designText(), heading = designHeadingText();
+      const borderSym = designBorderSym();
+      ctx.textAlign = "center"; ctx.textBaseline = "middle";
+
+      if (borderSym) {
+        const strip = borderSym.split(" ").filter(Boolean);
+        const count = 11, gap = (W - 120) / (count - 1);
+        ctx.font = "34px " + FONT; ctx.fillStyle = "#c8ccd6";
+        for (let i = 0; i < count; i++) {
+          ctx.fillText(strip[i % strip.length], 60 + i * gap, 78);
+          ctx.fillText(strip[i % strip.length], 60 + i * gap, H - 48);
+        }
+      }
+
+      let cy = 700;
+      if (heading) { ctx.font = "700 62px " + FONT; ctx.fillStyle = INK; ctx.fillText(heading, W / 2, 168); cy = 740; }
+
+      const len = Math.max(1, [...text].length);
+      let fs = Math.max(110, Math.min(360, Math.round((W - 140) * 1.3 / len)));
+      ctx.font = "700 " + fs + "px " + FONT;
+      const measured = ctx.measureText(text).width;
+      if (measured > W - 140) { fs = Math.floor(fs * (W - 140) / measured); ctx.font = "700 " + fs + "px " + FONT; }
+      ctx.lineJoin = "round";
+      ctx.fillStyle = "#ffffff"; ctx.fillText(text, W / 2, cy);
+      ctx.lineWidth = Math.max(6, STROKE); ctx.strokeStyle = INK; ctx.strokeText(text, W / 2, cy);
+
+      if (designFooterOn()) {
+        ctx.textAlign = "left"; ctx.font = "600 30px " + FONT; ctx.fillStyle = INK;
+        const fy = H - 150;
+        ctx.fillText("Name:", 90, fy); ctx.fillText("Date:", 560, fy);
+        ctx.strokeStyle = "#9aa3b2"; ctx.lineWidth = 2;
+        ctx.beginPath(); ctx.moveTo(200, fy + 16); ctx.lineTo(470, fy + 16);
+        ctx.moveTo(670, fy + 16); ctx.lineTo(910, fy + 16); ctx.stroke();
+        ctx.textAlign = "center";
+      }
+
+      ctx.font = "22px " + FONT; ctx.fillStyle = "#aeb4c0"; ctx.fillText("ultratextgen.com", W / 2, H - 24);
+      downloadCanvas(canvas, PNG_PREFIX + "-" + (slugify(text) || "sheet") + ".png");
+    });
+  }
+
+  function buildDesigner() {
+    if (!el.designInput || !el.designPreview) return;
+    let timer = null;
+    const schedule = () => { if (timer) clearTimeout(timer); timer = setTimeout(renderDesignPreview, 120); };
+    el.designInput.addEventListener("input", schedule);
+    if (el.designHeading) el.designHeading.addEventListener("input", schedule);
+    [el.designFill, el.designBorder, el.designFooter].forEach((c) => { if (c) c.addEventListener("change", renderDesignPreview); });
+    if (el.designPrint) el.designPrint.addEventListener("click", printDesign);
+    if (el.designPng) el.designPng.addEventListener("click", designPNG);
+    renderDesignPreview();
+  }
+
+  /* ---------------------------------------------------------------
      Wiring
      --------------------------------------------------------------- */
 
   function init() {
     buildStrip();
     buildAlphabetGrid();
+    buildDesigner();
 
     if (el.practicePrint) el.practicePrint.addEventListener("click", buildPracticeSheet);
 

--- a/printables/alphabet-coloring-pages/index.html
+++ b/printables/alphabet-coloring-pages/index.html
@@ -443,6 +443,12 @@
     </section>
 
     <div class="cta-card">
+      <h3>Want a name or word coloring page?</h3>
+      <p>Type any name or word and make your own coloring page — with a heading, a name-and-date line, cute borders, and dotted or starry fills to color.</p>
+      <a class="cta-btn" href="/printables/coloring-page-maker/">Open the coloring page maker →</a>
+    </div>
+
+    <div class="cta-card">
       <h3>Looking for handwriting practice instead?</h3>
       <p>Type any name and print a tracing worksheet with model and trace rows — perfect for preschool and kindergarten.</p>
       <a class="cta-btn" href="/printables/name-tracing/">Open name tracing worksheets →</a>

--- a/printables/coloring-page-maker/index.html
+++ b/printables/coloring-page-maker/index.html
@@ -1,0 +1,330 @@
+<!DOCTYPE html><html lang="en"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Coloring Page Maker — Make Your Own Name &amp; Word Coloring Pages Free | UltraTextGen</title>
+  <meta name="description" content="Free coloring page maker: type any name or word and print a big colorable outline sheet. Add a heading, a name-and-date line, cute borders, and dotted or starry fills — no sign-up, print or download PNG.">
+  <link rel="canonical" href="https://ultratextgen.com/printables/coloring-page-maker/">
+  <meta property="og:title" content="Coloring Page Maker — Make Your Own Coloring Pages Free | UltraTextGen">
+  <meta property="og:description" content="Type any name or word and print your own coloring page — heading, name-and-date line, cute borders, and multi-color fills. Free, no sign-up.">
+  <meta property="og:url" content="https://ultratextgen.com/printables/coloring-page-maker/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Coloring Page Maker — Make Your Own Coloring Pages Free | UltraTextGen">
+  <meta name="twitter:description" content="Type any name or word and print your own coloring page — heading, name line, cute borders, and multi-color fills. Free, no sign-up.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;family=Baloo+2:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ultratextgen.com/" },
+    { "@type": "ListItem", "position": 2, "name": "Printables", "item": "https://ultratextgen.com/printables/" },
+    { "@type": "ListItem", "position": 3, "name": "Coloring Page Maker", "item": "https://ultratextgen.com/printables/coloring-page-maker/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Coloring Page Maker",
+  "url": "https://ultratextgen.com/printables/coloring-page-maker/",
+  "applicationCategory": "DesignApplication",
+  "operatingSystem": "Any (web browser)",
+  "browserRequirements": "Requires JavaScript",
+  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+  "description": "Free in-browser coloring page maker. Type any name or word to generate a big colorable outline sheet, add a heading, a name-and-date line, decorative borders, and multi-color interior fills, then print it or download a PNG. No sign-up or watermark."
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "How do I make my own coloring page?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Type any name or word into the box. The tool instantly builds a big colorable outline sheet in your browser. Add an optional heading, turn on a name-and-date line, pick a decorative border, and choose an interior fill, then press Print the sheet or Download PNG. There is no sign-up, watermark, or limit."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I put a child's name or a word on the coloring page?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. That is what the maker is for. Type a first name, a word like LOVE or SUMMER, or a short phrase, and it becomes a large outline to color. Names and words are perfect for classroom name pages, birthday sheets, and welcome signs."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I make the letters more detailed so kids use lots of colors?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Choose an interior fill — polka dots, stripes, hearts, or stars — and the inside of each letter fills with small shapes to color one by one. It turns a single letter into a multi-color, fine-motor activity. Choose Plain outline instead for a simple open letter to color freely."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is the coloring page maker free?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Completely free, with no sign-up, no account, and no watermark. Everything is generated in your browser and nothing is uploaded. Make as many coloring pages as you like."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Do I need Canva or a design app?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. Unlike a general design app, you do not place letters or hunt for a template — you type a word and the finished sheet appears, ready to print. It runs in any browser on phone, tablet, or computer, with no install and no login."
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/">Home</a>
+  <span class="breadcrumb-separator">›</span>
+  <a href="/printables/">Printables</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Coloring Page Maker</span>
+</nav>
+
+  <section class="hero">
+    <div class="hero-inner" style="max-width:820px;">
+      <h1 class="hero-headline">Coloring Page Maker</h1>
+      <p class="hero-tagline">
+        Type any name or word and make your own coloring page in seconds. Add a heading, a name-and-date line,
+        cute borders, and dotted or starry fills — then print it or save a PNG. Free, no sign-up.
+      </p>
+    </div>
+  </section>
+
+  <main class="container">
+
+    <!-- Designer (primary tool) -->
+    <section class="bubble-alphabet" aria-labelledby="ptDesignHeading">
+      <h2 id="ptDesignHeading">Make your own coloring page</h2>
+      <p class="bubble-az-intro">Type a name or word, then style the sheet. The preview updates as you go — press <strong>Print the sheet</strong> for paper, or <strong>Download PNG</strong> to save the outline.</p>
+
+      <div class="pt-design-tool">
+        <div class="input-wrapper">
+          <input type="text" class="main-input pt-design-input" id="pt-design-input" placeholder="Type a name or word… e.g. Emma" maxlength="24" autocomplete="off">
+        </div>
+
+        <div class="pt-design-options">
+          <div class="pt-design-field">
+            <label for="pt-design-heading">Heading (optional)</label>
+            <input type="text" id="pt-design-heading" placeholder="e.g. Emma's Coloring Page" maxlength="48" autocomplete="off">
+          </div>
+          <div class="pt-design-field">
+            <label for="pt-design-fill">Letter fill</label>
+            <select id="pt-design-fill">
+              <option value="plain" selected>Plain outline</option>
+              <option value="dots">Polka dots</option>
+              <option value="stripes">Stripes</option>
+              <option value="hearts">Hearts</option>
+              <option value="stars">Stars</option>
+            </select>
+          </div>
+          <div class="pt-design-field">
+            <label for="pt-design-border">Border</label>
+            <select id="pt-design-border">
+              <option value="none" selected>None</option>
+              <option value="stars">Stars</option>
+              <option value="hearts">Hearts</option>
+              <option value="dots">Dots</option>
+              <option value="flowers">Flowers</option>
+              <option value="party">Party mix</option>
+            </select>
+          </div>
+          <label class="pt-design-check" for="pt-design-footer">
+            <input type="checkbox" id="pt-design-footer">
+            Add name &amp; date line
+          </label>
+        </div>
+
+        <div class="pt-design-preview" id="pt-design-preview" aria-live="polite"></div>
+
+        <div class="bubble-actions pt-design-actions">
+          <button type="button" class="bubble-btn bubble-btn-primary" id="pt-design-print">Print the sheet</button>
+          <button type="button" class="bubble-btn" id="pt-design-png">Download PNG</button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Quick single letters / numbers -->
+    <section class="bubble-az" aria-labelledby="ptPickHeading">
+      <h2 class="bubble-az-heading" id="ptPickHeading">Or color a single letter or number</h2>
+      <p class="bubble-az-intro">Tap any letter A–Z or number 0–9 for a big single-character coloring outline you can print or download on its own.</p>
+      <div class="bubble-strip" id="pt-strip" role="tablist" aria-label="Choose a letter or number to color"></div>
+      <div class="bubble-letter-panel" id="pt-panel" aria-live="polite"></div>
+    </section>
+
+    <!-- Whole alphabet -->
+    <section class="bubble-alphabet" aria-labelledby="ptAlphaHeading">
+      <div class="bubble-alphabet-head">
+        <h2 id="ptAlphaHeading">Printable alphabet &amp; numbers</h2>
+        <button class="bubble-btn bubble-btn-primary" type="button" id="pt-alphabet-print">Print the alphabet</button>
+      </div>
+      <p class="bubble-az-intro">The full A–Z and 0–9 as clean coloring outlines. Print the whole sheet, or tap any character to open its print and download options.</p>
+      <div class="bubble-alphabet-grid" id="pt-alphabet-grid"></div>
+    </section>
+
+    <!-- Editorial -->
+    <section class="editorial-section">
+      <h2>What you can make</h2>
+      <ul class="compat-list">
+        <li><span class="ts-pill-safe">Name pages</span> A child's name as a big outline for a classroom name tag, cubby label, or first-day welcome sheet.</li>
+        <li><span class="ts-pill-safe">Word pages</span> Words like LOVE, SUMMER, or a spelling word — great for themes, holidays, and word practice.</li>
+        <li><span class="ts-pill-safe">Multi-color</span> Fill the letters with polka dots, stripes, hearts, or stars so kids color many small regions — fine-motor practice, not just one flat shape.</li>
+        <li><span class="ts-pill-safe">Ready to hand out</span> Add a heading and a name-and-date line so the sheet is finished for a class set — no editing app needed.</li>
+      </ul>
+      <h3>Prefer copy-paste letters instead of a coloring page?</h3>
+      <p>This maker is for paper. If you want stylish letters to paste into a bio or caption, use the
+        <a href="/category/">font generators</a>. For more printable looks, try
+        <a href="/printables/alphabet-coloring-pages/">alphabet coloring pages</a>,
+        <a href="/printables/bubble-letters/">bubble letters</a>, or
+        <a href="/printables/name-tracing/">name tracing worksheets</a>.</p>
+    </section>
+
+    <!-- Cross-family navigation -->
+    <section class="related-pages">
+      <h2>Explore more printables</h2>
+      <div class="related-pages-grid">
+        <a href="/printables/alphabet-coloring-pages/" class="related-page-card">
+          <span class="related-page-label">Coloring</span>
+          <h4>Alphabet coloring pages A–Z</h4>
+        </a>
+        <a href="/printables/name-tracing/" class="related-page-card">
+          <span class="related-page-label">Handwriting</span>
+          <h4>Name tracing worksheets</h4>
+        </a>
+        <a href="/printables/bubble-letters/" class="related-page-card">
+          <span class="related-page-label">Printable</span>
+          <h4>Bubble letters</h4>
+        </a>
+        <a href="/printables/" class="related-page-card">
+          <span class="related-page-label">All</span>
+          <h4>Printables home</h4>
+        </a>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <h2 class="faq-category">Coloring Page Maker — FAQ</h2>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          How do I make my own coloring page?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Type any name or word into the box — the tool instantly builds a big colorable outline sheet in your browser. Add an optional heading, turn on a name-and-date line, pick a decorative border, and choose an interior fill, then press <strong>Print the sheet</strong> or <strong>Download PNG</strong>. No sign-up, watermark, or limit.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Can I put a child's name or a word on the coloring page?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Yes — that is what the maker is for. Type a first name, a word like <strong>LOVE</strong> or <strong>SUMMER</strong>, or a short phrase, and it becomes a large outline to color. Perfect for classroom name pages, birthday sheets, and welcome signs.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Can I make the letters more detailed so kids use lots of colors?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Yes. Choose an interior fill — <strong>polka dots</strong>, <strong>stripes</strong>, <strong>hearts</strong>, or <strong>stars</strong> — and the inside of each letter fills with small shapes to color one by one, turning a single letter into a multi-color, fine-motor activity. Choose <strong>Plain outline</strong> for a simple open letter to color freely.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Is the coloring page maker free?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Completely free, with no sign-up, no account, and no watermark. Everything is generated in your browser and nothing is uploaded. Make as many coloring pages as you like.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Do I need Canva or a design app?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          No. Unlike a general design app, you do not place letters or hunt for a template — you type a word and the finished sheet appears, ready to print. It runs in any browser on phone, tablet, or computer, with no install and no login.
+        </div>
+      </div>
+
+    </div>
+  </footer>
+
+  <!-- Print surface (hidden on screen, isolated when printing) -->
+  <div id="pt-print-root" aria-hidden="true"></div>
+
+  <script>
+    window.UTG_PRINTABLE = {
+      key: "coloring-page-maker",
+      render: "outline",
+      noun: "coloring page",
+      pngPrefix: "coloring",
+      font: "'Baloo 2', 'Plus Jakarta Sans', sans-serif",
+      strokeWidth: 5,
+      charset: "alnum",
+      designer: { demo: "Emma" }
+    };
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/js/printables/printablesEngine.js" defer></script>
+
+  <!-- FAQ toggle -->
+  <script>
+    document.querySelectorAll('.faq-question').forEach(function(btn) {
+      btn.addEventListener('click', function() { this.closest('.faq-item').classList.toggle('open'); });
+    });
+  </script>
+<script src="/footer.js" defer></script>
+</body></html>

--- a/printables/index.html
+++ b/printables/index.html
@@ -40,12 +40,13 @@
   "mainEntity": {
     "@type": "ItemList",
     "itemListElement": [
-      { "@type": "ListItem", "position": 1, "name": "Alphabet Coloring Pages", "url": "https://ultratextgen.com/printables/alphabet-coloring-pages/" },
-      { "@type": "ListItem", "position": 2, "name": "Printable Bubble Letters", "url": "https://ultratextgen.com/printables/bubble-letters/" },
-      { "@type": "ListItem", "position": 3, "name": "Cursive Alphabet & Practice Sheets", "url": "https://ultratextgen.com/printables/cursive-alphabet/" },
-      { "@type": "ListItem", "position": 4, "name": "Calligraphy Alphabet & Practice Sheets", "url": "https://ultratextgen.com/printables/calligraphy-alphabet/" },
-      { "@type": "ListItem", "position": 5, "name": "Printable Block Letters & Stencils", "url": "https://ultratextgen.com/printables/block-letters/" },
-      { "@type": "ListItem", "position": 6, "name": "Name Tracing Worksheets", "url": "https://ultratextgen.com/printables/name-tracing/" }
+      { "@type": "ListItem", "position": 1, "name": "Coloring Page Maker", "url": "https://ultratextgen.com/printables/coloring-page-maker/" },
+      { "@type": "ListItem", "position": 2, "name": "Alphabet Coloring Pages", "url": "https://ultratextgen.com/printables/alphabet-coloring-pages/" },
+      { "@type": "ListItem", "position": 3, "name": "Printable Bubble Letters", "url": "https://ultratextgen.com/printables/bubble-letters/" },
+      { "@type": "ListItem", "position": 4, "name": "Cursive Alphabet & Practice Sheets", "url": "https://ultratextgen.com/printables/cursive-alphabet/" },
+      { "@type": "ListItem", "position": 5, "name": "Calligraphy Alphabet & Practice Sheets", "url": "https://ultratextgen.com/printables/calligraphy-alphabet/" },
+      { "@type": "ListItem", "position": 6, "name": "Printable Block Letters & Stencils", "url": "https://ultratextgen.com/printables/block-letters/" },
+      { "@type": "ListItem", "position": 7, "name": "Name Tracing Worksheets", "url": "https://ultratextgen.com/printables/name-tracing/" }
     ]
   }
 }
@@ -136,6 +137,13 @@
     <section class="editorial-section" id="printables">
       <h2>Choose a printable</h2>
       <div class="printable-hub-grid">
+
+        <a class="printable-card" href="/printables/coloring-page-maker/">
+          <span class="printable-card-art" aria-hidden="true">✎ A+</span>
+          <h3>Coloring Page Maker</h3>
+          <p>Type any name or word and make your own coloring page — add a heading, a name-and-date line, cute borders, and dotted or starry fills, then print it or save a PNG.</p>
+          <span class="printable-card-cta">Open the coloring page maker →</span>
+        </a>
 
         <a class="printable-card" href="/printables/alphabet-coloring-pages/">
           <span class="printable-card-art" aria-hidden="true">A B C</span>

--- a/style.css
+++ b/style.css
@@ -5425,6 +5425,79 @@ body.dark-mode .pt-letter-figures { -webkit-text-stroke-color: var(--accent-blue
 body.dark-mode .pt-az-link-letter { color: var(--accent-blue); }
 
 /* ============================================================
+   Coloring-sheet designer (type a word -> decorated colorable
+   sheet). Powers /printables/coloring-page-maker/ via the shared
+   engine's #pt-design-* mounts.
+   ============================================================ */
+.pt-design-tool { margin: 0.5rem 0 0; }
+.pt-design-input { min-height: auto; height: 54px; resize: none; }
+.pt-design-options {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.85rem;
+  margin: 1rem 0 0;
+}
+.pt-design-field { display: flex; flex-direction: column; gap: 0.35rem; }
+.pt-design-field label {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+.pt-design-field input[type="text"],
+.pt-design-field select {
+  padding: 0.55rem 0.7rem;
+  border: 1px solid var(--border-light);
+  border-radius: 10px;
+  background: var(--bg-white);
+  color: var(--text-primary);
+  font-size: 0.92rem;
+  cursor: pointer;
+}
+.pt-design-field input[type="text"] { cursor: text; }
+.pt-design-check {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  align-self: end;
+  padding-bottom: 0.55rem;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+.pt-design-check input { width: 1.05rem; height: 1.05rem; cursor: pointer; }
+.pt-design-preview {
+  margin: 1.25rem 0;
+  padding: 1rem;
+  display: flex;
+  justify-content: center;
+  background: var(--bg-subtle, #f4f5f8);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-lg);
+}
+.pt-design-sheet-svg {
+  display: block;
+  width: 100%;
+  max-width: 420px;
+  height: auto;
+  background: #fff;
+  border-radius: 10px;
+  box-shadow: var(--shadow-soft);
+}
+.pt-design-actions { margin-top: 0.25rem; }
+
+/* Keep the designer preview light in dark mode so the white sheet reads */
+body.dark-mode .pt-design-preview { background: #1c2030; }
+
+/* Print: the designed sheet fills the page on its own */
+.pt-design-print-holder { text-align: center; }
+.pt-design-print-holder .pt-design-sheet-svg {
+  width: 100%;
+  max-width: 680px;
+  margin: 0 auto;
+  box-shadow: none;
+}
+
+/* ============================================================
    Contextual decoration showcase — static, crawlable SEO block
    Injected as the final section of <main> on decorator pages.
    ============================================================ */

--- a/styles.js
+++ b/styles.js
@@ -166,6 +166,11 @@ const PRINTABLE_PAGES = {
     slug: 'alphabet-coloring-pages',
     title: 'Alphabet Coloring Pages',
     description: 'Free printable alphabet coloring pages A–Z — big single-line letter outlines to color and print, plus a page for every letter.'
+  },
+  'coloring-page-maker': {
+    slug: 'coloring-page-maker',
+    title: 'Coloring Page Maker',
+    description: 'Type any name or word to make your own printable coloring page — heading, name-and-date line, decorative borders, and multi-color fills. Print or PNG, no sign-up.'
   }
 };
 


### PR DESCRIPTION
## Summary

Adds a new **Coloring Page Maker** tool (`/printables/coloring-page-maker/`) that lets users type any name or word and instantly generate a decorated, print-ready coloring sheet. This is a new page that extends the shared printables engine with a designer UI and SVG-based sheet rendering.

## Key Changes

- **New page:** `/printables/coloring-page-maker/index.html` — targets "coloring page maker," "coloring page generator," and "name coloring pages" search intent (4,700+ monthly volume, 0.10–0.32 competition).

- **Engine additions** (in `js/printables/printablesEngine.js`):
  - Designer UI mounts: `#pt-design-input`, `#pt-design-heading`, `#pt-design-fill`, `#pt-design-border`, `#pt-design-footer`, `#pt-design-preview`, `#pt-design-print`, `#pt-design-png`
  - `designSheetSVG()` — renders a full portrait sheet (1000×1400) as a single SVG with:
    - User-typed word/name as a big colorable outline
    - Optional heading
    - Decorative symbol borders (stars, hearts, dots, flowers, party mix)
    - Interior fill patterns (polka dots, stripes, hearts, stars) painted as SVG `<pattern>` fills so children color many small regions (fine-motor practice)
    - Optional name/date signature footer
    - Print-ready layout with rounded border and branding
  - `designPNG()` — Canvas-based PNG export (clean outline, no patterns)
  - `buildDesigner()` — wires up live preview, print, and download
  - Modified `printWrap()` to allow optional title (gated on truthiness)

- **Styling** (in `style.css`):
  - `.pt-design-tool`, `.pt-design-options`, `.pt-design-field` — form layout (responsive grid)
  - `.pt-design-preview` — centered preview container with soft shadow
  - `.pt-design-sheet-svg` — SVG display (max 420px on screen, 680px on print)
  - `.pt-design-print-holder` — print-surface wrapper
  - Dark mode support for preview background

- **Registration** (in `styles.js`):
  - Added `coloring-page-maker` to `PRINTABLE_PAGES` with metadata

- **Cross-linking**:
  - Updated `/printables/index.html` to include the new maker in the ItemList
  - Added CTA card to `/printables/alphabet-coloring-pages/` pointing to the maker for name/word use cases

- **SEO & metadata**:
  - Full `<head>` with og:, twitter:, canonical, and description tags
  - `BreadcrumbList`, `WebApplication`, and `FAQPage` JSON-LD schemas
  - 5-question FAQ covering maker workflow, personalization, multi-color fills, pricing, and design-app comparison

- **Documentation** (in `docs/coloring-sheet-generator-strategy.md`):
  - Owner brief with demand analysis, engine audit, guardrails, and roadmap
  - Keyword research showing low-competition targets (maker/generator cluster, name/word coloring)
  - Phase 2 roadmap: reference examples, occasion presets, monogram maker, dot-to-dot, tracing parity

## Implementation Details

- **Client-side only:** All rendering is native SVG + Canvas in the browser; no server, no image library, no font binaries.
- **SVG pattern fills:** Interior patterns (dots, stripes, hearts, stars) are defined as `<pattern>` elements and painted as the glyph's fill, ensuring they render only inside letters and stay crisp across print/screen/PNG.
- **Responsive preview:** Live updates as the user types, with debounced input (120ms) to avoid excessive re-renders.
- **Charset:** Supports alphanumeric (`alnum`) so users can also color numbers.
- **Print isolation:** Uses the existing `

https://claude.ai/code/session_01J8NM95h49XfRV762oo2ZFC