### PR TITLE
Redesign generator UIs with new "studio" layout and level ladder

### DIFF
--- a/js/printables/printablesEngine.js
+++ b/js/printables/printablesEngine.js
@@ -75,7 +75,9 @@
     // Difficulty generator (handwriting-worksheet-generator)
     genInput: $("#pt-gen-input"),
     genPreview: $("#pt-gen-preview"),
+    genPreviewMeta: $("#pt-gen-preview-meta"),
     genSlider: $("#pt-gen-slider"),
+    genLevels: $("#pt-gen-levels"),
     genLevel: $("#pt-gen-level"),
     genHint: $("#pt-gen-hint"),
     genPresets: $("#pt-gen-presets"),
@@ -89,6 +91,8 @@
     designHeading: $("#pt-design-heading"),
     designFill: $("#pt-design-fill"),
     designBorder: $("#pt-design-border"),
+    designFillGroup: $("#pt-design-fill-group"),
+    designBorderGroup: $("#pt-design-border-group"),
     designFooter: $("#pt-design-footer"),
     designPreview: $("#pt-design-preview"),
     designPrint: $("#pt-design-print"),
@@ -757,25 +761,42 @@
     const v = (raw && raw.trim()) ? raw.trim().slice(0, 42) : GEN_DEMO;
     return applyCase(v);
   }
-  function genLevel() {
-    const v = el.genSlider ? parseInt(el.genSlider.value, 10) : 2;
-    return Math.max(1, Math.min(TRACE_LEVELS.length, v || 2));
-  }
 
-  function renderGenPreview() {
+  // Difficulty is one internal source of truth (1..7). The level buttons
+  // (authored as crawlable HTML) and the age presets both set it; an optional
+  // slider stays in sync when a page still ships one.
+  let genLevelState = 2;
+  function clampLevel(v) { return Math.max(1, Math.min(TRACE_LEVELS.length, v || 2)); }
+  function genLevel() {
+    if (el.genSlider) return clampLevel(parseInt(el.genSlider.value, 10));
+    return clampLevel(genLevelState);
+  }
+  function setGenLevel(v) {
+    genLevelState = clampLevel(v);
+    if (el.genSlider) el.genSlider.value = String(genLevelState);
+    renderGenPreview();
+  }
+  function genRowCount() {
+    return Math.max(1, Math.min(8, parseInt((el.genRows && el.genRows.value) || "3", 10) || 3));
+  }
+  function genModelOn() { return !el.genModel || el.genModel.checked; }
+
+  // The full worksheet as a DOM node — the SINGLE primitive behind both the
+  // live paper preview and the printed sheet, so what you see is what prints.
+  function genSheetNode() {
+    const word = genValue();
     const level = genLevel();
-    const spec = levelSpec(level);
-    if (el.genLevel) el.genLevel.textContent = "Level " + level + " · " + spec.label;
-    if (el.genHint) el.genHint.textContent = spec.hint;
-    if (el.genPresets) {
-      $$(".pt-gen-preset", el.genPresets).forEach((b) => {
-        b.classList.toggle("is-active", parseInt(b.dataset.level, 10) === level);
-        b.setAttribute("aria-pressed", parseInt(b.dataset.level, 10) === level ? "true" : "false");
-      });
-    }
-    if (!el.genPreview) return;
-    el.genPreview.innerHTML = "";
-    el.genPreview.appendChild(traceWordSVG(genValue(), level, { guides: true }));
+    const sheet = document.createElement("div");
+    sheet.className = "pt-gen-sheet";
+    // A solid model row on top so the target is always visible (unless the
+    // chosen level already IS the solid model, or the user turned it off).
+    if (genModelOn() && level !== 1) sheet.appendChild(genRow(word, 1));
+    const traceCount = genRowCount();
+    for (let i = 0; i < traceCount; i++) sheet.appendChild(genRow(word, level));
+    // Finish on blank ruled lines for independent writing (skip if already blank).
+    const blanks = level === TRACE_LEVELS.length ? 0 : 2;
+    for (let i = 0; i < blanks; i++) sheet.appendChild(genRow(word, TRACE_LEVELS.length));
+    return sheet;
   }
 
   function genRow(word, level) {
@@ -785,22 +806,61 @@
     return row;
   }
 
-  function buildGeneratorSheet() {
-    const word = genValue();
+  // A small inline sample of a level's look, injected into each level button
+  // so the ladder shows — not just tells — dotted vs dashed vs faded.
+  function levelSampleSVG(level) {
+    if (levelSpec(level).blank) {
+      const svg = document.createElementNS(SVGNS, "svg");
+      svg.setAttribute("viewBox", "0 0 120 60");
+      svg.setAttribute("class", "pt-level-sample");
+      svg.setAttribute("aria-hidden", "true");
+      addGuide(svg, 120, 42, false);
+      return svg;
+    }
+    const svg = traceWordSVG("Aa", level, { guides: false });
+    svg.setAttribute("class", "pt-trace-svg pt-level-sample");
+    svg.setAttribute("aria-hidden", "true");
+    return svg;
+  }
+
+  function updateGenUI() {
     const level = genLevel();
     const spec = levelSpec(level);
-    const includeModel = !el.genModel || el.genModel.checked;
-    const traceCount = Math.max(1, Math.min(8, parseInt((el.genRows && el.genRows.value) || "3", 10) || 3));
-    const sheet = document.createElement("div");
-    sheet.className = "pt-gen-sheet";
-    // A solid model row on top so the target is always visible (unless the
-    // chosen level already IS the solid model).
-    if (includeModel && level !== 1) sheet.appendChild(genRow(word, 1));
-    for (let i = 0; i < traceCount; i++) sheet.appendChild(genRow(word, level));
-    // Finish on blank ruled lines for independent writing (skip if already blank).
-    const blanks = level === TRACE_LEVELS.length ? 0 : 2;
-    for (let i = 0; i < blanks; i++) sheet.appendChild(genRow(word, TRACE_LEVELS.length));
-    printWrap(word + " — " + spec.label + " worksheet · ultratextgen.com", sheet);
+    if (el.genLevel) el.genLevel.textContent = "Level " + level + " · " + spec.label;
+    if (el.genHint) el.genHint.textContent = spec.hint;
+    // Level ladder buttons.
+    $$(".pt-level", el.genLevels || document).forEach((b) => {
+      const on = parseInt(b.dataset.level, 10) === level;
+      b.classList.toggle("is-active", on);
+      b.setAttribute("aria-checked", on ? "true" : "false");
+    });
+    // Age presets are shortcuts; light up the one that matches the level.
+    if (el.genPresets) {
+      $$(".pt-gen-preset", el.genPresets).forEach((b) => {
+        const on = parseInt(b.dataset.level, 10) === level;
+        b.classList.toggle("is-active", on);
+        b.setAttribute("aria-pressed", on ? "true" : "false");
+      });
+    }
+    if (el.genPreviewMeta) {
+      const parts = [];
+      if (genModelOn() && level !== 1) parts.push("1 model");
+      parts.push(genRowCount() + " trace");
+      if (level !== TRACE_LEVELS.length) parts.push("2 blank");
+      el.genPreviewMeta.textContent = parts.join(" · ") + " · US Letter";
+    }
+  }
+
+  function renderGenPreview() {
+    updateGenUI();
+    if (!el.genPreview) return;
+    el.genPreview.innerHTML = "";
+    el.genPreview.appendChild(genSheetNode());
+  }
+
+  function buildGeneratorSheet() {
+    const spec = levelSpec(genLevel());
+    printWrap(genValue() + " — " + spec.label + " worksheet · ultratextgen.com", genSheetNode());
   }
 
   // Word at a level -> wide PNG (mirrors the SVG spec on Canvas).
@@ -860,7 +920,7 @@
   }
 
   function initGenerator() {
-    if (!el.genInput && !el.genSlider) return;
+    if (!el.genInput && !el.genSlider && !el.genLevels) return;
     if (el.genInput) {
       let timer = null;
       el.genInput.addEventListener("input", () => {
@@ -868,18 +928,27 @@
         timer = setTimeout(renderGenPreview, 120);
       });
     }
-    if (el.genSlider) el.genSlider.addEventListener("input", renderGenPreview);
+    if (el.genSlider) el.genSlider.addEventListener("input", () => setGenLevel(parseInt(el.genSlider.value, 10)));
     if (el.genCase) el.genCase.addEventListener("change", renderGenPreview);
+    if (el.genRows) el.genRows.addEventListener("change", renderGenPreview);
+    if (el.genModel) el.genModel.addEventListener("change", renderGenPreview);
+    // Level ladder — buttons authored in HTML (crawlable); wire + add samples.
+    if (el.genLevels) {
+      $$(".pt-level", el.genLevels).forEach((b) => {
+        const lvl = parseInt(b.dataset.level, 10);
+        const slot = b.querySelector(".pt-level-sample-slot");
+        if (slot) slot.appendChild(levelSampleSVG(lvl));
+        b.addEventListener("click", () => setGenLevel(lvl));
+      });
+    }
     if (el.genPresets) {
       $$(".pt-gen-preset", el.genPresets).forEach((b) => {
-        b.addEventListener("click", () => {
-          if (el.genSlider) el.genSlider.value = b.dataset.level;
-          renderGenPreview();
-        });
+        b.addEventListener("click", () => setGenLevel(parseInt(b.dataset.level, 10)));
       });
     }
     if (el.genPrint) el.genPrint.addEventListener("click", buildGeneratorSheet);
     if (el.genPng) el.genPng.addEventListener("click", () => genWordPNG(genValue(), genLevel()));
+    if (el.genSlider) genLevelState = clampLevel(parseInt(el.genSlider.value, 10));
     renderGenPreview();
   }
 
@@ -907,6 +976,10 @@
   }, DESIGN.borders || {});
 
   let designUid = 0;
+  // Selection state for the swatch button groups (fill + border). Buttons are
+  // authored in HTML (crawlable) and drive this; falls back to <select> values
+  // for any page still shipping selects.
+  const designState = { fill: "plain", border: "none" };
 
   function svgMake(tag, attrs, parent) {
     const node = document.createElementNS(SVGNS, tag);
@@ -942,11 +1015,46 @@
     return el.designHeading ? el.designHeading.value.trim().slice(0, 48) : "";
   }
   function designFillKind() {
-    const v = el.designFill ? el.designFill.value : "plain";
+    const v = el.designFillGroup ? designState.fill : (el.designFill ? el.designFill.value : "plain");
     return FILL_KINDS.indexOf(v) === -1 ? "plain" : v;
   }
+  function designBorderKey() {
+    return el.designBorderGroup ? designState.border : (el.designBorder ? el.designBorder.value : "none");
+  }
   function designBorderSym() {
-    return BORDER_SETS[el.designBorder ? el.designBorder.value : "none"] || "";
+    return BORDER_SETS[designBorderKey()] || "";
+  }
+
+  // Mini swatch previews injected into the fill / border option buttons so the
+  // choices are visible (not hidden inside a <select>).
+  function fillSwatchSVG(kind) {
+    const svg = svgMake("svg", { viewBox: "0 0 44 44", class: "pt-swatch-svg", "aria-hidden": "true" });
+    const defs = svgMake("defs", null, svg);
+    // White base so the swatch reads the same in light and dark mode…
+    svgMake("rect", { x: 4, y: 4, width: 36, height: 36, rx: 9, fill: "#ffffff", stroke: INK, "stroke-width": 2.5 }, svg);
+    // …then the tiled fill pattern on top for the non-plain kinds.
+    if (kind !== "plain") {
+      svgMake("rect", { x: 5, y: 5, width: 34, height: 34, rx: 8, fill: addFillPattern(defs, kind, "sw-" + kind), stroke: "none" }, svg);
+    }
+    return svg;
+  }
+  function borderSwatchSVG(key) {
+    const sym = BORDER_SETS[key] || "";
+    const svg = svgMake("svg", { viewBox: "0 0 44 44", class: "pt-swatch-svg", "aria-hidden": "true" });
+    svgMake("rect", { x: 4, y: 4, width: 36, height: 36, rx: 9, fill: "#ffffff", stroke: "#d7dbe4", "stroke-width": 2 }, svg);
+    const symbols = sym.split(" ").filter(Boolean);
+    if (!symbols.length) {
+      const dash = svgMake("text", { x: 22, y: 22, "text-anchor": "middle", "dominant-baseline": "central", "font-family": FONT, "font-size": 18, fill: "#c8ccd6" }, svg);
+      dash.textContent = "—";
+      return svg;
+    }
+    [10, 22, 34].forEach((x, i) => {
+      const t = svgMake("text", { x: x, y: 12, "text-anchor": "middle", "dominant-baseline": "central", "font-family": FONT, "font-size": 11, fill: "#aab0bd" }, svg);
+      t.textContent = symbols[i % symbols.length];
+    });
+    const big = svgMake("text", { x: 22, y: 27, "text-anchor": "middle", "dominant-baseline": "central", "font-family": FONT, "font-size": 17, fill: "#8b93a7" }, svg);
+    big.textContent = symbols[0];
+    return svg;
   }
   function designFooterOn() { return !!(el.designFooter && el.designFooter.checked); }
 
@@ -1119,12 +1227,38 @@
     });
   }
 
+  // Wire one swatch button group: inject each swatch preview, set the active
+  // state, and re-render on click. `field` is the designState key it drives.
+  function wireSwatchGroup(group, field, swatchFor) {
+    if (!group) return;
+    const buttons = $$(".pt-swatch", group);
+    const preset = buttons.filter((b) => b.classList.contains("is-active"))[0] || buttons[0];
+    if (preset) designState[field] = preset.dataset.value;
+    buttons.forEach((b) => {
+      const slot = b.querySelector(".pt-swatch-art");
+      if (slot) slot.appendChild(swatchFor(b.dataset.value));
+      b.setAttribute("aria-checked", b === preset ? "true" : "false");
+      b.classList.toggle("is-active", b === preset);
+      b.addEventListener("click", () => {
+        designState[field] = b.dataset.value;
+        buttons.forEach((o) => {
+          const on = o === b;
+          o.classList.toggle("is-active", on);
+          o.setAttribute("aria-checked", on ? "true" : "false");
+        });
+        renderDesignPreview();
+      });
+    });
+  }
+
   function buildDesigner() {
     if (!el.designInput || !el.designPreview) return;
     let timer = null;
     const schedule = () => { if (timer) clearTimeout(timer); timer = setTimeout(renderDesignPreview, 120); };
     el.designInput.addEventListener("input", schedule);
     if (el.designHeading) el.designHeading.addEventListener("input", schedule);
+    wireSwatchGroup(el.designFillGroup, "fill", fillSwatchSVG);
+    wireSwatchGroup(el.designBorderGroup, "border", borderSwatchSVG);
     [el.designFill, el.designBorder, el.designFooter].forEach((c) => { if (c) c.addEventListener("change", renderDesignPreview); });
     if (el.designPrint) el.designPrint.addEventListener("click", printDesign);
     if (el.designPng) el.designPng.addEventListener("click", designPNG);

--- a/printables/coloring-page-maker/index.html
+++ b/printables/coloring-page-maker/index.html
@@ -126,61 +126,78 @@
     <div class="hero-inner" style="max-width:820px;">
       <h1 class="hero-headline">Coloring Page Maker</h1>
       <p class="hero-tagline">
-        Type any name or word and make your own coloring page in seconds. Add a heading, a name-and-date line,
-        cute borders, and dotted or starry fills — then print it or save a PNG. Free, no sign-up.
+        Turn any name, word, or letter into your own coloring page in seconds. Pick a fill and a
+        cute border, add a heading and a name-and-date line, and watch it build live — then print
+        it or save a PDF/PNG. Free, no sign-up.
       </p>
     </div>
   </section>
 
   <main class="container">
 
-    <!-- Designer (primary tool) -->
+    <!-- Coloring studio (primary tool) -->
     <section class="bubble-alphabet" aria-labelledby="ptDesignHeading">
       <h2 id="ptDesignHeading">Make your own coloring page</h2>
-      <p class="bubble-az-intro">Type a name or word, then style the sheet. The preview updates as you go — press <strong>Print the sheet</strong> for paper, or <strong>Download PNG</strong> to save the outline.</p>
+      <p class="bubble-az-intro">Type a name or word, tap a fill and a border, and the sheet builds live on the right. Print it, save a PDF, or download a PNG — free, no sign-up.</p>
 
-      <div class="pt-design-tool">
-        <div class="input-wrapper">
-          <input type="text" class="main-input pt-design-input" id="pt-design-input" placeholder="Type a name or word… e.g. Emma" maxlength="24" autocomplete="off">
+      <div class="pt-studio">
+        <!-- Controls -->
+        <div class="pt-studio-controls">
+          <div class="pt-field">
+            <label class="pt-field-label" for="pt-design-input">Name or word</label>
+            <div class="input-wrapper">
+              <input type="text" class="main-input pt-design-input" id="pt-design-input" placeholder="Type a name or word… e.g. Emma" maxlength="24" autocomplete="off">
+            </div>
+          </div>
+
+          <div class="pt-field">
+            <label class="pt-field-label" for="pt-design-heading">Heading <span class="pt-field-opt">— optional</span></label>
+            <input type="text" class="main-input pt-design-input" id="pt-design-heading" placeholder="e.g. Emma’s Coloring Page" maxlength="48" autocomplete="off">
+          </div>
+
+          <div class="pt-field">
+            <span class="pt-field-label">Letter fill</span>
+            <div class="pt-swatches" id="pt-design-fill-group" role="radiogroup" aria-label="Letter fill">
+              <button type="button" class="pt-swatch is-active" data-value="plain" role="radio" aria-checked="true"><span class="pt-swatch-art"></span><span class="pt-swatch-label">Plain</span></button>
+              <button type="button" class="pt-swatch" data-value="dots" role="radio" aria-checked="false"><span class="pt-swatch-art"></span><span class="pt-swatch-label">Dots</span></button>
+              <button type="button" class="pt-swatch" data-value="stripes" role="radio" aria-checked="false"><span class="pt-swatch-art"></span><span class="pt-swatch-label">Stripes</span></button>
+              <button type="button" class="pt-swatch" data-value="hearts" role="radio" aria-checked="false"><span class="pt-swatch-art"></span><span class="pt-swatch-label">Hearts</span></button>
+              <button type="button" class="pt-swatch" data-value="stars" role="radio" aria-checked="false"><span class="pt-swatch-art"></span><span class="pt-swatch-label">Stars</span></button>
+            </div>
+          </div>
+
+          <div class="pt-field">
+            <span class="pt-field-label">Border</span>
+            <div class="pt-swatches" id="pt-design-border-group" role="radiogroup" aria-label="Border">
+              <button type="button" class="pt-swatch is-active" data-value="none" role="radio" aria-checked="true"><span class="pt-swatch-art"></span><span class="pt-swatch-label">None</span></button>
+              <button type="button" class="pt-swatch" data-value="stars" role="radio" aria-checked="false"><span class="pt-swatch-art"></span><span class="pt-swatch-label">Stars</span></button>
+              <button type="button" class="pt-swatch" data-value="hearts" role="radio" aria-checked="false"><span class="pt-swatch-art"></span><span class="pt-swatch-label">Hearts</span></button>
+              <button type="button" class="pt-swatch" data-value="dots" role="radio" aria-checked="false"><span class="pt-swatch-art"></span><span class="pt-swatch-label">Dots</span></button>
+              <button type="button" class="pt-swatch" data-value="flowers" role="radio" aria-checked="false"><span class="pt-swatch-art"></span><span class="pt-swatch-label">Flowers</span></button>
+              <button type="button" class="pt-swatch" data-value="party" role="radio" aria-checked="false"><span class="pt-swatch-art"></span><span class="pt-swatch-label">Party</span></button>
+            </div>
+          </div>
+
+          <div class="pt-field">
+            <label class="pt-check" for="pt-design-footer">
+              <input type="checkbox" id="pt-design-footer">
+              Add a name &amp; date line
+            </label>
+          </div>
         </div>
 
-        <div class="pt-design-options">
-          <div class="pt-design-field">
-            <label for="pt-design-heading">Heading (optional)</label>
-            <input type="text" id="pt-design-heading" placeholder="e.g. Emma's Coloring Page" maxlength="48" autocomplete="off">
+        <!-- Live preview -->
+        <div class="pt-studio-preview">
+          <div class="pt-preview-head">
+            <span class="pt-preview-tag">Live preview</span>
+            <span class="pt-preview-meta">US Letter · color-ready</span>
           </div>
-          <div class="pt-design-field">
-            <label for="pt-design-fill">Letter fill</label>
-            <select id="pt-design-fill">
-              <option value="plain" selected>Plain outline</option>
-              <option value="dots">Polka dots</option>
-              <option value="stripes">Stripes</option>
-              <option value="hearts">Hearts</option>
-              <option value="stars">Stars</option>
-            </select>
+          <div class="pt-design-preview" id="pt-design-preview" aria-live="polite"></div>
+          <div class="pt-preview-actions">
+            <button type="button" class="bubble-btn bubble-btn-primary" id="pt-design-print">Print sheet</button>
+            <button type="button" class="bubble-btn" id="pt-design-png">Download PNG</button>
           </div>
-          <div class="pt-design-field">
-            <label for="pt-design-border">Border</label>
-            <select id="pt-design-border">
-              <option value="none" selected>None</option>
-              <option value="stars">Stars</option>
-              <option value="hearts">Hearts</option>
-              <option value="dots">Dots</option>
-              <option value="flowers">Flowers</option>
-              <option value="party">Party mix</option>
-            </select>
-          </div>
-          <label class="pt-design-check" for="pt-design-footer">
-            <input type="checkbox" id="pt-design-footer">
-            Add name &amp; date line
-          </label>
-        </div>
-
-        <div class="pt-design-preview" id="pt-design-preview" aria-live="polite"></div>
-
-        <div class="bubble-actions pt-design-actions">
-          <button type="button" class="bubble-btn bubble-btn-primary" id="pt-design-print">Print the sheet</button>
-          <button type="button" class="bubble-btn" id="pt-design-png">Download PNG</button>
+          <p class="pt-preview-note">Runs entirely in your browser — nothing is uploaded. In the print dialog, choose “Save as PDF” to keep a copy.</p>
         </div>
       </div>
     </section>

--- a/printables/handwriting-worksheet-generator/index.html
+++ b/printables/handwriting-worksheet-generator/index.html
@@ -66,15 +66,15 @@
       "name": "How do I make my own handwriting worksheet?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Type a name or a few words, choose an age preset or move the difficulty slider, then click Print the worksheet. The sheet includes a solid model row, several rows at your chosen difficulty to trace, and blank ruled lines for free practice. You can also download it as a PNG."
+        "text": "Type a name or a few words, tap an age preset or a difficulty level, then click Print the worksheet. The sheet includes a solid model row, several rows at your chosen difficulty to trace, and blank ruled lines for free practice. You can also download it as a PNG."
       }
     },
     {
       "@type": "Question",
-      "name": "How does the difficulty slider work?",
+      "name": "How do the difficulty levels work?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "The slider moves through seven levels that get gradually harder: solid model, bold dotted, fine dotted, dashed, faded ghost, faint guide, and blank line. Each level combines three things a teacher thinks about — stroke thickness, how close the dots sit, and how dark the letters are — so one control cleanly raises or lowers the challenge."
+        "text": "The seven levels get gradually harder: solid model, bold dotted, fine dotted, dashed, faded ghost, faint guide, and blank line. Each level combines three things a teacher thinks about — stroke thickness, how close the dots sit, and how dark the letters are — so one control cleanly raises or lowers the challenge."
       }
     },
     {
@@ -82,7 +82,7 @@
       "name": "What difficulty is right for my child's age?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "As a starting point: Pre-K works well with bold dotted letters, Kindergarten with fine dotted, Grade 1 with dashed, and Grade 2 and up with a faint guide before writing solo. Use the age presets to jump to a sensible level, then nudge the slider up a notch as the child gets more confident."
+        "text": "As a starting point: Pre-K works well with bold dotted letters, Kindergarten with fine dotted, Grade 1 with dashed, and Grade 2 and up with a faint guide before writing solo. Use the age presets to jump to a sensible level, then nudge up a notch as the child gets more confident."
       }
     },
     {
@@ -118,97 +118,142 @@
     <div class="hero-inner" style="max-width:820px;">
       <h1 class="hero-headline">Handwriting Worksheet Generator</h1>
       <p class="hero-tagline">
-        Design your own tracing worksheet — type any name or words, then dial the difficulty
-        from bold dotted letters all the way to a blank line. Nudge it up a notch as your
-        child improves. Free, no sign-up, print or download.
+        Make your own handwriting worksheet in seconds. Type any name or words, tap a
+        difficulty level from bold dotted letters to a blank line, and watch the sheet
+        build live. Great for Pre-K to Grade 2 — and adult handwriting practice.
+        Free, no sign-up, print or save a PDF/PNG.
       </p>
     </div>
   </section>
 
   <main class="container">
 
-    <!-- Generator (primary) -->
+    <!-- Generator studio (primary) -->
     <section class="bubble-alphabet" aria-labelledby="ptGenHeading">
       <h2 id="ptGenHeading">Build your worksheet</h2>
-      <p class="bubble-az-intro">Type what you want to practice, pick a starting level by age or drag the difficulty slider, then preview it below and print — or download a PNG.</p>
+      <p class="bubble-az-intro">Type a name or words, tap a difficulty level, and the sheet builds live on the right. Print it, save a PDF, or download a PNG — free, no sign-up.</p>
 
-      <div class="pt-gen-tool">
-        <div class="input-wrapper">
-          <input type="text" class="main-input pt-gen-input" id="pt-gen-input" placeholder="Type a name or words… e.g. Emma" maxlength="42">
-        </div>
+      <div class="pt-studio">
+        <!-- Controls -->
+        <div class="pt-studio-controls">
+          <div class="pt-field">
+            <label class="pt-field-label" for="pt-gen-input">Name or words to practice</label>
+            <div class="input-wrapper">
+              <input type="text" class="main-input pt-gen-input" id="pt-gen-input" placeholder="Type a name or words… e.g. Emma" maxlength="42" autocomplete="off">
+            </div>
+          </div>
 
-        <div class="pt-gen-field">
-          <span class="pt-gen-field-label">Start by age (optional)</span>
-          <div class="pt-gen-presets" id="pt-gen-presets">
-            <button type="button" class="pt-gen-preset" data-level="2" aria-pressed="false">Pre-K <small>bold dotted</small></button>
-            <button type="button" class="pt-gen-preset" data-level="3" aria-pressed="false">Kindergarten <small>fine dotted</small></button>
-            <button type="button" class="pt-gen-preset" data-level="4" aria-pressed="false">Grade 1 <small>dashed</small></button>
-            <button type="button" class="pt-gen-preset" data-level="6" aria-pressed="false">Grade 2+ <small>faint guide</small></button>
+          <div class="pt-field">
+            <span class="pt-field-label">Start by age <span class="pt-field-opt">— optional shortcut</span></span>
+            <div class="pt-segment" id="pt-gen-presets" role="group" aria-label="Age preset">
+              <button type="button" class="pt-gen-preset" data-level="2" aria-pressed="false">Pre-K <small>bold dotted</small></button>
+              <button type="button" class="pt-gen-preset" data-level="3" aria-pressed="false">Kindergarten <small>fine dotted</small></button>
+              <button type="button" class="pt-gen-preset" data-level="4" aria-pressed="false">Grade 1 <small>dashed</small></button>
+              <button type="button" class="pt-gen-preset" data-level="6" aria-pressed="false">Grade 2+ <small>faint guide</small></button>
+            </div>
+          </div>
+
+          <div class="pt-field">
+            <span class="pt-field-label">Difficulty level <span class="pt-field-opt">— tap one, nudge up as they improve</span></span>
+            <div class="pt-levels" id="pt-gen-levels" role="radiogroup" aria-label="Difficulty level">
+              <button type="button" class="pt-level" data-level="1" role="radio" aria-checked="false">
+                <span class="pt-level-badge">1</span>
+                <span class="pt-level-body"><span class="pt-level-name">Solid model</span><span class="pt-level-hint">Full dark letters to trace right on top — the gentlest start.</span></span>
+                <span class="pt-level-sample-slot"></span>
+              </button>
+              <button type="button" class="pt-level" data-level="2" role="radio" aria-checked="false">
+                <span class="pt-level-badge">2</span>
+                <span class="pt-level-body"><span class="pt-level-name">Bold dotted</span><span class="pt-level-hint">Thick, closely-spaced dots that are easy to join up.</span></span>
+                <span class="pt-level-sample-slot"></span>
+              </button>
+              <button type="button" class="pt-level" data-level="3" role="radio" aria-checked="false">
+                <span class="pt-level-badge">3</span>
+                <span class="pt-level-body"><span class="pt-level-name">Fine dotted</span><span class="pt-level-hint">Thinner dots with a little more space between them.</span></span>
+                <span class="pt-level-sample-slot"></span>
+              </button>
+              <button type="button" class="pt-level" data-level="4" role="radio" aria-checked="false">
+                <span class="pt-level-badge">4</span>
+                <span class="pt-level-body"><span class="pt-level-name">Dashed</span><span class="pt-level-hint">Broken dashes — more line for the child to complete.</span></span>
+                <span class="pt-level-sample-slot"></span>
+              </button>
+              <button type="button" class="pt-level" data-level="5" role="radio" aria-checked="false">
+                <span class="pt-level-badge">5</span>
+                <span class="pt-level-body"><span class="pt-level-name">Faded ghost</span><span class="pt-level-hint">Light gray letters to write over without a hard outline.</span></span>
+                <span class="pt-level-sample-slot"></span>
+              </button>
+              <button type="button" class="pt-level" data-level="6" role="radio" aria-checked="false">
+                <span class="pt-level-badge">6</span>
+                <span class="pt-level-body"><span class="pt-level-name">Faint guide</span><span class="pt-level-hint">A barely-there outline — almost writing solo.</span></span>
+                <span class="pt-level-sample-slot"></span>
+              </button>
+              <button type="button" class="pt-level" data-level="7" role="radio" aria-checked="false">
+                <span class="pt-level-badge">7</span>
+                <span class="pt-level-body"><span class="pt-level-name">Blank line</span><span class="pt-level-hint">Just the ruled line — writing from memory.</span></span>
+                <span class="pt-level-sample-slot"></span>
+              </button>
+            </div>
+            <p class="pt-level-readout">Building at <strong id="pt-gen-level">Level 2 · Bold dotted</strong> — <span id="pt-gen-hint">thick, closely-spaced dots to join</span>.</p>
+          </div>
+
+          <div class="pt-field pt-field-inline">
+            <span class="pt-opt">
+              <label for="pt-gen-case">Letters</label>
+              <select id="pt-gen-case" class="pt-select">
+                <option value="as-typed" selected>As typed</option>
+                <option value="title">Title Case</option>
+                <option value="upper">UPPERCASE</option>
+                <option value="lower">lowercase</option>
+              </select>
+            </span>
+            <span class="pt-opt">
+              <label for="pt-gen-rows">Trace rows</label>
+              <select id="pt-gen-rows" class="pt-select">
+                <option value="2">2</option>
+                <option value="3" selected>3</option>
+                <option value="4">4</option>
+                <option value="5">5</option>
+                <option value="6">6</option>
+                <option value="8">8</option>
+              </select>
+            </span>
+            <label class="pt-check" for="pt-gen-model">
+              <input type="checkbox" id="pt-gen-model" checked>
+              Solid model row on top
+            </label>
           </div>
         </div>
 
-        <div class="pt-gen-field">
-          <label class="pt-gen-field-label" for="pt-gen-slider">Difficulty</label>
-          <input type="range" class="pt-gen-slider" id="pt-gen-slider" min="1" max="7" step="1" value="2" aria-describedby="pt-gen-hint">
-          <div class="pt-gen-scale"><span>Easier</span><span>Harder</span></div>
-          <div class="pt-gen-readout">
-            <span class="pt-gen-level" id="pt-gen-level">Level 2 · Bold dotted</span>
-            <span class="pt-gen-hint" id="pt-gen-hint">Thick, closely-spaced dots to join</span>
+        <!-- Live preview -->
+        <div class="pt-studio-preview">
+          <div class="pt-preview-head">
+            <span class="pt-preview-tag">Live preview</span>
+            <span class="pt-preview-meta" id="pt-gen-preview-meta"></span>
           </div>
-        </div>
-
-        <div class="pt-gen-options">
-          <div class="pt-gen-opt">
-            <label for="pt-gen-case">Letters</label>
-            <select id="pt-gen-case" class="pt-gen-select">
-              <option value="as-typed" selected>As typed</option>
-              <option value="title">Title Case</option>
-              <option value="upper">UPPERCASE</option>
-              <option value="lower">lowercase</option>
-            </select>
+          <div class="pt-paper" id="pt-gen-preview" aria-live="polite"></div>
+          <div class="pt-preview-actions">
+            <button type="button" class="bubble-btn bubble-btn-primary" id="pt-gen-print">Print worksheet</button>
+            <button type="button" class="bubble-btn" id="pt-gen-png">Download PNG</button>
           </div>
-          <div class="pt-gen-opt">
-            <label for="pt-gen-rows">Trace rows</label>
-            <select id="pt-gen-rows" class="pt-gen-select">
-              <option value="2">2</option>
-              <option value="3" selected>3</option>
-              <option value="4">4</option>
-              <option value="5">5</option>
-              <option value="6">6</option>
-              <option value="8">8</option>
-            </select>
-          </div>
-          <div class="pt-gen-opt">
-            <input type="checkbox" id="pt-gen-model" checked>
-            <label for="pt-gen-model">Include a solid model row</label>
-          </div>
-        </div>
-
-        <div class="pt-gen-preview" id="pt-gen-preview" aria-live="polite"></div>
-
-        <div class="bubble-actions pt-gen-actions">
-          <button type="button" class="bubble-btn bubble-btn-primary" id="pt-gen-print">Print the worksheet</button>
-          <button type="button" class="bubble-btn" id="pt-gen-png">Download PNG</button>
+          <p class="pt-preview-note">Runs entirely in your browser — nothing is uploaded. In the print dialog, choose “Save as PDF” to keep a copy.</p>
         </div>
       </div>
     </section>
 
-    <!-- Difficulty ladder explainer (static, crawlable) -->
+    <!-- How difficulty works (crawlable explainer; the ladder above is interactive) -->
     <section class="editorial-section" aria-labelledby="ptLadderHeading">
-      <h2 id="ptLadderHeading">The seven difficulty levels</h2>
-      <p>One slider raises or lowers three things at once — how <strong>thick</strong> the guide is,
-        how <strong>close</strong> the dots sit, and how <strong>dark</strong> the letters are — so the
-        challenge grows smoothly as a child’s control improves. Start easy, then move up a single notch
-        at a time.</p>
-      <ul class="compat-list">
-        <li><span class="ts-pill-safe">1 · Solid model</span> Full dark letters to trace right on top — the gentlest start.</li>
-        <li><span class="ts-pill-safe">2 · Bold dotted</span> Thick, closely-spaced dots that are easy to join up.</li>
-        <li><span class="ts-pill-safe">3 · Fine dotted</span> Thinner dots with a little more space between them.</li>
-        <li><span class="ts-pill-safe">4 · Dashed</span> Broken dashes — more line for the child to complete.</li>
-        <li><span class="ts-pill-safe">5 · Faded ghost</span> Light gray letters to write over without a hard outline.</li>
-        <li><span class="ts-pill-safe">6 · Faint guide</span> A barely-there outline — almost writing solo.</li>
-        <li><span class="ts-pill-safe">7 · Blank line</span> Just the ruled line — writing from memory.</li>
-      </ul>
+      <h2 id="ptLadderHeading">How the difficulty works</h2>
+      <p>Every difficulty level combines three things a teacher thinks about — how <strong>thick</strong>
+        the guide is, how <strong>close</strong> the dots sit, and how <strong>dark</strong> the letters
+        are — so one tap cleanly raises or lowers the challenge. The seven levels run from a
+        <strong>solid model</strong> to trace on top, through <strong>bold dotted</strong>,
+        <strong>fine dotted</strong>, <strong>dashed</strong>, <strong>faded ghost</strong> and
+        <strong>faint guide</strong>, all the way to a <strong>blank ruled line</strong> for writing from
+        memory. Start easy and move up a single notch as a child’s control improves.</p>
+      <p>Not sure where to start? As a rule of thumb, <strong>Pre-K</strong> does well with bold dotted,
+        <strong>Kindergarten</strong> with fine dotted, <strong>Grade 1</strong> with dashed, and
+        <strong>Grade 2 and up</strong> with a faint guide before writing solo. Adults relearning
+        penmanship often start at faded ghost and drop to a blank line. The age buttons jump to a
+        sensible level — then fine-tune with the ladder.</p>
       <p>Want a ready-made sheet instead of building one? Grab a
         <a href="/printables/name-tracing/">name tracing worksheet</a>, the
         <a href="/printables/cursive-alphabet/">cursive practice sheets</a>, or browse all
@@ -226,7 +271,7 @@
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
         </button>
         <div class="faq-answer">
-          Type a name or a few words, choose an age preset or move the difficulty slider, then click
+          Type a name or a few words, tap an age preset or a difficulty level, then click
           <strong>Print the worksheet</strong>. The sheet includes a solid model row, several rows at your
           chosen difficulty to trace, and blank ruled lines for free practice. You can also download it as a PNG.
         </div>
@@ -234,11 +279,11 @@
 
       <div class="faq-item">
         <button class="faq-question" type="button">
-          How does the difficulty slider work?
+          How do the difficulty levels work?
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
         </button>
         <div class="faq-answer">
-          The slider moves through seven levels that get gradually harder: solid model, bold dotted, fine dotted,
+          The seven levels get gradually harder: solid model, bold dotted, fine dotted,
           dashed, faded ghost, faint guide, and blank line. Each level combines three things a teacher thinks about —
           stroke thickness, how close the dots sit, and how dark the letters are — so one control cleanly raises or
           lowers the challenge.
@@ -253,7 +298,7 @@
         <div class="faq-answer">
           As a starting point: Pre-K works well with bold dotted letters, Kindergarten with fine dotted, Grade 1 with
           dashed, and Grade 2 and up with a faint guide before writing solo. Use the age presets to jump to a sensible
-          level, then nudge the slider up a notch as the child gets more confident.
+          level, then nudge up a notch as the child gets more confident.
         </div>
       </div>
 

--- a/printables/index.html
+++ b/printables/index.html
@@ -142,14 +142,14 @@
         <a class="printable-card" href="/printables/handwriting-worksheet-generator/">
           <span class="printable-card-art" aria-hidden="true">a·b·c</span>
           <h3>Handwriting Worksheet Generator</h3>
-          <p>Design your own tracing worksheet and dial the difficulty as a child improves — bold dotted, fine dotted, dashed, faded, or blank. Age presets for Pre-K to Grade 2. Print or PNG.</p>
+          <p>Type a name or words, tap a difficulty level from bold dotted to blank line, and watch the sheet build live. Age presets for Pre-K to Grade 2 — and adult handwriting practice. Print, PDF, or PNG.</p>
           <span class="printable-card-cta">Open the generator →</span>
         </a>
 
         <a class="printable-card" href="/printables/coloring-page-maker/">
           <span class="printable-card-art" aria-hidden="true">✎ A+</span>
           <h3>Coloring Page Maker</h3>
-          <p>Type any name or word and make your own coloring page — add a heading, a name-and-date line, cute borders, and dotted or starry fills, then print it or save a PNG.</p>
+          <p>Turn any name, word, or letter into a coloring page with a live preview — pick a fill and a cute border, add a heading and a name-and-date line, then print it or save a PDF/PNG.</p>
           <span class="printable-card-cta">Open the coloring page maker →</span>
         </a>
 

--- a/style.css
+++ b/style.css
@@ -5322,106 +5322,19 @@ html[dir="rtl"] .rtl-flip { display: inline-block; transform: scaleX(-1); }
 }
 .pt-name-word.is-trace { color: #cbd5e1; }
 
-/* ---- Adjustable-difficulty tracing generator ---- */
-.pt-gen-tool { margin: 0.5rem 0 0; }
+/* ---- Adjustable-difficulty tracing generator (shared sheet primitives) ----
+   The generator UI now lives in the "studio" block below; these rules are the
+   worksheet primitives reused by both the live preview and the printed sheet. */
 .pt-gen-input { min-height: auto; height: 52px; resize: none; }
-
-.pt-gen-field { margin-top: 1rem; }
-.pt-gen-field-label {
-  display: block;
-  font-size: 0.85rem;
-  font-weight: 700;
-  color: var(--text-secondary);
-  margin-bottom: 0.5rem;
-}
-
-/* Age presets — shortcuts that snap the slider */
-.pt-gen-presets { display: flex; flex-wrap: wrap; gap: 0.5rem; }
-.pt-gen-preset {
-  padding: 0.5rem 0.85rem;
-  border: 1px solid var(--border-light);
-  border-radius: 999px;
-  background: var(--bg-white);
-  color: var(--text-primary);
-  font-size: 0.85rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease;
-}
-.pt-gen-preset:hover { border-color: var(--accent-purple); }
-.pt-gen-preset.is-active {
-  background: var(--accent-purple);
-  border-color: var(--accent-purple);
-  color: #fff;
-}
-.pt-gen-preset small { display: block; font-weight: 500; opacity: 0.8; font-size: 0.72rem; }
-
-/* Difficulty slider — the source of truth */
-.pt-gen-slider {
-  width: 100%;
-  margin: 0.25rem 0 0.4rem;
-  accent-color: var(--accent-purple);
-  cursor: pointer;
-}
-.pt-gen-scale {
-  display: flex;
-  justify-content: space-between;
-  font-size: 0.72rem;
-  color: var(--text-secondary);
-}
-.pt-gen-readout {
-  display: flex;
-  align-items: baseline;
-  gap: 0.5rem;
-  margin-top: 0.6rem;
-}
-.pt-gen-level { font-weight: 700; color: var(--accent-purple); }
-.pt-gen-hint { font-size: 0.85rem; color: var(--text-secondary); }
-
-/* Secondary options (case, rows, model row) */
-.pt-gen-options {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.75rem 1.25rem;
-  margin-top: 1rem;
-}
-.pt-gen-opt { display: flex; align-items: center; gap: 0.45rem; }
-.pt-gen-opt label { font-size: 0.85rem; color: var(--text-secondary); font-weight: 600; }
-.pt-gen-select {
-  padding: 0.4rem 0.6rem;
-  border: 1px solid var(--border-light);
-  border-radius: 8px;
-  background: var(--bg-white);
-  color: var(--text-primary);
-  font-size: 0.9rem;
-  cursor: pointer;
-}
-
-/* Live preview */
-.pt-gen-preview {
-  margin: 1.1rem 0;
-  padding: 1rem 1.25rem;
-  min-height: 132px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: #fff;
-  border: 1px solid var(--border-light);
-  border-radius: var(--radius-lg);
-  overflow: hidden;
-}
 .pt-trace-svg { display: block; width: 100%; height: auto; max-height: 160px; }
-.pt-gen-actions { margin-top: 0.25rem; }
 
-/* Generator worksheet (print) */
+/* Generator worksheet (preview + print) */
 .pt-gen-sheet { display: flex; flex-direction: column; gap: 0.55rem; }
 .pt-gen-row { width: 100%; }
 .pt-gen-row .pt-trace-svg { width: 100%; max-height: 150px; }
 
 /* Dark-mode: keep print-preview cards light so white-fill outlines stay visible */
 body.dark-mode .pt-name-preview { background: #fff; border-color: var(--border-light); }
-body.dark-mode .pt-gen-preview { background: #fff; border-color: var(--border-light); }
 body.dark-mode .printable-card-art { color: var(--accent-blue); }
 
 /* ============================================================
@@ -5527,42 +5440,7 @@ body.dark-mode .pt-az-link-letter { color: var(--accent-blue); }
    sheet). Powers /printables/coloring-page-maker/ via the shared
    engine's #pt-design-* mounts.
    ============================================================ */
-.pt-design-tool { margin: 0.5rem 0 0; }
 .pt-design-input { min-height: auto; height: 54px; resize: none; }
-.pt-design-options {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 0.85rem;
-  margin: 1rem 0 0;
-}
-.pt-design-field { display: flex; flex-direction: column; gap: 0.35rem; }
-.pt-design-field label {
-  font-size: 0.82rem;
-  font-weight: 600;
-  color: var(--text-secondary);
-}
-.pt-design-field input[type="text"],
-.pt-design-field select {
-  padding: 0.55rem 0.7rem;
-  border: 1px solid var(--border-light);
-  border-radius: 10px;
-  background: var(--bg-white);
-  color: var(--text-primary);
-  font-size: 0.92rem;
-  cursor: pointer;
-}
-.pt-design-field input[type="text"] { cursor: text; }
-.pt-design-check {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  align-self: end;
-  padding-bottom: 0.55rem;
-  font-size: 0.9rem;
-  color: var(--text-secondary);
-  cursor: pointer;
-}
-.pt-design-check input { width: 1.05rem; height: 1.05rem; cursor: pointer; }
 .pt-design-preview {
   margin: 1.25rem 0;
   padding: 1rem;
@@ -5581,7 +5459,6 @@ body.dark-mode .pt-az-link-letter { color: var(--accent-blue); }
   border-radius: 10px;
   box-shadow: var(--shadow-soft);
 }
-.pt-design-actions { margin-top: 0.25rem; }
 
 /* Keep the designer preview light in dark mode so the white sheet reads */
 body.dark-mode .pt-design-preview { background: #1c2030; }
@@ -5593,6 +5470,209 @@ body.dark-mode .pt-design-preview { background: #1c2030; }
   max-width: 680px;
   margin: 0 auto;
   box-shadow: none;
+}
+
+/* ============================================================
+   Generator "studio" layout — shared by the handwriting worksheet
+   generator and the coloring page maker. Grouped controls on the left,
+   a big live paper preview on the right that mirrors exactly what prints.
+   ============================================================ */
+.pt-studio {
+  display: grid;
+  grid-template-columns: minmax(0, 380px) minmax(0, 1fr);
+  gap: 1.75rem;
+  align-items: start;
+  margin-top: 1.25rem;
+}
+.pt-studio-controls { min-width: 0; }
+.pt-studio-preview { min-width: 0; position: sticky; top: 1rem; }
+
+/* Grouped control fields */
+.pt-field { margin-bottom: 1.35rem; }
+.pt-field:last-child { margin-bottom: 0; }
+.pt-field-label {
+  display: block;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  margin-bottom: 0.55rem;
+}
+.pt-field-opt { text-transform: none; font-weight: 500; opacity: 0.8; }
+.pt-studio .pt-gen-input,
+.pt-studio .pt-design-input {
+  width: 100%;
+  height: 54px;
+  min-height: auto;
+}
+
+/* Segmented age presets */
+.pt-segment { display: flex; flex-wrap: wrap; gap: 0.4rem; }
+.pt-segment .pt-gen-preset {
+  flex: 1 1 auto;
+  padding: 0.5rem 0.6rem;
+  border: 1px solid var(--border-light);
+  border-radius: 12px;
+  background: var(--bg-white);
+  color: var(--text-primary);
+  font-size: 0.84rem;
+  font-weight: 700;
+  line-height: 1.2;
+  text-align: center;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease, transform 0.08s ease;
+}
+.pt-segment .pt-gen-preset small { display: block; font-weight: 500; opacity: 0.75; font-size: 0.68rem; margin-top: 2px; }
+.pt-segment .pt-gen-preset:hover { border-color: var(--accent-purple); transform: translateY(-1px); }
+.pt-segment .pt-gen-preset.is-active {
+  background: var(--accent-purple);
+  border-color: var(--accent-purple);
+  color: #fff;
+}
+.pt-segment .pt-gen-preset.is-active small { opacity: 0.9; }
+
+/* Difficulty ladder — the interactive difficulty control */
+.pt-levels { display: flex; flex-direction: column; gap: 0.4rem; }
+.pt-level {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  width: 100%;
+  padding: 0.5rem 0.6rem;
+  border: 1px solid var(--border-light);
+  border-radius: 12px;
+  background: var(--bg-white);
+  color: var(--text-primary);
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.12s ease, transform 0.08s ease;
+}
+.pt-level:hover { border-color: var(--accent-purple); transform: translateX(2px); }
+.pt-level.is-active {
+  border-color: var(--accent-purple);
+  background: rgba(139, 92, 246, 0.09);
+  box-shadow: inset 0 0 0 1px var(--accent-purple);
+}
+.pt-level-badge {
+  flex: 0 0 auto;
+  width: 1.7rem; height: 1.7rem;
+  display: inline-flex; align-items: center; justify-content: center;
+  border-radius: 8px;
+  background: var(--bg-base);
+  color: var(--text-secondary);
+  font-weight: 700; font-size: 0.85rem;
+}
+.pt-level.is-active .pt-level-badge { background: var(--accent-purple); color: #fff; }
+.pt-level-body { flex: 1 1 auto; min-width: 0; }
+.pt-level-name { display: block; font-weight: 700; font-size: 0.9rem; }
+.pt-level-hint { display: block; font-size: 0.75rem; color: var(--text-secondary); line-height: 1.3; }
+.pt-level-sample-slot {
+  flex: 0 0 auto;
+  width: 62px; height: 34px;
+  display: flex; align-items: center; justify-content: center;
+  background: #fff;
+  border: 1px solid var(--border-light);
+  border-radius: 8px;
+  overflow: hidden;
+}
+.pt-level-sample { width: 100%; height: auto; max-height: 30px; }
+.pt-level-readout { margin-top: 0.75rem; font-size: 0.85rem; color: var(--text-secondary); }
+.pt-level-readout strong { color: var(--accent-purple); }
+
+/* Compact inline options (case / rows / model row) */
+.pt-field-inline { display: flex; flex-wrap: wrap; align-items: center; gap: 0.6rem 1.1rem; }
+.pt-opt { display: flex; align-items: center; gap: 0.4rem; }
+.pt-opt > label { font-size: 0.82rem; font-weight: 600; color: var(--text-secondary); }
+.pt-select {
+  padding: 0.4rem 0.55rem;
+  border: 1px solid var(--border-light);
+  border-radius: 9px;
+  background: var(--bg-white);
+  color: var(--text-primary);
+  font-size: 0.88rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+.pt-check { display: inline-flex; align-items: center; gap: 0.4rem; font-size: 0.82rem; font-weight: 600; color: var(--text-secondary); cursor: pointer; }
+.pt-check input { width: 1rem; height: 1rem; accent-color: var(--accent-purple); cursor: pointer; }
+
+/* The live paper preview */
+.pt-preview-head {
+  display: flex; align-items: center; justify-content: space-between; gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+.pt-preview-tag {
+  display: inline-flex; align-items: center; gap: 0.45rem;
+  font-size: 0.76rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.03em;
+  color: var(--accent-purple);
+}
+.pt-preview-tag::before {
+  content: ""; width: 7px; height: 7px; border-radius: 50%;
+  background: var(--accent-purple);
+  box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.22);
+}
+.pt-preview-meta { font-size: 0.75rem; color: var(--text-muted); font-weight: 600; }
+.pt-paper {
+  background: #fff;
+  border: 1px solid var(--border-light);
+  border-radius: 14px;
+  box-shadow: var(--shadow-soft);
+  padding: 1.4rem 1.5rem;
+  max-height: 66vh;
+  overflow: auto;
+}
+.pt-paper .pt-gen-sheet { gap: 0.35rem; }
+.pt-paper .pt-gen-row .pt-trace-svg { max-height: 92px; }
+.pt-preview-actions { display: flex; gap: 0.6rem; margin-top: 0.9rem; }
+.pt-preview-actions .bubble-btn { padding: 0.72rem 1rem; font-size: 0.95rem; }
+.pt-preview-note { margin: 0.6rem 0 0; font-size: 0.78rem; color: var(--text-muted); }
+
+/* Design preview sits directly in the preview column as its own paper */
+.pt-studio-preview .pt-design-preview {
+  margin: 0;
+  padding: 0;
+  background: transparent;
+  border: none;
+}
+.pt-studio-preview .pt-design-sheet-svg { max-width: 100%; max-height: 66vh; }
+body.dark-mode .pt-studio-preview .pt-design-preview { background: transparent; }
+
+/* Coloring swatch button groups */
+.pt-swatches { display: flex; flex-wrap: wrap; gap: 0.45rem; }
+.pt-swatch {
+  display: flex; flex-direction: column; align-items: center; gap: 0.3rem;
+  width: 64px; padding: 0.45rem 0.3rem 0.4rem;
+  border: 1px solid var(--border-light);
+  border-radius: 12px;
+  background: var(--bg-white);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: border-color 0.15s ease, transform 0.08s ease, color 0.15s ease, box-shadow 0.15s ease;
+}
+.pt-swatch:hover { border-color: var(--accent-purple); transform: translateY(-1px); }
+.pt-swatch.is-active {
+  border-color: var(--accent-purple);
+  color: var(--accent-purple);
+  box-shadow: inset 0 0 0 1px var(--accent-purple);
+}
+.pt-swatch-art { width: 40px; height: 40px; display: flex; }
+.pt-swatch-svg { width: 100%; height: 100%; }
+.pt-swatch-label { font-size: 0.72rem; font-weight: 700; }
+
+/* Keep the paper light in dark mode so the printed look reads true */
+body.dark-mode .pt-paper { background: #fff; border-color: var(--border-light); }
+
+/* Single-column studio + non-sticky preview on narrow screens */
+@media (max-width: 900px) {
+  .pt-studio { grid-template-columns: 1fr; gap: 1.4rem; }
+  .pt-studio-preview { position: static; }
+  .pt-paper { max-height: none; }
+  .pt-studio-preview .pt-design-sheet-svg { max-height: none; }
+}
+@media (max-width: 420px) {
+  .pt-segment .pt-gen-preset { flex-basis: calc(50% - 0.2rem); }
+  .pt-level-sample-slot { display: none; }
 }
 
 /* ============================================================


### PR DESCRIPTION
## Summary

Refactors the handwriting worksheet generator and coloring page maker into a unified "studio" layout pattern with a two-column design: grouped controls on the left, a sticky live paper preview on the right that mirrors exactly what prints. Replaces the difficulty slider with an interactive "level ladder" — seven clickable buttons that show visual samples of each difficulty level inline.

## Key Changes

**Layout & Structure**
- Introduced `.pt-studio` grid layout (380px controls + 1fr preview, gap 1.75rem) shared by both generators
- Moved all generator UI controls into a left sidebar (`.pt-studio-controls`)
- Created sticky right preview column (`.pt-studio-preview`) that stays visible while scrolling
- Unified control field styling with `.pt-field`, `.pt-field-label`, and `.pt-field-inline` classes

**Difficulty Control Redesign**
- Replaced slider (`#pt-gen-slider`) with interactive level ladder (`.pt-levels`)
- Seven clickable buttons (`.pt-level`) with badges, descriptions, and inline visual samples
- Each level button shows a small SVG preview of what that difficulty looks like (via `levelSampleSVG()`)
- Slider still supported for backward compatibility; level state syncs between buttons, presets, and slider
- Added `genLevelState` internal state variable to track difficulty independently of DOM

**Shared Worksheet Primitive**
- Extracted `genSheetNode()` — the single source of truth for the worksheet structure (model row + trace rows + blank lines)
- Both live preview and printed sheet now use the same function, ensuring "what you see is what prints"
- Refactored `renderGenPreview()` to call `updateGenUI()` + render the sheet node

**Coloring Page Maker Updates**
- Replaced `<select>` dropdowns for fill and border with visual swatch button groups (`.pt-swatches`)
- Each swatch shows a mini preview of the fill pattern or border style via `fillSwatchSVG()` and `borderSwatchSVG()`
- Added `designState` object to track fill/border selection independently of legacy `<select>` elements
- Introduced `wireSwatchGroup()` to manage swatch button groups with active state and re-render on click

**Preview & Metadata**
- Added `.pt-paper` container styling for the live preview (white background, border, shadow, scrollable)
- New `.pt-preview-head` with live tag and metadata (e.g., "1 model · 3 trace · 2 blank · US Letter")
- Preview metadata updates dynamically as controls change via `updateGenUI()`

**Responsive Design**
- Single-column layout on screens ≤900px (preview becomes non-sticky)
- Level sample slots hidden on screens ≤420px to save space
- Age preset buttons flex to 50% width on mobile

**CSS Reorganization**
- Removed old generator/designer tool styles (`.pt-gen-tool`, `.pt-gen-field`, `.pt-gen-options`, `.pt-design-tool`, `.pt-design-options`, etc.)
- Consolidated shared worksheet primitives (`.pt-gen-input`, `.pt-trace-svg`, `.pt-gen-sheet`, `.pt-gen-row`) at the top
- Added 200+ lines of new `.pt-studio` and related component styles
- Maintained dark mode support (white paper in dark mode, etc.)

**JavaScript Refactoring**
- New element selectors: `genPreviewMeta`, `genLevels`, `designFillGroup`, `designBorderGroup`
- Extracted helper functions: `clampLevel()`, `genRowCount()`, `genModelOn()`, `levelSampleSVG()`, `updateGenUI()`, `fillSwatchSVG()`, `borderSwatchSVG()`, `wireSwatchGroup()`
- Simplified event handling: presets and level buttons now call `setGenLevel()` instead of directly manipulating the slider
- Added event listeners for rows and model checkbox to trigger re-render

**HTML Structure Updates**
- Handwriting generator: wrapped controls in `.pt-studio` with `.pt-studio-controls` and `.pt-

https://claude.ai/code/session_01WF2xEoWV93oBpBFKJVPBJk