### PR TITLE
Rewrite printables intro section to explain how generators work

### DIFF
--- a/printables/index.html
+++ b/printables/index.html
@@ -175,14 +175,17 @@
     </section>
 
     <section class="editorial-section">
-      <h2>Printables vs. the font generators</h2>
-      <p>UltraTextGen does two different jobs. The <a href="/category/">font generators</a> turn your text into
-        copy-paste Unicode fonts for <a href="/usecase/bio-font/">bios</a>, captions, and comments — styling that
-        travels with your text on screens. These <strong>printables</strong> do the opposite: they turn letters into
-        large outlines and worksheets you put on <em>paper</em> to trace, color, cut out, or practice by hand.</p>
-      <p>They're linked — a bubble-letter poster and a bubble-text caption are cousins — but they answer different
-        searches and belong on different pages. Looking to copy-paste instead of print? Head to
-        <a href="/category/bubble-fonts/">bubble fonts</a> or the <a href="/category/cursive-fonts/">cursive generator</a>.</p>
+      <h2>How the printables work</h2>
+      <p>Every printable comes two ways. There are <strong>ready-made worksheets</strong> — full A–Z alphabet sheets and
+        per-letter pages you can print as-is: <a href="/printables/bubble-letters/">bubble letters</a> to color,
+        <a href="/printables/cursive-alphabet/">cursive</a> and <a href="/printables/calligraphy-alphabet/">calligraphy</a>
+        practice sheets with model rows to trace, and <a href="/printables/block-letters/">block-letter stencils</a> to cut out.
+        Pick a letter and go — nothing to set up.</p>
+      <p>And there's a <strong>generator</strong> on every page for making your own. Type a word or a whole
+        <a href="/printables/name-tracing/">name</a> and the tool lays out a fresh worksheet on the spot — a solid model row,
+        faded rows to trace, and blank practice lines. When you like what you see, <strong>Print</strong> it straight from
+        your browser or <strong>Download PNG</strong> for a high-resolution image. It all runs client-side, so it's free,
+        instant, and works with no sign-up.</p>
     </section>
 
     <!-- Cross-family Navigation -->


### PR DESCRIPTION
## Summary
Replaced the "Printables vs. the font generators" comparison section with a clearer, more actionable explanation of how the printables feature works — emphasizing both ready-made worksheets and the in-page generator tool.

## Changes
- **Rewrote section heading** from "Printables vs. the font generators" to "How the printables work" — shifts focus from comparison to feature explanation
- **Restructured content into two paragraphs:**
  1. **Ready-made worksheets**: Describes pre-built A–Z alphabet sheets and per-letter pages (bubble letters, cursive, calligraphy, block-letter stencils) with direct links to each printable type
  2. **Generator tool**: Explains the on-page generator for custom worksheets (type a word/name, get instant layout with model row, faded trace rows, and blank practice lines), plus Print and Download PNG options
- **Removed comparison language** that referenced font generators and Unicode styling — no longer needed since the section now focuses on the printables product itself
- **Added concrete CTAs**: Links to specific printable types (`/printables/bubble-letters/`, `/printables/cursive-alphabet/`, etc.) and action verbs (Print, Download PNG)
- **Emphasized key benefits**: Free, instant, client-side, no sign-up required

## Implementation Notes
- Maintains the same `editorial-section` wrapper and semantic HTML structure
- All internal links point to existing printables pages (no new pages created)
- Tone shifts from comparative/defensive to instructional/feature-focused, better aligned with user intent on the printables landing page

https://claude.ai/code/session_01N5qNZDGkdk1GG2qTifwqMq