### PR TITLE
Add support for Bosnian, Croatian, Czech, Romanian, and Serbian locales

### DIFF
--- a/bs/fontovi-za-discord/index.html
+++ b/bs/fontovi-za-discord/index.html
@@ -1,0 +1,301 @@
+<!DOCTYPE html><html lang="bs"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Fontovi za Discord: Slova za Nadimak i Bio (Bez Nitra) | UltraTextGen</title>
+  <meta name="description" content="Fontovi za Discord besplatno: pretvori ime u 𝗽𝗼𝗱𝗲𝗯𝗹𝗷𝗮𝗻𝗼, 𝓴𝓾𝓻𝔃𝓲𝓿 ili 𝔤𝔬𝔱𝔦𝔠𝔲 i zalijepi u nadimak, u odjeljak „O meni” i u chat. Fontovi za Discord bez Nitra.">
+  <link rel="canonical" href="https://ultratextgen.com/bs/fontovi-za-discord/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/discord/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/discord/">
+  <link rel="alternate" hreflang="bs" href="https://ultratextgen.com/bs/fontovi-za-discord/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Fontovi za Discord: Slova za Nadimak i Bio (Bez Nitra)">
+  <meta property="og:description" content="Generator fontova za Discord: upiši ime i zalijepi stilizirano slovo u nadimak, u „O meni”, u naziv kanala i u status. Podebljano, kurziv i gotica — bez Nitra.">
+  <meta property="og:url" content="https://ultratextgen.com/bs/fontovi-za-discord/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/discord.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Fontovi za Discord: Slova za Nadimak i Bio (Bez Nitra)">
+  <meta name="twitter:description" content="Podebljano, kurziv, gotica i balončasta spremni za lijepljenje u nadimak i „O meni” na Discordu — bez Nitra.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/discord.png">
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+  <link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Generator Fontova za Discord",
+  "alternateName": ["Fontovi za Discord", "Fontovi na Discordu", "Slova za Discord", "Generator Nadimka za Discord"],
+  "url": "https://ultratextgen.com/bs/fontovi-za-discord/",
+  "applicationCategory": "UtilitiesApplication",
+  "operatingSystem": "Any",
+  "description": "Generator fontova za Discord: pretvara tvoje ime u stilizirana slova — podebljano, kurziv, goticu, balončasta, elegantna i kapitalke — za lijepljenje u nadimak, u „O meni”, u naziv kanala i u status, bez potrebe za Nitrom.",
+  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "BAM" }
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "bs",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Kako promijeniti font u nadimku na Discordu?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Upiši svoje ime u polje na vrhu stranice. Odmah će se pojaviti deseci fontova za Discord — podebljano, kurziv, gotička, balončasta, kapitalke. Klikni „Kopiraj” kod onog koji ti se sviđa, otvori Discord, uđi u Korisničke postavke i zalijepi ga u prikazano ime, ili desnim klikom na serveru promijeni nadimak na tom serveru. Budući da su to Unicode znakovi, stilizirano slovo se lijepi u polje bez ikakvog dodatka." }
+    },
+    {
+      "@type": "Question",
+      "name": "Treba li za fontove na Discordu Nitro?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Ne. Slova iz ovog generatora obični su Unicode znakovi, isti kao s tastature, samo drukčijeg izgleda — zato se lijepe u prikazano ime, u nadimak na serveru, u odjeljak „O meni”, u naziv kanala i u poruke bez ikakvog Nitra. Nitro je potreban samo za plaćene dodatke, poput boja i gradijenta u imenu (Display Name Styles), a ne za sam stilizirani tekst." }
+    },
+    {
+      "@type": "Question",
+      "name": "Rade li fontovi u korisničkom imenu (@) na Discordu?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Ne. Korisničko ime (jedinstveni @ koji se koristi za pozivnice prijateljima) prima samo mala slova od a do z, brojke, tačku i podvlaku — bez stilskih fontova, razmaka, emojija ili simbola. Fontovi za Discord rade u prikazanom imenu, u nadimku na serveru, u odjeljku „O meni”, u nazivu kanala i u chatu. Ako želiš stil u imenu, koristi prikazano ime, a ne @login." }
+    },
+    {
+      "@type": "Question",
+      "name": "Po čemu se razlikuje Discordovo oblikovanje (**podebljanje**) od Unicode fontova?",
+      "acceptedAnswer": { "@type": "Answer", "text": "To su dvije različite stvari. Discordov Markdown (**podebljanje**, *kurziv*, `kod`) oblikuje tekst samo unutar poruka u chatu i nestane kad ga pokušaš upotrijebiti u imenu ili u biju. Unicode fontovi s ove stranice sam su stilizirani znak, pa rade svugdje — u nadimku, u „O meni”, u nazivu kanala, u statusu i u chatu. Praktično pravilo: u običnoj poruci koristi Markdown, a da stiliziraš nadimak ili bio, koristi Unicode font." }
+    },
+    {
+      "@type": "Question",
+      "name": "Kako napraviti ukrasni nadimak za Discord s okvirima i simbolima?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Odaberi font za ime (gotica i balončasta izlaze najbolje) i okruži ga okvirima te simbolima u stilu ꧁༒ ༒꧂. Na ovoj stranici je mreža gotovih nadimaka s okvirima — klikni za kopiranje i zalijepi u nadimak na serveru. Možeš i upisati svoje ime na vrhu, staviti font i upotrijebiti kartice Simboli i Okviri da dotjeraš izgled prije kopiranja." }
+    },
+    {
+      "@type": "Question",
+      "name": "Zašto se slova na Discordu prikazuju kao kvadratići?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Zato što uređaj osobe koja to gleda nema font koji crta taj znak — obično je to stariji telefon ili računar. To nije greška stranice ni tvog kopiranja. Osnovni stilovi — podebljano, kurziv, gotica, balončasta i kapitalke — najsigurniji su i prikazuju se ispravno gotovo svugdje. Ako netko prijavi kvadratić (□), zamijeni jednim od tih stilova." }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "inLanguage": "bs",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Početna", "item": "https://ultratextgen.com/bs/" },
+    { "@type": "ListItem", "position": 2, "name": "Fontovi za Discord", "item": "https://ultratextgen.com/bs/fontovi-za-discord/" }
+  ]
+}
+</script>
+</head>
+<body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<script src="/header.js"></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/bs/">Početna</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Fontovi za Discord</span>
+</nav>
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/discord.svg" width="1200" height="340" loading="lazy" alt="">
+</figure>
+
+<section class="hero">
+  <div class="hero-inner">
+    <div class="hero-card">
+      <h1 class="hero-headline">Fontovi za Discord: slova za nadimak i bio</h1>
+      <p class="hero-tagline">Upiši svoje ime i vidi ga odmah u desecima fontova za Discord — podebljano, kurziv, gotička, balončasta i kapitalke. Kopiraš i lijepiš u nadimak, u nadimak na serveru, u odjeljak „O meni”, u naziv kanala i u chat. Sve besplatno i <strong>bez Nitra</strong>.</p>
+      <div class="input-wrapper">
+        <textarea class="main-input" id="mainInput" placeholder="Upiši ime ili tekst..." maxlength="500" autofocus=""></textarea>
+        <span class="char-count"><span id="charCount">0</span>/500</span>
+      </div>
+      <div class="decoration-section">
+        <div class="decoration-label">Dodaj simbole i okvire rezultatu</div>
+        <div class="decoration-tabs">
+          <button class="decoration-tab active" data-deco-tab="symbols">Simboli</button>
+          <button class="decoration-tab" data-deco-tab="frames">Okviri</button>
+          <button class="decoration-tab" data-deco-tab="dividers">Razdjelnici</button>
+          <button class="decoration-tab" data-deco-tab="arrows">Strelice</button>
+          <button class="decoration-tab" data-deco-tab="minimal">Minimalni</button>
+          <button class="decoration-tab" data-deco-tab="emojis">Emoji</button>
+        </div>
+        <div class="decoration-grid" id="decorationGrid"></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<main class="container">
+  <div class="category-section"><div class="category-tabs" id="categoryTabs"></div></div>
+  <div class="results-grid" id="resultsGrid"></div>
+
+  <!-- Kako to radi -->
+  <section class="editorial-section">
+    <h2>Fontovi za Discord: kako to radi</h2>
+    <p class="editorial-intro"><strong>Fontovi za Discord</strong> s ove stranice nisu instalirani font ni slika — to su <strong>Unicode znakovi</strong>, prava slova, ista kao s tastature, samo drukčijeg izgleda (𝗔, 𝘈, 𝓐, 𝔄). Budući da Discord prihvaća Unicode u gotovo svakom tekstualnom polju, stilizirano slovo lijepi se ravno u tvoje <strong>prikazano ime</strong>, u <strong>nadimak na serveru</strong>, u odjeljak <strong>„O meni”</strong>, u <strong>naziv kanala</strong>, u <strong>status</strong> pa i u <strong>poruke</strong> — bez Nitra, dodatka ili posebne aplikacije.</p>
+    <div class="block-example">
+      <strong>Primjer:</strong> „marko” → 𝗺𝗮𝗿𝗸𝗼 (podebljano), 𝘮𝘢𝘳𝘬𝘰 (kurziv), 𝓶𝓪𝓻𝓴𝓸 (ukrasni kurziv), 𝔪𝔞𝔯𝔨𝔬 (gotička), ⓜⓐⓡⓚⓞ (balončasta), ᴍᴀʀᴋᴏ (kapitalke)
+    </div>
+    <p>Koristi se u nekoliko sekundi: upišeš ime u polje na vrhu, generator prikaže isti tekst u brojnim <strong>fontovima za Discord</strong>, klikneš „Kopiraj” i zalijepiš u aplikaciji. Želiš samo gola slova abecede? Odmah su ispod. A ako radije pregledavaš još rezova, potpuni generator naći ćeš na <a href="/bs/">glavnoj stranici sa slovima za kopiranje</a>.</p>
+  </section>
+
+  <!-- Abeceda A-Z -->
+  <section class="editorial-section glyph-section">
+    <h2>Abeceda fontova za Discord (A–Z za kopiranje)</h2>
+    <p class="editorial-intro">Cijela abeceda u stilovima koji se najčešće pojavljuju u nadimcima i biju na Discordu. Klikni redak da kopiraš cijelu abecedu u tom stilu, ili upiši svoje ime na vrhu i uzmi vlastitu riječ odmah stiliziranu.</p>
+    <div class="alpha-list">
+      <div class="alpha-row">
+        <span class="alpha-label">Podebljano</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝗔𝗕𝗖𝗗𝗘𝗙𝗚𝗛𝗜𝗝𝗞𝗟𝗠𝗡𝗢𝗣𝗤𝗥𝗦𝗧𝗨𝗩𝗪𝗫𝗬𝗭 𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇" aria-label="Kopiraj podebljanu abecedu">𝗔𝗕𝗖𝗗𝗘𝗙𝗚𝗛𝗜𝗝𝗞𝗟𝗠𝗡𝗢𝗣𝗤𝗥𝗦𝗧𝗨𝗩𝗪𝗫𝗬𝗭 · 𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Kurziv</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩 𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃" aria-label="Kopiraj abecedu u kurzivu">𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩 · 𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Elegantno</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵 𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏" aria-label="Kopiraj elegantnu abecedu">𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵 · 𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Gotička</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝔄𝔅ℭ𝔇𝔈𝔉𝔊ℌℑ𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔ℜ𝔖𝔗𝔘𝔙𝔚𝔛𝔜ℨ 𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷" aria-label="Kopiraj gotičku abecedu">𝔄𝔅ℭ𝔇𝔈𝔉𝔊ℌℑ𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔ℜ𝔖𝔗𝔘𝔙𝔚𝔛𝔜ℨ · 𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Balončasta</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ" aria-label="Kopiraj balončastu abecedu">ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ · ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Kapitalke</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="ᴀʙᴄᴅᴇꜰɢʜɪᴊᴋʟᴍɴᴏᴘqʀsᴛᴜᴠᴡxʏᴢ" aria-label="Kopiraj abecedu u kapitalkama">ᴀ ʙ ᴄ ᴅ ᴇ ꜰ ɢ ʜ ɪ ᴊ ᴋ ʟ ᴍ ɴ ᴏ ᴘ q ʀ s ᴛ ᴜ ᴠ ᴡ x ʏ ᴢ</button>
+      </div>
+    </div>
+    <p class="uname-note">Napomena o bosanskim znakovima: ovi Unicode fontovi obuhvaćaju osnovnu abecedu A–Z. Hrvatske kvačice (č, ć, đ, š, ž) u većini stilova ostaju obična slova usred stilizirane riječi — pa npr. „željko” izađe kao ž𝓮𝓵𝓳𝓴𝓸. Za nadimke bez kvačica izgleda idealno, a za dulje tekstove najsigurniji su podebljano i kurziv.</p>
+    <p class="u-mt-15">Želiš se udubiti u jedan stil? Cijelu abecedu i verzije svakog reza naći ćeš na <a href="/bs/">glavnoj stranici sa slovima za kopiranje</a>, a zvjezdice i okvire za nadimak — u <a href="/library/aesthetic-symbols/">ukrasnim simbolima</a>.</p>
+  </section>
+
+  <!-- Fontovi za nadimak i O meni -->
+  <section class="editorial-section">
+    <h2>Fontovi za nadimak i odjeljak „O meni” na Discordu</h2>
+    <p class="editorial-intro">Najbrži način da istakneš profil jest staviti font na <strong>prikazano ime</strong> i zasebno u odjeljak <strong>„O meni”</strong> (bio profila). Discord prihvaća Unicode u oba polja — a uz to možeš imati <strong>drukčiji nadimak na svakom serveru</strong>, pa na gaming serveru koristiš goticu, a na serveru s prijateljima kurziv, sve pod istim računom.</p>
+    <p class="uname-note">Kako zalijepiti:</p>
+    <div class="block-example">
+      — <strong>Prikazano ime:</strong> Korisničke postavke › Profil › uredi prikazano ime i zalijepi font<br>
+      — <strong>Nadimak na serveru:</strong> desni klik na svom imenu na serveru › Uredi profil servera › zalijepi stilizirani nadimak<br>
+      — <strong>„O meni”:</strong> Korisničke postavke › Profil › polje „O meni” › zalijepi tekst<br>
+      — <strong>Naziv kanala:</strong> ako si administrator, uredi kanal i zalijepi font u naziv
+    </div>
+    <p>Savjet od nekoga tko svakodnevno slaže profile: stiliziraj samo ime, a ostatak „O meni” ostavi običnim tekstom — kontrast čini cijeli efekt. Kad je sve ukrašeno, ništa ne privlači pogled. Za pojedinačne zvjezdice i sjaj u biju svrati na stranicu s <a href="/library/aesthetic-symbols/">ukrasnim simbolima za kopiranje</a>.</p>
+  </section>
+
+  <!-- Markdown vs Unicode -->
+  <section class="editorial-section">
+    <h2>Discordov Markdown vs Unicode fontovi — kad što upotrijebiti</h2>
+    <p class="editorial-intro">Discord ima <strong>dva načina</strong> za petljanje po tekstu i vrijedi ih ne miješati. Jedan je izvorno <strong>Markdown oblikovanje</strong>, drugi su <strong>Unicode fontovi</strong> s ove stranice. Služe za različite stvari.</p>
+    <div class="block-example">
+      — <strong>Markdown (izvorni):</strong> <code>**podebljanje**</code> → <strong>podebljanje</strong>, <code>*kurziv*</code> → <em>kurziv</em>, <code>__podcrtavanje__</code>, <code>~~precrtavanje~~</code>, <code>`kod`</code>. Radi samo <strong>unutar poruka</strong> u chatu i nestane kad ga pokušaš u imenu ili u biju.<br>
+      — <strong>Unicode fontovi (ova stranica):</strong> 𝗽𝗼𝗱𝗲𝗯𝗹𝗷𝗮𝗻𝗼, 𝓴𝓾𝓻𝔃𝓲𝓿, 𝔤𝔬𝔱𝔦𝔠𝔞. To je sam stilizirani znak, pa radi <strong>svugdje</strong> — u nadimku, u „O meni”, u nazivu kanala, u statusu i u chatu.
+    </div>
+    <p>Praktično pravilo: da oblikuješ običnu <strong>poruku</strong> (podebljaš riječ usred rečenice), koristi Discordov Markdown — čišći je. Da stiliziraš <strong>nadimak, bio ili naziv kanala</strong>, koristi Unicode font, jer Markdown tu neće raditi. I važno upozorenje: ništa od toga ne radi u <strong>korisničkom imenu (@)</strong>, koje prima samo mala slova od a do z, brojke, tačku i podvlaku — nikakav font, razmak ni emoji. Ako želiš stil u imenu, pravo polje je prikazano ime, a ne @login.</p>
+  </section>
+
+  <!-- Ukrasni nadimci s okvirima -->
+  <section class="editorial-section">
+    <h2>Ukrasni nadimci za Discord s okvirima i simbolima</h2>
+    <p class="editorial-intro">Nadimci koji najviše ostavljaju dojam na Discordu spajaju snažan font (goticu ili balončasta) s okvirima i simbolima s obje strane, u stilu ꧁༒ ༒꧂. Klikni za kopiranje i zalijepi u nadimak na serveru — potom zamijeni svojim imenom.</p>
+    <div class="uname-grid">
+      <button class="uname-chip symbol-tile" data-symbol="꧁༒𝕯𝖆𝖗𝖐༒꧂" aria-label="Kopiraj nadimak">꧁༒𝕯𝖆𝖗𝖐༒꧂</button>
+      <button class="uname-chip symbol-tile" data-symbol="꧁༒𝕸𝖆𝖗𝖐𝖔༒꧂" aria-label="Kopiraj nadimak">꧁༒𝕸𝖆𝖗𝖐𝖔༒꧂</button>
+      <button class="uname-chip symbol-tile" data-symbol="★彡ʟᴜᴋᴀ彡★" aria-label="Kopiraj nadimak">★彡ʟᴜᴋᴀ彡★</button>
+      <button class="uname-chip symbol-tile" data-symbol="⋆˚࿔ 𝓏𝒶𝓇𝒶 𝜗𝜚˚⋆" aria-label="Kopiraj nadimak">⋆˚࿔ 𝓏𝒶𝓇𝒶 𝜗𝜚˚⋆</button>
+      <button class="uname-chip symbol-tile" data-symbol="꧁✿𝓝𝓲𝓴𝓪✿꧂" aria-label="Kopiraj nadimak">꧁✿𝓝𝓲𝓴𝓪✿꧂</button>
+      <button class="uname-chip symbol-tile" data-symbol="✧˖°ℙ𝕖𝕥𝕣𝕒°˖✧" aria-label="Kopiraj nadimak">✧˖°ℙ𝕖𝕥𝕣𝕒°˖✧</button>
+      <button class="uname-chip symbol-tile" data-symbol="⛧🖤 𝔩𝔲𝔨𝔞 🖤⛧" aria-label="Kopiraj nadimak">⛧🖤 𝔩𝔲𝔨𝔞 🖤⛧</button>
+      <button class="uname-chip symbol-tile" data-symbol="「 ᴍᴀᴛᴇᴏ 」" aria-label="Kopiraj nadimak">「 ᴍᴀᴛᴇᴏ 」</button>
+      <button class="uname-chip symbol-tile" data-symbol="༺ 𝕾𝖍𝖆𝖉𝖔𝖜 ༻" aria-label="Kopiraj nadimak">༺ 𝕾𝖍𝖆𝖉𝖔𝖜 ༻</button>
+      <button class="uname-chip symbol-tile" data-symbol="⋆｡˚ⓝⓘⓝⓐ˚｡⋆" aria-label="Kopiraj nadimak">⋆｡˚ⓝⓘⓝⓐ˚｡⋆</button>
+    </div>
+    <p class="u-mt-15">Želiš cijeli set gotovih okvira, zvjezdica i razdjelnika da složiš vlastiti nadimak? Cijela paleta je na stranici s <a href="/library/aesthetic-symbols/">ukrasnim simbolima za kopiranje</a> — isti se znakovi lijepe u nadimak tvog servera na Discordu.</p>
+  </section>
+
+  <!-- Gdje radi + kvadratići -->
+  <section class="editorial-section">
+    <h2>Gdje rade fontovi na Discordu (i napomena o kvadratićima)</h2>
+    <p class="editorial-intro">Budući da je ono što kopiraš čisti Unicode, slova za Discord lijepe se praktički u svako tekstualno polje aplikacije:</p>
+    <div class="block-example">
+      — <strong>Prikazano ime</strong> i <strong>nadimak na serveru</strong> (zaseban na svakom serveru)<br>
+      — <strong>„O meni”</strong> (bio tvog profila)<br>
+      — <strong>Naziv kanala</strong> (ako imaš administratorska prava)<br>
+      — <strong>Prilagođeni status</strong> i <strong>poruke</strong> u chatu<br>
+      — <strong>Naziv servera</strong> (ako si njegov vlasnik)
+    </div>
+    <p>Jedino mjesto gdje to <strong>ne</strong> radi jest <strong>korisničko ime (@)</strong>, namjerno ograničeno na mala slova, brojke, tačku i podvlaku. Uz to iskrena napomena: ako je uređaj osobe koja to gleda vrlo star, dio rjeđih stilova može se prikazati kao <strong>kvadratići (□)</strong> — to je font koji nedostaje na njezinu uređaju, a ne problem s tvojim tekstom. Držiš li se osnovnih stilova (podebljano, kurziv, gotica, balončasta, kapitalke) to se gotovo nikad ne događa. I zapamti: ništa od toga ne traži <strong>Nitro</strong> — Nitro ulazi samo kod boje i gradijenta u imenu, ne kod samog stiliziranog teksta. Za prazne redove u „O meni” dobro će doći <a href="/library/invisible-character/">nevidljivi znak</a>.</p>
+  </section>
+
+  <!-- Related -->
+  <section class="editorial-section">
+    <span class="article-section-label">Povezane stranice</span>
+    <div class="compare-grid">
+      <a href="/bs/" class="compare-card variant-muted u-no-underline">
+        <h4>Lijepa Slova</h4>
+        <p>Desetci stilova slova za stiliziranje imena prije nego što ga zalijepiš na Discord.</p>
+      </a>
+      <a href="/bs/" class="compare-card variant-muted u-no-underline">
+        <h4>Slova za Kopiranje</h4>
+        <p>Cijela abeceda u brojnim rezovima — bold, kurziv, gotica i balončasta.</p>
+      </a>
+      <a href="/library/aesthetic-symbols/" class="compare-card variant-muted u-no-underline">
+        <h4>Ukrasni Simboli za Kopiranje</h4>
+        <p>Zvjezdice, srca, okviri i razdjelnici za ukrašavanje nadimka i „O meni”.</p>
+      </a>
+      <a href="/library/invisible-character/" class="compare-card variant-muted u-no-underline">
+        <h4>Nevidljivi Znak</h4>
+        <p>Prazan razmak za čiste redove u biju i prazne nazive na Discordu.</p>
+      </a>
+    </div>
+  </section>
+</main>
+
+<footer class="footer">
+  <div class="footer-inner">
+    <h2 class="faq-category">Najčešća pitanja o fontovima za Discord</h2>
+    <div class="faq-item"><button class="faq-question" type="button">Kako promijeniti font u nadimku na Discordu?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Upiši svoje ime u polje na vrhu stranice. Odmah će se pojaviti deseci fontova za Discord — podebljano, kurziv, gotička, balončasta, kapitalke. Klikni „Kopiraj” kod onog koji ti se sviđa, otvori Discord, uđi u Korisničke postavke i zalijepi ga u prikazano ime, ili desnim klikom na serveru promijeni nadimak na tom serveru. Budući da su to Unicode znakovi, stilizirano slovo se lijepi u polje bez ikakvog dodatka.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Treba li za fontove na Discordu Nitro?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Ne. Slova iz ovog generatora obični su Unicode znakovi, isti kao s tastature, samo drukčijeg izgleda — zato se lijepe u prikazano ime, u nadimak na serveru, u odjeljak „O meni”, u naziv kanala i u poruke bez ikakvog Nitra. Nitro je potreban samo za plaćene dodatke, poput boja i gradijenta u imenu (Display Name Styles), a ne za sam stilizirani tekst.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Rade li fontovi u korisničkom imenu (@) na Discordu?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Ne. Korisničko ime (jedinstveni @ koji se koristi za pozivnice prijateljima) prima samo mala slova od a do z, brojke, tačku i podvlaku — bez stilskih fontova, razmaka, emojija ili simbola. Fontovi za Discord rade u prikazanom imenu, u nadimku na serveru, u odjeljku „O meni”, u nazivu kanala i u chatu. Ako želiš stil u imenu, koristi prikazano ime, a ne @login.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Po čemu se razlikuje Discordovo oblikovanje (**podebljanje**) od Unicode fontova?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">To su dvije različite stvari. Discordov Markdown (**podebljanje**, *kurziv*, `kod`) oblikuje tekst samo unutar poruka u chatu i nestane kad ga pokušaš upotrijebiti u imenu ili u biju. Unicode fontovi s ove stranice sam su stilizirani znak, pa rade svugdje — u nadimku, u „O meni”, u nazivu kanala, u statusu i u chatu. Praktično pravilo: u običnoj poruci koristi Markdown, a da stiliziraš nadimak ili bio, koristi Unicode font.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Kako napraviti ukrasni nadimak za Discord s okvirima i simbolima?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Odaberi font za ime (gotica i balončasta izlaze najbolje) i okruži ga okvirima te simbolima u stilu ꧁༒ ༒꧂. Na ovoj stranici je mreža gotovih nadimaka s okvirima — klikni za kopiranje i zalijepi u nadimak na serveru. Možeš i upisati svoje ime na vrhu, staviti font i upotrijebiti kartice Simboli i Okviri da dotjeraš izgled prije kopiranja.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Zašto se slova na Discordu prikazuju kao kvadratići?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Zato što uređaj osobe koja to gleda nema font koji crta taj znak — obično je to stariji telefon ili računar. To nije greška stranice ni tvog kopiranja. Osnovni stilovi — podebljano, kurziv, gotica, balončasta i kapitalke — najsigurniji su i prikazuju se ispravno gotovo svugdje. Ako netko prijavi kvadratić (□), zamijeni jednim od tih stilova.</div></div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Odabir jezika">
+      <a class="lang-option" href="/discord/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/bs/fontovi-za-discord/" hreflang="bs">BS</a>
+    </div>
+  </div>
+</footer>
+
+<div class="copy-toast" id="copyToast">Kopirano!</div>
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/styles.js"></script>
+<script src="/renderer.js"></script>
+<script src="/script.js" defer=""></script>
+<script src="/symbol-explorer.js"></script>
+<script src="/footer.js"></script>
+</body></html>

--- a/bs/fontovi-za-instagram/index.html
+++ b/bs/fontovi-za-instagram/index.html
@@ -1,0 +1,310 @@
+<!DOCTYPE html><html lang="bs"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Fontovi za Instagram: lijepa slova za bio i opise | UltraTextGen</title>
+  <meta name="description" content="Fontovi za Instagram besplatno: pretvori tekst u 𝗽𝗼𝗱𝗲𝗯𝗹𝗷𝗮𝗻𝗼, 𝘬𝘶𝘳𝘻𝘪𝘷 ili 𝓴𝓪𝓵𝓲𝓰𝓻𝓪𝓯𝓲𝓳𝓾 i zalijepi u bio, u ime profila, u opis i u komentare. Lijepa slova za Instagram — bez aplikacije.">
+  <link rel="canonical" href="https://ultratextgen.com/bs/fontovi-za-instagram/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/instagram/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/instagram/">
+  <link rel="alternate" hreflang="bs" href="https://ultratextgen.com/bs/fontovi-za-instagram/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Fontovi za Instagram: lijepa slova za bio i opise">
+  <meta property="og:description" content="Generator fontova za Instagram: upiši tekst i zalijepi stilizirano slovo u bio, u ime profila, u opis i u komentare. Podebljano, kurziv, kaligrafija i gotica — bez aplikacije.">
+  <meta property="og:url" content="https://ultratextgen.com/bs/fontovi-za-instagram/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/instagram.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Fontovi za Instagram: lijepa slova za bio i opise">
+  <meta name="twitter:description" content="Podebljano, kurziv, kaligrafija i gotica spremni za lijepljenje u bio i ime profila na Instagramu — bez aplikacije.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/instagram.png">
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+  <link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Generator Fontova za Instagram",
+  "alternateName": ["Fontovi za Instagram", "Fontovi za Instu", "Lijepa slova za Instagram", "Fontovi za bio na Instagramu", "Generator fontova za IG", "Slova za Instagram"],
+  "url": "https://ultratextgen.com/bs/fontovi-za-instagram/",
+  "inLanguage": "bs",
+  "applicationCategory": "UtilitiesApplication",
+  "operatingSystem": "Any",
+  "description": "Generator fontova za Instagram: pretvara tvoj tekst u stilizirana slova — podebljano, kurziv, kaligrafiju, goticu, balončasta i kapitalke — za lijepljenje u bio, u ime profila, u opis objave, u komentare i u Priče, bez preuzimanja aplikacije.",
+  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "BAM" }
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "bs",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Kako promijeniti font u biju na Instagramu?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Upiši svoj tekst u polje na vrhu stranice. Odmah će se pojaviti deseci fontova za Instagram — podebljano, kurziv, kaligrafija, gotica, balončasta i kapitalke. Klikni „Kopiraj” kod onog koji ti se sviđa, otvori Instagram, uđi u Uredi profil i zalijepi ga u polje Bio. Budući da su to Unicode znakovi, stilizirano slovo se lijepi u polje bez ikakve aplikacije ni dodatne tastature." }
+    },
+    {
+      "@type": "Question",
+      "name": "Kako napraviti drukčiji font u imenu profila na Instagramu?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Kopiraj ovdje odabrani font i zalijepi ga u polje „Ime” u Uredi profil — to je ono podebljano ime na vrhu profila, a ne @login. Instagram prihvaća Unicode u tom polju, pa se stilizirano slovo prikazuje ispravno. Samo imaj na umu da Instagram dopušta promjenu Imena ograničen broj puta u kratkom periodu (obično dvaput u 14 dana), pa zalijepi odmah gotov stil." }
+    },
+    {
+      "@type": "Question",
+      "name": "Može li se koristiti ukrasni font u korisničkom imenu (@) na Instagramu?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Ne. Korisničko ime (@login koji je u tvom linku i služi za označavanje) prima samo mala slova od a do z, brojke, tačku i podvlaku — bez stilskih fontova, razmaka, emojija ili simbola. Fontovi za Instagram rade u imenu profila (Ime), u biju, u opisima i u komentarima. Ako želiš stil u imenu, koristi polje Ime, a ne @login." }
+    },
+    {
+      "@type": "Question",
+      "name": "Rade li fontovi u opisima objava i u komentarima na Instagramu?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Da. Budući da su to obični Unicode znakovi, stilizirano slovo lijepiš u opis fotografije i reela, u komentare, u tekst u Pričama i u poruke na Directu. Radi jednako u aplikaciji na mobitelu i u verziji za browser. Jedino polje koje to ne prima jest @login (korisničko ime)." }
+    },
+    {
+      "@type": "Question",
+      "name": "Šteti li stilizirani font u biju prikazu u pretrazi na Instagramu?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Može štetiti ako sve stiliziraš. Pretraga i čitači ekrana bolje razumiju običan tekst, pa je najbolje stilizirati samo ime ili jednu kratku frazu, a važne ključne riječi — čime se baviš, tvoj grad, tvoja niša — ostaviti običnim fontom. Tada profil izgleda lijepo i i dalje ga je lako pronaći." }
+    },
+    {
+      "@type": "Question",
+      "name": "Zašto se font na Instagramu prikazuje kao kvadratić?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Zato što uređaj osobe koja to gleda nema font koji crta taj znak — obično je to stariji telefon ili računar. To nije greška stranice ni tvog kopiranja. Osnovni stilovi — podebljano, kurziv, kaligrafija, gotica, balončasta i kapitalke — najsigurniji su i prikazuju se ispravno gotovo svugdje. Ako vidiš kvadratić (□), zamijeni jednim od tih stilova." }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "inLanguage": "bs",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Početna", "item": "https://ultratextgen.com/bs/" },
+    { "@type": "ListItem", "position": 2, "name": "Fontovi za Instagram", "item": "https://ultratextgen.com/bs/fontovi-za-instagram/" }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/bs/">Početna</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Fontovi za Instagram</span>
+</nav>
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/instagram.svg" width="1200" height="340" loading="lazy" alt="">
+</figure>
+
+<section class="hero">
+  <div class="hero-inner">
+    <div class="hero-card">
+      <h1 class="hero-headline">Fontovi za Instagram: lijepa slova za bio i opise</h1>
+      <p class="hero-tagline">Upiši tekst i vidi ga odmah u desecima fontova za Instagram — podebljano, kurziv, kaligrafija, gotica, balončasta i kapitalke. Kopiraš i lijepiš u bio, u ime profila, u opis objave i u komentare. Sve besplatno i <strong>bez aplikacije</strong>.</p>
+      <div class="input-wrapper">
+        <textarea class="main-input" id="mainInput" placeholder="Upiši tekst za bio ili opis..." maxlength="500" autofocus=""></textarea>
+        <span class="char-count"><span id="charCount">0</span>/500</span>
+      </div>
+      <div class="decoration-section">
+        <div class="decoration-label">Dodaj simbole i okvire rezultatu</div>
+        <div class="decoration-tabs">
+          <button class="decoration-tab active" data-deco-tab="symbols">Simboli</button>
+          <button class="decoration-tab" data-deco-tab="frames">Okviri</button>
+          <button class="decoration-tab" data-deco-tab="dividers">Razdjelnici</button>
+          <button class="decoration-tab" data-deco-tab="arrows">Strelice</button>
+          <button class="decoration-tab" data-deco-tab="minimal">Minimalni</button>
+          <button class="decoration-tab" data-deco-tab="emojis">Emoji</button>
+        </div>
+        <div class="decoration-grid" id="decorationGrid"></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<main class="container">
+  <div class="category-section"><div class="category-tabs" id="categoryTabs"></div></div>
+  <div class="results-grid" id="resultsGrid"></div>
+
+  <!-- Kako to radi -->
+  <section class="editorial-section">
+    <h2>Fontovi za Instagram: kako to radi</h2>
+    <p class="editorial-intro"><strong>Fontovi za Instagram</strong> s ove stranice nisu instalirani font ni slika — to su <strong>Unicode znakovi</strong>, prava slova, ista kao s tastature, samo drukčijeg izgleda (𝗔, 𝘈, 𝓐, 𝔄). Budući da Instagram prihvaća Unicode u gotovo svakom tekstualnom polju, stilizirano slovo lijepi se ravno u tvoj <strong>bio</strong>, u <strong>ime profila</strong>, u <strong>opis objave</strong>, u <strong>komentare</strong>, u tekst u <strong>Pričama</strong> i u poruke na <strong>Directu</strong> — bez aplikacije, dodatka ili posebne tastature.</p>
+    <div class="block-example">
+      <strong>Primjer:</strong> „ana” → 𝗮𝗻𝗮 (podebljano), 𝘢𝘯𝘢 (kurziv), 𝒶𝓃𝒶 (kaligrafija), 𝔞𝔫𝔞 (gotička), ⓐⓝⓐ (balončasta), ᴀɴᴀ (kapitalke)
+    </div>
+    <p>Koristi se u nekoliko sekundi: upišeš tekst u polje na vrhu, generator ga prikaže u brojnim <strong>fontovima za Instagram</strong>, klikneš „Kopiraj” i zalijepiš u aplikaciji. Želiš samo gola slova abecede? Odmah su ispod. A ako radije pregledavaš još rezova, potpuni generator naći ćeš na <a href="/bs/">glavnoj stranici sa slovima za kopiranje</a>.</p>
+  </section>
+
+  <!-- Abeceda A-Z -->
+  <section class="editorial-section glyph-section">
+    <h2>Abeceda fontova za Instagram (A–Z za kopiranje)</h2>
+    <p class="editorial-intro">Cijela abeceda u stilovima koji se najčešće pojavljuju u biju i opisima na Instagramu. Klikni redak da kopiraš cijelu abecedu u tom stilu, ili upiši svoj tekst na vrhu i uzmi vlastitu riječ odmah stiliziranu.</p>
+    <div class="alpha-list">
+      <div class="alpha-row">
+        <span class="alpha-label">Podebljano</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝗔𝗕𝗖𝗗𝗘𝗙𝗚𝗛𝗜𝗝𝗞𝗟𝗠𝗡𝗢𝗣𝗤𝗥𝗦𝗧𝗨𝗩𝗪𝗫𝗬𝗭 𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇" aria-label="Kopiraj podebljanu abecedu">𝗔𝗕𝗖𝗗𝗘𝗙𝗚𝗛𝗜𝗝𝗞𝗟𝗠𝗡𝗢𝗣𝗤𝗥𝗦𝗧𝗨𝗩𝗪𝗫𝗬𝗭 · 𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Kurziv</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩 𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃" aria-label="Kopiraj abecedu u kurzivu">𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩 · 𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Elegantno</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵 𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏" aria-label="Kopiraj elegantnu abecedu">𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵 · 𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Gotička</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝔄𝔅ℭ𝔇𝔈𝔉𝔊ℌℑ𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔ℜ𝔖𝔗𝔘𝔙𝔚𝔛𝔜ℨ 𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷" aria-label="Kopiraj gotičku abecedu">𝔄𝔅ℭ𝔇𝔈𝔉𝔊ℌℑ𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔ℜ𝔖𝔗𝔘𝔙𝔚𝔛𝔜ℨ · 𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Balončasta</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ" aria-label="Kopiraj balončastu abecedu">ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ · ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Kapitalke</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="ᴀʙᴄᴅᴇꜰɢʜɪᴊᴋʟᴍɴᴏᴘqʀsᴛᴜᴠᴡxʏᴢ" aria-label="Kopiraj abecedu u kapitalkama">ᴀ ʙ ᴄ ᴅ ᴇ ꜰ ɢ ʜ ɪ ᴊ ᴋ ʟ ᴍ ɴ ᴏ ᴘ q ʀ s ᴛ ᴜ ᴠ ᴡ x ʏ ᴢ</button>
+      </div>
+    </div>
+    <p class="uname-note">Napomena o bosanskim znakovima: ovi Unicode fontovi obuhvaćaju osnovnu abecedu A–Z. Hrvatske kvačice (č, ć, đ, š, ž) u većini stilova ostaju obična slova usred stilizirane riječi — pa npr. „ana” izađe savršeno, a „nataša” prikaže š kao obično slovo. Za bio i imena bez kvačica izgleda savršeno, a za dulje opise najsigurniji su podebljano i kurziv.</p>
+    <p class="u-mt-15">Želiš se udubiti u jedan stil? Cijelu abecedu i verzije svakog reza naći ćeš na <a href="/bs/">glavnoj stranici sa slovima za kopiranje</a>, a najpopularniji za bio na Instagramu je <a href="/bs/kurziv/">kurziv</a>.</p>
+  </section>
+
+  <!-- Fontovi za bio i ime -->
+  <section class="editorial-section">
+    <h2>Fontovi za bio i ime profila na Instagramu</h2>
+    <p class="editorial-intro">Najbrži način da istakneš profil jest staviti font na <strong>ime profila</strong> (polje „Ime”) i zasebno u <strong>bio</strong>. To su dva različita polja — „Ime” je ono podebljano ime na vrhu profila, a bio je opis ispod njega. Instagram prihvaća Unicode u oba, ali <strong>ne u @loginu</strong>.</p>
+    <p class="uname-note">Kako zalijepiti:</p>
+    <div class="block-example">
+      — <strong>Ime profila (Ime):</strong> Uredi profil › polje „Ime” › zalijepi stilizirani font<br>
+      — <strong>Bio:</strong> Uredi profil › polje „Bio” › zalijepi tekst (možeš spajati više stilova u zasebnim redovima)<br>
+      — <strong>Opis objave / reela:</strong> pri dodavanju objave zalijepi font u polje opisa<br>
+      — <strong>Komentari i Direct:</strong> zalijepi stilizirano slovo ravno u polje komentara ili poruke
+    </div>
+    <p>Savjet od nekoga tko svakodnevno slaže profile: stiliziraj samo ime ili jednu frazu, a ostatak bija ostavi običnim tekstom — kontrast čini cijeli efekt. Kad je sve ukrašeno, ništa ne privlači pogled. Važan detalj: Instagram dopušta promjenu polja „Ime” samo ograničen broj puta u kratkom periodu, pa zalijepi odmah gotov stil. Za pojedinačne zvjezdice i sjaj u biju svrati na stranicu s <a href="/library/aesthetic-symbols/">ukrasnim simbolima za kopiranje</a>.</p>
+  </section>
+
+  <!-- Gdje radi i gdje ne -->
+  <section class="editorial-section">
+    <h2>Gdje ćeš zalijepiti fontove na Instagramu (a gdje ne)</h2>
+    <p class="editorial-intro">Budući da je ono što kopiraš čisti Unicode, slova za Instagram lijepe se praktički u svako tekstualno polje aplikacije:</p>
+    <div class="block-example">
+      — <strong>Ime profila (Ime)</strong> i <strong>bio</strong><br>
+      — <strong>Opisi objava</strong> i <strong>reelova</strong><br>
+      — <strong>Komentari</strong> ispod objava<br>
+      — <strong>Tekst u Pričama</strong> i <strong>bilješke (Notes)</strong><br>
+      — <strong>Poruke na Directu</strong>
+    </div>
+    <p>Jedino mjesto gdje to <strong>ne</strong> radi jest <strong>korisničko ime (@login)</strong> — Instagram ga namjerno ograničava na mala slova od a do z, brojke, tačku i podvlaku, pa nikakav stilizirani font, razmak ni emoji tu ne prolazi. Uz to iskrena napomena: ako je uređaj osobe koja to gleda vrlo star, dio rjeđih stilova može se prikazati kao <strong>kvadratići (□)</strong> — to je font koji nedostaje na njezinu uređaju, a ne problem s tvojim tekstom. Držiš li se osnovnih stilova (podebljano, kurziv, kaligrafija, gotica, balončasta, kapitalke) to se gotovo nikad ne događa. Za čiste prazne redove u biju dobro će doći <a href="/library/invisible-character/">nevidljivi znak</a>.</p>
+  </section>
+
+  <!-- Ukrasni bio sa simbolima -->
+  <section class="editorial-section">
+    <h2>Ukrasni bio i imena za Instagram sa simbolima</h2>
+    <p class="editorial-intro">Imena i redovi bija koji najviše ostavljaju dojam na Instagramu spajaju nježan font (kaligrafiju ili kurziv) sa zvjezdicama i simbolima s obje strane, u stilu ⋆˚₊‧ ‧₊˚⋆. Klikni za kopiranje i zalijepi u polje „Ime” ili u bio — potom zamijeni svojom riječju.</p>
+    <div class="uname-grid">
+      <button class="uname-chip symbol-tile" data-symbol="⋆˚₊‧ 𝒶𝓃𝒶 ‧₊˚⋆" aria-label="Kopiraj ime">⋆˚₊‧ 𝒶𝓃𝒶 ‧₊˚⋆</button>
+      <button class="uname-chip symbol-tile" data-symbol="✿ 𝓶𝓪𝓳𝓪 ✿" aria-label="Kopiraj ime">✿ 𝓶𝓪𝓳𝓪 ✿</button>
+      <button class="uname-chip symbol-tile" data-symbol="꒰ঌ 𝓃𝒾𝓀𝒶 ໒꒱" aria-label="Kopiraj ime">꒰ঌ 𝓃𝒾𝓀𝒶 ໒꒱</button>
+      <button class="uname-chip symbol-tile" data-symbol="⋆｡˚ 𝓮𝓶𝓪 ˚｡⋆" aria-label="Kopiraj ime">⋆｡˚ 𝓮𝓶𝓪 ˚｡⋆</button>
+      <button class="uname-chip symbol-tile" data-symbol="✧˖° 𝓵𝓾𝓬𝓲𝓳𝓪 °˖✧" aria-label="Kopiraj ime">✧˖° 𝓵𝓾𝓬𝓲𝓳𝓪 °˖✧</button>
+      <button class="uname-chip symbol-tile" data-symbol="ᯓ★ 𝓅ℯ𝓉𝓇𝒶 ★" aria-label="Kopiraj ime">ᯓ★ 𝓅ℯ𝓉𝓇𝒶 ★</button>
+      <button class="uname-chip symbol-tile" data-symbol="˚ʚ 𝓁𝒶𝓃𝒶 ɞ˚" aria-label="Kopiraj ime">˚ʚ 𝓁𝒶𝓃𝒶 ɞ˚</button>
+      <button class="uname-chip symbol-tile" data-symbol="⊹ ࣪ ˖ 𝓀𝓁𝒶𝓇𝒶 ˖ ࣪ ⊹" aria-label="Kopiraj ime">⊹ ࣪ ˖ 𝓀𝓁𝒶𝓇𝒶 ˖ ࣪ ⊹</button>
+      <button class="uname-chip symbol-tile" data-symbol="⟡ 𝓲𝓿𝓪 ⟡" aria-label="Kopiraj ime">⟡ 𝓲𝓿𝓪 ⟡</button>
+      <button class="uname-chip symbol-tile" data-symbol="๑ 𝓼𝓪𝓻𝓪 ๑" aria-label="Kopiraj ime">๑ 𝓼𝓪𝓻𝓪 ๑</button>
+    </div>
+    <p class="u-mt-15">Želiš cijeli set gotovih zvjezdica, srca i razdjelnika da složiš vlastiti bio? Cijela paleta je na stranici s <a href="/library/aesthetic-symbols/">ukrasnim simbolima za kopiranje</a> — isti se znakovi lijepe u ime i u bio na Instagramu.</p>
+  </section>
+
+  <!-- Pretraga i kvadratići -->
+  <section class="editorial-section">
+    <h2>Fontovi i pretraga na Instagramu (i napomena o kvadratićima)</h2>
+    <p class="editorial-intro">Stilizirani tekst izgleda sjajno, ali ima jednu kvaku: pretraga Instagrama i čitači ekrana tretiraju Unicode znakove drukčije od običnih slova. Ako stiliziraš cijeli bio, tvoje ključne riječi mogu slabije iskakati u pretrazi.</p>
+    <div class="block-example">
+      — <strong>Dobra praksa:</strong> stiliziraj ime ili kratku frazu, ostalo ostavi običnim tekstom<br>
+      — <strong>Ostavi običnim fontom:</strong> čime se baviš, grad, niša, riječi po kojima te traže<br>
+      — <strong>Primjer:</strong> 𝓶𝓪𝓳𝓪 𝓴𝓸𝓿𝓪č𝓲ć (kaligrafija) + „vjenčana fotografija · Sarajevo” običnim fontom
+    </div>
+    <p>Druga stvar su <strong>kvadratići (□)</strong>: kad netko na mjestu slova vidi prazan pravokutnik, to znači da njegov uređaj nema font koji crta taj znak — obično vrlo star telefon. To nije problem s tvojim tekstom ni s kopiranjem. Držiš li se osnovnih stilova, to se gotovo nikad ne događa. Za prazne redove i razmake u biju dobro će doći <a href="/library/invisible-character/">nevidljivi znak</a>, a snažniji, taman stil za ime naći ćeš u <a href="/bs/goticka-slova/">gotičkim slovima</a>.</p>
+  </section>
+
+  <!-- Related -->
+  <section class="editorial-section">
+    <span class="article-section-label">Povezane stranice</span>
+    <div class="compare-grid">
+      <a href="/bs/" class="compare-card variant-muted u-no-underline">
+        <h4>Slova za Kopiranje</h4>
+        <p>Cijela abeceda u brojnim rezovima — podebljano, kurziv, kaligrafija i balončasta.</p>
+      </a>
+      <a href="/bs/kurziv/" class="compare-card variant-muted u-no-underline">
+        <h4>Kurziv</h4>
+        <p>Ukrasni, rukopisni kurziv — najčešći izbor za bio na Instagramu.</p>
+      </a>
+      <a href="/library/aesthetic-symbols/" class="compare-card variant-muted u-no-underline">
+        <h4>Ukrasni Simboli za Kopiranje</h4>
+        <p>Zvjezdice, srca, okviri i razdjelnici za ukrašavanje imena i bija.</p>
+      </a>
+      <a href="/library/invisible-character/" class="compare-card variant-muted u-no-underline">
+        <h4>Nevidljivi Znak</h4>
+        <p>Prazan razmak za čiste redove i odmake u biju na Instagramu.</p>
+      </a>
+      <a href="/bs/goticka-slova/" class="compare-card variant-muted u-no-underline">
+        <h4>Gotička Slova</h4>
+        <p>Tamna, snažna slova za ime profila s karakterom.</p>
+      </a>
+    </div>
+  </section>
+</main>
+
+<footer class="footer">
+  <div class="footer-inner">
+    <h2 class="faq-category">Najčešća pitanja o fontovima za Instagram</h2>
+    <div class="faq-item"><button class="faq-question" type="button">Kako promijeniti font u biju na Instagramu?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Upiši svoj tekst u polje na vrhu stranice. Odmah će se pojaviti deseci fontova za Instagram — podebljano, kurziv, kaligrafija, gotica, balončasta i kapitalke. Klikni „Kopiraj” kod onog koji ti se sviđa, otvori Instagram, uđi u Uredi profil i zalijepi ga u polje Bio. Budući da su to Unicode znakovi, stilizirano slovo se lijepi u polje bez ikakve aplikacije ni dodatne tastature.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Kako napraviti drukčiji font u imenu profila na Instagramu?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Kopiraj ovdje odabrani font i zalijepi ga u polje „Ime” u Uredi profil — to je ono podebljano ime na vrhu profila, a ne @login. Instagram prihvaća Unicode u tom polju, pa se stilizirano slovo prikazuje ispravno. Samo imaj na umu da Instagram dopušta promjenu Imena ograničen broj puta u kratkom periodu (obično dvaput u 14 dana), pa zalijepi odmah gotov stil.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Može li se koristiti ukrasni font u korisničkom imenu (@) na Instagramu?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Ne. Korisničko ime (@login koji je u tvom linku i služi za označavanje) prima samo mala slova od a do z, brojke, tačku i podvlaku — bez stilskih fontova, razmaka, emojija ili simbola. Fontovi za Instagram rade u imenu profila (Ime), u biju, u opisima i u komentarima. Ako želiš stil u imenu, koristi polje Ime, a ne @login.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Rade li fontovi u opisima objava i u komentarima na Instagramu?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Da. Budući da su to obični Unicode znakovi, stilizirano slovo lijepiš u opis fotografije i reela, u komentare, u tekst u Pričama i u poruke na Directu. Radi jednako u aplikaciji na mobitelu i u verziji za browser. Jedino polje koje to ne prima jest @login (korisničko ime).</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Šteti li stilizirani font u biju prikazu u pretrazi na Instagramu?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Može štetiti ako sve stiliziraš. Pretraga i čitači ekrana bolje razumiju običan tekst, pa je najbolje stilizirati samo ime ili jednu kratku frazu, a važne ključne riječi — čime se baviš, tvoj grad, tvoja niša — ostaviti običnim fontom. Tada profil izgleda lijepo i i dalje ga je lako pronaći.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Zašto se font na Instagramu prikazuje kao kvadratić?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Zato što uređaj osobe koja to gleda nema font koji crta taj znak — obično je to stariji telefon ili računar. To nije greška stranice ni tvog kopiranja. Osnovni stilovi — podebljano, kurziv, kaligrafija, gotica, balončasta i kapitalke — najsigurniji su i prikazuju se ispravno gotovo svugdje. Ako vidiš kvadratić (□), zamijeni jednim od tih stilova.</div></div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Odabir jezika">
+      <a class="lang-option" href="/instagram/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/bs/fontovi-za-instagram/" hreflang="bs">BS</a>
+    </div>
+  </div>
+</footer>
+
+<div class="copy-toast" id="copyToast">Kopirano!</div>
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script>window.UTG_PREVIEW_PLATFORM='instagram';window.UTG_SHOW_PLATFORMS=true;window.UTG_DEMO_TEXT='ana aesthetic\nlink u biju ⬇';</script>
+<script src="/styles.js"></script>
+<script src="/renderer.js"></script>
+<script src="/script.js" defer=""></script>
+<script src="/symbol-explorer.js"></script>
+<script src="/footer.js" defer></script>
+</body></html>

--- a/bs/goticka-slova/index.html
+++ b/bs/goticka-slova/index.html
@@ -1,0 +1,299 @@
+<!DOCTYPE html><html lang="bs"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZGVh");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Generator Gotičkih Slova — 𝔤𝔬𝔱𝔦𝔠𝔞 za kopiranje | UltraTextGen</title>
+  <meta name="description" content="Besplatan generator gotičkih slova: pretvori tekst u gotičke Unicode znakove (fraktura) za kopiranje i lijepljenje — u bio na Instagramu, Discord, TikTok, nadimke i skice tetovaža. Odmah, bez registracije.">
+  <link rel="canonical" href="https://ultratextgen.com/bs/goticka-slova/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/category/gothic-fonts/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/category/gothic-fonts/">
+  <link rel="alternate" hreflang="bs" href="https://ultratextgen.com/bs/goticka-slova/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Generator Gotičkih Slova — 𝔤𝔬𝔱𝔦𝔠𝔞 za kopiranje | UltraTextGen">
+  <meta property="og:description" content="Besplatan generator gotičkih slova — gotički Unicode znakovi (fraktura) za kopiranje i lijepljenje na Instagram, Discord, TikTok i u nadimke. Odmah, bez registracije.">
+  <meta property="og:url" content="https://ultratextgen.com/bs/goticka-slova/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category-gothic-fonts.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Generator Gotičkih Slova — 𝔤𝔬𝔱𝔦𝔠𝔞 za kopiranje | UltraTextGen">
+  <meta name="twitter:description" content="Besplatan generator gotičkih slova — gotički Unicode znakovi (fraktura) za kopiranje i lijepljenje na društvene mreže, Discord i u nadimke.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category-gothic-fonts.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "bs",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Što je generator gotičkih slova i kako radi?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Pretvara slova koja upišeš u gotičke Unicode znakove (𝔭𝔬𝔭𝔲𝔱 𝔬𝔳𝔦𝔥) — prave znakove iz porodice frakture, a ne font ni sliku. Budući da su to obični tekstualni znakovi, možeš ih kopirati i zalijepiti svugdje gdje je dopušten tekst: u bio, opise, komentare, nadimke i poruke. Više u našem vodiču o tome kako rade Unicode fontovi."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Radi li gotički tekst na Instagramu, Discordu, TikToku i u drugim aplikacijama?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da. Bio, opisi, komentari, nazivi kanala na Discordu i poruke na chatu bez problema primaju gotičke znakove jer je to običan Unicode. Sjajno se pokaže u nadimcima i profilima goth, metal ili srednjovjekovnog ugođaja. Napomena: neka polja s @korisničkim imenom filtriraju nestandardne znakove — u samom handleu treba ostati na običnom tekstu, ali u biju i opisima gotica radi bez zapreka."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Po čemu se razlikuje gotica (fraktura) od podebljane gotice?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "To su dvije verzije istog stila. Obična fraktura (𝔤𝔬𝔱𝔦𝔠𝔞) tanja je i klasičnija, a podebljana gotica (𝖌𝖔𝖙𝖎𝖈𝖆) ima deblje, snažnije poteze i bolje izgleda u kratkim naslovima i nadimcima. U rezultatima ispod naći ćeš obje verzije — dovoljno je kliknuti onu koja odgovara tvom projektu i kopirati."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Mogu li pisati bosanske znakove (č, ć, đ, š, ž) gotičkim slovima?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Unicode gotica obuhvaća A–Z i a–z, pa bosanski znakovi poput č, ć, đ, š, ž nemaju vlastiti gotički oblik i ostaju obični. Za dosljedan gotički efekt možeš ih zamijeniti osnovnim slovima (c, d, s, z) — to mijenja pravopis — ili ih ostaviti u normalnom obliku, što u kratkom tekstu, nadimku ili naslovu obično ionako izgleda dobro."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Je li generator gotičkih slova besplatan?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da, potpuno besplatan i bez registracije. Upisuj, kopiraj i lijepi koliko god puta želiš — nema ograničenja ni skrivenih troškova."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Zašto se neka gotička slova prikazuju kao kvadratići ili izgledaju drukčije?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Prazni kvadratić (▯) znači da uređaj nema odgovarajući glif za taj gotički znak — to se obično odnosi na starije sisteme. Osim toga, nekoliko velikih slova frakture (C, H, I, R, Z) dolazi iz drugog Unicode bloka i izgleda drukčije od ostatka abecede — to je normalno. Odaberi tada podebljanu verziju gotice ili ažuriraj uređaj; više u članku o tome zašto se fontovi prikazuju kao kvadratići."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "inLanguage": "bs",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Početna", "item": "https://ultratextgen.com/bs/" },
+    { "@type": "ListItem", "position": 2, "name": "Gotička slova", "item": "https://ultratextgen.com/bs/goticka-slova/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Generator Gotičkih Slova",
+  "alternateName": ["Gotička slova","Gotički tekst","Gotica za kopiranje","Unicode fraktura","Gotička slova za tetovažu","Generator gotice","Gotički font","Blackletter na bosanskom"],
+  "url": "https://ultratextgen.com/bs/goticka-slova/",
+  "inLanguage": "bs",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "BAM"
+  },
+  "description": "Besplatan generator gotičkih slova: pretvori tekst u gotičke Unicode znakove (fraktura i podebljana gotica) za kopiranje i lijepljenje na Instagram, Discord, TikTok, u nadimke i skice tetovaža.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/bs/">Početna</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Gotička slova</span>
+</nav>
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/category-gothic-fonts.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+  <!-- Hero -->
+  <section class="hero">
+    <div class="hero-inner">
+      <div class="hero-card">
+        <h1 class="hero-headline">Generator Gotičkih Slova</h1>
+        <p class="hero-tagline">Pretvori bilo koji tekst u 𝔤𝔬𝔱𝔦𝔠𝔲 za kopiranje i lijepljenje — mračna,
+          ukrasna Unicode slova (fraktura i podebljana gotica) za bio, nadimke i naslove. Besplatno, odmah, bez registracije.</p>
+        <div class="input-wrapper">
+          <textarea class="main-input" id="mainInput" placeholder="Upiši tekst, riječ ili ime…" maxlength="500" autofocus></textarea>
+          <span class="char-count"><span id="charCount">0</span>/500</span>
+        </div>
+
+        <!-- Decoration Selector -->
+        <div class="decoration-section">
+          <div class="decoration-label">
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"></path>
+            </svg>
+            Dodaj simbole oko rezultata
+          </div>
+          <div class="decoration-tabs">
+            <button class="decoration-tab active" data-deco-tab="symbols">Simboli</button>
+            <button class="decoration-tab" data-deco-tab="frames">Okviri</button>
+            <button class="decoration-tab" data-deco-tab="dividers">Razdjelnici</button>
+            <button class="decoration-tab" data-deco-tab="minimal">Minimalni</button>
+            <button class="decoration-tab" data-deco-tab="emojis">Emoji</button>
+          </div>
+          <div class="decoration-grid" id="decorationGrid"></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Main Content -->
+  <main class="container">
+
+    <section class="editorial-section">
+      <span class="article-section-label">Gotička Unicode slova</span>
+      <h2>Gotički tekst za kopiranje — za bio, nadimke i tetovaže</h2>
+      <p>Ova slova nisu font ni slika, nego pravi <strong>Unicode znakovi</strong> iz porodice frakture. Daj
+        svom biju goth ugođaj, napravi mračan nadimak ili pripremi natpis u srednjovjekovnom ili metal stilu — gotica
+        sjajno paše i uz skice tetovaža. Upiši tekst iznad, klikni <strong>Kopiraj</strong> i zalijepi
+        gotička slova gdje god želiš.</p>
+    </section>
+
+    <!-- Category Tabs (populated by script.js) -->
+    <div class="category-section">
+      <div class="category-tabs" id="categoryTabs"></div>
+    </div>
+
+    <!-- Results -->
+    <div class="results-grid" id="resultsGrid"></div>
+
+    <section class="editorial-section">
+      <span class="article-section-label">Povezano</span>
+      <p>Spoji goticu s <a href="/bs/podebljana-slova/">podebljanim slovima</a>,
+        <a href="/library/aesthetic-symbols/">ukrasnim simbolima</a> ili <a href="/library/invisible-character/">nevidljivim znakom</a>
+        za čiste razmake. Za skice tetovaža dobro će doći <a href="/usecase/tattoo-fonts/">generator fontova za tetovažu</a>,
+        a za okomite rasporede — <a href="/usecase/vertical-text/">okomiti tekst</a>.</p>
+    </section>
+  </main>
+
+  <!-- Footer + FAQ -->
+  <footer class="footer">
+    <div class="footer-inner">
+<div class="faq-section" id="gothic-faq">
+
+<h2 class="faq-category">Generator Gotičkih Slova — FAQ</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Što je generator gotičkih slova i kako radi?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Pretvara slova koja upišeš u gotičke Unicode znakove (𝔭𝔬𝔭𝔲𝔱 𝔬𝔳𝔦𝔥) — prave znakove iz porodice frakture, a ne font ni sliku. Budući da su to obični tekstualni znakovi, možeš ih kopirati i zalijepiti svugdje gdje je dopušten tekst: u bio, opise, komentare, nadimke i poruke. Više u našem <a href="/guide/how-unicode-fonts-work/">vodiču o tome kako rade Unicode fontovi</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Radi li gotički tekst na Instagramu, Discordu, TikToku i u drugim aplikacijama?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Da. Bio, opisi, komentari, nazivi kanala na Discordu i poruke na chatu bez problema primaju gotičke znakove jer je to običan Unicode. Sjajno se pokaže u nadimcima i profilima goth, metal ili srednjovjekovnog ugođaja. Napomena: neka polja s <strong>@korisničkim imenom</strong> filtriraju nestandardne znakove — u samom handleu treba ostati na običnom tekstu, ali u biju i opisima gotica radi bez zapreka.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Po čemu se razlikuje gotica (fraktura) od podebljane gotice?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    To su dvije verzije istog stila. Obična fraktura (𝔤𝔬𝔱𝔦𝔠𝔞) tanja je i klasičnija, a podebljana gotica (𝖌𝖔𝖙𝖎𝖈𝖆) ima deblje, snažnije poteze i bolje izgleda u kratkim naslovima i nadimcima. U rezultatima ispod naći ćeš obje verzije — dovoljno je kliknuti onu koja odgovara tvom projektu i kopirati.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Mogu li pisati bosanske znakove (č, ć, đ, š, ž) gotičkim slovima?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Unicode gotica obuhvaća A–Z i a–z, pa bosanski znakovi poput č, ć, đ, š, ž nemaju vlastiti gotički oblik i ostaju obični. Za dosljedan gotički efekt možeš ih zamijeniti osnovnim slovima (<strong>c, d, s, z</strong>) — to mijenja pravopis — ili ih ostaviti u normalnom obliku, što u kratkom tekstu, nadimku ili naslovu obično ionako izgleda dobro.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Je li generator gotičkih slova besplatan?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Da, potpuno besplatan i bez registracije. Upisuj, kopiraj i lijepi koliko god puta želiš — nema ograničenja ni skrivenih troškova.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Zašto se neka gotička slova prikazuju kao kvadratići ili izgledaju drukčije?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Prazni kvadratić (▯) znači da uređaj nema odgovarajući glif za taj gotički znak — to se obično odnosi na starije sisteme. Osim toga, nekoliko velikih slova frakture (C, H, I, R, Z) dolazi iz drugog Unicode bloka i izgleda drukčije od ostatka abecede — to je normalno. Odaberi tada podebljanu verziju gotice ili ažuriraj uređaj; više u članku o tome, <a href="/guide/why-fonts-show-as-boxes/">zašto se fontovi prikazuju kao kvadratići</a>.
+  </div>
+</div>
+
+</div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Odabir jezika">
+      <a class="lang-option" href="/category/gothic-fonts/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/bs/goticka-slova/" hreflang="bs">BS</a>
+    </div>
+
+    </div>
+  </footer>
+
+  <div class="copy-toast" id="copyToast">Kopirano!</div>
+
+  <script>
+    window.UTG_FAMILY = "gothic";
+    window.UTG_DEMO_TEXT = "gotička slova\ngotički tekst";
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/script.js" defer></script>
+  <script src="/footer.js" defer></script>
+</body></html>

--- a/bs/index.html
+++ b/bs/index.html
@@ -1,0 +1,1020 @@
+<!DOCTYPE html><html lang="bs" dir="ltr"><head>
+  <meta name="yandex-verification" content="aa326290e0338f4f">
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title data-i18n="meta.title">Lijepi Fontovi i Stilizirana Slova za Kopiranje — Slova za Instagram, TikTok i Nadimke</title>
+<meta name="description" data-i18n-content="meta.description" content="Generator lijepih fontova, estetskih slova i stiliziranog teksta za kopiranje. Podebljano, kurziv, gotica, balončasta, Zalgo i simboli — zalijepi u instagram bio, u opis na TikToku, u nadimak u igri ili na Discord. Besplatno, bez računa.">
+
+<link rel="canonical" href="https://ultratextgen.com/bs/">
+
+<link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/">
+<link rel="alternate" hreflang="en" href="https://ultratextgen.com/">
+<link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/">
+<link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/">
+<link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/">
+<link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/">
+<link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/">
+<link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/">
+<link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/">
+<link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/">
+<link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/">
+<link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/">
+<link rel="alternate" hreflang="sv" href="https://ultratextgen.com/sv/">
+<link rel="alternate" hreflang="no" href="https://ultratextgen.com/no/">
+<link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/">
+<link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/">
+<link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/">
+<link rel="alternate" hreflang="ar" href="https://ultratextgen.com/ar/">
+<link rel="alternate" hreflang="hr" href="https://ultratextgen.com/hr/">
+<link rel="alternate" hreflang="cs" href="https://ultratextgen.com/cs/">
+<link rel="alternate" hreflang="sk" href="https://ultratextgen.com/sk/">
+<link rel="alternate" hreflang="bs" href="https://ultratextgen.com/bs/">
+<link rel="alternate" hreflang="sr" href="https://ultratextgen.com/sr/">
+<link rel="alternate" hreflang="ro" href="https://ultratextgen.com/ro/">
+<link rel="alternate" hreflang="sr-ME" href="https://ultratextgen.com/hr/">
+<link rel="alternate" hreflang="bs-ME" href="https://ultratextgen.com/hr/">
+
+<meta name="robots" content="index, follow">
+
+<meta property="og:site_name" content="UltraTextGen">
+<meta property="og:title" content="Lijepi Fontovi i Stilizirana Slova za Kopiranje — Slova za Instagram, TikTok i Nadimke">
+<meta property="og:description" content="Generator lijepih fontova, estetskih slova i stiliziranog teksta za kopiranje. Podebljano, kurziv, gotica, balončasta, Zalgo i simboli — zalijepi u instagram bio, u opis na TikToku, u nadimak u igri ili na Discord.">
+<meta property="og:url" content="https://ultratextgen.com/bs/">
+<meta property="og:type" content="website">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/fancy-text-generator-preview.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Lijepi Fontovi i Stilizirana Slova za Kopiranje — Slova za Instagram, TikTok i Nadimke">
+<meta name="twitter:description" content="Generator lijepih fontova, estetskih slova i stiliziranog teksta za kopiranje. Podebljano, kurziv, gotica, balončasta, Zalgo i simboli — zalijepi u instagram bio, u opis na TikToku, u nadimak u igri ili na Discord.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/fancy-text-generator-preview.png">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/style.css">
+
+ <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+[
+  {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/bs/",
+    "inLanguage": "bs",
+    "description": "Brz i pregledan generator Unicode teksta za bio na društvenim mrežama, opise i korisnička imena.",
+    "potentialAction": {
+      "@type": "SearchAction",
+      "target": {
+        "@type": "EntryPoint",
+        "urlTemplate": "https://ultratextgen.com/bs/?q={search_term_string}"
+      },
+      "query-input": "required name=search_term_string"
+    }
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com",
+    "logo": "https://ultratextgen.com/logo.png",
+    "sameAs": [
+      "https://www.youtube.com/@UltraTextGen",
+      "https://www.facebook.com/profile.php?id=61588587387596",
+      "https://www.linkedin.com/company/71290348/",
+      "https://x.com/UltraTextGen"
+    ]
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "WebApplication",
+    "name": "UltraTextGen",
+    "alternateName": ["Generator Unicode fontova", "Generator lijepog teksta", "Mijenjač fontova", "Fontovi za kopiranje i lijepljenje"],
+    "url": "https://ultratextgen.com/bs/",
+    "inLanguage": "bs",
+    "applicationCategory": "UtilitiesApplication",
+    "operatingSystem": "All",
+    "browserRequirements": "Requires JavaScript",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "description": "Generiraj stilizirani Unicode tekst u trenu za Instagram, TikTok, X, WhatsApp i Discord. Kopiraj i zalijepi stilove teksta za bio, korisnička imena i objave."
+  }
+]
+</script>
+
+
+
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "bs",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Što je UltraTextGen i što se tu zapravo događa?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "To je besplatan generator slova — upišeš običan tekst, a mi ga pretvaramo u stilizirane Unicode znakove koji izgledaju kao lijep font. Najvažnije: to su pravi znakovi , a ne podebljanje iz Worda ni markdown s Discorda. Zato rade svugdje gdje se može upisati običan tekst — u instagram bio, u nadimak, u komentar, u mail, u WhatsApp status. Primjer Upišeš „bok\" → dobiješ 𝗯𝗼𝗸 (podebljano), 𝘣𝘰𝘬 (kurziv), 𝒷ℴ𝓀 (kaligrafija) ili ⓑⓞⓚ (balončasta). Sve jednim klikom."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Kako kopirati lijepa slova u 5 sekundi?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "1. Upišeš ili zalijepiš tekst u polje na vrhu. 2. Stilovi se pojave odmah ispod — bold, kurziv, gotica, balončasta i još desetak drugih. 3. Ako želiš, dodaj ukrase — okvire, zvjezdice, strelice. 4. Klikneš „Kopiraj\" kod onog koji ti odgovara i zalijepiš gdje god želiš. To je to. Bez registracije, bez instaliranja aplikacije. Radi jednako na računaru i na mobitelu."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Besplatno? Bez ograničenja, bez računa?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da, sve je 100% besplatno . Bez računa, bez dnevnog ograničenja, bez vodenih žigova, bez kvake. Možeš kroz to propustiti cijelu knjigu i ništa se neće dogoditi."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Kako ubaciti stilizirani tekst u bio na Instagramu?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Instagram nema nikakvu alatnu traku za oblikovanje, ali prihvaća Unicode — dakle sve što ovdje generiraš uredno uleti u bio. Kako to napraviti 1. Upiši ono što želiš u biju (npr. ime, hashtag, kratak opis). 2. Odaberi stil — podebljano i kurziv rade najbolje na većini uređaja. 3. Kopiraj rezultat i zalijepi u „Uredi profil → Bio\" u aplikaciji. Savjet: ako želiš ukrasiti, dodaj okvir tipa ⋆｡˚ ili zvjezdicu ✦ sa strane — izgleda dobro, a ne krade pažnju ostatku bija."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Rade li slova u opisima na TikToku?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da — TikTok prikazuje Unicode u opisima, opisima profila i komentarima. Najbolje se pokažu podebljano , kurziv , balončasta i kapitalke . Stilovi s puno ukrasa znaju se odrezati kod dugih opisa, pa za svaki slučaj provjeri objavu u pregledu prije objavljivanja."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Može li se napraviti nadimak za igru ili za Discord?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Naravno — to je vjerovatno najčešći razlog zbog kojeg ljudi dolaze na ovakve generatore. Discord, Roblox, Steam, Minecraft, većina igara prihvaća Unicode u nadimcima. Primjer Obični nadimak: „DarkWolf\" Nakon stiliziranja: „𝔇𝔞𝔯𝔨𝔚𝔬𝔩𝔣\" (gotica), „ⒹⓐⓡⓚⓌⓞⓛⓕ\" (balončasta) ili „๖ۣۜDarkWolf\" (s ukrasom sa strane). Napomena: neke igre imaju filtre i neće primiti egzotične znakove. Ako jedan stil ne prolazi, uzmi drugi — bold i kurziv obično prolaze svugdje."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Radi li u WhatsApp statusu, na Telegramu i u Messengeru?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da — WhatsApp, Telegram, Messenger, Signal, iMessage. Sve što prima običan tekst prima i Unicode slova. Zalijepiš u status ili u poruku i izgleda kao ukrasan font. Za WhatsApp dodajem: ako ti treba samo podebljanje, možeš koristiti njihovu vlastitu sintaksu (`*tekst*` daje bold). Ali Unicode radi svugdje — i ondje gdje ga WhatsApp ne podržava, npr. u imenu kontakta."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "A u naslovu maila ili u CV-u?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Tu Unicode odradi najviše. Naslov maila je običan tekst, pa podebljanje iz Outlooka otpada. Ali „𝗥𝗮č𝘂𝗻 — 𝗵𝗶𝘁𝗻𝗼\" već izgleda snažnije u sandučiću primaoca. U CV-u blago podebljano ime u zaglavlju zna privući pogled poslodavca. Samo nemoj pretjerati — cijeli CV u gotici ne izgleda profesionalno."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Koje stilove slova imam na izbor?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Puno. Zaista puno. Ukratko: Osnovni Podebljano (bold), kurziv, kaligrafija (script), gotica, balončasta (u kružićima), kapitalke, precrtano, podcrtano, double struck. Zabavni Tekst naopako, ogledalno, Zalgo (glitch s crticama nad slovima), tekst u kvadratićima, u zagradama, fullwidth (razmaknuti). Dodaci Okviri oko teksta, zvjezdice, srca, strelice, razdjelnici, zastave, emoji — sve to možeš nasloniti na stil slova. S vremena na vrijeme dolaze novi — vrijedi dodati stranicu u knjižne oznake."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Mogu li spojiti više stilova odjednom?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da — i to je najveća prednost UltraTextGena. Možeš nasloniti npr. balončasta + Zalgo , gotica + naopako ili kapitalke + podcrtano , a onda cijelo to zatvoriti u okvir ili zvjezdicu. Primjer „bok\" → odabereš goticu → dodaš okvir sa zvjezdicama → izađe: ★彡[ 𝔟𝔬𝔨 ]彡★ Što više eksperimentiraš, to zanimljivije stvari izlaze. Preporučujem da kreneš s jednim stilom i dodaš jedan ukras — ne sve odjednom."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Što je Zalgo i te čudne crtice nad slovima?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Zalgo je onakav „ukleti\", glitchani stil — nad i pod svakim slovom naleti hrpa dijakritičkih znakova. Izgleda kao da se tekst raspada ili kao da je iz horora. Primjer „bok\" → b̷̢o̴̢k̷̛ Najčešće to viđaš u mračnim biojevima na Instagramu, u halloweenskim memeovima, u gaming klanovima koji žele izgledati opasno ili kad netko od toga radi foru."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Odakle uzeti lijepe simbole, zvjezdice i srca?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Sve što imaš u odjeljku „Ukrasi\" ispod tekstualnog polja možeš kopirati zasebno — čak i bez upisivanja teksta. Naprosto kao zasebne znakove za bio, nadimak ili objavu. — Estetski simboli : ✦ ✧ ⋆ ｡ ☆ ♡ ❀ ✿ — Okviri i obrubi : ╭─▸ │ ╰─▸ ili ★彡[ ]彡★ — Strelice : → ⇨ ➤ ⟶ — Minimalni razdjelnici : · ⋅ ─ • — Zastave i emoji . Najčešće se koriste u estetskim biojevima na Instagramu i Pinterestu — pašu uz sve, od citata do popisa interesa."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "A bosanski znakovi? Radi li s č, ć, đ, š, ž?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ukratko: ovisi o stilu. Unicode ima stilizirane verzije za osnovnu abecedu A–Z, pa se c , s , z bez problema pretvore npr. u podebljano. Ali za č , ć , đ , š , ž stilizirane verzije postoje samo u dijelu stilova (uglavnom bold, kurziv, kapitalke). Ako stil nema verziju za bosanski znak, on ostaje u izvornom obliku — tekst je i dalje čitljiv, bosansko slovo naprosto izgleda „običnije\" od ostatka. Za nadimke bez kvačica to nije nikakav problem. Za cijele rečenice na bosanskom preporučujem bold , kurziv ili monospace — oni se najbolje snalaze s našom abecedom. Napomena i za digrafe: dž, lj i nj su samo dva obična slova jedno do drugoga, pa se svako stilizira zasebno."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Zašto se nekome prikazuju kvadratići umjesto slova?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Zato što sistemski font na strani primaoca ne sadrži određeni Unicode znak. To nije problem s tvojim tekstom — naprosto njegov mobitel ili aplikacija nema taj konkretni znak u kompletu. Drži se bolda , kurziva i balončaste — imaju najširu podršku. Vrlo egzotični stilovi (fullwidth, kvadratići) mogu se prikazati kao □ na starijim Androidima ili u nekim mail klijentima."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Instagram mi je izrezao dio znakova u nadimku — što sad?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Instagram ima filtar na polju korisničko ime (dakle @login) — prima samo slova, brojke, tačke i podvlake. Tu stilizirana slova ne možeš zalijepiti. Ali u polju „Ime\" (prikazano ime) i u biju može — i tu prolazi većina stilova. Ako se jedan ne sprema, uzmi drugi. Bold obično prolazi bez problema."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Postoje li znakovi koji se uopće ne mogu pretvoriti?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Standardna slova (A–Z, a–z), brojke i osnovni interpunkcijski znakovi pretvaraju se bez problema. Neki rijetki simboli ili posebni znakovi nemaju stilizirane parnjake u Unicodeu — tada ostaju u izvorniku. Ništa se ne kvari, tekst je i dalje za kopiranje."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Sprema li se moj tekst negdje?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ne. Cijela pretvorba slova događa se u tvom browseru — ništa ne ide na naše servere, ništa se ne sprema, ništa se ne prati. Kopirani tekst je čisti Unicode, bez skrivenih znakova, bez ikakvih identifikatora."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Je li sigurno lijepiti ova slova bilo gdje?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da — to su standardni Unicode znakovi, isti kakve koristi cijeli internet. Ništa unutra, bez skripti, bez skrivenog oblikovanja, bez kodova. Slobodno lijepi u CV, u poslovni mail, u bio na LinkedInu — gdje god želiš."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Radi li na mobitelu?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da — stranica se u potpunosti prilagođava mobitelu. iPhone, Android, tablet — sve štima. Upišeš tekst, klikneš, kopira se u clipboard, zalijepiš u aplikaciji. Bez instaliranja ičega iz trgovine."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Po čemu se razlikujete od drugih generatora slova?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Konkretno: — Jedna od većih kolekcija Ultra stilova — bold, kurziv, gotica, balončasta i još desetak drugih. — Spajanje stilova — većina generatora daje ti jedan stil odjednom, mi dopuštamo naslanjanje. — Ukrasi jednim klikom — okviri, zvjezdice, razdjelnici bez lijepljenja znak po znak. — Stranice za konkretne platforme — Instagram, TikTok, Discord. Ondje prikazujemo samo stilove koji na toj aplikaciji rade. — Brzo i bez skočnih prozora — bez captcha, bez „prihvati sve\" prije svakog klika."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Dolaze li novi stilovi?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da, redovito. S vremena na vrijeme upadnu nove verzije, ukrasi i okviri. Najlakše je zapamtiti stranicu ili svratiti povremeno."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Kako pronaći točno onaj stil koji tražim?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Tri puta: Po stilu — kategorije na vrhu: bold, kurziv, gotica, balončasta, precrtano, naopako i još. Po platformi — svrati na podstranicu za Instagram, TikTok, Discord — ondje su samo stilovi koji se na toj platformi pokažu. Po cilju — odjeljak s primjenama ima alate prilagođene konkretnoj potrebi: naslov na LinkedInu, komentari, tekst s emojijima."
+      }
+    }
+  ]
+}
+</script>
+</head>
+
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer=""></script>
+
+  <!-- Hero Section -->
+  <section class="hero">
+    <div class="hero-inner">
+      <div class="hero-card">
+        <h1 class="hero-headline" data-i18n="hero.title">Lijepi Fontovi i Stilizirana Slova za Kopiranje</h1>
+        <p class="hero-tagline" data-i18n="hero.subtitle">Upiši tekst, odaberi stil — podebljano, kurziv, gotica, balončasta ili s ukrasima. Ubaci u instagram bio, u nadimak u igri, u WhatsApp status ili u opis pod TikTokom. Bez aplikacije, bez prijave.</p>
+        <div class="input-wrapper">
+          <textarea class="main-input" id="mainInput" placeholder="Upiši tekst..." data-i18n-placeholder="ui.placeholder" maxlength="500" autofocus=""></textarea>
+          <button class="input-clear-btn" id="inputClearBtn" aria-label="Clear input" hidden="">✕</button>
+          <span class="char-count" id="charCountWrapper" hidden=""><span id="charCount">0</span>/500</span>
+        </div>
+
+        <!-- Decoration Selector -->
+        <div class="decoration-section">
+          <div class="decoration-label">
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"></path>
+            </svg>
+            <span data-i18n="decorations.label">Dodaj ukrase tekstu</span>
+       </div>
+    <div class="decoration-tabs">
+    <button class="decoration-tab active" data-deco-tab="symbols" data-i18n="decorations.tabs.symbols">Simboli</button>
+    <button class="decoration-tab" data-deco-tab="frames" data-i18n="decorations.tabs.frames">Okviri</button>
+    <button class="decoration-tab" data-deco-tab="dividers" data-i18n="decorations.tabs.dividers">Razdjelnici</button>
+    <button class="decoration-tab" data-deco-tab="arrows" data-i18n="decorations.tabs.arrows">Strelice</button>
+    <button class="decoration-tab" data-deco-tab="minimal" data-i18n="decorations.tabs.minimal">Minimalni</button>
+    <button class="decoration-tab" data-deco-tab="emojis" data-i18n="decorations.tabs.emojis">Emoji</button>
+    <button class="decoration-tab" data-deco-tab="flags" data-i18n="decorations.tabs.flags">Zastave</button>
+      </div>
+          <div class="decoration-grid" id="decorationGrid"></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Main Content -->
+  <main class="container">
+    <!-- Category Tabs -->
+    <div class="category-section">
+      <div class="category-tabs" id="categoryTabs">
+        <!-- Tabs will be dynamically loaded from fonts.json -->
+      </div>
+    </div>
+
+    <!-- Results -->
+    <div class="results-grid" id="resultsGrid"></div>
+  </main>
+
+  <!-- How To: Kako kopirati lijepa slova -->
+  <section class="editorial-section">
+    <h2>Slova i slovca za kopiranje — kako to radi</h2>
+    <p class="editorial-intro">Lijepa <strong>slova za kopiranje</strong> napraviš u nekoliko sekundi — bez instaliranja aplikacije i bez otvaranja računa. Upišeš tekst, a generator ga pretvara u desetke stilova lijepih slova, spremnih za kopiranje i lijepljenje.</p>
+    <div class="steps-grid">
+      <div class="step-card">
+        <div class="step-number">1</div>
+        <h3>Upiši tekst</h3>
+        <p>Upiši ime, riječ ili cijelu rečenicu u polje na samom vrhu. Možeš i zalijepiti nešto što već imaš kopirano.</p>
+      </div>
+      <div class="step-card">
+        <div class="step-number">2</div>
+        <h3>Odaberi stil slova</h3>
+        <p>Lijepa slova pojave se odmah — podebljano, kurziv, kaligrafija, gotica, balončasta i kapitalke. Suzi izbor kategorijom na vrhu.</p>
+      </div>
+      <div class="step-card">
+        <div class="step-number">3</div>
+        <h3>Kopiraj i zalijepi</h3>
+        <p>Klikneš „Kopiraj", zalijepiš u instagram bio, nadimak u igri, WhatsApp status ili opis na TikToku. Stil se ne gubi.</p>
+      </div>
+    </div>
+    <p class="u-mt-15 u-text-center">Isti koraci vrijede za <strong>lijepe fontove za kopiranje</strong>, ukrasna slova i estetska slovca — jednako na računaru i na mobitelu.</p>
+  </section>
+
+  <!-- Abeceda lijepih slova A–Z -->
+  <section class="editorial-section abc-section" aria-label="Abeceda lijepih slova za kopiranje">
+    <h2>Lijepa slova A–Z za kopiranje</h2>
+    <p>Cijela abeceda — velika slova (A–Z), mala slova (a–z) i brojke (0–9) — u najčešće korištenim stilovima lijepih slova. Upiši nešto u generator na vrhu i klikni „Kopiraj" da uzmeš cijelu riječ u danom stilu, ili označi slova iz tablice i kopiraj sam.</p>
+
+    <div class="abc-list">
+      <div class="abc-row">
+        <span class="abc-name">Podebljano</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝗔𝗕𝗖𝗗𝗘𝗙𝗚𝗛𝗜𝗝𝗞𝗟𝗠𝗡𝗢𝗣𝗤𝗥𝗦𝗧𝗨𝗩𝗪𝗫𝗬𝗭</span>
+          <span class="abc-line">𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇</span>
+          <span class="abc-line">𝟬𝟭𝟮𝟯𝟰𝟱𝟲𝟳𝟴𝟵</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Kurziv</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝘈𝘉𝘊𝘋𝘌𝘍𝘎𝘏𝘐𝘑𝘒𝘓𝘔𝘕𝘖𝘗𝘘𝘙𝘚𝘛𝘜𝘝𝘞𝘟𝘠𝘡</span>
+          <span class="abc-line">𝘢𝘣𝘤𝘥𝘦𝘧𝘨𝘩𝘪𝘫𝘬𝘭𝘮𝘯𝘰𝘱𝘲𝘳𝘴𝘵𝘶𝘷𝘸𝘹𝘺𝘻</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Kaligrafija</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵</span>
+          <span class="abc-line">𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Kaligrafija podebljana</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩</span>
+          <span class="abc-line">𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Gotica</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝔄𝔅ℭ𝔇𝔈𝔉𝔊ℌℑ𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔ℜ𝔖𝔗𝔘𝔙𝔚𝔛𝔜ℨ</span>
+          <span class="abc-line">𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Balončasta</span>
+        <div class="abc-lines">
+          <span class="abc-line">ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ</span>
+          <span class="abc-line">ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ</span>
+          <span class="abc-line">⓪①②③④⑤⑥⑦⑧⑨</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Kapitalke</span>
+        <div class="abc-lines">
+          <span class="abc-line">ᴀʙᴄᴅᴇꜰɢʜɪᴊᴋʟᴍɴᴏᴘqʀsᴛᴜᴠᴡxʏᴢ</span>
+          <span class="abc-line">ᴀʙᴄᴅᴇꜰɢʜɪᴊᴋʟᴍɴᴏᴘqʀsᴛᴜᴠᴡxʏᴢ</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+    </div>
+    <p class="u-mt-15">Tražiš određeni rez? Zaviri u <a href="/bs/podebljana-slova/">podebljana slova</a>, <a href="/bs/goticka-slova/">gotička slova za kopiranje</a> ili <a href="/bs/kurziv/">kurziv i rukopisna slova</a> — svaka kategorija prikazuje samo jedan stil, od velikih do malih slova.</p>
+  </section>
+
+  <!-- Ukrasi i simboli za kopiranje -->
+  <section class="editorial-section glyph-section" aria-label="Ukrasi i simboli za kopiranje">
+    <h2>Ukrasi i simboli za kopiranje</h2>
+    <p class="editorial-intro">Gotovi <strong>ukrasi teksta za kopiranje</strong> — zvjezdice, srca, okviri, strelice i razdjelnici. Klikni bilo koji znak da ga kopiraš, ili ih automatski dodaj tekstu preko kartica <strong>Simboli</strong>, <strong>Okviri</strong> i <strong>Razdjelnici</strong> u generatoru na vrhu.</p>
+    <div class="glyph-group">
+      <h3>Zvjezdice i bljeskovi</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="✦">✦</button>
+        <button class="glyph-copy" type="button" data-text="✧">✧</button>
+        <button class="glyph-copy" type="button" data-text="⋆">⋆</button>
+        <button class="glyph-copy" type="button" data-text="✩">✩</button>
+        <button class="glyph-copy" type="button" data-text="★">★</button>
+        <button class="glyph-copy" type="button" data-text="☆">☆</button>
+        <button class="glyph-copy" type="button" data-text="✰">✰</button>
+        <button class="glyph-copy" type="button" data-text="⊹">⊹</button>
+        <button class="glyph-copy" type="button" data-text="࿐">࿐</button>
+        <button class="glyph-copy" type="button" data-text="˚">˚</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Srca</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="♡">♡</button>
+        <button class="glyph-copy" type="button" data-text="♥">♥</button>
+        <button class="glyph-copy" type="button" data-text="❤">❤</button>
+        <button class="glyph-copy" type="button" data-text="❥">❥</button>
+        <button class="glyph-copy" type="button" data-text="❣">❣</button>
+        <button class="glyph-copy" type="button" data-text="ღ">ღ</button>
+        <button class="glyph-copy" type="button" data-text="ꨄ">ꨄ</button>
+        <button class="glyph-copy" type="button" data-text="ஐ">ஐ</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Mjesec i nebo</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="☾">☾</button>
+        <button class="glyph-copy" type="button" data-text="☽">☽</button>
+        <button class="glyph-copy" type="button" data-text="☁">☁</button>
+        <button class="glyph-copy" type="button" data-text="✶">✶</button>
+        <button class="glyph-copy" type="button" data-text="⍣">⍣</button>
+        <button class="glyph-copy" type="button" data-text="ꕥ">ꕥ</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Cvijeće</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="❀">❀</button>
+        <button class="glyph-copy" type="button" data-text="✿">✿</button>
+        <button class="glyph-copy" type="button" data-text="⚘">⚘</button>
+        <button class="glyph-copy" type="button" data-text="✾">✾</button>
+        <button class="glyph-copy" type="button" data-text="❁">❁</button>
+        <button class="glyph-copy" type="button" data-text="ꕤ">ꕤ</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Okviri i ornamenti</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="꧁">꧁</button>
+        <button class="glyph-copy" type="button" data-text="꧂">꧂</button>
+        <button class="glyph-copy" type="button" data-text="༺">༺</button>
+        <button class="glyph-copy" type="button" data-text="༻">༻</button>
+        <button class="glyph-copy" type="button" data-text="⟡">⟡</button>
+        <button class="glyph-copy" type="button" data-text="❪">❪</button>
+        <button class="glyph-copy" type="button" data-text="❫">❫</button>
+        <button class="glyph-copy" type="button" data-text="★彡">★彡</button>
+        <button class="glyph-copy" type="button" data-text="彡★">彡★</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Strelice</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="→">→</button>
+        <button class="glyph-copy" type="button" data-text="⇨">⇨</button>
+        <button class="glyph-copy" type="button" data-text="➤">➤</button>
+        <button class="glyph-copy" type="button" data-text="⟶">⟶</button>
+        <button class="glyph-copy" type="button" data-text="➳">➳</button>
+        <button class="glyph-copy" type="button" data-text="↬">↬</button>
+        <button class="glyph-copy" type="button" data-text="⇢">⇢</button>
+        <button class="glyph-copy" type="button" data-text="↳">↳</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Razdjelnici</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="·">·</button>
+        <button class="glyph-copy" type="button" data-text="•">•</button>
+        <button class="glyph-copy" type="button" data-text="◦">◦</button>
+        <button class="glyph-copy" type="button" data-text="➛">➛</button>
+        <button class="glyph-copy" type="button" data-text="⟢">⟢</button>
+        <button class="glyph-copy" type="button" data-text="—">—</button>
+        <button class="glyph-copy" type="button" data-text="☰">☰</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Kaomoji (smješkovi)</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="(◍•ᴗ•◍)">(◍•ᴗ•◍)</button>
+        <button class="glyph-copy" type="button" data-text="(｡♥‿♥｡)">(｡♥‿♥｡)</button>
+        <button class="glyph-copy" type="button" data-text="ʕ•ᴥ•ʔ">ʕ•ᴥ•ʔ</button>
+        <button class="glyph-copy" type="button" data-text="(＾▽＾)">(＾▽＾)</button>
+        <button class="glyph-copy" type="button" data-text="٩(◕‿◕)۶">٩(◕‿◕)۶</button>
+      </div>
+    </div>
+  </section>
+
+  <!-- Popular Use Cases -->
+  <section class="editorial-section">
+    <h2 data-i18n="useCases.title">Za što ljudi ovo najčešće koriste</h2>
+    <div class="tips-grid">
+      <a class="tip-card" href="/usecase/linkedin-headline/" aria-label="Naslov na LinkedInu">
+        <div class="tip-icon">💼</div>
+        <h3 data-i18n="useCases.items.0.title">Naslov na LinkedInu</h3>
+        <p data-i18n="useCases.items.0.description">Istakni se u pretrazi na LinkedInu — podebljan ili blago ukrašen naslov odradi svoje prije nego što netko stigne skrolati dalje.</p>
+      </a>
+      <a class="tip-card" href="/usecase/comment-font/" aria-label="Komentari ispod objava">
+        <div class="tip-icon">💬</div>
+        <h3 data-i18n="useCases.items.1.title">Komentari ispod objava</h3>
+        <p data-i18n="useCases.items.1.description">Stilizirani komentari na Instagramu, YouTubeu i TikToku — lakše ih je uočiti nego stotine običnih ispod popularne objave.</p>
+      </a>
+      <a class="tip-card" href="/usecase/text-to-emoji/" aria-label="Tekst ispisan u emojijima">
+        <div class="tip-icon">😊</div>
+        <h3 data-i18n="useCases.items.2.title">Tekst ispisan u emojijima</h3>
+        <p data-i18n="useCases.items.2.description">Pretvori natpis u niz slova od emojija — kreativan bio, story, grupni chat ili čisto za zezanje s prijateljima.</p>
+      </a>
+      <a class="tip-card" href="/usecase/tattoo-fonts/" aria-label="Fontovi za tetovažu">
+        <div class="tip-icon">🖤</div>
+        <h3>Fontovi za tetovažu</h3>
+        <p>Provjeri ime ili natpis u kurzivu, gotici i italicu — prije nego što ode pod iglu.</p>
+      </a>
+      <a class="tip-card" href="/usecase/zalgo-text/" aria-label="Generator Zalgo teksta">
+        <div class="tip-icon">👻</div>
+        <h3>Iskrivljena Zalgo slova</h3>
+        <p>Glitchani tekst s crticama nad i pod slovima — paše uz halloweenske memeove, mračne biojeve i gaming klanove koji žele izgledati opasno.</p>
+      </a>
+    </div>
+    <p class="u-mt-15 u-text-center"><a class="cat-cta" href="/usecase/" data-i18n="useCases.viewAll">Pogledaj više primjena →</a></p>
+  </section>
+
+  <!-- Popular Guides -->
+  <section class="editorial-section">
+    <h2 data-i18n="guides.title">Svrati na vodiče</h2>
+    <div class="tips-grid">
+      <a class="tip-card" href="/guide/the-rhetoric-of-fonts/" aria-label="Retorika fontova">
+        <div class="tip-icon">📚</div>
+        <h3 data-i18n="guides.items.0.title">Retorika fontova</h3>
+        <p data-i18n="guides.items.0.description">Zašto jedan font budi povjerenje, a drugi izgleda kao spam — odnosno kako tipografija utječe na ono što osjećamo dok čitamo.</p>
+      </a>
+      <a class="tip-card" href="/guide/personal-branding-through-typography/" aria-label="Osobni brend kroz tipografiju">
+        <div class="tip-icon">🎨</div>
+        <h3 data-i18n="guides.items.1.title">Osobni brend kroz tipografiju</h3>
+        <p data-i18n="guides.items.1.description">Kako odabrati slova koja odgovaraju tvom vibeu i ostaju u pamćenju — bilo da je riječ o LinkedInu, Instagramu ili Discordu.</p>
+      </a>
+      <a class="tip-card" href="/guide/stop-the-scroll-with-font-variation/" aria-label="Zaustavi skrolanje igrom fontova">
+        <div class="tip-icon">📱</div>
+        <h3 data-i18n="guides.items.2.title">Zaustavi skrolanje igrom fontova</h3>
+        <p data-i18n="guides.items.2.description">Zašto se ljudi zaustavljaju kod objava s drukčijim stilom teksta i kako to iskoristiti da podigneš doseg.</p>
+      </a>
+    </div>
+    <p class="u-mt-15 u-text-center"><a class="cat-cta" href="/guide/" data-i18n="guides.viewAll">Svi vodiči →</a></p>
+  </section>
+
+  <!-- FAQ Section -->
+  <section class="faq-section-wrapper" aria-label="Frequently asked questions">
+    <div class="faq-inner">
+
+<!-- Slova i ukrasi za kopiranje -->
+<h2 class="faq-category">Slova i ukrasi za kopiranje</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span>Gdje ću naći lijepa slova za kopiranje?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer">Na ovoj stranici. Upišeš tekst u polje na vrhu, a lijepa slova — <strong>podebljano</strong>, <strong>kurziv</strong>, <strong>gotica</strong>, <strong>balončasta</strong> i još desetak drugih — pojave se odmah ispod. Klikneš „Kopiraj" i zalijepiš gdje želiš.
+    <br><br>
+    Imaš i gotovu <strong>abecedu A–Z za kopiranje</strong> u popularnim stilovima — velika slova, mala slova i brojke — koju možeš uzeti čak i bez upisivanja ičega.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span>Što su ukrasi za kopiranje i gdje ih tražiti?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer">Ukrasi su mali simboli kojima dekoriraš tekst — zvjezdice ✦, srca ♡, okviri ꧁꧂, strelice → i razdjelnici.
+    <br><br>
+    U odjeljku <strong>„Ukrasi i simboli za kopiranje"</strong> klikneš bilo koji znak da ga kopiraš zasebno. Možeš i automatski dodati <strong>ukrase tekstu</strong> cijelom natpisu — na karticama <strong>Simboli</strong>, <strong>Okviri</strong> i <strong>Razdjelnici</strong> iznad polja za upisivanje.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span>Imate li lijepe i estetske fontove za kopiranje?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer">Da — od minimalističkih, razmaknutih <strong>estetskih fontova za kopiranje</strong> do ukrasnih slova sa simbolima. Upišeš tekst, a svi se stilovi lijepih fontova pojave odjednom. Sve je besplatno i spremno za kopiranje jednim klikom, jednako na mobitelu i na računaru.</div>
+</div>
+
+
+<!-- Prva pitanja -->
+<h2 class="faq-category" data-i18n="faq.categories.0.title">Prva pitanja</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.0.items.0.question">Što je UltraTextGen i što se tu zapravo događa?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.0.items.0.answer">To je besplatan generator slova — upišeš običan tekst, a mi ga pretvaramo u stilizirane Unicode znakove koji izgledaju kao lijep font.
+    <br><br>
+    Najvažnije: to su <strong>pravi znakovi</strong>, a ne podebljanje iz Worda ni markdown s Discorda. Zato rade svugdje gdje se može upisati običan tekst — u instagram bio, u nadimak, u komentar, u mail, u WhatsApp status.
+    <br><br>
+    <strong>Primjer</strong><br>
+    Upišeš „bok" → dobiješ 𝗯𝗼𝗸 (podebljano), 𝘣𝘰𝘬 (kurziv), 𝒷ℴ𝓀 (kaligrafija) ili ⓑⓞⓚ (balončasta). Sve jednim klikom.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.0.items.1.question">Kako kopirati lijepa slova u 5 sekundi?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.0.items.1.answer">1. Upišeš ili zalijepiš tekst u polje na vrhu.<br>
+    2. Stilovi se pojave odmah ispod — bold, kurziv, gotica, balončasta i još desetak drugih.<br>
+    3. Ako želiš, dodaj ukrase — okvire, zvjezdice, strelice.<br>
+    4. Klikneš „Kopiraj" kod onog koji ti odgovara i zalijepiš gdje god želiš.
+    <br><br>
+    To je to. Bez registracije, bez instaliranja aplikacije. Radi jednako na računaru i na mobitelu.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.0.items.2.question">Besplatno? Bez ograničenja, bez računa?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.0.items.2.answer">Da, sve je <strong>100% besplatno</strong>. Bez računa, bez dnevnog ograničenja, bez vodenih žigova, bez kvake. Možeš kroz to propustiti cijelu knjigu i ništa se neće dogoditi.</div>
+</div>
+
+
+<!-- Instagram, TikTok, Discord -->
+<h2 class="faq-category" data-i18n="faq.categories.1.title">Instagram, TikTok, Discord — gdje to zalijepiti</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.1.items.0.question">Kako ubaciti stilizirani tekst u bio na Instagramu?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.1.items.0.answer">Instagram nema nikakvu alatnu traku za oblikovanje, ali prihvaća Unicode — dakle sve što ovdje generiraš uredno uleti u bio.
+    <br><br>
+    <strong>Kako to napraviti</strong><br>
+    1. Upiši ono što želiš u biju (npr. ime, hashtag, kratak opis).<br>
+    2. Odaberi stil — podebljano i kurziv rade najbolje na većini uređaja.<br>
+    3. Kopiraj rezultat i zalijepi u „Uredi profil → Bio" u aplikaciji.
+    <br><br>
+    Savjet: ako želiš ukrasiti, dodaj okvir tipa ⋆｡˚ ili zvjezdicu ✦ sa strane — izgleda dobro, a ne krade pažnju ostatku bija.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.1.items.1.question">Rade li slova u opisima na TikToku?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.1.items.1.answer">Da — TikTok prikazuje Unicode u opisima, opisima profila i komentarima. Najbolje se pokažu <strong>podebljano</strong>, <strong>kurziv</strong>, <strong>balončasta</strong> i <strong>kapitalke</strong>. Stilovi s puno ukrasa znaju se odrezati kod dugih opisa, pa za svaki slučaj provjeri objavu u pregledu prije objavljivanja.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.1.items.2.question">Može li se napraviti nadimak za igru ili za Discord?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.1.items.2.answer">Naravno — to je vjerovatno najčešći razlog zbog kojeg ljudi dolaze na ovakve generatore. Discord, Roblox, Steam, Minecraft, većina igara prihvaća Unicode u nadimcima.
+    <br><br>
+    <strong>Primjer</strong><br>
+    Obični nadimak: „DarkWolf"<br>
+    Nakon stiliziranja: „𝔇𝔞𝔯𝔨𝔚𝔬𝔩𝔣" (gotica), „ⒹⓐⓡⓚⓌⓞⓛⓕ" (balončasta) ili „๖ۣۜDarkWolf" (s ukrasom sa strane).
+    <br><br>
+    <strong>Napomena:</strong> neke igre imaju filtre i neće primiti egzotične znakove. Ako jedan stil ne prolazi, uzmi drugi — bold i kurziv obično prolaze svugdje.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.1.items.3.question">Radi li u WhatsApp statusu, na Telegramu i u Messengeru?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.1.items.3.answer">Da — WhatsApp, Telegram, Messenger, Signal, iMessage. Sve što prima običan tekst prima i Unicode slova. Zalijepiš u status ili u poruku i izgleda kao ukrasan font.
+    <br><br>
+    Za WhatsApp dodajem: ako ti treba samo podebljanje, možeš koristiti njihovu vlastitu sintaksu (`*tekst*` daje bold). Ali Unicode radi svugdje — i ondje gdje ga WhatsApp ne podržava, npr. u imenu kontakta.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.1.items.4.question">A u naslovu maila ili u CV-u?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.1.items.4.answer">Tu Unicode odradi najviše. Naslov maila je običan tekst, pa podebljanje iz Outlooka otpada. Ali „𝗥𝗮č𝘂𝗻 — 𝗵𝗶𝘁𝗻𝗼" već izgleda snažnije u sandučiću primaoca.
+    <br><br>
+    U CV-u blago podebljano ime u zaglavlju zna privući pogled poslodavca. Samo nemoj pretjerati — cijeli CV u gotici ne izgleda profesionalno.</div>
+</div>
+
+
+<!-- Stilovi, slova i ukrasi -->
+<h2 class="faq-category" data-i18n="faq.categories.2.title">Stilovi, slova i ukrasi</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.2.items.0.question">Koje stilove slova imam na izbor?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.2.items.0.answer">Puno. Zaista puno. Ukratko:
+    <br><br>
+    <strong>Osnovni</strong><br>
+    Podebljano (bold), kurziv, kaligrafija (script), gotica, balončasta (u kružićima), kapitalke, precrtano, podcrtano, double struck.
+    <br><br>
+    <strong>Zabavni</strong><br>
+    Tekst naopako, ogledalno, Zalgo (glitch s crticama nad slovima), tekst u kvadratićima, u zagradama, fullwidth (razmaknuti).
+    <br><br>
+    <strong>Dodaci</strong><br>
+    Okviri oko teksta, zvjezdice, srca, strelice, razdjelnici, zastave, emoji — sve to možeš nasloniti na stil slova.
+    <br><br>
+    S vremena na vrijeme dolaze novi — vrijedi dodati stranicu u knjižne oznake.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.2.items.1.question">Mogu li spojiti više stilova odjednom?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.2.items.1.answer">Da — i to je najveća prednost UltraTextGena. Možeš nasloniti npr. <strong>balončasta + Zalgo</strong>, <strong>gotica + naopako</strong> ili <strong>kapitalke + podcrtano</strong>, a onda cijelo to zatvoriti u okvir ili zvjezdicu.
+    <br><br>
+    <strong>Primjer</strong><br>
+    „bok" → odabereš goticu → dodaš okvir sa zvjezdicama → izađe: ★彡[ 𝔟𝔬𝔨 ]彡★
+    <br><br>
+    Što više eksperimentiraš, to zanimljivije stvari izlaze. Preporučujem da kreneš s jednim stilom i dodaš jedan ukras — ne sve odjednom.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.2.items.2.question">Što je Zalgo i te čudne crtice nad slovima?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.2.items.2.answer">Zalgo je onakav „ukleti", glitchani stil — nad i pod svakim slovom naleti hrpa dijakritičkih znakova. Izgleda kao da se tekst raspada ili kao da je iz horora.
+    <br><br>
+    <strong>Primjer</strong><br>
+    „bok" → b̷̢o̴̢k̷̛
+    <br><br>
+    Najčešće to viđaš u mračnim biojevima na Instagramu, u halloweenskim memeovima, u gaming klanovima koji žele izgledati opasno ili kad netko od toga radi foru.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.2.items.3.question">Odakle uzeti lijepe simbole, zvjezdice i srca?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.2.items.3.answer">Sve što imaš u odjeljku „Ukrasi" ispod tekstualnog polja možeš kopirati zasebno — čak i bez upisivanja teksta. Naprosto kao zasebne znakove za bio, nadimak ili objavu.
+    <br><br>
+    — <strong>Estetski simboli</strong>: ✦ ✧ ⋆ ｡ ☆ ♡ ❀ ✿<br>
+    — <strong>Okviri i obrubi</strong>: ╭─▸ │ ╰─▸ ili ★彡[ ]彡★<br>
+    — <strong>Strelice</strong>: → ⇨ ➤ ⟶<br>
+    — <strong>Minimalni razdjelnici</strong>: ·  ⋅  ─  •<br>
+    — <strong>Zastave i emoji</strong>.
+    <br><br>
+    Najčešće se koriste u estetskim biojevima na Instagramu i Pinterestu — pašu uz sve, od citata do popisa interesa.</div>
+</div>
+
+
+<!-- Bosanski znakovi, kompatibilnost -->
+<h2 class="faq-category" data-i18n="faq.categories.3.title">Bosanski znakovi, kompatibilnost, problemi</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.3.items.0.question">A bosanski znakovi? Radi li s č, ć, đ, š, ž?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.3.items.0.answer"><strong>Ukratko:</strong> ovisi o stilu.
+    <br><br>
+    Unicode ima stilizirane verzije za osnovnu abecedu A–Z, pa se <em>c</em>, <em>s</em>, <em>z</em> bez problema pretvore npr. u podebljano. Ali za <em>č</em>, <em>ć</em>, <em>đ</em>, <em>š</em>, <em>ž</em> stilizirane verzije postoje samo u dijelu stilova (uglavnom bold, kurziv, kapitalke).
+    <br><br>
+    Ako stil nema verziju za bosanski znak, on ostaje u izvornom obliku — tekst je i dalje čitljiv, bosansko slovo naprosto izgleda „običnije" od ostatka. Za nadimke bez kvačica to nije nikakav problem. Za cijele rečenice na bosanskom preporučujem <strong>bold</strong>, <strong>kurziv</strong> ili <strong>monospace</strong> — oni se najbolje snalaze s našom abecedom. Napomena i za digrafe: dž, lj i nj su samo dva obična slova jedno do drugoga, pa se svako stilizira zasebno.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.3.items.1.question">Zašto se nekome prikazuju kvadratići umjesto slova?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.3.items.1.answer">Zato što sistemski font na strani primaoca ne sadrži određeni Unicode znak. To nije problem s tvojim tekstom — naprosto njegov mobitel ili aplikacija nema taj konkretni znak u kompletu.
+    <br><br>
+    Drži se <strong>bolda</strong>, <strong>kurziva</strong> i <strong>balončaste</strong> — imaju najširu podršku. Vrlo egzotični stilovi (fullwidth, kvadratići) mogu se prikazati kao □ na starijim Androidima ili u nekim mail klijentima.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.3.items.2.question">Instagram mi je izrezao dio znakova u nadimku — što sad?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.3.items.2.answer">Instagram ima filtar na polju <strong>korisničko ime</strong> (dakle @login) — prima samo slova, brojke, tačke i podvlake. Tu stilizirana slova ne možeš zalijepiti.
+    <br><br>
+    Ali u polju <strong>„Ime"</strong> (prikazano ime) i u <strong>biju</strong> može — i tu prolazi većina stilova. Ako se jedan ne sprema, uzmi drugi. Bold obično prolazi bez problema.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.3.items.3.question">Postoje li znakovi koji se uopće ne mogu pretvoriti?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.3.items.3.answer">Standardna slova (A–Z, a–z), brojke i osnovni interpunkcijski znakovi pretvaraju se bez problema. Neki rijetki simboli ili posebni znakovi nemaju stilizirane parnjake u Unicodeu — tada ostaju u izvorniku. Ništa se ne kvari, tekst je i dalje za kopiranje.</div>
+</div>
+
+
+<!-- Sigurnost, privatnost, mobitel -->
+<h2 class="faq-category" data-i18n="faq.categories.4.title">Sigurnost, privatnost, mobitel</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.4.items.0.question">Sprema li se moj tekst negdje?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.4.items.0.answer">Ne. Cijela pretvorba slova događa se <strong>u tvom browseru</strong> — ništa ne ide na naše servere, ništa se ne sprema, ništa se ne prati. Kopirani tekst je čisti Unicode, bez skrivenih znakova, bez ikakvih identifikatora.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.4.items.1.question">Je li sigurno lijepiti ova slova bilo gdje?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.4.items.1.answer">Da — to su standardni Unicode znakovi, isti kakve koristi cijeli internet. Ništa unutra, bez skripti, bez skrivenog oblikovanja, bez kodova. Slobodno lijepi u CV, u poslovni mail, u bio na LinkedInu — gdje god želiš.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.4.items.2.question">Radi li na mobitelu?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.4.items.2.answer">Da — stranica se u potpunosti prilagođava mobitelu. iPhone, Android, tablet — sve štima. Upišeš tekst, klikneš, kopira se u clipboard, zalijepiš u aplikaciji. Bez instaliranja ičega iz trgovine.</div>
+</div>
+
+
+<!-- Po čemu se razlikujemo -->
+<h2 class="faq-category" data-i18n="faq.categories.5.title">Po čemu se razlikujemo</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.5.items.0.question">Po čemu se razlikujete od drugih generatora slova?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.5.items.0.answer">Konkretno:
+    <br><br>
+    — <strong>Jedna od većih kolekcija</strong> Ultra stilova — bold, kurziv, gotica, balončasta i još desetak drugih.<br>
+    — <strong>Spajanje stilova</strong> — većina generatora daje ti jedan stil odjednom, mi dopuštamo naslanjanje.<br>
+    — <strong>Ukrasi jednim klikom</strong> — okviri, zvjezdice, razdjelnici bez lijepljenja znak po znak.<br>
+    — <strong>Stranice za konkretne platforme</strong> — Instagram, TikTok, Discord. Ondje prikazujemo samo stilove koji na toj aplikaciji rade.<br>
+    — <strong>Brzo i bez skočnih prozora</strong> — bez captcha, bez „prihvati sve" prije svakog klika.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.5.items.1.question">Dolaze li novi stilovi?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.5.items.1.answer">Da, redovito. S vremena na vrijeme upadnu nove verzije, ukrasi i okviri. Najlakše je zapamtiti stranicu ili svratiti povremeno.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.5.items.2.question">Kako pronaći točno onaj stil koji tražim?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.5.items.2.answer">Tri puta:
+    <br><br>
+    <strong>Po stilu</strong> — kategorije na vrhu: bold, kurziv, gotica, balončasta, precrtano, naopako i još.<br>
+    <strong>Po platformi</strong> — svrati na podstranicu za Instagram, TikTok, Discord — ondje su samo stilovi koji se na toj platformi pokažu.<br>
+    <strong>Po cilju</strong> — odjeljak s primjenama ima alate prilagođene konkretnoj potrebi: naslov na LinkedInu, komentari, tekst s emojijima.</div>
+</div>
+    </div>
+  </section>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-inner">
+      <!-- Language Switcher -->
+      <div class="lang-switcher" role="navigation" aria-label="Language switcher">
+        <a class="lang-option" href="/" hreflang="en">EN</a>
+        <a class="lang-option" href="/es/" hreflang="es">ES</a>
+        <a class="lang-option" href="/fr/" hreflang="fr">FR</a>
+        <a class="lang-option" href="/pt/" hreflang="pt">PT</a>
+        <a class="lang-option" href="/de/" hreflang="de">DE</a>
+        <a class="lang-option" href="/id/" hreflang="id">ID</a>
+        <a class="lang-option" href="/it/" hreflang="it">IT</a>
+        <a class="lang-option" href="/nl/" hreflang="nl">NL</a>
+        <a class="lang-option" href="/tr/" hreflang="tr">TR</a>
+        <a class="lang-option" href="/pl/" hreflang="pl">PL</a>
+        <a class="lang-option active" href="/bs/" hreflang="bs">BS</a>
+        <a class="lang-option" href="/vi/" hreflang="vi">VI</a>
+        <a class="lang-option" href="/sv/" hreflang="sv">SV</a>
+        <a class="lang-option" href="/no/" hreflang="no">NO</a>
+        <a class="lang-option" href="/ja/" hreflang="ja">JA</a>
+        <a class="lang-option" href="/th/" hreflang="th">TH</a>
+        <a class="lang-option" href="/ru/" hreflang="ru">RU</a>
+        <a class="lang-option" href="/ar/" hreflang="ar">AR</a>
+      </div>
+    </div>
+  </footer>
+
+  <div class="copy-toast" id="copyToast">Copied!</div>
+
+  <script src="/styles.js" defer=""></script>
+<script src="/renderer.js" defer=""></script>
+<script src="/script.js" defer=""></script>
+<script src="/i18n.js" defer=""></script>
+
+
+
+
+<script src="/footer.js" defer=""></script>
+
+
+</body></html>

--- a/bs/kurziv/index.html
+++ b/bs/kurziv/index.html
@@ -1,0 +1,299 @@
+<!DOCTYPE html><html lang="bs"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZGVh");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Generator Kurziva — 𝘬𝘶𝘳𝘻𝘪𝘷 za kopiranje | UltraTextGen</title>
+  <meta name="description" content="Besplatan generator kurziva: pretvori tekst u ukošena Unicode slova za kopiranje i lijepljenje — u bio na Instagramu, WhatsApp, TikTok, Discord i LinkedIn. Odmah, bez registracije.">
+  <link rel="canonical" href="https://ultratextgen.com/bs/kurziv/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/category/italic-fonts/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/category/italic-fonts/">
+  <link rel="alternate" hreflang="bs" href="https://ultratextgen.com/bs/kurziv/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Generator Kurziva — 𝘬𝘶𝘳𝘻𝘪𝘷 za kopiranje | UltraTextGen">
+  <meta property="og:description" content="Besplatan generator kurziva — ukošena Unicode slova za kopiranje i lijepljenje na Instagram, TikTok, WhatsApp, Discord i LinkedIn. Odmah, bez registracije.">
+  <meta property="og:url" content="https://ultratextgen.com/bs/kurziv/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category-italic-fonts.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Generator Kurziva — 𝘬𝘶𝘳𝘻𝘪𝘷 za kopiranje | UltraTextGen">
+  <meta name="twitter:description" content="Besplatan generator kurziva — ukošena Unicode slova za kopiranje i lijepljenje na društvene mreže, chatove i u nadimke.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category-italic-fonts.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "bs",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Kako napraviti kurziv za kopiranje i lijepljenje?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Upiši tekst u polje na vrhu, a generator će ga odmah prikazati u kurzivu (𝘱𝘰𝘱𝘶𝘵 𝘰𝘷𝘰𝘨𝘢) — to su pravi Unicode znakovi, a ne instalirani font ni slika. Budući da su obični tekstualni znakovi, možeš ih kopirati i zalijepiti svugdje gdje se može upisati tekst: u bio, opise, komentare i poruke. Više u našem vodiču o tome kako rade Unicode fontovi."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Radi li Unicode kurziv na Instagramu, WhatsAppu, TikToku i LinkedInu?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da. Bio, opisi, komentari i poruke na chatu primaju te znakove bez problema. Osobito na LinkedInu i X-u, gdje nema izvornog kurziva, ukošeni Unicode font omogućuje da istakneš najvažnije riječi. Napomena: neka polja korisničkog imena (@) filtriraju takve znakove — za sam login ostavi običan tekst, ali u biju kurziv radi sjajno."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Podržava li kurziv bosanske znakove (č, ć, đ, š, ž)?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Unicode kurziv obuhvaća osnovnu abecedu A–Z i brojke 0–9, pa bosanske kvačice (č, ć, đ, š, ž) nemaju vlastiti ukošeni oblik i ostaju obična slova usred riječi (npr. „šuma” izađe kao š𝘶𝘮𝘢). Za nadimke i kratke natpise bez kvačica izgleda idealno; u duljem tekstu najsigurnije je birati riječi koje ih ne sadrže."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Je li generator kurziva besplatan?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da, potpuno besplatan i bez registracije. Upisuj, kopiraj i lijepi koliko god puta želiš — nema nikakvog ograničenja ni skrivenih troškova."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Zašto se neka slova kurziva prikazuju kao prazni kvadratići?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Prazni kvadratić (▯) znači da uređaj primaoca nema glif za taj ukošeni znak — najčešće je to stariji telefon ili računar. Odaberi jednostavniju verziju kurziva ili ažuriraj uređaj — više u tekstu o tome zašto se fontovi prikazuju kao kvadratići."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Utječe li Unicode kurziv na čitljivost i doseg?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ukošeni Unicode znakovi lijepo privlače pogled i sjajno rade u sloganima, naslovima i pozivima na akciju na društvenim mrežama. Koristi ih namjerno — kratak naglasak u kurzivu, ostalo običnim tekstom. Za sadržaj na vlastitoj web-stranici bolje je koristiti CSS ukošenje da pretraživači čitaju normalne riječi; u tekstualnim poljima društvenih mreža idealan je Unicode kurziv. Kod duljih dijelova vodi računa o pristupačnosti."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "inLanguage": "bs",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Početna", "item": "https://ultratextgen.com/bs/" },
+    { "@type": "ListItem", "position": 2, "name": "Kurziv", "item": "https://ultratextgen.com/bs/kurziv/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Generator Kurziva",
+  "alternateName": ["Kurziv za kopiranje","Ukošeni font","Ukošena slova","Unicode kurziv","Kurzivni font","Tekst u kurzivu","Kurziv online"],
+  "url": "https://ultratextgen.com/bs/kurziv/",
+  "inLanguage": "bs",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "BAM"
+  },
+  "description": "Besplatan generator kurziva: pretvara tekst u ukošena Unicode slova za kopiranje i lijepljenje na Instagram, TikTok, WhatsApp, Discord, LinkedIn i u nadimke.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/bs/">Početna</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Kurziv</span>
+</nav>
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/category-italic-fonts.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+  <!-- Hero -->
+  <section class="hero">
+    <div class="hero-inner">
+      <div class="hero-card">
+        <h1 class="hero-headline">Generator Kurziva</h1>
+        <p class="hero-tagline">Pretvori bilo koji tekst u 𝘬𝘶𝘳𝘻𝘪𝘷 za kopiranje i lijepljenje — elegantna,
+          ukošena Unicode slova za bio, nadimke i naslove. Besplatno, odmah, bez registracije.</p>
+        <div class="input-wrapper">
+          <textarea class="main-input" id="mainInput" placeholder="Upiši tekst, riječ ili ime…" maxlength="500" autofocus></textarea>
+          <span class="char-count"><span id="charCount">0</span>/500</span>
+        </div>
+
+        <!-- Decoration Selector -->
+        <div class="decoration-section">
+          <div class="decoration-label">
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"></path>
+            </svg>
+            Dodaj simbole oko rezultata
+          </div>
+          <div class="decoration-tabs">
+            <button class="decoration-tab active" data-deco-tab="symbols">Simboli</button>
+            <button class="decoration-tab" data-deco-tab="frames">Okviri</button>
+            <button class="decoration-tab" data-deco-tab="dividers">Razdjelnici</button>
+            <button class="decoration-tab" data-deco-tab="minimal">Minimalni</button>
+            <button class="decoration-tab" data-deco-tab="emojis">Emoji</button>
+          </div>
+          <div class="decoration-grid" id="decorationGrid"></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Main Content -->
+  <main class="container">
+
+    <section class="editorial-section">
+      <span class="article-section-label">Unicode kurziv</span>
+      <h2>Kurziv za kopiranje — za bio, nadimke i naslove</h2>
+      <p>Ova slova nisu instalirani font ni slika, nego pravi <strong>Unicode znakovi</strong>. Istakni
+        ključnu riječ u biju, napravi ukošen nadimak ili učini da naslov na LinkedInu i X-u privlači pogled — svugdje ondje,
+        gdje nema izvornog kurziva. Upiši tekst iznad, klikni <strong>Kopiraj</strong> i zalijepi kurziv gdje god želiš.</p>
+    </section>
+
+    <!-- Category Tabs (populated by script.js) -->
+    <div class="category-section">
+      <div class="category-tabs" id="categoryTabs"></div>
+    </div>
+
+    <!-- Results -->
+    <div class="results-grid" id="resultsGrid"></div>
+
+    <section class="editorial-section">
+      <span class="article-section-label">Povezano</span>
+      <p>Spoji kurziv s <a href="/bs/fontovi-za-discord/">fontovima za Discord</a>,
+        <a href="/bs/">slovima za kopiranje</a> ili
+        <a href="/library/invisible-character/">nevidljivim znakom</a> za čiste razmake. Za tetovaže tu je
+        <a href="/usecase/tattoo-fonts/">generator fontova za tetovažu</a>, a za okomite rasporede —
+        <a href="/usecase/vertical-text/">okomiti tekst</a>.</p>
+    </section>
+  </main>
+
+  <!-- Footer + FAQ -->
+  <footer class="footer">
+    <div class="footer-inner">
+<div class="faq-section" id="faq">
+
+<h2 class="faq-category">Generator Kurziva — FAQ</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Kako napraviti kurziv za kopiranje i lijepljenje?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Upiši tekst u polje na vrhu, a generator će ga odmah prikazati u kurzivu (𝘱𝘰𝘱𝘶𝘵 𝘰𝘷𝘰𝘨𝘢) — to su pravi Unicode znakovi, a ne instalirani font ni slika. Budući da su obični tekstualni znakovi, možeš ih kopirati i zalijepiti svugdje gdje se može upisati tekst: u bio, opise, komentare i poruke. Više u našem <a href="/guide/how-unicode-fonts-work/">vodiču o tome kako rade Unicode fontovi</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Radi li Unicode kurziv na Instagramu, WhatsAppu, TikToku i LinkedInu?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Da. Bio, opisi, komentari i poruke na chatu primaju te znakove bez problema. Osobito na LinkedInu i X-u, gdje nema izvornog kurziva, ukošeni Unicode font omogućuje da istakneš najvažnije riječi. Napomena: neka <strong>polja korisničkog imena (@)</strong> filtriraju takve znakove — za sam login ostavi običan tekst, ali u biju kurziv radi sjajno.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Podržava li kurziv bosanske znakove (č, ć, đ, š, ž)?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Unicode kurziv obuhvaća osnovnu abecedu A–Z i brojke 0–9, pa bosanske kvačice (č, ć, đ, š, ž) nemaju vlastiti ukošeni oblik i ostaju obična slova usred riječi (npr. „šuma” izađe kao š𝘶𝘮𝘢). Za nadimke i kratke natpise <strong>bez kvačica</strong> izgleda idealno; u duljem tekstu najsigurnije je birati riječi koje ih ne sadrže.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Je li generator kurziva besplatan?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Da, potpuno besplatan i bez registracije. Upisuj, kopiraj i lijepi koliko god puta želiš — nema nikakvog ograničenja ni skrivenih troškova.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Zašto se neka slova kurziva prikazuju kao prazni kvadratići?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Prazni kvadratić (▯) znači da uređaj primaoca nema glif za taj ukošeni znak — najčešće je to stariji telefon ili računar. Odaberi jednostavniju verziju kurziva ili ažuriraj uređaj — više u tekstu o tome, <a href="/guide/why-fonts-show-as-boxes/">zašto se fontovi prikazuju kao kvadratići</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Utječe li Unicode kurziv na čitljivost i doseg?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Ukošeni Unicode znakovi lijepo privlače pogled i sjajno rade u sloganima, naslovima i pozivima na akciju na društvenim mrežama. Koristi ih namjerno — kratak naglasak u kurzivu, ostalo običnim tekstom. Za sadržaj na vlastitoj web-stranici bolje je koristiti CSS ukošenje da pretraživači čitaju normalne riječi; u tekstualnim poljima društvenih mreža idealan je Unicode kurziv. Kod duljih dijelova vodi računa o <a href="/guide/fancy-fonts-accessibility-guide/">pristupačnosti</a>.
+  </div>
+</div>
+
+</div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Odabir jezika">
+      <a class="lang-option" href="/category/italic-fonts/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/bs/kurziv/" hreflang="bs">BS</a>
+    </div>
+
+    </div>
+  </footer>
+
+  <div class="copy-toast" id="copyToast">Kopirano!</div>
+
+  <script>
+    window.UTG_FAMILY = "italic";
+    window.UTG_DEMO_TEXT = "kurziv online\nstilizirani tekst";
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/script.js" defer></script>
+  <script src="/footer.js" defer></script>
+</body></html>

--- a/bs/mala-slova/index.html
+++ b/bs/mala-slova/index.html
@@ -1,0 +1,299 @@
+<!DOCTYPE html><html lang="bs"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZGVh");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Generator Malih Slova — ᴍᴀʟᴀ sʟᴏᴠᴀ i kapitalke za kopiranje | UltraTextGen</title>
+  <meta name="description" content="Besplatan generator malih slova: pretvori tekst u mali Unicode tekst i kapitalke za kopiranje i lijepljenje — u bio na Instagramu, Discordu, TikToku, X-u i nadimke. Odmah, bez registracije.">
+  <link rel="canonical" href="https://ultratextgen.com/bs/mala-slova/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/category/small-text/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/category/small-text/">
+  <link rel="alternate" hreflang="bs" href="https://ultratextgen.com/bs/mala-slova/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Generator Malih Slova — ᴍᴀʟᴀ sʟᴏᴠᴀ i kapitalke za kopiranje | UltraTextGen">
+  <meta property="og:description" content="Besplatan generator malih slova — mali Unicode tekst i kapitalke za kopiranje i lijepljenje na Instagram, TikTok, Discord i X. Odmah, bez registracije.">
+  <meta property="og:url" content="https://ultratextgen.com/bs/mala-slova/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category-small-text.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Generator Malih Slova — ᴍᴀʟᴀ sʟᴏᴠᴀ i kapitalke za kopiranje | UltraTextGen">
+  <meta name="twitter:description" content="Besplatan generator malih slova — mali Unicode tekst i kapitalke za kopiranje i lijepljenje na društvene mreže, chatove i u nadimke.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category-small-text.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "bs",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Što su mala slova i kako radi generator malih slova?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Generator pretvara slova koja upišeš u manje Unicode znakove — kapitalke (ᴍᴀʟᴀ sʟᴏᴠᴀ) te mali tekst u gornjem i donjem indeksu. To su pravi znakovi, a ne font ni slika, pa ih možeš kopirati i zalijepiti svugdje gdje je dopušten tekst: u bio, opise, komentare i poruke. Više u našem vodiču o tome kako rade Unicode fontovi."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Rade li mala slova na Discordu, Instagramu, TikToku i X-u?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da. Bio, opisi, komentari i poruke na chatu obično bez problema primaju mali tekst. Dobro se pokaže kao pomoćni, suptilan opis ispod nadimka ili nježan potpis koji ne viče kao velik podebljan font. Kompatibilnost ipak ovisi o stilu i uređaju — najbolje je zalijepiti rezultat i provjeriti kako izgleda u danoj aplikaciji."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Po čemu se razlikuju kapitalke od malog teksta u gornjem indeksu?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Kapitalke su mala verzalna slova (ᴋᴀᴘɪᴛᴀʟᴋᴇ) — slova imaju oblik velikih, ali visinu malih, pa tekst ostaje čitljiv i elegantan. Mali tekst u gornjem indeksu (ᵗᵃᵏᵒ) ili donjem još je sitniji i lagano podignut ili spušten, pa je sjajan za kratke ukrasne naglaske. Za dulje fraze obično bolje izgledaju kapitalke."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Mogu li pisati bosanske znakove (č, ć, đ, š, ž) malim slovima?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Male Unicode verzije obuhvaćaju uglavnom A–Z i dio brojki, pa bosanski znakovi poput č, ć, đ, š, ž nemaju vlastiti mali oblik i ostaju u normalnoj veličini. Za ujednačen efekt možeš ih zamijeniti osnovnim slovima (c, d, s, z) — to mijenja pravopis — ili ih ostaviti nepromijenjene, što u kratkom nadimku ili potpisu obično ionako izgleda dobro."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Je li generator malih slova besplatan?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da, potpuno besplatan i bez registracije. Upisuj, kopiraj i lijepi koliko god puta želiš — nema ograničenja ni skrivenih troškova. Sve radi u browseru, pa ništa ne instaliraš."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Zašto se neka mala slova prikazuju kao kvadratići i utječu li na čitljivost?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Prazni kvadratić (▯) znači da uređaj nema odgovarajući glif za taj mali znak — to se obično odnosi na starije sisteme. Odaberi tada jednostavniji stil (npr. kapitalke) ili ažuriraj uređaj; više u članku o tome zašto se fontovi prikazuju kao kvadratići. Imaj i na umu da se vrlo mali tekst teže čita — koristi ga za kratke fraze, a najvažnije informacije ostavi običnim tekstom zbog pristupačnosti."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "inLanguage": "bs",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Početna", "item": "https://ultratextgen.com/bs/" },
+    { "@type": "ListItem", "position": 2, "name": "Mala slova", "item": "https://ultratextgen.com/bs/mala-slova/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Generator Malih Slova",
+  "alternateName": ["Mala slova","Mali tekst","Generator malih slova","Kapitalke","Mala slova za kopiranje","Mali Unicode tekst","Sitni tekst","Mali natpisi"],
+  "url": "https://ultratextgen.com/bs/mala-slova/",
+  "inLanguage": "bs",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "BAM"
+  },
+  "description": "Besplatan generator malih slova: pretvori tekst u mali Unicode tekst i kapitalke za kopiranje i lijepljenje na Instagram, TikTok, Discord, X i u nadimke.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/bs/">Početna</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Mala slova</span>
+</nav>
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/category-small-text.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+  <!-- Hero -->
+  <section class="hero">
+    <div class="hero-inner">
+      <div class="hero-card">
+        <h1 class="hero-headline">Generator Malih Slova</h1>
+        <p class="hero-tagline">Pretvori bilo koji tekst u ᴍᴀʟᴀ sʟᴏᴠᴀ i kapitalke za kopiranje i lijepljenje — suptilni,
+          sitni Unicode znakovi za bio, nadimke i potpise. Besplatno, odmah, bez registracije.</p>
+        <div class="input-wrapper">
+          <textarea class="main-input" id="mainInput" placeholder="Upiši tekst, riječ ili ime…" maxlength="500" autofocus></textarea>
+          <span class="char-count"><span id="charCount">0</span>/500</span>
+        </div>
+
+        <!-- Decoration Selector -->
+        <div class="decoration-section">
+          <div class="decoration-label">
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"></path>
+            </svg>
+            Dodaj simbole oko rezultata
+          </div>
+          <div class="decoration-tabs">
+            <button class="decoration-tab active" data-deco-tab="symbols">Simboli</button>
+            <button class="decoration-tab" data-deco-tab="frames">Okviri</button>
+            <button class="decoration-tab" data-deco-tab="dividers">Razdjelnici</button>
+            <button class="decoration-tab" data-deco-tab="minimal">Minimalni</button>
+            <button class="decoration-tab" data-deco-tab="emojis">Emoji</button>
+          </div>
+          <div class="decoration-grid" id="decorationGrid"></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Main Content -->
+  <main class="container">
+
+    <section class="editorial-section">
+      <span class="article-section-label">Mali Unicode tekst</span>
+      <h2>Mala slova za kopiranje — za bio, nadimke i potpise</h2>
+      <p>Ova slova nisu font ni slika, nego pravi <strong>Unicode znakovi</strong>. Dodaj suptilan opis
+        ispod nadimka, ispiši ime elegantnim <strong>kapitalkama</strong> ili upleti sitan tekst u gornjem indeksu
+        ondje gdje bi velik podebljan font bio previše napadan. Upiši tekst iznad, klikni <strong>Kopiraj</strong>
+        i zalijepi mala slova gdje god želiš.</p>
+    </section>
+
+    <!-- Category Tabs (populated by script.js) -->
+    <div class="category-section">
+      <div class="category-tabs" id="categoryTabs"></div>
+    </div>
+
+    <!-- Results -->
+    <div class="results-grid" id="resultsGrid"></div>
+
+    <section class="editorial-section">
+      <span class="article-section-label">Povezano</span>
+      <p>Spoji mala slova s <a href="/bs/podebljana-slova/">podebljanim slovima</a>,
+        <a href="/library/aesthetic-symbols/">ukrasnim simbolima</a> ili <a href="/library/invisible-character/">nevidljivim znakom</a>
+        za čiste razmake. Pogledaj i <a href="/bs/">slova za kopiranje</a>,
+        a za okomite rasporede — <a href="/usecase/vertical-text/">okomiti tekst</a>.</p>
+    </section>
+  </main>
+
+  <!-- Footer + FAQ -->
+  <footer class="footer">
+    <div class="footer-inner">
+<div class="faq-section" id="small-faq">
+
+<h2 class="faq-category">Generator Malih Slova — FAQ</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Što su mala slova i kako radi generator malih slova?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Generator pretvara slova koja upišeš u manje Unicode znakove — kapitalke (ᴍᴀʟᴀ sʟᴏᴠᴀ) te mali tekst u gornjem i donjem indeksu. To su pravi znakovi, a ne font ni slika, pa ih možeš kopirati i zalijepiti svugdje gdje je dopušten tekst: u bio, opise, komentare i poruke. Više u našem <a href="/guide/how-unicode-fonts-work/">vodiču o tome kako rade Unicode fontovi</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Rade li mala slova na Discordu, Instagramu, TikToku i X-u?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Da. Bio, opisi, komentari i poruke na chatu obično bez problema primaju mali tekst. Dobro se pokaže kao pomoćni, suptilan opis ispod nadimka ili nježan potpis koji ne viče kao velik podebljan font. Kompatibilnost ipak ovisi o stilu i uređaju — najbolje je zalijepiti rezultat i provjeriti kako izgleda u danoj aplikaciji.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Po čemu se razlikuju kapitalke od malog teksta u gornjem indeksu?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Kapitalke su mala verzalna slova (ᴋᴀᴘɪᴛᴀʟᴋᴇ) — slova imaju oblik velikih, ali visinu malih, pa tekst ostaje čitljiv i elegantan. Mali tekst u gornjem indeksu (ᵗᵃᵏᵒ) ili donjem još je sitniji i lagano podignut ili spušten, pa je sjajan za kratke ukrasne naglaske. Za dulje fraze obično bolje izgledaju <strong>kapitalke</strong>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Mogu li pisati bosanske znakove (č, ć, đ, š, ž) malim slovima?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Male Unicode verzije obuhvaćaju uglavnom A–Z i dio brojki, pa bosanski znakovi poput č, ć, đ, š, ž nemaju vlastiti mali oblik i ostaju u normalnoj veličini. Za ujednačen efekt možeš ih zamijeniti osnovnim slovima (<strong>c, d, s, z</strong>) — to mijenja pravopis — ili ih ostaviti nepromijenjene, što u kratkom nadimku ili potpisu obično ionako izgleda dobro.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Je li generator malih slova besplatan?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Da, potpuno besplatan i bez registracije. Upisuj, kopiraj i lijepi koliko god puta želiš — nema ograničenja ni skrivenih troškova. Sve radi u browseru, pa ništa ne instaliraš.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Zašto se neka mala slova prikazuju kao kvadratići i utječu li na čitljivost?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Prazni kvadratić (▯) znači da uređaj nema odgovarajući glif za taj mali znak — to se obično odnosi na starije sisteme. Odaberi tada jednostavniji stil (npr. kapitalke) ili ažuriraj uređaj; više u članku o tome, <a href="/guide/why-fonts-show-as-boxes/">zašto se fontovi prikazuju kao kvadratići</a>. Imaj i na umu da se vrlo mali tekst teže čita — koristi ga za kratke fraze, a najvažnije informacije ostavi običnim tekstom zbog <a href="/guide/fancy-fonts-accessibility-guide/">pristupačnosti</a>.
+  </div>
+</div>
+
+</div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Odabir jezika">
+      <a class="lang-option" href="/category/small-text/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/bs/mala-slova/" hreflang="bs">BS</a>
+    </div>
+
+    </div>
+  </footer>
+
+  <div class="copy-toast" id="copyToast">Kopirano!</div>
+
+  <script>
+    window.UTG_FAMILY = "small-text";
+    window.UTG_DEMO_TEXT = "mala slova\nmali tekst";
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/script.js" defer></script>
+  <script src="/footer.js" defer></script>
+</body></html>

--- a/bs/podebljana-slova/index.html
+++ b/bs/podebljana-slova/index.html
@@ -1,0 +1,299 @@
+<!DOCTYPE html><html lang="bs"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZGVh");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Generator Podebljanih Slova — 𝐩𝐨𝐝𝐞𝐛𝐥𝐣𝐚𝐧𝐚 𝐬𝐥𝐨𝐯𝐚 za kopiranje | UltraTextGen</title>
+  <meta name="description" content="Besplatan generator podebljanih slova: pretvori tekst u podebljane Unicode znakove za kopiranje i lijepljenje — u bio na Instagramu, WhatsApp, TikTok, Discord, LinkedIn i nadimke. Odmah, bez registracije.">
+  <link rel="canonical" href="https://ultratextgen.com/bs/podebljana-slova/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/category/bold-fonts/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/category/bold-fonts/">
+  <link rel="alternate" hreflang="bs" href="https://ultratextgen.com/bs/podebljana-slova/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Generator Podebljanih Slova — 𝐩𝐨𝐝𝐞𝐛𝐥𝐣𝐚𝐧𝐚 𝐬𝐥𝐨𝐯𝐚 za kopiranje | UltraTextGen">
+  <meta property="og:description" content="Besplatan generator podebljanih slova — podebljani Unicode znakovi za kopiranje i lijepljenje na Instagram, TikTok, WhatsApp, Discord i LinkedIn. Odmah, bez registracije.">
+  <meta property="og:url" content="https://ultratextgen.com/bs/podebljana-slova/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category-bold-fonts.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Generator Podebljanih Slova — 𝐩𝐨𝐝𝐞𝐛𝐥𝐣𝐚𝐧𝐚 𝐬𝐥𝐨𝐯𝐚 za kopiranje | UltraTextGen">
+  <meta name="twitter:description" content="Besplatan generator podebljanih slova — podebljani Unicode znakovi za kopiranje i lijepljenje na društvene mreže, chatove i u nadimke.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category-bold-fonts.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "bs",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Što je generator podebljanih slova i kako radi?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Pretvara slova koja upišeš u podebljane Unicode znakove (𝐩𝐨𝐩𝐮𝐭 𝐨𝐯𝐢𝐡) — prave znakove, a ne font ni sliku. Budući da su to obični tekstualni znakovi, možeš ih kopirati i zalijepiti svugdje gdje je dopušten tekst: u bio, opise, komentare i poruke. Više u našem vodiču o tome kako rade Unicode fontovi."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Rade li podebljana slova na Instagramu, WhatsAppu, TikToku i LinkedInu?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da. Bio, opisi, komentari i poruke na chatu bez problema primaju te znakove. Osobito na LinkedInu i X-u, gdje nema izvornog podebljanja, podebljana Unicode slova čine da se najvažniji dijelovi istaknu. Napomena: neka polja s @korisničkim imenom filtriraju te znakove — u samom handleu treba ostati na običnom tekstu, ali u biju podebljana slova rade sjajno."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Mogu li pisati bosanske znakove (č, ć, đ, š, ž) podebljanim slovima?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Unicode podebljanje obuhvaća A–Z i 0–9, pa bosanski znakovi poput č, ć, đ, š, ž nemaju vlastiti podebljani oblik i ostaju obični. Za potpuno podebljan efekt možeš ih zamijeniti osnovnim slovima (c, d, s, z) — to mijenja pravopis — ili ih ostaviti u normalnoj debljini, što u kratkom tekstu obično ionako izgleda dobro. Najbolje se s našom abecedom snalaze bold, kurziv i monospace."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Je li generator podebljanih slova besplatan?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da, potpuno besplatan i bez registracije. Upisuj, kopiraj i lijepi koliko god puta želiš — nema ograničenja ni skrivenih troškova."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Zašto se neki znakovi prikazuju kao prazni kvadratići?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Prazni kvadratić (▯) znači da uređaj nema odgovarajući glif za taj podebljani znak. To se obično odnosi na starije sisteme. Odaberi jednostavniji podebljani stil ili ažuriraj uređaj — više u članku o tome zašto se fontovi prikazuju kao kvadratići."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Utječe li podebljani Unicode tekst na čitljivost i doseg?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Podebljani Unicode znakovi privlače pogled u feedu i sjajno rade kao hook, naslov i CTA na društvenim mrežama. Koristi ih namjerno — kratki podebljani naglasci, ostalo običnim tekstom. Za sadržaj na web-stranici bolje je koristiti CSS podebljanje da pretraživači čitaju tekst kao obične riječi. Za tekstualna polja na društvenim mrežama Unicode podebljanje je idealno rješenje. Vodi računa o pristupačnosti kad oblikuješ dulje dijelove."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "inLanguage": "bs",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Početna", "item": "https://ultratextgen.com/bs/" },
+    { "@type": "ListItem", "position": 2, "name": "Podebljana slova", "item": "https://ultratextgen.com/bs/podebljana-slova/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Generator Podebljanih Slova",
+  "alternateName": ["Podebljana slova","Podebljani tekst","Bold slova","Generator podebljanog teksta","Podebljana slova za kopiranje","Podebljani Unicode tekst","Bold za kopiranje"],
+  "url": "https://ultratextgen.com/bs/podebljana-slova/",
+  "inLanguage": "bs",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "BAM"
+  },
+  "description": "Besplatan generator podebljanih slova: pretvori tekst u podebljane Unicode znakove za kopiranje i lijepljenje na Instagram, TikTok, WhatsApp, Discord, LinkedIn i u nadimke.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/bs/">Početna</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Podebljana slova</span>
+</nav>
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/category-bold-fonts.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+  <!-- Hero -->
+  <section class="hero">
+    <div class="hero-inner">
+      <div class="hero-card">
+        <h1 class="hero-headline">Generator Podebljanih Slova</h1>
+        <p class="hero-tagline">Pretvori bilo koji tekst u 𝐩𝐨𝐝𝐞𝐛𝐥𝐣𝐚𝐧𝐢 𝐭𝐞𝐤𝐬𝐭 za kopiranje i lijepljenje — snažni,
+          uočljivi Unicode znakovi za bio, nadimke i naslove. Besplatno, odmah, bez registracije.</p>
+        <div class="input-wrapper">
+          <textarea class="main-input" id="mainInput" placeholder="Upiši tekst, riječ ili ime…" maxlength="500" autofocus></textarea>
+          <span class="char-count"><span id="charCount">0</span>/500</span>
+        </div>
+
+        <!-- Decoration Selector -->
+        <div class="decoration-section">
+          <div class="decoration-label">
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"></path>
+            </svg>
+            Dodaj simbole oko rezultata
+          </div>
+          <div class="decoration-tabs">
+            <button class="decoration-tab active" data-deco-tab="symbols">Simboli</button>
+            <button class="decoration-tab" data-deco-tab="frames">Okviri</button>
+            <button class="decoration-tab" data-deco-tab="dividers">Razdjelnici</button>
+            <button class="decoration-tab" data-deco-tab="minimal">Minimalni</button>
+            <button class="decoration-tab" data-deco-tab="emojis">Emoji</button>
+          </div>
+          <div class="decoration-grid" id="decorationGrid"></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Main Content -->
+  <main class="container">
+
+    <section class="editorial-section">
+      <span class="article-section-label">Podebljana Unicode slova</span>
+      <h2>Podebljani tekst za kopiranje — za bio, nadimke i naslove</h2>
+      <p>Ova slova nisu font ni slika, nego pravi <strong>Unicode znakovi</strong>. Istakni ključnu riječ
+        u svom biju, napravi podebljan nadimak ili učini da naslov na LinkedInu i X-u privlači pogled — svugdje ondje,
+        gdje nema izvornog podebljanja. Upiši tekst iznad, klikni <strong>Kopiraj</strong> i zalijepi podebljana
+        slova gdje god želiš.</p>
+    </section>
+
+    <!-- Category Tabs (populated by script.js) -->
+    <div class="category-section">
+      <div class="category-tabs" id="categoryTabs"></div>
+    </div>
+
+    <!-- Results -->
+    <div class="results-grid" id="resultsGrid"></div>
+
+    <section class="editorial-section">
+      <span class="article-section-label">Povezano</span>
+      <p>Spoji podebljana slova s <a href="/bs/fontovi-za-discord/">fontovima za Discord</a>,
+        <a href="/library/aesthetic-symbols/">ukrasnim simbolima</a> ili <a href="/library/invisible-character/">nevidljivim znakom</a>
+        za čiste razmake. Za body art imamo <a href="/usecase/tattoo-fonts/">generator fontova za tetovažu</a>,
+        a za okomite rasporede — <a href="/usecase/vertical-text/">okomiti tekst</a>.</p>
+    </section>
+  </main>
+
+  <!-- Footer + FAQ -->
+  <footer class="footer">
+    <div class="footer-inner">
+<div class="faq-section" id="bold-faq">
+
+<h2 class="faq-category">Generator Podebljanih Slova — FAQ</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Što je generator podebljanih slova i kako radi?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Pretvara slova koja upišeš u podebljane Unicode znakove (𝐩𝐨𝐩𝐮𝐭 𝐨𝐯𝐢𝐡) — prave znakove, a ne font ni sliku. Budući da su to obični tekstualni znakovi, možeš ih kopirati i zalijepiti svugdje gdje je dopušten tekst: u bio, opise, komentare i poruke. Više u našem <a href="/guide/how-unicode-fonts-work/">vodiču o tome kako rade Unicode fontovi</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Rade li podebljana slova na Instagramu, WhatsAppu, TikToku i LinkedInu?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Da. Bio, opisi, komentari i poruke na chatu bez problema primaju te znakove. Osobito na LinkedInu i X-u, gdje nema izvornog podebljanja, podebljana Unicode slova čine da se najvažniji dijelovi istaknu. Napomena: neka polja s <strong>@korisničkim imenom</strong> filtriraju te znakove — u samom handleu treba ostati na običnom tekstu, ali u biju podebljana slova rade sjajno.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Mogu li pisati bosanske znakove (č, ć, đ, š, ž) podebljanim slovima?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Unicode podebljanje obuhvaća A–Z i 0–9, pa bosanski znakovi poput č, ć, đ, š, ž nemaju vlastiti podebljani oblik i ostaju obični. Za potpuno podebljan efekt možeš ih zamijeniti osnovnim slovima (<strong>c, d, s, z</strong>) — to mijenja pravopis — ili ih ostaviti u normalnoj debljini, što u kratkom tekstu obično ionako izgleda dobro. Najbolje se s našom abecedom snalaze bold, kurziv i monospace.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Je li generator podebljanih slova besplatan?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Da, potpuno besplatan i bez registracije. Upisuj, kopiraj i lijepi koliko god puta želiš — nema ograničenja ni skrivenih troškova.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Zašto se neki znakovi prikazuju kao prazni kvadratići?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Prazni kvadratić (▯) znači da uređaj nema odgovarajući glif za taj podebljani znak. To se obično odnosi na starije sisteme. Odaberi jednostavniji podebljani stil ili ažuriraj uređaj — više u članku o tome, <a href="/guide/why-fonts-show-as-boxes/">zašto se fontovi prikazuju kao kvadratići</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Utječe li podebljani Unicode tekst na čitljivost i doseg?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Podebljani Unicode znakovi privlače pogled u feedu i sjajno rade kao hook, naslov i CTA na društvenim mrežama. Koristi ih namjerno — kratki podebljani naglasci, ostalo običnim tekstom. Za sadržaj na web-stranici bolje je koristiti CSS podebljanje da pretraživači čitaju tekst kao obične riječi. Za tekstualna polja na društvenim mrežama Unicode podebljanje je idealno rješenje. Vodi računa o <a href="/guide/fancy-fonts-accessibility-guide/">pristupačnosti</a> kad oblikuješ dulje dijelove.
+  </div>
+</div>
+
+</div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Odabir jezika">
+      <a class="lang-option" href="/category/bold-fonts/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/bs/podebljana-slova/" hreflang="bs">BS</a>
+    </div>
+
+    </div>
+  </footer>
+
+  <div class="copy-toast" id="copyToast">Kopirano!</div>
+
+  <script>
+    window.UTG_FAMILY = "bold";
+    window.UTG_DEMO_TEXT = "podebljana slova\npodebljani tekst";
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/script.js" defer></script>
+  <script src="/footer.js" defer></script>
+</body></html>

--- a/cs/goticke-pismo/index.html
+++ b/cs/goticke-pismo/index.html
@@ -1,0 +1,299 @@
+<!DOCTYPE html><html lang="cs"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZGVh");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Generátor gotického písma — 𝔤𝔬𝔱𝔦𝔠𝔨ý 𝔱𝔢𝔵𝔱 ke zkopírování | UltraTextGen</title>
+  <meta name="description" content="Bezplatný generátor gotického písma: převeď text na gotické znaky Unicode (fraktura) ke zkopírování a vložení — do bia na Instagramu, na Discord, TikTok, do nicků a návrhů tetování. Ihned, bez registrace.">
+  <link rel="canonical" href="https://ultratextgen.com/cs/goticke-pismo/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/category/gothic-fonts/">
+  <link rel="alternate" hreflang="cs" href="https://ultratextgen.com/cs/goticke-pismo/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/category/gothic-fonts/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Generátor gotického písma — 𝔤𝔬𝔱𝔦𝔠𝔨ý 𝔱𝔢𝔵𝔱 ke zkopírování | UltraTextGen">
+  <meta property="og:description" content="Bezplatný generátor gotického písma — gotické znaky Unicode (fraktura) ke zkopírování a vložení na Instagram, Discord, TikTok a do nicků. Ihned, bez registrace.">
+  <meta property="og:url" content="https://ultratextgen.com/cs/goticke-pismo/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category-gothic-fonts.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Generátor gotického písma — 𝔤𝔬𝔱𝔦𝔠𝔨ý 𝔱𝔢𝔵𝔱 ke zkopírování | UltraTextGen">
+  <meta name="twitter:description" content="Bezplatný generátor gotického písma — gotické znaky Unicode (fraktura) ke zkopírování a vložení do sociálních sítí, na Discord a do nicků.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category-gothic-fonts.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "cs",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Co je generátor gotického písma a jak funguje?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Převádí písmena, která napíšeš, na gotické znaky Unicode (𝔱𝔞𝔨𝔬𝔳é 𝔧𝔞𝔨𝔬 𝔱𝔞𝔱𝔬) — opravdové znaky z rodiny fraktury, ne písmo ani obrázek. Protože jde o obyčejné textové znaky, můžeš je zkopírovat a vložit všude, kde je povolený text: do bia, popisků, komentářů, nicků a zpráv. Víc v našem průvodci o tom, jak funguje písmo Unicode."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Funguje gotický text na Instagramu, Discordu, TikToku a v dalších aplikacích?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ano. Bio, popisky, komentáře, názvy kanálů na Discordu i zprávy na chatu gotické znaky bez problémů přijmou, protože jde o obyčejný Unicode. Skvěle se hodí do nicků a profilů s goth, metalovou nebo středověkou náladou. Pozor: některá pole s @uživatelským jménem nestandardní znaky filtrují — v samotném handlu je nutné zůstat u obyčejného textu, ale v biu a popiscích gotika funguje bez potíží."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Čím se liší gotika (fraktura) od tučné gotiky?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Jsou to dvě varianty téhož stylu. Obyčejná fraktura (𝔤𝔬𝔱𝔦𝔨𝔞) je tenčí a klasičtější, kdežto tučná gotika (𝖌𝖔𝖙𝖎𝖐𝖆) má silnější, výraznější tahy a lépe vypadá v krátkých titulcích a nickách. Ve výsledcích níže najdeš obě varianty — stačí kliknout na tu, která k tvému návrhu sedí, a zkopírovat."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Můžu psát české znaky (á, č, ď, é, ě, í, ň, ó, ř, š, ť, ú, ů, ý, ž) gotickým písmem?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Gotika Unicode pokrývá A–Z a a–z, proto české znaky jako á, č, ě, ř, š, ž nemají vlastní gotickou podobu a zůstávají obyčejné. Pro jednotný gotický efekt je můžeš nahradit základními písmeny (a, c, e, r, s, z) — mění to ovšem pravopis — nebo je nechat v normální podobě, což u krátkého textu, nicku nebo titulku obvykle stejně vypadá dobře."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Je generátor gotického písma zdarma?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ano, plně zdarma a bez registrace. Piš, kopíruj a vkládej, kolikrát chceš — není tu žádný limit ani skryté náklady."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Proč se některá gotická písmena zobrazují jako čtverečky nebo vypadají jinak?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Prázdný čtvereček (▯) znamená, že zařízení nemá odpovídající glyf pro daný gotický znak — týká se to většinou starších systémů. Navíc pár velkých písmen fraktury (C, H, I, R, Z) pochází z jiného bloku Unicode a vypadá jinak než zbytek abecedy — to je normální. Vyber v takovém případě tučnou variantu gotiky nebo zařízení aktualizuj; víc v článku o tom, proč se písmo zobrazuje jako čtverečky."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "inLanguage": "cs",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Domů", "item": "https://ultratextgen.com/cs/" },
+    { "@type": "ListItem", "position": 2, "name": "Gotické písmo", "item": "https://ultratextgen.com/cs/goticke-pismo/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Generátor gotického písma",
+  "alternateName": ["Gotické písmo","Gotický text","Gotika ke zkopírování","Fraktura Unicode","Gotická písmena","Generátor gotiky","Gotické písmo","Blackletter česky"],
+  "url": "https://ultratextgen.com/cs/goticke-pismo/",
+  "inLanguage": "cs",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "CZK"
+  },
+  "description": "Bezplatný generátor gotického písma: převeď text na gotické znaky Unicode (fraktura a tučná gotika) ke zkopírování a vložení na Instagram, Discord, TikTok, do nicků a návrhů tetování.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/cs/">Domů</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Gotické písmo</span>
+</nav>
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/category-gothic-fonts.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+  <!-- Hero -->
+  <section class="hero">
+    <div class="hero-inner">
+      <div class="hero-card">
+        <h1 class="hero-headline">Generátor gotického písma</h1>
+        <p class="hero-tagline">Proměň libovolný text v 𝔤𝔬𝔱𝔦𝔠𝔨é 𝔭í𝔰𝔪𝔬 ke zkopírování a vložení — temná,
+          ozdobná písmena Unicode (fraktura a tučná gotika) do bia, nicků a titulků. Zdarma, ihned, bez registrace.</p>
+        <div class="input-wrapper">
+          <textarea class="main-input" id="mainInput" placeholder="Napiš text, slovo nebo jméno…" maxlength="500" autofocus></textarea>
+          <span class="char-count"><span id="charCount">0</span>/500</span>
+        </div>
+
+        <!-- Decoration Selector -->
+        <div class="decoration-section">
+          <div class="decoration-label">
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"></path>
+            </svg>
+            Přidej symboly kolem výsledku
+          </div>
+          <div class="decoration-tabs">
+            <button class="decoration-tab active" data-deco-tab="symbols">Symboly</button>
+            <button class="decoration-tab" data-deco-tab="frames">Rámečky</button>
+            <button class="decoration-tab" data-deco-tab="dividers">Oddělovače</button>
+            <button class="decoration-tab" data-deco-tab="minimal">Minimalistické</button>
+            <button class="decoration-tab" data-deco-tab="emojis">Emoji</button>
+          </div>
+          <div class="decoration-grid" id="decorationGrid"></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Main Content -->
+  <main class="container">
+
+    <section class="editorial-section">
+      <span class="article-section-label">Gotické písmo Unicode</span>
+      <h2>Gotický text ke zkopírování — do bia, nicků a na tetování</h2>
+      <p>Tato písmena nejsou písmo ani obrázek, ale opravdové <strong>znaky Unicode</strong> z rodiny fraktury. Dodej
+        svému biu goth náladu, vytvoř temný nick nebo připrav nápis ve středověkém či metalovém stylu — gotika
+        skvěle sedne i na návrhy tetování. Napiš text výše, klikni na <strong>Kopírovat</strong> a vlož
+        gotické písmo tam, kam chceš.</p>
+    </section>
+
+    <!-- Category Tabs (populated by script.js) -->
+    <div class="category-section">
+      <div class="category-tabs" id="categoryTabs"></div>
+    </div>
+
+    <!-- Results -->
+    <div class="results-grid" id="resultsGrid"></div>
+
+    <section class="editorial-section">
+      <span class="article-section-label">Související</span>
+      <p>Spoj gotiku s <a href="/cs/tucne-pismo/">tučným písmem</a>,
+        <a href="/library/aesthetic-symbols/">ozdobami</a> nebo <a href="/library/invisible-character/">neviditelným znakem</a>
+        pro čisté mezery. Na návrhy tetování se hodí <a href="/usecase/tattoo-fonts/">generátor písma na tetování</a>,
+        a na svislé sazby — <a href="/usecase/vertical-text/">svislý text</a>.</p>
+    </section>
+  </main>
+
+  <!-- Footer + FAQ -->
+  <footer class="footer">
+    <div class="footer-inner">
+<div class="faq-section" id="gothic-faq">
+
+<h2 class="faq-category">Generátor gotického písma — FAQ</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Co je generátor gotického písma a jak funguje?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Převádí písmena, která napíšeš, na gotické znaky Unicode (𝔱𝔞𝔨𝔬𝔳é 𝔧𝔞𝔨𝔬 𝔱𝔞𝔱𝔬) — opravdové znaky z rodiny fraktury, ne písmo ani obrázek. Protože jde o obyčejné textové znaky, můžeš je zkopírovat a vložit všude, kde je povolený text: do bia, popisků, komentářů, nicků a zpráv. Víc v našem <a href="/guide/how-unicode-fonts-work/">průvodci o tom, jak funguje písmo Unicode</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Funguje gotický text na Instagramu, Discordu, TikToku a v dalších aplikacích?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Ano. Bio, popisky, komentáře, názvy kanálů na Discordu i zprávy na chatu gotické znaky bez problémů přijmou, protože jde o obyčejný Unicode. Skvěle se hodí do nicků a profilů s goth, metalovou nebo středověkou náladou. Pozor: některá pole s <strong>@uživatelským jménem</strong> nestandardní znaky filtrují — v samotném handlu je nutné zůstat u obyčejného textu, ale v biu a popiscích gotika funguje bez potíží.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Čím se liší gotika (fraktura) od tučné gotiky?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Jsou to dvě varianty téhož stylu. Obyčejná fraktura (𝔤𝔬𝔱𝔦𝔨𝔞) je tenčí a klasičtější, kdežto tučná gotika (𝖌𝖔𝖙𝖎𝖐𝖆) má silnější, výraznější tahy a lépe vypadá v krátkých titulcích a nickách. Ve výsledcích níže najdeš obě varianty — stačí kliknout na tu, která k tvému návrhu sedí, a zkopírovat.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Můžu psát české znaky (á, č, ď, é, ě, í, ň, ó, ř, š, ť, ú, ů, ý, ž) gotickým písmem?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Gotika Unicode pokrývá A–Z a a–z, proto české znaky jako á, č, ě, ř, š, ž nemají vlastní gotickou podobu a zůstávají obyčejné. Pro jednotný gotický efekt je můžeš nahradit základními písmeny (<strong>a, c, e, r, s, z</strong>) — mění to ovšem pravopis — nebo je nechat v normální podobě, což u krátkého textu, nicku nebo titulku obvykle stejně vypadá dobře.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Je generátor gotického písma zdarma?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Ano, plně zdarma a bez registrace. Piš, kopíruj a vkládej, kolikrát chceš — není tu žádný limit ani skryté náklady.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Proč se některá gotická písmena zobrazují jako čtverečky nebo vypadají jinak?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Prázdný čtvereček (▯) znamená, že zařízení nemá odpovídající glyf pro daný gotický znak — týká se to většinou starších systémů. Navíc pár velkých písmen fraktury (C, H, I, R, Z) pochází z jiného bloku Unicode a vypadá jinak než zbytek abecedy — to je normální. Vyber v takovém případě tučnou variantu gotiky nebo zařízení aktualizuj; víc v článku o tom, <a href="/guide/why-fonts-show-as-boxes/">proč se písmo zobrazuje jako čtverečky</a>.
+  </div>
+</div>
+
+</div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Výběr jazyka">
+      <a class="lang-option" href="/category/gothic-fonts/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/cs/goticke-pismo/" hreflang="cs">CS</a>
+    </div>
+
+    </div>
+  </footer>
+
+  <div class="copy-toast" id="copyToast">Zkopírováno!</div>
+
+  <script>
+    window.UTG_FAMILY = "gothic";
+    window.UTG_DEMO_TEXT = "gotické písmo\ngotický text";
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/script.js" defer></script>
+  <script src="/footer.js" defer></script>
+</body></html>

--- a/cs/index.html
+++ b/cs/index.html
@@ -1,0 +1,1018 @@
+<!DOCTYPE html><html lang="cs" dir="ltr"><head>
+  <meta name="yandex-verification" content="aa326290e0338f4f">
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title data-i18n="meta.title">Ozdobné písmo a stylový text ke zkopírování — písmenka na Instagram, TikTok a nicky</title>
+<meta name="description" data-i18n-content="meta.description" content="Generátor ozdobného písma, estetických písmenek a stylového textu ke zkopírování. Tučné, kurzíva, gotika, bublinkové, Zalgo a symboly — vlož do bia na Instagramu, do popisku na TikToku, do herního nicku nebo na Discord. Zdarma, bez účtu.">
+
+<link rel="canonical" href="https://ultratextgen.com/cs/">
+
+<link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/">
+<link rel="alternate" hreflang="en" href="https://ultratextgen.com/">
+<link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/">
+<link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/">
+<link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/">
+<link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/">
+<link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/">
+<link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/">
+<link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/">
+<link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/">
+<link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/">
+<link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/">
+<link rel="alternate" hreflang="sv" href="https://ultratextgen.com/sv/">
+<link rel="alternate" hreflang="no" href="https://ultratextgen.com/no/">
+<link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/">
+<link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/">
+<link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/">
+<link rel="alternate" hreflang="ar" href="https://ultratextgen.com/ar/">
+<link rel="alternate" hreflang="cs" href="https://ultratextgen.com/cs/">
+<link rel="alternate" hreflang="sk" href="https://ultratextgen.com/sk/">
+<link rel="alternate" hreflang="hr" href="https://ultratextgen.com/hr/">
+<link rel="alternate" hreflang="bs" href="https://ultratextgen.com/bs/">
+<link rel="alternate" hreflang="sr" href="https://ultratextgen.com/sr/">
+<link rel="alternate" hreflang="ro" href="https://ultratextgen.com/ro/">
+
+<meta name="robots" content="index, follow">
+
+<meta property="og:site_name" content="UltraTextGen">
+<meta property="og:title" content="Ozdobné písmo a stylový text ke zkopírování — písmenka na Instagram, TikTok a nicky">
+<meta property="og:description" content="Generátor ozdobného písma, estetických písmenek a stylového textu ke zkopírování. Tučné, kurzíva, gotika, bublinkové, Zalgo a symboly — vlož do bia na Instagramu, do popisku na TikToku, do herního nicku nebo na Discord.">
+<meta property="og:url" content="https://ultratextgen.com/cs/">
+<meta property="og:type" content="website">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/generator-ladnych-czcionek-preview.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Ozdobné písmo a stylový text ke zkopírování — písmenka na Instagram, TikTok a nicky">
+<meta name="twitter:description" content="Generátor ozdobného písma, estetických písmenek a stylového textu ke zkopírování. Tučné, kurzíva, gotika, bublinkové, Zalgo a symboly — vlož do bia na Instagramu, do popisku na TikToku, do herního nicku nebo na Discord.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/generator-ladnych-czcionek-preview.png">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/style.css">
+
+ <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+[
+  {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/",
+    "inLanguage": "cs",
+    "description": "Rychlý a přehledný generátor textu Unicode pro bio na sociálních sítích, popisky a uživatelská jména.",
+    "potentialAction": {
+      "@type": "SearchAction",
+      "target": {
+        "@type": "EntryPoint",
+        "urlTemplate": "https://ultratextgen.com/?q={search_term_string}"
+      },
+      "query-input": "required name=search_term_string"
+    }
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com",
+    "logo": "https://ultratextgen.com/logo.png",
+    "sameAs": [
+      "https://www.youtube.com/@UltraTextGen",
+      "https://www.facebook.com/profile.php?id=61588587387596",
+      "https://www.linkedin.com/company/71290348/",
+      "https://x.com/UltraTextGen"
+    ]
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "WebApplication",
+    "name": "UltraTextGen",
+    "alternateName": ["Generátor písma Unicode", "Generátor ozdobného textu", "Měnič písma", "Písmo ke kopírování a vkládání"],
+    "url": "https://ultratextgen.com/cs/",
+    "inLanguage": "cs",
+    "applicationCategory": "UtilitiesApplication",
+    "operatingSystem": "All",
+    "browserRequirements": "Requires JavaScript",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "description": "Okamžitě generuj stylové písmo Unicode pro Instagram, TikTok, X, WhatsApp a Discord. Kopíruj a vkládej textové styly do bia na sítích, uživatelských jmen a příspěvků."
+  }
+]
+</script>
+
+
+
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "cs",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Co je UltraTextGen a co se tu vlastně děje?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Je to bezplatný generátor písmenek — napíšeš obyčejný text a my ho převedeme na stylizované znaky Unicode, které vypadají jako ozdobné písmo. Hlavní věc: jsou to opravdové znaky , ne ztučnění z Wordu nebo markdown z Discordu. Proto fungují všude, kam se dá napsat obyčejný text — v biu na Instagramu, v nicku, v komentáři, v e-mailu, ve statusu na WhatsAppu. Příklad Napíšeš „ahoj\" → dostaneš 𝗮𝗵𝗼𝗷 (tučné), 𝘢𝘩𝘰𝘫 (kurzíva), 𝒶𝒽ℴ𝒿 (kaligrafie) nebo ⓐⓗⓞⓙ (bublinkové). Všechno jedním kliknutím."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Jak zkopírovat ozdobná písmenka za 5 vteřin?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "1. Napíšeš nebo vložíš text do pole nahoře. 2. Styly se hned objeví pod ním — tučné, kurzíva, gotika, bublinkové a ještě pár desítek dalších. 3. Když chceš, přidej ozdoby — rámečky, hvězdičky, šipky. 4. Klikneš na „Kopírovat\" u toho, který ti sedí, a vložíš, kam jen chceš. A je to. Bez registrace, bez instalace apky. Funguje stejně na počítači i na telefonu."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Zdarma? Bez limitů, bez účtu?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ano, celé je to 100% zdarma . Žádný účet, žádný denní limit, žádné vodoznaky, žádný háček. Můžeš tím prohnat celou knížku a nic se nestane."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Jak dostat stylový text do bia na Instagramu?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Instagram nemá žádnou lištu pro formátování, ale přijímá Unicode — takže všechno, co u nás vygeneruješ, ti v biu naskočí bez problémů. Jak na to 1. Napiš, co chceš mít v biu (třeba jméno, hashtag, krátký popis). 2. Vyber styl — tučné a kurzíva fungují na většině zařízení nejlíp. 3. Zkopíruj výsledek a vlož ho v „Upravit profil → Bio\" v aplikaci. Tip: když chceš ozdobit, přidej rámeček typu ⋆｡˚ nebo hvězdičku ✦ po straně — vypadá to dobře a nekrade to pozornost zbytku bia."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Fungují písmenka v popiscích na TikToku?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ano — TikTok vykresluje Unicode v popiscích, popisech profilu i komentářích. Nejlíp se osvědčí tučné , kurzíva , bublinkové a kapitálky . Styly s hromadou ozdob se u dlouhých popisků občas ořežou, tak si pro jistotu příspěvek zkontroluj v náhledu před zveřejněním."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Dá se udělat nick do hry nebo na Discord?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Jasně — to je asi nejčastější důvod, proč lidé na takové generátory chodí. Discord, Roblox, Steam, Minecraft, většina her přijímá Unicode v nicku. Příklad Obyčejný nick: „DarkWolf\" Po stylizaci: „𝔇𝔞𝔯𝔨𝔚𝔬𝔩𝔣\" (gotika), „ⒹⓐⓡⓚⓌⓞⓛⓕ\" (bublinkové) nebo „๖ۣۜDarkWolf\" (s ozdobou po straně). Pozor: některé hry mají filtry a exotické znaky nepřijmou. Když jeden styl neprojde, dej jiný — tučné a kurzíva projdou skoro všude."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Funguje to ve statusu na WhatsAppu, na Telegramu a v Messengeru?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ano — WhatsApp, Telegram, Messenger, Signal, iMessage. Cokoli přijímá obyčejný text, přijme i písmenka Unicode. Vložíš je do statusu nebo do zprávy a vypadají jako ozdobné písmo. K WhatsAppu ještě dodám: pokud ti jde jen o ztučnění, můžeš použít jejich vlastní syntax ( *text* udělá tučné). Ale Unicode funguje všude — i tam, kde to WhatsApp nepodporuje, třeba v názvu kontaktu."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "A v předmětu e-mailu nebo v životopise?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Tady Unicode odvede největší práci. Předmět e-mailu je obyčejný text, takže ztučnění z Outlooku odpadá. Ale „𝗙𝗮𝗸𝘁𝘂𝗿𝗮 — 𝗣𝗢𝗭𝗢𝗥\" už v příjemcově schránce působí silněji. V životopise dokáže lehce ztučněné jméno v záhlaví přitáhnout pohled personalisty. Jen to nepřeháněj — celý životopis v gotice nepůsobí profesionálně."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Jaké styly písmenek mám na výběr?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Hodně. Vážně hodně. Ve zkratce: Základní Tučné (bold), kurzíva, kaligrafie (script), gotika, bublinkové (v kolečkách), kapitálky, přeškrtnuté, podtržené, dvojitě tažené (double struck). Zábavné Text vzhůru nohama, zrcadlově obrácený, Zalgo (glitch s čárkami nad písmeny), text ve čtverečcích, v závorkách, fullwidth (rozházený). Doplňky Rámečky kolem textu, hvězdičky, srdíčka, šipky, oddělovače, vlajky, emoji — dají se na styl písmenek navrstvit. Čas od času přibývají nové — vyplatí se přidat si stránku do záložek."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Můžu spojit několik stylů najednou?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ano — a to je největší přednost UltraTextGenu. Můžeš navrstvit třeba bublinkové + Zalgo , gotiku + vzhůru nohama nebo kapitálky + podtržení a pak to celé uzavřít do rámečku nebo hvězdičky. Příklad „ahoj\" → vybereš gotiku → přidáš rámeček s hvězdičkami → vyjde: ★彡[ 𝔞𝔥𝔬𝔧 ]彡★ Čím víc experimentuješ, tím zajímavější věci vzniknou. Doporučuju začít jedním stylem a přidat jednu ozdobu — ne všechno naráz."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Co je Zalgo a ty divné čárky nad písmeny?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Zalgo je takový „prokletý\", glitchový styl — nad a pod každé písmeno naletí spousta diakritických znamének. Vypadá to, jako by se text rozpadal nebo byl z hororu. Příklad „ahoj\" → a̷̢h̴̢ơ̷j̴̜ Nejčastěji to vídáš v temných biích na Instagramu, v halloweenských memech, v herních klanech, které chtějí vypadat hrozivě, nebo když si z toho někdo dělá srandu."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Kde brát hezké symboly, hvězdičky a srdíčka?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Všechno, co máš v sekci „Ozdoby\" pod textovým polem, můžeš kopírovat zvlášť — i bez psaní textu. Prostě jako samostatné znaky do bia, nicku nebo příspěvku. — Estetické symboly : ✦ ✧ ⋆ ｡ ☆ ♡ ❀ ✿ — Rámečky a obruby : ╭─▸ │ ╰─▸ nebo ★彡[ ]彡★ — Šipky : → ⇨ ➤ ⟶ — Minimalistické oddělovače : · ⋅ ─ • — Vlajky a emoji . Nejčastěji se používají v estetických biích na Instagramu a Pinterestu — hodí se úplně ke všemu, od citátů po seznamy zájmů."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "A české znaky? Funguje to s á, č, ď, é, ě, í, ň, ó, ř, š, ť, ú, ů, ý, ž?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Krátce: záleží na stylu. Unicode má stylizované varianty pro základní abecedu A–Z, takže a , c , e , s , z se v pohodě promění třeba na tučné. Ale pro á , č , ě , ř , š , ž stylizované verze existují jen v části stylů (hlavně tučné, kurzíva, kapitálky). Když styl nemá verzi pro český znak s diakritikou, zůstane v původní podobě — text je pořád čitelný, česká písmenka s háčky a čárkami prostě vypadají „obyčejněji\" než zbytek. Pro nicky bez diakritiky to není žádný problém. Pro celé věty v češtině doporučuju tučné , kurzívu nebo monospace — ty si s naší abecedou poradí nejlíp."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Proč se někomu zobrazují čtverečky místo písmenek?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Protože systémové písmo na straně příjemce daný znak Unicode neobsahuje. Není to problém s tvým textem — jeho telefon nebo aplikace prostě ten konkrétní znak v sadě nemá. Drž se tučných , kurzívy a bublinkových — ty mají nejširší podporu. Hodně exotické styly (fullwidth, čtverečky) se na starších Androidech nebo v některých e-mailových klientech můžou zobrazit jako □."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Instagram mi v nicku ořízl část znaků — co teď?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Instagram má filtr na pole uživatelské jméno (čili @login) — bere jen písmena, číslice, tečky a podtržítka. Sem stylizovaná písmenka nevložíš. Ale do pole „Jméno\" (zobrazované jméno) a do bia ano — a tam projde většina stylů. Když se jeden neuloží, dej jiný. Tučné obvykle projde bez problémů."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Jsou nějaké znaky, které vůbec nejdou převést?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Standardní písmena (A–Z, a–z), číslice a základní interpunkce se převedou bez problémů. Některé vzácné symboly nebo speciální znaky nemají v Unicode stylizované protějšky — pak zůstanou v původní podobě. Nic se nerozbije, text je pořád ke zkopírování."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Ukládá se můj text někam?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ne. Celý převod písmenek probíhá ve tvém prohlížeči — nic neputuje na naše servery, nic se neukládá, nic se nesleduje. Zkopírovaný text je čistý Unicode, bez skrytých znaků, bez jakýchkoli identifikátorů."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Je bezpečné vkládat tato písmenka kamkoli?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ano — jsou to standardní znaky Unicode, stejné jako ty, které používá celý internet. Nic uvnitř, žádné skripty, žádné skryté formátování, žádné kódy. V klidu je vlož do životopisu, do pracovního e-mailu, do bia na LinkedInu — kam chceš."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Funguje to na telefonu?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ano — stránka se plně přizpůsobí mobilu. iPhone, Android, tablet — všechno klape. Napíšeš text, klikneš, zkopíruje se do schránky, vložíš v aplikaci. Bez instalace čehokoli z obchodu."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Čím se lišíte od jiných generátorů písmenek?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Konkrétně: — Jedna z největších sbírek stylů Ultra — tučné, kurzíva, gotika, bublinkové a ještě pár desítek dalších. — Kombinování stylů — většina generátorů ti dá jeden styl naráz, my dovolíme vrstvit. — Ozdoby jedním kliknutím — rámečky, hvězdičky, oddělovače bez lepení znak po znaku. — Stránky pro konkrétní platformy — Instagram, TikTok, Discord. Ukazujeme tam jen styly, které v dané apce fungují. — Rychle a bez vyskakovacích oken — žádné captchy, žádné „přijmout vše\" před každým kliknutím."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Přibývají nové styly?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ano, pravidelně. Čas od času naskočí nové varianty, ozdoby a rámečky. Nejjednodušší je uložit si stránku do záložek nebo se sem jednou za čas vrátit."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Jak najít přesně ten styl, který hledám?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Tři cesty: Podle stylu — kategorie nahoře: tučné, kurzíva, gotika, bublinkové, přeškrtnuté, vzhůru nohama a další. Podle platformy — mrkni na podstránku pro Instagram, TikTok, Discord — tam jsou jen styly, které na dané platformě fungují. Podle cíle — sekce využití má nástroje ušité na konkrétní potřebu: titulek na LinkedIn, komentáře, text s emoji."
+      }
+    }
+  ]
+}
+</script>
+</head>
+
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer=""></script>
+
+  <!-- Hero Section -->
+  <section class="hero">
+    <div class="hero-inner">
+      <div class="hero-card">
+        <h1 class="hero-headline" data-i18n="hero.title">Ozdobné písmo a stylová písmenka ke zkopírování</h1>
+        <p class="hero-tagline" data-i18n="hero.subtitle">Napiš text, vyber styl — tučné, kurzíva, gotika, bublinkové nebo s ozdobami. Vlož do bia na Instagramu, do herního nicku, do statusu na WhatsAppu nebo do popisku na TikToku. Bez aplikace, bez přihlašování.</p>
+        <div class="input-wrapper">
+          <textarea class="main-input" id="mainInput" placeholder="Napiš text..." data-i18n-placeholder="ui.placeholder" maxlength="500" autofocus=""></textarea>
+          <button class="input-clear-btn" id="inputClearBtn" aria-label="Clear input" hidden="">✕</button>
+          <span class="char-count" id="charCountWrapper" hidden=""><span id="charCount">0</span>/500</span>
+        </div>
+
+        <!-- Decoration Selector -->
+        <div class="decoration-section">
+          <div class="decoration-label">
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"></path>
+            </svg>
+            <span data-i18n="decorations.label">Přidej ozdoby k textu</span>
+       </div>
+    <div class="decoration-tabs">
+    <button class="decoration-tab active" data-deco-tab="symbols" data-i18n="decorations.tabs.symbols">Symboly</button>
+    <button class="decoration-tab" data-deco-tab="frames" data-i18n="decorations.tabs.frames">Rámečky</button>
+    <button class="decoration-tab" data-deco-tab="dividers" data-i18n="decorations.tabs.dividers">Oddělovače</button>
+    <button class="decoration-tab" data-deco-tab="arrows" data-i18n="decorations.tabs.arrows">Šipky</button>
+    <button class="decoration-tab" data-deco-tab="minimal" data-i18n="decorations.tabs.minimal">Minimalistické</button>
+    <button class="decoration-tab" data-deco-tab="emojis" data-i18n="decorations.tabs.emojis">Emoji</button>
+    <button class="decoration-tab" data-deco-tab="flags" data-i18n="decorations.tabs.flags">Vlajky</button>
+      </div>
+          <div class="decoration-grid" id="decorationGrid"></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Main Content -->
+  <main class="container">
+    <!-- Category Tabs -->
+    <div class="category-section">
+      <div class="category-tabs" id="categoryTabs">
+        <!-- Tabs will be dynamically loaded from fonts.json -->
+      </div>
+    </div>
+
+    <!-- Results -->
+    <div class="results-grid" id="resultsGrid"></div>
+  </main>
+
+  <!-- How To: Jak zkopírovat ozdobná písmenka -->
+  <section class="editorial-section">
+    <h2>Písmena a písmenka ke zkopírování — jak to funguje</h2>
+    <p class="editorial-intro">Ozdobná <strong>písmena ke zkopírování</strong> zvládneš za pár vteřin — bez instalace aplikace a bez zakládání účtu. Napíšeš text a generátor ho převede na desítky stylů hezkých písmenek, připravených ke zkopírování a vložení.</p>
+    <div class="steps-grid">
+      <div class="step-card">
+        <div class="step-number">1</div>
+        <h3>Napiš text</h3>
+        <p>Napiš jméno, slovo nebo celou větu do pole úplně nahoře. Můžeš taky vložit něco, co už máš zkopírované.</p>
+      </div>
+      <div class="step-card">
+        <div class="step-number">2</div>
+        <h3>Vyber styl písmenek</h3>
+        <p>Hezká písmenka se objeví hned — tučné, kurzíva, kaligrafie, gotika, bublinkové a kapitálky. Výběr zúžíš kategorií nahoře.</p>
+      </div>
+      <div class="step-card">
+        <div class="step-number">3</div>
+        <h3>Zkopíruj a vlož</h3>
+        <p>Klikneš na „Kopírovat", vložíš do bia na Instagramu, herního nicku, statusu na WhatsAppu nebo popisku na TikToku. Styl se neztratí.</p>
+      </div>
+    </div>
+    <p class="u-mt-15 u-text-center">Stejné kroky fungují pro <strong>ozdobná písma ke zkopírování</strong>, ozdobná písmena i estetická písmenka — stejně na počítači i na telefonu.</p>
+  </section>
+
+  <!-- Abeceda ozdobných písmenek A–Z -->
+  <section class="editorial-section abc-section" aria-label="Abeceda ozdobných písmenek ke zkopírování">
+    <h2>Ozdobná písmenka A–Z ke zkopírování</h2>
+    <p>Celá abeceda — velká písmena (A–Z), malá písmena (a–z) i číslice (0–9) — v nejčastěji používaných stylech ozdobných písmenek. Napiš něco do generátoru nahoře a klikni na „Kopírovat", abys vzal celé slovo v daném stylu, nebo označ písmena z tabulky a zkopíruj je sám.</p>
+
+    <div class="abc-list">
+      <div class="abc-row">
+        <span class="abc-name">Tučné</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝗔𝗕𝗖𝗗𝗘𝗙𝗚𝗛𝗜𝗝𝗞𝗟𝗠𝗡𝗢𝗣𝗤𝗥𝗦𝗧𝗨𝗩𝗪𝗫𝗬𝗭</span>
+          <span class="abc-line">𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇</span>
+          <span class="abc-line">𝟬𝟭𝟮𝟯𝟰𝟱𝟲𝟳𝟴𝟵</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Kurzíva</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝘈𝘉𝘊𝘋𝘌𝘍𝘎𝘏𝘐𝘑𝘒𝘓𝘔𝘕𝘖𝘗𝘘𝘙𝘚𝘛𝘜𝘝𝘞𝘟𝘠𝘡</span>
+          <span class="abc-line">𝘢𝘣𝘤𝘥𝘦𝘧𝘨𝘩𝘪𝘫𝘬𝘭𝘮𝘯𝘰𝘱𝘲𝘳𝘴𝘵𝘶𝘷𝘸𝘹𝘺𝘻</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Kaligrafie</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵</span>
+          <span class="abc-line">𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Kaligrafie tučná</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩</span>
+          <span class="abc-line">𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Gotika</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝔄𝔅ℭ𝔇𝔈𝔉𝔊ℌℑ𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔ℜ𝔖𝔗𝔘𝔙𝔚𝔛𝔜ℨ</span>
+          <span class="abc-line">𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Bublinkové</span>
+        <div class="abc-lines">
+          <span class="abc-line">ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ</span>
+          <span class="abc-line">ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ</span>
+          <span class="abc-line">⓪①②③④⑤⑥⑦⑧⑨</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Kapitálky</span>
+        <div class="abc-lines">
+          <span class="abc-line">ᴀʙᴄᴅᴇꜰɢʜɪᴊᴋʟᴍɴᴏᴘqʀsᴛᴜᴠᴡxʏᴢ</span>
+          <span class="abc-line">ᴀʙᴄᴅᴇꜰɢʜɪᴊᴋʟᴍɴᴏᴘqʀsᴛᴜᴠᴡxʏᴢ</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+    </div>
+    <p class="u-mt-15">Hledáš konkrétní řez? Mrkni na <a href="/cs/tucne-pismo/">tučná písmena</a>, <a href="/cs/goticke-pismo/">gotická písmena ke zkopírování</a> nebo <a href="/category/cursive-fonts/">psaná písmena a kurzívu</a> — každá kategorie ukazuje jen jeden styl, od velkých po malá písmena.</p>
+  </section>
+
+  <!-- Ozdoby a symboly ke zkopírování -->
+  <section class="editorial-section glyph-section" aria-label="Ozdoby a symboly ke zkopírování">
+    <h2>Ozdoby a symboly ke zkopírování</h2>
+    <p class="editorial-intro">Hotové <strong>ozdoby textu ke zkopírování</strong> — hvězdičky, srdíčka, rámečky, šipky a oddělovače. Klikni na libovolný znak a zkopíruj ho, nebo je přidej automaticky k textu přes záložky <strong>Symboly</strong>, <strong>Rámečky</strong> a <strong>Oddělovače</strong> v generátoru nahoře.</p>
+    <div class="glyph-group">
+      <h3>Hvězdičky a záblesky</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="✦">✦</button>
+        <button class="glyph-copy" type="button" data-text="✧">✧</button>
+        <button class="glyph-copy" type="button" data-text="⋆">⋆</button>
+        <button class="glyph-copy" type="button" data-text="✩">✩</button>
+        <button class="glyph-copy" type="button" data-text="★">★</button>
+        <button class="glyph-copy" type="button" data-text="☆">☆</button>
+        <button class="glyph-copy" type="button" data-text="✰">✰</button>
+        <button class="glyph-copy" type="button" data-text="⊹">⊹</button>
+        <button class="glyph-copy" type="button" data-text="࿐">࿐</button>
+        <button class="glyph-copy" type="button" data-text="˚">˚</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Srdíčka</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="♡">♡</button>
+        <button class="glyph-copy" type="button" data-text="♥">♥</button>
+        <button class="glyph-copy" type="button" data-text="❤">❤</button>
+        <button class="glyph-copy" type="button" data-text="❥">❥</button>
+        <button class="glyph-copy" type="button" data-text="❣">❣</button>
+        <button class="glyph-copy" type="button" data-text="ღ">ღ</button>
+        <button class="glyph-copy" type="button" data-text="ꨄ">ꨄ</button>
+        <button class="glyph-copy" type="button" data-text="ஐ">ஐ</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Měsíc a obloha</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="☾">☾</button>
+        <button class="glyph-copy" type="button" data-text="☽">☽</button>
+        <button class="glyph-copy" type="button" data-text="☁">☁</button>
+        <button class="glyph-copy" type="button" data-text="✶">✶</button>
+        <button class="glyph-copy" type="button" data-text="⍣">⍣</button>
+        <button class="glyph-copy" type="button" data-text="ꕥ">ꕥ</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Květiny</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="❀">❀</button>
+        <button class="glyph-copy" type="button" data-text="✿">✿</button>
+        <button class="glyph-copy" type="button" data-text="⚘">⚘</button>
+        <button class="glyph-copy" type="button" data-text="✾">✾</button>
+        <button class="glyph-copy" type="button" data-text="❁">❁</button>
+        <button class="glyph-copy" type="button" data-text="ꕤ">ꕤ</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Rámečky a ornamenty</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="꧁">꧁</button>
+        <button class="glyph-copy" type="button" data-text="꧂">꧂</button>
+        <button class="glyph-copy" type="button" data-text="༺">༺</button>
+        <button class="glyph-copy" type="button" data-text="༻">༻</button>
+        <button class="glyph-copy" type="button" data-text="⟡">⟡</button>
+        <button class="glyph-copy" type="button" data-text="❪">❪</button>
+        <button class="glyph-copy" type="button" data-text="❫">❫</button>
+        <button class="glyph-copy" type="button" data-text="★彡">★彡</button>
+        <button class="glyph-copy" type="button" data-text="彡★">彡★</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Šipky</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="→">→</button>
+        <button class="glyph-copy" type="button" data-text="⇨">⇨</button>
+        <button class="glyph-copy" type="button" data-text="➤">➤</button>
+        <button class="glyph-copy" type="button" data-text="⟶">⟶</button>
+        <button class="glyph-copy" type="button" data-text="➳">➳</button>
+        <button class="glyph-copy" type="button" data-text="↬">↬</button>
+        <button class="glyph-copy" type="button" data-text="⇢">⇢</button>
+        <button class="glyph-copy" type="button" data-text="↳">↳</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Oddělovače</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="·">·</button>
+        <button class="glyph-copy" type="button" data-text="•">•</button>
+        <button class="glyph-copy" type="button" data-text="◦">◦</button>
+        <button class="glyph-copy" type="button" data-text="➛">➛</button>
+        <button class="glyph-copy" type="button" data-text="⟢">⟢</button>
+        <button class="glyph-copy" type="button" data-text="—">—</button>
+        <button class="glyph-copy" type="button" data-text="☰">☰</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Kaomoji (obličeje)</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="(◍•ᴗ•◍)">(◍•ᴗ•◍)</button>
+        <button class="glyph-copy" type="button" data-text="(｡♥‿♥｡)">(｡♥‿♥｡)</button>
+        <button class="glyph-copy" type="button" data-text="ʕ•ᴥ•ʔ">ʕ•ᴥ•ʔ</button>
+        <button class="glyph-copy" type="button" data-text="(＾▽＾)">(＾▽＾)</button>
+        <button class="glyph-copy" type="button" data-text="٩(◕‿◕)۶">٩(◕‿◕)۶</button>
+      </div>
+    </div>
+  </section>
+
+  <!-- Popular Use Cases -->
+  <section class="editorial-section">
+    <h2 data-i18n="useCases.title">Na co to lidé nejčastěji používají</h2>
+    <div class="tips-grid">
+      <a class="tip-card" href="/usecase/linkedin-headline/" aria-label="Titulek na LinkedInu">
+        <div class="tip-icon">💼</div>
+        <h3 data-i18n="useCases.items.0.title">Titulek na LinkedInu</h3>
+        <p data-i18n="useCases.items.0.description">Vyčnívej ve vyhledávání na LinkedInu — tučný nebo lehce ozdobený titulek zabere dřív, než někdo stihne odscrollovat dál.</p>
+      </a>
+      <a class="tip-card" href="/usecase/comment-font/" aria-label="Komentáře pod příspěvky">
+        <div class="tip-icon">💬</div>
+        <h3 data-i18n="useCases.items.1.title">Komentáře pod příspěvky</h3>
+        <p data-i18n="useCases.items.1.description">Stylové komentáře na Instagramu, YouTube i TikToku — okem je zachytíš snáz než stovky obyčejných pod populárním příspěvkem.</p>
+      </a>
+      <a class="tip-card" href="/usecase/text-to-emoji/" aria-label="Text zapsaný v emoji">
+        <div class="tip-icon">😊</div>
+        <h3 data-i18n="useCases.items.2.title">Text zapsaný v emoji</h3>
+        <p data-i18n="useCases.items.2.description">Proměň nápis v sekvenci písmenek-emoji — kreativní bio, story, skupinové chaty nebo čistě pro srandu s kamarády.</p>
+      </a>
+      <a class="tip-card" href="/usecase/tattoo-fonts/" aria-label="Písmo na tetování">
+        <div class="tip-icon">🖤</div>
+        <h3>Písmo na tetování</h3>
+        <p>Vyzkoušej si jméno nebo nápis v kaligrafii, gotice a kurzívě — dřív, než půjde pod jehlu.</p>
+      </a>
+      <a class="tip-card" href="/usecase/zalgo-text/" aria-label="Generátor textu Zalgo">
+        <div class="tip-icon">👻</div>
+        <h3>Pokroucená písmenka Zalgo</h3>
+        <p>Glitchový text s čárkami nad a pod písmeny — hodí se k halloweenským memům, temným biím a herním klanům, které chtějí vypadat hrozivě.</p>
+      </a>
+    </div>
+    <p class="u-mt-15 u-text-center"><a class="cat-cta" href="/usecase/" data-i18n="useCases.viewAll">Zobrazit další využití →</a></p>
+  </section>
+
+  <!-- Popular Guides -->
+  <section class="editorial-section">
+    <h2 data-i18n="guides.title">Mrkni na návody</h2>
+    <div class="tips-grid">
+      <a class="tip-card" href="/guide/the-rhetoric-of-fonts/" aria-label="Rétorika písma">
+        <div class="tip-icon">📚</div>
+        <h3 data-i18n="guides.items.0.title">Rétorika písma</h3>
+        <p data-i18n="guides.items.0.description">Proč jedno písmo budí důvěru a druhé vypadá jako spam — čili jak typografie ovlivňuje to, co při čtení cítíme.</p>
+      </a>
+      <a class="tip-card" href="/guide/personal-branding-through-typography/" aria-label="Osobní značka skrze typografii">
+        <div class="tip-icon">🎨</div>
+        <h3 data-i18n="guides.items.1.title">Osobní značka skrze typografii</h3>
+        <p data-i18n="guides.items.1.description">Jak vybrat písmenka, která ladí s tvým vibem a zůstanou divákovi v hlavě — ať jde o LinkedIn, Instagram nebo Discord.</p>
+      </a>
+      <a class="tip-card" href="/guide/stop-the-scroll-with-font-variation/" aria-label="Zastav scrollování — hraj si s písmem">
+        <div class="tip-icon">📱</div>
+        <h3 data-i18n="guides.items.2.title">Zastav scrollování — hraj si s písmem</h3>
+        <p data-i18n="guides.items.2.description">Proč se lidé zastaví u příspěvků s jiným stylem textu a jak toho využít ke zvýšení dosahů.</p>
+      </a>
+    </div>
+    <p class="u-mt-15 u-text-center"><a class="cat-cta" href="/guide/" data-i18n="guides.viewAll">Všechny návody →</a></p>
+  </section>
+
+  <!-- FAQ Section -->
+  <section class="faq-section-wrapper" aria-label="Frequently asked questions">
+    <div class="faq-inner">
+
+<!-- Písmenka a ozdoby ke zkopírování -->
+<h2 class="faq-category">Písmenka a ozdoby ke zkopírování</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span>Kde najdu hezká písmenka ke zkopírování?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer">Přímo tady. Napíšeš text do pole nahoře a hezká písmenka — <strong>tučná</strong>, <strong>kurzíva</strong>, <strong>gotika</strong>, <strong>bublinková</strong> a ještě pár desítek dalších — se hned objeví pod ním. Klikneš na „Kopírovat" a vložíš, kam chceš.
+    <br><br>
+    Máš tu i hotovou <strong>abecedu A–Z ke zkopírování</strong> v oblíbených stylech — velká písmena, malá písmena i číslice — kterou si můžeš vzít i bez psaní čehokoli.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span>Co jsou ozdoby ke zkopírování a kde je hledat?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer">Ozdoby jsou malé symboly, kterými zdobíš text — hvězdičky ✦, srdíčka ♡, rámečky ꧁꧂, šipky → a oddělovače.
+    <br><br>
+    V sekci <strong>„Ozdoby a symboly ke zkopírování"</strong> klikneš na libovolný znak a zkopíruješ ho zvlášť. <strong>Ozdoby textu</strong> můžeš taky přidat automaticky k celému nápisu — přes záložky <strong>Symboly</strong>, <strong>Rámečky</strong> a <strong>Oddělovače</strong> nad polem pro psaní.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span>Máte hezká a estetická písma ke zkopírování?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer">Ano — od minimalistických, rozházených <strong>estetických písem ke zkopírování</strong> po ozdobná písmenka se symboly. Napíšeš text a všechny styly hezkých písem se objeví naráz. Celé je to zdarma a připravené ke zkopírování jedním kliknutím, stejně na telefonu i na počítači.</div>
+</div>
+
+
+<!-- První otázky -->
+<h2 class="faq-category" data-i18n="faq.categories.0.title">První otázky</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.0.items.0.question">Co je UltraTextGen a co se tu vlastně děje?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.0.items.0.answer">Je to bezplatný generátor písmenek — napíšeš obyčejný text a my ho převedeme na stylizované znaky Unicode, které vypadají jako ozdobné písmo.
+    <br><br>
+    Hlavní věc: jsou to <strong>opravdové znaky</strong>, ne ztučnění z Wordu nebo markdown z Discordu. Proto fungují všude, kam se dá napsat obyčejný text — v biu na Instagramu, v nicku, v komentáři, v e-mailu, ve statusu na WhatsAppu.
+    <br><br>
+    <strong>Příklad</strong><br>
+    Napíšeš „ahoj" → dostaneš 𝗮𝗵𝗼𝗷 (tučné), 𝘢𝘩𝘰𝘫 (kurzíva), 𝒶𝒽ℴ𝒿 (kaligrafie) nebo ⓐⓗⓞⓙ (bublinkové). Všechno jedním kliknutím.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.0.items.1.question">Jak zkopírovat ozdobná písmenka za 5 vteřin?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.0.items.1.answer">1. Napíšeš nebo vložíš text do pole nahoře.<br>
+    2. Styly se hned objeví pod ním — tučné, kurzíva, gotika, bublinkové a ještě pár desítek dalších.<br>
+    3. Když chceš, přidej ozdoby — rámečky, hvězdičky, šipky.<br>
+    4. Klikneš na „Kopírovat" u toho, který ti sedí, a vložíš, kam jen chceš.
+    <br><br>
+    A je to. Bez registrace, bez instalace apky. Funguje stejně na počítači i na telefonu.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.0.items.2.question">Zdarma? Bez limitů, bez účtu?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.0.items.2.answer">Ano, celé je to <strong>100% zdarma</strong>. Žádný účet, žádný denní limit, žádné vodoznaky, žádný háček. Můžeš tím prohnat celou knížku a nic se nestane.</div>
+</div>
+
+
+<!-- Instagram, TikTok, Discord -->
+<h2 class="faq-category" data-i18n="faq.categories.1.title">Instagram, TikTok, Discord — kam to vložit</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.1.items.0.question">Jak dostat stylový text do bia na Instagramu?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.1.items.0.answer">Instagram nemá žádnou lištu pro formátování, ale přijímá Unicode — takže všechno, co u nás vygeneruješ, ti v biu naskočí bez problémů.
+    <br><br>
+    <strong>Jak na to</strong><br>
+    1. Napiš, co chceš mít v biu (třeba jméno, hashtag, krátký popis).<br>
+    2. Vyber styl — tučné a kurzíva fungují na většině zařízení nejlíp.<br>
+    3. Zkopíruj výsledek a vlož ho v „Upravit profil → Bio" v aplikaci.
+    <br><br>
+    Tip: když chceš ozdobit, přidej rámeček typu ⋆｡˚ nebo hvězdičku ✦ po straně — vypadá to dobře a nekrade to pozornost zbytku bia.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.1.items.1.question">Fungují písmenka v popiscích na TikToku?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.1.items.1.answer">Ano — TikTok vykresluje Unicode v popiscích, popisech profilu i komentářích. Nejlíp se osvědčí <strong>tučné</strong>, <strong>kurzíva</strong>, <strong>bublinkové</strong> a <strong>kapitálky</strong>. Styly s hromadou ozdob se u dlouhých popisků občas ořežou, tak si pro jistotu příspěvek zkontroluj v náhledu před zveřejněním.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.1.items.2.question">Dá se udělat nick do hry nebo na Discord?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.1.items.2.answer">Jasně — to je asi nejčastější důvod, proč lidé na takové generátory chodí. Discord, Roblox, Steam, Minecraft, většina her přijímá Unicode v nicku.
+    <br><br>
+    <strong>Příklad</strong><br>
+    Obyčejný nick: „DarkWolf"<br>
+    Po stylizaci: „𝔇𝔞𝔯𝔨𝔚𝔬𝔩𝔣" (gotika), „ⒹⓐⓡⓚⓌⓞⓛⓕ" (bublinkové) nebo „๖ۣۜDarkWolf" (s ozdobou po straně).
+    <br><br>
+    <strong>Pozor:</strong> některé hry mají filtry a exotické znaky nepřijmou. Když jeden styl neprojde, dej jiný — tučné a kurzíva projdou skoro všude.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.1.items.3.question">Funguje to ve statusu na WhatsAppu, na Telegramu a v Messengeru?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.1.items.3.answer">Ano — WhatsApp, Telegram, Messenger, Signal, iMessage. Cokoli přijímá obyčejný text, přijme i písmenka Unicode. Vložíš je do statusu nebo do zprávy a vypadají jako ozdobné písmo.
+    <br><br>
+    K WhatsAppu ještě dodám: pokud ti jde jen o ztučnění, můžeš použít jejich vlastní syntax (<code>*text*</code> udělá tučné). Ale Unicode funguje všude — i tam, kde to WhatsApp nepodporuje, třeba v názvu kontaktu.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.1.items.4.question">A v předmětu e-mailu nebo v životopise?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.1.items.4.answer">Tady Unicode odvede největší práci. Předmět e-mailu je obyčejný text, takže ztučnění z Outlooku odpadá. Ale „𝗙𝗮𝗸𝘁𝘂𝗿𝗮 — 𝗣𝗢𝗭𝗢𝗥" už v příjemcově schránce působí silněji.
+    <br><br>
+    V životopise dokáže lehce ztučněné jméno v záhlaví přitáhnout pohled personalisty. Jen to nepřeháněj — celý životopis v gotice nepůsobí profesionálně.</div>
+</div>
+
+
+<!-- Styly, písmenka a ozdoby -->
+<h2 class="faq-category" data-i18n="faq.categories.2.title">Styly, písmenka a ozdoby</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.2.items.0.question">Jaké styly písmenek mám na výběr?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.2.items.0.answer">Hodně. Vážně hodně. Ve zkratce:
+    <br><br>
+    <strong>Základní</strong><br>
+    Tučné (bold), kurzíva, kaligrafie (script), gotika, bublinkové (v kolečkách), kapitálky, přeškrtnuté, podtržené, dvojitě tažené (double struck).
+    <br><br>
+    <strong>Zábavné</strong><br>
+    Text vzhůru nohama, zrcadlově obrácený, Zalgo (glitch s čárkami nad písmeny), text ve čtverečcích, v závorkách, fullwidth (rozházený).
+    <br><br>
+    <strong>Doplňky</strong><br>
+    Rámečky kolem textu, hvězdičky, srdíčka, šipky, oddělovače, vlajky, emoji — dají se na styl písmenek navrstvit.
+    <br><br>
+    Čas od času přibývají nové — vyplatí se přidat si stránku do záložek.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.2.items.1.question">Můžu spojit několik stylů najednou?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.2.items.1.answer">Ano — a to je největší přednost UltraTextGenu. Můžeš navrstvit třeba <strong>bublinkové + Zalgo</strong>, <strong>gotiku + vzhůru nohama</strong> nebo <strong>kapitálky + podtržení</strong> a pak to celé uzavřít do rámečku nebo hvězdičky.
+    <br><br>
+    <strong>Příklad</strong><br>
+    „ahoj" → vybereš gotiku → přidáš rámeček s hvězdičkami → vyjde: ★彡[ 𝔞𝔥𝔬𝔧 ]彡★
+    <br><br>
+    Čím víc experimentuješ, tím zajímavější věci vzniknou. Doporučuju začít jedním stylem a přidat jednu ozdobu — ne všechno naráz.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.2.items.2.question">Co je Zalgo a ty divné čárky nad písmeny?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.2.items.2.answer">Zalgo je takový „prokletý", glitchový styl — nad a pod každé písmeno naletí spousta diakritických znamének. Vypadá to, jako by se text rozpadal nebo byl z hororu.
+    <br><br>
+    <strong>Příklad</strong><br>
+    „ahoj" → a̷̢h̴̢ơ̷j̴̜
+    <br><br>
+    Nejčastěji to vídáš v temných biích na Instagramu, v halloweenských memech, v herních klanech, které chtějí vypadat hrozivě, nebo když si z toho někdo dělá srandu.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.2.items.3.question">Kde brát hezké symboly, hvězdičky a srdíčka?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.2.items.3.answer">Všechno, co máš v sekci „Ozdoby" pod textovým polem, můžeš kopírovat zvlášť — i bez psaní textu. Prostě jako samostatné znaky do bia, nicku nebo příspěvku.
+    <br><br>
+    — <strong>Estetické symboly</strong>: ✦ ✧ ⋆ ｡ ☆ ♡ ❀ ✿<br>
+    — <strong>Rámečky a obruby</strong>: ╭─▸ │ ╰─▸ nebo ★彡[ ]彡★<br>
+    — <strong>Šipky</strong>: → ⇨ ➤ ⟶<br>
+    — <strong>Minimalistické oddělovače</strong>: ·  ⋅  ─  •<br>
+    — <strong>Vlajky a emoji</strong>.
+    <br><br>
+    Nejčastěji se používají v estetických biích na Instagramu a Pinterestu — hodí se úplně ke všemu, od citátů po seznamy zájmů.</div>
+</div>
+
+
+<!-- České znaky, kompatibilita -->
+<h2 class="faq-category" data-i18n="faq.categories.3.title">České znaky, kompatibilita, problémy</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.3.items.0.question">A české znaky? Funguje to s á, č, ď, é, ě, í, ň, ó, ř, š, ť, ú, ů, ý, ž?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.3.items.0.answer"><strong>Krátce:</strong> záleží na stylu.
+    <br><br>
+    Unicode má stylizované varianty pro základní abecedu A–Z, takže <em>a</em>, <em>c</em>, <em>e</em>, <em>s</em>, <em>z</em> se v pohodě promění třeba na tučné. Ale pro <em>á</em>, <em>č</em>, <em>ě</em>, <em>ř</em>, <em>š</em>, <em>ž</em> stylizované verze existují jen v části stylů (hlavně tučné, kurzíva, kapitálky).
+    <br><br>
+    Když styl nemá verzi pro český znak s diakritikou, zůstane v původní podobě — text je pořád čitelný, česká písmenka s háčky a čárkami prostě vypadají „obyčejněji" než zbytek. Pro nicky bez diakritiky to není žádný problém. Pro celé věty v češtině doporučuju <strong>tučné</strong>, <strong>kurzívu</strong> nebo <strong>monospace</strong> — ty si s naší abecedou poradí nejlíp.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.3.items.1.question">Proč se někomu zobrazují čtverečky místo písmenek?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.3.items.1.answer">Protože systémové písmo na straně příjemce daný znak Unicode neobsahuje. Není to problém s tvým textem — jeho telefon nebo aplikace prostě ten konkrétní znak v sadě nemá.
+    <br><br>
+    Drž se <strong>tučných</strong>, <strong>kurzívy</strong> a <strong>bublinkových</strong> — ty mají nejširší podporu. Hodně exotické styly (fullwidth, čtverečky) se na starších Androidech nebo v některých e-mailových klientech můžou zobrazit jako □.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.3.items.2.question">Instagram mi v nicku ořízl část znaků — co teď?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.3.items.2.answer">Instagram má filtr na pole <strong>uživatelské jméno</strong> (čili @login) — bere jen písmena, číslice, tečky a podtržítka. Sem stylizovaná písmenka nevložíš.
+    <br><br>
+    Ale do pole <strong>„Jméno"</strong> (zobrazované jméno) a do <strong>bia</strong> ano — a tam projde většina stylů. Když se jeden neuloží, dej jiný. Tučné obvykle projde bez problémů.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.3.items.3.question">Jsou nějaké znaky, které vůbec nejdou převést?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.3.items.3.answer">Standardní písmena (A–Z, a–z), číslice a základní interpunkce se převedou bez problémů. Některé vzácné symboly nebo speciální znaky nemají v Unicode stylizované protějšky — pak zůstanou v původní podobě. Nic se nerozbije, text je pořád ke zkopírování.</div>
+</div>
+
+
+<!-- Bezpečnost, soukromí, telefon -->
+<h2 class="faq-category" data-i18n="faq.categories.4.title">Bezpečnost, soukromí, telefon</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.4.items.0.question">Ukládá se můj text někam?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.4.items.0.answer">Ne. Celý převod písmenek probíhá <strong>ve tvém prohlížeči</strong> — nic neputuje na naše servery, nic se neukládá, nic se nesleduje. Zkopírovaný text je čistý Unicode, bez skrytých znaků, bez jakýchkoli identifikátorů.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.4.items.1.question">Je bezpečné vkládat tato písmenka kamkoli?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.4.items.1.answer">Ano — jsou to standardní znaky Unicode, stejné jako ty, které používá celý internet. Nic uvnitř, žádné skripty, žádné skryté formátování, žádné kódy. V klidu je vlož do životopisu, do pracovního e-mailu, do bia na LinkedInu — kam chceš.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.4.items.2.question">Funguje to na telefonu?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.4.items.2.answer">Ano — stránka se plně přizpůsobí mobilu. iPhone, Android, tablet — všechno klape. Napíšeš text, klikneš, zkopíruje se do schránky, vložíš v aplikaci. Bez instalace čehokoli z obchodu.</div>
+</div>
+
+
+<!-- Čím se lišíme -->
+<h2 class="faq-category" data-i18n="faq.categories.5.title">Čím se lišíme</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.5.items.0.question">Čím se lišíte od jiných generátorů písmenek?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.5.items.0.answer">Konkrétně:
+    <br><br>
+    — <strong>Jedna z největších sbírek</strong> stylů Ultra — tučné, kurzíva, gotika, bublinkové a ještě pár desítek dalších.<br>
+    — <strong>Kombinování stylů</strong> — většina generátorů ti dá jeden styl naráz, my dovolíme vrstvit.<br>
+    — <strong>Ozdoby jedním kliknutím</strong> — rámečky, hvězdičky, oddělovače bez lepení znak po znaku.<br>
+    — <strong>Stránky pro konkrétní platformy</strong> — Instagram, TikTok, Discord. Ukazujeme tam jen styly, které v dané apce fungují.<br>
+    — <strong>Rychle a bez vyskakovacích oken</strong> — žádné captchy, žádné „přijmout vše" před každým kliknutím.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.5.items.1.question">Přibývají nové styly?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.5.items.1.answer">Ano, pravidelně. Čas od času naskočí nové varianty, ozdoby a rámečky. Nejjednodušší je uložit si stránku do záložek nebo se sem jednou za čas vrátit.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.5.items.2.question">Jak najít přesně ten styl, který hledám?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.5.items.2.answer">Tři cesty:
+    <br><br>
+    <strong>Podle stylu</strong> — kategorie nahoře: tučné, kurzíva, gotika, bublinkové, přeškrtnuté, vzhůru nohama a další.<br>
+    <strong>Podle platformy</strong> — mrkni na podstránku pro Instagram, TikTok, Discord — tam jsou jen styly, které na dané platformě fungují.<br>
+    <strong>Podle cíle</strong> — sekce využití má nástroje ušité na konkrétní potřebu: titulek na LinkedIn, komentáře, text s emoji.</div>
+</div>
+    </div>
+  </section>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-inner">
+      <!-- Language Switcher -->
+      <div class="lang-switcher" role="navigation" aria-label="Language switcher">
+        <a class="lang-option" href="/" hreflang="en">EN</a>
+        <a class="lang-option active" href="/cs/" hreflang="cs">CS</a>
+        <a class="lang-option" href="/es/" hreflang="es">ES</a>
+        <a class="lang-option" href="/fr/" hreflang="fr">FR</a>
+        <a class="lang-option" href="/pt/" hreflang="pt">PT</a>
+        <a class="lang-option" href="/de/" hreflang="de">DE</a>
+        <a class="lang-option" href="/id/" hreflang="id">ID</a>
+        <a class="lang-option" href="/it/" hreflang="it">IT</a>
+        <a class="lang-option" href="/nl/" hreflang="nl">NL</a>
+        <a class="lang-option" href="/tr/" hreflang="tr">TR</a>
+        <a class="lang-option" href="/pl/" hreflang="pl">PL</a>
+        <a class="lang-option" href="/vi/" hreflang="vi">VI</a>
+        <a class="lang-option" href="/sv/" hreflang="sv">SV</a>
+        <a class="lang-option" href="/no/" hreflang="no">NO</a>
+        <a class="lang-option" href="/ja/" hreflang="ja">JA</a>
+        <a class="lang-option" href="/th/" hreflang="th">TH</a>
+        <a class="lang-option" href="/ru/" hreflang="ru">RU</a>
+        <a class="lang-option" href="/ar/" hreflang="ar">AR</a>
+      </div>
+    </div>
+  </footer>
+
+  <div class="copy-toast" id="copyToast">Copied!</div>
+
+  <script src="/styles.js" defer=""></script>
+<script src="/renderer.js" defer=""></script>
+<script src="/script.js" defer=""></script>
+<script src="/i18n.js" defer=""></script>
+
+
+
+
+<script src="/footer.js" defer=""></script>
+
+
+</body></html>

--- a/cs/kurziva/index.html
+++ b/cs/kurziva/index.html
@@ -1,0 +1,299 @@
+<!DOCTYPE html><html lang="cs"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZGVh");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Generátor kurzívy — 𝘬𝘶𝘳𝘻í𝘷𝘢 ke zkopírování | UltraTextGen</title>
+  <meta name="description" content="Bezplatný generátor kurzívy: převeď text na skloněná písmena Unicode ke zkopírování a vložení — do bia na Instagramu, na WhatsApp, TikTok, Discord a LinkedIn. Ihned, bez registrace.">
+  <link rel="canonical" href="https://ultratextgen.com/cs/kurziva/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/category/italic-fonts/">
+  <link rel="alternate" hreflang="cs" href="https://ultratextgen.com/cs/kurziva/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/category/italic-fonts/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Generátor kurzívy — 𝘬𝘶𝘳𝘻í𝘷𝘢 ke zkopírování | UltraTextGen">
+  <meta property="og:description" content="Bezplatný generátor kurzívy — skloněná písmena Unicode ke zkopírování a vložení na Instagram, TikTok, WhatsApp, Discord a LinkedIn. Ihned, bez registrace.">
+  <meta property="og:url" content="https://ultratextgen.com/cs/kurziva/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category-italic-fonts.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Generátor kurzívy — 𝘬𝘶𝘳𝘻í𝘷𝘢 ke zkopírování | UltraTextGen">
+  <meta name="twitter:description" content="Bezplatný generátor kurzívy — skloněná písmena Unicode ke zkopírování a vložení na sociálních sítích, v chatech a nickách.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category-italic-fonts.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "cs",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Jak vytvořit kurzívu ke zkopírování a vložení?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Napiš text do pole nahoře a generátor ho hned ukáže kurzívou (𝘵𝘢𝘬𝘰𝘷á 𝘫𝘢𝘬𝘰 𝘵𝘢𝘵𝘰) — jsou to opravdové znaky Unicode, ne nainstalované písmo ani obrázek. Protože jde o obyčejné textové znaky, můžeš je zkopírovat a vložit všude, kde se dá napsat text: do bia, popisků, komentářů a zpráv. Víc v našem průvodci o tom, jak funguje písmo Unicode."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Funguje kurzíva Unicode na Instagramu, WhatsAppu, TikToku a LinkedInu?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ano. Bio, popisky, komentáře i zprávy na chatu tyto znaky bez problémů přijmou. Hlavně na LinkedInu a X, kde nativní kurzíva chybí, skloněné písmo Unicode umožňuje zvýraznit nejdůležitější slova. Pozor: některá pole uživatelského jména (@) takové znaky odfiltrují — v samotném loginu zůstaň u obyčejného textu, ale v biu kurzíva funguje skvěle."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Podporuje kurzíva české znaky (á, č, ě, í, ř, š, ž)?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Kurzíva Unicode pokrývá základní abecedu A–Z a číslice 0–9, proto česká diakritika (á, č, ě, í, ň, ó, ř, š, ú, ů, ý, ž) nemá vlastní skloněnou podobu a zůstává obyčejnými písmeny uprostřed slova (např. „řeka“ vyjde jako ř𝘦𝘬𝘢). Pro nicky a krátká hesla bez diakritiky vypadá kurzíva perfektně; v delším textu je nejbezpečnější volit slova, která ji neobsahují."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Je generátor kurzívy zdarma?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ano, plně zdarma a bez registrace. Piš, kopíruj a vkládej, kolikrát chceš — není tu žádný limit ani skryté poplatky."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Proč se některá písmena kurzívy zobrazují jako prázdné čtverečky?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Prázdný čtvereček (▯) znamená, že zařízení příjemce nemá glyf pro daný skloněný znak — nejčastěji jde o starší telefon nebo počítač. Vyber jednodušší variantu kurzívy nebo zařízení aktualizuj — víc v textu o tom, proč se písmo zobrazuje jako čtverečky."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Ovlivňuje kurzíva Unicode čitelnost a dosah?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Skloněné znaky Unicode hezky přitahují pohled a skvěle slouží v heslech, titulcích a výzvách k akci na sociálních sítích. Používej je cíleně — krátký akcent kurzívou, zbytek obyčejným textem. V obsahu na vlastním webu je lepší použít sklonění přes CSS, aby vyhledávače četly běžná slova; v textových polích sociálních sítí je ideální kurzíva Unicode. U delších úseků nezapomeň na přístupnost."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "inLanguage": "cs",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Domů", "item": "https://ultratextgen.com/cs/" },
+    { "@type": "ListItem", "position": 2, "name": "Kurzíva", "item": "https://ultratextgen.com/cs/kurziva/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Generátor kurzívy",
+  "alternateName": ["Kurzíva ke zkopírování","Skloněné písmo","Skloněná písmena","Kurzíva Unicode","Písmo kurzíva","Text kurzívou","Kurzíva online"],
+  "url": "https://ultratextgen.com/cs/kurziva/",
+  "inLanguage": "cs",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "CZK"
+  },
+  "description": "Bezplatný generátor kurzívy: převádí text na skloněná písmena Unicode ke zkopírování a vložení na Instagram, TikTok, WhatsApp, Discord, LinkedIn a do nicků.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/cs/">Domů</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Kurzíva</span>
+</nav>
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/category-italic-fonts.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+  <!-- Hero -->
+  <section class="hero">
+    <div class="hero-inner">
+      <div class="hero-card">
+        <h1 class="hero-headline">Generátor kurzívy</h1>
+        <p class="hero-tagline">Proměň libovolný text v 𝘬𝘶𝘳𝘻í𝘷𝘶 ke zkopírování a vložení — elegantní,
+          skloněná písmena Unicode do bia, nicků a titulků. Zdarma, ihned, bez registrace.</p>
+        <div class="input-wrapper">
+          <textarea class="main-input" id="mainInput" placeholder="Napiš text, slovo nebo jméno…" maxlength="500" autofocus></textarea>
+          <span class="char-count"><span id="charCount">0</span>/500</span>
+        </div>
+
+        <!-- Decoration Selector -->
+        <div class="decoration-section">
+          <div class="decoration-label">
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"></path>
+            </svg>
+            Přidej symboly kolem výsledku
+          </div>
+          <div class="decoration-tabs">
+            <button class="decoration-tab active" data-deco-tab="symbols">Symboly</button>
+            <button class="decoration-tab" data-deco-tab="frames">Rámečky</button>
+            <button class="decoration-tab" data-deco-tab="dividers">Oddělovače</button>
+            <button class="decoration-tab" data-deco-tab="minimal">Minimalistické</button>
+            <button class="decoration-tab" data-deco-tab="emojis">Emoji</button>
+          </div>
+          <div class="decoration-grid" id="decorationGrid"></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Main Content -->
+  <main class="container">
+
+    <section class="editorial-section">
+      <span class="article-section-label">Kurzíva Unicode</span>
+      <h2>Kurzíva ke zkopírování — do bia, nicků a titulků</h2>
+      <p>Tato písmena nejsou nainstalované písmo ani obrázek, ale opravdové <strong>znaky Unicode</strong>. Zvýrazni
+        klíčové slovo v biu, udělej skloněný nick nebo zařiď, aby titulek na LinkedInu a X přitahoval pohled — všude tam,
+        kde nativní kurzíva chybí. Napiš text výše, klikni na <strong>Kopírovat</strong> a vlož kurzívu tam, kam chceš.</p>
+    </section>
+
+    <!-- Category Tabs (populated by script.js) -->
+    <div class="category-section">
+      <div class="category-tabs" id="categoryTabs"></div>
+    </div>
+
+    <!-- Results -->
+    <div class="results-grid" id="resultsGrid"></div>
+
+    <section class="editorial-section">
+      <span class="article-section-label">Související</span>
+      <p>Spoj kurzívu s <a href="/cs/pismo-pro-discord/">písmem na Discord</a>,
+        <a href="/cs/">písmeny ke zkopírování</a> nebo
+        <a href="/library/invisible-character/">neviditelným znakem</a> pro čisté mezery. Na tetování je
+        <a href="/usecase/tattoo-fonts/">generátor písma na tetování</a>, a na svislé sazby —
+        <a href="/usecase/vertical-text/">svislý text</a>.</p>
+    </section>
+  </main>
+
+  <!-- Footer + FAQ -->
+  <footer class="footer">
+    <div class="footer-inner">
+<div class="faq-section" id="faq">
+
+<h2 class="faq-category">Generátor kurzívy — FAQ</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Jak vytvořit kurzívu ke zkopírování a vložení?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Napiš text do pole nahoře a generátor ho hned ukáže kurzívou (𝘵𝘢𝘬𝘰𝘷á 𝘫𝘢𝘬𝘰 𝘵𝘢𝘵𝘰) — jsou to opravdové znaky Unicode, ne nainstalované písmo ani obrázek. Protože jde o obyčejné textové znaky, můžeš je zkopírovat a vložit všude, kde se dá napsat text: do bia, popisků, komentářů a zpráv. Víc v našem <a href="/guide/how-unicode-fonts-work/">průvodci o tom, jak funguje písmo Unicode</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Funguje kurzíva Unicode na Instagramu, WhatsAppu, TikToku a LinkedInu?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Ano. Bio, popisky, komentáře i zprávy na chatu tyto znaky bez problémů přijmou. Hlavně na LinkedInu a X, kde nativní kurzíva chybí, skloněné písmo Unicode umožňuje zvýraznit nejdůležitější slova. Pozor: některá <strong>pole uživatelského jména (@)</strong> takové znaky odfiltrují — v samotném loginu zůstaň u obyčejného textu, ale v biu kurzíva funguje skvěle.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Podporuje kurzíva české znaky (á, č, ě, í, ř, š, ž)?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Kurzíva Unicode pokrývá základní abecedu A–Z a číslice 0–9, proto česká diakritika (á, č, ě, í, ň, ó, ř, š, ú, ů, ý, ž) nemá vlastní skloněnou podobu a zůstává obyčejnými písmeny uprostřed slova (např. „řeka“ vyjde jako ř𝘦𝘬𝘢). Pro nicky a krátká hesla <strong>bez diakritiky</strong> vypadá kurzíva perfektně; v delším textu je nejbezpečnější volit slova, která ji neobsahují.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Je generátor kurzívy zdarma?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Ano, plně zdarma a bez registrace. Piš, kopíruj a vkládej, kolikrát chceš — není tu žádný limit ani skryté poplatky.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Proč se některá písmena kurzívy zobrazují jako prázdné čtverečky?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Prázdný čtvereček (▯) znamená, že zařízení příjemce nemá glyf pro daný skloněný znak — nejčastěji jde o starší telefon nebo počítač. Vyber jednodušší variantu kurzívy nebo zařízení aktualizuj — víc v textu o tom, <a href="/guide/why-fonts-show-as-boxes/">proč se písmo zobrazuje jako čtverečky</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Ovlivňuje kurzíva Unicode čitelnost a dosah?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Skloněné znaky Unicode hezky přitahují pohled a skvěle slouží v heslech, titulcích a výzvách k akci na sociálních sítích. Používej je cíleně — krátký akcent kurzívou, zbytek obyčejným textem. V obsahu na vlastním webu je lepší použít sklonění přes CSS, aby vyhledávače četly běžná slova; v textových polích sociálních sítí je ideální kurzíva Unicode. U delších úseků nezapomeň na <a href="/guide/fancy-fonts-accessibility-guide/">přístupnost</a>.
+  </div>
+</div>
+
+</div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Language switcher">
+      <a class="lang-option" href="/category/italic-fonts/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/cs/kurziva/" hreflang="cs">CS</a>
+    </div>
+
+    </div>
+  </footer>
+
+  <div class="copy-toast" id="copyToast">Zkopírováno!</div>
+
+  <script>
+    window.UTG_FAMILY = "italic";
+    window.UTG_DEMO_TEXT = "kurzíva online\nstylový text";
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/script.js" defer></script>
+  <script src="/footer.js" defer></script>
+</body></html>

--- a/cs/male-pismo/index.html
+++ b/cs/male-pismo/index.html
@@ -1,0 +1,299 @@
+<!DOCTYPE html><html lang="cs"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZGVh");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Generátor malého písma — ᴍᴀʟé ᴘísᴍᴏ a kapitálky ke zkopírování | UltraTextGen</title>
+  <meta name="description" content="Bezplatný generátor malého písma: převeď text na malý text Unicode a kapitálky ke zkopírování a vložení — do bia na Instagramu, Discordu, TikToku, X a do nicků. Ihned, bez registrace.">
+  <link rel="canonical" href="https://ultratextgen.com/cs/male-pismo/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/category/small-text/">
+  <link rel="alternate" hreflang="cs" href="https://ultratextgen.com/cs/male-pismo/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/category/small-text/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Generátor malého písma — ᴍᴀʟé ᴘísᴍᴏ a kapitálky ke zkopírování | UltraTextGen">
+  <meta property="og:description" content="Bezplatný generátor malého písma — malý text Unicode a kapitálky ke zkopírování a vložení na Instagram, TikTok, Discord a X. Ihned, bez registrace.">
+  <meta property="og:url" content="https://ultratextgen.com/cs/male-pismo/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category-small-text.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Generátor malého písma — ᴍᴀʟé ᴘísᴍᴏ a kapitálky ke zkopírování | UltraTextGen">
+  <meta name="twitter:description" content="Bezplatný generátor malého písma — malý text Unicode a kapitálky ke zkopírování a vložení do sociálních sítí, chatů a nicků.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category-small-text.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "cs",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Co je malé písmo a jak funguje generátor malého písma?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Generátor převádí písmena, která napíšeš, na menší znaky Unicode — kapitálky (ᴍᴀʟé ᴘísᴍᴏ) i malý text v horním a dolním indexu. Jsou to opravdové znaky, ne písmo ani obrázek, proto je můžeš zkopírovat a vložit všude, kde je povolený text: do bia, popisků, komentářů a zpráv. Víc v našem průvodci o tom, jak funguje písmo Unicode."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Funguje malé písmo na Discordu, Instagramu, TikToku a X?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ano. Bio, popisky, komentáře i zprávy na chatu malý text obvykle bez problémů přijmou. Dobře se hodí jako druhoplánový, jemný popis pod nickem nebo decentní podpis, který nekřičí tak jako velké tučné písmo. Kompatibilita ale závisí na stylu a zařízení — nejlíp výsledek vlož a podívej se, jak vypadá v dané aplikaci."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Čím se liší kapitálky od malého textu v horním indexu?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Kapitálky jsou malé verzálky (ᴋᴀᴘɪᴛáʟᴋʏ) — písmena mají tvar velkých písmen, ale výšku malých, takže text zůstává čitelný a elegantní. Malý text v horním indexu (ᵗᵃᵏᵉᵗᵒ) nebo dolním je ještě drobnější a lehce nadzvednutý nebo snížený, proto se skvěle hodí na krátké ozdobné akcenty. Na delší fráze obvykle lépe vypadají kapitálky."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Můžu psát české znaky (á, č, ď, é, ě, í, ň, ó, ř, š, ť, ú, ů, ý, ž) malým písmem?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Malé varianty Unicode pokrývají hlavně A–Z a část číslic, proto české znaky jako á, č, ě, ř, š, ž nemají vlastní malou podobu a zůstávají v normální velikosti. Pro jednotný efekt je můžeš nahradit základními písmeny (a, c, e, r, s, z) — mění to ovšem pravopis — nebo je nechat beze změny, což u krátkého nicku nebo podpisu obvykle stejně vypadá dobře."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Je generátor malého písma zdarma?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ano, plně zdarma a bez registrace. Piš, kopíruj a vkládej, kolikrát chceš — není tu žádný limit ani skryté náklady. Vše běží v prohlížeči, takže nic neinstaluješ."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Proč se některá malá písmena zobrazují jako čtverečky a ovlivňují čitelnost?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Prázdný čtvereček (▯) znamená, že zařízení nemá odpovídající glyf pro daný malý znak — týká se to většinou starších systémů. Vyber v takovém případě jednodušší styl (např. kapitálky) nebo zařízení aktualizuj; víc v článku o tom, proč se písmo zobrazuje jako čtverečky. Pamatuj taky, že velmi malý text se hůř čte — používej ho na krátké fráze a nejdůležitější informace nech obyčejným textem kvůli přístupnosti."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "inLanguage": "cs",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Domů", "item": "https://ultratextgen.com/cs/" },
+    { "@type": "ListItem", "position": 2, "name": "Malé písmo", "item": "https://ultratextgen.com/cs/male-pismo/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Generátor malého písma",
+  "alternateName": ["Malé písmo","Malý text","Generátor malého písma","Kapitálky","Malá písmenka ke zkopírování","Malý text Unicode","Drobný text","Malé nápisy"],
+  "url": "https://ultratextgen.com/cs/male-pismo/",
+  "inLanguage": "cs",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "CZK"
+  },
+  "description": "Bezplatný generátor malého písma: převeď text na malý text Unicode a kapitálky ke zkopírování a vložení na Instagram, TikTok, Discord, X a do nicků.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/cs/">Domů</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Malé písmo</span>
+</nav>
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/category-small-text.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+  <!-- Hero -->
+  <section class="hero">
+    <div class="hero-inner">
+      <div class="hero-card">
+        <h1 class="hero-headline">Generátor malého písma</h1>
+        <p class="hero-tagline">Proměň libovolný text v ᴍᴀʟé ᴘísᴍᴏ a kapitálky ke zkopírování a vložení — jemné,
+          drobné znaky Unicode do bia, nicků a podpisů. Zdarma, ihned, bez registrace.</p>
+        <div class="input-wrapper">
+          <textarea class="main-input" id="mainInput" placeholder="Napiš text, slovo nebo jméno…" maxlength="500" autofocus></textarea>
+          <span class="char-count"><span id="charCount">0</span>/500</span>
+        </div>
+
+        <!-- Decoration Selector -->
+        <div class="decoration-section">
+          <div class="decoration-label">
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"></path>
+            </svg>
+            Přidej symboly kolem výsledku
+          </div>
+          <div class="decoration-tabs">
+            <button class="decoration-tab active" data-deco-tab="symbols">Symboly</button>
+            <button class="decoration-tab" data-deco-tab="frames">Rámečky</button>
+            <button class="decoration-tab" data-deco-tab="dividers">Oddělovače</button>
+            <button class="decoration-tab" data-deco-tab="minimal">Minimalistické</button>
+            <button class="decoration-tab" data-deco-tab="emojis">Emoji</button>
+          </div>
+          <div class="decoration-grid" id="decorationGrid"></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Main Content -->
+  <main class="container">
+
+    <section class="editorial-section">
+      <span class="article-section-label">Malý text Unicode</span>
+      <h2>Malé písmo ke zkopírování — do bia, nicků a podpisů</h2>
+      <p>Tato písmena nejsou písmo ani obrázek, ale opravdové <strong>znaky Unicode</strong>. Přidej jemný popis
+        pod nick, napiš jméno elegantními <strong>kapitálkami</strong> nebo vpleť drobný text v horním indexu
+        tam, kde by velké tučné písmo bylo příliš křiklavé. Napiš text výše, klikni na <strong>Kopírovat</strong>
+        a vlož malé písmo, kam chceš.</p>
+    </section>
+
+    <!-- Category Tabs (populated by script.js) -->
+    <div class="category-section">
+      <div class="category-tabs" id="categoryTabs"></div>
+    </div>
+
+    <!-- Results -->
+    <div class="results-grid" id="resultsGrid"></div>
+
+    <section class="editorial-section">
+      <span class="article-section-label">Související</span>
+      <p>Spoj malé písmo s <a href="/cs/tucne-pismo/">tučným písmem</a>,
+        <a href="/library/aesthetic-symbols/">ozdobami</a> nebo <a href="/library/invisible-character/">neviditelným znakem</a>
+        pro čisté mezery. Mrkni taky na <a href="/cs/">písmena ke zkopírování</a>,
+        a na svislé sazby — <a href="/usecase/vertical-text/">svislý text</a>.</p>
+    </section>
+  </main>
+
+  <!-- Footer + FAQ -->
+  <footer class="footer">
+    <div class="footer-inner">
+<div class="faq-section" id="small-faq">
+
+<h2 class="faq-category">Generátor malého písma — FAQ</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Co je malé písmo a jak funguje generátor malého písma?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Generátor převádí písmena, která napíšeš, na menší znaky Unicode — kapitálky (ᴍᴀʟé ᴘísᴍᴏ) i malý text v horním a dolním indexu. Jsou to opravdové znaky, ne písmo ani obrázek, proto je můžeš zkopírovat a vložit všude, kde je povolený text: do bia, popisků, komentářů a zpráv. Víc v našem <a href="/guide/how-unicode-fonts-work/">průvodci o tom, jak funguje písmo Unicode</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Funguje malé písmo na Discordu, Instagramu, TikToku a X?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Ano. Bio, popisky, komentáře i zprávy na chatu malý text obvykle bez problémů přijmou. Dobře se hodí jako druhoplánový, jemný popis pod nickem nebo decentní podpis, který nekřičí tak jako velké tučné písmo. Kompatibilita ale závisí na stylu a zařízení — nejlíp výsledek vlož a podívej se, jak vypadá v dané aplikaci.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Čím se liší kapitálky od malého textu v horním indexu?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Kapitálky jsou malé verzálky (ᴋᴀᴘɪᴛáʟᴋʏ) — písmena mají tvar velkých písmen, ale výšku malých, takže text zůstává čitelný a elegantní. Malý text v horním indexu (ᵗᵃᵏᵉᵗᵒ) nebo dolním je ještě drobnější a lehce nadzvednutý nebo snížený, proto se skvěle hodí na krátké ozdobné akcenty. Na delší fráze obvykle lépe vypadají <strong>kapitálky</strong>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Můžu psát české znaky (á, č, ď, é, ě, í, ň, ó, ř, š, ť, ú, ů, ý, ž) malým písmem?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Malé varianty Unicode pokrývají hlavně A–Z a část číslic, proto české znaky jako á, č, ě, ř, š, ž nemají vlastní malou podobu a zůstávají v normální velikosti. Pro jednotný efekt je můžeš nahradit základními písmeny (<strong>a, c, e, r, s, z</strong>) — mění to ovšem pravopis — nebo je nechat beze změny, což u krátkého nicku nebo podpisu obvykle stejně vypadá dobře.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Je generátor malého písma zdarma?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Ano, plně zdarma a bez registrace. Piš, kopíruj a vkládej, kolikrát chceš — není tu žádný limit ani skryté náklady. Vše běží v prohlížeči, takže nic neinstaluješ.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Proč se některá malá písmena zobrazují jako čtverečky a ovlivňují čitelnost?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Prázdný čtvereček (▯) znamená, že zařízení nemá odpovídající glyf pro daný malý znak — týká se to většinou starších systémů. Vyber v takovém případě jednodušší styl (např. kapitálky) nebo zařízení aktualizuj; víc v článku o tom, <a href="/guide/why-fonts-show-as-boxes/">proč se písmo zobrazuje jako čtverečky</a>. Pamatuj taky, že velmi malý text se hůř čte — používej ho na krátké fráze a nejdůležitější informace nech obyčejným textem kvůli <a href="/guide/fancy-fonts-accessibility-guide/">přístupnosti</a>.
+  </div>
+</div>
+
+</div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Výběr jazyka">
+      <a class="lang-option" href="/category/small-text/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/cs/male-pismo/" hreflang="cs">CS</a>
+    </div>
+
+    </div>
+  </footer>
+
+  <div class="copy-toast" id="copyToast">Zkopírováno!</div>
+
+  <script>
+    window.UTG_FAMILY = "small-text";
+    window.UTG_DEMO_TEXT = "malé písmo\nmalý text";
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/script.js" defer></script>
+  <script src="/footer.js" defer></script>
+</body></html>

--- a/cs/pismo-pro-discord/index.html
+++ b/cs/pismo-pro-discord/index.html
@@ -1,0 +1,302 @@
+<!DOCTYPE html><html lang="cs"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Písmo pro Discord: písmenka do nicku a bia (bez Nitra) | UltraTextGen</title>
+  <meta name="description" content="Písmo pro Discord zdarma: převeď jméno na 𝘁𝘂č𝗻é, 𝓴𝓾𝓻𝔃𝓲𝓿𝓾 nebo 𝔤𝔬𝔱𝔦𝔨𝔲 a vlož do nicku, do sekce „O mně“ a na chat. Písmo pro Discord bez Nitra.">
+  <link rel="canonical" href="https://ultratextgen.com/cs/pismo-pro-discord/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/discord/">
+  <link rel="alternate" hreflang="cs" href="https://ultratextgen.com/cs/pismo-pro-discord/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/discord/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Písmo pro Discord: písmenka do nicku a bia (bez Nitra)">
+  <meta property="og:description" content="Generátor písma pro Discord: napiš jméno a vlož stylové písmenko do nicku, do „O mně“, do názvu kanálu a do statusu. Tučné, kurzíva a gotika — bez Nitra.">
+  <meta property="og:url" content="https://ultratextgen.com/cs/pismo-pro-discord/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/pl-czcionki-discord.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Písmo pro Discord: písmenka do nicku a bia (bez Nitra)">
+  <meta name="twitter:description" content="Tučné, kurzíva, gotika a bublinková připravené k vložení do nicku a „O mně“ na Discordu — bez Nitra.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/pl-czcionki-discord.png">
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+  <link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Generátor písma pro Discord",
+  "alternateName": ["Písmo pro Discord", "Písmo na Discord", "Písmenka pro Discord", "Generátor nicku na Discord"],
+  "url": "https://ultratextgen.com/cs/pismo-pro-discord/",
+  "inLanguage": "cs",
+  "applicationCategory": "UtilitiesApplication",
+  "operatingSystem": "Any",
+  "description": "Generátor písma pro Discord: převede tvé jméno na stylizovaná písmenka — tučná, kurzívu, gotiku, bublinková, elegantní a kapitálky — k vložení do nicku, do „O mně“, do názvu kanálu a do statusu, bez nutnosti mít Nitro.",
+  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "CZK" }
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "cs",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Jak změnit písmo v nicku na Discordu?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Napiš své jméno do pole nahoře na stránce. Hned se objeví desítky písem pro Discord — tučné, kurzíva, gotické, bublinková, kapitálky. Klikni na „Kopírovat“ u toho, které se ti líbí, otevři Discord, přejdi do Nastavení uživatele a vlož ho do zobrazovaného jména, nebo klikni pravým tlačítkem na serveru a změň přezdívku na tomto serveru. Protože jde o znaky Unicode, stylové písmenko se vloží do pole bez jakéhokoli pluginu." }
+    },
+    {
+      "@type": "Question",
+      "name": "Je k písmu na Discordu potřeba Nitro?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Ne. Písmenka z tohoto generátoru jsou obyčejné znaky Unicode, stejné jako z klávesnice, jen s jiným vzhledem — proto se vloží do zobrazovaného jména, do přezdívky na serveru, do sekce „O mně“, do názvu kanálu a do zpráv bez jakéhokoli Nitra. Nitro je potřeba jen na placené doplňky, jako jsou barvy a přechod ve jménu (Display Name Styles), ne na samotný stylový text." }
+    },
+    {
+      "@type": "Question",
+      "name": "Fungují písma v uživatelském jménu (@) na Discordu?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Ne. Uživatelské jméno (unikátní @ používané k pozvánkám mezi přátele) přijímá jen malá písmena a až z, číslice, tečku a podtržítko — žádné stylové písmo, mezery, emoji ani symboly. Písmo pro Discord funguje v zobrazovaném jméně, v serverové přezdívce, v sekci „O mně“, v názvu kanálu a na chatu. Pokud chceš styl ve jménu, použij zobrazované jméno, ne login @." }
+    },
+    {
+      "@type": "Question",
+      "name": "Čím se liší formátování Discordu (**tučné**) od písem Unicode?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Jsou to dvě různé věci. Markdown Discordu (**tučné**, *kurzíva*, `kód`) formátuje text jen uvnitř zpráv na chatu a zmizí, když ho zkusíš použít ve jméně nebo v biu. Písma Unicode z této stránky jsou samotný ostylovaný znak, takže fungují všude — v nicku, v „O mně“, v názvu kanálu, ve statusu i na chatu. Praktické pravidlo: v běžné zprávě použij Markdown, a pro ostylování nicku nebo bia použij písmo Unicode." }
+    },
+    {
+      "@type": "Question",
+      "name": "Jak udělat ozdobný nick na Discord s rámečky a symboly?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Vyber písmo na jméno (gotika a bublinková vycházejí nejlíp) a obklop ho rámečky a symboly ve stylu ꧁༒ ༒꧂. Na této stránce je mřížka hotových nicků s rámečky — klikni a zkopíruj a vlož do přezdívky na serveru. Můžeš taky napsat své jméno nahoře, nasadit písmo a použít záložky Symboly a Rámečky, aby sis vzhled doladil před zkopírováním." }
+    },
+    {
+      "@type": "Question",
+      "name": "Proč se písmenka na Discordu zobrazují jako čtverečky?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Protože zařízení toho, kdo si to prohlíží, nemá písmo, které daný znak vykreslí — obvykle jde o starší telefon nebo počítač. Není to chyba stránky ani tvého kopírování. Základní styly — tučné, kurzíva, gotika, bublinková a kapitálky — jsou nejbezpečnější a zobrazí se správně skoro všude. Pokud někdo nahlásí čtvereček (□), přepni na jeden z těchto stylů." }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "inLanguage": "cs",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Domů", "item": "https://ultratextgen.com/cs/" },
+    { "@type": "ListItem", "position": 2, "name": "Písmo pro Discord", "item": "https://ultratextgen.com/cs/pismo-pro-discord/" }
+  ]
+}
+</script>
+</head>
+<body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<script src="/header.js"></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/cs/">Domů</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Písmo pro Discord</span>
+</nav>
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pl-czcionki-discord.svg" width="1200" height="340" loading="lazy" alt="">
+</figure>
+
+<section class="hero">
+  <div class="hero-inner">
+    <div class="hero-card">
+      <h1 class="hero-headline">Písmo pro Discord: písmenka do nicku a bia</h1>
+      <p class="hero-tagline">Napiš své jméno a hned ho uvidíš v desítkách písem pro Discord — tučné, kurzíva, gotické, bublinková a kapitálky. Zkopíruješ a vložíš do nicku, do serverové přezdívky, do sekce „O mně“, do názvu kanálu a na chat. Vše zdarma a <strong>bez Nitra</strong>.</p>
+      <div class="input-wrapper">
+        <textarea class="main-input" id="mainInput" placeholder="Napiš jméno nebo text..." maxlength="500" autofocus=""></textarea>
+        <span class="char-count"><span id="charCount">0</span>/500</span>
+      </div>
+      <div class="decoration-section">
+        <div class="decoration-label">Přidej symboly a rámečky k výsledku</div>
+        <div class="decoration-tabs">
+          <button class="decoration-tab active" data-deco-tab="symbols">Symboly</button>
+          <button class="decoration-tab" data-deco-tab="frames">Rámečky</button>
+          <button class="decoration-tab" data-deco-tab="dividers">Oddělovače</button>
+          <button class="decoration-tab" data-deco-tab="arrows">Šipky</button>
+          <button class="decoration-tab" data-deco-tab="minimal">Minimalistické</button>
+          <button class="decoration-tab" data-deco-tab="emojis">Emoji</button>
+        </div>
+        <div class="decoration-grid" id="decorationGrid"></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<main class="container">
+  <div class="category-section"><div class="category-tabs" id="categoryTabs"></div></div>
+  <div class="results-grid" id="resultsGrid"></div>
+
+  <!-- Jak to funguje -->
+  <section class="editorial-section">
+    <h2>Písmo pro Discord: jak to funguje</h2>
+    <p class="editorial-intro"><strong>Písmo pro Discord</strong> z této stránky není nainstalované písmo ani obrázek — jsou to <strong>znaky Unicode</strong>, opravdová písmena, stejná jako z klávesnice, jen s jiným vzhledem (𝗔, 𝘈, 𝓐, 𝔄). Protože Discord přijímá Unicode skoro v každém textovém poli, stylové písmenko se vloží rovnou do tvého <strong>zobrazovaného jména</strong>, do <strong>serverové přezdívky</strong>, do sekce <strong>„O mně“</strong>, do <strong>názvu kanálu</strong>, do <strong>statusu</strong> a dokonce i do <strong>zpráv</strong> — bez Nitra, pluginu nebo aplikace navíc.</p>
+    <div class="block-example">
+      <strong>Příklad:</strong> „adam“ → 𝗮𝗱𝗮𝗺 (tučné), 𝘢𝘥𝘢𝘮 (kurzíva), 𝓪𝓭𝓪𝓶 (ozdobná kurzíva), 𝔞𝔡𝔞𝔪 (gotické), ⓐⓓⓐⓜ (bublinková), ᴀᴅᴀᴍ (kapitálky)
+    </div>
+    <p>Používá se to během pár vteřin: napíšeš jméno do pole nahoře, generátor ukáže tentýž text v mnoha <strong>písmech pro Discord</strong>, klikneš na „Kopírovat“ a vložíš v aplikaci. Chceš jen holá písmena abecedy? Jsou hned pod tím. A pokud chceš procházet ještě víc řezů, plný generátor najdeš na stránce s <a href="/cs/">písmeny ke zkopírování</a>.</p>
+  </section>
+
+  <!-- Abeceda A-Z -->
+  <section class="editorial-section glyph-section">
+    <h2>Abeceda písem pro Discord (A–Z ke zkopírování)</h2>
+    <p class="editorial-intro">Celá abeceda ve stylech, které se v nickách a biích na Discordu objevují nejčastěji. Klikni na daný řádek a zkopíruj celou abecedu v tom stylu, nebo napiš své jméno nahoře a vezmi si vlastní slovo rovnou ostylované.</p>
+    <div class="alpha-list">
+      <div class="alpha-row">
+        <span class="alpha-label">Tučné</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝗔𝗕𝗖𝗗𝗘𝗙𝗚𝗛𝗜𝗝𝗞𝗟𝗠𝗡𝗢𝗣𝗤𝗥𝗦𝗧𝗨𝗩𝗪𝗫𝗬𝗭 𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇" aria-label="Kopírovat tučnou abecedu">𝗔𝗕𝗖𝗗𝗘𝗙𝗚𝗛𝗜𝗝𝗞𝗟𝗠𝗡𝗢𝗣𝗤𝗥𝗦𝗧𝗨𝗩𝗪𝗫𝗬𝗭 · 𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Kurzíva</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩 𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃" aria-label="Kopírovat abecedu kurzívou">𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩 · 𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Elegantní</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵 𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏" aria-label="Kopírovat elegantní abecedu">𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵 · 𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Gotické</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝔄𝔅ℭ𝔇𝔈𝔉𝔊ℌℑ𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔ℜ𝔖𝔗𝔘𝔙𝔚𝔛𝔜ℨ 𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷" aria-label="Kopírovat gotickou abecedu">𝔄𝔅ℭ𝔇𝔈𝔉𝔊ℌℑ𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔ℜ𝔖𝔗𝔘𝔙𝔚𝔛𝔜ℨ · 𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Bublinková</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ" aria-label="Kopírovat bublinkovou abecedu">ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ · ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Kapitálky</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="ᴀʙᴄᴅᴇꜰɢʜɪᴊᴋʟᴍɴᴏᴘqʀsᴛᴜᴠᴡxʏᴢ" aria-label="Kopírovat abecedu v kapitálkách">ᴀ ʙ ᴄ ᴅ ᴇ ꜰ ɢ ʜ ɪ ᴊ ᴋ ʟ ᴍ ɴ ᴏ ᴘ q ʀ s ᴛ ᴜ ᴠ ᴡ x ʏ ᴢ</button>
+      </div>
+    </div>
+    <p class="uname-note">Poznámka o českých znacích: tato písma Unicode pokrývají základní abecedu A–Z. Česká diakritika (á, č, ě, í, ň, ó, ř, š, ú, ů, ý, ž) ve většině stylů zůstává obyčejnými písmeny uprostřed ostylovaného slova — proto např. „adam“ vyjde perfektně, kdežto „řehoř“ ukáže ř jako obyčejné písmeno. Pro nicky bez diakritiky to vypadá skvěle a pro delší texty jsou nejbezpečnější tučné a kurzíva.</p>
+    <p class="u-mt-15">Chceš se zakousnout do jednoho stylu? Celou abecedu a varianty každého řezu najdeš na stránce s <a href="/cs/">písmeny ke zkopírování</a>, a hvězdičky a rámečky do nicku — v <a href="/library/aesthetic-symbols/">ozdobách</a>.</p>
+  </section>
+
+  <!-- Písmo do nicku a O mně -->
+  <section class="editorial-section">
+    <h2>Písmo do nicku a sekce „O mně“ na Discordu</h2>
+    <p class="editorial-intro">Nejrychlejší způsob, jak vypíchnout profil, je nasadit písmo na <strong>zobrazované jméno</strong> a zvlášť ho poskládat v sekci <strong>„O mně“</strong> (bio profilu). Discord přijímá Unicode v obou polích — a k tomu můžeš mít <strong>jinou přezdívku na každém serveru</strong>, takže na herním serveru používáš gotiku a na serveru s kamarády kurzívu, vše pod stejným účtem.</p>
+    <p class="uname-note">Jak vložit:</p>
+    <div class="block-example">
+      — <strong>Zobrazované jméno:</strong> Nastavení uživatele › Profil › uprav zobrazované jméno a vlož písmo<br>
+      — <strong>Serverová přezdívka:</strong> klikni pravým na svém jméně na serveru › Upravit profil serveru › vlož stylovou přezdívku<br>
+      — <strong>„O mně“:</strong> Nastavení uživatele › Profil › pole „O mně“ › vlož text<br>
+      — <strong>Název kanálu:</strong> pokud jsi administrátor, uprav kanál a vlož písmo do názvu
+    </div>
+    <p>Rada od někoho, kdo profily skládá denně: ostyluj samotné jméno a zbytek „O mně“ nech obyčejným textem — celý efekt dělá ten kontrast. Když je všechno ozdobné, nic nepřitahuje pohled. Pro jednotlivé hvězdičky a třpytky do bia mrkni na stránku s <a href="/library/aesthetic-symbols/">ozdobami ke zkopírování</a>.</p>
+  </section>
+
+  <!-- Markdown vs Unicode -->
+  <section class="editorial-section">
+    <h2>Markdown Discordu vs písma Unicode — kdy co použít</h2>
+    <p class="editorial-intro">Discord má <strong>dva způsoby</strong>, jak si pohrát s textem, a vyplatí se je neplést. Jeden je nativní <strong>formátování Markdown</strong>, druhý jsou <strong>písma Unicode</strong> z této stránky. Slouží k různým věcem.</p>
+    <div class="block-example">
+      — <strong>Markdown (nativní):</strong> <code>**tučné**</code> → <strong>tučné</strong>, <code>*kurzíva*</code> → <em>kurzíva</em>, <code>__podtržení__</code>, <code>~~přeškrtnutí~~</code>, <code>`kód`</code>. Funguje jen <strong>uvnitř zpráv</strong> na chatu a zmizí, když to zkusíš ve jméně nebo v biu.<br>
+      — <strong>Písma Unicode (tato stránka):</strong> 𝘁𝘂č𝗻é, 𝓴𝓾𝓻𝔃𝓲𝓿𝓪, 𝔤𝔬𝔱𝔦𝔨𝔞. Je to samotný ostylovaný znak, takže funguje <strong>všude</strong> — v nicku, v „O mně“, v názvu kanálu, ve statusu i na chatu.
+    </div>
+    <p>Praktické pravidlo: k naformátování běžné <strong>zprávy</strong> (ztučnit slovo uprostřed věty) použij Markdown Discordu — je čistší. Pro ostylování <strong>nicku, bia nebo názvu kanálu</strong> použij písmo Unicode, protože Markdown tam nezafunguje. A důležité varování: nic z toho nefunguje v <strong>uživatelském jménu (@)</strong>, které přijímá jen malá písmena a až z, číslice, tečku a podtržítko — žádné písmo, mezery ani emoji. Pokud chceš styl ve jménu, správným polem je zobrazované jméno, ne login @.</p>
+  </section>
+
+  <!-- Ozdobné nicky s rámečky -->
+  <section class="editorial-section">
+    <h2>Ozdobné nicky na Discord s rámečky a symboly</h2>
+    <p class="editorial-intro">Nicky, které na Discordu udělají největší dojem, kombinují výrazné písmo (gotika nebo bublinková) s rámečky a symboly po obou stranách, ve stylu ꧁༒ ༒꧂. Klikni a zkopíruj a vlož do přezdívky na serveru — potom vyměň za své jméno.</p>
+    <div class="uname-grid">
+      <button class="uname-chip symbol-tile" data-symbol="꧁༒𝕯𝖆𝖗𝖐༒꧂" aria-label="Kopírovat nick">꧁༒𝕯𝖆𝖗𝖐༒꧂</button>
+      <button class="uname-chip symbol-tile" data-symbol="꧁༒𝕶𝖆𝖈𝖕𝖊𝖗༒꧂" aria-label="Kopírovat nick">꧁༒𝕶𝖆𝖈𝖕𝖊𝖗༒꧂</button>
+      <button class="uname-chip symbol-tile" data-symbol="★彡ᴋᴜʙᴀ彡★" aria-label="Kopírovat nick">★彡ᴋᴜʙᴀ彡★</button>
+      <button class="uname-chip symbol-tile" data-symbol="⋆˚࿔ 𝓏𝓊𝓏𝒾𝒶 𝜗𝜚˚⋆" aria-label="Kopírovat nick">⋆˚࿔ 𝓏𝓊𝓏𝒾𝒶 𝜗𝜚˚⋆</button>
+      <button class="uname-chip symbol-tile" data-symbol="꧁✿𝓞𝓵𝓪✿꧂" aria-label="Kopírovat nick">꧁✿𝓞𝓵𝓪✿꧂</button>
+      <button class="uname-chip symbol-tile" data-symbol="✧˖°𝕁𝕦𝕝𝕚𝕒°˖✧" aria-label="Kopírovat nick">✧˖°𝕁𝕦𝕝𝕚𝕒°˖✧</button>
+      <button class="uname-chip symbol-tile" data-symbol="⛧🖤 𝔩𝔲𝔨𝔞𝔰 🖤⛧" aria-label="Kopírovat nick">⛧🖤 𝔩𝔲𝔨𝔞𝔰 🖤⛧</button>
+      <button class="uname-chip symbol-tile" data-symbol="「 ᴍᴀᴛᴇᴜsᴢ 」" aria-label="Kopírovat nick">「 ᴍᴀᴛᴇᴜsᴢ 」</button>
+      <button class="uname-chip symbol-tile" data-symbol="༺ 𝕾𝖍𝖆𝖉𝖔𝖜 ༻" aria-label="Kopírovat nick">༺ 𝕾𝖍𝖆𝖉𝖔𝖜 ༻</button>
+      <button class="uname-chip symbol-tile" data-symbol="⋆｡˚ⓝⓐⓣⓘⓐ˚｡⋆" aria-label="Kopírovat nick">⋆｡˚ⓝⓐⓣⓘⓐ˚｡⋆</button>
+    </div>
+    <p class="u-mt-15">Chceš celou sadu hotových rámečků, hvězdiček a oddělovačů na sestavení vlastního nicku? Kompletní paleta je na stránce s <a href="/library/aesthetic-symbols/">ozdobami ke zkopírování</a> — tytéž znaky se vloží do přezdívky tvého serveru na Discordu.</p>
+  </section>
+
+  <!-- Kde funguje + čtverečky -->
+  <section class="editorial-section">
+    <h2>Kde funguje písmo na Discordu (a poznámka o čtverečcích)</h2>
+    <p class="editorial-intro">Protože to, co kopíruješ, je čistý Unicode, písmenka pro Discord se vloží prakticky do každého textového pole aplikace:</p>
+    <div class="block-example">
+      — <strong>Zobrazované jméno</strong> a <strong>serverová přezdívka</strong> (zvlášť na každém serveru)<br>
+      — <strong>„O mně“</strong> (bio tvého profilu)<br>
+      — <strong>Název kanálu</strong> (pokud máš oprávnění administrátora)<br>
+      — <strong>Vlastní status</strong> a <strong>zprávy</strong> na chatu<br>
+      — <strong>Název serveru</strong> (pokud jsi jeho vlastník)
+    </div>
+    <p>Jediné místo, kde to <strong>ne</strong>funguje, je <strong>uživatelské jméno (@)</strong>, záměrně omezené na malá písmena, číslice, tečku a podtržítko. Kromě toho upřímná poznámka: pokud je zařízení toho, kdo si to prohlíží, hodně staré, část vzácnějších stylů se může zobrazit jako <strong>čtverečky (□)</strong> — to je chybějící písmo na jeho zařízení, ne problém s tvým textem. Když se držíš základních stylů (tučné, kurzíva, gotika, bublinková, kapitálky), skoro nikdy se to nestane. A pamatuj: nic z toho nevyžaduje <strong>Nitro</strong> — Nitro vstupuje jen u barvy a přechodu ve jméně, ne u samotného stylového textu. Na prázdné řádky v „O mně“ se hodí <a href="/library/invisible-character/">neviditelný znak</a>.</p>
+  </section>
+
+  <!-- Related -->
+  <section class="editorial-section">
+    <span class="article-section-label">Související stránky</span>
+    <div class="compare-grid">
+      <a href="/cs/" class="compare-card variant-muted u-no-underline">
+        <h4>Ozdobná písmenka</h4>
+        <p>Desítky stylů písmenek na ostylování jména, než ho vložíš na Discord.</p>
+      </a>
+      <a href="/cs/" class="compare-card variant-muted u-no-underline">
+        <h4>Písmena ke zkopírování</h4>
+        <p>Celá abeceda v mnoha řezech — bold, kurzíva, gotika a bublinková.</p>
+      </a>
+      <a href="/library/aesthetic-symbols/" class="compare-card variant-muted u-no-underline">
+        <h4>Ozdoby ke zkopírování</h4>
+        <p>Hvězdičky, srdíčka, rámečky a oddělovače na ozdobení nicku a „O mně“.</p>
+      </a>
+      <a href="/library/invisible-character/" class="compare-card variant-muted u-no-underline">
+        <h4>Neviditelný znak</h4>
+        <p>Prázdná mezera na čisté řádky v biu a prázdné nicky na Discordu.</p>
+      </a>
+    </div>
+  </section>
+</main>
+
+<footer class="footer">
+  <div class="footer-inner">
+    <h2 class="faq-category">Nejčastější otázky o písmu pro Discord</h2>
+    <div class="faq-item"><button class="faq-question" type="button">Jak změnit písmo v nicku na Discordu?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Napiš své jméno do pole nahoře na stránce. Hned se objeví desítky písem pro Discord — tučné, kurzíva, gotické, bublinková, kapitálky. Klikni na „Kopírovat“ u toho, které se ti líbí, otevři Discord, přejdi do Nastavení uživatele a vlož ho do zobrazovaného jména, nebo klikni pravým tlačítkem na serveru a změň přezdívku na tomto serveru. Protože jde o znaky Unicode, stylové písmenko se vloží do pole bez jakéhokoli pluginu.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Je k písmu na Discordu potřeba Nitro?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Ne. Písmenka z tohoto generátoru jsou obyčejné znaky Unicode, stejné jako z klávesnice, jen s jiným vzhledem — proto se vloží do zobrazovaného jména, do přezdívky na serveru, do sekce „O mně“, do názvu kanálu a do zpráv bez jakéhokoli Nitra. Nitro je potřeba jen na placené doplňky, jako jsou barvy a přechod ve jméně (Display Name Styles), ne na samotný stylový text.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Fungují písma v uživatelském jménu (@) na Discordu?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Ne. Uživatelské jméno (unikátní @ používané k pozvánkám mezi přátele) přijímá jen malá písmena a až z, číslice, tečku a podtržítko — žádné stylové písmo, mezery, emoji ani symboly. Písmo pro Discord funguje v zobrazovaném jméně, v serverové přezdívce, v sekci „O mně“, v názvu kanálu a na chatu. Pokud chceš styl ve jménu, použij zobrazované jméno, ne login @.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Čím se liší formátování Discordu (**tučné**) od písem Unicode?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Jsou to dvě různé věci. Markdown Discordu (**tučné**, *kurzíva*, `kód`) formátuje text jen uvnitř zpráv na chatu a zmizí, když ho zkusíš použít ve jméně nebo v biu. Písma Unicode z této stránky jsou samotný ostylovaný znak, takže fungují všude — v nicku, v „O mně“, v názvu kanálu, ve statusu i na chatu. Praktické pravidlo: v běžné zprávě použij Markdown, a pro ostylování nicku nebo bia použij písmo Unicode.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Jak udělat ozdobný nick na Discord s rámečky a symboly?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Vyber písmo na jméno (gotika a bublinková vycházejí nejlíp) a obklop ho rámečky a symboly ve stylu ꧁༒ ༒꧂. Na této stránce je mřížka hotových nicků s rámečky — klikni a zkopíruj a vlož do přezdívky na serveru. Můžeš taky napsat své jméno nahoře, nasadit písmo a použít záložky Symboly a Rámečky, aby sis vzhled doladil před zkopírováním.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Proč se písmenka na Discordu zobrazují jako čtverečky?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Protože zařízení toho, kdo si to prohlíží, nemá písmo, které daný znak vykreslí — obvykle jde o starší telefon nebo počítač. Není to chyba stránky ani tvého kopírování. Základní styly — tučné, kurzíva, gotika, bublinková a kapitálky — jsou nejbezpečnější a zobrazí se správně skoro všude. Pokud někdo nahlásí čtvereček (□), přepni na jeden z těchto stylů.</div></div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Výběr jazyka">
+      <a class="lang-option" href="/discord/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/cs/pismo-pro-discord/" hreflang="cs">CS</a>
+    </div>
+  </div>
+</footer>
+
+<div class="copy-toast" id="copyToast">Zkopírováno!</div>
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/styles.js"></script>
+<script src="/renderer.js"></script>
+<script src="/script.js" defer=""></script>
+<script src="/symbol-explorer.js"></script>
+<script src="/footer.js"></script>
+</body></html>

--- a/cs/pismo-pro-instagram/index.html
+++ b/cs/pismo-pro-instagram/index.html
@@ -1,0 +1,310 @@
+<!DOCTYPE html><html lang="cs"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Písmo pro Instagram: ozdobná písmenka do bia a popisků | UltraTextGen</title>
+  <meta name="description" content="Písmo pro Instagram zdarma: převeď text na 𝘁𝘂č𝗻é, 𝘬𝘶𝘳𝘻í𝘷𝘶 nebo 𝓴𝓪𝓵𝓲𝓰𝓻𝓪𝓯𝓲𝓲 a vlož do bia, do jména profilu, do popisku a do komentářů. Ozdobná písmenka pro Instagram — bez aplikace.">
+  <link rel="canonical" href="https://ultratextgen.com/cs/pismo-pro-instagram/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/instagram/">
+  <link rel="alternate" hreflang="cs" href="https://ultratextgen.com/cs/pismo-pro-instagram/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/instagram/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Písmo pro Instagram: ozdobná písmenka do bia a popisků">
+  <meta property="og:description" content="Generátor písma pro Instagram: napiš text a vlož stylové písmenko do bia, do jména profilu, do popisku a do komentářů. Tučné, kurzíva, kaligrafie a gotika — bez aplikace.">
+  <meta property="og:url" content="https://ultratextgen.com/cs/pismo-pro-instagram/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/pl-czcionki-na-instagram.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Písmo pro Instagram: ozdobná písmenka do bia a popisků">
+  <meta name="twitter:description" content="Tučné, kurzíva, kaligrafie a gotika připravené k vložení do bia a jména profilu na Instagramu — bez aplikace.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/pl-czcionki-na-instagram.png">
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+  <link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Generátor písma pro Instagram",
+  "alternateName": ["Písmo pro Instagram", "Písmo na Instagram", "Ozdobná písmenka pro Instagram", "Písmo do bia na Instagram", "Generátor písma na IG", "Fonty na Instagram", "Písmenka pro Instagram"],
+  "url": "https://ultratextgen.com/cs/pismo-pro-instagram/",
+  "inLanguage": "cs",
+  "applicationCategory": "UtilitiesApplication",
+  "operatingSystem": "Any",
+  "description": "Generátor písma pro Instagram: převede tvůj text na stylizovaná písmenka — tučná, kurzívu, kaligrafii, gotiku, bublinková a kapitálky — k vložení do bia, do jména profilu, do popisku příspěvku, do komentářů a do Stories, bez stahování aplikace.",
+  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "CZK" }
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "cs",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Jak změnit písmo v biu na Instagramu?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Napiš svůj text do pole nahoře na stránce. Hned se objeví desítky písem pro Instagram — tučné, kurzíva, kaligrafie, gotika, bublinková a kapitálky. Klikni na „Kopírovat“ u toho, které se ti líbí, otevři Instagram, přejdi do Upravit profil a vlož ho do pole Bio. Protože jde o znaky Unicode, stylové písmenko se vloží do pole bez jakékoli aplikace nebo klávesnice navíc." }
+    },
+    {
+      "@type": "Question",
+      "name": "Jak udělat jiné písmo ve jménu profilu na Instagramu?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Zkopíruj tady vybrané písmo a vlož ho do pole „Jméno“ v Upravit profil — to je ten tučný název nahoře na profilu, ne login @. Instagram v tomto poli přijímá Unicode, takže se stylové písmenko zobrazí správně. Jen pamatuj, že Instagram povoluje měnit Jméno omezeně často v krátkém čase (obvykle dvakrát za 14 dní), takže vlož rovnou hotový styl." }
+    },
+    {
+      "@type": "Question",
+      "name": "Dá se použít ozdobné písmo v uživatelském jménu (@) na Instagramu?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Ne. Uživatelské jméno (login @, který je v tvém odkazu a slouží k označování) přijímá jen malá písmena a až z, číslice, tečku a podtržítko — žádné stylové písmo, mezery, emoji ani symboly. Písmo pro Instagram funguje ve jménu profilu (Jméno), v biu, v popiscích a v komentářích. Pokud chceš styl ve jménu, použij pole Jméno, ne login @." }
+    },
+    {
+      "@type": "Question",
+      "name": "Fungují písma v popiscích příspěvků a v komentářích na Instagramu?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Ano. Protože jde o obyčejné znaky Unicode, stylové písmenko vložíš do popisku fotky i reelu, do komentářů, do textu ve Stories a do zpráv na Directu. Funguje to stejně v aplikaci na telefonu i ve verzi v prohlížeči. Jediné pole, které to nepřijímá, je login @ (uživatelské jméno)." }
+    },
+    {
+      "@type": "Question",
+      "name": "Škodí stylové písmo v biu zobrazování ve vyhledávání na Instagramu?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Může uškodit, pokud ostyluješ všechno. Vyhledávání a čtečky obrazovky lépe rozumějí obyčejnému textu, takže je nejlepší ostylovat jen jméno nebo jedno krátké heslo a důležitá klíčová slova — čím se zabýváš, tvé město, tvá nika — nechat obyčejným písmem. Profil pak vypadá hezky a pořád se snadno najde." }
+    },
+    {
+      "@type": "Question",
+      "name": "Proč se písmo na Instagramu zobrazuje jako čtvereček?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Protože zařízení toho, kdo si to prohlíží, nemá písmo, které daný znak vykreslí — obvykle jde o starší telefon nebo počítač. Není to chyba stránky ani tvého kopírování. Základní styly — tučné, kurzíva, kaligrafie, gotika, bublinková a kapitálky — jsou nejbezpečnější a zobrazí se správně skoro všude. Pokud uvidíš čtvereček (□), přepni na jeden z těchto stylů." }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "inLanguage": "cs",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Domů", "item": "https://ultratextgen.com/cs/" },
+    { "@type": "ListItem", "position": 2, "name": "Písmo pro Instagram", "item": "https://ultratextgen.com/cs/pismo-pro-instagram/" }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/cs/">Domů</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Písmo pro Instagram</span>
+</nav>
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pl-czcionki-na-instagram.svg" width="1200" height="340" loading="lazy" alt="">
+</figure>
+
+<section class="hero">
+  <div class="hero-inner">
+    <div class="hero-card">
+      <h1 class="hero-headline">Písmo pro Instagram: ozdobná písmenka do bia a popisků</h1>
+      <p class="hero-tagline">Napiš text a hned ho uvidíš v desítkách písem pro Instagram — tučné, kurzíva, kaligrafie, gotika, bublinková a kapitálky. Zkopíruješ a vložíš do bia, do jména profilu, do popisku příspěvku a do komentářů. Vše zdarma a <strong>bez aplikace</strong>.</p>
+      <div class="input-wrapper">
+        <textarea class="main-input" id="mainInput" placeholder="Napiš text do bia nebo popisku..." maxlength="500" autofocus=""></textarea>
+        <span class="char-count"><span id="charCount">0</span>/500</span>
+      </div>
+      <div class="decoration-section">
+        <div class="decoration-label">Přidej symboly a rámečky k výsledku</div>
+        <div class="decoration-tabs">
+          <button class="decoration-tab active" data-deco-tab="symbols">Symboly</button>
+          <button class="decoration-tab" data-deco-tab="frames">Rámečky</button>
+          <button class="decoration-tab" data-deco-tab="dividers">Oddělovače</button>
+          <button class="decoration-tab" data-deco-tab="arrows">Šipky</button>
+          <button class="decoration-tab" data-deco-tab="minimal">Minimalistické</button>
+          <button class="decoration-tab" data-deco-tab="emojis">Emoji</button>
+        </div>
+        <div class="decoration-grid" id="decorationGrid"></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<main class="container">
+  <div class="category-section"><div class="category-tabs" id="categoryTabs"></div></div>
+  <div class="results-grid" id="resultsGrid"></div>
+
+  <!-- Jak to funguje -->
+  <section class="editorial-section">
+    <h2>Písmo pro Instagram: jak to funguje</h2>
+    <p class="editorial-intro"><strong>Písmo pro Instagram</strong> z této stránky není nainstalované písmo ani obrázek — jsou to <strong>znaky Unicode</strong>, opravdová písmena, stejná jako z klávesnice, jen s jiným vzhledem (𝗔, 𝘈, 𝓐, 𝔄). Protože Instagram přijímá Unicode skoro v každém textovém poli, stylové písmenko se vloží rovnou do tvého <strong>bia</strong>, do <strong>jména profilu</strong>, do <strong>popisku příspěvku</strong>, do <strong>komentářů</strong>, do textu ve <strong>Stories</strong> i do zpráv na <strong>Directu</strong> — bez aplikace, pluginu nebo klávesnice navíc.</p>
+    <div class="block-example">
+      <strong>Příklad:</strong> „tereza“ → 𝘁𝗲𝗿𝗲𝘇𝗮 (tučné), 𝘵𝘦𝘳𝘦𝘻𝘢 (kurzíva), 𝓉𝑒𝓇𝑒𝓏𝒶 (kaligrafie), 𝔱𝔢𝔯𝔢𝔷𝔞 (gotické), ⓣⓔⓡⓔⓩⓐ (bublinková), ᴛᴇʀᴇᴢᴀ (kapitálky)
+    </div>
+    <p>Používá se to během pár vteřin: napíšeš text do pole nahoře, generátor ho ukáže v mnoha <strong>písmech pro Instagram</strong>, klikneš na „Kopírovat“ a vložíš v aplikaci. Chceš jen holá písmena abecedy? Jsou hned pod tím. A pokud chceš procházet ještě víc řezů, plný generátor najdeš na stránce s <a href="/cs/">písmeny ke zkopírování</a>.</p>
+  </section>
+
+  <!-- Abeceda A-Z -->
+  <section class="editorial-section glyph-section">
+    <h2>Abeceda písem pro Instagram (A–Z ke zkopírování)</h2>
+    <p class="editorial-intro">Celá abeceda ve stylech, které se v biu a popiscích na Instagramu objevují nejčastěji. Klikni na daný řádek a zkopíruj celou abecedu v tom stylu, nebo napiš svůj text nahoře a vezmi si vlastní slovo rovnou ostylované.</p>
+    <div class="alpha-list">
+      <div class="alpha-row">
+        <span class="alpha-label">Tučné</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝗔𝗕𝗖𝗗𝗘𝗙𝗚𝗛𝗜𝗝𝗞𝗟𝗠𝗡𝗢𝗣𝗤𝗥𝗦𝗧𝗨𝗩𝗪𝗫𝗬𝗭 𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇" aria-label="Kopírovat tučnou abecedu">𝗔𝗕𝗖𝗗𝗘𝗙𝗚𝗛𝗜𝗝𝗞𝗟𝗠𝗡𝗢𝗣𝗤𝗥𝗦𝗧𝗨𝗩𝗪𝗫𝗬𝗭 · 𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Kurzíva</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩 𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃" aria-label="Kopírovat abecedu kurzívou">𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩 · 𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Elegantní</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵 𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏" aria-label="Kopírovat elegantní abecedu">𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵 · 𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Gotické</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝔄𝔅ℭ𝔇𝔈𝔉𝔊ℌℑ𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔ℜ𝔖𝔗𝔘𝔙𝔚𝔛𝔜ℨ 𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷" aria-label="Kopírovat gotickou abecedu">𝔄𝔅ℭ𝔇𝔈𝔉𝔊ℌℑ𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔ℜ𝔖𝔗𝔘𝔙𝔚𝔛𝔜ℨ · 𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Bublinková</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ" aria-label="Kopírovat bublinkovou abecedu">ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ · ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Kapitálky</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="ᴀʙᴄᴅᴇꜰɢʜɪᴊᴋʟᴍɴᴏᴘqʀsᴛᴜᴠᴡxʏᴢ" aria-label="Kopírovat abecedu v kapitálkách">ᴀ ʙ ᴄ ᴅ ᴇ ꜰ ɢ ʜ ɪ ᴊ ᴋ ʟ ᴍ ɴ ᴏ ᴘ q ʀ s ᴛ ᴜ ᴠ ᴡ x ʏ ᴢ</button>
+      </div>
+    </div>
+    <p class="uname-note">Poznámka o českých znacích: tato písma Unicode pokrývají základní abecedu A–Z. Česká diakritika (á, č, ě, í, ň, ó, ř, š, ú, ů, ý, ž) ve většině stylů zůstává obyčejnými písmeny uprostřed ostylovaného slova — proto např. „klara“ vyjde perfektně, kdežto „žofie“ ukáže ž jako obyčejné písmeno. Do bia a jmen bez diakritiky to vypadá skvěle a do delších popisků jsou nejbezpečnější tučné a kurzíva.</p>
+    <p class="u-mt-15">Chceš se zakousnout do jednoho stylu? Celou abecedu a varianty každého řezu najdeš na stránce s <a href="/cs/">písmeny ke zkopírování</a>, a nejoblíbenější do bia na Instagramu je <a href="/cs/kurziva/">kurzíva</a>.</p>
+  </section>
+
+  <!-- Písmo do bia a jména -->
+  <section class="editorial-section">
+    <h2>Písmo do bia a jména profilu na Instagramu</h2>
+    <p class="editorial-intro">Nejrychlejší způsob, jak vypíchnout profil, je nasadit písmo na <strong>jméno profilu</strong> (pole „Jméno“) a zvlášť ho poskládat v <strong>biu</strong>. Jsou to dvě různá pole — „Jméno“ je ten tučný název nahoře na profilu a bio je popis pod ním. Instagram přijímá Unicode v obou, ale <strong>ne v loginu @</strong>.</p>
+    <p class="uname-note">Jak vložit:</p>
+    <div class="block-example">
+      — <strong>Jméno profilu:</strong> Upravit profil › pole „Jméno“ › vlož stylové písmo<br>
+      — <strong>Bio:</strong> Upravit profil › pole „Bio“ › vlož text (můžeš kombinovat několik stylů v samostatných řádcích)<br>
+      — <strong>Popisek příspěvku / reelu:</strong> při přidávání příspěvku vlož písmo do pole popisku<br>
+      — <strong>Komentáře a Direct:</strong> vlož stylové písmenko rovnou do pole komentáře nebo zprávy
+    </div>
+    <p>Rada od někoho, kdo profily skládá denně: ostyluj samotné jméno nebo jedno heslo a zbytek bia nech obyčejným textem — celý efekt dělá ten kontrast. Když je všechno ozdobné, nic nepřitahuje pohled. Důležitý detail: Instagram povoluje měnit pole „Jméno“ jen omezeně často v krátkém čase, takže vlož rovnou hotový styl. Pro jednotlivé hvězdičky a třpytky do bia mrkni na stránku s <a href="/library/aesthetic-symbols/">ozdobami ke zkopírování</a>.</p>
+  </section>
+
+  <!-- Kde funguje a kde ne -->
+  <section class="editorial-section">
+    <h2>Kam vložíš písmo na Instagramu (a kam ne)</h2>
+    <p class="editorial-intro">Protože to, co kopíruješ, je čistý Unicode, písmenka pro Instagram se vloží prakticky do každého textového pole aplikace:</p>
+    <div class="block-example">
+      — <strong>Jméno profilu</strong> a <strong>bio</strong><br>
+      — <strong>Popisky příspěvků</strong> a <strong>reelů</strong><br>
+      — <strong>Komentáře</strong> pod příspěvky<br>
+      — <strong>Text ve Stories</strong> a <strong>poznámky (Notes)</strong><br>
+      — <strong>Zprávy na Directu</strong>
+    </div>
+    <p>Jediné místo, kde to <strong>ne</strong>funguje, je <strong>uživatelské jméno (login @)</strong> — Instagram ho záměrně omezuje na malá písmena a až z, číslice, tečku a podtržítko, takže žádné stylové písmo, mezera ani emoji tam neprojde. Kromě toho upřímná poznámka: pokud je zařízení toho, kdo si to prohlíží, hodně staré, část vzácnějších stylů se může zobrazit jako <strong>čtverečky (□)</strong> — to je chybějící písmo na jeho zařízení, ne problém s tvým textem. Když se držíš základních stylů (tučné, kurzíva, kaligrafie, gotika, bublinková, kapitálky), skoro nikdy se to nestane. Na čisté prázdné řádky v biu se hodí <a href="/library/invisible-character/">neviditelný znak</a>.</p>
+  </section>
+
+  <!-- Ozdobné bio se symboly -->
+  <section class="editorial-section">
+    <h2>Ozdobné bio a jména na Instagram se symboly</h2>
+    <p class="editorial-intro">Jména a řádky bia, které na Instagramu udělají největší dojem, kombinují jemné písmo (kaligrafie nebo kurzíva) s hvězdičkami a symboly po obou stranách, ve stylu ⋆˚₊‧ ‧₊˚⋆. Klikni a zkopíruj, pak vlož do pole „Jméno“ nebo do bia — potom vyměň za své slovo.</p>
+    <div class="uname-grid">
+      <button class="uname-chip symbol-tile" data-symbol="⋆˚₊‧ 𝓏𝑜𝓈𝒾𝒶 ‧₊˚⋆" aria-label="Kopírovat jméno">⋆˚₊‧ 𝓏𝑜𝓈𝒾𝒶 ‧₊˚⋆</button>
+      <button class="uname-chip symbol-tile" data-symbol="✿ 𝓸𝓵𝓪 ✿" aria-label="Kopírovat jméno">✿ 𝓸𝓵𝓪 ✿</button>
+      <button class="uname-chip symbol-tile" data-symbol="꒰ঌ 𝒷𝒶𝓈𝒾𝒶 ໒꒱" aria-label="Kopírovat jméno">꒰ঌ 𝒷𝒶𝓈𝒾𝒶 ໒꒱</button>
+      <button class="uname-chip symbol-tile" data-symbol="⋆｡˚ 𝓴𝓪𝓼𝓲𝓪 ˚｡⋆" aria-label="Kopírovat jméno">⋆｡˚ 𝓴𝓪𝓼𝓲𝓪 ˚｡⋆</button>
+      <button class="uname-chip symbol-tile" data-symbol="✧˖° 𝓶𝓪𝓳𝓪 °˖✧" aria-label="Kopírovat jméno">✧˖° 𝓶𝓪𝓳𝓪 °˖✧</button>
+      <button class="uname-chip symbol-tile" data-symbol="ᯓ★ 𝓌𝒾𝓀𝓉𝑜𝓇𝒾𝒶 ★" aria-label="Kopírovat jméno">ᯓ★ 𝓌𝒾𝓀𝓉𝑜𝓇𝒾𝒶 ★</button>
+      <button class="uname-chip symbol-tile" data-symbol="˚ʚ 𝒶𝓃𝒾𝒶 ɞ˚" aria-label="Kopírovat jméno">˚ʚ 𝒶𝓃𝒾𝒶 ɞ˚</button>
+      <button class="uname-chip symbol-tile" data-symbol="⊹ ࣪ ˖ 𝓃𝒶𝓉𝒶𝓁𝒾𝒶 ˖ ࣪ ⊹" aria-label="Kopírovat jméno">⊹ ࣪ ˖ 𝓃𝒶𝓉𝒶𝓁𝒾𝒶 ˖ ࣪ ⊹</button>
+      <button class="uname-chip symbol-tile" data-symbol="⟡ 𝓵𝓮𝓷𝓪 ⟡" aria-label="Kopírovat jméno">⟡ 𝓵𝓮𝓷𝓪 ⟡</button>
+      <button class="uname-chip symbol-tile" data-symbol="๑ 𝓳𝓾𝓵𝓴𝓪 ๑" aria-label="Kopírovat jméno">๑ 𝓳𝓾𝓵𝓴𝓪 ๑</button>
+    </div>
+    <p class="u-mt-15">Chceš celou sadu hotových hvězdiček, srdíček a oddělovačů na sestavení vlastního bia? Kompletní paleta je na stránce s <a href="/library/aesthetic-symbols/">ozdobami ke zkopírování</a> — tytéž znaky se vloží do jména i do bia na Instagramu.</p>
+  </section>
+
+  <!-- Vyhledávání a čtverečky -->
+  <section class="editorial-section">
+    <h2>Písmo a vyhledávání na Instagramu (a poznámka o čtverečcích)</h2>
+    <p class="editorial-intro">Stylizovaný text vypadá skvěle, ale má jeden háček: vyhledávání na Instagramu a čtečky obrazovky zacházejí se znaky Unicode jinak než s obyčejnými písmeny. Pokud ostyluješ celé bio, tvá klíčová slova můžou hůř vyskakovat ve vyhledávání.</p>
+    <div class="block-example">
+      — <strong>Dobrá praxe:</strong> ostyluj jméno nebo krátké heslo, zbytek nech obyčejným textem<br>
+      — <strong>Nech obyčejným písmem:</strong> čím se zabýváš, město, niku, slova, podle kterých tě hledají<br>
+      — <strong>Příklad:</strong> 𝓶𝓪𝓳𝓪 𝓴𝓸𝔀𝓪𝓵𝓼𝓴𝓪 (kaligrafie) + „svatební fotografie · Praha“ obyčejným písmem
+    </div>
+    <p>Druhá věc jsou <strong>čtverečky (□)</strong>: když někdo vidí místo písmen prázdný obdélník, znamená to, že jeho zařízení nemá písmo, které daný znak vykreslí — obvykle hodně starý telefon. Není to problém s tvým textem ani s kopírováním. Když se držíš základních stylů, skoro nikdy se to nestane. Na prázdné řádky a mezery v biu se hodí <a href="/library/invisible-character/">neviditelný znak</a>, a výraznější, temný styl na jméno najdeš v <a href="/cs/goticke-pismo/">gotickém písmu</a>.</p>
+  </section>
+
+  <!-- Related -->
+  <section class="editorial-section">
+    <span class="article-section-label">Související stránky</span>
+    <div class="compare-grid">
+      <a href="/cs/" class="compare-card variant-muted u-no-underline">
+        <h4>Písmena ke zkopírování</h4>
+        <p>Celá abeceda v mnoha řezech — tučné, kurzíva, kaligrafie a bublinková.</p>
+      </a>
+      <a href="/cs/kurziva/" class="compare-card variant-muted u-no-underline">
+        <h4>Kurzíva</h4>
+        <p>Ozdobná, ručně psaná kurzíva — nejčastější volba do bia na Instagramu.</p>
+      </a>
+      <a href="/library/aesthetic-symbols/" class="compare-card variant-muted u-no-underline">
+        <h4>Ozdoby ke zkopírování</h4>
+        <p>Hvězdičky, srdíčka, rámečky a oddělovače na ozdobení jména a bia.</p>
+      </a>
+      <a href="/library/invisible-character/" class="compare-card variant-muted u-no-underline">
+        <h4>Neviditelný znak</h4>
+        <p>Prázdná mezera na čisté řádky a odsazení v biu na Instagramu.</p>
+      </a>
+      <a href="/cs/goticke-pismo/" class="compare-card variant-muted u-no-underline">
+        <h4>Gotické písmo</h4>
+        <p>Temná, výrazná písmena na jméno profilu s charakterem.</p>
+      </a>
+    </div>
+  </section>
+</main>
+
+<footer class="footer">
+  <div class="footer-inner">
+    <h2 class="faq-category">Nejčastější otázky o písmu pro Instagram</h2>
+    <div class="faq-item"><button class="faq-question" type="button">Jak změnit písmo v biu na Instagramu?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Napiš svůj text do pole nahoře na stránce. Hned se objeví desítky písem pro Instagram — tučné, kurzíva, kaligrafie, gotika, bublinková a kapitálky. Klikni na „Kopírovat“ u toho, které se ti líbí, otevři Instagram, přejdi do Upravit profil a vlož ho do pole Bio. Protože jde o znaky Unicode, stylové písmenko se vloží do pole bez jakékoli aplikace nebo klávesnice navíc.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Jak udělat jiné písmo ve jménu profilu na Instagramu?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Zkopíruj tady vybrané písmo a vlož ho do pole „Jméno“ v Upravit profil — to je ten tučný název nahoře na profilu, ne login @. Instagram v tomto poli přijímá Unicode, takže se stylové písmenko zobrazí správně. Jen pamatuj, že Instagram povoluje měnit Jméno omezeně často v krátkém čase (obvykle dvakrát za 14 dní), takže vlož rovnou hotový styl.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Dá se použít ozdobné písmo v uživatelském jménu (@) na Instagramu?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Ne. Uživatelské jméno (login @, který je v tvém odkazu a slouží k označování) přijímá jen malá písmena a až z, číslice, tečku a podtržítko — žádné stylové písmo, mezery, emoji ani symboly. Písmo pro Instagram funguje ve jménu profilu (Jméno), v biu, v popiscích a v komentářích. Pokud chceš styl ve jménu, použij pole Jméno, ne login @.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Fungují písma v popiscích příspěvků a v komentářích na Instagramu?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Ano. Protože jde o obyčejné znaky Unicode, stylové písmenko vložíš do popisku fotky i reelu, do komentářů, do textu ve Stories a do zpráv na Directu. Funguje to stejně v aplikaci na telefonu i ve verzi v prohlížeči. Jediné pole, které to nepřijímá, je login @ (uživatelské jméno).</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Škodí stylové písmo v biu zobrazování ve vyhledávání na Instagramu?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Může uškodit, pokud ostyluješ všechno. Vyhledávání a čtečky obrazovky lépe rozumějí obyčejnému textu, takže je nejlepší ostylovat jen jméno nebo jedno krátké heslo a důležitá klíčová slova — čím se zabýváš, tvé město, tvá nika — nechat obyčejným písmem. Profil pak vypadá hezky a pořád se snadno najde.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Proč se písmo na Instagramu zobrazuje jako čtvereček?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Protože zařízení toho, kdo si to prohlíží, nemá písmo, které daný znak vykreslí — obvykle jde o starší telefon nebo počítač. Není to chyba stránky ani tvého kopírování. Základní styly — tučné, kurzíva, kaligrafie, gotika, bublinková a kapitálky — jsou nejbezpečnější a zobrazí se správně skoro všude. Pokud uvidíš čtvereček (□), přepni na jeden z těchto stylů.</div></div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Výběr jazyka">
+      <a class="lang-option" href="/instagram/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/cs/pismo-pro-instagram/" hreflang="cs">CS</a>
+    </div>
+  </div>
+</footer>
+
+<div class="copy-toast" id="copyToast">Zkopírováno!</div>
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script>window.UTG_PREVIEW_PLATFORM='instagram';window.UTG_SHOW_PLATFORMS=true;window.UTG_DEMO_TEXT='tereza aesthetic\nlink v biu ⬇';</script>
+<script src="/styles.js"></script>
+<script src="/renderer.js"></script>
+<script src="/script.js" defer=""></script>
+<script src="/symbol-explorer.js"></script>
+<script src="/footer.js" defer></script>
+</body></html>

--- a/cs/tucne-pismo/index.html
+++ b/cs/tucne-pismo/index.html
@@ -1,0 +1,299 @@
+<!DOCTYPE html><html lang="cs"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZGVh");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Generátor tučného písma — 𝐭𝐮č𝐧é 𝐩í𝐬𝐦𝐨 ke zkopírování | UltraTextGen</title>
+  <meta name="description" content="Bezplatný generátor tučného písma: převeď text na tučné znaky Unicode ke zkopírování a vložení — do bia na Instagramu, na WhatsApp, TikTok, Discord, LinkedIn a do nicků. Ihned, bez registrace.">
+  <link rel="canonical" href="https://ultratextgen.com/cs/tucne-pismo/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/category/bold-fonts/">
+  <link rel="alternate" hreflang="cs" href="https://ultratextgen.com/cs/tucne-pismo/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/category/bold-fonts/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Generátor tučného písma — 𝐭𝐮č𝐧é 𝐩í𝐬𝐦𝐨 ke zkopírování | UltraTextGen">
+  <meta property="og:description" content="Bezplatný generátor tučného písma — tučné znaky Unicode ke zkopírování a vložení na Instagram, TikTok, WhatsApp, Discord a LinkedIn. Ihned, bez registrace.">
+  <meta property="og:url" content="https://ultratextgen.com/cs/tucne-pismo/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category-bold-fonts.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Generátor tučného písma — 𝐭𝐮č𝐧é 𝐩í𝐬𝐦𝐨 ke zkopírování | UltraTextGen">
+  <meta name="twitter:description" content="Bezplatný generátor tučného písma — tučné znaky Unicode ke zkopírování a vložení do sociálních sítí, chatů a nicků.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category-bold-fonts.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "cs",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Co je generátor tučného písma a jak funguje?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Převádí písmena, která napíšeš, na tučné znaky Unicode (𝐭𝐚𝐤𝐨𝐯é 𝐣𝐚𝐤𝐨 𝐭𝐚𝐭𝐨) — opravdové znaky, ne písmo ani obrázek. Protože jde o obyčejné textové znaky, můžeš je zkopírovat a vložit všude, kde je povolený text: do bia, popisků, komentářů a zpráv. Víc v našem průvodci o tom, jak funguje písmo Unicode."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Funguje tučné písmo na Instagramu, WhatsAppu, TikToku a LinkedInu?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ano. Bio, popisky, komentáře i zprávy na chatu tyto znaky bez problémů přijmou. Hlavně na LinkedInu a X, kde nativní ztučnění chybí, tučné písmo Unicode zajistí, že nejdůležitější části vyniknou. Pozor: některá pole s @uživatelským jménem tyto znaky filtrují — v samotném handlu je nutné zůstat u obyčejného textu, ale v biu tučné písmo funguje skvěle."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Můžu psát české znaky (á, č, ď, é, ě, í, ň, ó, ř, š, ť, ú, ů, ý, ž) tučným písmem?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Tučné písmo Unicode pokrývá A–Z a 0–9, proto české znaky jako á, č, ě, ř, š, ž nemají vlastní tučnou podobu a zůstávají obyčejné. Pro plně tučný efekt je můžeš nahradit základními písmeny (a, c, e, r, s, z) — mění to ovšem pravopis — nebo je nechat v normální síle, což u krátkého textu obvykle stejně vypadá dobře."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Je generátor tučného písma zdarma?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ano, plně zdarma a bez registrace. Piš, kopíruj a vkládej, kolikrát chceš — není tu žádný limit ani skryté náklady."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Proč se některé znaky zobrazují jako prázdné čtverečky?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Prázdný čtvereček (▯) znamená, že zařízení nemá odpovídající glyf pro daný tučný znak. Týká se to většinou starších systémů. Vyber jednodušší tučný styl nebo zařízení aktualizuj — víc v článku o tom, proč se písmo zobrazuje jako čtverečky."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Ovlivňuje tučný text Unicode čitelnost a dosahy?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Tučné znaky Unicode přitahují pohled ve feedu a skvěle slouží jako háčky, titulky a CTA na sociálních sítích. Používej je cíleně — krátké tučné akcenty, zbytek obyčejným textem. Pro obsah na webu je lepší použít tučnění přes CSS, aby vyhledávače četly text jako běžná slova. Pro textová pole na sociálních sítích je tučné písmo Unicode ideální řešení. Nezapomeň na přístupnost, když formátuješ delší úseky."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "inLanguage": "cs",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Domů", "item": "https://ultratextgen.com/cs/" },
+    { "@type": "ListItem", "position": 2, "name": "Tučné písmo", "item": "https://ultratextgen.com/cs/tucne-pismo/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Generátor tučného písma",
+  "alternateName": ["Tučné písmo","Tučný text","Tučná písmena","Generátor tučného textu","Tučné písmo ke zkopírování","Tučný text Unicode","Bold ke zkopírování"],
+  "url": "https://ultratextgen.com/cs/tucne-pismo/",
+  "inLanguage": "cs",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "CZK"
+  },
+  "description": "Bezplatný generátor tučného písma: převeď text na tučné znaky Unicode ke zkopírování a vložení na Instagram, TikTok, WhatsApp, Discord, LinkedIn a do nicků.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/cs/">Domů</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Tučné písmo</span>
+</nav>
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/category-bold-fonts.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+  <!-- Hero -->
+  <section class="hero">
+    <div class="hero-inner">
+      <div class="hero-card">
+        <h1 class="hero-headline">Generátor tučného písma</h1>
+        <p class="hero-tagline">Proměň libovolný text v 𝐭𝐮č𝐧ý 𝐭𝐞𝐱𝐭 ke zkopírování a vložení — výrazné,
+          pohled přitahující znaky Unicode do bia, nicků a titulků. Zdarma, ihned, bez registrace.</p>
+        <div class="input-wrapper">
+          <textarea class="main-input" id="mainInput" placeholder="Napiš text, slovo nebo jméno…" maxlength="500" autofocus></textarea>
+          <span class="char-count"><span id="charCount">0</span>/500</span>
+        </div>
+
+        <!-- Decoration Selector -->
+        <div class="decoration-section">
+          <div class="decoration-label">
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"></path>
+            </svg>
+            Přidej symboly kolem výsledku
+          </div>
+          <div class="decoration-tabs">
+            <button class="decoration-tab active" data-deco-tab="symbols">Symboly</button>
+            <button class="decoration-tab" data-deco-tab="frames">Rámečky</button>
+            <button class="decoration-tab" data-deco-tab="dividers">Oddělovače</button>
+            <button class="decoration-tab" data-deco-tab="minimal">Minimalistické</button>
+            <button class="decoration-tab" data-deco-tab="emojis">Emoji</button>
+          </div>
+          <div class="decoration-grid" id="decorationGrid"></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Main Content -->
+  <main class="container">
+
+    <section class="editorial-section">
+      <span class="article-section-label">Tučné písmo Unicode</span>
+      <h2>Tučný text ke zkopírování — do bia, nicků a titulků</h2>
+      <p>Tato písmena nejsou písmo ani obrázek, ale opravdové <strong>znaky Unicode</strong>. Zvýrazni klíčové slovo
+        ve svém biu, vytvoř tučný nick nebo zařiď, aby titulek na LinkedInu a X přitahoval pohled — všude tam,
+        kde nativní ztučnění chybí. Napiš text výše, klikni na <strong>Kopírovat</strong> a vlož tučné
+        písmo tam, kam chceš.</p>
+    </section>
+
+    <!-- Category Tabs (populated by script.js) -->
+    <div class="category-section">
+      <div class="category-tabs" id="categoryTabs"></div>
+    </div>
+
+    <!-- Results -->
+    <div class="results-grid" id="resultsGrid"></div>
+
+    <section class="editorial-section">
+      <span class="article-section-label">Související</span>
+      <p>Spoj tučné písmo s <a href="/cs/pismo-pro-discord/">písmem na Discord</a>,
+        <a href="/library/aesthetic-symbols/">ozdobami</a> nebo <a href="/library/invisible-character/">neviditelným znakem</a>
+        pro čisté mezery. Na body art máme <a href="/usecase/tattoo-fonts/">generátor písma na tetování</a>,
+        a na svislé sazby — <a href="/usecase/vertical-text/">svislý text</a>.</p>
+    </section>
+  </main>
+
+  <!-- Footer + FAQ -->
+  <footer class="footer">
+    <div class="footer-inner">
+<div class="faq-section" id="bold-faq">
+
+<h2 class="faq-category">Generátor tučného písma — FAQ</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Co je generátor tučného písma a jak funguje?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Převádí písmena, která napíšeš, na tučné znaky Unicode (𝐭𝐚𝐤𝐨𝐯é 𝐣𝐚𝐤𝐨 𝐭𝐚𝐭𝐨) — opravdové znaky, ne písmo ani obrázek. Protože jde o obyčejné textové znaky, můžeš je zkopírovat a vložit všude, kde je povolený text: do bia, popisků, komentářů a zpráv. Víc v našem <a href="/guide/how-unicode-fonts-work/">průvodci o tom, jak funguje písmo Unicode</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Funguje tučné písmo na Instagramu, WhatsAppu, TikToku a LinkedInu?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Ano. Bio, popisky, komentáře i zprávy na chatu tyto znaky bez problémů přijmou. Hlavně na LinkedInu a X, kde nativní ztučnění chybí, tučné písmo Unicode zajistí, že nejdůležitější části vyniknou. Pozor: některá pole s <strong>@uživatelským jménem</strong> tyto znaky filtrují — v samotném handlu je nutné zůstat u obyčejného textu, ale v biu tučné písmo funguje skvěle.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Můžu psát české znaky (á, č, ď, é, ě, í, ň, ó, ř, š, ť, ú, ů, ý, ž) tučným písmem?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Tučné písmo Unicode pokrývá A–Z a 0–9, proto české znaky jako á, č, ě, ř, š, ž nemají vlastní tučnou podobu a zůstávají obyčejné. Pro plně tučný efekt je můžeš nahradit základními písmeny (<strong>a, c, e, r, s, z</strong>) — mění to ovšem pravopis — nebo je nechat v normální síle, což u krátkého textu obvykle stejně vypadá dobře.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Je generátor tučného písma zdarma?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Ano, plně zdarma a bez registrace. Piš, kopíruj a vkládej, kolikrát chceš — není tu žádný limit ani skryté náklady.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Proč se některé znaky zobrazují jako prázdné čtverečky?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Prázdný čtvereček (▯) znamená, že zařízení nemá odpovídající glyf pro daný tučný znak. Týká se to většinou starších systémů. Vyber jednodušší tučný styl nebo zařízení aktualizuj — víc v článku o tom, <a href="/guide/why-fonts-show-as-boxes/">proč se písmo zobrazuje jako čtverečky</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Ovlivňuje tučný text Unicode čitelnost a dosahy?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Tučné znaky Unicode přitahují pohled ve feedu a skvěle slouží jako háčky, titulky a CTA na sociálních sítích. Používej je cíleně — krátké tučné akcenty, zbytek obyčejným textem. Pro obsah na webu je lepší použít tučnění přes CSS, aby vyhledávače četly text jako běžná slova. Pro textová pole na sociálních sítích je tučné písmo Unicode ideální řešení. Nezapomeň na <a href="/guide/fancy-fonts-accessibility-guide/">přístupnost</a>, když formátuješ delší úseky.
+  </div>
+</div>
+
+</div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Výběr jazyka">
+      <a class="lang-option" href="/category/bold-fonts/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/cs/tucne-pismo/" hreflang="cs">CS</a>
+    </div>
+
+    </div>
+  </footer>
+
+  <div class="copy-toast" id="copyToast">Zkopírováno!</div>
+
+  <script>
+    window.UTG_FAMILY = "bold";
+    window.UTG_DEMO_TEXT = "tučné písmo\ntučný text";
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/script.js" defer></script>
+  <script src="/footer.js" defer></script>
+</body></html>

--- a/hr/fontovi-za-discord/index.html
+++ b/hr/fontovi-za-discord/index.html
@@ -1,0 +1,301 @@
+<!DOCTYPE html><html lang="hr"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Fontovi za Discord: Slova za Nadimak i Bio (Bez Nitra) | UltraTextGen</title>
+  <meta name="description" content="Fontovi za Discord besplatno: pretvori ime u 𝗽𝗼𝗱𝗲𝗯𝗹𝗷𝗮𝗻𝗼, 𝓴𝓾𝓻𝔃𝓲𝓿 ili 𝔤𝔬𝔱𝔦𝔠𝔲 i zalijepi u nadimak, u odjeljak „O meni” i u chat. Fontovi za Discord bez Nitra.">
+  <link rel="canonical" href="https://ultratextgen.com/hr/fontovi-za-discord/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/discord/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/discord/">
+  <link rel="alternate" hreflang="hr" href="https://ultratextgen.com/hr/fontovi-za-discord/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Fontovi za Discord: Slova za Nadimak i Bio (Bez Nitra)">
+  <meta property="og:description" content="Generator fontova za Discord: upiši ime i zalijepi stilizirano slovo u nadimak, u „O meni”, u naziv kanala i u status. Podebljano, kurziv i gotica — bez Nitra.">
+  <meta property="og:url" content="https://ultratextgen.com/hr/fontovi-za-discord/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/discord.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Fontovi za Discord: Slova za Nadimak i Bio (Bez Nitra)">
+  <meta name="twitter:description" content="Podebljano, kurziv, gotica i balončasta spremni za lijepljenje u nadimak i „O meni” na Discordu — bez Nitra.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/discord.png">
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+  <link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Generator Fontova za Discord",
+  "alternateName": ["Fontovi za Discord", "Fontovi na Discordu", "Slova za Discord", "Generator Nadimka za Discord"],
+  "url": "https://ultratextgen.com/hr/fontovi-za-discord/",
+  "applicationCategory": "UtilitiesApplication",
+  "operatingSystem": "Any",
+  "description": "Generator fontova za Discord: pretvara tvoje ime u stilizirana slova — podebljano, kurziv, goticu, balončasta, elegantna i kapitalke — za lijepljenje u nadimak, u „O meni”, u naziv kanala i u status, bez potrebe za Nitrom.",
+  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "EUR" }
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "hr",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Kako promijeniti font u nadimku na Discordu?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Upiši svoje ime u polje na vrhu stranice. Odmah će se pojaviti desetci fontova za Discord — podebljano, kurziv, gotička, balončasta, kapitalke. Klikni „Kopiraj” kod onog koji ti se sviđa, otvori Discord, uđi u Korisničke postavke i zalijepi ga u prikazano ime, ili desnim klikom na serveru promijeni nadimak na tom serveru. Budući da su to Unicode znakovi, stilizirano slovo se lijepi u polje bez ikakvog dodatka." }
+    },
+    {
+      "@type": "Question",
+      "name": "Treba li za fontove na Discordu Nitro?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Ne. Slova iz ovog generatora obični su Unicode znakovi, isti kao s tipkovnice, samo drukčijeg izgleda — zato se lijepe u prikazano ime, u nadimak na serveru, u odjeljak „O meni”, u naziv kanala i u poruke bez ikakvog Nitra. Nitro je potreban samo za plaćene dodatke, poput boja i gradijenta u imenu (Display Name Styles), a ne za sam stilizirani tekst." }
+    },
+    {
+      "@type": "Question",
+      "name": "Rade li fontovi u korisničkom imenu (@) na Discordu?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Ne. Korisničko ime (jedinstveni @ koji se koristi za pozivnice prijateljima) prima samo mala slova od a do z, brojke, točku i podvlaku — bez stilskih fontova, razmaka, emojija ili simbola. Fontovi za Discord rade u prikazanom imenu, u nadimku na serveru, u odjeljku „O meni”, u nazivu kanala i u chatu. Ako želiš stil u imenu, koristi prikazano ime, a ne @login." }
+    },
+    {
+      "@type": "Question",
+      "name": "Po čemu se razlikuje Discordovo oblikovanje (**podebljanje**) od Unicode fontova?",
+      "acceptedAnswer": { "@type": "Answer", "text": "To su dvije različite stvari. Discordov Markdown (**podebljanje**, *kurziv*, `kod`) oblikuje tekst samo unutar poruka u chatu i nestane kad ga pokušaš upotrijebiti u imenu ili u biju. Unicode fontovi s ove stranice sam su stilizirani znak, pa rade svugdje — u nadimku, u „O meni”, u nazivu kanala, u statusu i u chatu. Praktično pravilo: u običnoj poruci koristi Markdown, a da stiliziraš nadimak ili bio, koristi Unicode font." }
+    },
+    {
+      "@type": "Question",
+      "name": "Kako napraviti ukrasni nadimak za Discord s okvirima i simbolima?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Odaberi font za ime (gotica i balončasta izlaze najbolje) i okruži ga okvirima te simbolima u stilu ꧁༒ ༒꧂. Na ovoj stranici je mreža gotovih nadimaka s okvirima — klikni za kopiranje i zalijepi u nadimak na serveru. Možeš i upisati svoje ime na vrhu, staviti font i upotrijebiti kartice Simboli i Okviri da dotjeraš izgled prije kopiranja." }
+    },
+    {
+      "@type": "Question",
+      "name": "Zašto se slova na Discordu prikazuju kao kvadratići?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Zato što uređaj osobe koja to gleda nema font koji crta taj znak — obično je to stariji telefon ili računalo. To nije greška stranice ni tvog kopiranja. Osnovni stilovi — podebljano, kurziv, gotica, balončasta i kapitalke — najsigurniji su i prikazuju se ispravno gotovo svugdje. Ako netko prijavi kvadratić (□), zamijeni jednim od tih stilova." }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "inLanguage": "hr",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Početna", "item": "https://ultratextgen.com/hr/" },
+    { "@type": "ListItem", "position": 2, "name": "Fontovi za Discord", "item": "https://ultratextgen.com/hr/fontovi-za-discord/" }
+  ]
+}
+</script>
+</head>
+<body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<script src="/header.js"></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/hr/">Početna</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Fontovi za Discord</span>
+</nav>
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/discord.svg" width="1200" height="340" loading="lazy" alt="">
+</figure>
+
+<section class="hero">
+  <div class="hero-inner">
+    <div class="hero-card">
+      <h1 class="hero-headline">Fontovi za Discord: slova za nadimak i bio</h1>
+      <p class="hero-tagline">Upiši svoje ime i vidi ga odmah u desetcima fontova za Discord — podebljano, kurziv, gotička, balončasta i kapitalke. Kopiraš i lijepiš u nadimak, u nadimak na serveru, u odjeljak „O meni”, u naziv kanala i u chat. Sve besplatno i <strong>bez Nitra</strong>.</p>
+      <div class="input-wrapper">
+        <textarea class="main-input" id="mainInput" placeholder="Upiši ime ili tekst..." maxlength="500" autofocus=""></textarea>
+        <span class="char-count"><span id="charCount">0</span>/500</span>
+      </div>
+      <div class="decoration-section">
+        <div class="decoration-label">Dodaj simbole i okvire rezultatu</div>
+        <div class="decoration-tabs">
+          <button class="decoration-tab active" data-deco-tab="symbols">Simboli</button>
+          <button class="decoration-tab" data-deco-tab="frames">Okviri</button>
+          <button class="decoration-tab" data-deco-tab="dividers">Razdjelnici</button>
+          <button class="decoration-tab" data-deco-tab="arrows">Strelice</button>
+          <button class="decoration-tab" data-deco-tab="minimal">Minimalni</button>
+          <button class="decoration-tab" data-deco-tab="emojis">Emoji</button>
+        </div>
+        <div class="decoration-grid" id="decorationGrid"></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<main class="container">
+  <div class="category-section"><div class="category-tabs" id="categoryTabs"></div></div>
+  <div class="results-grid" id="resultsGrid"></div>
+
+  <!-- Kako to radi -->
+  <section class="editorial-section">
+    <h2>Fontovi za Discord: kako to radi</h2>
+    <p class="editorial-intro"><strong>Fontovi za Discord</strong> s ove stranice nisu instalirani font ni slika — to su <strong>Unicode znakovi</strong>, prava slova, ista kao s tipkovnice, samo drukčijeg izgleda (𝗔, 𝘈, 𝓐, 𝔄). Budući da Discord prihvaća Unicode u gotovo svakom tekstualnom polju, stilizirano slovo lijepi se ravno u tvoje <strong>prikazano ime</strong>, u <strong>nadimak na serveru</strong>, u odjeljak <strong>„O meni”</strong>, u <strong>naziv kanala</strong>, u <strong>status</strong> pa i u <strong>poruke</strong> — bez Nitra, dodatka ili posebne aplikacije.</p>
+    <div class="block-example">
+      <strong>Primjer:</strong> „marko” → 𝗺𝗮𝗿𝗸𝗼 (podebljano), 𝘮𝘢𝘳𝘬𝘰 (kurziv), 𝓶𝓪𝓻𝓴𝓸 (ukrasni kurziv), 𝔪𝔞𝔯𝔨𝔬 (gotička), ⓜⓐⓡⓚⓞ (balončasta), ᴍᴀʀᴋᴏ (kapitalke)
+    </div>
+    <p>Koristi se u nekoliko sekundi: upišeš ime u polje na vrhu, generator prikaže isti tekst u brojnim <strong>fontovima za Discord</strong>, klikneš „Kopiraj” i zalijepiš u aplikaciji. Želiš samo gola slova abecede? Odmah su ispod. A ako radije pregledavaš još rezova, potpuni generator naći ćeš na <a href="/hr/">glavnoj stranici sa slovima za kopiranje</a>.</p>
+  </section>
+
+  <!-- Abeceda A-Z -->
+  <section class="editorial-section glyph-section">
+    <h2>Abeceda fontova za Discord (A–Z za kopiranje)</h2>
+    <p class="editorial-intro">Cijela abeceda u stilovima koji se najčešće pojavljuju u nadimcima i biju na Discordu. Klikni redak da kopiraš cijelu abecedu u tom stilu, ili upiši svoje ime na vrhu i uzmi vlastitu riječ odmah stiliziranu.</p>
+    <div class="alpha-list">
+      <div class="alpha-row">
+        <span class="alpha-label">Podebljano</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝗔𝗕𝗖𝗗𝗘𝗙𝗚𝗛𝗜𝗝𝗞𝗟𝗠𝗡𝗢𝗣𝗤𝗥𝗦𝗧𝗨𝗩𝗪𝗫𝗬𝗭 𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇" aria-label="Kopiraj podebljanu abecedu">𝗔𝗕𝗖𝗗𝗘𝗙𝗚𝗛𝗜𝗝𝗞𝗟𝗠𝗡𝗢𝗣𝗤𝗥𝗦𝗧𝗨𝗩𝗪𝗫𝗬𝗭 · 𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Kurziv</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩 𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃" aria-label="Kopiraj abecedu u kurzivu">𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩 · 𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Elegantno</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵 𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏" aria-label="Kopiraj elegantnu abecedu">𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵 · 𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Gotička</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝔄𝔅ℭ𝔇𝔈𝔉𝔊ℌℑ𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔ℜ𝔖𝔗𝔘𝔙𝔚𝔛𝔜ℨ 𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷" aria-label="Kopiraj gotičku abecedu">𝔄𝔅ℭ𝔇𝔈𝔉𝔊ℌℑ𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔ℜ𝔖𝔗𝔘𝔙𝔚𝔛𝔜ℨ · 𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Balončasta</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ" aria-label="Kopiraj balončastu abecedu">ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ · ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Kapitalke</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="ᴀʙᴄᴅᴇꜰɢʜɪᴊᴋʟᴍɴᴏᴘqʀsᴛᴜᴠᴡxʏᴢ" aria-label="Kopiraj abecedu u kapitalkama">ᴀ ʙ ᴄ ᴅ ᴇ ꜰ ɢ ʜ ɪ ᴊ ᴋ ʟ ᴍ ɴ ᴏ ᴘ q ʀ s ᴛ ᴜ ᴠ ᴡ x ʏ ᴢ</button>
+      </div>
+    </div>
+    <p class="uname-note">Napomena o hrvatskim znakovima: ovi Unicode fontovi obuhvaćaju osnovnu abecedu A–Z. Hrvatske kvačice (č, ć, đ, š, ž) u većini stilova ostaju obična slova usred stilizirane riječi — pa npr. „željko” izađe kao ž𝓮𝓵𝓳𝓴𝓸. Za nadimke bez kvačica izgleda idealno, a za dulje tekstove najsigurniji su podebljano i kurziv.</p>
+    <p class="u-mt-15">Želiš se udubiti u jedan stil? Cijelu abecedu i inačice svakog reza naći ćeš na <a href="/hr/">glavnoj stranici sa slovima za kopiranje</a>, a zvjezdice i okvire za nadimak — u <a href="/library/aesthetic-symbols/">ukrasnim simbolima</a>.</p>
+  </section>
+
+  <!-- Fontovi za nadimak i O meni -->
+  <section class="editorial-section">
+    <h2>Fontovi za nadimak i odjeljak „O meni” na Discordu</h2>
+    <p class="editorial-intro">Najbrži način da istakneš profil jest staviti font na <strong>prikazano ime</strong> i zasebno u odjeljak <strong>„O meni”</strong> (bio profila). Discord prihvaća Unicode u oba polja — a uz to možeš imati <strong>drukčiji nadimak na svakom serveru</strong>, pa na gaming serveru koristiš goticu, a na serveru s prijateljima kurziv, sve pod istim računom.</p>
+    <p class="uname-note">Kako zalijepiti:</p>
+    <div class="block-example">
+      — <strong>Prikazano ime:</strong> Korisničke postavke › Profil › uredi prikazano ime i zalijepi font<br>
+      — <strong>Nadimak na serveru:</strong> desni klik na svom imenu na serveru › Uredi profil servera › zalijepi stilizirani nadimak<br>
+      — <strong>„O meni”:</strong> Korisničke postavke › Profil › polje „O meni” › zalijepi tekst<br>
+      — <strong>Naziv kanala:</strong> ako si administrator, uredi kanal i zalijepi font u naziv
+    </div>
+    <p>Savjet od nekoga tko svakodnevno slaže profile: stiliziraj samo ime, a ostatak „O meni” ostavi običnim tekstom — kontrast čini cijeli efekt. Kad je sve ukrašeno, ništa ne privlači pogled. Za pojedinačne zvjezdice i sjaj u biju svrati na stranicu s <a href="/library/aesthetic-symbols/">ukrasnim simbolima za kopiranje</a>.</p>
+  </section>
+
+  <!-- Markdown vs Unicode -->
+  <section class="editorial-section">
+    <h2>Discordov Markdown vs Unicode fontovi — kad što upotrijebiti</h2>
+    <p class="editorial-intro">Discord ima <strong>dva načina</strong> za petljanje po tekstu i vrijedi ih ne miješati. Jedan je izvorno <strong>Markdown oblikovanje</strong>, drugi su <strong>Unicode fontovi</strong> s ove stranice. Služe za različite stvari.</p>
+    <div class="block-example">
+      — <strong>Markdown (izvorni):</strong> <code>**podebljanje**</code> → <strong>podebljanje</strong>, <code>*kurziv*</code> → <em>kurziv</em>, <code>__podcrtavanje__</code>, <code>~~precrtavanje~~</code>, <code>`kod`</code>. Radi samo <strong>unutar poruka</strong> u chatu i nestane kad ga pokušaš u imenu ili u biju.<br>
+      — <strong>Unicode fontovi (ova stranica):</strong> 𝗽𝗼𝗱𝗲𝗯𝗹𝗷𝗮𝗻𝗼, 𝓴𝓾𝓻𝔃𝓲𝓿, 𝔤𝔬𝔱𝔦𝔠𝔞. To je sam stilizirani znak, pa radi <strong>svugdje</strong> — u nadimku, u „O meni”, u nazivu kanala, u statusu i u chatu.
+    </div>
+    <p>Praktično pravilo: da oblikuješ običnu <strong>poruku</strong> (podebljaš riječ usred rečenice), koristi Discordov Markdown — čišći je. Da stiliziraš <strong>nadimak, bio ili naziv kanala</strong>, koristi Unicode font, jer Markdown tu neće raditi. I važno upozorenje: ništa od toga ne radi u <strong>korisničkom imenu (@)</strong>, koje prima samo mala slova od a do z, brojke, točku i podvlaku — nikakav font, razmak ni emoji. Ako želiš stil u imenu, pravo polje je prikazano ime, a ne @login.</p>
+  </section>
+
+  <!-- Ukrasni nadimci s okvirima -->
+  <section class="editorial-section">
+    <h2>Ukrasni nadimci za Discord s okvirima i simbolima</h2>
+    <p class="editorial-intro">Nadimci koji najviše ostavljaju dojam na Discordu spajaju snažan font (goticu ili balončasta) s okvirima i simbolima s obje strane, u stilu ꧁༒ ༒꧂. Klikni za kopiranje i zalijepi u nadimak na serveru — potom zamijeni svojim imenom.</p>
+    <div class="uname-grid">
+      <button class="uname-chip symbol-tile" data-symbol="꧁༒𝕯𝖆𝖗𝖐༒꧂" aria-label="Kopiraj nadimak">꧁༒𝕯𝖆𝖗𝖐༒꧂</button>
+      <button class="uname-chip symbol-tile" data-symbol="꧁༒𝕸𝖆𝖗𝖐𝖔༒꧂" aria-label="Kopiraj nadimak">꧁༒𝕸𝖆𝖗𝖐𝖔༒꧂</button>
+      <button class="uname-chip symbol-tile" data-symbol="★彡ʟᴜᴋᴀ彡★" aria-label="Kopiraj nadimak">★彡ʟᴜᴋᴀ彡★</button>
+      <button class="uname-chip symbol-tile" data-symbol="⋆˚࿔ 𝓏𝒶𝓇𝒶 𝜗𝜚˚⋆" aria-label="Kopiraj nadimak">⋆˚࿔ 𝓏𝒶𝓇𝒶 𝜗𝜚˚⋆</button>
+      <button class="uname-chip symbol-tile" data-symbol="꧁✿𝓝𝓲𝓴𝓪✿꧂" aria-label="Kopiraj nadimak">꧁✿𝓝𝓲𝓴𝓪✿꧂</button>
+      <button class="uname-chip symbol-tile" data-symbol="✧˖°ℙ𝕖𝕥𝕣𝕒°˖✧" aria-label="Kopiraj nadimak">✧˖°ℙ𝕖𝕥𝕣𝕒°˖✧</button>
+      <button class="uname-chip symbol-tile" data-symbol="⛧🖤 𝔩𝔲𝔨𝔞 🖤⛧" aria-label="Kopiraj nadimak">⛧🖤 𝔩𝔲𝔨𝔞 🖤⛧</button>
+      <button class="uname-chip symbol-tile" data-symbol="「 ᴍᴀᴛᴇᴏ 」" aria-label="Kopiraj nadimak">「 ᴍᴀᴛᴇᴏ 」</button>
+      <button class="uname-chip symbol-tile" data-symbol="༺ 𝕾𝖍𝖆𝖉𝖔𝖜 ༻" aria-label="Kopiraj nadimak">༺ 𝕾𝖍𝖆𝖉𝖔𝖜 ༻</button>
+      <button class="uname-chip symbol-tile" data-symbol="⋆｡˚ⓝⓘⓝⓐ˚｡⋆" aria-label="Kopiraj nadimak">⋆｡˚ⓝⓘⓝⓐ˚｡⋆</button>
+    </div>
+    <p class="u-mt-15">Želiš cijeli set gotovih okvira, zvjezdica i razdjelnika da složiš vlastiti nadimak? Cijela paleta je na stranici s <a href="/library/aesthetic-symbols/">ukrasnim simbolima za kopiranje</a> — isti se znakovi lijepe u nadimak tvog servera na Discordu.</p>
+  </section>
+
+  <!-- Gdje radi + kvadratići -->
+  <section class="editorial-section">
+    <h2>Gdje rade fontovi na Discordu (i napomena o kvadratićima)</h2>
+    <p class="editorial-intro">Budući da je ono što kopiraš čisti Unicode, slova za Discord lijepe se praktički u svako tekstualno polje aplikacije:</p>
+    <div class="block-example">
+      — <strong>Prikazano ime</strong> i <strong>nadimak na serveru</strong> (zaseban na svakom serveru)<br>
+      — <strong>„O meni”</strong> (bio tvog profila)<br>
+      — <strong>Naziv kanala</strong> (ako imaš administratorska prava)<br>
+      — <strong>Prilagođeni status</strong> i <strong>poruke</strong> u chatu<br>
+      — <strong>Naziv servera</strong> (ako si njegov vlasnik)
+    </div>
+    <p>Jedino mjesto gdje to <strong>ne</strong> radi jest <strong>korisničko ime (@)</strong>, namjerno ograničeno na mala slova, brojke, točku i podvlaku. Uz to iskrena napomena: ako je uređaj osobe koja to gleda vrlo star, dio rjeđih stilova može se prikazati kao <strong>kvadratići (□)</strong> — to je font koji nedostaje na njezinu uređaju, a ne problem s tvojim tekstom. Držiš li se osnovnih stilova (podebljano, kurziv, gotica, balončasta, kapitalke) to se gotovo nikad ne događa. I zapamti: ništa od toga ne traži <strong>Nitro</strong> — Nitro ulazi samo kod boje i gradijenta u imenu, ne kod samog stiliziranog teksta. Za prazne redove u „O meni” dobro će doći <a href="/library/invisible-character/">nevidljivi znak</a>.</p>
+  </section>
+
+  <!-- Related -->
+  <section class="editorial-section">
+    <span class="article-section-label">Povezane stranice</span>
+    <div class="compare-grid">
+      <a href="/hr/" class="compare-card variant-muted u-no-underline">
+        <h4>Lijepa Slova</h4>
+        <p>Desetci stilova slova za stiliziranje imena prije nego što ga zalijepiš na Discord.</p>
+      </a>
+      <a href="/hr/" class="compare-card variant-muted u-no-underline">
+        <h4>Slova za Kopiranje</h4>
+        <p>Cijela abeceda u brojnim rezovima — bold, kurziv, gotica i balončasta.</p>
+      </a>
+      <a href="/library/aesthetic-symbols/" class="compare-card variant-muted u-no-underline">
+        <h4>Ukrasni Simboli za Kopiranje</h4>
+        <p>Zvjezdice, srca, okviri i razdjelnici za ukrašavanje nadimka i „O meni”.</p>
+      </a>
+      <a href="/library/invisible-character/" class="compare-card variant-muted u-no-underline">
+        <h4>Nevidljivi Znak</h4>
+        <p>Prazan razmak za čiste redove u biju i prazne nazive na Discordu.</p>
+      </a>
+    </div>
+  </section>
+</main>
+
+<footer class="footer">
+  <div class="footer-inner">
+    <h2 class="faq-category">Najčešća pitanja o fontovima za Discord</h2>
+    <div class="faq-item"><button class="faq-question" type="button">Kako promijeniti font u nadimku na Discordu?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Upiši svoje ime u polje na vrhu stranice. Odmah će se pojaviti desetci fontova za Discord — podebljano, kurziv, gotička, balončasta, kapitalke. Klikni „Kopiraj” kod onog koji ti se sviđa, otvori Discord, uđi u Korisničke postavke i zalijepi ga u prikazano ime, ili desnim klikom na serveru promijeni nadimak na tom serveru. Budući da su to Unicode znakovi, stilizirano slovo se lijepi u polje bez ikakvog dodatka.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Treba li za fontove na Discordu Nitro?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Ne. Slova iz ovog generatora obični su Unicode znakovi, isti kao s tipkovnice, samo drukčijeg izgleda — zato se lijepe u prikazano ime, u nadimak na serveru, u odjeljak „O meni”, u naziv kanala i u poruke bez ikakvog Nitra. Nitro je potreban samo za plaćene dodatke, poput boja i gradijenta u imenu (Display Name Styles), a ne za sam stilizirani tekst.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Rade li fontovi u korisničkom imenu (@) na Discordu?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Ne. Korisničko ime (jedinstveni @ koji se koristi za pozivnice prijateljima) prima samo mala slova od a do z, brojke, točku i podvlaku — bez stilskih fontova, razmaka, emojija ili simbola. Fontovi za Discord rade u prikazanom imenu, u nadimku na serveru, u odjeljku „O meni”, u nazivu kanala i u chatu. Ako želiš stil u imenu, koristi prikazano ime, a ne @login.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Po čemu se razlikuje Discordovo oblikovanje (**podebljanje**) od Unicode fontova?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">To su dvije različite stvari. Discordov Markdown (**podebljanje**, *kurziv*, `kod`) oblikuje tekst samo unutar poruka u chatu i nestane kad ga pokušaš upotrijebiti u imenu ili u biju. Unicode fontovi s ove stranice sam su stilizirani znak, pa rade svugdje — u nadimku, u „O meni”, u nazivu kanala, u statusu i u chatu. Praktično pravilo: u običnoj poruci koristi Markdown, a da stiliziraš nadimak ili bio, koristi Unicode font.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Kako napraviti ukrasni nadimak za Discord s okvirima i simbolima?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Odaberi font za ime (gotica i balončasta izlaze najbolje) i okruži ga okvirima te simbolima u stilu ꧁༒ ༒꧂. Na ovoj stranici je mreža gotovih nadimaka s okvirima — klikni za kopiranje i zalijepi u nadimak na serveru. Možeš i upisati svoje ime na vrhu, staviti font i upotrijebiti kartice Simboli i Okviri da dotjeraš izgled prije kopiranja.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Zašto se slova na Discordu prikazuju kao kvadratići?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Zato što uređaj osobe koja to gleda nema font koji crta taj znak — obično je to stariji telefon ili računalo. To nije greška stranice ni tvog kopiranja. Osnovni stilovi — podebljano, kurziv, gotica, balončasta i kapitalke — najsigurniji su i prikazuju se ispravno gotovo svugdje. Ako netko prijavi kvadratić (□), zamijeni jednim od tih stilova.</div></div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Odabir jezika">
+      <a class="lang-option" href="/discord/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/hr/fontovi-za-discord/" hreflang="hr">HR</a>
+    </div>
+  </div>
+</footer>
+
+<div class="copy-toast" id="copyToast">Kopirano!</div>
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/styles.js"></script>
+<script src="/renderer.js"></script>
+<script src="/script.js" defer=""></script>
+<script src="/symbol-explorer.js"></script>
+<script src="/footer.js"></script>
+</body></html>

--- a/hr/fontovi-za-instagram/index.html
+++ b/hr/fontovi-za-instagram/index.html
@@ -1,0 +1,310 @@
+<!DOCTYPE html><html lang="hr"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Fontovi za Instagram: lijepa slova za bio i opise | UltraTextGen</title>
+  <meta name="description" content="Fontovi za Instagram besplatno: pretvori tekst u 𝗽𝗼𝗱𝗲𝗯𝗹𝗷𝗮𝗻𝗼, 𝘬𝘶𝘳𝘻𝘪𝘷 ili 𝓴𝓪𝓵𝓲𝓰𝓻𝓪𝓯𝓲𝓳𝓾 i zalijepi u bio, u ime profila, u opis i u komentare. Lijepa slova za Instagram — bez aplikacije.">
+  <link rel="canonical" href="https://ultratextgen.com/hr/fontovi-za-instagram/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/instagram/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/instagram/">
+  <link rel="alternate" hreflang="hr" href="https://ultratextgen.com/hr/fontovi-za-instagram/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Fontovi za Instagram: lijepa slova za bio i opise">
+  <meta property="og:description" content="Generator fontova za Instagram: upiši tekst i zalijepi stilizirano slovo u bio, u ime profila, u opis i u komentare. Podebljano, kurziv, kaligrafija i gotica — bez aplikacije.">
+  <meta property="og:url" content="https://ultratextgen.com/hr/fontovi-za-instagram/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/instagram.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Fontovi za Instagram: lijepa slova za bio i opise">
+  <meta name="twitter:description" content="Podebljano, kurziv, kaligrafija i gotica spremni za lijepljenje u bio i ime profila na Instagramu — bez aplikacije.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/instagram.png">
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+  <link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Generator Fontova za Instagram",
+  "alternateName": ["Fontovi za Instagram", "Fontovi za Instu", "Lijepa slova za Instagram", "Fontovi za bio na Instagramu", "Generator fontova za IG", "Slova za Instagram"],
+  "url": "https://ultratextgen.com/hr/fontovi-za-instagram/",
+  "inLanguage": "hr",
+  "applicationCategory": "UtilitiesApplication",
+  "operatingSystem": "Any",
+  "description": "Generator fontova za Instagram: pretvara tvoj tekst u stilizirana slova — podebljano, kurziv, kaligrafiju, goticu, balončasta i kapitalke — za lijepljenje u bio, u ime profila, u opis objave, u komentare i u Priče, bez preuzimanja aplikacije.",
+  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "EUR" }
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "hr",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Kako promijeniti font u biju na Instagramu?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Upiši svoj tekst u polje na vrhu stranice. Odmah će se pojaviti desetci fontova za Instagram — podebljano, kurziv, kaligrafija, gotica, balončasta i kapitalke. Klikni „Kopiraj” kod onog koji ti se sviđa, otvori Instagram, uđi u Uredi profil i zalijepi ga u polje Bio. Budući da su to Unicode znakovi, stilizirano slovo se lijepi u polje bez ikakve aplikacije ni dodatne tipkovnice." }
+    },
+    {
+      "@type": "Question",
+      "name": "Kako napraviti drukčiji font u imenu profila na Instagramu?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Kopiraj ovdje odabrani font i zalijepi ga u polje „Ime” u Uredi profil — to je ono podebljano ime na vrhu profila, a ne @login. Instagram prihvaća Unicode u tom polju, pa se stilizirano slovo prikazuje ispravno. Samo imaj na umu da Instagram dopušta promjenu Imena ograničen broj puta u kratkom razdoblju (obično dvaput u 14 dana), pa zalijepi odmah gotov stil." }
+    },
+    {
+      "@type": "Question",
+      "name": "Može li se koristiti ukrasni font u korisničkom imenu (@) na Instagramu?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Ne. Korisničko ime (@login koji je u tvom linku i služi za označavanje) prima samo mala slova od a do z, brojke, točku i podvlaku — bez stilskih fontova, razmaka, emojija ili simbola. Fontovi za Instagram rade u imenu profila (Ime), u biju, u opisima i u komentarima. Ako želiš stil u imenu, koristi polje Ime, a ne @login." }
+    },
+    {
+      "@type": "Question",
+      "name": "Rade li fontovi u opisima objava i u komentarima na Instagramu?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Da. Budući da su to obični Unicode znakovi, stilizirano slovo lijepiš u opis fotografije i reela, u komentare, u tekst u Pričama i u poruke na Directu. Radi jednako u aplikaciji na mobitelu i u verziji za preglednik. Jedino polje koje to ne prima jest @login (korisničko ime)." }
+    },
+    {
+      "@type": "Question",
+      "name": "Šteti li stilizirani font u biju prikazu u pretrazi na Instagramu?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Može štetiti ako sve stiliziraš. Pretraga i čitači zaslona bolje razumiju običan tekst, pa je najbolje stilizirati samo ime ili jednu kratku frazu, a važne ključne riječi — čime se baviš, tvoj grad, tvoja niša — ostaviti običnim fontom. Tada profil izgleda lijepo i i dalje ga je lako pronaći." }
+    },
+    {
+      "@type": "Question",
+      "name": "Zašto se font na Instagramu prikazuje kao kvadratić?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Zato što uređaj osobe koja to gleda nema font koji crta taj znak — obično je to stariji telefon ili računalo. To nije greška stranice ni tvog kopiranja. Osnovni stilovi — podebljano, kurziv, kaligrafija, gotica, balončasta i kapitalke — najsigurniji su i prikazuju se ispravno gotovo svugdje. Ako vidiš kvadratić (□), zamijeni jednim od tih stilova." }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "inLanguage": "hr",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Početna", "item": "https://ultratextgen.com/hr/" },
+    { "@type": "ListItem", "position": 2, "name": "Fontovi za Instagram", "item": "https://ultratextgen.com/hr/fontovi-za-instagram/" }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/hr/">Početna</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Fontovi za Instagram</span>
+</nav>
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/instagram.svg" width="1200" height="340" loading="lazy" alt="">
+</figure>
+
+<section class="hero">
+  <div class="hero-inner">
+    <div class="hero-card">
+      <h1 class="hero-headline">Fontovi za Instagram: lijepa slova za bio i opise</h1>
+      <p class="hero-tagline">Upiši tekst i vidi ga odmah u desetcima fontova za Instagram — podebljano, kurziv, kaligrafija, gotica, balončasta i kapitalke. Kopiraš i lijepiš u bio, u ime profila, u opis objave i u komentare. Sve besplatno i <strong>bez aplikacije</strong>.</p>
+      <div class="input-wrapper">
+        <textarea class="main-input" id="mainInput" placeholder="Upiši tekst za bio ili opis..." maxlength="500" autofocus=""></textarea>
+        <span class="char-count"><span id="charCount">0</span>/500</span>
+      </div>
+      <div class="decoration-section">
+        <div class="decoration-label">Dodaj simbole i okvire rezultatu</div>
+        <div class="decoration-tabs">
+          <button class="decoration-tab active" data-deco-tab="symbols">Simboli</button>
+          <button class="decoration-tab" data-deco-tab="frames">Okviri</button>
+          <button class="decoration-tab" data-deco-tab="dividers">Razdjelnici</button>
+          <button class="decoration-tab" data-deco-tab="arrows">Strelice</button>
+          <button class="decoration-tab" data-deco-tab="minimal">Minimalni</button>
+          <button class="decoration-tab" data-deco-tab="emojis">Emoji</button>
+        </div>
+        <div class="decoration-grid" id="decorationGrid"></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<main class="container">
+  <div class="category-section"><div class="category-tabs" id="categoryTabs"></div></div>
+  <div class="results-grid" id="resultsGrid"></div>
+
+  <!-- Kako to radi -->
+  <section class="editorial-section">
+    <h2>Fontovi za Instagram: kako to radi</h2>
+    <p class="editorial-intro"><strong>Fontovi za Instagram</strong> s ove stranice nisu instalirani font ni slika — to su <strong>Unicode znakovi</strong>, prava slova, ista kao s tipkovnice, samo drukčijeg izgleda (𝗔, 𝘈, 𝓐, 𝔄). Budući da Instagram prihvaća Unicode u gotovo svakom tekstualnom polju, stilizirano slovo lijepi se ravno u tvoj <strong>bio</strong>, u <strong>ime profila</strong>, u <strong>opis objave</strong>, u <strong>komentare</strong>, u tekst u <strong>Pričama</strong> i u poruke na <strong>Directu</strong> — bez aplikacije, dodatka ili posebne tipkovnice.</p>
+    <div class="block-example">
+      <strong>Primjer:</strong> „ana” → 𝗮𝗻𝗮 (podebljano), 𝘢𝘯𝘢 (kurziv), 𝒶𝓃𝒶 (kaligrafija), 𝔞𝔫𝔞 (gotička), ⓐⓝⓐ (balončasta), ᴀɴᴀ (kapitalke)
+    </div>
+    <p>Koristi se u nekoliko sekundi: upišeš tekst u polje na vrhu, generator ga prikaže u brojnim <strong>fontovima za Instagram</strong>, klikneš „Kopiraj” i zalijepiš u aplikaciji. Želiš samo gola slova abecede? Odmah su ispod. A ako radije pregledavaš još rezova, potpuni generator naći ćeš na <a href="/hr/">glavnoj stranici sa slovima za kopiranje</a>.</p>
+  </section>
+
+  <!-- Abeceda A-Z -->
+  <section class="editorial-section glyph-section">
+    <h2>Abeceda fontova za Instagram (A–Z za kopiranje)</h2>
+    <p class="editorial-intro">Cijela abeceda u stilovima koji se najčešće pojavljuju u biju i opisima na Instagramu. Klikni redak da kopiraš cijelu abecedu u tom stilu, ili upiši svoj tekst na vrhu i uzmi vlastitu riječ odmah stiliziranu.</p>
+    <div class="alpha-list">
+      <div class="alpha-row">
+        <span class="alpha-label">Podebljano</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝗔𝗕𝗖𝗗𝗘𝗙𝗚𝗛𝗜𝗝𝗞𝗟𝗠𝗡𝗢𝗣𝗤𝗥𝗦𝗧𝗨𝗩𝗪𝗫𝗬𝗭 𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇" aria-label="Kopiraj podebljanu abecedu">𝗔𝗕𝗖𝗗𝗘𝗙𝗚𝗛𝗜𝗝𝗞𝗟𝗠𝗡𝗢𝗣𝗤𝗥𝗦𝗧𝗨𝗩𝗪𝗫𝗬𝗭 · 𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Kurziv</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩 𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃" aria-label="Kopiraj abecedu u kurzivu">𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩 · 𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Elegantno</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵 𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏" aria-label="Kopiraj elegantnu abecedu">𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵 · 𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Gotička</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝔄𝔅ℭ𝔇𝔈𝔉𝔊ℌℑ𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔ℜ𝔖𝔗𝔘𝔙𝔚𝔛𝔜ℨ 𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷" aria-label="Kopiraj gotičku abecedu">𝔄𝔅ℭ𝔇𝔈𝔉𝔊ℌℑ𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔ℜ𝔖𝔗𝔘𝔙𝔚𝔛𝔜ℨ · 𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Balončasta</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ" aria-label="Kopiraj balončastu abecedu">ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ · ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Kapitalke</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="ᴀʙᴄᴅᴇꜰɢʜɪᴊᴋʟᴍɴᴏᴘqʀsᴛᴜᴠᴡxʏᴢ" aria-label="Kopiraj abecedu u kapitalkama">ᴀ ʙ ᴄ ᴅ ᴇ ꜰ ɢ ʜ ɪ ᴊ ᴋ ʟ ᴍ ɴ ᴏ ᴘ q ʀ s ᴛ ᴜ ᴠ ᴡ x ʏ ᴢ</button>
+      </div>
+    </div>
+    <p class="uname-note">Napomena o hrvatskim znakovima: ovi Unicode fontovi obuhvaćaju osnovnu abecedu A–Z. Hrvatske kvačice (č, ć, đ, š, ž) u većini stilova ostaju obična slova usred stilizirane riječi — pa npr. „ana” izađe savršeno, a „nataša” prikaže š kao obično slovo. Za bio i imena bez kvačica izgleda savršeno, a za dulje opise najsigurniji su podebljano i kurziv.</p>
+    <p class="u-mt-15">Želiš se udubiti u jedan stil? Cijelu abecedu i inačice svakog reza naći ćeš na <a href="/hr/">glavnoj stranici sa slovima za kopiranje</a>, a najpopularniji za bio na Instagramu je <a href="/hr/kurziv/">kurziv</a>.</p>
+  </section>
+
+  <!-- Fontovi za bio i ime -->
+  <section class="editorial-section">
+    <h2>Fontovi za bio i ime profila na Instagramu</h2>
+    <p class="editorial-intro">Najbrži način da istakneš profil jest staviti font na <strong>ime profila</strong> (polje „Ime”) i zasebno u <strong>bio</strong>. To su dva različita polja — „Ime” je ono podebljano ime na vrhu profila, a bio je opis ispod njega. Instagram prihvaća Unicode u oba, ali <strong>ne u @loginu</strong>.</p>
+    <p class="uname-note">Kako zalijepiti:</p>
+    <div class="block-example">
+      — <strong>Ime profila (Ime):</strong> Uredi profil › polje „Ime” › zalijepi stilizirani font<br>
+      — <strong>Bio:</strong> Uredi profil › polje „Bio” › zalijepi tekst (možeš spajati više stilova u zasebnim redovima)<br>
+      — <strong>Opis objave / reela:</strong> pri dodavanju objave zalijepi font u polje opisa<br>
+      — <strong>Komentari i Direct:</strong> zalijepi stilizirano slovo ravno u polje komentara ili poruke
+    </div>
+    <p>Savjet od nekoga tko svakodnevno slaže profile: stiliziraj samo ime ili jednu frazu, a ostatak bija ostavi običnim tekstom — kontrast čini cijeli efekt. Kad je sve ukrašeno, ništa ne privlači pogled. Važan detalj: Instagram dopušta promjenu polja „Ime” samo ograničen broj puta u kratkom razdoblju, pa zalijepi odmah gotov stil. Za pojedinačne zvjezdice i sjaj u biju svrati na stranicu s <a href="/library/aesthetic-symbols/">ukrasnim simbolima za kopiranje</a>.</p>
+  </section>
+
+  <!-- Gdje radi i gdje ne -->
+  <section class="editorial-section">
+    <h2>Gdje ćeš zalijepiti fontove na Instagramu (a gdje ne)</h2>
+    <p class="editorial-intro">Budući da je ono što kopiraš čisti Unicode, slova za Instagram lijepe se praktički u svako tekstualno polje aplikacije:</p>
+    <div class="block-example">
+      — <strong>Ime profila (Ime)</strong> i <strong>bio</strong><br>
+      — <strong>Opisi objava</strong> i <strong>reelova</strong><br>
+      — <strong>Komentari</strong> ispod objava<br>
+      — <strong>Tekst u Pričama</strong> i <strong>bilješke (Notes)</strong><br>
+      — <strong>Poruke na Directu</strong>
+    </div>
+    <p>Jedino mjesto gdje to <strong>ne</strong> radi jest <strong>korisničko ime (@login)</strong> — Instagram ga namjerno ograničava na mala slova od a do z, brojke, točku i podvlaku, pa nikakav stilizirani font, razmak ni emoji tu ne prolazi. Uz to iskrena napomena: ako je uređaj osobe koja to gleda vrlo star, dio rjeđih stilova može se prikazati kao <strong>kvadratići (□)</strong> — to je font koji nedostaje na njezinu uređaju, a ne problem s tvojim tekstom. Držiš li se osnovnih stilova (podebljano, kurziv, kaligrafija, gotica, balončasta, kapitalke) to se gotovo nikad ne događa. Za čiste prazne redove u biju dobro će doći <a href="/library/invisible-character/">nevidljivi znak</a>.</p>
+  </section>
+
+  <!-- Ukrasni bio sa simbolima -->
+  <section class="editorial-section">
+    <h2>Ukrasni bio i imena za Instagram sa simbolima</h2>
+    <p class="editorial-intro">Imena i redovi bija koji najviše ostavljaju dojam na Instagramu spajaju nježan font (kaligrafiju ili kurziv) sa zvjezdicama i simbolima s obje strane, u stilu ⋆˚₊‧ ‧₊˚⋆. Klikni za kopiranje i zalijepi u polje „Ime” ili u bio — potom zamijeni svojom riječju.</p>
+    <div class="uname-grid">
+      <button class="uname-chip symbol-tile" data-symbol="⋆˚₊‧ 𝒶𝓃𝒶 ‧₊˚⋆" aria-label="Kopiraj ime">⋆˚₊‧ 𝒶𝓃𝒶 ‧₊˚⋆</button>
+      <button class="uname-chip symbol-tile" data-symbol="✿ 𝓶𝓪𝓳𝓪 ✿" aria-label="Kopiraj ime">✿ 𝓶𝓪𝓳𝓪 ✿</button>
+      <button class="uname-chip symbol-tile" data-symbol="꒰ঌ 𝓃𝒾𝓀𝒶 ໒꒱" aria-label="Kopiraj ime">꒰ঌ 𝓃𝒾𝓀𝒶 ໒꒱</button>
+      <button class="uname-chip symbol-tile" data-symbol="⋆｡˚ 𝓮𝓶𝓪 ˚｡⋆" aria-label="Kopiraj ime">⋆｡˚ 𝓮𝓶𝓪 ˚｡⋆</button>
+      <button class="uname-chip symbol-tile" data-symbol="✧˖° 𝓵𝓾𝓬𝓲𝓳𝓪 °˖✧" aria-label="Kopiraj ime">✧˖° 𝓵𝓾𝓬𝓲𝓳𝓪 °˖✧</button>
+      <button class="uname-chip symbol-tile" data-symbol="ᯓ★ 𝓅ℯ𝓉𝓇𝒶 ★" aria-label="Kopiraj ime">ᯓ★ 𝓅ℯ𝓉𝓇𝒶 ★</button>
+      <button class="uname-chip symbol-tile" data-symbol="˚ʚ 𝓁𝒶𝓃𝒶 ɞ˚" aria-label="Kopiraj ime">˚ʚ 𝓁𝒶𝓃𝒶 ɞ˚</button>
+      <button class="uname-chip symbol-tile" data-symbol="⊹ ࣪ ˖ 𝓀𝓁𝒶𝓇𝒶 ˖ ࣪ ⊹" aria-label="Kopiraj ime">⊹ ࣪ ˖ 𝓀𝓁𝒶𝓇𝒶 ˖ ࣪ ⊹</button>
+      <button class="uname-chip symbol-tile" data-symbol="⟡ 𝓲𝓿𝓪 ⟡" aria-label="Kopiraj ime">⟡ 𝓲𝓿𝓪 ⟡</button>
+      <button class="uname-chip symbol-tile" data-symbol="๑ 𝓼𝓪𝓻𝓪 ๑" aria-label="Kopiraj ime">๑ 𝓼𝓪𝓻𝓪 ๑</button>
+    </div>
+    <p class="u-mt-15">Želiš cijeli set gotovih zvjezdica, srca i razdjelnika da složiš vlastiti bio? Cijela paleta je na stranici s <a href="/library/aesthetic-symbols/">ukrasnim simbolima za kopiranje</a> — isti se znakovi lijepe u ime i u bio na Instagramu.</p>
+  </section>
+
+  <!-- Pretraga i kvadratići -->
+  <section class="editorial-section">
+    <h2>Fontovi i pretraga na Instagramu (i napomena o kvadratićima)</h2>
+    <p class="editorial-intro">Stilizirani tekst izgleda sjajno, ali ima jednu kvaku: pretraga Instagrama i čitači zaslona tretiraju Unicode znakove drukčije od običnih slova. Ako stiliziraš cijeli bio, tvoje ključne riječi mogu slabije iskakati u pretrazi.</p>
+    <div class="block-example">
+      — <strong>Dobra praksa:</strong> stiliziraj ime ili kratku frazu, ostalo ostavi običnim tekstom<br>
+      — <strong>Ostavi običnim fontom:</strong> čime se baviš, grad, niša, riječi po kojima te traže<br>
+      — <strong>Primjer:</strong> 𝓶𝓪𝓳𝓪 𝓴𝓸𝓿𝓪č𝓲ć (kaligrafija) + „vjenčana fotografija · Zagreb” običnim fontom
+    </div>
+    <p>Druga stvar su <strong>kvadratići (□)</strong>: kad netko na mjestu slova vidi prazan pravokutnik, to znači da njegov uređaj nema font koji crta taj znak — obično vrlo star telefon. To nije problem s tvojim tekstom ni s kopiranjem. Držiš li se osnovnih stilova, to se gotovo nikad ne događa. Za prazne redove i razmake u biju dobro će doći <a href="/library/invisible-character/">nevidljivi znak</a>, a snažniji, taman stil za ime naći ćeš u <a href="/hr/goticka-slova/">gotičkim slovima</a>.</p>
+  </section>
+
+  <!-- Related -->
+  <section class="editorial-section">
+    <span class="article-section-label">Povezane stranice</span>
+    <div class="compare-grid">
+      <a href="/hr/" class="compare-card variant-muted u-no-underline">
+        <h4>Slova za Kopiranje</h4>
+        <p>Cijela abeceda u brojnim rezovima — podebljano, kurziv, kaligrafija i balončasta.</p>
+      </a>
+      <a href="/hr/kurziv/" class="compare-card variant-muted u-no-underline">
+        <h4>Kurziv</h4>
+        <p>Ukrasni, rukopisni kurziv — najčešći izbor za bio na Instagramu.</p>
+      </a>
+      <a href="/library/aesthetic-symbols/" class="compare-card variant-muted u-no-underline">
+        <h4>Ukrasni Simboli za Kopiranje</h4>
+        <p>Zvjezdice, srca, okviri i razdjelnici za ukrašavanje imena i bija.</p>
+      </a>
+      <a href="/library/invisible-character/" class="compare-card variant-muted u-no-underline">
+        <h4>Nevidljivi Znak</h4>
+        <p>Prazan razmak za čiste redove i odmake u biju na Instagramu.</p>
+      </a>
+      <a href="/hr/goticka-slova/" class="compare-card variant-muted u-no-underline">
+        <h4>Gotička Slova</h4>
+        <p>Tamna, snažna slova za ime profila s karakterom.</p>
+      </a>
+    </div>
+  </section>
+</main>
+
+<footer class="footer">
+  <div class="footer-inner">
+    <h2 class="faq-category">Najčešća pitanja o fontovima za Instagram</h2>
+    <div class="faq-item"><button class="faq-question" type="button">Kako promijeniti font u biju na Instagramu?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Upiši svoj tekst u polje na vrhu stranice. Odmah će se pojaviti desetci fontova za Instagram — podebljano, kurziv, kaligrafija, gotica, balončasta i kapitalke. Klikni „Kopiraj” kod onog koji ti se sviđa, otvori Instagram, uđi u Uredi profil i zalijepi ga u polje Bio. Budući da su to Unicode znakovi, stilizirano slovo se lijepi u polje bez ikakve aplikacije ni dodatne tipkovnice.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Kako napraviti drukčiji font u imenu profila na Instagramu?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Kopiraj ovdje odabrani font i zalijepi ga u polje „Ime” u Uredi profil — to je ono podebljano ime na vrhu profila, a ne @login. Instagram prihvaća Unicode u tom polju, pa se stilizirano slovo prikazuje ispravno. Samo imaj na umu da Instagram dopušta promjenu Imena ograničen broj puta u kratkom razdoblju (obično dvaput u 14 dana), pa zalijepi odmah gotov stil.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Može li se koristiti ukrasni font u korisničkom imenu (@) na Instagramu?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Ne. Korisničko ime (@login koji je u tvom linku i služi za označavanje) prima samo mala slova od a do z, brojke, točku i podvlaku — bez stilskih fontova, razmaka, emojija ili simbola. Fontovi za Instagram rade u imenu profila (Ime), u biju, u opisima i u komentarima. Ako želiš stil u imenu, koristi polje Ime, a ne @login.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Rade li fontovi u opisima objava i u komentarima na Instagramu?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Da. Budući da su to obični Unicode znakovi, stilizirano slovo lijepiš u opis fotografije i reela, u komentare, u tekst u Pričama i u poruke na Directu. Radi jednako u aplikaciji na mobitelu i u verziji za preglednik. Jedino polje koje to ne prima jest @login (korisničko ime).</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Šteti li stilizirani font u biju prikazu u pretrazi na Instagramu?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Može štetiti ako sve stiliziraš. Pretraga i čitači zaslona bolje razumiju običan tekst, pa je najbolje stilizirati samo ime ili jednu kratku frazu, a važne ključne riječi — čime se baviš, tvoj grad, tvoja niša — ostaviti običnim fontom. Tada profil izgleda lijepo i i dalje ga je lako pronaći.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Zašto se font na Instagramu prikazuje kao kvadratić?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Zato što uređaj osobe koja to gleda nema font koji crta taj znak — obično je to stariji telefon ili računalo. To nije greška stranice ni tvog kopiranja. Osnovni stilovi — podebljano, kurziv, kaligrafija, gotica, balončasta i kapitalke — najsigurniji su i prikazuju se ispravno gotovo svugdje. Ako vidiš kvadratić (□), zamijeni jednim od tih stilova.</div></div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Odabir jezika">
+      <a class="lang-option" href="/instagram/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/hr/fontovi-za-instagram/" hreflang="hr">HR</a>
+    </div>
+  </div>
+</footer>
+
+<div class="copy-toast" id="copyToast">Kopirano!</div>
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script>window.UTG_PREVIEW_PLATFORM='instagram';window.UTG_SHOW_PLATFORMS=true;window.UTG_DEMO_TEXT='ana aesthetic\nlink u biju ⬇';</script>
+<script src="/styles.js"></script>
+<script src="/renderer.js"></script>
+<script src="/script.js" defer=""></script>
+<script src="/symbol-explorer.js"></script>
+<script src="/footer.js" defer></script>
+</body></html>

--- a/hr/goticka-slova/index.html
+++ b/hr/goticka-slova/index.html
@@ -1,0 +1,299 @@
+<!DOCTYPE html><html lang="hr"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZGVh");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Generator Gotičkih Slova — 𝔤𝔬𝔱𝔦𝔠𝔞 za kopiranje | UltraTextGen</title>
+  <meta name="description" content="Besplatan generator gotičkih slova: pretvori tekst u gotičke Unicode znakove (fraktura) za kopiranje i lijepljenje — u bio na Instagramu, Discord, TikTok, nadimke i skice tetovaža. Odmah, bez registracije.">
+  <link rel="canonical" href="https://ultratextgen.com/hr/goticka-slova/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/category/gothic-fonts/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/category/gothic-fonts/">
+  <link rel="alternate" hreflang="hr" href="https://ultratextgen.com/hr/goticka-slova/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Generator Gotičkih Slova — 𝔤𝔬𝔱𝔦𝔠𝔞 za kopiranje | UltraTextGen">
+  <meta property="og:description" content="Besplatan generator gotičkih slova — gotički Unicode znakovi (fraktura) za kopiranje i lijepljenje na Instagram, Discord, TikTok i u nadimke. Odmah, bez registracije.">
+  <meta property="og:url" content="https://ultratextgen.com/hr/goticka-slova/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category-gothic-fonts.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Generator Gotičkih Slova — 𝔤𝔬𝔱𝔦𝔠𝔞 za kopiranje | UltraTextGen">
+  <meta name="twitter:description" content="Besplatan generator gotičkih slova — gotički Unicode znakovi (fraktura) za kopiranje i lijepljenje na društvene mreže, Discord i u nadimke.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category-gothic-fonts.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "hr",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Što je generator gotičkih slova i kako radi?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Pretvara slova koja upišeš u gotičke Unicode znakove (𝔭𝔬𝔭𝔲𝔱 𝔬𝔳𝔦𝔥) — prave znakove iz obitelji frakture, a ne font ni sliku. Budući da su to obični tekstualni znakovi, možeš ih kopirati i zalijepiti svugdje gdje je dopušten tekst: u bio, opise, komentare, nadimke i poruke. Više u našem vodiču o tome kako rade Unicode fontovi."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Radi li gotički tekst na Instagramu, Discordu, TikToku i u drugim aplikacijama?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da. Bio, opisi, komentari, nazivi kanala na Discordu i poruke na chatu bez problema primaju gotičke znakove jer je to običan Unicode. Sjajno se pokaže u nadimcima i profilima goth, metal ili srednjovjekovnog ugođaja. Napomena: neka polja s @korisničkim imenom filtriraju nestandardne znakove — u samom handleu treba ostati na običnom tekstu, ali u biju i opisima gotica radi bez zapreka."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Po čemu se razlikuje gotica (fraktura) od podebljane gotice?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "To su dvije inačice istog stila. Obična fraktura (𝔤𝔬𝔱𝔦𝔠𝔞) tanja je i klasičnija, a podebljana gotica (𝖌𝖔𝖙𝖎𝖈𝖆) ima deblje, snažnije poteze i bolje izgleda u kratkim naslovima i nadimcima. U rezultatima ispod naći ćeš obje inačice — dovoljno je kliknuti onu koja odgovara tvom projektu i kopirati."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Mogu li pisati hrvatske znakove (č, ć, đ, š, ž) gotičkim slovima?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Unicode gotica obuhvaća A–Z i a–z, pa hrvatski znakovi poput č, ć, đ, š, ž nemaju vlastiti gotički oblik i ostaju obični. Za dosljedan gotički efekt možeš ih zamijeniti osnovnim slovima (c, d, s, z) — to mijenja pravopis — ili ih ostaviti u normalnom obliku, što u kratkom tekstu, nadimku ili naslovu obično ionako izgleda dobro."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Je li generator gotičkih slova besplatan?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da, potpuno besplatan i bez registracije. Upisuj, kopiraj i lijepi koliko god puta želiš — nema ograničenja ni skrivenih troškova."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Zašto se neka gotička slova prikazuju kao kvadratići ili izgledaju drukčije?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Prazni kvadratić (▯) znači da uređaj nema odgovarajući glif za taj gotički znak — to se obično odnosi na starije sustave. Osim toga, nekoliko velikih slova frakture (C, H, I, R, Z) dolazi iz drugog Unicode bloka i izgleda drukčije od ostatka abecede — to je normalno. Odaberi tada podebljanu inačicu gotice ili ažuriraj uređaj; više u članku o tome zašto se fontovi prikazuju kao kvadratići."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "inLanguage": "hr",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Početna", "item": "https://ultratextgen.com/hr/" },
+    { "@type": "ListItem", "position": 2, "name": "Gotička slova", "item": "https://ultratextgen.com/hr/goticka-slova/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Generator Gotičkih Slova",
+  "alternateName": ["Gotička slova","Gotički tekst","Gotica za kopiranje","Unicode fraktura","Gotička slova za tetovažu","Generator gotice","Gotički font","Blackletter na hrvatskom"],
+  "url": "https://ultratextgen.com/hr/goticka-slova/",
+  "inLanguage": "hr",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "EUR"
+  },
+  "description": "Besplatan generator gotičkih slova: pretvori tekst u gotičke Unicode znakove (fraktura i podebljana gotica) za kopiranje i lijepljenje na Instagram, Discord, TikTok, u nadimke i skice tetovaža.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/hr/">Početna</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Gotička slova</span>
+</nav>
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/category-gothic-fonts.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+  <!-- Hero -->
+  <section class="hero">
+    <div class="hero-inner">
+      <div class="hero-card">
+        <h1 class="hero-headline">Generator Gotičkih Slova</h1>
+        <p class="hero-tagline">Pretvori bilo koji tekst u 𝔤𝔬𝔱𝔦𝔠𝔲 za kopiranje i lijepljenje — mračna,
+          ukrasna Unicode slova (fraktura i podebljana gotica) za bio, nadimke i naslove. Besplatno, odmah, bez registracije.</p>
+        <div class="input-wrapper">
+          <textarea class="main-input" id="mainInput" placeholder="Upiši tekst, riječ ili ime…" maxlength="500" autofocus></textarea>
+          <span class="char-count"><span id="charCount">0</span>/500</span>
+        </div>
+
+        <!-- Decoration Selector -->
+        <div class="decoration-section">
+          <div class="decoration-label">
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"></path>
+            </svg>
+            Dodaj simbole oko rezultata
+          </div>
+          <div class="decoration-tabs">
+            <button class="decoration-tab active" data-deco-tab="symbols">Simboli</button>
+            <button class="decoration-tab" data-deco-tab="frames">Okviri</button>
+            <button class="decoration-tab" data-deco-tab="dividers">Razdjelnici</button>
+            <button class="decoration-tab" data-deco-tab="minimal">Minimalni</button>
+            <button class="decoration-tab" data-deco-tab="emojis">Emoji</button>
+          </div>
+          <div class="decoration-grid" id="decorationGrid"></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Main Content -->
+  <main class="container">
+
+    <section class="editorial-section">
+      <span class="article-section-label">Gotička Unicode slova</span>
+      <h2>Gotički tekst za kopiranje — za bio, nadimke i tetovaže</h2>
+      <p>Ova slova nisu font ni slika, nego pravi <strong>Unicode znakovi</strong> iz obitelji frakture. Daj
+        svom biju goth ugođaj, napravi mračan nadimak ili pripremi natpis u srednjovjekovnom ili metal stilu — gotica
+        sjajno paše i uz skice tetovaža. Upiši tekst iznad, klikni <strong>Kopiraj</strong> i zalijepi
+        gotička slova gdje god želiš.</p>
+    </section>
+
+    <!-- Category Tabs (populated by script.js) -->
+    <div class="category-section">
+      <div class="category-tabs" id="categoryTabs"></div>
+    </div>
+
+    <!-- Results -->
+    <div class="results-grid" id="resultsGrid"></div>
+
+    <section class="editorial-section">
+      <span class="article-section-label">Povezano</span>
+      <p>Spoji goticu s <a href="/hr/podebljana-slova/">podebljanim slovima</a>,
+        <a href="/library/aesthetic-symbols/">ukrasnim simbolima</a> ili <a href="/library/invisible-character/">nevidljivim znakom</a>
+        za čiste razmake. Za skice tetovaža dobro će doći <a href="/usecase/tattoo-fonts/">generator fontova za tetovažu</a>,
+        a za okomite rasporede — <a href="/usecase/vertical-text/">okomiti tekst</a>.</p>
+    </section>
+  </main>
+
+  <!-- Footer + FAQ -->
+  <footer class="footer">
+    <div class="footer-inner">
+<div class="faq-section" id="gothic-faq">
+
+<h2 class="faq-category">Generator Gotičkih Slova — FAQ</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Što je generator gotičkih slova i kako radi?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Pretvara slova koja upišeš u gotičke Unicode znakove (𝔭𝔬𝔭𝔲𝔱 𝔬𝔳𝔦𝔥) — prave znakove iz obitelji frakture, a ne font ni sliku. Budući da su to obični tekstualni znakovi, možeš ih kopirati i zalijepiti svugdje gdje je dopušten tekst: u bio, opise, komentare, nadimke i poruke. Više u našem <a href="/guide/how-unicode-fonts-work/">vodiču o tome kako rade Unicode fontovi</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Radi li gotički tekst na Instagramu, Discordu, TikToku i u drugim aplikacijama?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Da. Bio, opisi, komentari, nazivi kanala na Discordu i poruke na chatu bez problema primaju gotičke znakove jer je to običan Unicode. Sjajno se pokaže u nadimcima i profilima goth, metal ili srednjovjekovnog ugođaja. Napomena: neka polja s <strong>@korisničkim imenom</strong> filtriraju nestandardne znakove — u samom handleu treba ostati na običnom tekstu, ali u biju i opisima gotica radi bez zapreka.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Po čemu se razlikuje gotica (fraktura) od podebljane gotice?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    To su dvije inačice istog stila. Obična fraktura (𝔤𝔬𝔱𝔦𝔠𝔞) tanja je i klasičnija, a podebljana gotica (𝖌𝖔𝖙𝖎𝖈𝖆) ima deblje, snažnije poteze i bolje izgleda u kratkim naslovima i nadimcima. U rezultatima ispod naći ćeš obje inačice — dovoljno je kliknuti onu koja odgovara tvom projektu i kopirati.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Mogu li pisati hrvatske znakove (č, ć, đ, š, ž) gotičkim slovima?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Unicode gotica obuhvaća A–Z i a–z, pa hrvatski znakovi poput č, ć, đ, š, ž nemaju vlastiti gotički oblik i ostaju obični. Za dosljedan gotički efekt možeš ih zamijeniti osnovnim slovima (<strong>c, d, s, z</strong>) — to mijenja pravopis — ili ih ostaviti u normalnom obliku, što u kratkom tekstu, nadimku ili naslovu obično ionako izgleda dobro.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Je li generator gotičkih slova besplatan?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Da, potpuno besplatan i bez registracije. Upisuj, kopiraj i lijepi koliko god puta želiš — nema ograničenja ni skrivenih troškova.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Zašto se neka gotička slova prikazuju kao kvadratići ili izgledaju drukčije?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Prazni kvadratić (▯) znači da uređaj nema odgovarajući glif za taj gotički znak — to se obično odnosi na starije sustave. Osim toga, nekoliko velikih slova frakture (C, H, I, R, Z) dolazi iz drugog Unicode bloka i izgleda drukčije od ostatka abecede — to je normalno. Odaberi tada podebljanu inačicu gotice ili ažuriraj uređaj; više u članku o tome, <a href="/guide/why-fonts-show-as-boxes/">zašto se fontovi prikazuju kao kvadratići</a>.
+  </div>
+</div>
+
+</div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Odabir jezika">
+      <a class="lang-option" href="/category/gothic-fonts/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/hr/goticka-slova/" hreflang="hr">HR</a>
+    </div>
+
+    </div>
+  </footer>
+
+  <div class="copy-toast" id="copyToast">Kopirano!</div>
+
+  <script>
+    window.UTG_FAMILY = "gothic";
+    window.UTG_DEMO_TEXT = "gotička slova\ngotički tekst";
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/script.js" defer></script>
+  <script src="/footer.js" defer></script>
+</body></html>

--- a/hr/index.html
+++ b/hr/index.html
@@ -1,0 +1,1020 @@
+<!DOCTYPE html><html lang="hr" dir="ltr"><head>
+  <meta name="yandex-verification" content="aa326290e0338f4f">
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title data-i18n="meta.title">Lijepi Fontovi i Stilizirana Slova za Kopiranje — Slova za Instagram, TikTok i Nadimke</title>
+<meta name="description" data-i18n-content="meta.description" content="Generator lijepih fontova, estetskih slova i stiliziranog teksta za kopiranje. Podebljano, kurziv, gotica, balončasta, Zalgo i simboli — zalijepi u instagram bio, u opis na TikToku, u nadimak u igri ili na Discord. Besplatno, bez računa.">
+
+<link rel="canonical" href="https://ultratextgen.com/hr/">
+
+<link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/">
+<link rel="alternate" hreflang="en" href="https://ultratextgen.com/">
+<link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/">
+<link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/">
+<link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/">
+<link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/">
+<link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/">
+<link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/">
+<link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/">
+<link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/">
+<link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/">
+<link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/">
+<link rel="alternate" hreflang="sv" href="https://ultratextgen.com/sv/">
+<link rel="alternate" hreflang="no" href="https://ultratextgen.com/no/">
+<link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/">
+<link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/">
+<link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/">
+<link rel="alternate" hreflang="ar" href="https://ultratextgen.com/ar/">
+<link rel="alternate" hreflang="hr" href="https://ultratextgen.com/hr/">
+<link rel="alternate" hreflang="cs" href="https://ultratextgen.com/cs/">
+<link rel="alternate" hreflang="sk" href="https://ultratextgen.com/sk/">
+<link rel="alternate" hreflang="bs" href="https://ultratextgen.com/bs/">
+<link rel="alternate" hreflang="sr" href="https://ultratextgen.com/sr/">
+<link rel="alternate" hreflang="ro" href="https://ultratextgen.com/ro/">
+<link rel="alternate" hreflang="sr-ME" href="https://ultratextgen.com/hr/">
+<link rel="alternate" hreflang="bs-ME" href="https://ultratextgen.com/hr/">
+
+<meta name="robots" content="index, follow">
+
+<meta property="og:site_name" content="UltraTextGen">
+<meta property="og:title" content="Lijepi Fontovi i Stilizirana Slova za Kopiranje — Slova za Instagram, TikTok i Nadimke">
+<meta property="og:description" content="Generator lijepih fontova, estetskih slova i stiliziranog teksta za kopiranje. Podebljano, kurziv, gotica, balončasta, Zalgo i simboli — zalijepi u instagram bio, u opis na TikToku, u nadimak u igri ili na Discord.">
+<meta property="og:url" content="https://ultratextgen.com/hr/">
+<meta property="og:type" content="website">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/fancy-text-generator-preview.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Lijepi Fontovi i Stilizirana Slova za Kopiranje — Slova za Instagram, TikTok i Nadimke">
+<meta name="twitter:description" content="Generator lijepih fontova, estetskih slova i stiliziranog teksta za kopiranje. Podebljano, kurziv, gotica, balončasta, Zalgo i simboli — zalijepi u instagram bio, u opis na TikToku, u nadimak u igri ili na Discord.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/fancy-text-generator-preview.png">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/style.css">
+
+ <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+[
+  {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/hr/",
+    "inLanguage": "hr",
+    "description": "Brz i pregledan generator Unicode teksta za bio na društvenim mrežama, opise i korisnička imena.",
+    "potentialAction": {
+      "@type": "SearchAction",
+      "target": {
+        "@type": "EntryPoint",
+        "urlTemplate": "https://ultratextgen.com/hr/?q={search_term_string}"
+      },
+      "query-input": "required name=search_term_string"
+    }
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com",
+    "logo": "https://ultratextgen.com/logo.png",
+    "sameAs": [
+      "https://www.youtube.com/@UltraTextGen",
+      "https://www.facebook.com/profile.php?id=61588587387596",
+      "https://www.linkedin.com/company/71290348/",
+      "https://x.com/UltraTextGen"
+    ]
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "WebApplication",
+    "name": "UltraTextGen",
+    "alternateName": ["Generator Unicode fontova", "Generator lijepog teksta", "Mijenjač fontova", "Fontovi za kopiranje i lijepljenje"],
+    "url": "https://ultratextgen.com/hr/",
+    "inLanguage": "hr",
+    "applicationCategory": "UtilitiesApplication",
+    "operatingSystem": "All",
+    "browserRequirements": "Requires JavaScript",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "description": "Generiraj stilizirani Unicode tekst u trenu za Instagram, TikTok, X, WhatsApp i Discord. Kopiraj i zalijepi stilove teksta za bio, korisnička imena i objave."
+  }
+]
+</script>
+
+
+
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "hr",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Što je UltraTextGen i što se tu zapravo događa?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "To je besplatan generator slova — upišeš običan tekst, a mi ga pretvaramo u stilizirane Unicode znakove koji izgledaju kao lijep font. Najvažnije: to su pravi znakovi , a ne podebljanje iz Worda ni markdown s Discorda. Zato rade svugdje gdje se može upisati običan tekst — u instagram bio, u nadimak, u komentar, u mail, u WhatsApp status. Primjer Upišeš „bok\" → dobiješ 𝗯𝗼𝗸 (podebljano), 𝘣𝘰𝘬 (kurziv), 𝒷ℴ𝓀 (kaligrafija) ili ⓑⓞⓚ (balončasta). Sve jednim klikom."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Kako kopirati lijepa slova u 5 sekundi?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "1. Upišeš ili zalijepiš tekst u polje na vrhu. 2. Stilovi se pojave odmah ispod — bold, kurziv, gotica, balončasta i još desetak drugih. 3. Ako želiš, dodaj ukrase — okvire, zvjezdice, strelice. 4. Klikneš „Kopiraj\" kod onog koji ti odgovara i zalijepiš gdje god želiš. To je to. Bez registracije, bez instaliranja aplikacije. Radi jednako na računalu i na mobitelu."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Besplatno? Bez ograničenja, bez računa?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da, sve je 100% besplatno . Bez računa, bez dnevnog ograničenja, bez vodenih žigova, bez kvake. Možeš kroz to propustiti cijelu knjigu i ništa se neće dogoditi."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Kako ubaciti stilizirani tekst u bio na Instagramu?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Instagram nema nikakvu alatnu traku za oblikovanje, ali prihvaća Unicode — dakle sve što ovdje generiraš uredno uleti u bio. Kako to napraviti 1. Upiši ono što želiš u biju (npr. ime, hashtag, kratak opis). 2. Odaberi stil — podebljano i kurziv rade najbolje na većini uređaja. 3. Kopiraj rezultat i zalijepi u „Uredi profil → Bio\" u aplikaciji. Savjet: ako želiš ukrasiti, dodaj okvir tipa ⋆｡˚ ili zvjezdicu ✦ sa strane — izgleda dobro, a ne krade pažnju ostatku bija."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Rade li slova u opisima na TikToku?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da — TikTok prikazuje Unicode u opisima, opisima profila i komentarima. Najbolje se pokažu podebljano , kurziv , balončasta i kapitalke . Stilovi s puno ukrasa znaju se odrezati kod dugih opisa, pa za svaki slučaj provjeri objavu u pregledu prije objavljivanja."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Može li se napraviti nadimak za igru ili za Discord?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Naravno — to je vjerojatno najčešći razlog zbog kojeg ljudi dolaze na ovakve generatore. Discord, Roblox, Steam, Minecraft, većina igara prihvaća Unicode u nadimcima. Primjer Obični nadimak: „DarkWolf\" Nakon stiliziranja: „𝔇𝔞𝔯𝔨𝔚𝔬𝔩𝔣\" (gotica), „ⒹⓐⓡⓚⓌⓞⓛⓕ\" (balončasta) ili „๖ۣۜDarkWolf\" (s ukrasom sa strane). Napomena: neke igre imaju filtre i neće primiti egzotične znakove. Ako jedan stil ne prolazi, uzmi drugi — bold i kurziv obično prolaze svugdje."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Radi li u WhatsApp statusu, na Telegramu i u Messengeru?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da — WhatsApp, Telegram, Messenger, Signal, iMessage. Sve što prima običan tekst prima i Unicode slova. Zalijepiš u status ili u poruku i izgleda kao ukrasan font. Za WhatsApp dodajem: ako ti treba samo podebljanje, možeš koristiti njihovu vlastitu sintaksu (`*tekst*` daje bold). Ali Unicode radi svugdje — i ondje gdje ga WhatsApp ne podržava, npr. u imenu kontakta."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "A u naslovu maila ili u životopisu?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Tu Unicode odradi najviše. Naslov maila je običan tekst, pa podebljanje iz Outlooka otpada. Ali „𝗥𝗮č𝘂𝗻 — 𝗵𝗶𝘁𝗻𝗼\" već izgleda snažnije u sandučiću primatelja. U životopisu blago podebljano ime u zaglavlju zna privući pogled poslodavca. Samo nemoj pretjerati — cijeli životopis u gotici ne izgleda profesionalno."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Koje stilove slova imam na izbor?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Puno. Zaista puno. Ukratko: Osnovni Podebljano (bold), kurziv, kaligrafija (script), gotica, balončasta (u kružićima), kapitalke, precrtano, podcrtano, double struck. Zabavni Tekst naopako, zrcalno, Zalgo (glitch s crticama nad slovima), tekst u kvadratićima, u zagradama, fullwidth (razmaknuti). Dodaci Okviri oko teksta, zvjezdice, srca, strelice, razdjelnici, zastave, emoji — sve to možeš nasloniti na stil slova. S vremena na vrijeme dolaze novi — vrijedi dodati stranicu u knjižne oznake."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Mogu li spojiti više stilova odjednom?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da — i to je najveća prednost UltraTextGena. Možeš nasloniti npr. balončasta + Zalgo , gotica + naopako ili kapitalke + podcrtano , a onda cijelo to zatvoriti u okvir ili zvjezdicu. Primjer „bok\" → odabereš goticu → dodaš okvir sa zvjezdicama → izađe: ★彡[ 𝔟𝔬𝔨 ]彡★ Što više eksperimentiraš, to zanimljivije stvari izlaze. Preporučujem da kreneš s jednim stilom i dodaš jedan ukras — ne sve odjednom."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Što je Zalgo i te čudne crtice nad slovima?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Zalgo je onakav „ukleti\", glitchani stil — nad i pod svakim slovom naleti hrpa dijakritičkih znakova. Izgleda kao da se tekst raspada ili kao da je iz horora. Primjer „bok\" → b̷̢o̴̢k̷̛ Najčešće to viđaš u mračnim biojevima na Instagramu, u halloweenskim memeovima, u gaming klanovima koji žele izgledati opasno ili kad netko od toga radi foru."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Odakle uzeti lijepe simbole, zvjezdice i srca?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Sve što imaš u odjeljku „Ukrasi\" ispod tekstualnog polja možeš kopirati zasebno — čak i bez upisivanja teksta. Naprosto kao zasebne znakove za bio, nadimak ili objavu. — Estetski simboli : ✦ ✧ ⋆ ｡ ☆ ♡ ❀ ✿ — Okviri i obrubi : ╭─▸ │ ╰─▸ ili ★彡[ ]彡★ — Strelice : → ⇨ ➤ ⟶ — Minimalni razdjelnici : · ⋅ ─ • — Zastave i emoji . Najčešće se koriste u estetskim biojevima na Instagramu i Pinterestu — pašu uz sve, od citata do popisa interesa."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "A hrvatski znakovi? Radi li s č, ć, đ, š, ž?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ukratko: ovisi o stilu. Unicode ima stilizirane inačice za osnovnu abecedu A–Z, pa se c , s , z bez problema pretvore npr. u podebljano. Ali za č , ć , đ , š , ž stilizirane verzije postoje samo u dijelu stilova (uglavnom bold, kurziv, kapitalke). Ako stil nema verziju za hrvatski znak, on ostaje u izvornom obliku — tekst je i dalje čitljiv, hrvatsko slovo naprosto izgleda „običnije\" od ostatka. Za nadimke bez kvačica to nije nikakav problem. Za cijele rečenice na hrvatskom preporučujem bold , kurziv ili monospace — oni se najbolje snalaze s našom abecedom. Napomena i za digrafe: dž, lj i nj su samo dva obična slova jedno do drugoga, pa se svako stilizira zasebno."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Zašto se nekome prikazuju kvadratići umjesto slova?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Zato što sistemski font na strani primatelja ne sadrži zadani Unicode znak. To nije problem s tvojim tekstom — naprosto njegov mobitel ili aplikacija nema taj konkretni znak u kompletu. Drži se bolda , kurziva i balončaste — imaju najširu podršku. Vrlo egzotični stilovi (fullwidth, kvadratići) mogu se prikazati kao □ na starijim Androidima ili u nekim mail klijentima."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Instagram mi je izrezao dio znakova u nadimku — što sad?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Instagram ima filtar na polju korisničko ime (dakle @login) — prima samo slova, brojke, točke i podvlake. Tu stilizirana slova ne možeš zalijepiti. Ali u polju „Ime\" (prikazano ime) i u biju može — i tu prolazi većina stilova. Ako se jedan ne sprema, uzmi drugi. Bold obično prolazi bez problema."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Postoje li znakovi koji se uopće ne mogu pretvoriti?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Standardna slova (A–Z, a–z), brojke i osnovni interpunkcijski znakovi pretvaraju se bez problema. Neki rijetki simboli ili posebni znakovi nemaju stilizirane parnjake u Unicodeu — tada ostaju u izvorniku. Ništa se ne kvari, tekst je i dalje za kopiranje."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Sprema li se moj tekst negdje?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ne. Cijela pretvorba slova događa se u tvom pregledniku — ništa ne ide na naše servere, ništa se ne sprema, ništa se ne prati. Kopirani tekst je čisti Unicode, bez skrivenih znakova, bez ikakvih identifikatora."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Je li sigurno lijepiti ova slova bilo gdje?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da — to su standardni Unicode znakovi, isti kakve koristi cijeli internet. Ništa unutra, bez skripti, bez skrivenog oblikovanja, bez kodova. Slobodno lijepi u životopis, u poslovni mail, u bio na LinkedInu — gdje god želiš."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Radi li na mobitelu?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da — stranica se u potpunosti prilagođava mobitelu. iPhone, Android, tablet — sve štima. Upišeš tekst, klikneš, kopira se u međuspremnik, zalijepiš u aplikaciji. Bez instaliranja ičega iz trgovine."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Po čemu se razlikujete od drugih generatora slova?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Konkretno: — Jedna od većih kolekcija Ultra stilova — bold, kurziv, gotica, balončasta i još desetak drugih. — Spajanje stilova — većina generatora daje ti jedan stil odjednom, mi dopuštamo naslanjanje. — Ukrasi jednim klikom — okviri, zvjezdice, razdjelnici bez lijepljenja znak po znak. — Stranice za konkretne platforme — Instagram, TikTok, Discord. Ondje prikazujemo samo stilove koji na toj aplikaciji rade. — Brzo i bez skočnih prozora — bez captcha, bez „prihvati sve\" prije svakog klika."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Dolaze li novi stilovi?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da, redovito. S vremena na vrijeme upadnu nove inačice, ukrasi i okviri. Najlakše je zapamtiti stranicu ili svratiti povremeno."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Kako pronaći točno onaj stil koji tražim?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Tri puta: Po stilu — kategorije na vrhu: bold, kurziv, gotica, balončasta, precrtano, naopako i još. Po platformi — svrati na podstranicu za Instagram, TikTok, Discord — ondje su samo stilovi koji se na toj platformi pokažu. Po cilju — odjeljak s primjenama ima alate prilagođene konkretnoj potrebi: naslov na LinkedInu, komentari, tekst s emojijima."
+      }
+    }
+  ]
+}
+</script>
+</head>
+
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer=""></script>
+
+  <!-- Hero Section -->
+  <section class="hero">
+    <div class="hero-inner">
+      <div class="hero-card">
+        <h1 class="hero-headline" data-i18n="hero.title">Lijepi Fontovi i Stilizirana Slova za Kopiranje</h1>
+        <p class="hero-tagline" data-i18n="hero.subtitle">Upiši tekst, odaberi stil — podebljano, kurziv, gotica, balončasta ili s ukrasima. Ubaci u instagram bio, u nadimak u igri, u WhatsApp status ili u opis pod TikTokom. Bez aplikacije, bez prijave.</p>
+        <div class="input-wrapper">
+          <textarea class="main-input" id="mainInput" placeholder="Upiši tekst..." data-i18n-placeholder="ui.placeholder" maxlength="500" autofocus=""></textarea>
+          <button class="input-clear-btn" id="inputClearBtn" aria-label="Clear input" hidden="">✕</button>
+          <span class="char-count" id="charCountWrapper" hidden=""><span id="charCount">0</span>/500</span>
+        </div>
+
+        <!-- Decoration Selector -->
+        <div class="decoration-section">
+          <div class="decoration-label">
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"></path>
+            </svg>
+            <span data-i18n="decorations.label">Dodaj ukrase tekstu</span>
+       </div>
+    <div class="decoration-tabs">
+    <button class="decoration-tab active" data-deco-tab="symbols" data-i18n="decorations.tabs.symbols">Simboli</button>
+    <button class="decoration-tab" data-deco-tab="frames" data-i18n="decorations.tabs.frames">Okviri</button>
+    <button class="decoration-tab" data-deco-tab="dividers" data-i18n="decorations.tabs.dividers">Razdjelnici</button>
+    <button class="decoration-tab" data-deco-tab="arrows" data-i18n="decorations.tabs.arrows">Strelice</button>
+    <button class="decoration-tab" data-deco-tab="minimal" data-i18n="decorations.tabs.minimal">Minimalni</button>
+    <button class="decoration-tab" data-deco-tab="emojis" data-i18n="decorations.tabs.emojis">Emoji</button>
+    <button class="decoration-tab" data-deco-tab="flags" data-i18n="decorations.tabs.flags">Zastave</button>
+      </div>
+          <div class="decoration-grid" id="decorationGrid"></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Main Content -->
+  <main class="container">
+    <!-- Category Tabs -->
+    <div class="category-section">
+      <div class="category-tabs" id="categoryTabs">
+        <!-- Tabs will be dynamically loaded from fonts.json -->
+      </div>
+    </div>
+
+    <!-- Results -->
+    <div class="results-grid" id="resultsGrid"></div>
+  </main>
+
+  <!-- How To: Kako kopirati lijepa slova -->
+  <section class="editorial-section">
+    <h2>Slova i slovca za kopiranje — kako to radi</h2>
+    <p class="editorial-intro">Lijepa <strong>slova za kopiranje</strong> napraviš u nekoliko sekundi — bez instaliranja aplikacije i bez otvaranja računa. Upišeš tekst, a generator ga pretvara u desetke stilova lijepih slova, spremnih za kopiranje i lijepljenje.</p>
+    <div class="steps-grid">
+      <div class="step-card">
+        <div class="step-number">1</div>
+        <h3>Upiši tekst</h3>
+        <p>Upiši ime, riječ ili cijelu rečenicu u polje na samom vrhu. Možeš i zalijepiti nešto što već imaš kopirano.</p>
+      </div>
+      <div class="step-card">
+        <div class="step-number">2</div>
+        <h3>Odaberi stil slova</h3>
+        <p>Lijepa slova pojave se odmah — podebljano, kurziv, kaligrafija, gotica, balončasta i kapitalke. Suzi izbor kategorijom na vrhu.</p>
+      </div>
+      <div class="step-card">
+        <div class="step-number">3</div>
+        <h3>Kopiraj i zalijepi</h3>
+        <p>Klikneš „Kopiraj", zalijepiš u instagram bio, nadimak u igri, WhatsApp status ili opis na TikToku. Stil se ne gubi.</p>
+      </div>
+    </div>
+    <p class="u-mt-15 u-text-center">Isti koraci vrijede za <strong>lijepe fontove za kopiranje</strong>, ukrasna slova i estetska slovca — jednako na računalu i na mobitelu.</p>
+  </section>
+
+  <!-- Abeceda lijepih slova A–Z -->
+  <section class="editorial-section abc-section" aria-label="Abeceda lijepih slova za kopiranje">
+    <h2>Lijepa slova A–Z za kopiranje</h2>
+    <p>Cijela abeceda — velika slova (A–Z), mala slova (a–z) i brojke (0–9) — u najčešće korištenim stilovima lijepih slova. Upiši nešto u generator na vrhu i klikni „Kopiraj" da uzmeš cijelu riječ u danom stilu, ili označi slova iz tablice i kopiraj sam.</p>
+
+    <div class="abc-list">
+      <div class="abc-row">
+        <span class="abc-name">Podebljano</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝗔𝗕𝗖𝗗𝗘𝗙𝗚𝗛𝗜𝗝𝗞𝗟𝗠𝗡𝗢𝗣𝗤𝗥𝗦𝗧𝗨𝗩𝗪𝗫𝗬𝗭</span>
+          <span class="abc-line">𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇</span>
+          <span class="abc-line">𝟬𝟭𝟮𝟯𝟰𝟱𝟲𝟳𝟴𝟵</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Kurziv</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝘈𝘉𝘊𝘋𝘌𝘍𝘎𝘏𝘐𝘑𝘒𝘓𝘔𝘕𝘖𝘗𝘘𝘙𝘚𝘛𝘜𝘝𝘞𝘟𝘠𝘡</span>
+          <span class="abc-line">𝘢𝘣𝘤𝘥𝘦𝘧𝘨𝘩𝘪𝘫𝘬𝘭𝘮𝘯𝘰𝘱𝘲𝘳𝘴𝘵𝘶𝘷𝘸𝘹𝘺𝘻</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Kaligrafija</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵</span>
+          <span class="abc-line">𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Kaligrafija podebljana</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩</span>
+          <span class="abc-line">𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Gotica</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝔄𝔅ℭ𝔇𝔈𝔉𝔊ℌℑ𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔ℜ𝔖𝔗𝔘𝔙𝔚𝔛𝔜ℨ</span>
+          <span class="abc-line">𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Balončasta</span>
+        <div class="abc-lines">
+          <span class="abc-line">ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ</span>
+          <span class="abc-line">ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ</span>
+          <span class="abc-line">⓪①②③④⑤⑥⑦⑧⑨</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Kapitalke</span>
+        <div class="abc-lines">
+          <span class="abc-line">ᴀʙᴄᴅᴇꜰɢʜɪᴊᴋʟᴍɴᴏᴘqʀsᴛᴜᴠᴡxʏᴢ</span>
+          <span class="abc-line">ᴀʙᴄᴅᴇꜰɢʜɪᴊᴋʟᴍɴᴏᴘqʀsᴛᴜᴠᴡxʏᴢ</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+    </div>
+    <p class="u-mt-15">Tražiš određeni rez? Zaviri u <a href="/hr/podebljana-slova/">podebljana slova</a>, <a href="/hr/goticka-slova/">gotička slova za kopiranje</a> ili <a href="/hr/kurziv/">kurziv i rukopisna slova</a> — svaka kategorija prikazuje samo jedan stil, od velikih do malih slova.</p>
+  </section>
+
+  <!-- Ukrasi i simboli za kopiranje -->
+  <section class="editorial-section glyph-section" aria-label="Ukrasi i simboli za kopiranje">
+    <h2>Ukrasi i simboli za kopiranje</h2>
+    <p class="editorial-intro">Gotovi <strong>ukrasi teksta za kopiranje</strong> — zvjezdice, srca, okviri, strelice i razdjelnici. Klikni bilo koji znak da ga kopiraš, ili ih automatski dodaj tekstu preko kartica <strong>Simboli</strong>, <strong>Okviri</strong> i <strong>Razdjelnici</strong> u generatoru na vrhu.</p>
+    <div class="glyph-group">
+      <h3>Zvjezdice i bljeskovi</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="✦">✦</button>
+        <button class="glyph-copy" type="button" data-text="✧">✧</button>
+        <button class="glyph-copy" type="button" data-text="⋆">⋆</button>
+        <button class="glyph-copy" type="button" data-text="✩">✩</button>
+        <button class="glyph-copy" type="button" data-text="★">★</button>
+        <button class="glyph-copy" type="button" data-text="☆">☆</button>
+        <button class="glyph-copy" type="button" data-text="✰">✰</button>
+        <button class="glyph-copy" type="button" data-text="⊹">⊹</button>
+        <button class="glyph-copy" type="button" data-text="࿐">࿐</button>
+        <button class="glyph-copy" type="button" data-text="˚">˚</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Srca</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="♡">♡</button>
+        <button class="glyph-copy" type="button" data-text="♥">♥</button>
+        <button class="glyph-copy" type="button" data-text="❤">❤</button>
+        <button class="glyph-copy" type="button" data-text="❥">❥</button>
+        <button class="glyph-copy" type="button" data-text="❣">❣</button>
+        <button class="glyph-copy" type="button" data-text="ღ">ღ</button>
+        <button class="glyph-copy" type="button" data-text="ꨄ">ꨄ</button>
+        <button class="glyph-copy" type="button" data-text="ஐ">ஐ</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Mjesec i nebo</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="☾">☾</button>
+        <button class="glyph-copy" type="button" data-text="☽">☽</button>
+        <button class="glyph-copy" type="button" data-text="☁">☁</button>
+        <button class="glyph-copy" type="button" data-text="✶">✶</button>
+        <button class="glyph-copy" type="button" data-text="⍣">⍣</button>
+        <button class="glyph-copy" type="button" data-text="ꕥ">ꕥ</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Cvijeće</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="❀">❀</button>
+        <button class="glyph-copy" type="button" data-text="✿">✿</button>
+        <button class="glyph-copy" type="button" data-text="⚘">⚘</button>
+        <button class="glyph-copy" type="button" data-text="✾">✾</button>
+        <button class="glyph-copy" type="button" data-text="❁">❁</button>
+        <button class="glyph-copy" type="button" data-text="ꕤ">ꕤ</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Okviri i ornamenti</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="꧁">꧁</button>
+        <button class="glyph-copy" type="button" data-text="꧂">꧂</button>
+        <button class="glyph-copy" type="button" data-text="༺">༺</button>
+        <button class="glyph-copy" type="button" data-text="༻">༻</button>
+        <button class="glyph-copy" type="button" data-text="⟡">⟡</button>
+        <button class="glyph-copy" type="button" data-text="❪">❪</button>
+        <button class="glyph-copy" type="button" data-text="❫">❫</button>
+        <button class="glyph-copy" type="button" data-text="★彡">★彡</button>
+        <button class="glyph-copy" type="button" data-text="彡★">彡★</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Strelice</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="→">→</button>
+        <button class="glyph-copy" type="button" data-text="⇨">⇨</button>
+        <button class="glyph-copy" type="button" data-text="➤">➤</button>
+        <button class="glyph-copy" type="button" data-text="⟶">⟶</button>
+        <button class="glyph-copy" type="button" data-text="➳">➳</button>
+        <button class="glyph-copy" type="button" data-text="↬">↬</button>
+        <button class="glyph-copy" type="button" data-text="⇢">⇢</button>
+        <button class="glyph-copy" type="button" data-text="↳">↳</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Razdjelnici</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="·">·</button>
+        <button class="glyph-copy" type="button" data-text="•">•</button>
+        <button class="glyph-copy" type="button" data-text="◦">◦</button>
+        <button class="glyph-copy" type="button" data-text="➛">➛</button>
+        <button class="glyph-copy" type="button" data-text="⟢">⟢</button>
+        <button class="glyph-copy" type="button" data-text="—">—</button>
+        <button class="glyph-copy" type="button" data-text="☰">☰</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Kaomoji (smješkovi)</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="(◍•ᴗ•◍)">(◍•ᴗ•◍)</button>
+        <button class="glyph-copy" type="button" data-text="(｡♥‿♥｡)">(｡♥‿♥｡)</button>
+        <button class="glyph-copy" type="button" data-text="ʕ•ᴥ•ʔ">ʕ•ᴥ•ʔ</button>
+        <button class="glyph-copy" type="button" data-text="(＾▽＾)">(＾▽＾)</button>
+        <button class="glyph-copy" type="button" data-text="٩(◕‿◕)۶">٩(◕‿◕)۶</button>
+      </div>
+    </div>
+  </section>
+
+  <!-- Popular Use Cases -->
+  <section class="editorial-section">
+    <h2 data-i18n="useCases.title">Za što ljudi ovo najčešće koriste</h2>
+    <div class="tips-grid">
+      <a class="tip-card" href="/usecase/linkedin-headline/" aria-label="Naslov na LinkedInu">
+        <div class="tip-icon">💼</div>
+        <h3 data-i18n="useCases.items.0.title">Naslov na LinkedInu</h3>
+        <p data-i18n="useCases.items.0.description">Istakni se u pretrazi na LinkedInu — podebljan ili blago ukrašen naslov odradi svoje prije nego što netko stigne skrolati dalje.</p>
+      </a>
+      <a class="tip-card" href="/usecase/comment-font/" aria-label="Komentari ispod objava">
+        <div class="tip-icon">💬</div>
+        <h3 data-i18n="useCases.items.1.title">Komentari ispod objava</h3>
+        <p data-i18n="useCases.items.1.description">Stilizirani komentari na Instagramu, YouTubeu i TikToku — lakše ih je uočiti nego stotine običnih ispod popularne objave.</p>
+      </a>
+      <a class="tip-card" href="/usecase/text-to-emoji/" aria-label="Tekst ispisan u emojijima">
+        <div class="tip-icon">😊</div>
+        <h3 data-i18n="useCases.items.2.title">Tekst ispisan u emojijima</h3>
+        <p data-i18n="useCases.items.2.description">Pretvori natpis u niz slova od emojija — kreativan bio, story, grupni chat ili čisto za zezanje s prijateljima.</p>
+      </a>
+      <a class="tip-card" href="/usecase/tattoo-fonts/" aria-label="Fontovi za tetovažu">
+        <div class="tip-icon">🖤</div>
+        <h3>Fontovi za tetovažu</h3>
+        <p>Provjeri ime ili natpis u kurzivu, gotici i italicu — prije nego što ode pod iglu.</p>
+      </a>
+      <a class="tip-card" href="/usecase/zalgo-text/" aria-label="Generator Zalgo teksta">
+        <div class="tip-icon">👻</div>
+        <h3>Iskrivljena Zalgo slova</h3>
+        <p>Glitchani tekst s crticama nad i pod slovima — paše uz halloweenske memeove, mračne biojeve i gaming klanove koji žele izgledati opasno.</p>
+      </a>
+    </div>
+    <p class="u-mt-15 u-text-center"><a class="cat-cta" href="/usecase/" data-i18n="useCases.viewAll">Pogledaj više primjena →</a></p>
+  </section>
+
+  <!-- Popular Guides -->
+  <section class="editorial-section">
+    <h2 data-i18n="guides.title">Svrati na vodiče</h2>
+    <div class="tips-grid">
+      <a class="tip-card" href="/guide/the-rhetoric-of-fonts/" aria-label="Retorika fontova">
+        <div class="tip-icon">📚</div>
+        <h3 data-i18n="guides.items.0.title">Retorika fontova</h3>
+        <p data-i18n="guides.items.0.description">Zašto jedan font budi povjerenje, a drugi izgleda kao spam — odnosno kako tipografija utječe na ono što osjećamo dok čitamo.</p>
+      </a>
+      <a class="tip-card" href="/guide/personal-branding-through-typography/" aria-label="Osobni brend kroz tipografiju">
+        <div class="tip-icon">🎨</div>
+        <h3 data-i18n="guides.items.1.title">Osobni brend kroz tipografiju</h3>
+        <p data-i18n="guides.items.1.description">Kako odabrati slova koja odgovaraju tvom vibeu i ostaju u pamćenju — bilo da je riječ o LinkedInu, Instagramu ili Discordu.</p>
+      </a>
+      <a class="tip-card" href="/guide/stop-the-scroll-with-font-variation/" aria-label="Zaustavi skrolanje igrom fontova">
+        <div class="tip-icon">📱</div>
+        <h3 data-i18n="guides.items.2.title">Zaustavi skrolanje igrom fontova</h3>
+        <p data-i18n="guides.items.2.description">Zašto se ljudi zaustavljaju kod objava s drukčijim stilom teksta i kako to iskoristiti da podigneš doseg.</p>
+      </a>
+    </div>
+    <p class="u-mt-15 u-text-center"><a class="cat-cta" href="/guide/" data-i18n="guides.viewAll">Svi vodiči →</a></p>
+  </section>
+
+  <!-- FAQ Section -->
+  <section class="faq-section-wrapper" aria-label="Frequently asked questions">
+    <div class="faq-inner">
+
+<!-- Slova i ukrasi za kopiranje -->
+<h2 class="faq-category">Slova i ukrasi za kopiranje</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span>Gdje ću naći lijepa slova za kopiranje?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer">Na ovoj stranici. Upišeš tekst u polje na vrhu, a lijepa slova — <strong>podebljano</strong>, <strong>kurziv</strong>, <strong>gotica</strong>, <strong>balončasta</strong> i još desetak drugih — pojave se odmah ispod. Klikneš „Kopiraj" i zalijepiš gdje želiš.
+    <br><br>
+    Imaš i gotovu <strong>abecedu A–Z za kopiranje</strong> u popularnim stilovima — velika slova, mala slova i brojke — koju možeš uzeti čak i bez upisivanja ičega.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span>Što su ukrasi za kopiranje i gdje ih tražiti?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer">Ukrasi su mali simboli kojima dekoriraš tekst — zvjezdice ✦, srca ♡, okviri ꧁꧂, strelice → i razdjelnici.
+    <br><br>
+    U odjeljku <strong>„Ukrasi i simboli za kopiranje"</strong> klikneš bilo koji znak da ga kopiraš zasebno. Možeš i automatski dodati <strong>ukrase tekstu</strong> cijelom natpisu — na karticama <strong>Simboli</strong>, <strong>Okviri</strong> i <strong>Razdjelnici</strong> iznad polja za upisivanje.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span>Imate li lijepe i estetske fontove za kopiranje?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer">Da — od minimalističkih, razmaknutih <strong>estetskih fontova za kopiranje</strong> do ukrasnih slova sa simbolima. Upišeš tekst, a svi se stilovi lijepih fontova pojave odjednom. Sve je besplatno i spremno za kopiranje jednim klikom, jednako na mobitelu i na računalu.</div>
+</div>
+
+
+<!-- Prva pitanja -->
+<h2 class="faq-category" data-i18n="faq.categories.0.title">Prva pitanja</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.0.items.0.question">Što je UltraTextGen i što se tu zapravo događa?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.0.items.0.answer">To je besplatan generator slova — upišeš običan tekst, a mi ga pretvaramo u stilizirane Unicode znakove koji izgledaju kao lijep font.
+    <br><br>
+    Najvažnije: to su <strong>pravi znakovi</strong>, a ne podebljanje iz Worda ni markdown s Discorda. Zato rade svugdje gdje se može upisati običan tekst — u instagram bio, u nadimak, u komentar, u mail, u WhatsApp status.
+    <br><br>
+    <strong>Primjer</strong><br>
+    Upišeš „bok" → dobiješ 𝗯𝗼𝗸 (podebljano), 𝘣𝘰𝘬 (kurziv), 𝒷ℴ𝓀 (kaligrafija) ili ⓑⓞⓚ (balončasta). Sve jednim klikom.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.0.items.1.question">Kako kopirati lijepa slova u 5 sekundi?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.0.items.1.answer">1. Upišeš ili zalijepiš tekst u polje na vrhu.<br>
+    2. Stilovi se pojave odmah ispod — bold, kurziv, gotica, balončasta i još desetak drugih.<br>
+    3. Ako želiš, dodaj ukrase — okvire, zvjezdice, strelice.<br>
+    4. Klikneš „Kopiraj" kod onog koji ti odgovara i zalijepiš gdje god želiš.
+    <br><br>
+    To je to. Bez registracije, bez instaliranja aplikacije. Radi jednako na računalu i na mobitelu.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.0.items.2.question">Besplatno? Bez ograničenja, bez računa?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.0.items.2.answer">Da, sve je <strong>100% besplatno</strong>. Bez računa, bez dnevnog ograničenja, bez vodenih žigova, bez kvake. Možeš kroz to propustiti cijelu knjigu i ništa se neće dogoditi.</div>
+</div>
+
+
+<!-- Instagram, TikTok, Discord -->
+<h2 class="faq-category" data-i18n="faq.categories.1.title">Instagram, TikTok, Discord — gdje to zalijepiti</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.1.items.0.question">Kako ubaciti stilizirani tekst u bio na Instagramu?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.1.items.0.answer">Instagram nema nikakvu alatnu traku za oblikovanje, ali prihvaća Unicode — dakle sve što ovdje generiraš uredno uleti u bio.
+    <br><br>
+    <strong>Kako to napraviti</strong><br>
+    1. Upiši ono što želiš u biju (npr. ime, hashtag, kratak opis).<br>
+    2. Odaberi stil — podebljano i kurziv rade najbolje na većini uređaja.<br>
+    3. Kopiraj rezultat i zalijepi u „Uredi profil → Bio" u aplikaciji.
+    <br><br>
+    Savjet: ako želiš ukrasiti, dodaj okvir tipa ⋆｡˚ ili zvjezdicu ✦ sa strane — izgleda dobro, a ne krade pažnju ostatku bija.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.1.items.1.question">Rade li slova u opisima na TikToku?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.1.items.1.answer">Da — TikTok prikazuje Unicode u opisima, opisima profila i komentarima. Najbolje se pokažu <strong>podebljano</strong>, <strong>kurziv</strong>, <strong>balončasta</strong> i <strong>kapitalke</strong>. Stilovi s puno ukrasa znaju se odrezati kod dugih opisa, pa za svaki slučaj provjeri objavu u pregledu prije objavljivanja.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.1.items.2.question">Može li se napraviti nadimak za igru ili za Discord?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.1.items.2.answer">Naravno — to je vjerojatno najčešći razlog zbog kojeg ljudi dolaze na ovakve generatore. Discord, Roblox, Steam, Minecraft, većina igara prihvaća Unicode u nadimcima.
+    <br><br>
+    <strong>Primjer</strong><br>
+    Obični nadimak: „DarkWolf"<br>
+    Nakon stiliziranja: „𝔇𝔞𝔯𝔨𝔚𝔬𝔩𝔣" (gotica), „ⒹⓐⓡⓚⓌⓞⓛⓕ" (balončasta) ili „๖ۣۜDarkWolf" (s ukrasom sa strane).
+    <br><br>
+    <strong>Napomena:</strong> neke igre imaju filtre i neće primiti egzotične znakove. Ako jedan stil ne prolazi, uzmi drugi — bold i kurziv obično prolaze svugdje.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.1.items.3.question">Radi li u WhatsApp statusu, na Telegramu i u Messengeru?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.1.items.3.answer">Da — WhatsApp, Telegram, Messenger, Signal, iMessage. Sve što prima običan tekst prima i Unicode slova. Zalijepiš u status ili u poruku i izgleda kao ukrasan font.
+    <br><br>
+    Za WhatsApp dodajem: ako ti treba samo podebljanje, možeš koristiti njihovu vlastitu sintaksu (`*tekst*` daje bold). Ali Unicode radi svugdje — i ondje gdje ga WhatsApp ne podržava, npr. u imenu kontakta.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.1.items.4.question">A u naslovu maila ili u životopisu?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.1.items.4.answer">Tu Unicode odradi najviše. Naslov maila je običan tekst, pa podebljanje iz Outlooka otpada. Ali „𝗥𝗮č𝘂𝗻 — 𝗵𝗶𝘁𝗻𝗼" već izgleda snažnije u sandučiću primatelja.
+    <br><br>
+    U životopisu blago podebljano ime u zaglavlju zna privući pogled poslodavca. Samo nemoj pretjerati — cijeli životopis u gotici ne izgleda profesionalno.</div>
+</div>
+
+
+<!-- Stilovi, slova i ukrasi -->
+<h2 class="faq-category" data-i18n="faq.categories.2.title">Stilovi, slova i ukrasi</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.2.items.0.question">Koje stilove slova imam na izbor?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.2.items.0.answer">Puno. Zaista puno. Ukratko:
+    <br><br>
+    <strong>Osnovni</strong><br>
+    Podebljano (bold), kurziv, kaligrafija (script), gotica, balončasta (u kružićima), kapitalke, precrtano, podcrtano, double struck.
+    <br><br>
+    <strong>Zabavni</strong><br>
+    Tekst naopako, zrcalno, Zalgo (glitch s crticama nad slovima), tekst u kvadratićima, u zagradama, fullwidth (razmaknuti).
+    <br><br>
+    <strong>Dodaci</strong><br>
+    Okviri oko teksta, zvjezdice, srca, strelice, razdjelnici, zastave, emoji — sve to možeš nasloniti na stil slova.
+    <br><br>
+    S vremena na vrijeme dolaze novi — vrijedi dodati stranicu u knjižne oznake.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.2.items.1.question">Mogu li spojiti više stilova odjednom?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.2.items.1.answer">Da — i to je najveća prednost UltraTextGena. Možeš nasloniti npr. <strong>balončasta + Zalgo</strong>, <strong>gotica + naopako</strong> ili <strong>kapitalke + podcrtano</strong>, a onda cijelo to zatvoriti u okvir ili zvjezdicu.
+    <br><br>
+    <strong>Primjer</strong><br>
+    „bok" → odabereš goticu → dodaš okvir sa zvjezdicama → izađe: ★彡[ 𝔟𝔬𝔨 ]彡★
+    <br><br>
+    Što više eksperimentiraš, to zanimljivije stvari izlaze. Preporučujem da kreneš s jednim stilom i dodaš jedan ukras — ne sve odjednom.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.2.items.2.question">Što je Zalgo i te čudne crtice nad slovima?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.2.items.2.answer">Zalgo je onakav „ukleti", glitchani stil — nad i pod svakim slovom naleti hrpa dijakritičkih znakova. Izgleda kao da se tekst raspada ili kao da je iz horora.
+    <br><br>
+    <strong>Primjer</strong><br>
+    „bok" → b̷̢o̴̢k̷̛
+    <br><br>
+    Najčešće to viđaš u mračnim biojevima na Instagramu, u halloweenskim memeovima, u gaming klanovima koji žele izgledati opasno ili kad netko od toga radi foru.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.2.items.3.question">Odakle uzeti lijepe simbole, zvjezdice i srca?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.2.items.3.answer">Sve što imaš u odjeljku „Ukrasi" ispod tekstualnog polja možeš kopirati zasebno — čak i bez upisivanja teksta. Naprosto kao zasebne znakove za bio, nadimak ili objavu.
+    <br><br>
+    — <strong>Estetski simboli</strong>: ✦ ✧ ⋆ ｡ ☆ ♡ ❀ ✿<br>
+    — <strong>Okviri i obrubi</strong>: ╭─▸ │ ╰─▸ ili ★彡[ ]彡★<br>
+    — <strong>Strelice</strong>: → ⇨ ➤ ⟶<br>
+    — <strong>Minimalni razdjelnici</strong>: ·  ⋅  ─  •<br>
+    — <strong>Zastave i emoji</strong>.
+    <br><br>
+    Najčešće se koriste u estetskim biojevima na Instagramu i Pinterestu — pašu uz sve, od citata do popisa interesa.</div>
+</div>
+
+
+<!-- Hrvatski znakovi, kompatibilnost -->
+<h2 class="faq-category" data-i18n="faq.categories.3.title">Hrvatski znakovi, kompatibilnost, problemi</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.3.items.0.question">A hrvatski znakovi? Radi li s č, ć, đ, š, ž?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.3.items.0.answer"><strong>Ukratko:</strong> ovisi o stilu.
+    <br><br>
+    Unicode ima stilizirane inačice za osnovnu abecedu A–Z, pa se <em>c</em>, <em>s</em>, <em>z</em> bez problema pretvore npr. u podebljano. Ali za <em>č</em>, <em>ć</em>, <em>đ</em>, <em>š</em>, <em>ž</em> stilizirane verzije postoje samo u dijelu stilova (uglavnom bold, kurziv, kapitalke).
+    <br><br>
+    Ako stil nema verziju za hrvatski znak, on ostaje u izvornom obliku — tekst je i dalje čitljiv, hrvatsko slovo naprosto izgleda „običnije" od ostatka. Za nadimke bez kvačica to nije nikakav problem. Za cijele rečenice na hrvatskom preporučujem <strong>bold</strong>, <strong>kurziv</strong> ili <strong>monospace</strong> — oni se najbolje snalaze s našom abecedom. Napomena i za digrafe: dž, lj i nj su samo dva obična slova jedno do drugoga, pa se svako stilizira zasebno.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.3.items.1.question">Zašto se nekome prikazuju kvadratići umjesto slova?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.3.items.1.answer">Zato što sistemski font na strani primatelja ne sadrži zadani Unicode znak. To nije problem s tvojim tekstom — naprosto njegov mobitel ili aplikacija nema taj konkretni znak u kompletu.
+    <br><br>
+    Drži se <strong>bolda</strong>, <strong>kurziva</strong> i <strong>balončaste</strong> — imaju najširu podršku. Vrlo egzotični stilovi (fullwidth, kvadratići) mogu se prikazati kao □ na starijim Androidima ili u nekim mail klijentima.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.3.items.2.question">Instagram mi je izrezao dio znakova u nadimku — što sad?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.3.items.2.answer">Instagram ima filtar na polju <strong>korisničko ime</strong> (dakle @login) — prima samo slova, brojke, točke i podvlake. Tu stilizirana slova ne možeš zalijepiti.
+    <br><br>
+    Ali u polju <strong>„Ime"</strong> (prikazano ime) i u <strong>biju</strong> može — i tu prolazi većina stilova. Ako se jedan ne sprema, uzmi drugi. Bold obično prolazi bez problema.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.3.items.3.question">Postoje li znakovi koji se uopće ne mogu pretvoriti?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.3.items.3.answer">Standardna slova (A–Z, a–z), brojke i osnovni interpunkcijski znakovi pretvaraju se bez problema. Neki rijetki simboli ili posebni znakovi nemaju stilizirane parnjake u Unicodeu — tada ostaju u izvorniku. Ništa se ne kvari, tekst je i dalje za kopiranje.</div>
+</div>
+
+
+<!-- Sigurnost, privatnost, mobitel -->
+<h2 class="faq-category" data-i18n="faq.categories.4.title">Sigurnost, privatnost, mobitel</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.4.items.0.question">Sprema li se moj tekst negdje?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.4.items.0.answer">Ne. Cijela pretvorba slova događa se <strong>u tvom pregledniku</strong> — ništa ne ide na naše servere, ništa se ne sprema, ništa se ne prati. Kopirani tekst je čisti Unicode, bez skrivenih znakova, bez ikakvih identifikatora.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.4.items.1.question">Je li sigurno lijepiti ova slova bilo gdje?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.4.items.1.answer">Da — to su standardni Unicode znakovi, isti kakve koristi cijeli internet. Ništa unutra, bez skripti, bez skrivenog oblikovanja, bez kodova. Slobodno lijepi u životopis, u poslovni mail, u bio na LinkedInu — gdje god želiš.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.4.items.2.question">Radi li na mobitelu?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.4.items.2.answer">Da — stranica se u potpunosti prilagođava mobitelu. iPhone, Android, tablet — sve štima. Upišeš tekst, klikneš, kopira se u međuspremnik, zalijepiš u aplikaciji. Bez instaliranja ičega iz trgovine.</div>
+</div>
+
+
+<!-- Po čemu se razlikujemo -->
+<h2 class="faq-category" data-i18n="faq.categories.5.title">Po čemu se razlikujemo</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.5.items.0.question">Po čemu se razlikujete od drugih generatora slova?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.5.items.0.answer">Konkretno:
+    <br><br>
+    — <strong>Jedna od većih kolekcija</strong> Ultra stilova — bold, kurziv, gotica, balončasta i još desetak drugih.<br>
+    — <strong>Spajanje stilova</strong> — većina generatora daje ti jedan stil odjednom, mi dopuštamo naslanjanje.<br>
+    — <strong>Ukrasi jednim klikom</strong> — okviri, zvjezdice, razdjelnici bez lijepljenja znak po znak.<br>
+    — <strong>Stranice za konkretne platforme</strong> — Instagram, TikTok, Discord. Ondje prikazujemo samo stilove koji na toj aplikaciji rade.<br>
+    — <strong>Brzo i bez skočnih prozora</strong> — bez captcha, bez „prihvati sve" prije svakog klika.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.5.items.1.question">Dolaze li novi stilovi?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.5.items.1.answer">Da, redovito. S vremena na vrijeme upadnu nove inačice, ukrasi i okviri. Najlakše je zapamtiti stranicu ili svratiti povremeno.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.5.items.2.question">Kako pronaći točno onaj stil koji tražim?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.5.items.2.answer">Tri puta:
+    <br><br>
+    <strong>Po stilu</strong> — kategorije na vrhu: bold, kurziv, gotica, balončasta, precrtano, naopako i još.<br>
+    <strong>Po platformi</strong> — svrati na podstranicu za Instagram, TikTok, Discord — ondje su samo stilovi koji se na toj platformi pokažu.<br>
+    <strong>Po cilju</strong> — odjeljak s primjenama ima alate prilagođene konkretnoj potrebi: naslov na LinkedInu, komentari, tekst s emojijima.</div>
+</div>
+    </div>
+  </section>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-inner">
+      <!-- Language Switcher -->
+      <div class="lang-switcher" role="navigation" aria-label="Language switcher">
+        <a class="lang-option" href="/" hreflang="en">EN</a>
+        <a class="lang-option" href="/es/" hreflang="es">ES</a>
+        <a class="lang-option" href="/fr/" hreflang="fr">FR</a>
+        <a class="lang-option" href="/pt/" hreflang="pt">PT</a>
+        <a class="lang-option" href="/de/" hreflang="de">DE</a>
+        <a class="lang-option" href="/id/" hreflang="id">ID</a>
+        <a class="lang-option" href="/it/" hreflang="it">IT</a>
+        <a class="lang-option" href="/nl/" hreflang="nl">NL</a>
+        <a class="lang-option" href="/tr/" hreflang="tr">TR</a>
+        <a class="lang-option" href="/pl/" hreflang="pl">PL</a>
+        <a class="lang-option active" href="/hr/" hreflang="hr">HR</a>
+        <a class="lang-option" href="/vi/" hreflang="vi">VI</a>
+        <a class="lang-option" href="/sv/" hreflang="sv">SV</a>
+        <a class="lang-option" href="/no/" hreflang="no">NO</a>
+        <a class="lang-option" href="/ja/" hreflang="ja">JA</a>
+        <a class="lang-option" href="/th/" hreflang="th">TH</a>
+        <a class="lang-option" href="/ru/" hreflang="ru">RU</a>
+        <a class="lang-option" href="/ar/" hreflang="ar">AR</a>
+      </div>
+    </div>
+  </footer>
+
+  <div class="copy-toast" id="copyToast">Copied!</div>
+
+  <script src="/styles.js" defer=""></script>
+<script src="/renderer.js" defer=""></script>
+<script src="/script.js" defer=""></script>
+<script src="/i18n.js" defer=""></script>
+
+
+
+
+<script src="/footer.js" defer=""></script>
+
+
+</body></html>

--- a/hr/kurziv/index.html
+++ b/hr/kurziv/index.html
@@ -1,0 +1,299 @@
+<!DOCTYPE html><html lang="hr"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZGVh");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Generator Kurziva — 𝘬𝘶𝘳𝘻𝘪𝘷 za kopiranje | UltraTextGen</title>
+  <meta name="description" content="Besplatan generator kurziva: pretvori tekst u ukošena Unicode slova za kopiranje i lijepljenje — u bio na Instagramu, WhatsApp, TikTok, Discord i LinkedIn. Odmah, bez registracije.">
+  <link rel="canonical" href="https://ultratextgen.com/hr/kurziv/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/category/italic-fonts/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/category/italic-fonts/">
+  <link rel="alternate" hreflang="hr" href="https://ultratextgen.com/hr/kurziv/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Generator Kurziva — 𝘬𝘶𝘳𝘻𝘪𝘷 za kopiranje | UltraTextGen">
+  <meta property="og:description" content="Besplatan generator kurziva — ukošena Unicode slova za kopiranje i lijepljenje na Instagram, TikTok, WhatsApp, Discord i LinkedIn. Odmah, bez registracije.">
+  <meta property="og:url" content="https://ultratextgen.com/hr/kurziv/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category-italic-fonts.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Generator Kurziva — 𝘬𝘶𝘳𝘻𝘪𝘷 za kopiranje | UltraTextGen">
+  <meta name="twitter:description" content="Besplatan generator kurziva — ukošena Unicode slova za kopiranje i lijepljenje na društvene mreže, chatove i u nadimke.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category-italic-fonts.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "hr",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Kako napraviti kurziv za kopiranje i lijepljenje?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Upiši tekst u polje na vrhu, a generator će ga odmah prikazati u kurzivu (𝘱𝘰𝘱𝘶𝘵 𝘰𝘷𝘰𝘨𝘢) — to su pravi Unicode znakovi, a ne instalirani font ni slika. Budući da su obični tekstualni znakovi, možeš ih kopirati i zalijepiti svugdje gdje se može upisati tekst: u bio, opise, komentare i poruke. Više u našem vodiču o tome kako rade Unicode fontovi."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Radi li Unicode kurziv na Instagramu, WhatsAppu, TikToku i LinkedInu?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da. Bio, opisi, komentari i poruke na chatu primaju te znakove bez problema. Osobito na LinkedInu i X-u, gdje nema izvornog kurziva, ukošeni Unicode font omogućuje da istakneš najvažnije riječi. Napomena: neka polja korisničkog imena (@) filtriraju takve znakove — za sam login ostavi običan tekst, ali u biju kurziv radi sjajno."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Podržava li kurziv hrvatske znakove (č, ć, đ, š, ž)?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Unicode kurziv obuhvaća osnovnu abecedu A–Z i brojke 0–9, pa hrvatske kvačice (č, ć, đ, š, ž) nemaju vlastiti ukošeni oblik i ostaju obična slova usred riječi (npr. „šuma” izađe kao š𝘶𝘮𝘢). Za nadimke i kratke natpise bez kvačica izgleda idealno; u duljem tekstu najsigurnije je birati riječi koje ih ne sadrže."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Je li generator kurziva besplatan?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da, potpuno besplatan i bez registracije. Upisuj, kopiraj i lijepi koliko god puta želiš — nema nikakvog ograničenja ni skrivenih troškova."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Zašto se neka slova kurziva prikazuju kao prazni kvadratići?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Prazni kvadratić (▯) znači da uređaj primatelja nema glif za taj ukošeni znak — najčešće je to stariji telefon ili računalo. Odaberi jednostavniju inačicu kurziva ili ažuriraj uređaj — više u tekstu o tome zašto se fontovi prikazuju kao kvadratići."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Utječe li Unicode kurziv na čitljivost i doseg?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ukošeni Unicode znakovi lijepo privlače pogled i sjajno rade u sloganima, naslovima i pozivima na akciju na društvenim mrežama. Koristi ih namjerno — kratak naglasak u kurzivu, ostalo običnim tekstom. Za sadržaj na vlastitoj web-stranici bolje je koristiti CSS ukošenje da tražilice čitaju normalne riječi; u tekstualnim poljima društvenih mreža idealan je Unicode kurziv. Kod duljih dijelova vodi računa o pristupačnosti."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "inLanguage": "hr",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Početna", "item": "https://ultratextgen.com/hr/" },
+    { "@type": "ListItem", "position": 2, "name": "Kurziv", "item": "https://ultratextgen.com/hr/kurziv/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Generator Kurziva",
+  "alternateName": ["Kurziv za kopiranje","Ukošeni font","Ukošena slova","Unicode kurziv","Kurzivni font","Tekst u kurzivu","Kurziv online"],
+  "url": "https://ultratextgen.com/hr/kurziv/",
+  "inLanguage": "hr",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "EUR"
+  },
+  "description": "Besplatan generator kurziva: pretvara tekst u ukošena Unicode slova za kopiranje i lijepljenje na Instagram, TikTok, WhatsApp, Discord, LinkedIn i u nadimke.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/hr/">Početna</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Kurziv</span>
+</nav>
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/category-italic-fonts.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+  <!-- Hero -->
+  <section class="hero">
+    <div class="hero-inner">
+      <div class="hero-card">
+        <h1 class="hero-headline">Generator Kurziva</h1>
+        <p class="hero-tagline">Pretvori bilo koji tekst u 𝘬𝘶𝘳𝘻𝘪𝘷 za kopiranje i lijepljenje — elegantna,
+          ukošena Unicode slova za bio, nadimke i naslove. Besplatno, odmah, bez registracije.</p>
+        <div class="input-wrapper">
+          <textarea class="main-input" id="mainInput" placeholder="Upiši tekst, riječ ili ime…" maxlength="500" autofocus></textarea>
+          <span class="char-count"><span id="charCount">0</span>/500</span>
+        </div>
+
+        <!-- Decoration Selector -->
+        <div class="decoration-section">
+          <div class="decoration-label">
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"></path>
+            </svg>
+            Dodaj simbole oko rezultata
+          </div>
+          <div class="decoration-tabs">
+            <button class="decoration-tab active" data-deco-tab="symbols">Simboli</button>
+            <button class="decoration-tab" data-deco-tab="frames">Okviri</button>
+            <button class="decoration-tab" data-deco-tab="dividers">Razdjelnici</button>
+            <button class="decoration-tab" data-deco-tab="minimal">Minimalni</button>
+            <button class="decoration-tab" data-deco-tab="emojis">Emoji</button>
+          </div>
+          <div class="decoration-grid" id="decorationGrid"></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Main Content -->
+  <main class="container">
+
+    <section class="editorial-section">
+      <span class="article-section-label">Unicode kurziv</span>
+      <h2>Kurziv za kopiranje — za bio, nadimke i naslove</h2>
+      <p>Ova slova nisu instalirani font ni slika, nego pravi <strong>Unicode znakovi</strong>. Istakni
+        ključnu riječ u biju, napravi ukošen nadimak ili učini da naslov na LinkedInu i X-u privlači pogled — svugdje ondje,
+        gdje nema izvornog kurziva. Upiši tekst iznad, klikni <strong>Kopiraj</strong> i zalijepi kurziv gdje god želiš.</p>
+    </section>
+
+    <!-- Category Tabs (populated by script.js) -->
+    <div class="category-section">
+      <div class="category-tabs" id="categoryTabs"></div>
+    </div>
+
+    <!-- Results -->
+    <div class="results-grid" id="resultsGrid"></div>
+
+    <section class="editorial-section">
+      <span class="article-section-label">Povezano</span>
+      <p>Spoji kurziv s <a href="/hr/fontovi-za-discord/">fontovima za Discord</a>,
+        <a href="/hr/">slovima za kopiranje</a> ili
+        <a href="/library/invisible-character/">nevidljivim znakom</a> za čiste razmake. Za tetovaže tu je
+        <a href="/usecase/tattoo-fonts/">generator fontova za tetovažu</a>, a za okomite rasporede —
+        <a href="/usecase/vertical-text/">okomiti tekst</a>.</p>
+    </section>
+  </main>
+
+  <!-- Footer + FAQ -->
+  <footer class="footer">
+    <div class="footer-inner">
+<div class="faq-section" id="faq">
+
+<h2 class="faq-category">Generator Kurziva — FAQ</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Kako napraviti kurziv za kopiranje i lijepljenje?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Upiši tekst u polje na vrhu, a generator će ga odmah prikazati u kurzivu (𝘱𝘰𝘱𝘶𝘵 𝘰𝘷𝘰𝘨𝘢) — to su pravi Unicode znakovi, a ne instalirani font ni slika. Budući da su obični tekstualni znakovi, možeš ih kopirati i zalijepiti svugdje gdje se može upisati tekst: u bio, opise, komentare i poruke. Više u našem <a href="/guide/how-unicode-fonts-work/">vodiču o tome kako rade Unicode fontovi</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Radi li Unicode kurziv na Instagramu, WhatsAppu, TikToku i LinkedInu?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Da. Bio, opisi, komentari i poruke na chatu primaju te znakove bez problema. Osobito na LinkedInu i X-u, gdje nema izvornog kurziva, ukošeni Unicode font omogućuje da istakneš najvažnije riječi. Napomena: neka <strong>polja korisničkog imena (@)</strong> filtriraju takve znakove — za sam login ostavi običan tekst, ali u biju kurziv radi sjajno.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Podržava li kurziv hrvatske znakove (č, ć, đ, š, ž)?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Unicode kurziv obuhvaća osnovnu abecedu A–Z i brojke 0–9, pa hrvatske kvačice (č, ć, đ, š, ž) nemaju vlastiti ukošeni oblik i ostaju obična slova usred riječi (npr. „šuma” izađe kao š𝘶𝘮𝘢). Za nadimke i kratke natpise <strong>bez kvačica</strong> izgleda idealno; u duljem tekstu najsigurnije je birati riječi koje ih ne sadrže.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Je li generator kurziva besplatan?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Da, potpuno besplatan i bez registracije. Upisuj, kopiraj i lijepi koliko god puta želiš — nema nikakvog ograničenja ni skrivenih troškova.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Zašto se neka slova kurziva prikazuju kao prazni kvadratići?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Prazni kvadratić (▯) znači da uređaj primatelja nema glif za taj ukošeni znak — najčešće je to stariji telefon ili računalo. Odaberi jednostavniju inačicu kurziva ili ažuriraj uređaj — više u tekstu o tome, <a href="/guide/why-fonts-show-as-boxes/">zašto se fontovi prikazuju kao kvadratići</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Utječe li Unicode kurziv na čitljivost i doseg?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Ukošeni Unicode znakovi lijepo privlače pogled i sjajno rade u sloganima, naslovima i pozivima na akciju na društvenim mrežama. Koristi ih namjerno — kratak naglasak u kurzivu, ostalo običnim tekstom. Za sadržaj na vlastitoj web-stranici bolje je koristiti CSS ukošenje da tražilice čitaju normalne riječi; u tekstualnim poljima društvenih mreža idealan je Unicode kurziv. Kod duljih dijelova vodi računa o <a href="/guide/fancy-fonts-accessibility-guide/">pristupačnosti</a>.
+  </div>
+</div>
+
+</div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Odabir jezika">
+      <a class="lang-option" href="/category/italic-fonts/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/hr/kurziv/" hreflang="hr">HR</a>
+    </div>
+
+    </div>
+  </footer>
+
+  <div class="copy-toast" id="copyToast">Kopirano!</div>
+
+  <script>
+    window.UTG_FAMILY = "italic";
+    window.UTG_DEMO_TEXT = "kurziv online\nstilizirani tekst";
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/script.js" defer></script>
+  <script src="/footer.js" defer></script>
+</body></html>

--- a/hr/mala-slova/index.html
+++ b/hr/mala-slova/index.html
@@ -1,0 +1,299 @@
+<!DOCTYPE html><html lang="hr"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZGVh");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Generator Malih Slova — ᴍᴀʟᴀ sʟᴏᴠᴀ i kapitalke za kopiranje | UltraTextGen</title>
+  <meta name="description" content="Besplatan generator malih slova: pretvori tekst u mali Unicode tekst i kapitalke za kopiranje i lijepljenje — u bio na Instagramu, Discordu, TikToku, X-u i nadimke. Odmah, bez registracije.">
+  <link rel="canonical" href="https://ultratextgen.com/hr/mala-slova/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/category/small-text/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/category/small-text/">
+  <link rel="alternate" hreflang="hr" href="https://ultratextgen.com/hr/mala-slova/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Generator Malih Slova — ᴍᴀʟᴀ sʟᴏᴠᴀ i kapitalke za kopiranje | UltraTextGen">
+  <meta property="og:description" content="Besplatan generator malih slova — mali Unicode tekst i kapitalke za kopiranje i lijepljenje na Instagram, TikTok, Discord i X. Odmah, bez registracije.">
+  <meta property="og:url" content="https://ultratextgen.com/hr/mala-slova/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category-small-text.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Generator Malih Slova — ᴍᴀʟᴀ sʟᴏᴠᴀ i kapitalke za kopiranje | UltraTextGen">
+  <meta name="twitter:description" content="Besplatan generator malih slova — mali Unicode tekst i kapitalke za kopiranje i lijepljenje na društvene mreže, chatove i u nadimke.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category-small-text.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "hr",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Što su mala slova i kako radi generator malih slova?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Generator pretvara slova koja upišeš u manje Unicode znakove — kapitalke (ᴍᴀʟᴀ sʟᴏᴠᴀ) te mali tekst u gornjem i donjem indeksu. To su pravi znakovi, a ne font ni slika, pa ih možeš kopirati i zalijepiti svugdje gdje je dopušten tekst: u bio, opise, komentare i poruke. Više u našem vodiču o tome kako rade Unicode fontovi."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Rade li mala slova na Discordu, Instagramu, TikToku i X-u?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da. Bio, opisi, komentari i poruke na chatu obično bez problema primaju mali tekst. Dobro se pokaže kao pomoćni, suptilan opis ispod nadimka ili nježan potpis koji ne viče kao velik podebljan font. Kompatibilnost ipak ovisi o stilu i uređaju — najbolje je zalijepiti rezultat i provjeriti kako izgleda u danoj aplikaciji."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Po čemu se razlikuju kapitalke od malog teksta u gornjem indeksu?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Kapitalke su mala verzalna slova (ᴋᴀᴘɪᴛᴀʟᴋᴇ) — slova imaju oblik velikih, ali visinu malih, pa tekst ostaje čitljiv i elegantan. Mali tekst u gornjem indeksu (ᵗᵃᵏᵒ) ili donjem još je sitniji i lagano podignut ili spušten, pa je sjajan za kratke ukrasne naglaske. Za dulje fraze obično bolje izgledaju kapitalke."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Mogu li pisati hrvatske znakove (č, ć, đ, š, ž) malim slovima?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Male Unicode inačice obuhvaćaju uglavnom A–Z i dio brojki, pa hrvatski znakovi poput č, ć, đ, š, ž nemaju vlastiti mali oblik i ostaju u normalnoj veličini. Za ujednačen efekt možeš ih zamijeniti osnovnim slovima (c, d, s, z) — to mijenja pravopis — ili ih ostaviti nepromijenjene, što u kratkom nadimku ili potpisu obično ionako izgleda dobro."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Je li generator malih slova besplatan?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da, potpuno besplatan i bez registracije. Upisuj, kopiraj i lijepi koliko god puta želiš — nema ograničenja ni skrivenih troškova. Sve radi u pregledniku, pa ništa ne instaliraš."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Zašto se neka mala slova prikazuju kao kvadratići i utječu li na čitljivost?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Prazni kvadratić (▯) znači da uređaj nema odgovarajući glif za taj mali znak — to se obično odnosi na starije sustave. Odaberi tada jednostavniji stil (npr. kapitalke) ili ažuriraj uređaj; više u članku o tome zašto se fontovi prikazuju kao kvadratići. Imaj i na umu da se vrlo mali tekst teže čita — koristi ga za kratke fraze, a najvažnije informacije ostavi običnim tekstom zbog pristupačnosti."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "inLanguage": "hr",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Početna", "item": "https://ultratextgen.com/hr/" },
+    { "@type": "ListItem", "position": 2, "name": "Mala slova", "item": "https://ultratextgen.com/hr/mala-slova/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Generator Malih Slova",
+  "alternateName": ["Mala slova","Mali tekst","Generator malih slova","Kapitalke","Mala slova za kopiranje","Mali Unicode tekst","Sitni tekst","Mali natpisi"],
+  "url": "https://ultratextgen.com/hr/mala-slova/",
+  "inLanguage": "hr",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "EUR"
+  },
+  "description": "Besplatan generator malih slova: pretvori tekst u mali Unicode tekst i kapitalke za kopiranje i lijepljenje na Instagram, TikTok, Discord, X i u nadimke.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/hr/">Početna</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Mala slova</span>
+</nav>
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/category-small-text.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+  <!-- Hero -->
+  <section class="hero">
+    <div class="hero-inner">
+      <div class="hero-card">
+        <h1 class="hero-headline">Generator Malih Slova</h1>
+        <p class="hero-tagline">Pretvori bilo koji tekst u ᴍᴀʟᴀ sʟᴏᴠᴀ i kapitalke za kopiranje i lijepljenje — suptilni,
+          sitni Unicode znakovi za bio, nadimke i potpise. Besplatno, odmah, bez registracije.</p>
+        <div class="input-wrapper">
+          <textarea class="main-input" id="mainInput" placeholder="Upiši tekst, riječ ili ime…" maxlength="500" autofocus></textarea>
+          <span class="char-count"><span id="charCount">0</span>/500</span>
+        </div>
+
+        <!-- Decoration Selector -->
+        <div class="decoration-section">
+          <div class="decoration-label">
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"></path>
+            </svg>
+            Dodaj simbole oko rezultata
+          </div>
+          <div class="decoration-tabs">
+            <button class="decoration-tab active" data-deco-tab="symbols">Simboli</button>
+            <button class="decoration-tab" data-deco-tab="frames">Okviri</button>
+            <button class="decoration-tab" data-deco-tab="dividers">Razdjelnici</button>
+            <button class="decoration-tab" data-deco-tab="minimal">Minimalni</button>
+            <button class="decoration-tab" data-deco-tab="emojis">Emoji</button>
+          </div>
+          <div class="decoration-grid" id="decorationGrid"></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Main Content -->
+  <main class="container">
+
+    <section class="editorial-section">
+      <span class="article-section-label">Mali Unicode tekst</span>
+      <h2>Mala slova za kopiranje — za bio, nadimke i potpise</h2>
+      <p>Ova slova nisu font ni slika, nego pravi <strong>Unicode znakovi</strong>. Dodaj suptilan opis
+        ispod nadimka, ispiši ime elegantnim <strong>kapitalkama</strong> ili upleti sitan tekst u gornjem indeksu
+        ondje gdje bi velik podebljan font bio previše napadan. Upiši tekst iznad, klikni <strong>Kopiraj</strong>
+        i zalijepi mala slova gdje god želiš.</p>
+    </section>
+
+    <!-- Category Tabs (populated by script.js) -->
+    <div class="category-section">
+      <div class="category-tabs" id="categoryTabs"></div>
+    </div>
+
+    <!-- Results -->
+    <div class="results-grid" id="resultsGrid"></div>
+
+    <section class="editorial-section">
+      <span class="article-section-label">Povezano</span>
+      <p>Spoji mala slova s <a href="/hr/podebljana-slova/">podebljanim slovima</a>,
+        <a href="/library/aesthetic-symbols/">ukrasnim simbolima</a> ili <a href="/library/invisible-character/">nevidljivim znakom</a>
+        za čiste razmake. Pogledaj i <a href="/hr/">slova za kopiranje</a>,
+        a za okomite rasporede — <a href="/usecase/vertical-text/">okomiti tekst</a>.</p>
+    </section>
+  </main>
+
+  <!-- Footer + FAQ -->
+  <footer class="footer">
+    <div class="footer-inner">
+<div class="faq-section" id="small-faq">
+
+<h2 class="faq-category">Generator Malih Slova — FAQ</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Što su mala slova i kako radi generator malih slova?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Generator pretvara slova koja upišeš u manje Unicode znakove — kapitalke (ᴍᴀʟᴀ sʟᴏᴠᴀ) te mali tekst u gornjem i donjem indeksu. To su pravi znakovi, a ne font ni slika, pa ih možeš kopirati i zalijepiti svugdje gdje je dopušten tekst: u bio, opise, komentare i poruke. Više u našem <a href="/guide/how-unicode-fonts-work/">vodiču o tome kako rade Unicode fontovi</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Rade li mala slova na Discordu, Instagramu, TikToku i X-u?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Da. Bio, opisi, komentari i poruke na chatu obično bez problema primaju mali tekst. Dobro se pokaže kao pomoćni, suptilan opis ispod nadimka ili nježan potpis koji ne viče kao velik podebljan font. Kompatibilnost ipak ovisi o stilu i uređaju — najbolje je zalijepiti rezultat i provjeriti kako izgleda u danoj aplikaciji.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Po čemu se razlikuju kapitalke od malog teksta u gornjem indeksu?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Kapitalke su mala verzalna slova (ᴋᴀᴘɪᴛᴀʟᴋᴇ) — slova imaju oblik velikih, ali visinu malih, pa tekst ostaje čitljiv i elegantan. Mali tekst u gornjem indeksu (ᵗᵃᵏᵒ) ili donjem još je sitniji i lagano podignut ili spušten, pa je sjajan za kratke ukrasne naglaske. Za dulje fraze obično bolje izgledaju <strong>kapitalke</strong>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Mogu li pisati hrvatske znakove (č, ć, đ, š, ž) malim slovima?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Male Unicode inačice obuhvaćaju uglavnom A–Z i dio brojki, pa hrvatski znakovi poput č, ć, đ, š, ž nemaju vlastiti mali oblik i ostaju u normalnoj veličini. Za ujednačen efekt možeš ih zamijeniti osnovnim slovima (<strong>c, d, s, z</strong>) — to mijenja pravopis — ili ih ostaviti nepromijenjene, što u kratkom nadimku ili potpisu obično ionako izgleda dobro.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Je li generator malih slova besplatan?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Da, potpuno besplatan i bez registracije. Upisuj, kopiraj i lijepi koliko god puta želiš — nema ograničenja ni skrivenih troškova. Sve radi u pregledniku, pa ništa ne instaliraš.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Zašto se neka mala slova prikazuju kao kvadratići i utječu li na čitljivost?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Prazni kvadratić (▯) znači da uređaj nema odgovarajući glif za taj mali znak — to se obično odnosi na starije sustave. Odaberi tada jednostavniji stil (npr. kapitalke) ili ažuriraj uređaj; više u članku o tome, <a href="/guide/why-fonts-show-as-boxes/">zašto se fontovi prikazuju kao kvadratići</a>. Imaj i na umu da se vrlo mali tekst teže čita — koristi ga za kratke fraze, a najvažnije informacije ostavi običnim tekstom zbog <a href="/guide/fancy-fonts-accessibility-guide/">pristupačnosti</a>.
+  </div>
+</div>
+
+</div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Odabir jezika">
+      <a class="lang-option" href="/category/small-text/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/hr/mala-slova/" hreflang="hr">HR</a>
+    </div>
+
+    </div>
+  </footer>
+
+  <div class="copy-toast" id="copyToast">Kopirano!</div>
+
+  <script>
+    window.UTG_FAMILY = "small-text";
+    window.UTG_DEMO_TEXT = "mala slova\nmali tekst";
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/script.js" defer></script>
+  <script src="/footer.js" defer></script>
+</body></html>

--- a/hr/podebljana-slova/index.html
+++ b/hr/podebljana-slova/index.html
@@ -1,0 +1,299 @@
+<!DOCTYPE html><html lang="hr"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZGVh");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Generator Podebljanih Slova — 𝐩𝐨𝐝𝐞𝐛𝐥𝐣𝐚𝐧𝐚 𝐬𝐥𝐨𝐯𝐚 za kopiranje | UltraTextGen</title>
+  <meta name="description" content="Besplatan generator podebljanih slova: pretvori tekst u podebljane Unicode znakove za kopiranje i lijepljenje — u bio na Instagramu, WhatsApp, TikTok, Discord, LinkedIn i nadimke. Odmah, bez registracije.">
+  <link rel="canonical" href="https://ultratextgen.com/hr/podebljana-slova/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/category/bold-fonts/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/category/bold-fonts/">
+  <link rel="alternate" hreflang="hr" href="https://ultratextgen.com/hr/podebljana-slova/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Generator Podebljanih Slova — 𝐩𝐨𝐝𝐞𝐛𝐥𝐣𝐚𝐧𝐚 𝐬𝐥𝐨𝐯𝐚 za kopiranje | UltraTextGen">
+  <meta property="og:description" content="Besplatan generator podebljanih slova — podebljani Unicode znakovi za kopiranje i lijepljenje na Instagram, TikTok, WhatsApp, Discord i LinkedIn. Odmah, bez registracije.">
+  <meta property="og:url" content="https://ultratextgen.com/hr/podebljana-slova/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category-bold-fonts.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Generator Podebljanih Slova — 𝐩𝐨𝐝𝐞𝐛𝐥𝐣𝐚𝐧𝐚 𝐬𝐥𝐨𝐯𝐚 za kopiranje | UltraTextGen">
+  <meta name="twitter:description" content="Besplatan generator podebljanih slova — podebljani Unicode znakovi za kopiranje i lijepljenje na društvene mreže, chatove i u nadimke.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category-bold-fonts.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "hr",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Što je generator podebljanih slova i kako radi?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Pretvara slova koja upišeš u podebljane Unicode znakove (𝐩𝐨𝐩𝐮𝐭 𝐨𝐯𝐢𝐡) — prave znakove, a ne font ni sliku. Budući da su to obični tekstualni znakovi, možeš ih kopirati i zalijepiti svugdje gdje je dopušten tekst: u bio, opise, komentare i poruke. Više u našem vodiču o tome kako rade Unicode fontovi."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Rade li podebljana slova na Instagramu, WhatsAppu, TikToku i LinkedInu?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da. Bio, opisi, komentari i poruke na chatu bez problema primaju te znakove. Osobito na LinkedInu i X-u, gdje nema izvornog podebljanja, podebljana Unicode slova čine da se najvažniji dijelovi istaknu. Napomena: neka polja s @korisničkim imenom filtriraju te znakove — u samom handleu treba ostati na običnom tekstu, ali u biju podebljana slova rade sjajno."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Mogu li pisati hrvatske znakove (č, ć, đ, š, ž) podebljanim slovima?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Unicode podebljanje obuhvaća A–Z i 0–9, pa hrvatski znakovi poput č, ć, đ, š, ž nemaju vlastiti podebljani oblik i ostaju obični. Za potpuno podebljan efekt možeš ih zamijeniti osnovnim slovima (c, d, s, z) — to mijenja pravopis — ili ih ostaviti u normalnoj debljini, što u kratkom tekstu obično ionako izgleda dobro. Najbolje se s našom abecedom snalaze bold, kurziv i monospace."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Je li generator podebljanih slova besplatan?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da, potpuno besplatan i bez registracije. Upisuj, kopiraj i lijepi koliko god puta želiš — nema ograničenja ni skrivenih troškova."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Zašto se neki znakovi prikazuju kao prazni kvadratići?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Prazni kvadratić (▯) znači da uređaj nema odgovarajući glif za taj podebljani znak. To se obično odnosi na starije sustave. Odaberi jednostavniji podebljani stil ili ažuriraj uređaj — više u članku o tome zašto se fontovi prikazuju kao kvadratići."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Utječe li podebljani Unicode tekst na čitljivost i doseg?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Podebljani Unicode znakovi privlače pogled u feedu i sjajno rade kao hook, naslov i CTA na društvenim mrežama. Koristi ih namjerno — kratki podebljani naglasci, ostalo običnim tekstom. Za sadržaj na web-stranici bolje je koristiti CSS podebljanje da tražilice čitaju tekst kao obične riječi. Za tekstualna polja na društvenim mrežama Unicode podebljanje je idealno rješenje. Vodi računa o pristupačnosti kad oblikuješ dulje dijelove."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "inLanguage": "hr",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Početna", "item": "https://ultratextgen.com/hr/" },
+    { "@type": "ListItem", "position": 2, "name": "Podebljana slova", "item": "https://ultratextgen.com/hr/podebljana-slova/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Generator Podebljanih Slova",
+  "alternateName": ["Podebljana slova","Podebljani tekst","Bold slova","Generator podebljanog teksta","Podebljana slova za kopiranje","Podebljani Unicode tekst","Bold za kopiranje"],
+  "url": "https://ultratextgen.com/hr/podebljana-slova/",
+  "inLanguage": "hr",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "EUR"
+  },
+  "description": "Besplatan generator podebljanih slova: pretvori tekst u podebljane Unicode znakove za kopiranje i lijepljenje na Instagram, TikTok, WhatsApp, Discord, LinkedIn i u nadimke.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/hr/">Početna</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Podebljana slova</span>
+</nav>
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/category-bold-fonts.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+  <!-- Hero -->
+  <section class="hero">
+    <div class="hero-inner">
+      <div class="hero-card">
+        <h1 class="hero-headline">Generator Podebljanih Slova</h1>
+        <p class="hero-tagline">Pretvori bilo koji tekst u 𝐩𝐨𝐝𝐞𝐛𝐥𝐣𝐚𝐧𝐢 𝐭𝐞𝐤𝐬𝐭 za kopiranje i lijepljenje — snažni,
+          uočljivi Unicode znakovi za bio, nadimke i naslove. Besplatno, odmah, bez registracije.</p>
+        <div class="input-wrapper">
+          <textarea class="main-input" id="mainInput" placeholder="Upiši tekst, riječ ili ime…" maxlength="500" autofocus></textarea>
+          <span class="char-count"><span id="charCount">0</span>/500</span>
+        </div>
+
+        <!-- Decoration Selector -->
+        <div class="decoration-section">
+          <div class="decoration-label">
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"></path>
+            </svg>
+            Dodaj simbole oko rezultata
+          </div>
+          <div class="decoration-tabs">
+            <button class="decoration-tab active" data-deco-tab="symbols">Simboli</button>
+            <button class="decoration-tab" data-deco-tab="frames">Okviri</button>
+            <button class="decoration-tab" data-deco-tab="dividers">Razdjelnici</button>
+            <button class="decoration-tab" data-deco-tab="minimal">Minimalni</button>
+            <button class="decoration-tab" data-deco-tab="emojis">Emoji</button>
+          </div>
+          <div class="decoration-grid" id="decorationGrid"></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Main Content -->
+  <main class="container">
+
+    <section class="editorial-section">
+      <span class="article-section-label">Podebljana Unicode slova</span>
+      <h2>Podebljani tekst za kopiranje — za bio, nadimke i naslove</h2>
+      <p>Ova slova nisu font ni slika, nego pravi <strong>Unicode znakovi</strong>. Istakni ključnu riječ
+        u svom biju, napravi podebljan nadimak ili učini da naslov na LinkedInu i X-u privlači pogled — svugdje ondje,
+        gdje nema izvornog podebljanja. Upiši tekst iznad, klikni <strong>Kopiraj</strong> i zalijepi podebljana
+        slova gdje god želiš.</p>
+    </section>
+
+    <!-- Category Tabs (populated by script.js) -->
+    <div class="category-section">
+      <div class="category-tabs" id="categoryTabs"></div>
+    </div>
+
+    <!-- Results -->
+    <div class="results-grid" id="resultsGrid"></div>
+
+    <section class="editorial-section">
+      <span class="article-section-label">Povezano</span>
+      <p>Spoji podebljana slova s <a href="/hr/fontovi-za-discord/">fontovima za Discord</a>,
+        <a href="/library/aesthetic-symbols/">ukrasnim simbolima</a> ili <a href="/library/invisible-character/">nevidljivim znakom</a>
+        za čiste razmake. Za body art imamo <a href="/usecase/tattoo-fonts/">generator fontova za tetovažu</a>,
+        a za okomite rasporede — <a href="/usecase/vertical-text/">okomiti tekst</a>.</p>
+    </section>
+  </main>
+
+  <!-- Footer + FAQ -->
+  <footer class="footer">
+    <div class="footer-inner">
+<div class="faq-section" id="bold-faq">
+
+<h2 class="faq-category">Generator Podebljanih Slova — FAQ</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Što je generator podebljanih slova i kako radi?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Pretvara slova koja upišeš u podebljane Unicode znakove (𝐩𝐨𝐩𝐮𝐭 𝐨𝐯𝐢𝐡) — prave znakove, a ne font ni sliku. Budući da su to obični tekstualni znakovi, možeš ih kopirati i zalijepiti svugdje gdje je dopušten tekst: u bio, opise, komentare i poruke. Više u našem <a href="/guide/how-unicode-fonts-work/">vodiču o tome kako rade Unicode fontovi</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Rade li podebljana slova na Instagramu, WhatsAppu, TikToku i LinkedInu?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Da. Bio, opisi, komentari i poruke na chatu bez problema primaju te znakove. Osobito na LinkedInu i X-u, gdje nema izvornog podebljanja, podebljana Unicode slova čine da se najvažniji dijelovi istaknu. Napomena: neka polja s <strong>@korisničkim imenom</strong> filtriraju te znakove — u samom handleu treba ostati na običnom tekstu, ali u biju podebljana slova rade sjajno.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Mogu li pisati hrvatske znakove (č, ć, đ, š, ž) podebljanim slovima?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Unicode podebljanje obuhvaća A–Z i 0–9, pa hrvatski znakovi poput č, ć, đ, š, ž nemaju vlastiti podebljani oblik i ostaju obični. Za potpuno podebljan efekt možeš ih zamijeniti osnovnim slovima (<strong>c, d, s, z</strong>) — to mijenja pravopis — ili ih ostaviti u normalnoj debljini, što u kratkom tekstu obično ionako izgleda dobro. Najbolje se s našom abecedom snalaze bold, kurziv i monospace.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Je li generator podebljanih slova besplatan?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Da, potpuno besplatan i bez registracije. Upisuj, kopiraj i lijepi koliko god puta želiš — nema ograničenja ni skrivenih troškova.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Zašto se neki znakovi prikazuju kao prazni kvadratići?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Prazni kvadratić (▯) znači da uređaj nema odgovarajući glif za taj podebljani znak. To se obično odnosi na starije sustave. Odaberi jednostavniji podebljani stil ili ažuriraj uređaj — više u članku o tome, <a href="/guide/why-fonts-show-as-boxes/">zašto se fontovi prikazuju kao kvadratići</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Utječe li podebljani Unicode tekst na čitljivost i doseg?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Podebljani Unicode znakovi privlače pogled u feedu i sjajno rade kao hook, naslov i CTA na društvenim mrežama. Koristi ih namjerno — kratki podebljani naglasci, ostalo običnim tekstom. Za sadržaj na web-stranici bolje je koristiti CSS podebljanje da tražilice čitaju tekst kao obične riječi. Za tekstualna polja na društvenim mrežama Unicode podebljanje je idealno rješenje. Vodi računa o <a href="/guide/fancy-fonts-accessibility-guide/">pristupačnosti</a> kad oblikuješ dulje dijelove.
+  </div>
+</div>
+
+</div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Odabir jezika">
+      <a class="lang-option" href="/category/bold-fonts/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/hr/podebljana-slova/" hreflang="hr">HR</a>
+    </div>
+
+    </div>
+  </footer>
+
+  <div class="copy-toast" id="copyToast">Kopirano!</div>
+
+  <script>
+    window.UTG_FAMILY = "bold";
+    window.UTG_DEMO_TEXT = "podebljana slova\npodebljani tekst";
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/script.js" defer></script>
+  <script src="/footer.js" defer></script>
+</body></html>

--- a/i18n.js
+++ b/i18n.js
@@ -104,7 +104,7 @@
   }
 
   function detectLang() {
-    var supported = ["en", "es", "fr", "pt", "de", "id", "it", "nl", "tr", "pl", "vi", "tl", "sv", "no", "ja", "th", "ru", "ar"];
+    var supported = ["en", "es", "fr", "pt", "de", "id", "it", "nl", "tr", "pl", "vi", "tl", "sv", "no", "ja", "th", "ru", "ar", "cs", "sk", "hr", "bs", "sr", "ro"];
 
     // 1. Detect from URL path prefix (e.g. /fr/, /de/)
     var pathMatch = window.location.pathname.match(/^\/([a-z]{2})\//);

--- a/locales/bs.json
+++ b/locales/bs.json
@@ -1,0 +1,202 @@
+{
+  "meta": {
+    "title": "Lijepi Fontovi i Stilizirana Slova za Kopiranje — Slova za Instagram, TikTok i Nadimke",
+    "description": "Generator lijepih fontova, estetskih slova i stiliziranog teksta za kopiranje. Podebljano, kurziv, gotica, balončasta, Zalgo i simboli — zalijepi u instagram bio, u opis na TikToku, u nadimak u igri ili na Discord. Besplatno, bez računa."
+  },
+  "hero": {
+    "title": "Lijepi Fontovi i Stilizirana Slova za Kopiranje",
+    "subtitle": "Upiši tekst, odaberi stil — podebljano, kurziv, gotica, balončasta ili s ukrasima. Ubaci u instagram bio, u nadimak u igri, u WhatsApp status ili u opis pod TikTokom. Bez aplikacije, bez prijave."
+  },
+  "decorations": {
+    "label": "Dodaj ukrase tekstu",
+    "tabs": {
+      "symbols": "Simboli",
+      "frames": "Okviri",
+      "dividers": "Razdjelnici",
+      "arrows": "Strelice",
+      "minimal": "Minimalni",
+      "emojis": "Emoji",
+      "flags": "Zastave"
+    }
+  },
+  "ui": {
+    "placeholder": "Upiši tekst...",
+    "advertisement": "Oglas"
+  },
+  "useCases": {
+    "title": "Za što ljudi ovo najčešće koriste",
+    "viewAll": "Pogledaj više primjena →",
+    "items": [
+      {
+        "title": "Naslov na LinkedInu",
+        "description": "Istakni se u pretrazi na LinkedInu — podebljan ili blago ukrašen naslov odradi svoje prije nego što netko stigne skrolati dalje."
+      },
+      {
+        "title": "Komentari ispod objava",
+        "description": "Stilizirani komentari na Instagramu, YouTubeu i TikToku — lakše ih je uočiti nego stotine običnih ispod popularne objave."
+      },
+      {
+        "title": "Tekst ispisan u emojijima",
+        "description": "Pretvori natpis u niz slova od emojija — kreativan bio, story, grupni chat ili čisto za zezanje s prijateljima."
+      }
+    ]
+  },
+  "guides": {
+    "title": "Svrati na vodiče",
+    "viewAll": "Svi vodiči →",
+    "items": [
+      {
+        "title": "Retorika fontova",
+        "description": "Zašto jedan font budi povjerenje, a drugi izgleda kao spam — odnosno kako tipografija utječe na ono što osjećamo dok čitamo."
+      },
+      {
+        "title": "Osobni brend kroz tipografiju",
+        "description": "Kako odabrati slova koja odgovaraju tvom vibeu i ostaju u pamćenju — bilo da je riječ o LinkedInu, Instagramu ili Discordu."
+      },
+      {
+        "title": "Zaustavi skrolanje igrom fontova",
+        "description": "Zašto se ljudi zaustavljaju kod objava s drukčijim stilom teksta i kako to iskoristiti da podigneš doseg."
+      }
+    ]
+  },
+  "faq": {
+    "categories": [
+      {
+        "title": "Prva pitanja",
+        "items": [
+          {
+            "question": "Što je UltraTextGen i što se tu zapravo događa?",
+            "answer": "To je besplatan generator slova — upišeš običan tekst, a mi ga pretvaramo u stilizirane Unicode znakove koji izgledaju kao lijep font.\n    <br><br>\n    Najvažnije: to su <strong>pravi znakovi</strong>, a ne podebljanje iz Worda ni markdown s Discorda. Zato rade svugdje gdje se može upisati običan tekst — u instagram bio, u nadimak, u komentar, u mail, u WhatsApp status.\n    <br><br>\n    <strong>Primjer</strong><br>\n    Upišeš „bok\" → dobiješ 𝗯𝗼𝗸 (podebljano), 𝘣𝘰𝘬 (kurziv), 𝒷ℴ𝓀 (kaligrafija) ili ⓑⓞⓚ (balončasta). Sve jednim klikom."
+          },
+          {
+            "question": "Kako kopirati lijepa slova u 5 sekundi?",
+            "answer": "1. Upišeš ili zalijepiš tekst u polje na vrhu.<br>\n    2. Stilovi se pojave odmah ispod — bold, kurziv, gotica, balončasta i još desetak drugih.<br>\n    3. Ako želiš, dodaj ukrase — okvire, zvjezdice, strelice.<br>\n    4. Klikneš „Kopiraj\" kod onog koji ti odgovara i zalijepiš gdje god želiš.\n    <br><br>\n    To je to. Bez registracije, bez instaliranja aplikacije. Radi jednako na računaru i na mobitelu."
+          },
+          {
+            "question": "Besplatno? Bez ograničenja, bez računa?",
+            "answer": "Da, sve je <strong>100% besplatno</strong>. Bez računa, bez dnevnog ograničenja, bez vodenih žigova, bez kvake. Možeš kroz to propustiti cijelu knjigu i ništa se neće dogoditi."
+          }
+        ]
+      },
+      {
+        "title": "Instagram, TikTok, Discord — gdje to zalijepiti",
+        "items": [
+          {
+            "question": "Kako ubaciti stilizirani tekst u bio na Instagramu?",
+            "answer": "Instagram nema nikakvu alatnu traku za oblikovanje, ali prihvaća Unicode — dakle sve što ovdje generiraš uredno uleti u bio.\n    <br><br>\n    <strong>Kako to napraviti</strong><br>\n    1. Upiši ono što želiš u biju (npr. ime, hashtag, kratak opis).<br>\n    2. Odaberi stil — podebljano i kurziv rade najbolje na većini uređaja.<br>\n    3. Kopiraj rezultat i zalijepi u „Uredi profil → Bio\" u aplikaciji.\n    <br><br>\n    Savjet: ako želiš ukrasiti, dodaj okvir tipa ⋆｡˚ ili zvjezdicu ✦ sa strane — izgleda dobro, a ne krade pažnju ostatku bija."
+          },
+          {
+            "question": "Rade li slova u opisima na TikToku?",
+            "answer": "Da — TikTok prikazuje Unicode u opisima, opisima profila i komentarima. Najbolje se pokažu <strong>podebljano</strong>, <strong>kurziv</strong>, <strong>balončasta</strong> i <strong>kapitalke</strong>. Stilovi s puno ukrasa znaju se odrezati kod dugih opisa, pa za svaki slučaj provjeri objavu u pregledu prije objavljivanja."
+          },
+          {
+            "question": "Može li se napraviti nadimak za igru ili za Discord?",
+            "answer": "Naravno — to je vjerovatno najčešći razlog zbog kojeg ljudi dolaze na ovakve generatore. Discord, Roblox, Steam, Minecraft, većina igara prihvaća Unicode u nadimcima.\n    <br><br>\n    <strong>Primjer</strong><br>\n    Obični nadimak: „DarkWolf\"<br>\n    Nakon stiliziranja: „𝔇𝔞𝔯𝔨𝔚𝔬𝔩𝔣\" (gotica), „ⒹⓐⓡⓚⓌⓞⓛⓕ\" (balončasta) ili „๖ۣۜDarkWolf\" (s ukrasom sa strane).\n    <br><br>\n    <strong>Napomena:</strong> neke igre imaju filtre i neće primiti egzotične znakove. Ako jedan stil ne prolazi, uzmi drugi — bold i kurziv obično prolaze svugdje."
+          },
+          {
+            "question": "Radi li u WhatsApp statusu, na Telegramu i u Messengeru?",
+            "answer": "Da — WhatsApp, Telegram, Messenger, Signal, iMessage. Sve što prima običan tekst prima i Unicode slova. Zalijepiš u status ili u poruku i izgleda kao ukrasan font.\n    <br><br>\n    Za WhatsApp dodajem: ako ti treba samo podebljanje, možeš koristiti njihovu vlastitu sintaksu (`*tekst*` daje bold). Ali Unicode radi svugdje — i ondje gdje ga WhatsApp ne podržava, npr. u imenu kontakta."
+          },
+          {
+            "question": "A u naslovu maila ili u CV-u?",
+            "answer": "Tu Unicode odradi najviše. Naslov maila je običan tekst, pa podebljanje iz Outlooka otpada. Ali „𝗥𝗮č𝘂𝗻 — 𝗵𝗶𝘁𝗻𝗼\" već izgleda snažnije u sandučiću primaoca.\n    <br><br>\n    U CV-u blago podebljano ime u zaglavlju zna privući pogled poslodavca. Samo nemoj pretjerati — cijeli CV u gotici ne izgleda profesionalno."
+          }
+        ]
+      },
+      {
+        "title": "Stilovi, slova i ukrasi",
+        "items": [
+          {
+            "question": "Koje stilove slova imam na izbor?",
+            "answer": "Puno. Zaista puno. Ukratko:\n    <br><br>\n    <strong>Osnovni</strong><br>\n    Podebljano (bold), kurziv, kaligrafija (script), gotica, balončasta (u kružićima), kapitalke, precrtano, podcrtano, double struck.\n    <br><br>\n    <strong>Zabavni</strong><br>\n    Tekst naopako, ogledalno, Zalgo (glitch s crticama nad slovima), tekst u kvadratićima, u zagradama, fullwidth (razmaknuti).\n    <br><br>\n    <strong>Dodaci</strong><br>\n    Okviri oko teksta, zvjezdice, srca, strelice, razdjelnici, zastave, emoji — sve to možeš nasloniti na stil slova.\n    <br><br>\n    S vremena na vrijeme dolaze novi — vrijedi dodati stranicu u knjižne oznake."
+          },
+          {
+            "question": "Mogu li spojiti više stilova odjednom?",
+            "answer": "Da — i to je najveća prednost UltraTextGena. Možeš nasloniti npr. <strong>balončasta + Zalgo</strong>, <strong>gotica + naopako</strong> ili <strong>kapitalke + podcrtano</strong>, a onda cijelo to zatvoriti u okvir ili zvjezdicu.\n    <br><br>\n    <strong>Primjer</strong><br>\n    „bok\" → odabereš goticu → dodaš okvir sa zvjezdicama → izađe: ★彡[ 𝔟𝔬𝔨 ]彡★\n    <br><br>\n    Što više eksperimentiraš, to zanimljivije stvari izlaze. Preporučujem da kreneš s jednim stilom i dodaš jedan ukras — ne sve odjednom."
+          },
+          {
+            "question": "Što je Zalgo i te čudne crtice nad slovima?",
+            "answer": "Zalgo je onakav „ukleti\", glitchani stil — nad i pod svakim slovom naleti hrpa dijakritičkih znakova. Izgleda kao da se tekst raspada ili kao da je iz horora.\n    <br><br>\n    <strong>Primjer</strong><br>\n    „bok\" → b̷̢o̴̢k̷̛\n    <br><br>\n    Najčešće to viđaš u mračnim biojevima na Instagramu, u halloweenskim memeovima, u gaming klanovima koji žele izgledati opasno ili kad netko od toga radi foru."
+          },
+          {
+            "question": "Odakle uzeti lijepe simbole, zvjezdice i srca?",
+            "answer": "Sve što imaš u odjeljku „Ukrasi\" ispod tekstualnog polja možeš kopirati zasebno — čak i bez upisivanja teksta. Naprosto kao zasebne znakove za bio, nadimak ili objavu.\n    <br><br>\n    — <strong>Estetski simboli</strong>: ✦ ✧ ⋆ ｡ ☆ ♡ ❀ ✿<br>\n    — <strong>Okviri i obrubi</strong>: ╭─▸ │ ╰─▸ ili ★彡[ ]彡★<br>\n    — <strong>Strelice</strong>: → ⇨ ➤ ⟶<br>\n    — <strong>Minimalni razdjelnici</strong>: ·  ⋅  ─  •<br>\n    — <strong>Zastave i emoji</strong>.\n    <br><br>\n    Najčešće se koriste u estetskim biojevima na Instagramu i Pinterestu — pašu uz sve, od citata do popisa interesa."
+          }
+        ]
+      },
+      {
+        "title": "Bosanski znakovi, kompatibilnost, problemi",
+        "items": [
+          {
+            "question": "A bosanski znakovi? Radi li s č, ć, đ, š, ž?",
+            "answer": "<strong>Ukratko:</strong> ovisi o stilu.\n    <br><br>\n    Unicode ima stilizirane verzije za osnovnu abecedu A–Z, pa se <em>c</em>, <em>s</em>, <em>z</em> bez problema pretvore npr. u podebljano. Ali za <em>č</em>, <em>ć</em>, <em>đ</em>, <em>š</em>, <em>ž</em> stilizirane verzije postoje samo u dijelu stilova (uglavnom bold, kurziv, kapitalke).\n    <br><br>\n    Ako stil nema verziju za bosanski znak, on ostaje u izvornom obliku — tekst je i dalje čitljiv, bosansko slovo naprosto izgleda „običnije\" od ostatka. Za nadimke bez kvačica to nije nikakav problem. Za cijele rečenice na bosanskom preporučujem <strong>bold</strong>, <strong>kurziv</strong> ili <strong>monospace</strong> — oni se najbolje snalaze s našom abecedom. Napomena i za digrafe: dž, lj i nj su samo dva obična slova jedno do drugoga, pa se svako stilizira zasebno."
+          },
+          {
+            "question": "Zašto se nekome prikazuju kvadratići umjesto slova?",
+            "answer": "Zato što sistemski font na strani primaoca ne sadrži određeni Unicode znak. To nije problem s tvojim tekstom — naprosto njegov mobitel ili aplikacija nema taj konkretni znak u kompletu.\n    <br><br>\n    Drži se <strong>bolda</strong>, <strong>kurziva</strong> i <strong>balončaste</strong> — imaju najširu podršku. Vrlo egzotični stilovi (fullwidth, kvadratići) mogu se prikazati kao □ na starijim Androidima ili u nekim mail klijentima."
+          },
+          {
+            "question": "Instagram mi je izrezao dio znakova u nadimku — što sad?",
+            "answer": "Instagram ima filtar na polju <strong>korisničko ime</strong> (dakle @login) — prima samo slova, brojke, tačke i podvlake. Tu stilizirana slova ne možeš zalijepiti.\n    <br><br>\n    Ali u polju <strong>„Ime\"</strong> (prikazano ime) i u <strong>biju</strong> može — i tu prolazi većina stilova. Ako se jedan ne sprema, uzmi drugi. Bold obično prolazi bez problema."
+          },
+          {
+            "question": "Postoje li znakovi koji se uopće ne mogu pretvoriti?",
+            "answer": "Standardna slova (A–Z, a–z), brojke i osnovni interpunkcijski znakovi pretvaraju se bez problema. Neki rijetki simboli ili posebni znakovi nemaju stilizirane parnjake u Unicodeu — tada ostaju u izvorniku. Ništa se ne kvari, tekst je i dalje za kopiranje."
+          }
+        ]
+      },
+      {
+        "title": "Sigurnost, privatnost, mobitel",
+        "items": [
+          {
+            "question": "Sprema li se moj tekst negdje?",
+            "answer": "Ne. Cijela pretvorba slova događa se <strong>u tvom browseru</strong> — ništa ne ide na naše servere, ništa se ne sprema, ništa se ne prati. Kopirani tekst je čisti Unicode, bez skrivenih znakova, bez ikakvih identifikatora."
+          },
+          {
+            "question": "Je li sigurno lijepiti ova slova bilo gdje?",
+            "answer": "Da — to su standardni Unicode znakovi, isti kakve koristi cijeli internet. Ništa unutra, bez skripti, bez skrivenog oblikovanja, bez kodova. Slobodno lijepi u CV, u poslovni mail, u bio na LinkedInu — gdje god želiš."
+          },
+          {
+            "question": "Radi li na mobitelu?",
+            "answer": "Da — stranica se u potpunosti prilagođava mobitelu. iPhone, Android, tablet — sve štima. Upišeš tekst, klikneš, kopira se u clipboard, zalijepiš u aplikaciji. Bez instaliranja ičega iz trgovine."
+          }
+        ]
+      },
+      {
+        "title": "Po čemu se razlikujemo",
+        "items": [
+          {
+            "question": "Po čemu se razlikujete od drugih generatora slova?",
+            "answer": "Konkretno:\n    <br><br>\n    — <strong>Jedna od većih kolekcija</strong> Ultra stilova — bold, kurziv, gotica, balončasta i još desetak drugih.<br>\n    — <strong>Spajanje stilova</strong> — većina generatora daje ti jedan stil odjednom, mi dopuštamo naslanjanje.<br>\n    — <strong>Ukrasi jednim klikom</strong> — okviri, zvjezdice, razdjelnici bez lijepljenja znak po znak.<br>\n    — <strong>Stranice za konkretne platforme</strong> — Instagram, TikTok, Discord. Ondje prikazujemo samo stilove koji na toj aplikaciji rade.<br>\n    — <strong>Brzo i bez skočnih prozora</strong> — bez captcha, bez „prihvati sve\" prije svakog klika."
+          },
+          {
+            "question": "Dolaze li novi stilovi?",
+            "answer": "Da, redovito. S vremena na vrijeme upadnu nove verzije, ukrasi i okviri. Najlakše je zapamtiti stranicu ili svratiti povremeno."
+          },
+          {
+            "question": "Kako pronaći točno onaj stil koji tražim?",
+            "answer": "Tri puta:\n    <br><br>\n    <strong>Po stilu</strong> — kategorije na vrhu: bold, kurziv, gotica, balončasta, precrtano, naopako i još.<br>\n    <strong>Po platformi</strong> — svrati na podstranicu za Instagram, TikTok, Discord — ondje su samo stilovi koji se na toj platformi pokažu.<br>\n    <strong>Po cilju</strong> — odjeljak s primjenama ima alate prilagođene konkretnoj potrebi: naslov na LinkedInu, komentari, tekst s emojijima."
+          }
+        ]
+      }
+    ]
+  },
+  "footer": {
+    "copyright": "© 2026 UltraTextGen. Lijepa slova koja rade svugdje."
+  },
+  "notFound": {
+    "eyebrow": "GREŠKA · 404 · NEDOSTAJE PRIMJERAK",
+    "title": "Ova je stranica ispala iz kolekcije stilova.",
+    "subtitle": "Adresa koju si otvorio ne odgovara ničemu u našoj kolekciji. Ali greška i dalje radi kao tekst — pogledaj „404\" u Ultra Boldu, Balončastoj, Gotici, Zalgu i još.",
+    "backCta": "← Natrag na generator",
+    "browseCta": "Pregledaj stilove",
+    "wallTitle": "404, prerađen na svaki način koji poznajemo.",
+    "wallSubtitle": "Svaki stil ispod prolazi kroz isti pogon kao i ostatak UltraTextGena.",
+    "playgroundTitle": "Isprobaj svoj tekst koji nedostaje.",
+    "playgroundSubtitle": "Upiši bilo što i vidi u nekoliko Ultra stilova prije nego što se vratiš na potpuni generator.",
+    "playgroundPlaceholder": "Upiši tekst...",
+    "fullGeneratorCta": "Otvori potpuni generator",
+    "copy": "Kopiraj",
+    "copied": "Kopirano"
+  }
+}

--- a/locales/cs.json
+++ b/locales/cs.json
@@ -1,0 +1,202 @@
+{
+  "meta": {
+    "title": "Ozdobné písmo a stylový text ke zkopírování — písmenka na Instagram, TikTok a nicky",
+    "description": "Generátor ozdobného písma, estetických písmenek a stylového textu ke zkopírování. Tučné, kurzíva, gotika, bublinkové, Zalgo a symboly — vlož do bia na Instagramu, do popisku na TikToku, do herního nicku nebo na Discord. Zdarma, bez účtu."
+  },
+  "hero": {
+    "title": "Ozdobné písmo a stylová písmenka ke zkopírování",
+    "subtitle": "Napiš text, vyber styl — tučné, kurzíva, gotika, bublinkové nebo s ozdobami. Vlož do bia na Instagramu, do herního nicku, do statusu na WhatsAppu nebo do popisku na TikToku. Bez aplikace, bez přihlašování."
+  },
+  "decorations": {
+    "label": "Přidej ozdoby k textu",
+    "tabs": {
+      "symbols": "Symboly",
+      "frames": "Rámečky",
+      "dividers": "Oddělovače",
+      "arrows": "Šipky",
+      "minimal": "Minimalistické",
+      "emojis": "Emoji",
+      "flags": "Vlajky"
+    }
+  },
+  "ui": {
+    "placeholder": "Napiš text...",
+    "advertisement": "Reklama"
+  },
+  "useCases": {
+    "title": "Na co to lidé nejčastěji používají",
+    "viewAll": "Zobrazit další využití →",
+    "items": [
+      {
+        "title": "Titulek na LinkedInu",
+        "description": "Vyčnívej ve vyhledávání na LinkedInu — tučný nebo lehce ozdobený titulek zabere dřív, než někdo stihne odscrollovat dál."
+      },
+      {
+        "title": "Komentáře pod příspěvky",
+        "description": "Stylové komentáře na Instagramu, YouTube i TikToku — okem je zachytíš snáz než stovky obyčejných pod populárním příspěvkem."
+      },
+      {
+        "title": "Text zapsaný v emoji",
+        "description": "Proměň nápis v sekvenci písmenek-emoji — kreativní bio, story, skupinové chaty nebo čistě pro srandu s kamarády."
+      }
+    ]
+  },
+  "guides": {
+    "title": "Mrkni na návody",
+    "viewAll": "Všechny návody →",
+    "items": [
+      {
+        "title": "Rétorika písma",
+        "description": "Proč jedno písmo budí důvěru a druhé vypadá jako spam — čili jak typografie ovlivňuje to, co při čtení cítíme."
+      },
+      {
+        "title": "Osobní značka skrze typografii",
+        "description": "Jak vybrat písmenka, která ladí s tvým vibem a zůstanou divákovi v hlavě — ať jde o LinkedIn, Instagram nebo Discord."
+      },
+      {
+        "title": "Zastav scrollování — hraj si s písmem",
+        "description": "Proč se lidé zastaví u příspěvků s jiným stylem textu a jak toho využít ke zvýšení dosahů."
+      }
+    ]
+  },
+  "faq": {
+    "categories": [
+      {
+        "title": "První otázky",
+        "items": [
+          {
+            "question": "Co je UltraTextGen a co se tu vlastně děje?",
+            "answer": "Je to bezplatný generátor písmenek — napíšeš obyčejný text a my ho převedeme na stylizované znaky Unicode, které vypadají jako ozdobné písmo.\n    <br><br>\n    Hlavní věc: jsou to <strong>opravdové znaky</strong>, ne ztučnění z Wordu nebo markdown z Discordu. Proto fungují všude, kam se dá napsat obyčejný text — v biu na Instagramu, v nicku, v komentáři, v e-mailu, ve statusu na WhatsAppu.\n    <br><br>\n    <strong>Příklad</strong><br>\n    Napíšeš „ahoj\" → dostaneš 𝗮𝗵𝗼𝗷 (tučné), 𝘢𝘩𝘰𝘫 (kurzíva), 𝒶𝒽ℴ𝒿 (kaligrafie) nebo ⓐⓗⓞⓙ (bublinkové). Všechno jedním kliknutím."
+          },
+          {
+            "question": "Jak zkopírovat ozdobná písmenka za 5 vteřin?",
+            "answer": "1. Napíšeš nebo vložíš text do pole nahoře.<br>\n    2. Styly se hned objeví pod ním — tučné, kurzíva, gotika, bublinkové a ještě pár desítek dalších.<br>\n    3. Když chceš, přidej ozdoby — rámečky, hvězdičky, šipky.<br>\n    4. Klikneš na „Kopírovat\" u toho, který ti sedí, a vložíš, kam jen chceš.\n    <br><br>\n    A je to. Bez registrace, bez instalace apky. Funguje stejně na počítači i na telefonu."
+          },
+          {
+            "question": "Zdarma? Bez limitů, bez účtu?",
+            "answer": "Ano, celé je to <strong>100% zdarma</strong>. Žádný účet, žádný denní limit, žádné vodoznaky, žádný háček. Můžeš tím prohnat celou knížku a nic se nestane."
+          }
+        ]
+      },
+      {
+        "title": "Instagram, TikTok, Discord — kam to vložit",
+        "items": [
+          {
+            "question": "Jak dostat stylový text do bia na Instagramu?",
+            "answer": "Instagram nemá žádnou lištu pro formátování, ale přijímá Unicode — takže všechno, co u nás vygeneruješ, ti v biu naskočí bez problémů.\n    <br><br>\n    <strong>Jak na to</strong><br>\n    1. Napiš, co chceš mít v biu (třeba jméno, hashtag, krátký popis).<br>\n    2. Vyber styl — tučné a kurzíva fungují na většině zařízení nejlíp.<br>\n    3. Zkopíruj výsledek a vlož ho v „Upravit profil → Bio\" v aplikaci.\n    <br><br>\n    Tip: když chceš ozdobit, přidej rámeček typu ⋆｡˚ nebo hvězdičku ✦ po straně — vypadá to dobře a nekrade to pozornost zbytku bia."
+          },
+          {
+            "question": "Fungují písmenka v popiscích na TikToku?",
+            "answer": "Ano — TikTok vykresluje Unicode v popiscích, popisech profilu i komentářích. Nejlíp se osvědčí <strong>tučné</strong>, <strong>kurzíva</strong>, <strong>bublinkové</strong> a <strong>kapitálky</strong>. Styly s hromadou ozdob se u dlouhých popisků občas ořežou, tak si pro jistotu příspěvek zkontroluj v náhledu před zveřejněním."
+          },
+          {
+            "question": "Dá se udělat nick do hry nebo na Discord?",
+            "answer": "Jasně — to je asi nejčastější důvod, proč lidé na takové generátory chodí. Discord, Roblox, Steam, Minecraft, většina her přijímá Unicode v nicku.\n    <br><br>\n    <strong>Příklad</strong><br>\n    Obyčejný nick: „DarkWolf\"<br>\n    Po stylizaci: „𝔇𝔞𝔯𝔨𝔚𝔬𝔩𝔣\" (gotika), „ⒹⓐⓡⓚⓌⓞⓛⓕ\" (bublinkové) nebo „๖ۣۜDarkWolf\" (s ozdobou po straně).\n    <br><br>\n    <strong>Pozor:</strong> některé hry mají filtry a exotické znaky nepřijmou. Když jeden styl neprojde, dej jiný — tučné a kurzíva projdou skoro všude."
+          },
+          {
+            "question": "Funguje to ve statusu na WhatsAppu, na Telegramu a v Messengeru?",
+            "answer": "Ano — WhatsApp, Telegram, Messenger, Signal, iMessage. Cokoli přijímá obyčejný text, přijme i písmenka Unicode. Vložíš je do statusu nebo do zprávy a vypadají jako ozdobné písmo.\n    <br><br>\n    K WhatsAppu ještě dodám: pokud ti jde jen o ztučnění, můžeš použít jejich vlastní syntax (<code>*text*</code> udělá tučné). Ale Unicode funguje všude — i tam, kde to WhatsApp nepodporuje, třeba v názvu kontaktu."
+          },
+          {
+            "question": "A v předmětu e-mailu nebo v životopise?",
+            "answer": "Tady Unicode odvede největší práci. Předmět e-mailu je obyčejný text, takže ztučnění z Outlooku odpadá. Ale „𝗙𝗮𝗸𝘁𝘂𝗿𝗮 — 𝗣𝗢𝗭𝗢𝗥\" už v příjemcově schránce působí silněji.\n    <br><br>\n    V životopise dokáže lehce ztučněné jméno v záhlaví přitáhnout pohled personalisty. Jen to nepřeháněj — celý životopis v gotice nepůsobí profesionálně."
+          }
+        ]
+      },
+      {
+        "title": "Styly, písmenka a ozdoby",
+        "items": [
+          {
+            "question": "Jaké styly písmenek mám na výběr?",
+            "answer": "Hodně. Vážně hodně. Ve zkratce:\n    <br><br>\n    <strong>Základní</strong><br>\n    Tučné (bold), kurzíva, kaligrafie (script), gotika, bublinkové (v kolečkách), kapitálky, přeškrtnuté, podtržené, dvojitě tažené (double struck).\n    <br><br>\n    <strong>Zábavné</strong><br>\n    Text vzhůru nohama, zrcadlově obrácený, Zalgo (glitch s čárkami nad písmeny), text ve čtverečcích, v závorkách, fullwidth (rozházený).\n    <br><br>\n    <strong>Doplňky</strong><br>\n    Rámečky kolem textu, hvězdičky, srdíčka, šipky, oddělovače, vlajky, emoji — dají se na styl písmenek navrstvit.\n    <br><br>\n    Čas od času přibývají nové — vyplatí se přidat si stránku do záložek."
+          },
+          {
+            "question": "Můžu spojit několik stylů najednou?",
+            "answer": "Ano — a to je největší přednost UltraTextGenu. Můžeš navrstvit třeba <strong>bublinkové + Zalgo</strong>, <strong>gotiku + vzhůru nohama</strong> nebo <strong>kapitálky + podtržení</strong> a pak to celé uzavřít do rámečku nebo hvězdičky.\n    <br><br>\n    <strong>Příklad</strong><br>\n    „ahoj\" → vybereš gotiku → přidáš rámeček s hvězdičkami → vyjde: ★彡[ 𝔞𝔥𝔬𝔧 ]彡★\n    <br><br>\n    Čím víc experimentuješ, tím zajímavější věci vzniknou. Doporučuju začít jedním stylem a přidat jednu ozdobu — ne všechno naráz."
+          },
+          {
+            "question": "Co je Zalgo a ty divné čárky nad písmeny?",
+            "answer": "Zalgo je takový „prokletý\", glitchový styl — nad a pod každé písmeno naletí spousta diakritických znamének. Vypadá to, jako by se text rozpadal nebo byl z hororu.\n    <br><br>\n    <strong>Příklad</strong><br>\n    „ahoj\" → a̷̢h̴̢ơ̷j̴̜\n    <br><br>\n    Nejčastěji to vídáš v temných biích na Instagramu, v halloweenských memech, v herních klanech, které chtějí vypadat hrozivě, nebo když si z toho někdo dělá srandu."
+          },
+          {
+            "question": "Kde brát hezké symboly, hvězdičky a srdíčka?",
+            "answer": "Všechno, co máš v sekci „Ozdoby\" pod textovým polem, můžeš kopírovat zvlášť — i bez psaní textu. Prostě jako samostatné znaky do bia, nicku nebo příspěvku.\n    <br><br>\n    — <strong>Estetické symboly</strong>: ✦ ✧ ⋆ ｡ ☆ ♡ ❀ ✿<br>\n    — <strong>Rámečky a obruby</strong>: ╭─▸ │ ╰─▸ nebo ★彡[ ]彡★<br>\n    — <strong>Šipky</strong>: → ⇨ ➤ ⟶<br>\n    — <strong>Minimalistické oddělovače</strong>: ·  ⋅  ─  •<br>\n    — <strong>Vlajky a emoji</strong>.\n    <br><br>\n    Nejčastěji se používají v estetických biích na Instagramu a Pinterestu — hodí se úplně ke všemu, od citátů po seznamy zájmů."
+          }
+        ]
+      },
+      {
+        "title": "České znaky, kompatibilita, problémy",
+        "items": [
+          {
+            "question": "A české znaky? Funguje to s á, č, ď, é, ě, í, ň, ó, ř, š, ť, ú, ů, ý, ž?",
+            "answer": "<strong>Krátce:</strong> záleží na stylu.\n    <br><br>\n    Unicode má stylizované varianty pro základní abecedu A–Z, takže <em>a</em>, <em>c</em>, <em>e</em>, <em>s</em>, <em>z</em> se v pohodě promění třeba na tučné. Ale pro <em>á</em>, <em>č</em>, <em>ě</em>, <em>ř</em>, <em>š</em>, <em>ž</em> stylizované verze existují jen v části stylů (hlavně tučné, kurzíva, kapitálky).\n    <br><br>\n    Když styl nemá verzi pro český znak s diakritikou, zůstane v původní podobě — text je pořád čitelný, česká písmenka s háčky a čárkami prostě vypadají „obyčejněji\" než zbytek. Pro nicky bez diakritiky to není žádný problém. Pro celé věty v češtině doporučuju <strong>tučné</strong>, <strong>kurzívu</strong> nebo <strong>monospace</strong> — ty si s naší abecedou poradí nejlíp."
+          },
+          {
+            "question": "Proč se někomu zobrazují čtverečky místo písmenek?",
+            "answer": "Protože systémové písmo na straně příjemce daný znak Unicode neobsahuje. Není to problém s tvým textem — jeho telefon nebo aplikace prostě ten konkrétní znak v sadě nemá.\n    <br><br>\n    Drž se <strong>tučných</strong>, <strong>kurzívy</strong> a <strong>bublinkových</strong> — ty mají nejširší podporu. Hodně exotické styly (fullwidth, čtverečky) se na starších Androidech nebo v některých e-mailových klientech můžou zobrazit jako □."
+          },
+          {
+            "question": "Instagram mi v nicku ořízl část znaků — co teď?",
+            "answer": "Instagram má filtr na pole <strong>uživatelské jméno</strong> (čili @login) — bere jen písmena, číslice, tečky a podtržítka. Sem stylizovaná písmenka nevložíš.\n    <br><br>\n    Ale do pole <strong>„Jméno\"</strong> (zobrazované jméno) a do <strong>bia</strong> ano — a tam projde většina stylů. Když se jeden neuloží, dej jiný. Tučné obvykle projde bez problémů."
+          },
+          {
+            "question": "Jsou nějaké znaky, které vůbec nejdou převést?",
+            "answer": "Standardní písmena (A–Z, a–z), číslice a základní interpunkce se převedou bez problémů. Některé vzácné symboly nebo speciální znaky nemají v Unicode stylizované protějšky — pak zůstanou v původní podobě. Nic se nerozbije, text je pořád ke zkopírování."
+          }
+        ]
+      },
+      {
+        "title": "Bezpečnost, soukromí, telefon",
+        "items": [
+          {
+            "question": "Ukládá se můj text někam?",
+            "answer": "Ne. Celý převod písmenek probíhá <strong>ve tvém prohlížeči</strong> — nic neputuje na naše servery, nic se neukládá, nic se nesleduje. Zkopírovaný text je čistý Unicode, bez skrytých znaků, bez jakýchkoli identifikátorů."
+          },
+          {
+            "question": "Je bezpečné vkládat tato písmenka kamkoli?",
+            "answer": "Ano — jsou to standardní znaky Unicode, stejné jako ty, které používá celý internet. Nic uvnitř, žádné skripty, žádné skryté formátování, žádné kódy. V klidu je vlož do životopisu, do pracovního e-mailu, do bia na LinkedInu — kam chceš."
+          },
+          {
+            "question": "Funguje to na telefonu?",
+            "answer": "Ano — stránka se plně přizpůsobí mobilu. iPhone, Android, tablet — všechno klape. Napíšeš text, klikneš, zkopíruje se do schránky, vložíš v aplikaci. Bez instalace čehokoli z obchodu."
+          }
+        ]
+      },
+      {
+        "title": "Čím se lišíme",
+        "items": [
+          {
+            "question": "Čím se lišíte od jiných generátorů písmenek?",
+            "answer": "Konkrétně:\n    <br><br>\n    — <strong>Jedna z největších sbírek</strong> stylů Ultra — tučné, kurzíva, gotika, bublinkové a ještě pár desítek dalších.<br>\n    — <strong>Kombinování stylů</strong> — většina generátorů ti dá jeden styl naráz, my dovolíme vrstvit.<br>\n    — <strong>Ozdoby jedním kliknutím</strong> — rámečky, hvězdičky, oddělovače bez lepení znak po znaku.<br>\n    — <strong>Stránky pro konkrétní platformy</strong> — Instagram, TikTok, Discord. Ukazujeme tam jen styly, které v dané apce fungují.<br>\n    — <strong>Rychle a bez vyskakovacích oken</strong> — žádné captchy, žádné „přijmout vše\" před každým kliknutím."
+          },
+          {
+            "question": "Přibývají nové styly?",
+            "answer": "Ano, pravidelně. Čas od času naskočí nové varianty, ozdoby a rámečky. Nejjednodušší je uložit si stránku do záložek nebo se sem jednou za čas vrátit."
+          },
+          {
+            "question": "Jak najít přesně ten styl, který hledám?",
+            "answer": "Tři cesty:\n    <br><br>\n    <strong>Podle stylu</strong> — kategorie nahoře: tučné, kurzíva, gotika, bublinkové, přeškrtnuté, vzhůru nohama a další.<br>\n    <strong>Podle platformy</strong> — mrkni na podstránku pro Instagram, TikTok, Discord — tam jsou jen styly, které na dané platformě fungují.<br>\n    <strong>Podle cíle</strong> — sekce využití má nástroje ušité na konkrétní potřebu: titulek na LinkedIn, komentáře, text s emoji."
+          }
+        ]
+      }
+    ]
+  },
+  "footer": {
+    "copyright": "© 2026 UltraTextGen. Ozdobná písmenka, která fungují všude."
+  },
+  "notFound": {
+    "eyebrow": "CHYBA · 404 · CHYBĚJÍCÍ EXEMPLÁŘ",
+    "title": "Tahle stránka vypadla ze sbírky stylů.",
+    "subtitle": "Adresa, kterou jsi otevřel, neodpovídá ničemu v naší sbírce. Ale chyba pořád funguje jako text — mrkni na „404\" v Ultra Bold, Bublinkovém, Gotice, Zalgu a dalších.",
+    "backCta": "← Zpět do generátoru",
+    "browseCta": "Procházet styly",
+    "wallTitle": "404 přepsané každým způsobem, který známe.",
+    "wallSubtitle": "Každý styl níže vzniká ve stejném enginu, který pohání celý UltraTextGen.",
+    "playgroundTitle": "Vyzkoušej svůj chybějící text.",
+    "playgroundSubtitle": "Napiš cokoli a podívej se na to v pár stylech Ultra, než se vrátíš do plného generátoru.",
+    "playgroundPlaceholder": "Napiš text...",
+    "fullGeneratorCta": "Otevřít plný generátor",
+    "copy": "Kopírovat",
+    "copied": "Zkopírováno"
+  }
+}

--- a/locales/hr.json
+++ b/locales/hr.json
@@ -1,0 +1,202 @@
+{
+  "meta": {
+    "title": "Lijepi Fontovi i Stilizirana Slova za Kopiranje — Slova za Instagram, TikTok i Nadimke",
+    "description": "Generator lijepih fontova, estetskih slova i stiliziranog teksta za kopiranje. Podebljano, kurziv, gotica, balončasta, Zalgo i simboli — zalijepi u instagram bio, u opis na TikToku, u nadimak u igri ili na Discord. Besplatno, bez računa."
+  },
+  "hero": {
+    "title": "Lijepi Fontovi i Stilizirana Slova za Kopiranje",
+    "subtitle": "Upiši tekst, odaberi stil — podebljano, kurziv, gotica, balončasta ili s ukrasima. Ubaci u instagram bio, u nadimak u igri, u WhatsApp status ili u opis pod TikTokom. Bez aplikacije, bez prijave."
+  },
+  "decorations": {
+    "label": "Dodaj ukrase tekstu",
+    "tabs": {
+      "symbols": "Simboli",
+      "frames": "Okviri",
+      "dividers": "Razdjelnici",
+      "arrows": "Strelice",
+      "minimal": "Minimalni",
+      "emojis": "Emoji",
+      "flags": "Zastave"
+    }
+  },
+  "ui": {
+    "placeholder": "Upiši tekst...",
+    "advertisement": "Oglas"
+  },
+  "useCases": {
+    "title": "Za što ljudi ovo najčešće koriste",
+    "viewAll": "Pogledaj više primjena →",
+    "items": [
+      {
+        "title": "Naslov na LinkedInu",
+        "description": "Istakni se u pretrazi na LinkedInu — podebljan ili blago ukrašen naslov odradi svoje prije nego što netko stigne skrolati dalje."
+      },
+      {
+        "title": "Komentari ispod objava",
+        "description": "Stilizirani komentari na Instagramu, YouTubeu i TikToku — lakše ih je uočiti nego stotine običnih ispod popularne objave."
+      },
+      {
+        "title": "Tekst ispisan u emojijima",
+        "description": "Pretvori natpis u niz slova od emojija — kreativan bio, story, grupni chat ili čisto za zezanje s prijateljima."
+      }
+    ]
+  },
+  "guides": {
+    "title": "Svrati na vodiče",
+    "viewAll": "Svi vodiči →",
+    "items": [
+      {
+        "title": "Retorika fontova",
+        "description": "Zašto jedan font budi povjerenje, a drugi izgleda kao spam — odnosno kako tipografija utječe na ono što osjećamo dok čitamo."
+      },
+      {
+        "title": "Osobni brend kroz tipografiju",
+        "description": "Kako odabrati slova koja odgovaraju tvom vibeu i ostaju u pamćenju — bilo da je riječ o LinkedInu, Instagramu ili Discordu."
+      },
+      {
+        "title": "Zaustavi skrolanje igrom fontova",
+        "description": "Zašto se ljudi zaustavljaju kod objava s drukčijim stilom teksta i kako to iskoristiti da podigneš doseg."
+      }
+    ]
+  },
+  "faq": {
+    "categories": [
+      {
+        "title": "Prva pitanja",
+        "items": [
+          {
+            "question": "Što je UltraTextGen i što se tu zapravo događa?",
+            "answer": "To je besplatan generator slova — upišeš običan tekst, a mi ga pretvaramo u stilizirane Unicode znakove koji izgledaju kao lijep font.\n    <br><br>\n    Najvažnije: to su <strong>pravi znakovi</strong>, a ne podebljanje iz Worda ni markdown s Discorda. Zato rade svugdje gdje se može upisati običan tekst — u instagram bio, u nadimak, u komentar, u mail, u WhatsApp status.\n    <br><br>\n    <strong>Primjer</strong><br>\n    Upišeš „bok\" → dobiješ 𝗯𝗼𝗸 (podebljano), 𝘣𝘰𝘬 (kurziv), 𝒷ℴ𝓀 (kaligrafija) ili ⓑⓞⓚ (balončasta). Sve jednim klikom."
+          },
+          {
+            "question": "Kako kopirati lijepa slova u 5 sekundi?",
+            "answer": "1. Upišeš ili zalijepiš tekst u polje na vrhu.<br>\n    2. Stilovi se pojave odmah ispod — bold, kurziv, gotica, balončasta i još desetak drugih.<br>\n    3. Ako želiš, dodaj ukrase — okvire, zvjezdice, strelice.<br>\n    4. Klikneš „Kopiraj\" kod onog koji ti odgovara i zalijepiš gdje god želiš.\n    <br><br>\n    To je to. Bez registracije, bez instaliranja aplikacije. Radi jednako na računalu i na mobitelu."
+          },
+          {
+            "question": "Besplatno? Bez ograničenja, bez računa?",
+            "answer": "Da, sve je <strong>100% besplatno</strong>. Bez računa, bez dnevnog ograničenja, bez vodenih žigova, bez kvake. Možeš kroz to propustiti cijelu knjigu i ništa se neće dogoditi."
+          }
+        ]
+      },
+      {
+        "title": "Instagram, TikTok, Discord — gdje to zalijepiti",
+        "items": [
+          {
+            "question": "Kako ubaciti stilizirani tekst u bio na Instagramu?",
+            "answer": "Instagram nema nikakvu alatnu traku za oblikovanje, ali prihvaća Unicode — dakle sve što ovdje generiraš uredno uleti u bio.\n    <br><br>\n    <strong>Kako to napraviti</strong><br>\n    1. Upiši ono što želiš u biju (npr. ime, hashtag, kratak opis).<br>\n    2. Odaberi stil — podebljano i kurziv rade najbolje na većini uređaja.<br>\n    3. Kopiraj rezultat i zalijepi u „Uredi profil → Bio\" u aplikaciji.\n    <br><br>\n    Savjet: ako želiš ukrasiti, dodaj okvir tipa ⋆｡˚ ili zvjezdicu ✦ sa strane — izgleda dobro, a ne krade pažnju ostatku bija."
+          },
+          {
+            "question": "Rade li slova u opisima na TikToku?",
+            "answer": "Da — TikTok prikazuje Unicode u opisima, opisima profila i komentarima. Najbolje se pokažu <strong>podebljano</strong>, <strong>kurziv</strong>, <strong>balončasta</strong> i <strong>kapitalke</strong>. Stilovi s puno ukrasa znaju se odrezati kod dugih opisa, pa za svaki slučaj provjeri objavu u pregledu prije objavljivanja."
+          },
+          {
+            "question": "Može li se napraviti nadimak za igru ili za Discord?",
+            "answer": "Naravno — to je vjerojatno najčešći razlog zbog kojeg ljudi dolaze na ovakve generatore. Discord, Roblox, Steam, Minecraft, većina igara prihvaća Unicode u nadimcima.\n    <br><br>\n    <strong>Primjer</strong><br>\n    Obični nadimak: „DarkWolf\"<br>\n    Nakon stiliziranja: „𝔇𝔞𝔯𝔨𝔚𝔬𝔩𝔣\" (gotica), „ⒹⓐⓡⓚⓌⓞⓛⓕ\" (balončasta) ili „๖ۣۜDarkWolf\" (s ukrasom sa strane).\n    <br><br>\n    <strong>Napomena:</strong> neke igre imaju filtre i neće primiti egzotične znakove. Ako jedan stil ne prolazi, uzmi drugi — bold i kurziv obično prolaze svugdje."
+          },
+          {
+            "question": "Radi li u WhatsApp statusu, na Telegramu i u Messengeru?",
+            "answer": "Da — WhatsApp, Telegram, Messenger, Signal, iMessage. Sve što prima običan tekst prima i Unicode slova. Zalijepiš u status ili u poruku i izgleda kao ukrasan font.\n    <br><br>\n    Za WhatsApp dodajem: ako ti treba samo podebljanje, možeš koristiti njihovu vlastitu sintaksu (`*tekst*` daje bold). Ali Unicode radi svugdje — i ondje gdje ga WhatsApp ne podržava, npr. u imenu kontakta."
+          },
+          {
+            "question": "A u naslovu maila ili u životopisu?",
+            "answer": "Tu Unicode odradi najviše. Naslov maila je običan tekst, pa podebljanje iz Outlooka otpada. Ali „𝗥𝗮č𝘂𝗻 — 𝗵𝗶𝘁𝗻𝗼\" već izgleda snažnije u sandučiću primatelja.\n    <br><br>\n    U životopisu blago podebljano ime u zaglavlju zna privući pogled poslodavca. Samo nemoj pretjerati — cijeli životopis u gotici ne izgleda profesionalno."
+          }
+        ]
+      },
+      {
+        "title": "Stilovi, slova i ukrasi",
+        "items": [
+          {
+            "question": "Koje stilove slova imam na izbor?",
+            "answer": "Puno. Zaista puno. Ukratko:\n    <br><br>\n    <strong>Osnovni</strong><br>\n    Podebljano (bold), kurziv, kaligrafija (script), gotica, balončasta (u kružićima), kapitalke, precrtano, podcrtano, double struck.\n    <br><br>\n    <strong>Zabavni</strong><br>\n    Tekst naopako, zrcalno, Zalgo (glitch s crticama nad slovima), tekst u kvadratićima, u zagradama, fullwidth (razmaknuti).\n    <br><br>\n    <strong>Dodaci</strong><br>\n    Okviri oko teksta, zvjezdice, srca, strelice, razdjelnici, zastave, emoji — sve to možeš nasloniti na stil slova.\n    <br><br>\n    S vremena na vrijeme dolaze novi — vrijedi dodati stranicu u knjižne oznake."
+          },
+          {
+            "question": "Mogu li spojiti više stilova odjednom?",
+            "answer": "Da — i to je najveća prednost UltraTextGena. Možeš nasloniti npr. <strong>balončasta + Zalgo</strong>, <strong>gotica + naopako</strong> ili <strong>kapitalke + podcrtano</strong>, a onda cijelo to zatvoriti u okvir ili zvjezdicu.\n    <br><br>\n    <strong>Primjer</strong><br>\n    „bok\" → odabereš goticu → dodaš okvir sa zvjezdicama → izađe: ★彡[ 𝔟𝔬𝔨 ]彡★\n    <br><br>\n    Što više eksperimentiraš, to zanimljivije stvari izlaze. Preporučujem da kreneš s jednim stilom i dodaš jedan ukras — ne sve odjednom."
+          },
+          {
+            "question": "Što je Zalgo i te čudne crtice nad slovima?",
+            "answer": "Zalgo je onakav „ukleti\", glitchani stil — nad i pod svakim slovom naleti hrpa dijakritičkih znakova. Izgleda kao da se tekst raspada ili kao da je iz horora.\n    <br><br>\n    <strong>Primjer</strong><br>\n    „bok\" → b̷̢o̴̢k̷̛\n    <br><br>\n    Najčešće to viđaš u mračnim biojevima na Instagramu, u halloweenskim memeovima, u gaming klanovima koji žele izgledati opasno ili kad netko od toga radi foru."
+          },
+          {
+            "question": "Odakle uzeti lijepe simbole, zvjezdice i srca?",
+            "answer": "Sve što imaš u odjeljku „Ukrasi\" ispod tekstualnog polja možeš kopirati zasebno — čak i bez upisivanja teksta. Naprosto kao zasebne znakove za bio, nadimak ili objavu.\n    <br><br>\n    — <strong>Estetski simboli</strong>: ✦ ✧ ⋆ ｡ ☆ ♡ ❀ ✿<br>\n    — <strong>Okviri i obrubi</strong>: ╭─▸ │ ╰─▸ ili ★彡[ ]彡★<br>\n    — <strong>Strelice</strong>: → ⇨ ➤ ⟶<br>\n    — <strong>Minimalni razdjelnici</strong>: ·  ⋅  ─  •<br>\n    — <strong>Zastave i emoji</strong>.\n    <br><br>\n    Najčešće se koriste u estetskim biojevima na Instagramu i Pinterestu — pašu uz sve, od citata do popisa interesa."
+          }
+        ]
+      },
+      {
+        "title": "Hrvatski znakovi, kompatibilnost, problemi",
+        "items": [
+          {
+            "question": "A hrvatski znakovi? Radi li s č, ć, đ, š, ž?",
+            "answer": "<strong>Ukratko:</strong> ovisi o stilu.\n    <br><br>\n    Unicode ima stilizirane inačice za osnovnu abecedu A–Z, pa se <em>c</em>, <em>s</em>, <em>z</em> bez problema pretvore npr. u podebljano. Ali za <em>č</em>, <em>ć</em>, <em>đ</em>, <em>š</em>, <em>ž</em> stilizirane verzije postoje samo u dijelu stilova (uglavnom bold, kurziv, kapitalke).\n    <br><br>\n    Ako stil nema verziju za hrvatski znak, on ostaje u izvornom obliku — tekst je i dalje čitljiv, hrvatsko slovo naprosto izgleda „običnije\" od ostatka. Za nadimke bez kvačica to nije nikakav problem. Za cijele rečenice na hrvatskom preporučujem <strong>bold</strong>, <strong>kurziv</strong> ili <strong>monospace</strong> — oni se najbolje snalaze s našom abecedom. Napomena i za digrafe: dž, lj i nj su samo dva obična slova jedno do drugoga, pa se svako stilizira zasebno."
+          },
+          {
+            "question": "Zašto se nekome prikazuju kvadratići umjesto slova?",
+            "answer": "Zato što sistemski font na strani primatelja ne sadrži zadani Unicode znak. To nije problem s tvojim tekstom — naprosto njegov mobitel ili aplikacija nema taj konkretni znak u kompletu.\n    <br><br>\n    Drži se <strong>bolda</strong>, <strong>kurziva</strong> i <strong>balončaste</strong> — imaju najširu podršku. Vrlo egzotični stilovi (fullwidth, kvadratići) mogu se prikazati kao □ na starijim Androidima ili u nekim mail klijentima."
+          },
+          {
+            "question": "Instagram mi je izrezao dio znakova u nadimku — što sad?",
+            "answer": "Instagram ima filtar na polju <strong>korisničko ime</strong> (dakle @login) — prima samo slova, brojke, točke i podvlake. Tu stilizirana slova ne možeš zalijepiti.\n    <br><br>\n    Ali u polju <strong>„Ime\"</strong> (prikazano ime) i u <strong>biju</strong> može — i tu prolazi većina stilova. Ako se jedan ne sprema, uzmi drugi. Bold obično prolazi bez problema."
+          },
+          {
+            "question": "Postoje li znakovi koji se uopće ne mogu pretvoriti?",
+            "answer": "Standardna slova (A–Z, a–z), brojke i osnovni interpunkcijski znakovi pretvaraju se bez problema. Neki rijetki simboli ili posebni znakovi nemaju stilizirane parnjake u Unicodeu — tada ostaju u izvorniku. Ništa se ne kvari, tekst je i dalje za kopiranje."
+          }
+        ]
+      },
+      {
+        "title": "Sigurnost, privatnost, mobitel",
+        "items": [
+          {
+            "question": "Sprema li se moj tekst negdje?",
+            "answer": "Ne. Cijela pretvorba slova događa se <strong>u tvom pregledniku</strong> — ništa ne ide na naše servere, ništa se ne sprema, ništa se ne prati. Kopirani tekst je čisti Unicode, bez skrivenih znakova, bez ikakvih identifikatora."
+          },
+          {
+            "question": "Je li sigurno lijepiti ova slova bilo gdje?",
+            "answer": "Da — to su standardni Unicode znakovi, isti kakve koristi cijeli internet. Ništa unutra, bez skripti, bez skrivenog oblikovanja, bez kodova. Slobodno lijepi u životopis, u poslovni mail, u bio na LinkedInu — gdje god želiš."
+          },
+          {
+            "question": "Radi li na mobitelu?",
+            "answer": "Da — stranica se u potpunosti prilagođava mobitelu. iPhone, Android, tablet — sve štima. Upišeš tekst, klikneš, kopira se u međuspremnik, zalijepiš u aplikaciji. Bez instaliranja ičega iz trgovine."
+          }
+        ]
+      },
+      {
+        "title": "Po čemu se razlikujemo",
+        "items": [
+          {
+            "question": "Po čemu se razlikujete od drugih generatora slova?",
+            "answer": "Konkretno:\n    <br><br>\n    — <strong>Jedna od većih kolekcija</strong> Ultra stilova — bold, kurziv, gotica, balončasta i još desetak drugih.<br>\n    — <strong>Spajanje stilova</strong> — većina generatora daje ti jedan stil odjednom, mi dopuštamo naslanjanje.<br>\n    — <strong>Ukrasi jednim klikom</strong> — okviri, zvjezdice, razdjelnici bez lijepljenja znak po znak.<br>\n    — <strong>Stranice za konkretne platforme</strong> — Instagram, TikTok, Discord. Ondje prikazujemo samo stilove koji na toj aplikaciji rade.<br>\n    — <strong>Brzo i bez skočnih prozora</strong> — bez captcha, bez „prihvati sve\" prije svakog klika."
+          },
+          {
+            "question": "Dolaze li novi stilovi?",
+            "answer": "Da, redovito. S vremena na vrijeme upadnu nove inačice, ukrasi i okviri. Najlakše je zapamtiti stranicu ili svratiti povremeno."
+          },
+          {
+            "question": "Kako pronaći točno onaj stil koji tražim?",
+            "answer": "Tri puta:\n    <br><br>\n    <strong>Po stilu</strong> — kategorije na vrhu: bold, kurziv, gotica, balončasta, precrtano, naopako i još.<br>\n    <strong>Po platformi</strong> — svrati na podstranicu za Instagram, TikTok, Discord — ondje su samo stilovi koji se na toj platformi pokažu.<br>\n    <strong>Po cilju</strong> — odjeljak s primjenama ima alate prilagođene konkretnoj potrebi: naslov na LinkedInu, komentari, tekst s emojijima."
+          }
+        ]
+      }
+    ]
+  },
+  "footer": {
+    "copyright": "© 2026 UltraTextGen. Lijepa slova koja rade svugdje."
+  },
+  "notFound": {
+    "eyebrow": "GREŠKA · 404 · NEDOSTAJE PRIMJERAK",
+    "title": "Ova je stranica ispala iz kolekcije stilova.",
+    "subtitle": "Adresa koju si otvorio ne odgovara ničemu u našoj kolekciji. Ali greška i dalje radi kao tekst — pogledaj „404\" u Ultra Boldu, Balončastoj, Gotici, Zalgu i još.",
+    "backCta": "← Natrag na generator",
+    "browseCta": "Pregledaj stilove",
+    "wallTitle": "404, prerađen na svaki način koji poznajemo.",
+    "wallSubtitle": "Svaki stil ispod prolazi kroz isti pogon kao i ostatak UltraTextGena.",
+    "playgroundTitle": "Isprobaj svoj tekst koji nedostaje.",
+    "playgroundSubtitle": "Upiši bilo što i vidi u nekoliko Ultra stilova prije nego što se vratiš na potpuni generator.",
+    "playgroundPlaceholder": "Upiši tekst...",
+    "fullGeneratorCta": "Otvori potpuni generator",
+    "copy": "Kopiraj",
+    "copied": "Kopirano"
+  }
+}

--- a/locales/ro.json
+++ b/locales/ro.json
@@ -1,0 +1,202 @@
+{
+  "meta": {
+    "title": "Fonturi Frumoase și Text Stilizat de Copiat — Litere pentru Insta, TikTok și Nickname-uri",
+    "description": "Generator de fonturi frumoase, litere estetice și text stilizat de copiat. Îngroșat, cursiv, gotic, bubble, Zalgo și simboluri — lipește-l în bio pe Insta, în descrierea unui TikTok, într-un nickname de joc sau pe Discord. Gratuit, fără cont."
+  },
+  "hero": {
+    "title": "Fonturi Frumoase și Litere Stilizate de Copiat",
+    "subtitle": "Scrie un text, alege un stil — îngroșat, cursiv, gotic, bubble sau cu ornamente. Pune-l în bio pe Insta, în nickname-ul din joc, în statusul de WhatsApp sau în descrierea unui TikTok. Fără aplicație, fără cont."
+  },
+  "decorations": {
+    "label": "Adaugă ornamente la text",
+    "tabs": {
+      "symbols": "Simboluri",
+      "frames": "Rame",
+      "dividers": "Separatoare",
+      "arrows": "Săgeți",
+      "minimal": "Minimale",
+      "emojis": "Emoji",
+      "flags": "Steaguri"
+    }
+  },
+  "ui": {
+    "placeholder": "Scrie textul...",
+    "advertisement": "Reclamă"
+  },
+  "useCases": {
+    "title": "Pentru ce folosesc oamenii asta cel mai des",
+    "viewAll": "Vezi mai multe utilizări →",
+    "items": [
+      {
+        "title": "Titlu pe LinkedIn",
+        "description": "Ieși în evidență în căutarea de pe LinkedIn — un titlu îngroșat sau ușor ornamentat își face treaba înainte ca cineva să apuce să deruleze mai departe."
+      },
+      {
+        "title": "Comentarii sub postări",
+        "description": "Comentarii stilizate pe Insta, YouTube și TikTok — se prind mai ușor cu ochiul decât sutele de comentarii banale de sub o postare populară."
+      },
+      {
+        "title": "Text scris cu emoji",
+        "description": "Transformă un cuvânt într-o secvență de litere-emoji — bio creative, story-uri, chat-uri de grup sau pur și simplu de dragul glumei cu prietenii."
+      }
+    ]
+  },
+  "guides": {
+    "title": "Aruncă un ochi pe ghiduri",
+    "viewAll": "Toate ghidurile →",
+    "items": [
+      {
+        "title": "Retorica Fonturilor",
+        "description": "De ce un font inspiră încredere, iar altul arată a spam — adică felul în care tipografia influențează ce simțim în timp ce citim."
+      },
+      {
+        "title": "Brand personal prin tipografie",
+        "description": "Cum alegi litere care se potrivesc cu vibe-ul tău și rămân cu cei care te citesc — indiferent dacă e vorba de LinkedIn, Insta sau Discord."
+      },
+      {
+        "title": "Oprește scroll-ul cu variații de font",
+        "description": "De ce oamenii se opresc la postările cu un alt stil de text și cum să folosești asta ca să-ți crești reach-ul."
+      }
+    ]
+  },
+  "faq": {
+    "categories": [
+      {
+        "title": "Primele întrebări",
+        "items": [
+          {
+            "question": "Ce este UltraTextGen și ce se întâmplă de fapt aici?",
+            "answer": "E un generator gratuit de litere — scrii un text obișnuit, iar noi îl transformăm în caractere Unicode stilizate, care arată ca un font frumos.\n    <br><br>\n    Cel mai important: sunt <strong>caractere reale</strong>, nu îngroșarea din Word sau markdown-ul de pe Discord. De asta funcționează peste tot unde poți scrie text obișnuit — în bio pe Insta, într-un nickname, într-un comentariu, într-un e-mail, în statusul de WhatsApp.\n    <br><br>\n    <strong>Exemplu</strong><br>\n    Scrii „hei” → primești 𝗵𝗲𝗶 (îngroșat), 𝘩𝘦𝘪 (cursiv), 𝒽ℯ𝒾 (caligrafic) sau ⓗⓔⓘ (bubble). Totul dintr-un singur click."
+          },
+          {
+            "question": "Cum copiez niște litere frumoase în 5 secunde?",
+            "answer": "1. Scrii sau lipești textul în câmpul de sus.<br>\n    2. Stilurile apar imediat dedesubt — bold, cursiv, gotic, bubble și încă vreo câteva zeci.<br>\n    3. Dacă vrei, adaugă ornamente — rame, steluțe, săgeți.<br>\n    4. Apeși „Copiază” la cel care îți place și îl lipești oriunde vrei.\n    <br><br>\n    Atât. Fără înregistrare, fără instalat aplicații. Merge la fel pe calculator și pe telefon."
+          },
+          {
+            "question": "Gratuit? Fără limite, fără cont?",
+            "answer": "Da, totul e <strong>100% gratuit</strong>. Fără cont, fără limită zilnică, fără watermark, fără nicio șmecherie. Poți trece prin el o carte întreagă și nu se întâmplă nimic."
+          }
+        ]
+      },
+      {
+        "title": "Insta, TikTok, Discord — unde le lipești",
+        "items": [
+          {
+            "question": "Cum pun text stilizat în bio pe Instagram?",
+            "answer": "Insta nu are nicio bară de formatare, dar acceptă Unicode — adică tot ce generezi la noi intră în bio fără probleme.\n    <br><br>\n    <strong>Cum faci</strong><br>\n    1. Scrie ce vrei să ai în bio (de ex. numele, un hashtag, o descriere scurtă).<br>\n    2. Alege un stil — îngroșatul și cursivul merg cel mai bine pe majoritatea dispozitivelor.<br>\n    3. Copiază rezultatul și lipește-l în „Editează profilul → Bio” din aplicație.\n    <br><br>\n    Pont: dacă vrei să ornamentezi, adaugă o ramă de tip ⋆｡˚ sau o steluță ✦ pe margine — arată bine și nu fură atenția de la restul bio-ului."
+          },
+          {
+            "question": "Funcționează literele în descrierile de pe TikTok?",
+            "answer": "Da — TikTok afișează Unicode în descrieri, în descrierea profilului și în comentarii. Cel mai bine ies <strong>îngroșatul</strong>, <strong>cursivul</strong>, <strong>bubble</strong> și <strong>small caps</strong>. Stilurile cu o grămadă de ornamente se pot tăia la descrierile lungi, așa că, pentru siguranță, verifică postarea în previzualizare înainte de publicare."
+          },
+          {
+            "question": "Pot să-mi fac un nickname de joc sau de Discord?",
+            "answer": "Clar — probabil e cel mai frecvent motiv pentru care oamenii ajung pe astfel de generatoare. Discord, Roblox, Steam, Minecraft, majoritatea jocurilor acceptă Unicode în nickname-uri.\n    <br><br>\n    <strong>Exemplu</strong><br>\n    Nickname obișnuit: „DarkWolf”<br>\n    După stilizare: „𝔇𝔞𝔯𝔨𝔚𝔬𝔩𝔣” (gotic), „ⒹⓐⓡⓚⓌⓞⓛⓕ” (bubble) sau „๖ۣۜDarkWolf” (cu un ornament pe margine).\n    <br><br>\n    <strong>Atenție:</strong> unele jocuri au filtre și nu acceptă caractere exotice. Dacă un stil nu intră, pune altul — bold-ul și cursivul trec de obicei peste tot."
+          },
+          {
+            "question": "Merge în statusul de WhatsApp, pe Telegram și în Messenger?",
+            "answer": "Da — WhatsApp, Telegram, Messenger, Signal, iMessage. Tot ce acceptă text obișnuit acceptă și litere Unicode. Le lipești în status sau într-un mesaj și arată ca un font ornamentat.\n    <br><br>\n    Pentru WhatsApp o completare: dacă ții doar la îngroșare, poți folosi sintaxa lui proprie (<code>*text*</code> dă bold). Dar Unicode funcționează peste tot — inclusiv acolo unde WhatsApp nu are asta, de exemplu în numele unui contact."
+          },
+          {
+            "question": "Dar în subiectul unui e-mail sau într-un CV?",
+            "answer": "Aici Unicode face cea mai mare treabă. Subiectul unui e-mail e text obișnuit, deci îngroșarea din Outlook nu are ce căuta. În schimb „𝗙𝗮𝗰𝘁𝘂𝗿𝗮 — 𝘂𝗿𝗴𝗲𝗻𝘁” arată deja mai puternic în inbox-ul destinatarului.\n    <br><br>\n    Într-un CV, un nume ușor îngroșat în antet poate atrage privirea recrutorului. Doar nu exagera — un CV întreg în gotic nu arată profesional."
+          }
+        ]
+      },
+      {
+        "title": "Stiluri, litere și ornamente",
+        "items": [
+          {
+            "question": "Ce stiluri de litere am la dispoziție?",
+            "answer": "Multe. Chiar multe. Pe scurt:\n    <br><br>\n    <strong>De bază</strong><br>\n    Îngroșat (bold), cursiv, caligrafic (script), gotic, bubble (în cerculețe), small caps, tăiat, subliniat, double struck.\n    <br><br>\n    <strong>De distracție</strong><br>\n    Text cu susul în jos, oglindit, Zalgo (glitch cu semne peste litere), text în pătrățele, în paranteze, fullwidth (răsfirat).\n    <br><br>\n    <strong>Adăugiri</strong><br>\n    Rame în jurul textului, steluțe, inimioare, săgeți, separatoare, steaguri, emoji — se pot suprapune peste stilul literelor.\n    <br><br>\n    Din când în când apar altele noi — merită să pui pagina la favorite."
+          },
+          {
+            "question": "Pot să combin mai multe stiluri deodată?",
+            "answer": "Da — și ăsta e cel mai mare avantaj al UltraTextGen. Poți suprapune de exemplu <strong>bubble + Zalgo</strong>, <strong>gotic + cu susul în jos</strong> sau <strong>small caps + subliniat</strong>, iar apoi să închizi totul într-o ramă sau o steluță.\n    <br><br>\n    <strong>Exemplu</strong><br>\n    „hei” → alegi gotic → adaugi o ramă cu steluțe → iese: ★彡[ 𝔥𝔢𝔦 ]彡★\n    <br><br>\n    Cu cât experimentezi mai mult, cu atât ies lucruri mai interesante. Îți recomand să începi cu un singur stil și să adaugi un singur ornament — nu tot deodată."
+          },
+          {
+            "question": "Ce este Zalgo și liniuțele alea ciudate de deasupra literelor?",
+            "answer": "Zalgo e un stil „blestemat”, glitchy — deasupra și dedesubtul fiecărei litere apare o grămadă de semne diacritice. Arată de parcă textul s-ar destrăma sau ar fi dintr-un film de groază.\n    <br><br>\n    <strong>Exemplu</strong><br>\n    „hei” → h̷̢e̴̢i̷̛\n    <br><br>\n    Cel mai des îl vezi în bio-uri sumbre pe Insta, în meme-uri de Halloween, în clanuri de gaming care vor să pară amenințătoare sau când cineva face haz de el."
+          },
+          {
+            "question": "De unde iau simboluri, steluțe și inimioare frumoase?",
+            "answer": "Tot ce ai în secțiunea „Ornamente” de sub câmpul de text îl poți copia separat — chiar și fără să scrii vreun text. Pur și simplu ca semne separate pentru bio, nickname sau o postare.\n    <br><br>\n    — <strong>Simboluri estetice</strong>: ✦ ✧ ⋆ ｡ ☆ ♡ ❀ ✿<br>\n    — <strong>Rame și margini</strong>: ╭─▸ │ ╰─▸ sau ★彡[ ]彡★<br>\n    — <strong>Săgeți</strong>: → ⇨ ➤ ⟶<br>\n    — <strong>Separatoare minimale</strong>: ·  ⋅  ─  •<br>\n    — <strong>Steaguri și emoji</strong>.\n    <br><br>\n    Cel mai des se folosesc în bio-uri estetice pe Instagram și Pinterest — se potrivesc cu orice, de la citate la liste de pasiuni."
+          }
+        ]
+      },
+      {
+        "title": "Diacritice românești, compatibilitate, probleme",
+        "items": [
+          {
+            "question": "Dar diacriticele românești? Merge cu ă, â, î, ș, ț?",
+            "answer": "<strong>Pe scurt:</strong> depinde de stil.\n    <br><br>\n    Unicode are variante stilizate pentru alfabetul de bază A–Z, așa că <em>a</em>, <em>i</em>, <em>s</em>, <em>t</em> se transformă fără probleme, de exemplu în îngroșat. Dar pentru <em>ă</em>, <em>â</em>, <em>î</em>, <em>ș</em>, <em>ț</em> variantele stilizate există doar în o parte dintre stiluri (mai ales bold, italic, small caps).\n    <br><br>\n    Dacă un stil nu are versiune pentru un caracter cu diacritic, acesta rămâne în forma originală — textul e în continuare lizibil, litera cu diacritic arată doar puțin mai „obișnuit” decât restul. Pentru nickname-uri fără diacritice nu e nicio problemă. Pentru propoziții întregi în română îți recomand <strong>bold</strong>, <strong>italic</strong> sau <strong>monospace</strong> — se descurcă cel mai bine cu alfabetul nostru."
+          },
+          {
+            "question": "De ce cineva vede pătrățele în loc de litere?",
+            "answer": "Pentru că fontul de sistem de la destinatar nu conține caracterul Unicode respectiv. Nu e o problemă cu textul tău — pur și simplu telefonul sau aplicația lui nu are semnul acela anume în set.\n    <br><br>\n    Rămâi la <strong>bold</strong>, <strong>italic</strong> și <strong>bubble</strong> — au cel mai larg suport. Stilurile foarte exotice (fullwidth, pătrățele) se pot afișa ca □ pe Android-uri mai vechi sau în unii clienți de e-mail."
+          },
+          {
+            "question": "Instagram mi-a tăiat o parte din caractere în nickname — și acum?",
+            "answer": "Insta are un filtru pe câmpul <strong>nume de utilizator</strong> (adică @-ul) — acceptă doar litere, cifre, punct și underscore. Aici nu poți lipi litere stilizate.\n    <br><br>\n    Dar în câmpul <strong>„Nume”</strong> (numele afișat) și în <strong>bio</strong> se poate — și aici intră majoritatea stilurilor. Dacă unul nu se salvează, pune altul. Bold-ul trece de obicei fără probleme."
+          },
+          {
+            "question": "Există caractere care nu pot fi transformate deloc?",
+            "answer": "Literele standard (A–Z, a–z), cifrele și semnele de punctuație de bază se transformă fără probleme. Unele simboluri rare sau caractere speciale nu au echivalente stilizate în Unicode — atunci rămân în original. Nimic nu se strică, textul rămâne de copiat."
+          }
+        ]
+      },
+      {
+        "title": "Securitate, confidențialitate, telefon",
+        "items": [
+          {
+            "question": "Textul meu se salvează undeva?",
+            "answer": "Nu. Toată transformarea literelor se întâmplă <strong>în browserul tău</strong> — nimic nu ajunge pe serverele noastre, nimic nu se salvează, nimic nu e urmărit. Textul copiat e Unicode curat, fără caractere ascunse, fără niciun identificator."
+          },
+          {
+            "question": "E sigur să lipesc literele astea oriunde?",
+            "answer": "Da — sunt caractere Unicode standard, identice cu cele folosite de tot internetul. Nimic în interior, niciun script, nicio formatare ascunsă, niciun cod. Le lipești liniștit într-un CV, într-un e-mail de serviciu, în bio-ul de LinkedIn — unde vrei."
+          },
+          {
+            "question": "Funcționează pe telefon?",
+            "answer": "Da — pagina se adaptează complet la mobil. iPhone, Android, tabletă — totul merge. Scrii textul, apeși, se copiază în clipboard, îl lipești în aplicație. Fără să instalezi nimic din vreun magazin."
+          }
+        ]
+      },
+      {
+        "title": "Ce ne diferențiază",
+        "items": [
+          {
+            "question": "Prin ce vă deosebiți de alte generatoare de litere?",
+            "answer": "Concret:\n    <br><br>\n    — <strong>Una dintre cele mai mari colecții</strong> de stiluri Ultra — bold, cursiv, gotic, bubble și încă vreo câteva zeci.<br>\n    — <strong>Combinarea stilurilor</strong> — majoritatea generatoarelor îți dau un singur stil deodată, noi te lăsăm să le suprapui.<br>\n    — <strong>Ornamente dintr-un click</strong> — rame, steluțe, separatoare fără să lipești semn cu semn.<br>\n    — <strong>Pagini pentru platforme anume</strong> — Insta, TikTok, Discord. Acolo arătăm doar stilurile care funcționează pe aplicația respectivă.<br>\n    — <strong>Rapid și fără pop-up-uri</strong> — fără captcha, fără „acceptă tot” înainte de fiecare click."
+          },
+          {
+            "question": "Apar stiluri noi?",
+            "answer": "Da, regulat. Din când în când apar variante noi, ornamente și rame. Cel mai simplu e să reții pagina sau să treci pe aici din când în când."
+          },
+          {
+            "question": "Cum găsesc exact stilul pe care îl caut?",
+            "answer": "Trei căi:\n    <br><br>\n    <strong>După stil</strong> — categoriile de sus: bold, cursiv, gotic, bubble, tăiat, cu susul în jos și altele.<br>\n    <strong>După platformă</strong> — intră pe pagina pentru Insta, TikTok, Discord — acolo sunt doar stilurile care funcționează pe platforma respectivă.<br>\n    <strong>După scop</strong> — secțiunea de utilizări are unelte potrivite pentru o nevoie anume: titlu pe LinkedIn, comentarii, text cu emoji."
+          }
+        ]
+      }
+    ]
+  },
+  "footer": {
+    "copyright": "© 2026 UltraTextGen. Litere frumoase care funcționează peste tot."
+  },
+  "notFound": {
+    "eyebrow": "EROARE · 404 · EXEMPLAR LIPSĂ",
+    "title": "Pagina asta a ieșit din colecția de stiluri.",
+    "subtitle": "Adresa pe care ai deschis-o nu se potrivește cu nimic din colecția noastră. Dar eroarea funcționează în continuare ca text — vezi „404” în Ultra Bold, Bubble, Gotic, Zalgo și nu numai.",
+    "backCta": "← Înapoi la generator",
+    "browseCta": "Răsfoiește stilurile",
+    "wallTitle": "404, transformat în toate felurile pe care le știm.",
+    "wallSubtitle": "Fiecare stil de mai jos trece prin același motor ca restul UltraTextGen.",
+    "playgroundTitle": "Testează-ți textul lipsă.",
+    "playgroundSubtitle": "Scrie orice și vezi-l în câteva stiluri Ultra înainte să te întorci la generatorul complet.",
+    "playgroundPlaceholder": "Scrie textul...",
+    "fullGeneratorCta": "Deschide generatorul complet",
+    "copy": "Copiază",
+    "copied": "Copiat"
+  }
+}

--- a/locales/sk.json
+++ b/locales/sk.json
@@ -1,0 +1,202 @@
+{
+  "meta": {
+    "title": "Ozdobné písmo a štýlový text na kopírovanie — písmená na Instagram, TikTok a prezývky",
+    "description": "Generátor ozdobného písma, estetických písmen a štýlového textu na kopírovanie. Tučné, kurzíva, gotika, bublinkové, Zalgo a symboly — vlož do bia na Instagrame, do popisu na TikToku, do herného nicku alebo na Discord. Zadarmo, bez účtu."
+  },
+  "hero": {
+    "title": "Ozdobné písmo a štýlové písmená na kopírovanie",
+    "subtitle": "Napíš text, vyber štýl — tučné, kurzíva, gotika, bublinkové alebo s ozdobami. Vlož do bia na Instagrame, do herného nicku, do statusu na WhatsAppe alebo do popisu na TikToku. Bez aplikácie, bez prihlasovania."
+  },
+  "decorations": {
+    "label": "Pridaj ozdoby k textu",
+    "tabs": {
+      "symbols": "Symboly",
+      "frames": "Rámčeky",
+      "dividers": "Oddeľovače",
+      "arrows": "Šípky",
+      "minimal": "Minimalistické",
+      "emojis": "Emoji",
+      "flags": "Vlajky"
+    }
+  },
+  "ui": {
+    "placeholder": "Napíš text...",
+    "advertisement": "Reklama"
+  },
+  "useCases": {
+    "title": "Na čo to ľudia najčastejšie používajú",
+    "viewAll": "Zobraziť ďalšie využitie →",
+    "items": [
+      {
+        "title": "Titulok na LinkedIne",
+        "description": "Vynikni vo vyhľadávaní na LinkedIne — tučný alebo jemne ozdobený titulok zaberie skôr, než niekto stihne odscrollovať ďalej."
+      },
+      {
+        "title": "Komentáre pod príspevkami",
+        "description": "Štýlové komentáre na Instagrame, YouTube aj TikToku — okom ich zachytíš ľahšie než stovky obyčajných pod populárnym príspevkom."
+      },
+      {
+        "title": "Text zapísaný v emoji",
+        "description": "Premeň nápis na sekvenciu písmen-emoji — kreatívne bio, story, skupinové chaty alebo čisto pre zábavu s kamarátmi."
+      }
+    ]
+  },
+  "guides": {
+    "title": "Pozri si návody",
+    "viewAll": "Všetky návody →",
+    "items": [
+      {
+        "title": "Rétorika písma",
+        "description": "Prečo jedno písmo budí dôveru a druhé vyzerá ako spam — čiže ako typografia ovplyvňuje to, čo pri čítaní cítime."
+      },
+      {
+        "title": "Osobná značka cez typografiu",
+        "description": "Ako vybrať písmená, ktoré ladia s tvojím vibom a zostanú divákovi v hlave — či už ide o LinkedIn, Instagram alebo Discord."
+      },
+      {
+        "title": "Zastav skrolovanie — pohraj sa s písmom",
+        "description": "Prečo sa ľudia zastavia pri príspevkoch s iným štýlom textu a ako to využiť na zvýšenie dosahov."
+      }
+    ]
+  },
+  "faq": {
+    "categories": [
+      {
+        "title": "Prvé otázky",
+        "items": [
+          {
+            "question": "Čo je UltraTextGen a čo sa tu vlastne deje?",
+            "answer": "Je to bezplatný generátor písmen — napíšeš obyčajný text a my ho prevedieme na štylizované znaky Unicode, ktoré vyzerajú ako ozdobné písmo.\n    <br><br>\n    Hlavná vec: sú to <strong>ozajstné znaky</strong>, nie stučnenie z Wordu alebo markdown z Discordu. Preto fungujú všade, kam sa dá napísať obyčajný text — v biu na Instagrame, v nicku, v komentári, v e-maile, v statuse na WhatsAppe.\n    <br><br>\n    <strong>Príklad</strong><br>\n    Napíšeš „ahoj\" → dostaneš 𝗮𝗵𝗼𝗷 (tučné), 𝘢𝘩𝘰𝘫 (kurzíva), 𝒶𝒽ℴ𝒿 (kaligrafia) alebo ⓐⓗⓞⓙ (bublinkové). Všetko jedným kliknutím."
+          },
+          {
+            "question": "Ako skopírovať ozdobné písmená za 5 sekúnd?",
+            "answer": "1. Napíšeš alebo vložíš text do poľa hore.<br>\n    2. Štýly sa hneď objavia pod ním — tučné, kurzíva, gotika, bublinkové a ešte pár desiatok ďalších.<br>\n    3. Keď chceš, pridaj ozdoby — rámčeky, hviezdičky, šípky.<br>\n    4. Klikneš na „Kopírovať\" pri tom, ktorý ti sedí, a vložíš, kam len chceš.\n    <br><br>\n    A je to. Bez registrácie, bez inštalácie apky. Funguje rovnako na počítači aj na telefóne."
+          },
+          {
+            "question": "Zadarmo? Bez limitov, bez účtu?",
+            "answer": "Áno, celé je to <strong>100% zadarmo</strong>. Žiadny účet, žiadny denný limit, žiadne vodoznaky, žiadny háčik. Môžeš cez to prehnať celú knižku a nič sa nestane."
+          }
+        ]
+      },
+      {
+        "title": "Instagram, TikTok, Discord — kam to vložiť",
+        "items": [
+          {
+            "question": "Ako dostať štýlový text do bia na Instagrame?",
+            "answer": "Instagram nemá žiadny panel na formátovanie, ale prijíma Unicode — takže všetko, čo u nás vygeneruješ, ti v biu naskočí bez problémov.\n    <br><br>\n    <strong>Ako na to</strong><br>\n    1. Napíš, čo chceš mať v biu (napríklad meno, hashtag, krátky popis).<br>\n    2. Vyber štýl — tučné a kurzíva fungujú na väčšine zariadení najlepšie.<br>\n    3. Skopíruj výsledok a vlož ho v „Upraviť profil → Bio\" v aplikácii.\n    <br><br>\n    Tip: keď chceš ozdobiť, pridaj rámček typu ⋆｡˚ alebo hviezdičku ✦ po strane — vyzerá to dobre a nekradne to pozornosť zvyšku bia."
+          },
+          {
+            "question": "Fungujú písmená v popisoch na TikToku?",
+            "answer": "Áno — TikTok vykresľuje Unicode v popisoch, popisoch profilu aj komentároch. Najlepšie sa osvedčí <strong>tučné</strong>, <strong>kurzíva</strong>, <strong>bublinkové</strong> a <strong>kapitálky</strong>. Štýly s kopou ozdôb sa pri dlhých popisoch občas orežú, tak si pre istotu príspevok skontroluj v náhľade pred zverejnením."
+          },
+          {
+            "question": "Dá sa spraviť nick do hry alebo na Discord?",
+            "answer": "Jasné — to je asi najčastejší dôvod, prečo ľudia na takéto generátory chodia. Discord, Roblox, Steam, Minecraft, väčšina hier prijíma Unicode v nicku.\n    <br><br>\n    <strong>Príklad</strong><br>\n    Obyčajný nick: „DarkWolf\"<br>\n    Po štylizácii: „𝔇𝔞𝔯𝔨𝔚𝔬𝔩𝔣\" (gotika), „ⒹⓐⓡⓚⓌⓞⓛⓕ\" (bublinkové) alebo „๖ۣۜDarkWolf\" (s ozdobou po strane).\n    <br><br>\n    <strong>Pozor:</strong> niektoré hry majú filtre a exotické znaky neprijmú. Keď jeden štýl neprejde, daj iný — tučné a kurzíva prejdú takmer všade."
+          },
+          {
+            "question": "Funguje to v statuse na WhatsAppe, na Telegrame a v Messengeri?",
+            "answer": "Áno — WhatsApp, Telegram, Messenger, Signal, iMessage. Čokoľvek prijíma obyčajný text, prijme aj písmená Unicode. Vložíš ich do statusu alebo do správy a vyzerajú ako ozdobné písmo.\n    <br><br>\n    K WhatsAppu ešte dodám: ak ti ide len o stučnenie, môžeš použiť ich vlastnú syntax (<code>*text*</code> spraví tučné). Ale Unicode funguje všade — aj tam, kde to WhatsApp nepodporuje, napríklad v názve kontaktu."
+          },
+          {
+            "question": "A v predmete e-mailu alebo v životopise?",
+            "answer": "Tu Unicode odvedie najväčšiu prácu. Predmet e-mailu je obyčajný text, takže stučnenie z Outlooku odpadá. Ale „𝗙𝗮𝗸𝘁𝘂𝗿𝗮 — 𝗣𝗢𝗭𝗢𝗥\" už v príjemcovej schránke pôsobí silnejšie.\n    <br><br>\n    V životopise dokáže jemne stučnené meno v hlavičke pritiahnuť pohľad personalistu. Len to nepreháňaj — celý životopis v gotike nepôsobí profesionálne."
+          }
+        ]
+      },
+      {
+        "title": "Štýly, písmená a ozdoby",
+        "items": [
+          {
+            "question": "Aké štýly písmen mám na výber?",
+            "answer": "Veľa. Vážne veľa. V skratke:\n    <br><br>\n    <strong>Základné</strong><br>\n    Tučné (bold), kurzíva, kaligrafia (script), gotika, bublinkové (v kolieskach), kapitálky, prečiarknuté, podčiarknuté, dvojito ťahané (double struck).\n    <br><br>\n    <strong>Zábavné</strong><br>\n    Text hore nohami, zrkadlovo obrátený, Zalgo (glitch s čiarkami nad písmenami), text v štvorčekoch, v zátvorkách, fullwidth (rozhádzaný).\n    <br><br>\n    <strong>Doplnky</strong><br>\n    Rámčeky okolo textu, hviezdičky, srdiečka, šípky, oddeľovače, vlajky, emoji — dajú sa na štýl písmen navrstviť.\n    <br><br>\n    Z času na čas pribúdajú nové — oplatí sa pridať si stránku do záložiek."
+          },
+          {
+            "question": "Môžem spojiť viac štýlov naraz?",
+            "answer": "Áno — a to je najväčšia prednosť UltraTextGenu. Môžeš navrstviť napríklad <strong>bublinkové + Zalgo</strong>, <strong>gotiku + hore nohami</strong> alebo <strong>kapitálky + podčiarknutie</strong> a potom to celé uzavrieť do rámčeka alebo hviezdičky.\n    <br><br>\n    <strong>Príklad</strong><br>\n    „ahoj\" → vyberieš gotiku → pridáš rámček s hviezdičkami → vyjde: ★彡[ 𝔞𝔥𝔬𝔧 ]彡★\n    <br><br>\n    Čím viac experimentuješ, tým zaujímavejšie veci vzniknú. Odporúčam začať jedným štýlom a pridať jednu ozdobu — nie všetko naraz."
+          },
+          {
+            "question": "Čo je Zalgo a tie divné čiarky nad písmenami?",
+            "answer": "Zalgo je taký „prekliaty\", glitchový štýl — nad a pod každé písmeno naletí kopa diakritických znamienok. Vyzerá to, akoby sa text rozpadal alebo bol z hororu.\n    <br><br>\n    <strong>Príklad</strong><br>\n    „ahoj\" → a̷̢h̴̢ơ̷j̴̜\n    <br><br>\n    Najčastejšie to vídavaš v temných biách na Instagrame, v halloweenskych memoch, v herných klanoch, ktoré chcú vyzerať hrozivo, alebo keď si z toho niekto robí srandu."
+          },
+          {
+            "question": "Kde brať pekné symboly, hviezdičky a srdiečka?",
+            "answer": "Všetko, čo máš v sekcii „Ozdoby\" pod textovým poľom, môžeš kopírovať zvlášť — aj bez písania textu. Jednoducho ako samostatné znaky do bia, nicku alebo príspevku.\n    <br><br>\n    — <strong>Estetické symboly</strong>: ✦ ✧ ⋆ ｡ ☆ ♡ ❀ ✿<br>\n    — <strong>Rámčeky a obruby</strong>: ╭─▸ │ ╰─▸ alebo ★彡[ ]彡★<br>\n    — <strong>Šípky</strong>: → ⇨ ➤ ⟶<br>\n    — <strong>Minimalistické oddeľovače</strong>: ·  ⋅  ─  •<br>\n    — <strong>Vlajky a emoji</strong>.\n    <br><br>\n    Najčastejšie sa používajú v estetických biách na Instagrame a Pintereste — hodia sa úplne ku všetkému, od citátov po zoznamy záujmov."
+          }
+        ]
+      },
+      {
+        "title": "Slovenské znaky, kompatibilita, problémy",
+        "items": [
+          {
+            "question": "A slovenské znaky? Funguje to s á, ä, č, ď, é, í, ĺ, ľ, ň, ó, ô, ŕ, š, ť, ú, ý, ž?",
+            "answer": "<strong>Krátko:</strong> záleží na štýle.\n    <br><br>\n    Unicode má štylizované varianty pre základnú abecedu A–Z, takže <em>a</em>, <em>c</em>, <em>e</em>, <em>s</em>, <em>z</em> sa v pohode premenia napríklad na tučné. Ale pre <em>á</em>, <em>č</em>, <em>ľ</em>, <em>š</em>, <em>ť</em>, <em>ž</em> štylizované verzie existujú len v časti štýlov (hlavne tučné, kurzíva, kapitálky).\n    <br><br>\n    Keď štýl nemá verziu pre slovenský znak s diakritikou, zostane v pôvodnej podobe — text je stále čitateľný, slovenské písmená s mäkčeňmi a dĺžňami jednoducho vyzerajú „obyčajnejšie\" než zvyšok. Pre nicky bez diakritiky to nie je žiadny problém. Pre celé vety v slovenčine odporúčam <strong>tučné</strong>, <strong>kurzívu</strong> alebo <strong>monospace</strong> — tie si s našou abecedou poradia najlepšie."
+          },
+          {
+            "question": "Prečo sa niekomu zobrazujú štvorčeky namiesto písmen?",
+            "answer": "Pretože systémové písmo na strane príjemcu daný znak Unicode neobsahuje. Nie je to problém s tvojím textom — jeho telefón alebo aplikácia jednoducho ten konkrétny znak v sade nemá.\n    <br><br>\n    Drž sa <strong>tučných</strong>, <strong>kurzívy</strong> a <strong>bublinkových</strong> — tie majú najširšiu podporu. Veľmi exotické štýly (fullwidth, štvorčeky) sa na starších Androidoch alebo v niektorých e-mailových klientoch môžu zobraziť ako □."
+          },
+          {
+            "question": "Instagram mi v nicku orezal časť znakov — čo teraz?",
+            "answer": "Instagram má filter na pole <strong>používateľské meno</strong> (čiže @login) — berie len písmená, číslice, bodky a podčiarkovníky. Sem štylizované písmená nevložíš.\n    <br><br>\n    Ale do poľa <strong>„Meno\"</strong> (zobrazované meno) a do <strong>bia</strong> áno — a tam prejde väčšina štýlov. Keď sa jeden neuloží, daj iný. Tučné obvykle prejde bez problémov."
+          },
+          {
+            "question": "Sú nejaké znaky, ktoré sa vôbec nedajú previesť?",
+            "answer": "Štandardné písmená (A–Z, a–z), číslice a základná interpunkcia sa prevedú bez problémov. Niektoré vzácne symboly alebo špeciálne znaky nemajú v Unicode štylizované náprotivky — potom zostanú v pôvodnej podobe. Nič sa nerozbije, text je stále na kopírovanie."
+          }
+        ]
+      },
+      {
+        "title": "Bezpečnosť, súkromie, telefón",
+        "items": [
+          {
+            "question": "Ukladá sa môj text niekam?",
+            "answer": "Nie. Celý prevod písmen prebieha <strong>v tvojom prehliadači</strong> — nič neputuje na naše servery, nič sa neukladá, nič sa nesleduje. Skopírovaný text je čistý Unicode, bez skrytých znakov, bez akýchkoľvek identifikátorov."
+          },
+          {
+            "question": "Je bezpečné vkladať tieto písmená kamkoľvek?",
+            "answer": "Áno — sú to štandardné znaky Unicode, rovnaké ako tie, ktoré používa celý internet. Nič vnútri, žiadne skripty, žiadne skryté formátovanie, žiadne kódy. Pokojne ich vlož do životopisu, do pracovného e-mailu, do bia na LinkedIne — kam chceš."
+          },
+          {
+            "question": "Funguje to na telefóne?",
+            "answer": "Áno — stránka sa plne prispôsobí mobilu. iPhone, Android, tablet — všetko klape. Napíšeš text, klikneš, skopíruje sa do schránky, vložíš v aplikácii. Bez inštalácie čohokoľvek z obchodu."
+          }
+        ]
+      },
+      {
+        "title": "Čím sa líšime",
+        "items": [
+          {
+            "question": "Čím sa líšite od iných generátorov písmen?",
+            "answer": "Konkrétne:\n    <br><br>\n    — <strong>Jedna z najväčších zbierok</strong> štýlov Ultra — tučné, kurzíva, gotika, bublinkové a ešte pár desiatok ďalších.<br>\n    — <strong>Kombinovanie štýlov</strong> — väčšina generátorov ti dá jeden štýl naraz, my dovolíme vrstviť.<br>\n    — <strong>Ozdoby jedným kliknutím</strong> — rámčeky, hviezdičky, oddeľovače bez lepenia znak po znaku.<br>\n    — <strong>Stránky pre konkrétne platformy</strong> — Instagram, TikTok, Discord. Ukazujeme tam len štýly, ktoré v danej apke fungujú.<br>\n    — <strong>Rýchlo a bez vyskakovacích okien</strong> — žiadne captchy, žiadne „prijať všetko\" pred každým kliknutím."
+          },
+          {
+            "question": "Pribúdajú nové štýly?",
+            "answer": "Áno, pravidelne. Z času na čas naskočia nové varianty, ozdoby a rámčeky. Najjednoduchšie je uložiť si stránku do záložiek alebo sa sem raz za čas vrátiť."
+          },
+          {
+            "question": "Ako nájsť presne ten štýl, ktorý hľadám?",
+            "answer": "Tri cesty:\n    <br><br>\n    <strong>Podľa štýlu</strong> — kategórie hore: tučné, kurzíva, gotika, bublinkové, prečiarknuté, hore nohami a ďalšie.<br>\n    <strong>Podľa platformy</strong> — pozri podstránku pre Instagram, TikTok, Discord — tam sú len štýly, ktoré na danej platforme fungujú.<br>\n    <strong>Podľa cieľa</strong> — sekcia využitia má nástroje ušité na konkrétnu potrebu: titulok na LinkedIn, komentáre, text s emoji."
+          }
+        ]
+      }
+    ]
+  },
+  "footer": {
+    "copyright": "© 2026 UltraTextGen. Ozdobné písmená, ktoré fungujú všade."
+  },
+  "notFound": {
+    "eyebrow": "CHYBA · 404 · CHÝBAJÚCI EXEMPLÁR",
+    "title": "Táto stránka vypadla zo zbierky štýlov.",
+    "subtitle": "Adresa, ktorú si otvoril, nezodpovedá ničomu v našej zbierke. Ale chyba stále funguje ako text — pozri „404\" v Ultra Bold, Bublinkovom, Gotike, Zalgu a ďalších.",
+    "backCta": "← Späť do generátora",
+    "browseCta": "Prechádzať štýly",
+    "wallTitle": "404 prepísané každým spôsobom, ktorý poznáme.",
+    "wallSubtitle": "Každý štýl nižšie vzniká v tom istom engine, ktorý poháňa celý UltraTextGen.",
+    "playgroundTitle": "Vyskúšaj svoj chýbajúci text.",
+    "playgroundSubtitle": "Napíš čokoľvek a pozri sa na to v pár štýloch Ultra, než sa vrátiš do plného generátora.",
+    "playgroundPlaceholder": "Napíš text...",
+    "fullGeneratorCta": "Otvoriť plný generátor",
+    "copy": "Kopírovať",
+    "copied": "Skopírované"
+  }
+}

--- a/locales/sr.json
+++ b/locales/sr.json
@@ -1,0 +1,202 @@
+{
+  "meta": {
+    "title": "Lepi Fontovi i Stilizovana Slova za Kopiranje — Slova za Instagram, TikTok i Nadimke",
+    "description": "Generator lepih fontova, estetskih slova i stilizovanog teksta za kopiranje. Podebljano, kurziv, gotica, balončasta, Zalgo i simboli — nalepi u instagram bio, u opis na TikToku, u nadimak u igri ili na Discord. Besplatno, bez naloga."
+  },
+  "hero": {
+    "title": "Lepi Fontovi i Stilizovana Slova za Kopiranje",
+    "subtitle": "Upiši tekst, odaberi stil — podebljano, kurziv, gotica, balončasta ili sa ukrasima. Ubaci u instagram bio, u nadimak u igri, u WhatsApp status ili u opis pod TikTokom. Bez aplikacije, bez prijave."
+  },
+  "decorations": {
+    "label": "Dodaj ukrase tekstu",
+    "tabs": {
+      "symbols": "Simboli",
+      "frames": "Okviri",
+      "dividers": "Razdelnici",
+      "arrows": "Strelice",
+      "minimal": "Minimalni",
+      "emojis": "Emoji",
+      "flags": "Zastave"
+    }
+  },
+  "ui": {
+    "placeholder": "Upiši tekst...",
+    "advertisement": "Oglas"
+  },
+  "useCases": {
+    "title": "Za šta ljudi ovo najčešće koriste",
+    "viewAll": "Pogledaj više primena →",
+    "items": [
+      {
+        "title": "Naslov na LinkedInu",
+        "description": "Istakni se u pretrazi na LinkedInu — podebljan ili blago ukrašen naslov odradi svoje pre nego što neko stigne da skroluje dalje."
+      },
+      {
+        "title": "Komentari ispod objava",
+        "description": "Stilizovani komentari na Instagramu, YouTubeu i TikToku — lakše ih je uočiti nego stotine običnih ispod popularne objave."
+      },
+      {
+        "title": "Tekst ispisan u emojijima",
+        "description": "Pretvori natpis u niz slova od emojija — kreativan bio, story, grupni chat ili čisto za zezanje sa prijateljima."
+      }
+    ]
+  },
+  "guides": {
+    "title": "Svrati na vodiče",
+    "viewAll": "Svi vodiči →",
+    "items": [
+      {
+        "title": "Retorika fontova",
+        "description": "Zašto jedan font budi poverenje, a drugi izgleda kao spam — odnosno kako tipografija utiče na ono što osećamo dok čitamo."
+      },
+      {
+        "title": "Osobni brend kroz tipografiju",
+        "description": "Kako odabrati slova koja odgovaraju tvom vibeu i ostaju u pamćenju — bilo da je reč o LinkedInu, Instagramu ili Discordu."
+      },
+      {
+        "title": "Zaustavi skrolovanje igrom fontova",
+        "description": "Zašto se ljudi zaustavljaju kod objava s drugačijim stilom teksta i kako to iskoristiti da podigneš doseg."
+      }
+    ]
+  },
+  "faq": {
+    "categories": [
+      {
+        "title": "Prva pitanja",
+        "items": [
+          {
+            "question": "Šta je UltraTextGen i šta se tu zapravo dešava?",
+            "answer": "To je besplatan generator slova — upišeš običan tekst, a mi ga pretvaramo u stilizovane Unicode znakove koji izgledaju kao lep font.\n    <br><br>\n    Najvažnije: to su <strong>pravi znakovi</strong>, a ne podebljanje iz Worda ni markdown sa Discorda. Zato rade svuda gde se može upisati običan tekst — u instagram bio, u nadimak, u komentar, u mejl, u WhatsApp status.\n    <br><br>\n    <strong>Primer</strong><br>\n    Upišeš „bok\" → dobiješ 𝗯𝗼𝗸 (podebljano), 𝘣𝘰𝘬 (kurziv), 𝒷ℴ𝓀 (kaligrafija) ili ⓑⓞⓚ (balončasta). Sve jednim klikom."
+          },
+          {
+            "question": "Kako kopirati lepa slova u 5 sekundi?",
+            "answer": "1. Upišeš ili nalepiš tekst u polje na vrhu.<br>\n    2. Stilovi se pojave odmah ispod — bold, kurziv, gotica, balončasta i još desetak drugih.<br>\n    3. Ako želiš, dodaj ukrase — okvire, zvezdice, strelice.<br>\n    4. Klikneš „Kopiraj\" kod onog koji ti odgovara i nalepiš gde god želiš.\n    <br><br>\n    To je to. Bez registracije, bez instaliranja aplikacije. Radi jednako na računaru i na telefonu."
+          },
+          {
+            "question": "Besplatno? Bez ograničenja, bez naloga?",
+            "answer": "Da, sve je <strong>100% besplatno</strong>. Bez naloga, bez dnevnog ograničenja, bez vodenih žigova, bez kvake. Možeš kroz to da propustiš celu knjigu i ništa se neće desiti."
+          }
+        ]
+      },
+      {
+        "title": "Instagram, TikTok, Discord — gde to nalepiti",
+        "items": [
+          {
+            "question": "Kako ubaciti stilizovani tekst u bio na Instagramu?",
+            "answer": "Instagram nema nikakvu alatnu traku za oblikovanje, ali prihvata Unicode — dakle sve što ovde generišeš uredno uleti u bio.\n    <br><br>\n    <strong>Kako to napraviti</strong><br>\n    1. Upiši ono što želiš u biju (npr. ime, hashtag, kratak opis).<br>\n    2. Odaberi stil — podebljano i kurziv rade najbolje na većini uređaja.<br>\n    3. Kopiraj rezultat i nalepi u „Uredi profil → Bio\" u aplikaciji.\n    <br><br>\n    Savet: ako želiš da ukrasiš, dodaj okvir tipa ⋆｡˚ ili zvezdicu ✦ sa strane — izgleda dobro, a ne krade pažnju ostatku bija."
+          },
+          {
+            "question": "Rade li slova u opisima na TikToku?",
+            "answer": "Da — TikTok prikazuje Unicode u opisima, opisima profila i komentarima. Najbolje se pokažu <strong>podebljano</strong>, <strong>kurziv</strong>, <strong>balončasta</strong> i <strong>kapitalke</strong>. Stilovi sa puno ukrasa znaju da se odrežu kod dugih opisa, pa za svaki slučaj proveri objavu u pregledu pre objavljivanja."
+          },
+          {
+            "question": "Može li se napraviti nadimak za igru ili za Discord?",
+            "answer": "Naravno — to je verovatno najčešći razlog zbog kojeg ljudi dolaze na ovakve generatore. Discord, Roblox, Steam, Minecraft, većina igara prihvata Unicode u nadimcima.\n    <br><br>\n    <strong>Primer</strong><br>\n    Obični nadimak: „DarkWolf\"<br>\n    Nakon stilizovanja: „𝔇𝔞𝔯𝔨𝔚𝔬𝔩𝔣\" (gotica), „ⒹⓐⓡⓚⓌⓞⓛⓕ\" (balončasta) ili „๖ۣۜDarkWolf\" (sa ukrasom sa strane).\n    <br><br>\n    <strong>Napomena:</strong> neke igre imaju filtre i neće primiti egzotične znakove. Ako jedan stil ne prolazi, uzmi drugi — bold i kurziv obično prolaze svuda."
+          },
+          {
+            "question": "Radi li u WhatsApp statusu, na Telegramu i u Messengeru?",
+            "answer": "Da — WhatsApp, Telegram, Messenger, Signal, iMessage. Sve što prima običan tekst prima i Unicode slova. Nalepiš u status ili u poruku i izgleda kao ukrasan font.\n    <br><br>\n    Za WhatsApp dodajem: ako ti treba samo podebljanje, možeš da koristiš njihovu sopstvenu sintaksu (`*tekst*` daje bold). Ali Unicode radi svuda — i onde gde ga WhatsApp ne podržava, npr. u imenu kontakta."
+          },
+          {
+            "question": "A u naslovu mejla ili u biografiji?",
+            "answer": "Tu Unicode odradi najviše. Naslov mejla je običan tekst, pa podebljanje iz Outlooka otpada. Ali „𝗥𝗮č𝘂𝗻 — 𝗵𝗶𝘁𝗻𝗼\" već izgleda snažnije u sandučiću primaoca.\n    <br><br>\n    U biografiji blago podebljano ime u zaglavlju zna da privuče pogled poslodavca. Samo nemoj da preteruješ — cela biografija u gotici ne izgleda profesionalno."
+          }
+        ]
+      },
+      {
+        "title": "Stilovi, slova i ukrasi",
+        "items": [
+          {
+            "question": "Koje stilove slova imam na izbor?",
+            "answer": "Puno. Zaista puno. Ukratko:\n    <br><br>\n    <strong>Osnovni</strong><br>\n    Podebljano (bold), kurziv, kaligrafija (script), gotica, balončasta (u kružićima), kapitalke, precrtano, podcrtano, double struck.\n    <br><br>\n    <strong>Zabavni</strong><br>\n    Tekst naopako, ogledalno, Zalgo (glitch sa crticama nad slovima), tekst u kvadratićima, u zagradama, fullwidth (razmaknuti).\n    <br><br>\n    <strong>Dodaci</strong><br>\n    Okviri oko teksta, zvezdice, srca, strelice, razdelnici, zastave, emoji — sve to možeš da nasloniš na stil slova.\n    <br><br>\n    S vremena na vreme dolaze novi — vredi dodati stranicu u obeleživače."
+          },
+          {
+            "question": "Mogu li spojiti više stilova odjednom?",
+            "answer": "Da — i to je najveća prednost UltraTextGena. Možeš da nasloniš npr. <strong>balončasta + Zalgo</strong>, <strong>gotica + naopako</strong> ili <strong>kapitalke + podcrtano</strong>, a onda sve to da zatvoriš u okvir ili zvezdicu.\n    <br><br>\n    <strong>Primer</strong><br>\n    „bok\" → odabereš goticu → dodaš okvir sa zvezdicama → izađe: ★彡[ 𝔟𝔬𝔨 ]彡★\n    <br><br>\n    Što više eksperimentišeš, to zanimljivije stvari izlaze. Preporučujem da kreneš sa jednim stilom i dodaš jedan ukras — ne sve odjednom."
+          },
+          {
+            "question": "Šta je Zalgo i te čudne crtice nad slovima?",
+            "answer": "Zalgo je onakav „ukleti\", glitchani stil — nad i pod svakim slovom naleti gomila dijakritičkih znakova. Izgleda kao da se tekst raspada ili kao da je iz horora.\n    <br><br>\n    <strong>Primer</strong><br>\n    „bok\" → b̷̢o̴̢k̷̛\n    <br><br>\n    Najčešće to viđaš u mračnim biojevima na Instagramu, u halloweenskim memovima, u gaming klanovima koji žele da izgledaju opasno ili kad neko od toga pravi foru."
+          },
+          {
+            "question": "Odakle uzeti lepe simbole, zvezdice i srca?",
+            "answer": "Sve što imaš u odeljku „Ukrasi\" ispod tekstualnog polja možeš kopirati zasebno — čak i bez upisivanja teksta. Naprosto kao zasebne znakove za bio, nadimak ili objavu.\n    <br><br>\n    — <strong>Estetski simboli</strong>: ✦ ✧ ⋆ ｡ ☆ ♡ ❀ ✿<br>\n    — <strong>Okviri i obrubi</strong>: ╭─▸ │ ╰─▸ ili ★彡[ ]彡★<br>\n    — <strong>Strelice</strong>: → ⇨ ➤ ⟶<br>\n    — <strong>Minimalni razdelnici</strong>: ·  ⋅  ─  •<br>\n    — <strong>Zastave i emoji</strong>.\n    <br><br>\n    Najčešće se koriste u estetskim biojevima na Instagramu i Pinterestu — pašu uz sve, od citata do spiska interesovanja."
+          }
+        ]
+      },
+      {
+        "title": "Srpski znakovi, kompatibilnost, problemi",
+        "items": [
+          {
+            "question": "A srpski znakovi? Radi li sa č, ć, đ, š, ž?",
+            "answer": "<strong>Ukratko:</strong> zavisi od stila.\n    <br><br>\n    Unicode ima stilizovane varijante za osnovnu abecedu A–Z, pa se <em>c</em>, <em>s</em>, <em>z</em> bez problema pretvore npr. u podebljano. Ali za <em>č</em>, <em>ć</em>, <em>đ</em>, <em>š</em>, <em>ž</em> stilizovane verzije postoje samo u delu stilova (uglavnom bold, kurziv, kapitalke).\n    <br><br>\n    Ako stil nema verziju za srpski znak, on ostaje u izvornom obliku — tekst je i dalje čitljiv, srpsko slovo naprosto izgleda „običnije\" od ostatka. Za nadimke bez kvačica to nije nikakav problem. Za cele rečenice na srpskom preporučujem <strong>bold</strong>, <strong>kurziv</strong> ili <strong>monospace</strong> — oni se najbolje snalaze sa našom abecedom. Napomena i za digrafe: dž, lj i nj su samo dva obična slova jedno do drugog, pa se svako stilizuje zasebno."
+          },
+          {
+            "question": "Zašto se nekome prikazuju kvadratići umesto slova?",
+            "answer": "Zato što sistemski font na strani primaoca ne sadrži zadati Unicode znak. To nije problem sa tvojim tekstom — naprosto njegov telefon ili aplikacija nema taj konkretni znak u kompletu.\n    <br><br>\n    Drži se <strong>bolda</strong>, <strong>kurziva</strong> i <strong>balončaste</strong> — imaju najširu podršku. Vrlo egzotični stilovi (fullwidth, kvadratići) mogu da se prikažu kao □ na starijim Androidima ili u nekim mejl klijentima."
+          },
+          {
+            "question": "Instagram mi je izrezao deo znakova u nadimku — šta sad?",
+            "answer": "Instagram ima filter na polju <strong>korisničko ime</strong> (dakle @login) — prima samo slova, brojke, tačke i podvlake. Tu stilizovana slova ne možeš da nalepiš.\n    <br><br>\n    Ali u polju <strong>„Ime\"</strong> (prikazano ime) i u <strong>biju</strong> može — i tu prolazi većina stilova. Ako se jedan ne sačuva, uzmi drugi. Bold obično prolazi bez problema."
+          },
+          {
+            "question": "Postoje li znakovi koji se uopšte ne mogu pretvoriti?",
+            "answer": "Standardna slova (A–Z, a–z), brojke i osnovni interpunkcijski znakovi pretvaraju se bez problema. Neki retki simboli ili posebni znakovi nemaju stilizovane parnjake u Unicodeu — tada ostaju u izvorniku. Ništa se ne kvari, tekst je i dalje za kopiranje."
+          }
+        ]
+      },
+      {
+        "title": "Sigurnost, privatnost, telefon",
+        "items": [
+          {
+            "question": "Čuva li se moj tekst negde?",
+            "answer": "Ne. Cela pretvorba slova dešava se <strong>u tvom pregledaču</strong> — ništa ne ide na naše servere, ništa se ne čuva, ništa se ne prati. Kopirani tekst je čisti Unicode, bez skrivenih znakova, bez ikakvih identifikatora."
+          },
+          {
+            "question": "Je li sigurno lepiti ova slova bilo gde?",
+            "answer": "Da — to su standardni Unicode znakovi, isti kakve koristi ceo internet. Ništa unutra, bez skripti, bez skrivenog oblikovanja, bez kodova. Slobodno lepi u biografiju, u poslovni mejl, u bio na LinkedInu — gde god želiš."
+          },
+          {
+            "question": "Radi li na telefonu?",
+            "answer": "Da — stranica se u potpunosti prilagođava telefonu. iPhone, Android, tablet — sve štima. Upišeš tekst, klikneš, kopira se u privremenu memoriju, nalepiš u aplikaciji. Bez instaliranja ičega iz prodavnice."
+          }
+        ]
+      },
+      {
+        "title": "Po čemu se razlikujemo",
+        "items": [
+          {
+            "question": "Po čemu se razlikujete od drugih generatora slova?",
+            "answer": "Konkretno:\n    <br><br>\n    — <strong>Jedna od većih kolekcija</strong> Ultra stilova — bold, kurziv, gotica, balončasta i još desetak drugih.<br>\n    — <strong>Spajanje stilova</strong> — većina generatora daje ti jedan stil odjednom, mi dozvoljavamo naslanjanje.<br>\n    — <strong>Ukrasi jednim klikom</strong> — okviri, zvezdice, razdelnici bez lepljenja znak po znak.<br>\n    — <strong>Stranice za konkretne platforme</strong> — Instagram, TikTok, Discord. Onde prikazujemo samo stilove koji na toj aplikaciji rade.<br>\n    — <strong>Brzo i bez iskačućih prozora</strong> — bez captcha, bez „prihvati sve\" pre svakog klika."
+          },
+          {
+            "question": "Dolaze li novi stilovi?",
+            "answer": "Da, redovno. S vremena na vreme upadnu nove varijante, ukrasi i okviri. Najlakše je zapamtiti stranicu ili svratiti povremeno."
+          },
+          {
+            "question": "Kako pronaći tačno onaj stil koji tražim?",
+            "answer": "Tri puta:\n    <br><br>\n    <strong>Po stilu</strong> — kategorije na vrhu: bold, kurziv, gotica, balončasta, precrtano, naopako i još.<br>\n    <strong>Po platformi</strong> — svrati na podstranicu za Instagram, TikTok, Discord — onde su samo stilovi koji se na toj platformi pokažu.<br>\n    <strong>Po cilju</strong> — odeljak s primenama ima alate prilagođene konkretnoj potrebi: naslov na LinkedInu, komentari, tekst sa emojijima."
+          }
+        ]
+      }
+    ]
+  },
+  "footer": {
+    "copyright": "© 2026 UltraTextGen. Lepa slova koja rade svuda."
+  },
+  "notFound": {
+    "eyebrow": "GREŠKA · 404 · NEDOSTAJE PRIMERAK",
+    "title": "Ova je stranica ispala iz kolekcije stilova.",
+    "subtitle": "Adresa koju si otvorio ne odgovara ničemu u našoj kolekciji. Ali greška i dalje radi kao tekst — pogledaj „404\" u Ultra Boldu, Balončastoj, Gotici, Zalgu i još.",
+    "backCta": "← Nazad na generator",
+    "browseCta": "Pregledaj stilove",
+    "wallTitle": "404, prerađen na svaki način koji poznajemo.",
+    "wallSubtitle": "Svaki stil ispod prolazi kroz isti pogon kao i ostatak UltraTextGena.",
+    "playgroundTitle": "Isprobaj svoj tekst koji nedostaje.",
+    "playgroundSubtitle": "Upiši bilo šta i vidi u nekoliko Ultra stilova pre nego što se vratiš na potpuni generator.",
+    "playgroundPlaceholder": "Upiši tekst...",
+    "fullGeneratorCta": "Otvori potpuni generator",
+    "copy": "Kopiraj",
+    "copied": "Kopirano"
+  }
+}

--- a/ro/fonturi-pentru-discord/index.html
+++ b/ro/fonturi-pentru-discord/index.html
@@ -1,0 +1,303 @@
+<!DOCTYPE html><html lang="ro"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Fonturi Discord: Litere pentru Nickname și Bio (Fără Nitro) | UltraTextGen</title>
+  <meta name="description" content="Fonturi pentru Discord gratuit: transformă-ți numele în 𝗶̂𝗻𝗴𝗿𝗼𝘀̦𝗮𝘁, 𝓬𝓾𝓻𝓼𝓲𝓿 sau 𝔤𝔬𝔱𝔦𝔠 și lipește-l în nickname, în secțiunea „Despre mine” și pe chat. Fonturi pentru Discord fără Nitro.">
+  <link rel="canonical" href="https://ultratextgen.com/ro/fonturi-pentru-discord/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/discord/">
+  <link rel="alternate" hreflang="ro" href="https://ultratextgen.com/ro/fonturi-pentru-discord/">
+  <link rel="alternate" hreflang="ro-MD" href="https://ultratextgen.com/ro/fonturi-pentru-discord/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/discord/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Fonturi Discord: Litere pentru Nickname și Bio (Fără Nitro)">
+  <meta property="og:description" content="Generator de fonturi pentru Discord: scrie-ți numele și lipește o literă stilizată în nickname, în „Despre mine”, în numele canalului și în status. Îngroșat, cursiv și gotic — fără Nitro.">
+  <meta property="og:url" content="https://ultratextgen.com/ro/fonturi-pentru-discord/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/pl-czcionki-discord.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Fonturi Discord: Litere pentru Nickname și Bio (Fără Nitro)">
+  <meta name="twitter:description" content="Îngroșat, cursiv, gotic și bubble gata de lipit în nickname și „Despre mine” pe Discord — fără Nitro.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/pl-czcionki-discord.png">
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+  <link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Generator de Fonturi pentru Discord",
+  "alternateName": ["Fonturi Discord", "Fonturi pentru Discord", "Litere pentru Discord", "Generator de Nickname pentru Discord"],
+  "url": "https://ultratextgen.com/ro/fonturi-pentru-discord/",
+  "inLanguage": "ro",
+  "applicationCategory": "UtilitiesApplication",
+  "operatingSystem": "Any",
+  "description": "Generator de fonturi pentru Discord: transformă-ți numele în litere stilizate — îngroșate, cursive, gotice, bubble, elegante și small caps — de lipit în nickname, în „Despre mine”, în numele canalului și în status, fără să ai nevoie de Nitro.",
+  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "RON" }
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "ro",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Cum schimb fontul în nickname pe Discord?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Scrie-ți numele în câmpul din partea de sus a paginii. Apar imediat zeci de fonturi pentru Discord — îngroșate, cursive, gotice, bubble, small caps. Apasă „Copiază” la cel care îți place, deschide Discord, intră în Setările utilizatorului și lipește-l în numele afișat, sau dă click dreapta pe server și schimbă-ți porecla pe acel server. Fiind caractere Unicode, litera stilizată intră în câmp fără nicio extensie." }
+    },
+    {
+      "@type": "Question",
+      "name": "Ai nevoie de Nitro pentru fonturile de pe Discord?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Nu. Literele din acest generator sunt caractere Unicode obișnuite, la fel ca de la tastatură, doar cu alt aspect — de aceea se lipesc în numele afișat, în porecla de pe server, în secțiunea „Despre mine”, în numele canalului și în mesaje fără niciun Nitro. Nitro e necesar doar pentru extra-uri plătite, cum ar fi culorile și gradientul din nume (Display Name Styles), nu pentru textul stilizat în sine." }
+    },
+    {
+      "@type": "Question",
+      "name": "Funcționează fonturile în numele de utilizator (@) pe Discord?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Nu. Numele de utilizator (@-ul unic folosit pentru invitații de prieteni) acceptă doar litere mici de la a la z, cifre, punct și underscore — niciun font stilizat, spații, emoji sau simboluri. Fonturile pentru Discord funcționează în numele afișat, în porecla de server, în secțiunea „Despre mine”, în numele canalului și pe chat. Dacă vrei stil în nume, folosește numele afișat, nu login-ul @." }
+    },
+    {
+      "@type": "Question",
+      "name": "Prin ce se deosebește formatarea Discord (**îngroșat**) de fonturile Unicode?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Sunt două lucruri diferite. Markdown-ul Discord (**îngroșat**, *cursiv*, `cod`) formatează textul doar în interiorul mesajelor de pe chat și dispare când încerci să-l folosești în nume sau în bio. Fonturile Unicode de pe această pagină sunt chiar caracterul stilizat, deci funcționează peste tot — în nickname, în „Despre mine”, în numele canalului, în status și pe chat. Regulă practică: într-un mesaj obișnuit folosește Markdown, iar ca să stilizezi nickname-ul sau bio-ul, folosește fontul Unicode." }
+    },
+    {
+      "@type": "Question",
+      "name": "Cum fac un nickname ornamentat pe Discord cu rame și simboluri?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Alege un font pentru nume (goticul și bubble ies cel mai bine) și înconjoară-l cu rame și simboluri în stilul ꧁༒ ༒꧂. Pe această pagină e o grilă de nickname-uri gata făcute cu rame — dă click ca să copiezi și lipește în porecla de pe server. Poți și să-ți scrii numele sus, să-i pui un font și să folosești filele Simboluri și Rame ca să reglezi aspectul înainte de copiere." }
+    },
+    {
+      "@type": "Question",
+      "name": "De ce se afișează literele pe Discord ca pătrățele?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Pentru că dispozitivul persoanei care se uită nu are fontul care desenează caracterul respectiv — de obicei un telefon sau un calculator mai vechi. Nu e o eroare a paginii sau a copierii tale. Stilurile de bază — îngroșate, cursive, gotice, bubble și small caps — sunt cele mai sigure și se afișează corect aproape peste tot. Dacă cineva raportează un pătrățel (□), schimbă la unul dintre aceste stiluri." }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "inLanguage": "ro",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Acasă", "item": "https://ultratextgen.com/ro/" },
+    { "@type": "ListItem", "position": 2, "name": "Fonturi Discord", "item": "https://ultratextgen.com/ro/fonturi-pentru-discord/" }
+  ]
+}
+</script>
+</head>
+<body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<script src="/header.js"></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/ro/">Acasă</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Fonturi Discord</span>
+</nav>
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pl-czcionki-discord.svg" width="1200" height="340" loading="lazy" alt="">
+</figure>
+
+<section class="hero">
+  <div class="hero-inner">
+    <div class="hero-card">
+      <h1 class="hero-headline">Fonturi Discord: litere pentru nickname și bio</h1>
+      <p class="hero-tagline">Scrie-ți numele și vezi-l imediat în zeci de fonturi pentru Discord — îngroșate, cursive, gotice, bubble și small caps. Copiezi și lipești în nickname, în porecla de server, în secțiunea „Despre mine”, în numele canalului și pe chat. Totul gratuit și <strong>fără Nitro</strong>.</p>
+      <div class="input-wrapper">
+        <textarea class="main-input" id="mainInput" placeholder="Scrie un nume sau text..." maxlength="500" autofocus=""></textarea>
+        <span class="char-count"><span id="charCount">0</span>/500</span>
+      </div>
+      <div class="decoration-section">
+        <div class="decoration-label">Adaugă simboluri și rame la rezultat</div>
+        <div class="decoration-tabs">
+          <button class="decoration-tab active" data-deco-tab="symbols">Simboluri</button>
+          <button class="decoration-tab" data-deco-tab="frames">Rame</button>
+          <button class="decoration-tab" data-deco-tab="dividers">Separatoare</button>
+          <button class="decoration-tab" data-deco-tab="arrows">Săgeți</button>
+          <button class="decoration-tab" data-deco-tab="minimal">Minimale</button>
+          <button class="decoration-tab" data-deco-tab="emojis">Emoji</button>
+        </div>
+        <div class="decoration-grid" id="decorationGrid"></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<main class="container">
+  <div class="category-section"><div class="category-tabs" id="categoryTabs"></div></div>
+  <div class="results-grid" id="resultsGrid"></div>
+
+  <!-- Cum funcționează -->
+  <section class="editorial-section">
+    <h2>Fonturi pentru Discord: cum funcționează</h2>
+    <p class="editorial-intro"><strong>Fonturile pentru Discord</strong> de pe pagina asta nu sunt un font instalat sau o imagine — sunt <strong>caractere Unicode</strong>, litere reale, la fel ca de la tastatură, doar cu alt aspect (𝗔, 𝘈, 𝓐, 𝔄). Fiindcă Discord acceptă Unicode în aproape orice câmp de text, litera stilizată se lipește direct în <strong>numele afișat</strong>, în <strong>porecla de server</strong>, în secțiunea <strong>„Despre mine”</strong>, în <strong>numele canalului</strong>, în <strong>status</strong> și chiar în <strong>mesaje</strong> — fără Nitro, extensie sau aplicație suplimentară.</p>
+    <div class="block-example">
+      <strong>Exemplu:</strong> „andrei” → 𝗮𝗻𝗱𝗿𝗲𝗶 (îngroșat), 𝘢𝘯𝘥𝘳𝘦𝘪 (cursiv), 𝓪𝓷𝓭𝓻𝓮𝓲 (cursiv ornamentat), 𝔞𝔫𝔡𝔯𝔢𝔦 (gotic), ⓐⓝⓓⓡⓔⓘ (bubble), ᴀɴᴅʀᴇɪ (small caps)
+    </div>
+    <p>Se folosește în câteva secunde: scrii numele în câmpul de sus, generatorul arată același text în mai multe <strong>fonturi pentru Discord</strong>, apeși „Copiază” și lipești în aplicație. Vrei doar literele brute ale alfabetului? Sunt chiar dedesubt. Iar dacă preferi să răsfoiești și mai multe tipuri de litere, generatorul complet îl găsești pe pagina cu <a href="/ro/">litere de copiat</a>.</p>
+  </section>
+
+  <!-- Alfabet A-Z -->
+  <section class="editorial-section glyph-section">
+    <h2>Alfabetul fonturilor pentru Discord (A–Z de copiat)</h2>
+    <p class="editorial-intro">Tot alfabetul în stilurile care apar cel mai des în nickname-uri și bio pe Discord. Dă click pe un rând ca să copiezi tot abecedarul în stilul respectiv, sau scrie-ți numele sus și ia-ți propriul cuvânt gata stilizat.</p>
+    <div class="alpha-list">
+      <div class="alpha-row">
+        <span class="alpha-label">Îngroșate</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝗔𝗕𝗖𝗗𝗘𝗙𝗚𝗛𝗜𝗝𝗞𝗟𝗠𝗡𝗢𝗣𝗤𝗥𝗦𝗧𝗨𝗩𝗪𝗫𝗬𝗭 𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇" aria-label="Copiază alfabetul îngroșat">𝗔𝗕𝗖𝗗𝗘𝗙𝗚𝗛𝗜𝗝𝗞𝗟𝗠𝗡𝗢𝗣𝗤𝗥𝗦𝗧𝗨𝗩𝗪𝗫𝗬𝗭 · 𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Cursive</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩 𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃" aria-label="Copiază alfabetul cursiv">𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩 · 𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Elegante</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵 𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏" aria-label="Copiază alfabetul elegant">𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵 · 𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Gotice</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝔄𝔅ℭ𝔇𝔈𝔉𝔊ℌℑ𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔ℜ𝔖𝔗𝔘𝔙𝔚𝔛𝔜ℨ 𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷" aria-label="Copiază alfabetul gotic">𝔄𝔅ℭ𝔇𝔈𝔉𝔊ℌℑ𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔ℜ𝔖𝔗𝔘𝔙𝔚𝔛𝔜ℨ · 𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Bubble</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ" aria-label="Copiază alfabetul bubble">ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ · ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Small caps</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="ᴀʙᴄᴅᴇꜰɢʜɪᴊᴋʟᴍɴᴏᴘqʀsᴛᴜᴠᴡxʏᴢ" aria-label="Copiază alfabetul în small caps">ᴀ ʙ ᴄ ᴅ ᴇ ꜰ ɢ ʜ ɪ ᴊ ᴋ ʟ ᴍ ɴ ᴏ ᴘ q ʀ s ᴛ ᴜ ᴠ ᴡ x ʏ ᴢ</button>
+      </div>
+    </div>
+    <p class="uname-note">Notă despre diacriticele românești: aceste fonturi Unicode acoperă alfabetul de bază A–Z. Diacriticele românești (ă, â, î, ș, ț) rămân în majoritatea stilurilor litere obișnuite în mijlocul cuvântului stilizat — de aceea, de ex. „ștefan” iese ca ș𝓽𝓮𝓯𝓪𝓷. Pentru nickname-uri fără diacritice arată perfect, iar pentru texte mai lungi cele mai sigure sunt îngroșatul și cursivul.</p>
+    <p class="u-mt-15">Vrei să te adâncești într-un singur stil? Alfabetul complet și variantele fiecărui tip de literă le găsești pe pagina cu <a href="/ro/">litere de copiat</a>, iar steluțe și rame pentru nickname — în <a href="/library/aesthetic-symbols/">ornamente</a>.</p>
+  </section>
+
+  <!-- Fonturi pentru nickname și Despre mine -->
+  <section class="editorial-section">
+    <h2>Fonturi pentru nickname și secțiunea „Despre mine” pe Discord</h2>
+    <p class="editorial-intro">Cel mai rapid mod de a-ți scoate în evidență profilul e să pui un font pe <strong>numele afișat</strong> și o combinație separată în secțiunea <strong>„Despre mine”</strong> (bio-ul profilului). Discord acceptă Unicode în ambele câmpuri — și, în plus, poți avea <strong>o altă poreclă pe fiecare server</strong>, așa că pe serverul de gaming folosești gotic, iar pe serverul cu prietenii cursiv, totul sub același cont.</p>
+    <p class="uname-note">Cum lipești:</p>
+    <div class="block-example">
+      — <strong>Numele afișat:</strong> Setările utilizatorului › Profil › editează numele afișat și lipește fontul<br>
+      — <strong>Porecla de server:</strong> click dreapta pe numele tău de pe server › Editează profilul de server › lipește porecla stilizată<br>
+      — <strong>„Despre mine”:</strong> Setările utilizatorului › Profil › câmpul „Despre mine” › lipește textul<br>
+      — <strong>Numele canalului:</strong> dacă ești administrator, editează canalul și lipește fontul în nume
+    </div>
+    <p>Un sfat de la cineva care compune profiluri zilnic: stilizează doar numele, iar restul din „Despre mine” lasă-l cu text obișnuit — contrastul face tot efectul. Când totul e ornamentat, nimic nu atrage privirea. Pentru steluțe și sclipici de pus în bio, aruncă un ochi pe pagina cu <a href="/library/aesthetic-symbols/">ornamente de copiat</a>.</p>
+  </section>
+
+  <!-- Markdown vs Unicode -->
+  <section class="editorial-section">
+    <h2>Markdown-ul Discord vs fonturile Unicode — când folosești fiecare</h2>
+    <p class="editorial-intro">Discord are <strong>două moduri</strong> de a te juca cu textul și merită să nu le confunzi. Unul e <strong>formatarea Markdown</strong> nativă, celălalt sunt <strong>fonturile Unicode</strong> de pe această pagină. Servesc la lucruri diferite.</p>
+    <div class="block-example">
+      — <strong>Markdown (nativ):</strong> <code>**îngroșat**</code> → <strong>îngroșat</strong>, <code>*cursiv*</code> → <em>cursiv</em>, <code>__subliniat__</code>, <code>~~tăiat~~</code>, <code>`cod`</code>. Funcționează doar <strong>în interiorul mesajelor</strong> de pe chat și dispare când încerci în nume sau în bio.<br>
+      — <strong>Fonturi Unicode (această pagină):</strong> 𝗶̂𝗻𝗴𝗿𝗼𝘀̦𝗮𝘁, 𝓬𝓾𝓻𝓼𝓲𝓿, 𝔤𝔬𝔱𝔦𝔠. Sunt chiar caracterul stilizat, deci funcționează <strong>peste tot</strong> — în nickname, în „Despre mine”, în numele canalului, în status și pe chat.
+    </div>
+    <p>Regulă practică: ca să formatezi un <strong>mesaj</strong> obișnuit (să îngroși un cuvânt în mijlocul propoziției), folosește Markdown-ul Discord — e mai curat. Ca să stilizezi <strong>nickname-ul, bio-ul sau numele canalului</strong>, folosește fontul Unicode, pentru că acolo Markdown-ul nu funcționează. Și un avertisment important: nimic din toate astea nu merge în <strong>numele de utilizator (@)</strong>, care acceptă doar litere mici de la a la z, cifre, punct și underscore — niciun font, spațiu sau emoji. Dacă vrei stil în nume, câmpul potrivit e numele afișat, nu login-ul @.</p>
+  </section>
+
+  <!-- Nickname-uri ornamentate cu rame -->
+  <section class="editorial-section">
+    <h2>Nickname-uri ornamentate pentru Discord cu rame și simboluri</h2>
+    <p class="editorial-intro">Nickname-urile care impresionează cel mai mult pe Discord combină un font puternic (gotic sau bubble) cu rame și simboluri de ambele părți, în stilul ꧁༒ ༒꧂. Dă click ca să copiezi și lipește în porecla de pe server — apoi înlocuiește cu numele tău.</p>
+    <div class="uname-grid">
+      <button class="uname-chip symbol-tile" data-symbol="꧁༒𝕯𝖆𝖗𝖐༒꧂" aria-label="Copiază nickname-ul">꧁༒𝕯𝖆𝖗𝖐༒꧂</button>
+      <button class="uname-chip symbol-tile" data-symbol="꧁༒𝕶𝖆𝖈𝖕𝖊𝖗༒꧂" aria-label="Copiază nickname-ul">꧁༒𝕶𝖆𝖈𝖕𝖊𝖗༒꧂</button>
+      <button class="uname-chip symbol-tile" data-symbol="★彡ᴋᴜʙᴀ彡★" aria-label="Copiază nickname-ul">★彡ᴋᴜʙᴀ彡★</button>
+      <button class="uname-chip symbol-tile" data-symbol="⋆˚࿔ 𝓏𝓊𝓏𝒾𝒶 𝜗𝜚˚⋆" aria-label="Copiază nickname-ul">⋆˚࿔ 𝓏𝓊𝓏𝒾𝒶 𝜗𝜚˚⋆</button>
+      <button class="uname-chip symbol-tile" data-symbol="꧁✿𝓞𝓵𝓪✿꧂" aria-label="Copiază nickname-ul">꧁✿𝓞𝓵𝓪✿꧂</button>
+      <button class="uname-chip symbol-tile" data-symbol="✧˖°𝕁𝕦𝕝𝕚𝕒°˖✧" aria-label="Copiază nickname-ul">✧˖°𝕁𝕦𝕝𝕚𝕒°˖✧</button>
+      <button class="uname-chip symbol-tile" data-symbol="⛧🖤 𝔩𝔲𝔨𝔞𝔰 🖤⛧" aria-label="Copiază nickname-ul">⛧🖤 𝔩𝔲𝔨𝔞𝔰 🖤⛧</button>
+      <button class="uname-chip symbol-tile" data-symbol="「 ᴍᴀᴛᴇᴜsᴢ 」" aria-label="Copiază nickname-ul">「 ᴍᴀᴛᴇᴜsᴢ 」</button>
+      <button class="uname-chip symbol-tile" data-symbol="༺ 𝕾𝖍𝖆𝖉𝖔𝖜 ༻" aria-label="Copiază nickname-ul">༺ 𝕾𝖍𝖆𝖉𝖔𝖜 ༻</button>
+      <button class="uname-chip symbol-tile" data-symbol="⋆｡˚ⓝⓐⓣⓘⓐ˚｡⋆" aria-label="Copiază nickname-ul">⋆｡˚ⓝⓐⓣⓘⓐ˚｡⋆</button>
+    </div>
+    <p class="u-mt-15">Vrei tot setul de rame, steluțe și separatoare gata făcute ca să-ți compui propriul nickname? Paleta completă e pe pagina cu <a href="/library/aesthetic-symbols/">ornamente de copiat</a> — aceleași semne se lipesc în porecla de server pe Discord.</p>
+  </section>
+
+  <!-- Unde merge + pătrățele -->
+  <section class="editorial-section">
+    <h2>Unde funcționează fonturile pe Discord (și o notă despre pătrățele)</h2>
+    <p class="editorial-intro">Fiindcă ceea ce copiezi e Unicode curat, literele pentru Discord se lipesc practic în orice câmp de text al aplicației:</p>
+    <div class="block-example">
+      — <strong>Numele afișat</strong> și <strong>porecla de server</strong> (separată pe fiecare server)<br>
+      — <strong>„Despre mine”</strong> (bio-ul profilului tău)<br>
+      — <strong>Numele canalului</strong> (dacă ai drepturi de administrator)<br>
+      — <strong>Statusul personalizat</strong> și <strong>mesajele</strong> de pe chat<br>
+      — <strong>Numele serverului</strong> (dacă ești proprietarul lui)
+    </div>
+    <p>Singurul loc unde <strong>nu</strong> funcționează este <strong>numele de utilizator (@)</strong>, limitat intenționat la litere mici, cifre, punct și underscore. În plus, o notă sinceră: dacă dispozitivul persoanei care se uită e foarte vechi, o parte dintre stilurile mai rare se pot afișa ca <strong>pătrățele (□)</strong> — e un font lipsă pe aparatul ei, nu o problemă cu textul tău. Rămânând la stilurile de bază (îngroșate, cursive, gotice, bubble, small caps) asta nu se întâmplă aproape niciodată. Și ține minte: nimic din toate astea nu are nevoie de <strong>Nitro</strong> — Nitro intră doar la culoarea și gradientul din nume, nu la textul stilizat în sine. Pentru linii goale în „Despre mine” e util <a href="/library/invisible-character/">caracterul invizibil</a>.</p>
+  </section>
+
+  <!-- Related -->
+  <section class="editorial-section">
+    <span class="article-section-label">Pagini asociate</span>
+    <div class="compare-grid">
+      <a href="/ro/" class="compare-card variant-muted u-no-underline">
+        <h4>Litere Frumoase</h4>
+        <p>Zeci de stiluri de litere ca să-ți stilizezi numele înainte să-l lipești pe Discord.</p>
+      </a>
+      <a href="/ro/" class="compare-card variant-muted u-no-underline">
+        <h4>Litere de Copiat</h4>
+        <p>Alfabetul complet în mai multe tipuri de litere — bold, cursiv, gotic și bubble.</p>
+      </a>
+      <a href="/library/aesthetic-symbols/" class="compare-card variant-muted u-no-underline">
+        <h4>Ornamente de Copiat</h4>
+        <p>Steluțe, inimioare, rame și separatoare pentru a-ți ornamenta nickname-ul și „Despre mine”.</p>
+      </a>
+      <a href="/library/invisible-character/" class="compare-card variant-muted u-no-underline">
+        <h4>Caracter Invizibil</h4>
+        <p>Un spațiu gol pentru linii curate în bio și nume goale pe Discord.</p>
+      </a>
+    </div>
+  </section>
+</main>
+
+<footer class="footer">
+  <div class="footer-inner">
+    <h2 class="faq-category">Întrebări frecvente despre fonturile pentru Discord</h2>
+    <div class="faq-item"><button class="faq-question" type="button">Cum schimb fontul în nickname pe Discord?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Scrie-ți numele în câmpul din partea de sus a paginii. Apar imediat zeci de fonturi pentru Discord — îngroșate, cursive, gotice, bubble, small caps. Apasă „Copiază” la cel care îți place, deschide Discord, intră în Setările utilizatorului și lipește-l în numele afișat, sau dă click dreapta pe server și schimbă-ți porecla pe acel server. Fiind caractere Unicode, litera stilizată intră în câmp fără nicio extensie.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Ai nevoie de Nitro pentru fonturile de pe Discord?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Nu. Literele din acest generator sunt caractere Unicode obișnuite, la fel ca de la tastatură, doar cu alt aspect — de aceea se lipesc în numele afișat, în porecla de pe server, în secțiunea „Despre mine”, în numele canalului și în mesaje fără niciun Nitro. Nitro e necesar doar pentru extra-uri plătite, cum ar fi culorile și gradientul din nume (Display Name Styles), nu pentru textul stilizat în sine.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Funcționează fonturile în numele de utilizator (@) pe Discord?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Nu. Numele de utilizator (@-ul unic folosit pentru invitații de prieteni) acceptă doar litere mici de la a la z, cifre, punct și underscore — niciun font stilizat, spații, emoji sau simboluri. Fonturile pentru Discord funcționează în numele afișat, în porecla de server, în secțiunea „Despre mine”, în numele canalului și pe chat. Dacă vrei stil în nume, folosește numele afișat, nu login-ul @.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Prin ce se deosebește formatarea Discord (**îngroșat**) de fonturile Unicode?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Sunt două lucruri diferite. Markdown-ul Discord (**îngroșat**, *cursiv*, `cod`) formatează textul doar în interiorul mesajelor de pe chat și dispare când încerci să-l folosești în nume sau în bio. Fonturile Unicode de pe această pagină sunt chiar caracterul stilizat, deci funcționează peste tot — în nickname, în „Despre mine”, în numele canalului, în status și pe chat. Regulă practică: într-un mesaj obișnuit folosește Markdown, iar ca să stilizezi nickname-ul sau bio-ul, folosește fontul Unicode.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Cum fac un nickname ornamentat pe Discord cu rame și simboluri?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Alege un font pentru nume (goticul și bubble ies cel mai bine) și înconjoară-l cu rame și simboluri în stilul ꧁༒ ༒꧂. Pe această pagină e o grilă de nickname-uri gata făcute cu rame — dă click ca să copiezi și lipește în porecla de pe server. Poți și să-ți scrii numele sus, să-i pui un font și să folosești filele Simboluri și Rame ca să reglezi aspectul înainte de copiere.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">De ce se afișează literele pe Discord ca pătrățele?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Pentru că dispozitivul persoanei care se uită nu are fontul care desenează caracterul respectiv — de obicei un telefon sau un calculator mai vechi. Nu e o eroare a paginii sau a copierii tale. Stilurile de bază — îngroșate, cursive, gotice, bubble și small caps — sunt cele mai sigure și se afișează corect aproape peste tot. Dacă cineva raportează un pătrățel (□), schimbă la unul dintre aceste stiluri.</div></div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Language switcher">
+      <a class="lang-option" href="/discord/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/ro/fonturi-pentru-discord/" hreflang="ro">RO</a>
+    </div>
+  </div>
+</footer>
+
+<div class="copy-toast" id="copyToast">Copiat!</div>
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/styles.js"></script>
+<script src="/renderer.js"></script>
+<script src="/script.js" defer=""></script>
+<script src="/symbol-explorer.js"></script>
+<script src="/footer.js"></script>
+</body></html>

--- a/ro/fonturi-pentru-instagram/index.html
+++ b/ro/fonturi-pentru-instagram/index.html
@@ -1,0 +1,311 @@
+<!DOCTYPE html><html lang="ro"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Fonturi pentru Instagram: litere frumoase pentru bio și descrieri | UltraTextGen</title>
+  <meta name="description" content="Fonturi pentru Instagram gratuit: transformă textul în 𝗶̂𝗻𝗴𝗿𝗼𝘀̦𝗮𝘁, 𝘤𝘶𝘳𝘴𝘪𝘷 sau 𝓬𝓪𝓵𝓲𝓰𝓻𝓪𝓯𝓲𝓬 și lipește-l în bio, în numele profilului, în descriere și în comentarii. Litere frumoase pentru Instagram — fără aplicație.">
+  <link rel="canonical" href="https://ultratextgen.com/ro/fonturi-pentru-instagram/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/instagram/">
+  <link rel="alternate" hreflang="ro" href="https://ultratextgen.com/ro/fonturi-pentru-instagram/">
+  <link rel="alternate" hreflang="ro-MD" href="https://ultratextgen.com/ro/fonturi-pentru-instagram/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/instagram/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Fonturi pentru Instagram: litere frumoase pentru bio și descrieri">
+  <meta property="og:description" content="Generator de fonturi pentru Instagram: scrie un text și lipește o literă stilizată în bio, în numele profilului, în descriere și în comentarii. Îngroșat, cursiv, caligrafic și gotic — fără aplicație.">
+  <meta property="og:url" content="https://ultratextgen.com/ro/fonturi-pentru-instagram/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/pl-czcionki-na-instagram.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Fonturi pentru Instagram: litere frumoase pentru bio și descrieri">
+  <meta name="twitter:description" content="Îngroșat, cursiv, caligrafic și gotic gata de lipit în bio și în numele profilului pe Instagram — fără aplicație.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/pl-czcionki-na-instagram.png">
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+  <link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Generator de Fonturi pentru Instagram",
+  "alternateName": ["Fonturi pentru Instagram", "Fonturi de Instagram", "Litere frumoase pentru Instagram", "Fonturi pentru bio pe Instagram", "Generator de fonturi pentru IG", "Fonturi Instagram", "Litere pentru Instagram"],
+  "url": "https://ultratextgen.com/ro/fonturi-pentru-instagram/",
+  "inLanguage": "ro",
+  "applicationCategory": "UtilitiesApplication",
+  "operatingSystem": "Any",
+  "description": "Generator de fonturi pentru Instagram: transformă textul tău în litere stilizate — îngroșate, cursive, caligrafice, gotice, bubble și small caps — de lipit în bio, în numele profilului, în descrierea postării, în comentarii și în Stories, fără să descarci vreo aplicație.",
+  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "RON" }
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "ro",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Cum schimb fontul în bio pe Instagram?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Scrie-ți textul în câmpul din partea de sus a paginii. Apar imediat zeci de fonturi pentru Instagram — îngroșate, cursive, caligrafice, gotice, bubble și small caps. Apasă „Copiază” la cel care îți place, deschide Instagram, intră în Editează profilul și lipește-l în câmpul Bio. Fiind caractere Unicode, litera stilizată intră în câmp fără nicio aplicație sau tastatură suplimentară." }
+    },
+    {
+      "@type": "Question",
+      "name": "Cum pun alt font în numele profilului pe Instagram?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Copiază de aici fontul ales și lipește-l în câmpul „Nume” din Editează profilul — acela e numele scris cu litere groase de sus, de pe profil, nu login-ul @. Instagram acceptă Unicode în acest câmp, deci litera stilizată se afișează corect. Ține cont doar că Instagram îți permite să schimbi Numele de un număr limitat de ori într-un interval scurt (de obicei de două ori în 14 zile), așa că lipește direct stilul final." }
+    },
+    {
+      "@type": "Question",
+      "name": "Se poate folosi un font ornamentat în numele de utilizator (@) pe Instagram?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Nu. Numele de utilizator (login-ul @, cel din linkul tău și folosit pentru menționări) acceptă doar litere mici de la a la z, cifre, punct și underscore — niciun font stilizat, spații, emoji sau simboluri. Fonturile pentru Instagram funcționează în numele profilului (Nume), în bio, în descrieri și în comentarii. Dacă vrei stil în nume, folosește câmpul Nume, nu login-ul @." }
+    },
+    {
+      "@type": "Question",
+      "name": "Funcționează fonturile în descrierile postărilor și în comentarii pe Instagram?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Da. Fiind caractere Unicode obișnuite, lipești litera stilizată în descrierea unei poze sau a unui reel, în comentarii, în textul din Stories și în mesajele din Direct. Funcționează la fel în aplicația de pe telefon și în versiunea din browser. Singurul câmp care nu acceptă asta este login-ul @ (numele de utilizator)." }
+    },
+    {
+      "@type": "Question",
+      "name": "Strică un font stilizat în bio afișarea în căutarea de pe Instagram?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Poate strica dacă stilizezi tot. Căutarea și cititoarele de ecran înțeleg mai bine textul obișnuit, așa că cel mai bine e să stilizezi doar numele sau un slogan scurt, iar cuvintele-cheie importante — cu ce te ocupi, orașul tău, nișa ta — să le lași cu font obișnuit. Astfel profilul arată frumos și rămâne ușor de găsit." }
+    },
+    {
+      "@type": "Question",
+      "name": "De ce se afișează fontul pe Instagram ca un pătrățel?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Pentru că dispozitivul persoanei care se uită nu are fontul care desenează caracterul respectiv — de obicei un telefon sau un calculator mai vechi. Nu e o eroare a paginii sau a copierii tale. Stilurile de bază — îngroșate, cursive, caligrafice, gotice, bubble și small caps — sunt cele mai sigure și se afișează corect aproape peste tot. Dacă vezi un pătrățel (□), schimbă la unul dintre aceste stiluri." }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "inLanguage": "ro",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Acasă", "item": "https://ultratextgen.com/ro/" },
+    { "@type": "ListItem", "position": 2, "name": "Fonturi pentru Instagram", "item": "https://ultratextgen.com/ro/fonturi-pentru-instagram/" }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/ro/">Acasă</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Fonturi pentru Instagram</span>
+</nav>
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pl-czcionki-na-instagram.svg" width="1200" height="340" loading="lazy" alt="">
+</figure>
+
+<section class="hero">
+  <div class="hero-inner">
+    <div class="hero-card">
+      <h1 class="hero-headline">Fonturi pentru Instagram: litere frumoase pentru bio și descrieri</h1>
+      <p class="hero-tagline">Scrie un text și vezi-l imediat în zeci de fonturi pentru Instagram — îngroșate, cursive, caligrafice, gotice, bubble și small caps. Copiezi și lipești în bio, în numele profilului, în descrierea postării și în comentarii. Totul gratuit și <strong>fără aplicație</strong>.</p>
+      <div class="input-wrapper">
+        <textarea class="main-input" id="mainInput" placeholder="Scrie un text pentru bio sau descriere..." maxlength="500" autofocus=""></textarea>
+        <span class="char-count"><span id="charCount">0</span>/500</span>
+      </div>
+      <div class="decoration-section">
+        <div class="decoration-label">Adaugă simboluri și rame la rezultat</div>
+        <div class="decoration-tabs">
+          <button class="decoration-tab active" data-deco-tab="symbols">Simboluri</button>
+          <button class="decoration-tab" data-deco-tab="frames">Rame</button>
+          <button class="decoration-tab" data-deco-tab="dividers">Separatoare</button>
+          <button class="decoration-tab" data-deco-tab="arrows">Săgeți</button>
+          <button class="decoration-tab" data-deco-tab="minimal">Minimale</button>
+          <button class="decoration-tab" data-deco-tab="emojis">Emoji</button>
+        </div>
+        <div class="decoration-grid" id="decorationGrid"></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<main class="container">
+  <div class="category-section"><div class="category-tabs" id="categoryTabs"></div></div>
+  <div class="results-grid" id="resultsGrid"></div>
+
+  <!-- Cum funcționează -->
+  <section class="editorial-section">
+    <h2>Fonturi pentru Instagram: cum funcționează</h2>
+    <p class="editorial-intro"><strong>Fonturile pentru Instagram</strong> de pe pagina asta nu sunt un font instalat sau o imagine — sunt <strong>caractere Unicode</strong>, litere reale, la fel ca de la tastatură, doar cu alt aspect (𝗔, 𝘈, 𝓐, 𝔄). Fiindcă Instagram acceptă Unicode în aproape orice câmp de text, litera stilizată se lipește direct în <strong>bio</strong>, în <strong>numele profilului</strong>, în <strong>descrierea postării</strong>, în <strong>comentarii</strong>, în textul din <strong>Stories</strong> și în mesajele din <strong>Direct</strong> — fără aplicație, extensie sau tastatură suplimentară.</p>
+    <div class="block-example">
+      <strong>Exemplu:</strong> „ana” → 𝗮𝗻𝗮 (îngroșat), 𝘢𝘯𝘢 (cursiv), 𝒶𝓃𝒶 (caligrafic), 𝔞𝔫𝔞 (gotic), ⓐⓝⓐ (bubble), ᴀɴᴀ (small caps)
+    </div>
+    <p>Se folosește în câteva secunde: scrii un text în câmpul de sus, generatorul îl arată în mai multe <strong>fonturi pentru Instagram</strong>, apeși „Copiază” și lipești în aplicație. Vrei doar literele brute ale alfabetului? Sunt chiar dedesubt. Iar dacă preferi să răsfoiești și mai multe tipuri de litere, generatorul complet îl găsești pe pagina cu <a href="/ro/">litere de copiat</a>.</p>
+  </section>
+
+  <!-- Alfabet A-Z -->
+  <section class="editorial-section glyph-section">
+    <h2>Alfabetul fonturilor pentru Instagram (A–Z de copiat)</h2>
+    <p class="editorial-intro">Tot alfabetul în stilurile care apar cel mai des în bio și descrieri pe Instagram. Dă click pe un rând ca să copiezi tot abecedarul în stilul respectiv, sau scrie-ți textul sus și ia-ți propriul cuvânt gata stilizat.</p>
+    <div class="alpha-list">
+      <div class="alpha-row">
+        <span class="alpha-label">Îngroșate</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝗔𝗕𝗖𝗗𝗘𝗙𝗚𝗛𝗜𝗝𝗞𝗟𝗠𝗡𝗢𝗣𝗤𝗥𝗦𝗧𝗨𝗩𝗪𝗫𝗬𝗭 𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇" aria-label="Copiază alfabetul îngroșat">𝗔𝗕𝗖𝗗𝗘𝗙𝗚𝗛𝗜𝗝𝗞𝗟𝗠𝗡𝗢𝗣𝗤𝗥𝗦𝗧𝗨𝗩𝗪𝗫𝗬𝗭 · 𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Cursive</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩 𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃" aria-label="Copiază alfabetul cursiv">𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩 · 𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Elegante</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵 𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏" aria-label="Copiază alfabetul elegant">𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵 · 𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Gotice</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝔄𝔅ℭ𝔇𝔈𝔉𝔊ℌℑ𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔ℜ𝔖𝔗𝔘𝔙𝔚𝔛𝔜ℨ 𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷" aria-label="Copiază alfabetul gotic">𝔄𝔅ℭ𝔇𝔈𝔉𝔊ℌℑ𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔ℜ𝔖𝔗𝔘𝔙𝔚𝔛𝔜ℨ · 𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Bubble</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ" aria-label="Copiază alfabetul bubble">ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ · ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Small caps</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="ᴀʙᴄᴅᴇꜰɢʜɪᴊᴋʟᴍɴᴏᴘqʀsᴛᴜᴠᴡxʏᴢ" aria-label="Copiază alfabetul în small caps">ᴀ ʙ ᴄ ᴅ ᴇ ꜰ ɢ ʜ ɪ ᴊ ᴋ ʟ ᴍ ɴ ᴏ ᴘ q ʀ s ᴛ ᴜ ᴠ ᴡ x ʏ ᴢ</button>
+      </div>
+    </div>
+    <p class="uname-note">Notă despre diacriticele românești: aceste fonturi Unicode acoperă alfabetul de bază A–Z. Diacriticele românești (ă, â, î, ș, ț) rămân în majoritatea stilurilor litere obișnuite în mijlocul cuvântului stilizat — de aceea, de ex. „maria” iese perfect, iar „ștefania” va afișa ș ca literă obișnuită. Pentru bio-uri și nume fără diacritice arată perfect, iar pentru descrieri mai lungi cele mai sigure sunt îngroșatul și cursivul.</p>
+    <p class="u-mt-15">Vrei să te adâncești într-un singur stil? Alfabetul complet și variantele fiecărui tip de literă le găsești pe pagina cu <a href="/ro/">litere de copiat</a>, iar cel mai popular pentru bio pe Instagram este <a href="/ro/text-cursiv/">textul cursiv</a>.</p>
+  </section>
+
+  <!-- Fonturi pentru bio și nume -->
+  <section class="editorial-section">
+    <h2>Fonturi pentru bio și numele profilului pe Instagram</h2>
+    <p class="editorial-intro">Cel mai rapid mod de a-ți scoate în evidență profilul e să pui un font pe <strong>numele profilului</strong> (câmpul „Nume”) și o combinație separată în <strong>bio</strong>. Sunt două câmpuri diferite — „Nume” e numele scris cu litere groase de sus, de pe profil, iar bio e descrierea de dedesubt. Instagram acceptă Unicode în ambele, dar <strong>nu în login-ul @</strong>.</p>
+    <p class="uname-note">Cum lipești:</p>
+    <div class="block-example">
+      — <strong>Numele profilului (Nume):</strong> Editează profilul › câmpul „Nume” › lipește fontul stilizat<br>
+      — <strong>Bio:</strong> Editează profilul › câmpul „Bio” › lipește textul (poți combina mai multe stiluri pe rânduri separate)<br>
+      — <strong>Descrierea postării / reelului:</strong> când adaugi o postare, lipește fontul în câmpul de descriere<br>
+      — <strong>Comentarii și Direct:</strong> lipește litera stilizată direct în câmpul de comentariu sau de mesaj
+    </div>
+    <p>Un sfat de la cineva care compune profiluri zilnic: stilizează doar numele sau un singur slogan, iar restul bio-ului lasă-l cu text obișnuit — contrastul face tot efectul. Când totul e ornamentat, nimic nu atrage privirea. Un detaliu important: Instagram îți permite să schimbi câmpul „Nume” doar de un număr limitat de ori într-un interval scurt, așa că lipește direct stilul final. Pentru steluțe și sclipici de pus în bio, aruncă un ochi pe pagina cu <a href="/library/aesthetic-symbols/">ornamente de copiat</a>.</p>
+  </section>
+
+  <!-- Unde merge și unde nu -->
+  <section class="editorial-section">
+    <h2>Unde lipești fonturile pe Instagram (și unde nu)</h2>
+    <p class="editorial-intro">Fiindcă ceea ce copiezi e Unicode curat, literele pentru Instagram se lipesc practic în orice câmp de text al aplicației:</p>
+    <div class="block-example">
+      — <strong>Numele profilului (Nume)</strong> și <strong>bio</strong><br>
+      — <strong>Descrierile postărilor</strong> și <strong>reelurilor</strong><br>
+      — <strong>Comentariile</strong> de sub postări<br>
+      — <strong>Textul din Stories</strong> și <strong>notele (Notes)</strong><br>
+      — <strong>Mesajele din Direct</strong>
+    </div>
+    <p>Singurul loc unde <strong>nu</strong> funcționează este <strong>numele de utilizator (login-ul @)</strong> — Instagram îl limitează intenționat la litere mici de la a la z, cifre, punct și underscore, așa că niciun font stilizat, spațiu sau emoji nu trece acolo. În plus, o notă sinceră: dacă dispozitivul persoanei care se uită e foarte vechi, o parte dintre stilurile mai rare se pot afișa ca <strong>pătrățele (□)</strong> — e un font lipsă pe aparatul ei, nu o problemă cu textul tău. Rămânând la stilurile de bază (îngroșate, cursive, caligrafice, gotice, bubble, small caps) asta nu se întâmplă aproape niciodată. Pentru linii goale curate în bio e util <a href="/library/invisible-character/">caracterul invizibil</a>.</p>
+  </section>
+
+  <!-- Bio ornamentat cu simboluri -->
+  <section class="editorial-section">
+    <h2>Bio și nume ornamentate pentru Instagram cu simboluri</h2>
+    <p class="editorial-intro">Numele și rândurile de bio care impresionează cel mai mult pe Instagram combină un font delicat (caligrafic sau cursiv) cu steluțe și simboluri de ambele părți, în stilul ⋆˚₊‧ ‧₊˚⋆. Dă click ca să copiezi și lipește în câmpul „Nume” sau în bio — apoi înlocuiește cu cuvântul tău.</p>
+    <div class="uname-grid">
+      <button class="uname-chip symbol-tile" data-symbol="⋆˚₊‧ 𝓏𝑜𝓈𝒾𝒶 ‧₊˚⋆" aria-label="Copiază numele">⋆˚₊‧ 𝓏𝑜𝓈𝒾𝒶 ‧₊˚⋆</button>
+      <button class="uname-chip symbol-tile" data-symbol="✿ 𝓸𝓵𝓪 ✿" aria-label="Copiază numele">✿ 𝓸𝓵𝓪 ✿</button>
+      <button class="uname-chip symbol-tile" data-symbol="꒰ঌ 𝒷𝒶𝓈𝒾𝒶 ໒꒱" aria-label="Copiază numele">꒰ঌ 𝒷𝒶𝓈𝒾𝒶 ໒꒱</button>
+      <button class="uname-chip symbol-tile" data-symbol="⋆｡˚ 𝓴𝓪𝓼𝓲𝓪 ˚｡⋆" aria-label="Copiază numele">⋆｡˚ 𝓴𝓪𝓼𝓲𝓪 ˚｡⋆</button>
+      <button class="uname-chip symbol-tile" data-symbol="✧˖° 𝓶𝓪𝓳𝓪 °˖✧" aria-label="Copiază numele">✧˖° 𝓶𝓪𝓳𝓪 °˖✧</button>
+      <button class="uname-chip symbol-tile" data-symbol="ᯓ★ 𝓌𝒾𝓀𝓉𝑜𝓇𝒾𝒶 ★" aria-label="Copiază numele">ᯓ★ 𝓌𝒾𝓀𝓉𝑜𝓇𝒾𝒶 ★</button>
+      <button class="uname-chip symbol-tile" data-symbol="˚ʚ 𝒶𝓃𝒾𝒶 ɞ˚" aria-label="Copiază numele">˚ʚ 𝒶𝓃𝒾𝒶 ɞ˚</button>
+      <button class="uname-chip symbol-tile" data-symbol="⊹ ࣪ ˖ 𝓃𝒶𝓉𝒶𝓁𝒾𝒶 ˖ ࣪ ⊹" aria-label="Copiază numele">⊹ ࣪ ˖ 𝓃𝒶𝓉𝒶𝓁𝒾𝒶 ˖ ࣪ ⊹</button>
+      <button class="uname-chip symbol-tile" data-symbol="⟡ 𝓵𝓮𝓷𝓪 ⟡" aria-label="Copiază numele">⟡ 𝓵𝓮𝓷𝓪 ⟡</button>
+      <button class="uname-chip symbol-tile" data-symbol="๑ 𝓳𝓾𝓵𝓴𝓪 ๑" aria-label="Copiază numele">๑ 𝓳𝓾𝓵𝓴𝓪 ๑</button>
+    </div>
+    <p class="u-mt-15">Vrei tot setul de steluțe, inimioare și separatoare gata făcute ca să-ți compui propriul bio? Paleta completă e pe pagina cu <a href="/library/aesthetic-symbols/">ornamente de copiat</a> — aceleași semne se lipesc în nume și în bio pe Instagram.</p>
+  </section>
+
+  <!-- Căutare și pătrățele -->
+  <section class="editorial-section">
+    <h2>Fonturi și căutarea pe Instagram (și o notă despre pătrățele)</h2>
+    <p class="editorial-intro">Textul stilizat arată excelent, dar are un cârlig: căutarea de pe Instagram și cititoarele de ecran tratează caracterele Unicode altfel decât literele obișnuite. Dacă stilizezi tot bio-ul, cuvintele-cheie pot ieși mai greu în căutare.</p>
+    <div class="block-example">
+      — <strong>Bună practică:</strong> stilizează numele sau un slogan scurt, restul lasă-l cu text obișnuit<br>
+      — <strong>Lasă cu font obișnuit:</strong> cu ce te ocupi, orașul, nișa, cuvintele după care te caută lumea<br>
+      — <strong>Exemplu:</strong> 𝓶𝓪𝓳𝓪 𝓴𝓸𝔀𝓪𝓵𝓼𝓴𝓪 (caligrafic) + „fotografie de nuntă · București” cu font obișnuit
+    </div>
+    <p>A doua chestie sunt <strong>pătrățelele (□)</strong>: când cineva vede în locul literelor un dreptunghi gol, înseamnă că dispozitivul lui nu are fontul care desenează caracterul acela — de obicei un telefon foarte vechi. Nu e o problemă cu textul tău sau cu copierea. Rămânând la stilurile de bază, asta nu se întâmplă aproape niciodată. Pentru linii goale și spații în bio e util <a href="/library/invisible-character/">caracterul invizibil</a>, iar un stil mai puternic și întunecat pentru nume găsești în <a href="/ro/scriere-gotica/">scrierea gotică</a>.</p>
+  </section>
+
+  <!-- Related -->
+  <section class="editorial-section">
+    <span class="article-section-label">Pagini asociate</span>
+    <div class="compare-grid">
+      <a href="/ro/" class="compare-card variant-muted u-no-underline">
+        <h4>Litere de Copiat</h4>
+        <p>Alfabetul complet în mai multe tipuri de litere — îngroșate, cursive, caligrafice și bubble.</p>
+      </a>
+      <a href="/ro/text-cursiv/" class="compare-card variant-muted u-no-underline">
+        <h4>Text Cursiv</h4>
+        <p>Cursiv ornamentat, de mână — cea mai frecventă alegere pentru bio pe Instagram.</p>
+      </a>
+      <a href="/library/aesthetic-symbols/" class="compare-card variant-muted u-no-underline">
+        <h4>Ornamente de Copiat</h4>
+        <p>Steluțe, inimioare, rame și separatoare pentru a-ți ornamenta numele și bio-ul.</p>
+      </a>
+      <a href="/library/invisible-character/" class="compare-card variant-muted u-no-underline">
+        <h4>Caracter Invizibil</h4>
+        <p>Un spațiu gol pentru linii curate și distanțe în bio pe Instagram.</p>
+      </a>
+      <a href="/ro/scriere-gotica/" class="compare-card variant-muted u-no-underline">
+        <h4>Scriere Gotică</h4>
+        <p>Litere întunecate, puternice pentru un nume de profil cu caracter.</p>
+      </a>
+    </div>
+  </section>
+</main>
+
+<footer class="footer">
+  <div class="footer-inner">
+    <h2 class="faq-category">Întrebări frecvente despre fonturile pentru Instagram</h2>
+    <div class="faq-item"><button class="faq-question" type="button">Cum schimb fontul în bio pe Instagram?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Scrie-ți textul în câmpul din partea de sus a paginii. Apar imediat zeci de fonturi pentru Instagram — îngroșate, cursive, caligrafice, gotice, bubble și small caps. Apasă „Copiază” la cel care îți place, deschide Instagram, intră în Editează profilul și lipește-l în câmpul Bio. Fiind caractere Unicode, litera stilizată intră în câmp fără nicio aplicație sau tastatură suplimentară.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Cum pun alt font în numele profilului pe Instagram?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Copiază de aici fontul ales și lipește-l în câmpul „Nume” din Editează profilul — acela e numele scris cu litere groase de sus, de pe profil, nu login-ul @. Instagram acceptă Unicode în acest câmp, deci litera stilizată se afișează corect. Ține cont doar că Instagram îți permite să schimbi Numele de un număr limitat de ori într-un interval scurt (de obicei de două ori în 14 zile), așa că lipește direct stilul final.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Se poate folosi un font ornamentat în numele de utilizator (@) pe Instagram?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Nu. Numele de utilizator (login-ul @, cel din linkul tău și folosit pentru menționări) acceptă doar litere mici de la a la z, cifre, punct și underscore — niciun font stilizat, spații, emoji sau simboluri. Fonturile pentru Instagram funcționează în numele profilului (Nume), în bio, în descrieri și în comentarii. Dacă vrei stil în nume, folosește câmpul Nume, nu login-ul @.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Funcționează fonturile în descrierile postărilor și în comentarii pe Instagram?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Da. Fiind caractere Unicode obișnuite, lipești litera stilizată în descrierea unei poze sau a unui reel, în comentarii, în textul din Stories și în mesajele din Direct. Funcționează la fel în aplicația de pe telefon și în versiunea din browser. Singurul câmp care nu acceptă asta este login-ul @ (numele de utilizator).</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Strică un font stilizat în bio afișarea în căutarea de pe Instagram?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Poate strica dacă stilizezi tot. Căutarea și cititoarele de ecran înțeleg mai bine textul obișnuit, așa că cel mai bine e să stilizezi doar numele sau un slogan scurt, iar cuvintele-cheie importante — cu ce te ocupi, orașul tău, nișa ta — să le lași cu font obișnuit. Astfel profilul arată frumos și rămâne ușor de găsit.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">De ce se afișează fontul pe Instagram ca un pătrățel?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Pentru că dispozitivul persoanei care se uită nu are fontul care desenează caracterul respectiv — de obicei un telefon sau un calculator mai vechi. Nu e o eroare a paginii sau a copierii tale. Stilurile de bază — îngroșate, cursive, caligrafice, gotice, bubble și small caps — sunt cele mai sigure și se afișează corect aproape peste tot. Dacă vezi un pătrățel (□), schimbă la unul dintre aceste stiluri.</div></div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Language switcher">
+      <a class="lang-option" href="/instagram/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/ro/fonturi-pentru-instagram/" hreflang="ro">RO</a>
+    </div>
+  </div>
+</footer>
+
+<div class="copy-toast" id="copyToast">Copiat!</div>
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script>window.UTG_PREVIEW_PLATFORM='instagram';window.UTG_SHOW_PLATFORMS=true;window.UTG_DEMO_TEXT='ana aesthetic\nlink în bio ⬇';</script>
+<script src="/styles.js"></script>
+<script src="/renderer.js"></script>
+<script src="/script.js" defer=""></script>
+<script src="/symbol-explorer.js"></script>
+<script src="/footer.js" defer></script>
+</body></html>

--- a/ro/index.html
+++ b/ro/index.html
@@ -1,0 +1,1019 @@
+<!DOCTYPE html><html lang="ro" dir="ltr"><head>
+  <meta name="yandex-verification" content="aa326290e0338f4f">
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZGVh");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title data-i18n="meta.title">Fonturi Frumoase și Text Stilizat de Copiat — Litere pentru Insta, TikTok și Nickname-uri</title>
+<meta name="description" data-i18n-content="meta.description" content="Generator de fonturi frumoase, litere estetice și text stilizat de copiat. Îngroșat, cursiv, gotic, bubble, Zalgo și simboluri — lipește-l în bio pe Insta, în descrierea unui TikTok, într-un nickname de joc sau pe Discord. Gratuit, fără cont.">
+
+<link rel="canonical" href="https://ultratextgen.com/ro/">
+
+<link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/">
+<link rel="alternate" hreflang="en" href="https://ultratextgen.com/">
+<link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/">
+<link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/">
+<link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/">
+<link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/">
+<link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/">
+<link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/">
+<link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/">
+<link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/">
+<link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/">
+<link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/">
+<link rel="alternate" hreflang="sv" href="https://ultratextgen.com/sv/">
+<link rel="alternate" hreflang="no" href="https://ultratextgen.com/no/">
+<link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/">
+<link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/">
+<link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/">
+<link rel="alternate" hreflang="ar" href="https://ultratextgen.com/ar/">
+<link rel="alternate" hreflang="cs" href="https://ultratextgen.com/cs/">
+<link rel="alternate" hreflang="sk" href="https://ultratextgen.com/sk/">
+<link rel="alternate" hreflang="hr" href="https://ultratextgen.com/hr/">
+<link rel="alternate" hreflang="bs" href="https://ultratextgen.com/bs/">
+<link rel="alternate" hreflang="sr" href="https://ultratextgen.com/sr/">
+<link rel="alternate" hreflang="ro" href="https://ultratextgen.com/ro/">
+<link rel="alternate" hreflang="ro-MD" href="https://ultratextgen.com/ro/">
+
+<meta name="robots" content="index, follow">
+
+<meta property="og:site_name" content="UltraTextGen">
+<meta property="og:title" content="Fonturi Frumoase și Text Stilizat de Copiat — Litere pentru Insta, TikTok și Nickname-uri">
+<meta property="og:description" content="Generator de fonturi frumoase, litere estetice și text stilizat de copiat. Îngroșat, cursiv, gotic, bubble, Zalgo și simboluri — lipește-l în bio pe Insta, în descrierea unui TikTok, într-un nickname de joc sau pe Discord.">
+<meta property="og:url" content="https://ultratextgen.com/ro/">
+<meta property="og:type" content="website">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/generator-ladnych-czcionek-preview.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Fonturi Frumoase și Text Stilizat de Copiat — Litere pentru Insta, TikTok și Nickname-uri">
+<meta name="twitter:description" content="Generator de fonturi frumoase, litere estetice și text stilizat de copiat. Îngroșat, cursiv, gotic, bubble, Zalgo și simboluri — lipește-l în bio pe Insta, în descrierea unui TikTok, într-un nickname de joc sau pe Discord.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/generator-ladnych-czcionek-preview.png">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/style.css">
+
+ <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+[
+  {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/",
+    "inLanguage": "ro",
+    "description": "Generator de text Unicode rapid și curat pentru bio-uri de social media, descrieri și nickname-uri.",
+    "potentialAction": {
+      "@type": "SearchAction",
+      "target": {
+        "@type": "EntryPoint",
+        "urlTemplate": "https://ultratextgen.com/?q={search_term_string}"
+      },
+      "query-input": "required name=search_term_string"
+    }
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com",
+    "logo": "https://ultratextgen.com/logo.png",
+    "sameAs": [
+      "https://www.youtube.com/@UltraTextGen",
+      "https://www.facebook.com/profile.php?id=61588587387596",
+      "https://www.linkedin.com/company/71290348/",
+      "https://x.com/UltraTextGen"
+    ]
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "WebApplication",
+    "name": "UltraTextGen",
+    "alternateName": ["Generator de fonturi Unicode", "Generator de text frumos", "Schimbător de fonturi", "Fonturi de copiat și lipit"],
+    "url": "https://ultratextgen.com/",
+    "inLanguage": "ro",
+    "applicationCategory": "UtilitiesApplication",
+    "operatingSystem": "All",
+    "browserRequirements": "Requires JavaScript",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "description": "Generează instantaneu text Unicode stilizat pentru Instagram, TikTok, X, WhatsApp și Discord. Copiază și lipește stiluri de text pentru bio-uri de social media, nickname-uri și postări."
+  }
+]
+</script>
+
+
+
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "ro",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Ce este UltraTextGen și ce se întâmplă de fapt aici?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "E un generator gratuit de litere — scrii un text obișnuit, iar noi îl transformăm în caractere Unicode stilizate, care arată ca un font frumos. Cel mai important: sunt caractere reale , nu îngroșarea din Word sau markdown-ul de pe Discord. De asta funcționează peste tot unde poți scrie text obișnuit — în bio pe Insta, într-un nickname, într-un comentariu, într-un e-mail, în statusul de WhatsApp. Exemplu Scrii „hei” → primești 𝗵𝗲𝗶 (îngroșat), 𝘩𝘦𝘪 (cursiv), 𝒽ℯ𝒾 (caligrafic) sau ⓗⓔⓘ (bubble). Totul dintr-un singur click."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Cum copiez niște litere frumoase în 5 secunde?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "1. Scrii sau lipești textul în câmpul de sus. 2. Stilurile apar imediat dedesubt — bold, cursiv, gotic, bubble și încă vreo câteva zeci. 3. Dacă vrei, adaugă ornamente — rame, steluțe, săgeți. 4. Apeși „Copiază” la cel care îți place și îl lipești oriunde vrei. Atât. Fără înregistrare, fără instalat aplicații. Merge la fel pe calculator și pe telefon."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Gratuit? Fără limite, fără cont?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da, totul e 100% gratuit . Fără cont, fără limită zilnică, fără watermark, fără nicio șmecherie. Poți trece prin el o carte întreagă și nu se întâmplă nimic."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Cum pun text stilizat în bio pe Instagram?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Insta nu are nicio bară de formatare, dar acceptă Unicode — adică tot ce generezi la noi intră în bio fără probleme. Cum faci 1. Scrie ce vrei să ai în bio (de ex. numele, un hashtag, o descriere scurtă). 2. Alege un stil — îngroșatul și cursivul merg cel mai bine pe majoritatea dispozitivelor. 3. Copiază rezultatul și lipește-l în „Editează profilul → Bio” din aplicație. Pont: dacă vrei să ornamentezi, adaugă o ramă de tip ⋆｡˚ sau o steluță ✦ pe margine — arată bine și nu fură atenția de la restul bio-ului."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Funcționează literele în descrierile de pe TikTok?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da — TikTok afișează Unicode în descrieri, în descrierea profilului și în comentarii. Cel mai bine ies îngroșatul , cursivul , bubble și small caps . Stilurile cu o grămadă de ornamente se pot tăia la descrierile lungi, așa că, pentru siguranță, verifică postarea în previzualizare înainte de publicare."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Pot să-mi fac un nickname de joc sau de Discord?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Clar — probabil e cel mai frecvent motiv pentru care oamenii ajung pe astfel de generatoare. Discord, Roblox, Steam, Minecraft, majoritatea jocurilor acceptă Unicode în nickname-uri. Exemplu Nickname obișnuit: „DarkWolf” După stilizare: „𝔇𝔞𝔯𝔨𝔚𝔬𝔩𝔣” (gotic), „ⒹⓐⓡⓚⓌⓞⓛⓕ” (bubble) sau „๖ۣۜDarkWolf” (cu un ornament pe margine). Atenție: unele jocuri au filtre și nu acceptă caractere exotice. Dacă un stil nu intră, pune altul — bold-ul și cursivul trec de obicei peste tot."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Merge în statusul de WhatsApp, pe Telegram și în Messenger?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da — WhatsApp, Telegram, Messenger, Signal, iMessage. Tot ce acceptă text obișnuit acceptă și litere Unicode. Le lipești în status sau într-un mesaj și arată ca un font ornamentat. Pentru WhatsApp o completare: dacă ții doar la îngroșare, poți folosi sintaxa lui proprie ( *text* dă bold). Dar Unicode funcționează peste tot — inclusiv acolo unde WhatsApp nu are asta, de exemplu în numele unui contact."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Dar în subiectul unui e-mail sau într-un CV?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Aici Unicode face cea mai mare treabă. Subiectul unui e-mail e text obișnuit, deci îngroșarea din Outlook nu are ce căuta. În schimb „𝗙𝗮𝗰𝘁𝘂𝗿𝗮 — 𝘂𝗿𝗴𝗲𝗻𝘁” arată deja mai puternic în inbox-ul destinatarului. Într-un CV, un nume ușor îngroșat în antet poate atrage privirea recrutorului. Doar nu exagera — un CV întreg în gotic nu arată profesional."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Ce stiluri de litere am la dispoziție?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Multe. Chiar multe. Pe scurt: De bază Îngroșat (bold), cursiv, caligrafic (script), gotic, bubble (în cerculețe), small caps, tăiat, subliniat, double struck. De distracție Text cu susul în jos, oglindit, Zalgo (glitch cu semne peste litere), text în pătrățele, în paranteze, fullwidth (răsfirat). Adăugiri Rame în jurul textului, steluțe, inimioare, săgeți, separatoare, steaguri, emoji — se pot suprapune peste stilul literelor. Din când în când apar altele noi — merită să pui pagina la favorite."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Pot să combin mai multe stiluri deodată?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da — și ăsta e cel mai mare avantaj al UltraTextGen. Poți suprapune de exemplu bubble + Zalgo , gotic + cu susul în jos sau small caps + subliniat , iar apoi să închizi totul într-o ramă sau o steluță. Exemplu „hei” → alegi gotic → adaugi o ramă cu steluțe → iese: ★彡[ 𝔥𝔢𝔦 ]彡★ Cu cât experimentezi mai mult, cu atât ies lucruri mai interesante. Îți recomand să începi cu un singur stil și să adaugi un singur ornament — nu tot deodată."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Ce este Zalgo și liniuțele alea ciudate de deasupra literelor?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Zalgo e un stil „blestemat”, glitchy — deasupra și dedesubtul fiecărei litere apare o grămadă de semne diacritice. Arată de parcă textul s-ar destrăma sau ar fi dintr-un film de groază. Exemplu „hei” → h̷̢e̴̢i̷̛ Cel mai des îl vezi în bio-uri sumbre pe Insta, în meme-uri de Halloween, în clanuri de gaming care vor să pară amenințătoare sau când cineva face haz de el."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "De unde iau simboluri, steluțe și inimioare frumoase?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Tot ce ai în secțiunea „Ornamente” de sub câmpul de text îl poți copia separat — chiar și fără să scrii vreun text. Pur și simplu ca semne separate pentru bio, nickname sau o postare. — Simboluri estetice : ✦ ✧ ⋆ ｡ ☆ ♡ ❀ ✿ — Rame și margini : ╭─▸ │ ╰─▸ sau ★彡[ ]彡★ — Săgeți : → ⇨ ➤ ⟶ — Separatoare minimale : · ⋅ ─ • — Steaguri și emoji . Cel mai des se folosesc în bio-uri estetice pe Instagram și Pinterest — se potrivesc cu orice, de la citate la liste de pasiuni."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Dar diacriticele românești? Merge cu ă, â, î, ș, ț?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Pe scurt: depinde de stil. Unicode are variante stilizate pentru alfabetul de bază A–Z, așa că a , i , s , t se transformă fără probleme, de exemplu în îngroșat. Dar pentru ă , â , î , ș , ț variantele stilizate există doar în o parte dintre stiluri (mai ales bold, italic, small caps). Dacă un stil nu are versiune pentru un caracter cu diacritic, acesta rămâne în forma originală — textul e în continuare lizibil, litera cu diacritic arată doar puțin mai „obișnuit” decât restul. Pentru nickname-uri fără diacritice nu e nicio problemă. Pentru propoziții întregi în română îți recomand bold , italic sau monospace — se descurcă cel mai bine cu alfabetul nostru."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "De ce cineva vede pătrățele în loc de litere?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Pentru că fontul de sistem de la destinatar nu conține caracterul Unicode respectiv. Nu e o problemă cu textul tău — pur și simplu telefonul sau aplicația lui nu are semnul acela anume în set. Rămâi la bold , italic și bubble — au cel mai larg suport. Stilurile foarte exotice (fullwidth, pătrățele) se pot afișa ca □ pe Android-uri mai vechi sau în unii clienți de e-mail."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Instagram mi-a tăiat o parte din caractere în nickname — și acum?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Insta are un filtru pe câmpul nume de utilizator (adică @-ul) — acceptă doar litere, cifre, punct și underscore. Aici nu poți lipi litere stilizate. Dar în câmpul „Nume” (numele afișat) și în bio se poate — și aici intră majoritatea stilurilor. Dacă unul nu se salvează, pune altul. Bold-ul trece de obicei fără probleme."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Există caractere care nu pot fi transformate deloc?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Literele standard (A–Z, a–z), cifrele și semnele de punctuație de bază se transformă fără probleme. Unele simboluri rare sau caractere speciale nu au echivalente stilizate în Unicode — atunci rămân în original. Nimic nu se strică, textul rămâne de copiat."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Textul meu se salvează undeva?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Nu. Toată transformarea literelor se întâmplă în browserul tău — nimic nu ajunge pe serverele noastre, nimic nu se salvează, nimic nu e urmărit. Textul copiat e Unicode curat, fără caractere ascunse, fără niciun identificator."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "E sigur să lipesc literele astea oriunde?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da — sunt caractere Unicode standard, identice cu cele folosite de tot internetul. Nimic în interior, niciun script, nicio formatare ascunsă, niciun cod. Le lipești liniștit într-un CV, într-un e-mail de serviciu, în bio-ul de LinkedIn — unde vrei."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Funcționează pe telefon?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da — pagina se adaptează complet la mobil. iPhone, Android, tabletă — totul merge. Scrii textul, apeși, se copiază în clipboard, îl lipești în aplicație. Fără să instalezi nimic din vreun magazin."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Prin ce vă deosebiți de alte generatoare de litere?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Concret: — Una dintre cele mai mari colecții de stiluri Ultra — bold, cursiv, gotic, bubble și încă vreo câteva zeci. — Combinarea stilurilor — majoritatea generatoarelor îți dau un singur stil deodată, noi te lăsăm să le suprapui. — Ornamente dintr-un click — rame, steluțe, separatoare fără să lipești semn cu semn. — Pagini pentru platforme anume — Insta, TikTok, Discord. Acolo arătăm doar stilurile care funcționează pe aplicația respectivă. — Rapid și fără pop-up-uri — fără captcha, fără „acceptă tot” înainte de fiecare click."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Apar stiluri noi?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da, regulat. Din când în când apar variante noi, ornamente și rame. Cel mai simplu e să reții pagina sau să treci pe aici din când în când."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Cum găsesc exact stilul pe care îl caut?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Trei căi: După stil — categoriile de sus: bold, cursiv, gotic, bubble, tăiat, cu susul în jos și altele. După platformă — intră pe pagina pentru Insta, TikTok, Discord — acolo sunt doar stilurile care funcționează pe platforma respectivă. După scop — secțiunea de utilizări are unelte potrivite pentru o nevoie anume: titlu pe LinkedIn, comentarii, text cu emoji."
+      }
+    }
+  ]
+}
+</script>
+</head>
+
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer=""></script>
+
+  <!-- Hero Section -->
+  <section class="hero">
+    <div class="hero-inner">
+      <div class="hero-card">
+        <h1 class="hero-headline" data-i18n="hero.title">Fonturi Frumoase și Litere Stilizate de Copiat</h1>
+        <p class="hero-tagline" data-i18n="hero.subtitle">Scrie un text, alege un stil — îngroșat, cursiv, gotic, bubble sau cu ornamente. Pune-l în bio pe Insta, în nickname-ul din joc, în statusul de WhatsApp sau în descrierea unui TikTok. Fără aplicație, fără cont.</p>
+        <div class="input-wrapper">
+          <textarea class="main-input" id="mainInput" placeholder="Scrie textul..." data-i18n-placeholder="ui.placeholder" maxlength="500" autofocus=""></textarea>
+          <button class="input-clear-btn" id="inputClearBtn" aria-label="Clear input" hidden="">✕</button>
+          <span class="char-count" id="charCountWrapper" hidden=""><span id="charCount">0</span>/500</span>
+        </div>
+
+        <!-- Decoration Selector -->
+        <div class="decoration-section">
+          <div class="decoration-label">
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"></path>
+            </svg>
+            <span data-i18n="decorations.label">Adaugă ornamente la text</span>
+       </div>
+    <div class="decoration-tabs">
+    <button class="decoration-tab active" data-deco-tab="symbols" data-i18n="decorations.tabs.symbols">Simboluri</button>
+    <button class="decoration-tab" data-deco-tab="frames" data-i18n="decorations.tabs.frames">Rame</button>
+    <button class="decoration-tab" data-deco-tab="dividers" data-i18n="decorations.tabs.dividers">Separatoare</button>
+    <button class="decoration-tab" data-deco-tab="arrows" data-i18n="decorations.tabs.arrows">Săgeți</button>
+    <button class="decoration-tab" data-deco-tab="minimal" data-i18n="decorations.tabs.minimal">Minimale</button>
+    <button class="decoration-tab" data-deco-tab="emojis" data-i18n="decorations.tabs.emojis">Emoji</button>
+    <button class="decoration-tab" data-deco-tab="flags" data-i18n="decorations.tabs.flags">Steaguri</button>
+      </div>
+          <div class="decoration-grid" id="decorationGrid"></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Main Content -->
+  <main class="container">
+    <!-- Category Tabs -->
+    <div class="category-section">
+      <div class="category-tabs" id="categoryTabs">
+        <!-- Tabs will be dynamically loaded from fonts.json -->
+      </div>
+    </div>
+
+    <!-- Results -->
+    <div class="results-grid" id="resultsGrid"></div>
+  </main>
+
+  <!-- How To: Cum copiezi litere frumoase -->
+  <section class="editorial-section">
+    <h2>Litere și litere frumoase de copiat — cum funcționează</h2>
+    <p class="editorial-intro">Faci <strong>litere de copiat</strong> frumoase în câteva secunde — fără să instalezi o aplicație și fără să-ți faci cont. Scrii un text, iar generatorul îl transformă în zeci de stiluri de litere frumoase, gata de copiat și lipit.</p>
+    <div class="steps-grid">
+      <div class="step-card">
+        <div class="step-number">1</div>
+        <h3>Scrie textul</h3>
+        <p>Scrie un nume, un cuvânt sau o propoziție întreagă în câmpul de sus. Poți și să lipești ceva ce ai deja copiat.</p>
+      </div>
+      <div class="step-card">
+        <div class="step-number">2</div>
+        <h3>Alege stilul de litere</h3>
+        <p>Literele frumoase apar imediat — îngroșate, cursive, caligrafice, gotice, bubble și small caps. Restrânge alegerea cu o categorie de sus.</p>
+      </div>
+      <div class="step-card">
+        <div class="step-number">3</div>
+        <h3>Copiază și lipește</h3>
+        <p>Apeși „Copiază”, lipești în bio pe Insta, în nickname-ul din joc, în statusul de WhatsApp sau în descrierea unui TikTok. Stilul nu se pierde.</p>
+      </div>
+    </div>
+    <p class="u-mt-15 u-text-center">Aceiași pași funcționează pentru <strong>fonturi frumoase de copiat</strong>, litere ornamentate și litere estetice — la fel pe calculator și pe telefon.</p>
+  </section>
+
+  <!-- Alfabet de litere frumoase A–Z -->
+  <section class="editorial-section abc-section" aria-label="Alfabet de litere frumoase de copiat">
+    <h2>Litere frumoase A–Z de copiat</h2>
+    <p>Tot alfabetul — majuscule (A–Z), minuscule (a–z) și cifre (0–9) — în cele mai folosite stiluri de litere frumoase. Scrie ceva în generatorul de sus și apasă „Copiază” ca să iei cuvântul întreg în stilul respectiv, sau selectează literele din tabel și copiază-le singur.</p>
+
+    <div class="abc-list">
+      <div class="abc-row">
+        <span class="abc-name">Îngroșat</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝗔𝗕𝗖𝗗𝗘𝗙𝗚𝗛𝗜𝗝𝗞𝗟𝗠𝗡𝗢𝗣𝗤𝗥𝗦𝗧𝗨𝗩𝗪𝗫𝗬𝗭</span>
+          <span class="abc-line">𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇</span>
+          <span class="abc-line">𝟬𝟭𝟮𝟯𝟰𝟱𝟲𝟳𝟴𝟵</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Cursiv</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝘈𝘉𝘊𝘋𝘌𝘍𝘎𝘏𝘐𝘑𝘒𝘓𝘔𝘕𝘖𝘗𝘘𝘙𝘚𝘛𝘜𝘝𝘞𝘟𝘠𝘡</span>
+          <span class="abc-line">𝘢𝘣𝘤𝘥𝘦𝘧𝘨𝘩𝘪𝘫𝘬𝘭𝘮𝘯𝘰𝘱𝘲𝘳𝘴𝘵𝘶𝘷𝘸𝘹𝘺𝘻</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Caligrafic</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵</span>
+          <span class="abc-line">𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Caligrafic gros</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩</span>
+          <span class="abc-line">𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Gotic</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝔄𝔅ℭ𝔇𝔈𝔉𝔊ℌℑ𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔ℜ𝔖𝔗𝔘𝔙𝔚𝔛𝔜ℨ</span>
+          <span class="abc-line">𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Bubble</span>
+        <div class="abc-lines">
+          <span class="abc-line">ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ</span>
+          <span class="abc-line">ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ</span>
+          <span class="abc-line">⓪①②③④⑤⑥⑦⑧⑨</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Small caps</span>
+        <div class="abc-lines">
+          <span class="abc-line">ᴀʙᴄᴅᴇꜰɢʜɪᴊᴋʟᴍɴᴏᴘqʀsᴛᴜᴠᴡxʏᴢ</span>
+          <span class="abc-line">ᴀʙᴄᴅᴇꜰɢʜɪᴊᴋʟᴍɴᴏᴘqʀsᴛᴜᴠᴡxʏᴢ</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+    </div>
+    <p class="u-mt-15">Cauți un anume tip de literă? Aruncă un ochi la <a href="/category/bold-fonts/">litere îngroșate</a>, <a href="/category/gothic-fonts/">litere gotice de copiat</a> sau <a href="/category/cursive-fonts/">litere de mână și cursive</a> — fiecare categorie arată doar un singur stil, de la majuscule la minuscule.</p>
+  </section>
+
+  <!-- Ornamente și simboluri de copiat -->
+  <section class="editorial-section glyph-section" aria-label="Ornamente și simboluri de copiat">
+    <h2>Ornamente și simboluri de copiat</h2>
+    <p class="editorial-intro">Ornamente gata făcute — <strong>ornamente de text de copiat</strong> — steluțe, inimioare, rame, săgeți și separatoare. Apasă pe orice semn ca să-l copiezi, sau adaugă-le automat la text din filele <strong>Simboluri</strong>, <strong>Rame</strong> și <strong>Separatoare</strong> ale generatorului de sus.</p>
+    <div class="glyph-group">
+      <h3>Steluțe și scânteieri</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="✦">✦</button>
+        <button class="glyph-copy" type="button" data-text="✧">✧</button>
+        <button class="glyph-copy" type="button" data-text="⋆">⋆</button>
+        <button class="glyph-copy" type="button" data-text="✩">✩</button>
+        <button class="glyph-copy" type="button" data-text="★">★</button>
+        <button class="glyph-copy" type="button" data-text="☆">☆</button>
+        <button class="glyph-copy" type="button" data-text="✰">✰</button>
+        <button class="glyph-copy" type="button" data-text="⊹">⊹</button>
+        <button class="glyph-copy" type="button" data-text="࿐">࿐</button>
+        <button class="glyph-copy" type="button" data-text="˚">˚</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Inimioare</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="♡">♡</button>
+        <button class="glyph-copy" type="button" data-text="♥">♥</button>
+        <button class="glyph-copy" type="button" data-text="❤">❤</button>
+        <button class="glyph-copy" type="button" data-text="❥">❥</button>
+        <button class="glyph-copy" type="button" data-text="❣">❣</button>
+        <button class="glyph-copy" type="button" data-text="ღ">ღ</button>
+        <button class="glyph-copy" type="button" data-text="ꨄ">ꨄ</button>
+        <button class="glyph-copy" type="button" data-text="ஐ">ஐ</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Lună și cer</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="☾">☾</button>
+        <button class="glyph-copy" type="button" data-text="☽">☽</button>
+        <button class="glyph-copy" type="button" data-text="☁">☁</button>
+        <button class="glyph-copy" type="button" data-text="✶">✶</button>
+        <button class="glyph-copy" type="button" data-text="⍣">⍣</button>
+        <button class="glyph-copy" type="button" data-text="ꕥ">ꕥ</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Flori</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="❀">❀</button>
+        <button class="glyph-copy" type="button" data-text="✿">✿</button>
+        <button class="glyph-copy" type="button" data-text="⚘">⚘</button>
+        <button class="glyph-copy" type="button" data-text="✾">✾</button>
+        <button class="glyph-copy" type="button" data-text="❁">❁</button>
+        <button class="glyph-copy" type="button" data-text="ꕤ">ꕤ</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Rame și ornamente</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="꧁">꧁</button>
+        <button class="glyph-copy" type="button" data-text="꧂">꧂</button>
+        <button class="glyph-copy" type="button" data-text="༺">༺</button>
+        <button class="glyph-copy" type="button" data-text="༻">༻</button>
+        <button class="glyph-copy" type="button" data-text="⟡">⟡</button>
+        <button class="glyph-copy" type="button" data-text="❪">❪</button>
+        <button class="glyph-copy" type="button" data-text="❫">❫</button>
+        <button class="glyph-copy" type="button" data-text="★彡">★彡</button>
+        <button class="glyph-copy" type="button" data-text="彡★">彡★</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Săgeți</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="→">→</button>
+        <button class="glyph-copy" type="button" data-text="⇨">⇨</button>
+        <button class="glyph-copy" type="button" data-text="➤">➤</button>
+        <button class="glyph-copy" type="button" data-text="⟶">⟶</button>
+        <button class="glyph-copy" type="button" data-text="➳">➳</button>
+        <button class="glyph-copy" type="button" data-text="↬">↬</button>
+        <button class="glyph-copy" type="button" data-text="⇢">⇢</button>
+        <button class="glyph-copy" type="button" data-text="↳">↳</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Separatoare</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="·">·</button>
+        <button class="glyph-copy" type="button" data-text="•">•</button>
+        <button class="glyph-copy" type="button" data-text="◦">◦</button>
+        <button class="glyph-copy" type="button" data-text="➛">➛</button>
+        <button class="glyph-copy" type="button" data-text="⟢">⟢</button>
+        <button class="glyph-copy" type="button" data-text="—">—</button>
+        <button class="glyph-copy" type="button" data-text="☰">☰</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Kaomoji (feței)</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="(◍•ᴗ•◍)">(◍•ᴗ•◍)</button>
+        <button class="glyph-copy" type="button" data-text="(｡♥‿♥｡)">(｡♥‿♥｡)</button>
+        <button class="glyph-copy" type="button" data-text="ʕ•ᴥ•ʔ">ʕ•ᴥ•ʔ</button>
+        <button class="glyph-copy" type="button" data-text="(＾▽＾)">(＾▽＾)</button>
+        <button class="glyph-copy" type="button" data-text="٩(◕‿◕)۶">٩(◕‿◕)۶</button>
+      </div>
+    </div>
+  </section>
+
+  <!-- Popular Use Cases -->
+  <section class="editorial-section">
+    <h2 data-i18n="useCases.title">Pentru ce folosesc oamenii asta cel mai des</h2>
+    <div class="tips-grid">
+      <a class="tip-card" href="/usecase/linkedin-headline/" aria-label="Titlu pe LinkedIn">
+        <div class="tip-icon">💼</div>
+        <h3 data-i18n="useCases.items.0.title">Titlu pe LinkedIn</h3>
+        <p data-i18n="useCases.items.0.description">Ieși în evidență în căutarea de pe LinkedIn — un titlu îngroșat sau ușor ornamentat își face treaba înainte ca cineva să apuce să deruleze mai departe.</p>
+      </a>
+      <a class="tip-card" href="/usecase/comment-font/" aria-label="Comentarii sub postări">
+        <div class="tip-icon">💬</div>
+        <h3 data-i18n="useCases.items.1.title">Comentarii sub postări</h3>
+        <p data-i18n="useCases.items.1.description">Comentarii stilizate pe Insta, YouTube și TikTok — se prind mai ușor cu ochiul decât sutele de comentarii banale de sub o postare populară.</p>
+      </a>
+      <a class="tip-card" href="/usecase/text-to-emoji/" aria-label="Text scris cu emoji">
+        <div class="tip-icon">😊</div>
+        <h3 data-i18n="useCases.items.2.title">Text scris cu emoji</h3>
+        <p data-i18n="useCases.items.2.description">Transformă un cuvânt într-o secvență de litere-emoji — bio creative, story-uri, chat-uri de grup sau pur și simplu de dragul glumei cu prietenii.</p>
+      </a>
+      <a class="tip-card" href="/usecase/tattoo-fonts/" aria-label="Fonturi pentru tatuaj">
+        <div class="tip-icon">🖤</div>
+        <h3>Fonturi pentru Tatuaj</h3>
+        <p>Verifică un nume sau un text în caligrafic, gotic și cursiv — înainte să ajungă sub ac.</p>
+      </a>
+      <a class="tip-card" href="/usecase/zalgo-text/" aria-label="Generator de Text Zalgo">
+        <div class="tip-icon">👻</div>
+        <h3>Litere răsucite Zalgo</h3>
+        <p>Text glitchy cu liniuțe deasupra și dedesubtul literelor — se potrivește la meme-uri de Halloween, bio-uri sumbre și clanuri de gaming care vor să pară amenințătoare.</p>
+      </a>
+    </div>
+    <p class="u-mt-15 u-text-center"><a class="cat-cta" href="/usecase/" data-i18n="useCases.viewAll">Vezi mai multe utilizări →</a></p>
+  </section>
+
+  <!-- Popular Guides -->
+  <section class="editorial-section">
+    <h2 data-i18n="guides.title">Aruncă un ochi pe ghiduri</h2>
+    <div class="tips-grid">
+      <a class="tip-card" href="/guide/the-rhetoric-of-fonts/" aria-label="Retorica Fonturilor">
+        <div class="tip-icon">📚</div>
+        <h3 data-i18n="guides.items.0.title">Retorica Fonturilor</h3>
+        <p data-i18n="guides.items.0.description">De ce un font inspiră încredere, iar altul arată a spam — adică felul în care tipografia influențează ce simțim în timp ce citim.</p>
+      </a>
+      <a class="tip-card" href="/guide/personal-branding-through-typography/" aria-label="Brand personal prin tipografie">
+        <div class="tip-icon">🎨</div>
+        <h3 data-i18n="guides.items.1.title">Brand personal prin tipografie</h3>
+        <p data-i18n="guides.items.1.description">Cum alegi litere care se potrivesc cu vibe-ul tău și rămân cu cei care te citesc — indiferent dacă e vorba de LinkedIn, Insta sau Discord.</p>
+      </a>
+      <a class="tip-card" href="/guide/stop-the-scroll-with-font-variation/" aria-label="Oprește scroll-ul cu variații de font">
+        <div class="tip-icon">📱</div>
+        <h3 data-i18n="guides.items.2.title">Oprește scroll-ul cu variații de font</h3>
+        <p data-i18n="guides.items.2.description">De ce oamenii se opresc la postările cu un alt stil de text și cum să folosești asta ca să-ți crești reach-ul.</p>
+      </a>
+    </div>
+    <p class="u-mt-15 u-text-center"><a class="cat-cta" href="/guide/" data-i18n="guides.viewAll">Toate ghidurile →</a></p>
+  </section>
+
+  <!-- FAQ Section -->
+  <section class="faq-section-wrapper" aria-label="Frequently asked questions">
+    <div class="faq-inner">
+
+<!-- Litere și ornamente de copiat -->
+<h2 class="faq-category">Litere și ornamente de copiat</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span>Unde găsesc litere frumoase de copiat?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer">Aici, pe pagina asta. Scrii un text în câmpul de sus, iar literele frumoase — <strong>îngroșate</strong>, <strong>cursive</strong>, <strong>gotice</strong>, <strong>bubble</strong> și încă vreo câteva zeci — apar imediat dedesubt. Apeși „Copiază” și lipești unde vrei.
+    <br><br>
+    Ai și un <strong>alfabet A–Z gata de copiat</strong> în stilurile populare — majuscule, minuscule și cifre — pe care îl poți lua chiar și fără să scrii nimic.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span>Ce sunt ornamentele de copiat și unde le găsesc?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer">Ornamentele sunt simboluri mici cu care decorezi textul — steluțe ✦, inimioare ♡, rame ꧁꧂, săgeți → și separatoare.
+    <br><br>
+    În secțiunea <strong>„Ornamente și simboluri de copiat”</strong> apeși pe orice semn ca să-l copiezi separat. Poți adăuga și <strong>ornamente de text</strong> automat la tot textul — din filele <strong>Simboluri</strong>, <strong>Rame</strong> și <strong>Separatoare</strong> de deasupra câmpului de scriere.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span>Aveți fonturi frumoase și estetice de copiat?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer">Da — de la <strong>fonturi estetice de copiat</strong> minimaliste și răsfirate până la litere ornamentate cu simboluri. Scrii un text și toate stilurile de fonturi frumoase apar deodată. Totul e gratuit și gata de copiat dintr-un click, la fel pe telefon și pe calculator.</div>
+</div>
+
+
+<!-- Primele întrebări -->
+<h2 class="faq-category" data-i18n="faq.categories.0.title">Primele întrebări</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.0.items.0.question">Ce este UltraTextGen și ce se întâmplă de fapt aici?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.0.items.0.answer">E un generator gratuit de litere — scrii un text obișnuit, iar noi îl transformăm în caractere Unicode stilizate, care arată ca un font frumos.
+    <br><br>
+    Cel mai important: sunt <strong>caractere reale</strong>, nu îngroșarea din Word sau markdown-ul de pe Discord. De asta funcționează peste tot unde poți scrie text obișnuit — în bio pe Insta, într-un nickname, într-un comentariu, într-un e-mail, în statusul de WhatsApp.
+    <br><br>
+    <strong>Exemplu</strong><br>
+    Scrii „hei” → primești 𝗵𝗲𝗶 (îngroșat), 𝘩𝘦𝘪 (cursiv), 𝒽ℯ𝒾 (caligrafic) sau ⓗⓔⓘ (bubble). Totul dintr-un singur click.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.0.items.1.question">Cum copiez niște litere frumoase în 5 secunde?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.0.items.1.answer">1. Scrii sau lipești textul în câmpul de sus.<br>
+    2. Stilurile apar imediat dedesubt — bold, cursiv, gotic, bubble și încă vreo câteva zeci.<br>
+    3. Dacă vrei, adaugă ornamente — rame, steluțe, săgeți.<br>
+    4. Apeși „Copiază” la cel care îți place și îl lipești oriunde vrei.
+    <br><br>
+    Atât. Fără înregistrare, fără instalat aplicații. Merge la fel pe calculator și pe telefon.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.0.items.2.question">Gratuit? Fără limite, fără cont?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.0.items.2.answer">Da, totul e <strong>100% gratuit</strong>. Fără cont, fără limită zilnică, fără watermark, fără nicio șmecherie. Poți trece prin el o carte întreagă și nu se întâmplă nimic.</div>
+</div>
+
+
+<!-- Insta, TikTok, Discord -->
+<h2 class="faq-category" data-i18n="faq.categories.1.title">Insta, TikTok, Discord — unde le lipești</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.1.items.0.question">Cum pun text stilizat în bio pe Instagram?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.1.items.0.answer">Insta nu are nicio bară de formatare, dar acceptă Unicode — adică tot ce generezi la noi intră în bio fără probleme.
+    <br><br>
+    <strong>Cum faci</strong><br>
+    1. Scrie ce vrei să ai în bio (de ex. numele, un hashtag, o descriere scurtă).<br>
+    2. Alege un stil — îngroșatul și cursivul merg cel mai bine pe majoritatea dispozitivelor.<br>
+    3. Copiază rezultatul și lipește-l în „Editează profilul → Bio” din aplicație.
+    <br><br>
+    Pont: dacă vrei să ornamentezi, adaugă o ramă de tip ⋆｡˚ sau o steluță ✦ pe margine — arată bine și nu fură atenția de la restul bio-ului.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.1.items.1.question">Funcționează literele în descrierile de pe TikTok?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.1.items.1.answer">Da — TikTok afișează Unicode în descrieri, în descrierea profilului și în comentarii. Cel mai bine ies <strong>îngroșatul</strong>, <strong>cursivul</strong>, <strong>bubble</strong> și <strong>small caps</strong>. Stilurile cu o grămadă de ornamente se pot tăia la descrierile lungi, așa că, pentru siguranță, verifică postarea în previzualizare înainte de publicare.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.1.items.2.question">Pot să-mi fac un nickname de joc sau de Discord?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.1.items.2.answer">Clar — probabil e cel mai frecvent motiv pentru care oamenii ajung pe astfel de generatoare. Discord, Roblox, Steam, Minecraft, majoritatea jocurilor acceptă Unicode în nickname-uri.
+    <br><br>
+    <strong>Exemplu</strong><br>
+    Nickname obișnuit: „DarkWolf”<br>
+    După stilizare: „𝔇𝔞𝔯𝔨𝔚𝔬𝔩𝔣” (gotic), „ⒹⓐⓡⓚⓌⓞⓛⓕ” (bubble) sau „๖ۣۜDarkWolf” (cu un ornament pe margine).
+    <br><br>
+    <strong>Atenție:</strong> unele jocuri au filtre și nu acceptă caractere exotice. Dacă un stil nu intră, pune altul — bold-ul și cursivul trec de obicei peste tot.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.1.items.3.question">Merge în statusul de WhatsApp, pe Telegram și în Messenger?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.1.items.3.answer">Da — WhatsApp, Telegram, Messenger, Signal, iMessage. Tot ce acceptă text obișnuit acceptă și litere Unicode. Le lipești în status sau într-un mesaj și arată ca un font ornamentat.
+    <br><br>
+    Pentru WhatsApp o completare: dacă ții doar la îngroșare, poți folosi sintaxa lui proprie (<code>*text*</code> dă bold). Dar Unicode funcționează peste tot — inclusiv acolo unde WhatsApp nu are asta, de exemplu în numele unui contact.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.1.items.4.question">Dar în subiectul unui e-mail sau într-un CV?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.1.items.4.answer">Aici Unicode face cea mai mare treabă. Subiectul unui e-mail e text obișnuit, deci îngroșarea din Outlook nu are ce căuta. În schimb „𝗙𝗮𝗰𝘁𝘂𝗿𝗮 — 𝘂𝗿𝗴𝗲𝗻𝘁” arată deja mai puternic în inbox-ul destinatarului.
+    <br><br>
+    Într-un CV, un nume ușor îngroșat în antet poate atrage privirea recrutorului. Doar nu exagera — un CV întreg în gotic nu arată profesional.</div>
+</div>
+
+
+<!-- Stiluri, litere și ornamente -->
+<h2 class="faq-category" data-i18n="faq.categories.2.title">Stiluri, litere și ornamente</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.2.items.0.question">Ce stiluri de litere am la dispoziție?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.2.items.0.answer">Multe. Chiar multe. Pe scurt:
+    <br><br>
+    <strong>De bază</strong><br>
+    Îngroșat (bold), cursiv, caligrafic (script), gotic, bubble (în cerculețe), small caps, tăiat, subliniat, double struck.
+    <br><br>
+    <strong>De distracție</strong><br>
+    Text cu susul în jos, oglindit, Zalgo (glitch cu semne peste litere), text în pătrățele, în paranteze, fullwidth (răsfirat).
+    <br><br>
+    <strong>Adăugiri</strong><br>
+    Rame în jurul textului, steluțe, inimioare, săgeți, separatoare, steaguri, emoji — se pot suprapune peste stilul literelor.
+    <br><br>
+    Din când în când apar altele noi — merită să pui pagina la favorite.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.2.items.1.question">Pot să combin mai multe stiluri deodată?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.2.items.1.answer">Da — și ăsta e cel mai mare avantaj al UltraTextGen. Poți suprapune de exemplu <strong>bubble + Zalgo</strong>, <strong>gotic + cu susul în jos</strong> sau <strong>small caps + subliniat</strong>, iar apoi să închizi totul într-o ramă sau o steluță.
+    <br><br>
+    <strong>Exemplu</strong><br>
+    „hei” → alegi gotic → adaugi o ramă cu steluțe → iese: ★彡[ 𝔥𝔢𝔦 ]彡★
+    <br><br>
+    Cu cât experimentezi mai mult, cu atât ies lucruri mai interesante. Îți recomand să începi cu un singur stil și să adaugi un singur ornament — nu tot deodată.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.2.items.2.question">Ce este Zalgo și liniuțele alea ciudate de deasupra literelor?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.2.items.2.answer">Zalgo e un stil „blestemat”, glitchy — deasupra și dedesubtul fiecărei litere apare o grămadă de semne diacritice. Arată de parcă textul s-ar destrăma sau ar fi dintr-un film de groază.
+    <br><br>
+    <strong>Exemplu</strong><br>
+    „hei” → h̷̢e̴̢i̷̛
+    <br><br>
+    Cel mai des îl vezi în bio-uri sumbre pe Insta, în meme-uri de Halloween, în clanuri de gaming care vor să pară amenințătoare sau când cineva face haz de el.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.2.items.3.question">De unde iau simboluri, steluțe și inimioare frumoase?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.2.items.3.answer">Tot ce ai în secțiunea „Ornamente” de sub câmpul de text îl poți copia separat — chiar și fără să scrii vreun text. Pur și simplu ca semne separate pentru bio, nickname sau o postare.
+    <br><br>
+    — <strong>Simboluri estetice</strong>: ✦ ✧ ⋆ ｡ ☆ ♡ ❀ ✿<br>
+    — <strong>Rame și margini</strong>: ╭─▸ │ ╰─▸ sau ★彡[ ]彡★<br>
+    — <strong>Săgeți</strong>: → ⇨ ➤ ⟶<br>
+    — <strong>Separatoare minimale</strong>: ·  ⋅  ─  •<br>
+    — <strong>Steaguri și emoji</strong>.
+    <br><br>
+    Cel mai des se folosesc în bio-uri estetice pe Instagram și Pinterest — se potrivesc cu orice, de la citate la liste de pasiuni.</div>
+</div>
+
+
+<!-- Diacritice românești, compatibilitate -->
+<h2 class="faq-category" data-i18n="faq.categories.3.title">Diacritice românești, compatibilitate, probleme</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.3.items.0.question">Dar diacriticele românești? Merge cu ă, â, î, ș, ț?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.3.items.0.answer"><strong>Pe scurt:</strong> depinde de stil.
+    <br><br>
+    Unicode are variante stilizate pentru alfabetul de bază A–Z, așa că <em>a</em>, <em>i</em>, <em>s</em>, <em>t</em> se transformă fără probleme, de exemplu în îngroșat. Dar pentru <em>ă</em>, <em>â</em>, <em>î</em>, <em>ș</em>, <em>ț</em> variantele stilizate există doar în o parte dintre stiluri (mai ales bold, italic, small caps).
+    <br><br>
+    Dacă un stil nu are versiune pentru un caracter cu diacritic, acesta rămâne în forma originală — textul e în continuare lizibil, litera cu diacritic arată doar puțin mai „obișnuit” decât restul. Pentru nickname-uri fără diacritice nu e nicio problemă. Pentru propoziții întregi în română îți recomand <strong>bold</strong>, <strong>italic</strong> sau <strong>monospace</strong> — se descurcă cel mai bine cu alfabetul nostru.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.3.items.1.question">De ce cineva vede pătrățele în loc de litere?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.3.items.1.answer">Pentru că fontul de sistem de la destinatar nu conține caracterul Unicode respectiv. Nu e o problemă cu textul tău — pur și simplu telefonul sau aplicația lui nu are semnul acela anume în set.
+    <br><br>
+    Rămâi la <strong>bold</strong>, <strong>italic</strong> și <strong>bubble</strong> — au cel mai larg suport. Stilurile foarte exotice (fullwidth, pătrățele) se pot afișa ca □ pe Android-uri mai vechi sau în unii clienți de e-mail.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.3.items.2.question">Instagram mi-a tăiat o parte din caractere în nickname — și acum?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.3.items.2.answer">Insta are un filtru pe câmpul <strong>nume de utilizator</strong> (adică @-ul) — acceptă doar litere, cifre, punct și underscore. Aici nu poți lipi litere stilizate.
+    <br><br>
+    Dar în câmpul <strong>„Nume”</strong> (numele afișat) și în <strong>bio</strong> se poate — și aici intră majoritatea stilurilor. Dacă unul nu se salvează, pune altul. Bold-ul trece de obicei fără probleme.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.3.items.3.question">Există caractere care nu pot fi transformate deloc?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.3.items.3.answer">Literele standard (A–Z, a–z), cifrele și semnele de punctuație de bază se transformă fără probleme. Unele simboluri rare sau caractere speciale nu au echivalente stilizate în Unicode — atunci rămân în original. Nimic nu se strică, textul rămâne de copiat.</div>
+</div>
+
+
+<!-- Securitate, confidențialitate, telefon -->
+<h2 class="faq-category" data-i18n="faq.categories.4.title">Securitate, confidențialitate, telefon</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.4.items.0.question">Textul meu se salvează undeva?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.4.items.0.answer">Nu. Toată transformarea literelor se întâmplă <strong>în browserul tău</strong> — nimic nu ajunge pe serverele noastre, nimic nu se salvează, nimic nu e urmărit. Textul copiat e Unicode curat, fără caractere ascunse, fără niciun identificator.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.4.items.1.question">E sigur să lipesc literele astea oriunde?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.4.items.1.answer">Da — sunt caractere Unicode standard, identice cu cele folosite de tot internetul. Nimic în interior, niciun script, nicio formatare ascunsă, niciun cod. Le lipești liniștit într-un CV, într-un e-mail de serviciu, în bio-ul de LinkedIn — unde vrei.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.4.items.2.question">Funcționează pe telefon?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.4.items.2.answer">Da — pagina se adaptează complet la mobil. iPhone, Android, tabletă — totul merge. Scrii textul, apeși, se copiază în clipboard, îl lipești în aplicație. Fără să instalezi nimic din vreun magazin.</div>
+</div>
+
+
+<!-- Ce ne diferențiază -->
+<h2 class="faq-category" data-i18n="faq.categories.5.title">Ce ne diferențiază</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.5.items.0.question">Prin ce vă deosebiți de alte generatoare de litere?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.5.items.0.answer">Concret:
+    <br><br>
+    — <strong>Una dintre cele mai mari colecții</strong> de stiluri Ultra — bold, cursiv, gotic, bubble și încă vreo câteva zeci.<br>
+    — <strong>Combinarea stilurilor</strong> — majoritatea generatoarelor îți dau un singur stil deodată, noi te lăsăm să le suprapui.<br>
+    — <strong>Ornamente dintr-un click</strong> — rame, steluțe, separatoare fără să lipești semn cu semn.<br>
+    — <strong>Pagini pentru platforme anume</strong> — Insta, TikTok, Discord. Acolo arătăm doar stilurile care funcționează pe aplicația respectivă.<br>
+    — <strong>Rapid și fără pop-up-uri</strong> — fără captcha, fără „acceptă tot” înainte de fiecare click.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.5.items.1.question">Apar stiluri noi?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.5.items.1.answer">Da, regulat. Din când în când apar variante noi, ornamente și rame. Cel mai simplu e să reții pagina sau să treci pe aici din când în când.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.5.items.2.question">Cum găsesc exact stilul pe care îl caut?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.5.items.2.answer">Trei căi:
+    <br><br>
+    <strong>După stil</strong> — categoriile de sus: bold, cursiv, gotic, bubble, tăiat, cu susul în jos și altele.<br>
+    <strong>După platformă</strong> — intră pe pagina pentru Insta, TikTok, Discord — acolo sunt doar stilurile care funcționează pe platforma respectivă.<br>
+    <strong>După scop</strong> — secțiunea de utilizări are unelte potrivite pentru o nevoie anume: titlu pe LinkedIn, comentarii, text cu emoji.</div>
+</div>
+    </div>
+  </section>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-inner">
+      <!-- Language Switcher -->
+      <div class="lang-switcher" role="navigation" aria-label="Language switcher">
+        <a class="lang-option" href="/" hreflang="en">EN</a>
+        <a class="lang-option" href="/es/" hreflang="es">ES</a>
+        <a class="lang-option" href="/fr/" hreflang="fr">FR</a>
+        <a class="lang-option" href="/pt/" hreflang="pt">PT</a>
+        <a class="lang-option" href="/de/" hreflang="de">DE</a>
+        <a class="lang-option" href="/id/" hreflang="id">ID</a>
+        <a class="lang-option" href="/it/" hreflang="it">IT</a>
+        <a class="lang-option" href="/nl/" hreflang="nl">NL</a>
+        <a class="lang-option" href="/tr/" hreflang="tr">TR</a>
+        <a class="lang-option" href="/pl/" hreflang="pl">PL</a>
+        <a class="lang-option active" href="/ro/" hreflang="ro">RO</a>
+        <a class="lang-option" href="/vi/" hreflang="vi">VI</a>
+        <a class="lang-option" href="/sv/" hreflang="sv">SV</a>
+        <a class="lang-option" href="/no/" hreflang="no">NO</a>
+        <a class="lang-option" href="/ja/" hreflang="ja">JA</a>
+        <a class="lang-option" href="/th/" hreflang="th">TH</a>
+        <a class="lang-option" href="/ru/" hreflang="ru">RU</a>
+        <a class="lang-option" href="/ar/" hreflang="ar">AR</a>
+      </div>
+    </div>
+  </footer>
+
+  <div class="copy-toast" id="copyToast">Copied!</div>
+
+  <script src="/styles.js" defer=""></script>
+<script src="/renderer.js" defer=""></script>
+<script src="/script.js" defer=""></script>
+<script src="/i18n.js" defer=""></script>
+
+
+
+
+<script src="/footer.js" defer=""></script>
+
+
+</body></html>

--- a/ro/scriere-gotica/index.html
+++ b/ro/scriere-gotica/index.html
@@ -1,0 +1,300 @@
+<!DOCTYPE html><html lang="ro"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZGVh");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Generator de Scriere Gotică — 𝔱𝔢𝔵𝔱 𝔤𝔬𝔱𝔦𝔠 de copiat | UltraTextGen</title>
+  <meta name="description" content="Generator gratuit de scriere gotică: transformă textul în caractere Unicode gotice (fraktur) de copiat și lipit — în bio pe Instagram, Discord, TikTok, în nickname-uri și în proiecte de tatuaj. Instant, fără cont.">
+  <link rel="canonical" href="https://ultratextgen.com/ro/scriere-gotica/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/category/gothic-fonts/">
+  <link rel="alternate" hreflang="ro" href="https://ultratextgen.com/ro/scriere-gotica/">
+  <link rel="alternate" hreflang="ro-MD" href="https://ultratextgen.com/ro/scriere-gotica/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/category/gothic-fonts/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Generator de Scriere Gotică — 𝔱𝔢𝔵𝔱 𝔤𝔬𝔱𝔦𝔠 de copiat | UltraTextGen">
+  <meta property="og:description" content="Generator gratuit de scriere gotică — caractere Unicode gotice (fraktur) de copiat și lipit pe Instagram, Discord, TikTok și în nickname-uri. Instant, fără cont.">
+  <meta property="og:url" content="https://ultratextgen.com/ro/scriere-gotica/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category-gothic-fonts.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Generator de Scriere Gotică — 𝔱𝔢𝔵𝔱 𝔤𝔬𝔱𝔦𝔠 de copiat | UltraTextGen">
+  <meta name="twitter:description" content="Generator gratuit de scriere gotică — caractere Unicode gotice (fraktur) de copiat și lipit în social media, pe Discord și în nickname-uri.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category-gothic-fonts.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "ro",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Ce este un generator de scriere gotică și cum funcționează?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Transformă literele pe care le scrii în caractere Unicode gotice (𝔞𝔠𝔢𝔰𝔱𝔢𝔞) — caractere reale din familia fraktur, nu un font sau o imagine. Fiind semne de text obișnuite, le poți copia și lipi oriunde e permis textul: în bio, descrieri, comentarii, nickname-uri și mesaje. Mai multe în ghidul nostru despre cum funcționează fonturile Unicode."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Funcționează textul gotic pe Instagram, Discord, TikTok și în alte aplicații?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da. Bio-urile, descrierile, comentariile, numele de canale de pe Discord și mesajele de chat acceptă fără probleme caracterele gotice, pentru că e Unicode obișnuit. Merge excelent în nickname-uri și profiluri cu atmosferă goth, metal sau medievală. Atenție: unele câmpuri de @nume de utilizator filtrează caracterele nestandard — în handle-ul propriu-zis trebuie să rămâi la text obișnuit, dar în bio și descrieri goticul merge fără piedici."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Prin ce se deosebește goticul (fraktur) de goticul îngroșat?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Sunt două variante ale aceluiași stil. Frakturul obișnuit (𝔤𝔬𝔱𝔦𝔠) este mai subțire și mai clasic, iar goticul îngroșat (𝖌𝖔𝖙𝖎𝖈) are linii mai groase și mai puternice și arată mai bine în titluri scurte și nickname-uri. În rezultatele de mai jos găsești ambele variante — dă click pe cea care se potrivește proiectului tău și copiază."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Pot să scriu diacritice românești (ă, â, î, ș, ț) cu scriere gotică?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Goticul Unicode acoperă A–Z și a–z, de aceea diacriticele românești ca ă, â, î, ș, ț nu au o formă gotică proprie și rămân obișnuite. Ca să obții un efect gotic uniform, le poți înlocui cu literele de bază (a, i, s, t) — dar asta schimbă ortografia — sau le poți lăsa în forma normală, ceea ce într-un text scurt, nickname sau titlu arată de obicei bine oricum."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Generatorul de scriere gotică este gratuit?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da, complet gratuit și fără cont. Scrie, copiază și lipește de câte ori vrei — nu există limită sau costuri ascunse."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "De ce unele litere gotice se afișează ca pătrățele sau arată diferit?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Un pătrățel gol (▯) înseamnă că dispozitivul nu are glifa potrivită pentru caracterul gotic respectiv — de obicei pe sisteme mai vechi. În plus, câteva majuscule fraktur (C, H, I, R, Z) provin dintr-un alt bloc Unicode și arată diferit față de restul alfabetului — e normal. Alege atunci varianta îngroșată de gotic sau actualizează dispozitivul; mai multe în articolul despre de ce fonturile se afișează ca pătrățele."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "inLanguage": "ro",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Acasă", "item": "https://ultratextgen.com/ro/" },
+    { "@type": "ListItem", "position": 2, "name": "Scriere gotică", "item": "https://ultratextgen.com/ro/scriere-gotica/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Generator de Scriere Gotică",
+  "alternateName": ["Scriere gotică","Text gotic","Gotic de copiat","Fraktur Unicode","Litere gotice","Generator de gotic","Font gotic","Blackletter în română"],
+  "url": "https://ultratextgen.com/ro/scriere-gotica/",
+  "inLanguage": "ro",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "RON"
+  },
+  "description": "Generator gratuit de scriere gotică: transformă textul în caractere Unicode gotice (fraktur și gotic îngroșat) de copiat și lipit pe Instagram, Discord, TikTok, în nickname-uri și în proiecte de tatuaj.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/ro/">Acasă</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Scriere gotică</span>
+</nav>
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/category-gothic-fonts.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+  <!-- Hero -->
+  <section class="hero">
+    <div class="hero-inner">
+      <div class="hero-card">
+        <h1 class="hero-headline">Generator de Scriere Gotică</h1>
+        <p class="hero-tagline">Transformă orice text în 𝔱𝔢𝔵𝔱 𝔤𝔬𝔱𝔦𝔠 de copiat și lipit — litere Unicode
+          sumbre și ornamentate (fraktur și gotic îngroșat) pentru bio-uri, nickname-uri și titluri. Gratuit, instant, fără cont.</p>
+        <div class="input-wrapper">
+          <textarea class="main-input" id="mainInput" placeholder="Scrie un text, cuvânt sau nume…" maxlength="500" autofocus></textarea>
+          <span class="char-count"><span id="charCount">0</span>/500</span>
+        </div>
+
+        <!-- Decoration Selector -->
+        <div class="decoration-section">
+          <div class="decoration-label">
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"></path>
+            </svg>
+            Adaugă simboluri în jurul rezultatului
+          </div>
+          <div class="decoration-tabs">
+            <button class="decoration-tab active" data-deco-tab="symbols">Simboluri</button>
+            <button class="decoration-tab" data-deco-tab="frames">Rame</button>
+            <button class="decoration-tab" data-deco-tab="dividers">Separatoare</button>
+            <button class="decoration-tab" data-deco-tab="minimal">Minimale</button>
+            <button class="decoration-tab" data-deco-tab="emojis">Emoji</button>
+          </div>
+          <div class="decoration-grid" id="decorationGrid"></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Main Content -->
+  <main class="container">
+
+    <section class="editorial-section">
+      <span class="article-section-label">Scriere gotică Unicode</span>
+      <h2>Text gotic de copiat — pentru bio-uri, nickname-uri și tatuaje</h2>
+      <p>Aceste litere nu sunt un font sau o imagine, ci <strong>caractere Unicode</strong> reale din familia fraktur.
+        Dă-i bio-ului tău o atmosferă goth, fă-ți un nickname sumbru sau pregătește un text în stil medieval ori metal —
+        goticul se potrivește excelent și pentru proiecte de tatuaj. Scrie textul mai sus, apasă <strong>Copiază</strong>
+        și lipește scrierea gotică unde vrei.</p>
+    </section>
+
+    <!-- Category Tabs (populated by script.js) -->
+    <div class="category-section">
+      <div class="category-tabs" id="categoryTabs"></div>
+    </div>
+
+    <!-- Results -->
+    <div class="results-grid" id="resultsGrid"></div>
+
+    <section class="editorial-section">
+      <span class="article-section-label">Legături</span>
+      <p>Combină goticul cu <a href="/ro/text-ingrosat/">text îngroșat</a>,
+        <a href="/library/aesthetic-symbols/">ornamente</a> sau <a href="/library/invisible-character/">caracterul invizibil</a>
+        pentru spații curate. Pentru proiecte de tatuaj e potrivit <a href="/usecase/tattoo-fonts/">generatorul de fonturi pentru tatuaj</a>,
+        iar pentru așezări pe verticală — <a href="/usecase/vertical-text/">text vertical</a>.</p>
+    </section>
+  </main>
+
+  <!-- Footer + FAQ -->
+  <footer class="footer">
+    <div class="footer-inner">
+<div class="faq-section" id="gothic-faq">
+
+<h2 class="faq-category">Generator de Scriere Gotică — Întrebări frecvente</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Ce este un generator de scriere gotică și cum funcționează?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Transformă literele pe care le scrii în caractere Unicode gotice (𝔞𝔠𝔢𝔰𝔱𝔢𝔞) — caractere reale din familia fraktur, nu un font sau o imagine. Fiind semne de text obișnuite, le poți copia și lipi oriunde e permis textul: în bio, descrieri, comentarii, nickname-uri și mesaje. Mai multe în <a href="/guide/how-unicode-fonts-work/">ghidul nostru despre cum funcționează fonturile Unicode</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Funcționează textul gotic pe Instagram, Discord, TikTok și în alte aplicații?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Da. Bio-urile, descrierile, comentariile, numele de canale de pe Discord și mesajele de chat acceptă fără probleme caracterele gotice, pentru că e Unicode obișnuit. Merge excelent în nickname-uri și profiluri cu atmosferă goth, metal sau medievală. Atenție: unele câmpuri de <strong>@nume de utilizator</strong> filtrează caracterele nestandard — în handle-ul propriu-zis trebuie să rămâi la text obișnuit, dar în bio și descrieri goticul merge fără piedici.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Prin ce se deosebește goticul (fraktur) de goticul îngroșat?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Sunt două variante ale aceluiași stil. Frakturul obișnuit (𝔤𝔬𝔱𝔦𝔠) este mai subțire și mai clasic, iar goticul îngroșat (𝖌𝖔𝖙𝖎𝖈) are linii mai groase și mai puternice și arată mai bine în titluri scurte și nickname-uri. În rezultatele de mai jos găsești ambele variante — dă click pe cea care se potrivește proiectului tău și copiază.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Pot să scriu diacritice românești (ă, â, î, ș, ț) cu scriere gotică?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Goticul Unicode acoperă A–Z și a–z, de aceea diacriticele românești ca ă, â, î, ș, ț nu au o formă gotică proprie și rămân obișnuite. Ca să obții un efect gotic uniform, le poți înlocui cu literele de bază (<strong>a, i, s, t</strong>) — dar asta schimbă ortografia — sau le poți lăsa în forma normală, ceea ce într-un text scurt, nickname sau titlu arată de obicei bine oricum.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Generatorul de scriere gotică este gratuit?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Da, complet gratuit și fără cont. Scrie, copiază și lipește de câte ori vrei — nu există limită sau costuri ascunse.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    De ce unele litere gotice se afișează ca pătrățele sau arată diferit?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Un pătrățel gol (▯) înseamnă că dispozitivul nu are glifa potrivită pentru caracterul gotic respectiv — de obicei pe sisteme mai vechi. În plus, câteva majuscule fraktur (C, H, I, R, Z) provin dintr-un alt bloc Unicode și arată diferit față de restul alfabetului — e normal. Alege atunci varianta îngroșată de gotic sau actualizează dispozitivul; mai multe în articolul despre <a href="/guide/why-fonts-show-as-boxes/">de ce fonturile se afișează ca pătrățele</a>.
+  </div>
+</div>
+
+</div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Language switcher">
+      <a class="lang-option" href="/category/gothic-fonts/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/ro/scriere-gotica/" hreflang="ro">RO</a>
+    </div>
+
+    </div>
+  </footer>
+
+  <div class="copy-toast" id="copyToast">Copiat!</div>
+
+  <script>
+    window.UTG_FAMILY = "gothic";
+    window.UTG_DEMO_TEXT = "scriere gotică\ntext gotic";
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/script.js" defer></script>
+  <script src="/footer.js" defer></script>
+</body></html>

--- a/ro/text-cursiv/index.html
+++ b/ro/text-cursiv/index.html
@@ -1,0 +1,301 @@
+<!DOCTYPE html><html lang="ro"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZGVh");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Generator de Text Cursiv — 𝘵𝘦𝘹𝘵 𝘤𝘶𝘳𝘴𝘪𝘷 de copiat | UltraTextGen</title>
+  <meta name="description" content="Generator gratuit de text cursiv: transformă textul în litere Unicode înclinate de copiat și lipit — în bio pe Instagram, WhatsApp, TikTok, Discord și LinkedIn. Instant, fără cont.">
+  <link rel="canonical" href="https://ultratextgen.com/ro/text-cursiv/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/category/italic-fonts/">
+  <link rel="alternate" hreflang="ro" href="https://ultratextgen.com/ro/text-cursiv/">
+  <link rel="alternate" hreflang="ro-MD" href="https://ultratextgen.com/ro/text-cursiv/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/category/italic-fonts/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Generator de Text Cursiv — 𝘵𝘦𝘹𝘵 𝘤𝘶𝘳𝘴𝘪𝘷 de copiat | UltraTextGen">
+  <meta property="og:description" content="Generator gratuit de text cursiv — litere Unicode înclinate de copiat și lipit pe Instagram, TikTok, WhatsApp, Discord și LinkedIn. Instant, fără cont.">
+  <meta property="og:url" content="https://ultratextgen.com/ro/text-cursiv/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category-italic-fonts.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Generator de Text Cursiv — 𝘵𝘦𝘹𝘵 𝘤𝘶𝘳𝘴𝘪𝘷 de copiat | UltraTextGen">
+  <meta name="twitter:description" content="Generator gratuit de text cursiv — litere Unicode înclinate de copiat și lipit în social media, chat-uri și nickname-uri.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category-italic-fonts.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "ro",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Cum fac text cursiv de copiat și lipit?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Scrie textul în câmpul de sus, iar generatorul îl arată imediat cu litere cursive (𝘵𝘦𝘹𝘵 𝘤𝘶𝘳𝘴𝘪𝘷) — sunt caractere Unicode reale, nu un font instalat sau o imagine. Fiind semne de text obișnuite, le poți copia și lipi oriunde poți scrie text: în bio, în descrieri, în comentarii și în mesaje. Mai multe în ghidul nostru despre cum funcționează fonturile Unicode."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Funcționează textul cursiv Unicode pe Instagram, WhatsApp, TikTok și LinkedIn?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da. Bio-urile, descrierile, comentariile și mesajele de chat acceptă aceste caractere fără probleme. Mai ales pe LinkedIn și X, unde nu există cursiv nativ, fontul înclinat Unicode îți permite să scoți în evidență cuvintele importante. Atenție: unele câmpuri de nume de utilizator (@) filtrează astfel de caractere — pentru login-ul propriu-zis lasă text obișnuit, dar în bio cursivul merge excelent."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Suportă cursivul diacriticele românești (ă, â, î, ș, ț)?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Cursivul Unicode acoperă alfabetul de bază A–Z și cifrele 0–9, de aceea diacriticele românești (ă, â, î, ș, ț) nu au o formă înclinată proprie și rămân litere obișnuite în mijlocul cuvântului (de ex. „șarpe” iese ca ș𝘢𝘳𝘱𝘦). Pentru nickname-uri și sloganuri scurte fără diacritice arată perfect; în text mai lung, cel mai sigur e să alegi cuvinte care nu le conțin."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Generatorul de text cursiv este gratuit?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da, complet gratuit și fără cont. Scrie, copiază și lipește de câte ori vrei — nu există nicio limită sau costuri ascunse."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "De ce unele litere cursive apar ca pătrățele goale?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Un pătrățel gol (▯) înseamnă că dispozitivul destinatarului nu are glifa pentru caracterul înclinat respectiv — de obicei un telefon sau un calculator mai vechi. Alege o variantă de cursiv mai simplă sau actualizează dispozitivul — mai multe în textul despre de ce fonturile apar ca pătrățele."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Afectează textul cursiv Unicode lizibilitatea și reach-ul?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Caracterele înclinate Unicode atrag frumos privirea și se descurcă grozav în sloganuri, titluri și îndemnuri la acțiune în social media. Folosește-le cu intenție — un accent scurt în cursiv, restul text obișnuit. În conținutul de pe propriul site e mai bine să folosești înclinarea CSS, ca motoarele de căutare să citească cuvinte normale; în câmpurile de text din social media, cursivul Unicode e ideal. La fragmente mai lungi, ține cont de accesibilitate."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "inLanguage": "ro",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Acasă", "item": "https://ultratextgen.com/ro/" },
+    { "@type": "ListItem", "position": 2, "name": "Text cursiv", "item": "https://ultratextgen.com/ro/text-cursiv/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Generator de Text Cursiv",
+  "alternateName": ["Text cursiv de copiat","Font înclinat","Litere înclinate","Cursiv Unicode","Font cursiv","Text cu litere cursive","Cursiv online"],
+  "url": "https://ultratextgen.com/ro/text-cursiv/",
+  "inLanguage": "ro",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "RON"
+  },
+  "description": "Generator gratuit de text cursiv: transformă textul în litere Unicode înclinate de copiat și lipit pe Instagram, TikTok, WhatsApp, Discord, LinkedIn și în nickname-uri.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/ro/">Acasă</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Text cursiv</span>
+</nav>
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/category-italic-fonts.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+  <!-- Hero -->
+  <section class="hero">
+    <div class="hero-inner">
+      <div class="hero-card">
+        <h1 class="hero-headline">Generator de Text Cursiv</h1>
+        <p class="hero-tagline">Transformă orice text în 𝘵𝘦𝘹𝘵 𝘤𝘶𝘳𝘴𝘪𝘷 de copiat și lipit — litere Unicode
+          înclinate, elegante, pentru bio-uri, nickname-uri și titluri. Gratuit, instant, fără cont.</p>
+        <div class="input-wrapper">
+          <textarea class="main-input" id="mainInput" placeholder="Scrie un text, cuvânt sau nume…" maxlength="500" autofocus></textarea>
+          <span class="char-count"><span id="charCount">0</span>/500</span>
+        </div>
+
+        <!-- Decoration Selector -->
+        <div class="decoration-section">
+          <div class="decoration-label">
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"></path>
+            </svg>
+            Adaugă simboluri în jurul rezultatului
+          </div>
+          <div class="decoration-tabs">
+            <button class="decoration-tab active" data-deco-tab="symbols">Simboluri</button>
+            <button class="decoration-tab" data-deco-tab="frames">Rame</button>
+            <button class="decoration-tab" data-deco-tab="dividers">Separatoare</button>
+            <button class="decoration-tab" data-deco-tab="minimal">Minimale</button>
+            <button class="decoration-tab" data-deco-tab="emojis">Emoji</button>
+          </div>
+          <div class="decoration-grid" id="decorationGrid"></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Main Content -->
+  <main class="container">
+
+    <section class="editorial-section">
+      <span class="article-section-label">Text cursiv Unicode</span>
+      <h2>Text cursiv de copiat — pentru bio-uri, nickname-uri și titluri</h2>
+      <p>Aceste litere nu sunt un font instalat sau o imagine, ci <strong>caractere Unicode</strong> reale. Scoate în
+        evidență un cuvânt-cheie din bio, fă-ți un nickname înclinat sau fă ca titlul de pe LinkedIn și X să atragă
+        privirea — peste tot unde nu există cursiv nativ. Scrie textul mai sus, apasă <strong>Copiază</strong> și lipește
+        textul cursiv unde vrei.</p>
+    </section>
+
+    <!-- Category Tabs (populated by script.js) -->
+    <div class="category-section">
+      <div class="category-tabs" id="categoryTabs"></div>
+    </div>
+
+    <!-- Results -->
+    <div class="results-grid" id="resultsGrid"></div>
+
+    <section class="editorial-section">
+      <span class="article-section-label">Legături</span>
+      <p>Combină cursivul cu <a href="/ro/fonturi-pentru-discord/">fonturi pentru Discord</a>,
+        <a href="/ro/">litere de copiat</a> sau
+        <a href="/library/invisible-character/">caracterul invizibil</a> pentru spații curate. Pentru tatuaje există un
+        <a href="/usecase/tattoo-fonts/">generator de fonturi pentru tatuaj</a>, iar pentru așezări pe verticală —
+        <a href="/usecase/vertical-text/">text vertical</a>.</p>
+    </section>
+  </main>
+
+  <!-- Footer + FAQ -->
+  <footer class="footer">
+    <div class="footer-inner">
+<div class="faq-section" id="faq">
+
+<h2 class="faq-category">Generator de Text Cursiv — Întrebări frecvente</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Cum fac text cursiv de copiat și lipit?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Scrie textul în câmpul de sus, iar generatorul îl arată imediat cu litere cursive (𝘵𝘦𝘹𝘵 𝘤𝘶𝘳𝘴𝘪𝘷) — sunt caractere Unicode reale, nu un font instalat sau o imagine. Fiind semne de text obișnuite, le poți copia și lipi oriunde poți scrie text: în bio, în descrieri, în comentarii și în mesaje. Mai multe în <a href="/guide/how-unicode-fonts-work/">ghidul nostru despre cum funcționează fonturile Unicode</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Funcționează textul cursiv Unicode pe Instagram, WhatsApp, TikTok și LinkedIn?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Da. Bio-urile, descrierile, comentariile și mesajele de chat acceptă aceste caractere fără probleme. Mai ales pe LinkedIn și X, unde nu există cursiv nativ, fontul înclinat Unicode îți permite să scoți în evidență cuvintele importante. Atenție: unele <strong>câmpuri de nume de utilizator (@)</strong> filtrează astfel de caractere — pentru login-ul propriu-zis lasă text obișnuit, dar în bio cursivul merge excelent.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Suportă cursivul diacriticele românești (ă, â, î, ș, ț)?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Cursivul Unicode acoperă alfabetul de bază A–Z și cifrele 0–9, de aceea diacriticele românești (ă, â, î, ș, ț) nu au o formă înclinată proprie și rămân litere obișnuite în mijlocul cuvântului (de ex. „șarpe” iese ca ș𝘢𝘳𝘱𝘦). Pentru nickname-uri și sloganuri scurte <strong>fără diacritice</strong> arată perfect; în text mai lung, cel mai sigur e să alegi cuvinte care nu le conțin.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Generatorul de text cursiv este gratuit?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Da, complet gratuit și fără cont. Scrie, copiază și lipește de câte ori vrei — nu există nicio limită sau costuri ascunse.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    De ce unele litere cursive apar ca pătrățele goale?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Un pătrățel gol (▯) înseamnă că dispozitivul destinatarului nu are glifa pentru caracterul înclinat respectiv — de obicei un telefon sau un calculator mai vechi. Alege o variantă de cursiv mai simplă sau actualizează dispozitivul — mai multe în textul despre <a href="/guide/why-fonts-show-as-boxes/">de ce fonturile apar ca pătrățele</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Afectează textul cursiv Unicode lizibilitatea și reach-ul?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Caracterele înclinate Unicode atrag frumos privirea și se descurcă grozav în sloganuri, titluri și îndemnuri la acțiune în social media. Folosește-le cu intenție — un accent scurt în cursiv, restul text obișnuit. În conținutul de pe propriul site e mai bine să folosești înclinarea CSS, ca motoarele de căutare să citească cuvinte normale; în câmpurile de text din social media, cursivul Unicode e ideal. La fragmente mai lungi, ține cont de <a href="/guide/fancy-fonts-accessibility-guide/">accesibilitate</a>.
+  </div>
+</div>
+
+</div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Language switcher">
+      <a class="lang-option" href="/category/italic-fonts/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/ro/text-cursiv/" hreflang="ro">RO</a>
+    </div>
+
+    </div>
+  </footer>
+
+  <div class="copy-toast" id="copyToast">Copiat!</div>
+
+  <script>
+    window.UTG_FAMILY = "italic";
+    window.UTG_DEMO_TEXT = "text cursiv\nscris cursiv";
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/script.js" defer></script>
+  <script src="/footer.js" defer></script>
+</body></html>

--- a/ro/text-ingrosat/index.html
+++ b/ro/text-ingrosat/index.html
@@ -1,0 +1,300 @@
+<!DOCTYPE html><html lang="ro"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZGVh");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Generator de Text Îngroșat — 𝐭𝐞𝐱𝐭 𝐢̂𝐧𝐠𝐫𝐨𝐬̦𝐚𝐭 de copiat | UltraTextGen</title>
+  <meta name="description" content="Generator gratuit de text îngroșat: transformă textul în caractere Unicode îngroșate de copiat și lipit — în bio pe Instagram, WhatsApp, TikTok, Discord, LinkedIn și în nickname-uri. Instant, fără cont.">
+  <link rel="canonical" href="https://ultratextgen.com/ro/text-ingrosat/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/category/bold-fonts/">
+  <link rel="alternate" hreflang="ro" href="https://ultratextgen.com/ro/text-ingrosat/">
+  <link rel="alternate" hreflang="ro-MD" href="https://ultratextgen.com/ro/text-ingrosat/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/category/bold-fonts/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Generator de Text Îngroșat — 𝐭𝐞𝐱𝐭 𝐢̂𝐧𝐠𝐫𝐨𝐬̦𝐚𝐭 de copiat | UltraTextGen">
+  <meta property="og:description" content="Generator gratuit de text îngroșat — caractere Unicode îngroșate de copiat și lipit pe Instagram, TikTok, WhatsApp, Discord și LinkedIn. Instant, fără cont.">
+  <meta property="og:url" content="https://ultratextgen.com/ro/text-ingrosat/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category-bold-fonts.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Generator de Text Îngroșat — 𝐭𝐞𝐱𝐭 𝐢̂𝐧𝐠𝐫𝐨𝐬̦𝐚𝐭 de copiat | UltraTextGen">
+  <meta name="twitter:description" content="Generator gratuit de text îngroșat — caractere Unicode îngroșate de copiat și lipit în social media, chat-uri și nickname-uri.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category-bold-fonts.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "ro",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Ce este un generator de text îngroșat și cum funcționează?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Transformă literele pe care le scrii în caractere Unicode îngroșate (𝐚𝐬̦𝐚 𝐜𝐚 𝐚𝐜𝐞𝐬𝐭𝐞𝐚) — caractere reale, nu un font sau o imagine. Fiind semne de text obișnuite, le poți copia și lipi oriunde e permis textul: în bio, descrieri, comentarii și mesaje. Mai multe în ghidul nostru despre cum funcționează fonturile Unicode."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Funcționează textul îngroșat pe Instagram, WhatsApp, TikTok și LinkedIn?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da. Bio-urile, descrierile, comentariile și mesajele de chat acceptă fără probleme aceste caractere. Mai ales pe LinkedIn și X, unde nu există îngroșare nativă, textul îngroșat Unicode face ca fragmentele importante să iasă în evidență. Atenție: unele câmpuri de @nume de utilizator filtrează aceste caractere — în handle-ul propriu-zis trebuie să rămâi la text obișnuit, dar în bio textul îngroșat merge excelent."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Pot să scriu diacritice românești (ă, â, î, ș, ț) cu text îngroșat?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Îngroșarea Unicode acoperă A–Z și 0–9, de aceea diacriticele românești ca ă, â, î, ș, ț nu au o formă îngroșată proprie și rămân obișnuite. Ca să obții un efect complet îngroșat, le poți înlocui cu literele de bază (a, i, s, t) — dar asta schimbă ortografia — sau le poți lăsa în grosime normală, ceea ce într-un text scurt arată de obicei bine oricum."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Generatorul de text îngroșat este gratuit?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da, complet gratuit și fără cont. Scrie, copiază și lipește de câte ori vrei — nu există limită sau costuri ascunse."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "De ce unele caractere se afișează ca pătrățele goale?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Un pătrățel gol (▯) înseamnă că dispozitivul nu are glifa potrivită pentru caracterul îngroșat respectiv. De obicei asta se întâmplă pe sisteme mai vechi. Alege un stil îngroșat mai simplu sau actualizează dispozitivul — mai multe în articolul despre de ce fonturile se afișează ca pătrățele."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Afectează textul îngroșat Unicode lizibilitatea și reach-ul?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Caracterele îngroșate Unicode atrag privirea în feed și se descurcă grozav ca hook-uri, titluri și CTA-uri în social media. Folosește-le cu intenție — accente scurte îngroșate, restul text obișnuit. Pentru conținutul de pe un site web e mai bine să folosești îngroșarea CSS, ca motoarele de căutare să citească textul ca pe niște cuvinte normale. Pentru câmpurile de text din social media, îngroșarea Unicode e soluția ideală. Ține cont de accesibilitate când formatezi fragmente mai lungi."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "inLanguage": "ro",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Acasă", "item": "https://ultratextgen.com/ro/" },
+    { "@type": "ListItem", "position": 2, "name": "Text îngroșat", "item": "https://ultratextgen.com/ro/text-ingrosat/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Generator de Text Îngroșat",
+  "alternateName": ["Text îngroșat","Text bold","Litere îngroșate","Generator de text bold","Text îngroșat de copiat","Text îngroșat Unicode","Bold de copiat"],
+  "url": "https://ultratextgen.com/ro/text-ingrosat/",
+  "inLanguage": "ro",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "RON"
+  },
+  "description": "Generator gratuit de text îngroșat: transformă textul în caractere Unicode îngroșate de copiat și lipit pe Instagram, TikTok, WhatsApp, Discord, LinkedIn și în nickname-uri.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/ro/">Acasă</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Text îngroșat</span>
+</nav>
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/category-bold-fonts.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+  <!-- Hero -->
+  <section class="hero">
+    <div class="hero-inner">
+      <div class="hero-card">
+        <h1 class="hero-headline">Generator de Text Îngroșat</h1>
+        <p class="hero-tagline">Transformă orice text în 𝐭𝐞𝐱𝐭 𝐢̂𝐧𝐠𝐫𝐨𝐬̦𝐚𝐭 de copiat și lipit — caractere Unicode
+          puternice, care atrag privirea, pentru bio-uri, nickname-uri și titluri. Gratuit, instant, fără cont.</p>
+        <div class="input-wrapper">
+          <textarea class="main-input" id="mainInput" placeholder="Scrie un text, cuvânt sau nume…" maxlength="500" autofocus></textarea>
+          <span class="char-count"><span id="charCount">0</span>/500</span>
+        </div>
+
+        <!-- Decoration Selector -->
+        <div class="decoration-section">
+          <div class="decoration-label">
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"></path>
+            </svg>
+            Adaugă simboluri în jurul rezultatului
+          </div>
+          <div class="decoration-tabs">
+            <button class="decoration-tab active" data-deco-tab="symbols">Simboluri</button>
+            <button class="decoration-tab" data-deco-tab="frames">Rame</button>
+            <button class="decoration-tab" data-deco-tab="dividers">Separatoare</button>
+            <button class="decoration-tab" data-deco-tab="minimal">Minimale</button>
+            <button class="decoration-tab" data-deco-tab="emojis">Emoji</button>
+          </div>
+          <div class="decoration-grid" id="decorationGrid"></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Main Content -->
+  <main class="container">
+
+    <section class="editorial-section">
+      <span class="article-section-label">Text îngroșat Unicode</span>
+      <h2>Text îngroșat de copiat — pentru bio-uri, nickname-uri și titluri</h2>
+      <p>Aceste litere nu sunt un font sau o imagine, ci <strong>caractere Unicode</strong> reale. Scoate în evidență
+        un cuvânt-cheie din bio, fă-ți un nickname îngroșat sau fă ca titlul de pe LinkedIn și X să atragă privirea —
+        peste tot unde nu există îngroșare nativă. Scrie textul mai sus, apasă <strong>Copiază</strong> și lipește textul
+        îngroșat unde vrei.</p>
+    </section>
+
+    <!-- Category Tabs (populated by script.js) -->
+    <div class="category-section">
+      <div class="category-tabs" id="categoryTabs"></div>
+    </div>
+
+    <!-- Results -->
+    <div class="results-grid" id="resultsGrid"></div>
+
+    <section class="editorial-section">
+      <span class="article-section-label">Legături</span>
+      <p>Combină textul îngroșat cu <a href="/ro/fonturi-pentru-discord/">fonturi pentru Discord</a>,
+        <a href="/library/aesthetic-symbols/">ornamente</a> sau <a href="/library/invisible-character/">caracterul invizibil</a>
+        pentru spații curate. Pentru body art avem un <a href="/usecase/tattoo-fonts/">generator de fonturi pentru tatuaj</a>,
+        iar pentru așezări pe verticală — <a href="/usecase/vertical-text/">text vertical</a>.</p>
+    </section>
+  </main>
+
+  <!-- Footer + FAQ -->
+  <footer class="footer">
+    <div class="footer-inner">
+<div class="faq-section" id="bold-faq">
+
+<h2 class="faq-category">Generator de Text Îngroșat — Întrebări frecvente</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Ce este un generator de text îngroșat și cum funcționează?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Transformă literele pe care le scrii în caractere Unicode îngroșate (𝐚𝐬̦𝐚 𝐜𝐚 𝐚𝐜𝐞𝐬𝐭𝐞𝐚) — caractere reale, nu un font sau o imagine. Fiind semne de text obișnuite, le poți copia și lipi oriunde e permis textul: în bio, descrieri, comentarii și mesaje. Mai multe în <a href="/guide/how-unicode-fonts-work/">ghidul nostru despre cum funcționează fonturile Unicode</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Funcționează textul îngroșat pe Instagram, WhatsApp, TikTok și LinkedIn?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Da. Bio-urile, descrierile, comentariile și mesajele de chat acceptă fără probleme aceste caractere. Mai ales pe LinkedIn și X, unde nu există îngroșare nativă, textul îngroșat Unicode face ca fragmentele importante să iasă în evidență. Atenție: unele câmpuri de <strong>@nume de utilizator</strong> filtrează aceste caractere — în handle-ul propriu-zis trebuie să rămâi la text obișnuit, dar în bio textul îngroșat merge excelent.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Pot să scriu diacritice românești (ă, â, î, ș, ț) cu text îngroșat?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Îngroșarea Unicode acoperă A–Z și 0–9, de aceea diacriticele românești ca ă, â, î, ș, ț nu au o formă îngroșată proprie și rămân obișnuite. Ca să obții un efect complet îngroșat, le poți înlocui cu literele de bază (<strong>a, i, s, t</strong>) — dar asta schimbă ortografia — sau le poți lăsa în grosime normală, ceea ce într-un text scurt arată de obicei bine oricum.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Generatorul de text îngroșat este gratuit?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Da, complet gratuit și fără cont. Scrie, copiază și lipește de câte ori vrei — nu există limită sau costuri ascunse.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    De ce unele caractere se afișează ca pătrățele goale?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Un pătrățel gol (▯) înseamnă că dispozitivul nu are glifa potrivită pentru caracterul îngroșat respectiv. De obicei asta se întâmplă pe sisteme mai vechi. Alege un stil îngroșat mai simplu sau actualizează dispozitivul — mai multe în articolul despre <a href="/guide/why-fonts-show-as-boxes/">de ce fonturile se afișează ca pătrățele</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Afectează textul îngroșat Unicode lizibilitatea și reach-ul?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Caracterele îngroșate Unicode atrag privirea în feed și se descurcă grozav ca hook-uri, titluri și CTA-uri în social media. Folosește-le cu intenție — accente scurte îngroșate, restul text obișnuit. Pentru conținutul de pe un site web e mai bine să folosești îngroșarea CSS, ca motoarele de căutare să citească textul ca pe niște cuvinte normale. Pentru câmpurile de text din social media, îngroșarea Unicode e soluția ideală. Ține cont de <a href="/guide/fancy-fonts-accessibility-guide/">accesibilitate</a> când formatezi fragmente mai lungi.
+  </div>
+</div>
+
+</div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Language switcher">
+      <a class="lang-option" href="/category/bold-fonts/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/ro/text-ingrosat/" hreflang="ro">RO</a>
+    </div>
+
+    </div>
+  </footer>
+
+  <div class="copy-toast" id="copyToast">Copiat!</div>
+
+  <script>
+    window.UTG_FAMILY = "bold";
+    window.UTG_DEMO_TEXT = "text îngroșat\ntext bold";
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/script.js" defer></script>
+  <script src="/footer.js" defer></script>
+</body></html>

--- a/ro/text-mic/index.html
+++ b/ro/text-mic/index.html
@@ -1,0 +1,300 @@
+<!DOCTYPE html><html lang="ro"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZGVh");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Generator de Text Mic — ᴛᴇxᴛ ᴍɪᴄ și small caps de copiat | UltraTextGen</title>
+  <meta name="description" content="Generator gratuit de text mic: transformă textul în text mic Unicode și small caps de copiat și lipit — în bio pe Instagram, Discord, TikTok, X și în nickname-uri. Instant, fără cont.">
+  <link rel="canonical" href="https://ultratextgen.com/ro/text-mic/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/category/small-text/">
+  <link rel="alternate" hreflang="ro" href="https://ultratextgen.com/ro/text-mic/">
+  <link rel="alternate" hreflang="ro-MD" href="https://ultratextgen.com/ro/text-mic/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/category/small-text/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Generator de Text Mic — ᴛᴇxᴛ ᴍɪᴄ și small caps de copiat | UltraTextGen">
+  <meta property="og:description" content="Generator gratuit de text mic — text mic Unicode și small caps de copiat și lipit pe Instagram, TikTok, Discord și X. Instant, fără cont.">
+  <meta property="og:url" content="https://ultratextgen.com/ro/text-mic/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category-small-text.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Generator de Text Mic — ᴛᴇxᴛ ᴍɪᴄ și small caps de copiat | UltraTextGen">
+  <meta name="twitter:description" content="Generator gratuit de text mic — text mic Unicode și small caps de copiat și lipit în social media, chat-uri și nickname-uri.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category-small-text.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "ro",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Ce este textul mic și cum funcționează generatorul de text mic?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Generatorul transformă literele pe care le scrii în caractere Unicode mai mici — small caps (ᴛᴇxᴛ ᴍɪᴄ) și text mic în superscript și subscript. Sunt caractere reale, nu un font sau o imagine, de aceea le poți copia și lipi oriunde e permis textul: în bio, descrieri, comentarii și mesaje. Mai multe în ghidul nostru despre cum funcționează fonturile Unicode."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Funcționează textul mic pe Discord, Instagram, TikTok și X?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da. Bio-urile, descrierile, comentariile și mesajele de chat acceptă de obicei fără probleme textul mic. Se descurcă bine ca o descriere secundară, subtilă, sub nickname sau ca un subtitlu delicat, care nu strigă la fel de tare ca un text mare îngroșat. Compatibilitatea depinde însă de stil și de dispozitiv — cel mai bine e să lipești rezultatul și să verifici cum arată în aplicația respectivă."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Prin ce se deosebesc small caps de textul mic în superscript?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Small caps sunt majuscule mici (sᴍᴀʟʟ ᴄᴀᴘs) — literele au forma majusculelor, dar înălțimea minusculelor, așa că textul rămâne lizibil și elegant. Textul mic în superscript (ᵃˢᵗᶠᵉˡ) sau subscript este și mai mărunt și ușor ridicat sau coborât, de aceea e excelent pentru accente ornamentale scurte. Pentru fraze mai lungi arată de obicei mai bine small caps."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Pot să scriu diacritice românești (ă, â, î, ș, ț) cu text mic?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Variantele mici Unicode acoperă în principal A–Z și o parte dintre cifre, de aceea diacriticele românești ca ă, â, î, ș, ț nu au o formă mică proprie și rămân la dimensiunea normală. Ca să obții un efect uniform, le poți înlocui cu literele de bază (a, i, s, t) — dar asta schimbă ortografia — sau le poți lăsa neschimbate, ceea ce într-un nickname sau subtitlu scurt arată de obicei bine oricum."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Generatorul de text mic este gratuit?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da, complet gratuit și fără cont. Scrie, copiază și lipește de câte ori vrei — nu există limită sau costuri ascunse. Totul funcționează în browser, deci nu instalezi nimic."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "De ce unele litere mici se afișează ca pătrățele și afectează lizibilitatea?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Un pătrățel gol (▯) înseamnă că dispozitivul nu are glifa pentru caracterul mic respectiv — de obicei pe sisteme mai vechi. Alege atunci un stil mai simplu (de ex. small caps) sau actualizează dispozitivul; mai multe în articolul despre de ce fonturile se afișează ca pătrățele. Ține cont și că textul foarte mic se citește mai greu — folosește-l pentru fraze scurte, iar informațiile importante lasă-le în text obișnuit, din motive de accesibilitate."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "inLanguage": "ro",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Acasă", "item": "https://ultratextgen.com/ro/" },
+    { "@type": "ListItem", "position": 2, "name": "Text mic", "item": "https://ultratextgen.com/ro/text-mic/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Generator de Text Mic",
+  "alternateName": ["Text mic","Litere mici","Generator de text mic","Small caps","Litere mici de copiat","Text mic Unicode","Text mărunt","Scris mic"],
+  "url": "https://ultratextgen.com/ro/text-mic/",
+  "inLanguage": "ro",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "RON"
+  },
+  "description": "Generator gratuit de text mic: transformă textul în text mic Unicode și small caps de copiat și lipit pe Instagram, TikTok, Discord, X și în nickname-uri.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/ro/">Acasă</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Text mic</span>
+</nav>
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/category-small-text.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+  <!-- Hero -->
+  <section class="hero">
+    <div class="hero-inner">
+      <div class="hero-card">
+        <h1 class="hero-headline">Generator de Text Mic</h1>
+        <p class="hero-tagline">Transformă orice text în ᴛᴇxᴛ ᴍɪᴄ și small caps de copiat și lipit — caractere Unicode
+          subtile și mărunte pentru bio-uri, nickname-uri și subtitluri. Gratuit, instant, fără cont.</p>
+        <div class="input-wrapper">
+          <textarea class="main-input" id="mainInput" placeholder="Scrie un text, cuvânt sau nume…" maxlength="500" autofocus></textarea>
+          <span class="char-count"><span id="charCount">0</span>/500</span>
+        </div>
+
+        <!-- Decoration Selector -->
+        <div class="decoration-section">
+          <div class="decoration-label">
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"></path>
+            </svg>
+            Adaugă simboluri în jurul rezultatului
+          </div>
+          <div class="decoration-tabs">
+            <button class="decoration-tab active" data-deco-tab="symbols">Simboluri</button>
+            <button class="decoration-tab" data-deco-tab="frames">Rame</button>
+            <button class="decoration-tab" data-deco-tab="dividers">Separatoare</button>
+            <button class="decoration-tab" data-deco-tab="minimal">Minimale</button>
+            <button class="decoration-tab" data-deco-tab="emojis">Emoji</button>
+          </div>
+          <div class="decoration-grid" id="decorationGrid"></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Main Content -->
+  <main class="container">
+
+    <section class="editorial-section">
+      <span class="article-section-label">Text mic Unicode</span>
+      <h2>Text mic de copiat — pentru bio-uri, nickname-uri și subtitluri</h2>
+      <p>Aceste litere nu sunt un font sau o imagine, ci <strong>caractere Unicode</strong> reale. Adaugă o descriere
+        subtilă sub nickname, scrie-ți numele cu <strong>small caps</strong> elegante sau strecoară un text mărunt în
+        superscript acolo unde un text mare îngroșat ar fi prea zgomotos. Scrie textul mai sus, apasă <strong>Copiază</strong>
+        și lipește textul mic unde vrei.</p>
+    </section>
+
+    <!-- Category Tabs (populated by script.js) -->
+    <div class="category-section">
+      <div class="category-tabs" id="categoryTabs"></div>
+    </div>
+
+    <!-- Results -->
+    <div class="results-grid" id="resultsGrid"></div>
+
+    <section class="editorial-section">
+      <span class="article-section-label">Legături</span>
+      <p>Combină textul mic cu <a href="/ro/text-ingrosat/">text îngroșat</a>,
+        <a href="/library/aesthetic-symbols/">ornamente</a> sau <a href="/library/invisible-character/">caracterul invizibil</a>
+        pentru spații curate. Vezi și <a href="/ro/">litere de copiat</a>,
+        iar pentru așezări pe verticală — <a href="/usecase/vertical-text/">text vertical</a>.</p>
+    </section>
+  </main>
+
+  <!-- Footer + FAQ -->
+  <footer class="footer">
+    <div class="footer-inner">
+<div class="faq-section" id="small-faq">
+
+<h2 class="faq-category">Generator de Text Mic — Întrebări frecvente</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Ce este textul mic și cum funcționează generatorul de text mic?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Generatorul transformă literele pe care le scrii în caractere Unicode mai mici — small caps (ᴛᴇxᴛ ᴍɪᴄ) și text mic în superscript și subscript. Sunt caractere reale, nu un font sau o imagine, de aceea le poți copia și lipi oriunde e permis textul: în bio, descrieri, comentarii și mesaje. Mai multe în <a href="/guide/how-unicode-fonts-work/">ghidul nostru despre cum funcționează fonturile Unicode</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Funcționează textul mic pe Discord, Instagram, TikTok și X?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Da. Bio-urile, descrierile, comentariile și mesajele de chat acceptă de obicei fără probleme textul mic. Se descurcă bine ca o descriere secundară, subtilă, sub nickname sau ca un subtitlu delicat, care nu strigă la fel de tare ca un text mare îngroșat. Compatibilitatea depinde însă de stil și de dispozitiv — cel mai bine e să lipești rezultatul și să verifici cum arată în aplicația respectivă.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Prin ce se deosebesc small caps de textul mic în superscript?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Small caps sunt majuscule mici (sᴍᴀʟʟ ᴄᴀᴘs) — literele au forma majusculelor, dar înălțimea minusculelor, așa că textul rămâne lizibil și elegant. Textul mic în superscript (ᵃˢᵗᶠᵉˡ) sau subscript este și mai mărunt și ușor ridicat sau coborât, de aceea e excelent pentru accente ornamentale scurte. Pentru fraze mai lungi arată de obicei mai bine <strong>small caps</strong>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Pot să scriu diacritice românești (ă, â, î, ș, ț) cu text mic?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Variantele mici Unicode acoperă în principal A–Z și o parte dintre cifre, de aceea diacriticele românești ca ă, â, î, ș, ț nu au o formă mică proprie și rămân la dimensiunea normală. Ca să obții un efect uniform, le poți înlocui cu literele de bază (<strong>a, i, s, t</strong>) — dar asta schimbă ortografia — sau le poți lăsa neschimbate, ceea ce într-un nickname sau subtitlu scurt arată de obicei bine oricum.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Generatorul de text mic este gratuit?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Da, complet gratuit și fără cont. Scrie, copiază și lipește de câte ori vrei — nu există limită sau costuri ascunse. Totul funcționează în browser, deci nu instalezi nimic.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    De ce unele litere mici se afișează ca pătrățele și afectează lizibilitatea?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Un pătrățel gol (▯) înseamnă că dispozitivul nu are glifa pentru caracterul mic respectiv — de obicei pe sisteme mai vechi. Alege atunci un stil mai simplu (de ex. small caps) sau actualizează dispozitivul; mai multe în articolul despre <a href="/guide/why-fonts-show-as-boxes/">de ce fonturile se afișează ca pătrățele</a>. Ține cont și că textul foarte mic se citește mai greu — folosește-l pentru fraze scurte, iar informațiile importante lasă-le în text obișnuit, din motive de <a href="/guide/fancy-fonts-accessibility-guide/">accesibilitate</a>.
+  </div>
+</div>
+
+</div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Language switcher">
+      <a class="lang-option" href="/category/small-text/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/ro/text-mic/" hreflang="ro">RO</a>
+    </div>
+
+    </div>
+  </footer>
+
+  <div class="copy-toast" id="copyToast">Copiat!</div>
+
+  <script>
+    window.UTG_FAMILY = "small-text";
+    window.UTG_DEMO_TEXT = "text mic\nlitere mici";
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/script.js" defer></script>
+  <script src="/footer.js" defer></script>
+</body></html>

--- a/scripts/prerender-i18n.js
+++ b/scripts/prerender-i18n.js
@@ -33,7 +33,7 @@ const cheerio = require("cheerio");
 
 const ROOT = path.resolve(__dirname, "..");
 const LOCALES_DIR = path.join(ROOT, "locales");
-const SUPPORTED = ["es", "fr", "pt", "de", "id", "it", "nl", "tr", "pl", "vi", "tl", "sv", "no", "ar"];
+const SUPPORTED = ["es", "fr", "pt", "de", "id", "it", "nl", "tr", "pl", "vi", "tl", "sv", "no", "ar", "cs", "sk", "hr", "bs", "sr", "ro"];
 
 // Right-to-left locales. Mirrors RTL_LANGS in i18n.js.
 const RTL_LANGS = ["ar", "he", "fa", "ur"];

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -289,29 +289,78 @@
   </url>
 
   <url>
-    <loc>https://ultratextgen.com/category/</loc>
-    <lastmod>2026-07-06</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <url>
-    <loc>https://ultratextgen.com/category/aesthetic-fonts/</loc>
-    <lastmod>2026-07-08</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-
-  <url>
-    <loc>https://ultratextgen.com/category/ancient-fonts/</loc>
+    <loc>https://ultratextgen.com/bs/</loc>
     <lastmod>2026-07-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
-    <loc>https://ultratextgen.com/category/bold-fonts/</loc>
+    <loc>https://ultratextgen.com/bs/fontovi-za-discord/</loc>
+    <lastmod>2026-07-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/bs/fontovi-za-instagram/</loc>
+    <lastmod>2026-07-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/bs/goticka-slova/</loc>
+    <lastmod>2026-07-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/bs/kurziv/</loc>
+    <lastmod>2026-07-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/bs/mala-slova/</loc>
+    <lastmod>2026-07-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/bs/podebljana-slova/</loc>
+    <lastmod>2026-07-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/category/</loc>
     <lastmod>2026-07-08</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/category/aesthetic-fonts/</loc>
+    <lastmod>2026-07-09</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/category/ancient-fonts/</loc>
+    <lastmod>2026-07-08</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/category/bold-fonts/</loc>
+    <lastmod>2026-07-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -325,7 +374,7 @@
 
   <url>
     <loc>https://ultratextgen.com/category/bubble-fonts/</loc>
-    <lastmod>2026-07-03</lastmod>
+    <lastmod>2026-07-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -339,63 +388,63 @@
 
   <url>
     <loc>https://ultratextgen.com/category/classified/</loc>
-    <lastmod>2026-07-02</lastmod>
+    <lastmod>2026-07-08</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/category/cursive-fonts/</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/category/cute-fonts/</loc>
-    <lastmod>2026-07-02</lastmod>
+    <lastmod>2026-07-08</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/category/emoji-letter-fonts/</loc>
-    <lastmod>2026-07-09</lastmod>
+    <lastmod>2026-07-08</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/category/faux-fonts/</loc>
-    <lastmod>2026-07-09</lastmod>
+    <lastmod>2026-07-08</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/category/fullwidth-fonts/</loc>
-    <lastmod>2026-07-09</lastmod>
+    <lastmod>2026-07-08</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/category/gothic-fonts/</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/category/italic-fonts/</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/category/novelty-fonts/</loc>
-    <lastmod>2026-07-09</lastmod>
+    <lastmod>2026-07-08</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -409,7 +458,7 @@
 
   <url>
     <loc>https://ultratextgen.com/category/small-text/</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -423,7 +472,7 @@
 
   <url>
     <loc>https://ultratextgen.com/category/text-decorator/</loc>
-    <lastmod>2026-07-06</lastmod>
+    <lastmod>2026-07-08</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -437,7 +486,7 @@
 
   <url>
     <loc>https://ultratextgen.com/category/upside-down-text/</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -450,8 +499,57 @@
   </url>
 
   <url>
-    <loc>https://ultratextgen.com/curved-text/</loc>
+    <loc>https://ultratextgen.com/cs/</loc>
     <lastmod>2026-07-09</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/cs/goticke-pismo/</loc>
+    <lastmod>2026-07-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/cs/kurziva/</loc>
+    <lastmod>2026-07-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/cs/male-pismo/</loc>
+    <lastmod>2026-07-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/cs/pismo-pro-discord/</loc>
+    <lastmod>2026-07-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/cs/pismo-pro-instagram/</loc>
+    <lastmod>2026-07-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/cs/tucne-pismo/</loc>
+    <lastmod>2026-07-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/curved-text/</loc>
+    <lastmod>2026-07-08</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -570,7 +668,7 @@
 
   <url>
     <loc>https://ultratextgen.com/discord/</loc>
-    <lastmod>2026-07-02</lastmod>
+    <lastmod>2026-07-08</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -787,7 +885,7 @@
 
   <url>
     <loc>https://ultratextgen.com/es/usecase/nombres-para-free-fire/</loc>
-    <lastmod>2026-07-06</lastmod>
+    <lastmod>2026-07-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -1185,6 +1283,55 @@
   </url>
 
   <url>
+    <loc>https://ultratextgen.com/hr/</loc>
+    <lastmod>2026-07-09</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/hr/fontovi-za-discord/</loc>
+    <lastmod>2026-07-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/hr/fontovi-za-instagram/</loc>
+    <lastmod>2026-07-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/hr/goticka-slova/</loc>
+    <lastmod>2026-07-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/hr/kurziv/</loc>
+    <lastmod>2026-07-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/hr/mala-slova/</loc>
+    <lastmod>2026-07-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/hr/podebljana-slova/</loc>
+    <lastmod>2026-07-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
     <loc>https://ultratextgen.com/id/</loc>
     <lastmod>2026-07-08</lastmod>
     <changefreq>weekly</changefreq>
@@ -1340,14 +1487,14 @@
 
   <url>
     <loc>https://ultratextgen.com/id/usecase/nama-ff-keren/</loc>
-    <lastmod>2026-07-06</lastmod>
+    <lastmod>2026-07-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/id/usecase/nama-guild-ff-keren/</loc>
-    <lastmod>2026-07-02</lastmod>
+    <lastmod>2026-07-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -3489,7 +3636,7 @@
 
   <url>
     <loc>https://ultratextgen.com/linkedin/</loc>
-    <lastmod>2026-07-07</lastmod>
+    <lastmod>2026-07-08</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -3601,7 +3748,7 @@
 
   <url>
     <loc>https://ultratextgen.com/pinterest/</loc>
-    <lastmod>2026-07-02</lastmod>
+    <lastmod>2026-07-08</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -3923,7 +4070,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/block-letters/</loc>
-    <lastmod>2026-07-09</lastmod>
+    <lastmod>2026-07-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -3937,6 +4084,13 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/calligraphy-alphabet/</loc>
+    <lastmod>2026-07-08</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/printables/coloring-page-maker/</loc>
     <lastmod>2026-07-09</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
@@ -3944,6 +4098,13 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/cursive-alphabet/</loc>
+    <lastmod>2026-07-08</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/printables/handwriting-worksheet-generator/</loc>
     <lastmod>2026-07-09</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
@@ -4126,7 +4287,7 @@
 
   <url>
     <loc>https://ultratextgen.com/pt/usecase/nick-ff/</loc>
-    <lastmod>2026-07-02</lastmod>
+    <lastmod>2026-07-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -4153,15 +4314,64 @@
   </url>
 
   <url>
+    <loc>https://ultratextgen.com/ro/</loc>
+    <lastmod>2026-07-09</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/ro/fonturi-pentru-discord/</loc>
+    <lastmod>2026-07-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/ro/fonturi-pentru-instagram/</loc>
+    <lastmod>2026-07-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/ro/scriere-gotica/</loc>
+    <lastmod>2026-07-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/ro/text-cursiv/</loc>
+    <lastmod>2026-07-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/ro/text-ingrosat/</loc>
+    <lastmod>2026-07-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/ro/text-mic/</loc>
+    <lastmod>2026-07-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
     <loc>https://ultratextgen.com/roblox/</loc>
-    <lastmod>2026-07-02</lastmod>
+    <lastmod>2026-07-08</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/roblox/name-generator/</loc>
-    <lastmod>2026-07-02</lastmod>
+    <lastmod>2026-07-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -4272,10 +4482,108 @@
   </url>
 
   <url>
-    <loc>https://ultratextgen.com/snapchat/</loc>
-    <lastmod>2026-07-02</lastmod>
+    <loc>https://ultratextgen.com/sk/</loc>
+    <lastmod>2026-07-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/sk/goticke-pismo/</loc>
+    <lastmod>2026-07-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/sk/kurziva/</loc>
+    <lastmod>2026-07-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/sk/male-pismo/</loc>
+    <lastmod>2026-07-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/sk/pismo-pre-discord/</loc>
+    <lastmod>2026-07-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/sk/pismo-pre-instagram/</loc>
+    <lastmod>2026-07-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/sk/tucne-pismo/</loc>
+    <lastmod>2026-07-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/snapchat/</loc>
+    <lastmod>2026-07-08</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/sr/</loc>
+    <lastmod>2026-07-09</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/sr/fontovi-za-discord/</loc>
+    <lastmod>2026-07-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/sr/fontovi-za-instagram/</loc>
+    <lastmod>2026-07-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/sr/goticka-slova/</loc>
+    <lastmod>2026-07-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/sr/kurziv/</loc>
+    <lastmod>2026-07-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/sr/mala-slova/</loc>
+    <lastmod>2026-07-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/sr/podebljana-slova/</loc>
+    <lastmod>2026-07-09</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
   </url>
 
   <url>
@@ -4294,7 +4602,7 @@
 
   <url>
     <loc>https://ultratextgen.com/telegram/</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -4336,14 +4644,14 @@
 
   <url>
     <loc>https://ultratextgen.com/tiktok/</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/tiktok/name-generator/</loc>
-    <lastmod>2026-07-02</lastmod>
+    <lastmod>2026-07-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -4490,14 +4798,14 @@
 
   <url>
     <loc>https://ultratextgen.com/usecase/bio-font/</loc>
-    <lastmod>2026-07-02</lastmod>
+    <lastmod>2026-07-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/usecase/clan-tag-generator/</loc>
-    <lastmod>2026-07-02</lastmod>
+    <lastmod>2026-07-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -4511,28 +4819,28 @@
 
   <url>
     <loc>https://ultratextgen.com/usecase/emoji-combinations/</loc>
-    <lastmod>2026-07-02</lastmod>
+    <lastmod>2026-07-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/usecase/football-font/</loc>
-    <lastmod>2026-07-02</lastmod>
+    <lastmod>2026-07-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/usecase/free-fire-guild-name-generator/</loc>
-    <lastmod>2026-07-09</lastmod>
+    <lastmod>2026-07-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/usecase/free-fire-name-generator/</loc>
-    <lastmod>2026-07-09</lastmod>
+    <lastmod>2026-07-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -4553,7 +4861,7 @@
 
   <url>
     <loc>https://ultratextgen.com/usecase/nickname-generator/</loc>
-    <lastmod>2026-07-06</lastmod>
+    <lastmod>2026-07-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -4756,28 +5064,28 @@
 
   <url>
     <loc>https://ultratextgen.com/whatsapp/</loc>
-    <lastmod>2026-07-08</lastmod>
+    <lastmod>2026-07-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/x/</loc>
-    <lastmod>2026-07-02</lastmod>
+    <lastmod>2026-07-08</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/youtube/</loc>
-    <lastmod>2026-07-02</lastmod>
+    <lastmod>2026-07-08</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/youtube/name-generator/</loc>
-    <lastmod>2026-07-02</lastmod>
+    <lastmod>2026-07-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>

--- a/sk/goticke-pismo/index.html
+++ b/sk/goticke-pismo/index.html
@@ -1,0 +1,299 @@
+<!DOCTYPE html><html lang="sk"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZGVh");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Generátor gotického písma — 𝔤𝔬𝔱𝔦𝔠𝔨ý 𝔱𝔢𝔵𝔱 na kopírovanie | UltraTextGen</title>
+  <meta name="description" content="Bezplatný generátor gotického písma: preveď text na gotické znaky Unicode (fraktúra) na kopírovanie a vloženie — do bia na Instagrame, na Discord, TikTok, do nickov a návrhov tetovania. Ihneď, bez registrácie.">
+  <link rel="canonical" href="https://ultratextgen.com/sk/goticke-pismo/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/category/gothic-fonts/">
+  <link rel="alternate" hreflang="sk" href="https://ultratextgen.com/sk/goticke-pismo/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/category/gothic-fonts/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Generátor gotického písma — 𝔤𝔬𝔱𝔦𝔠𝔨ý 𝔱𝔢𝔵𝔱 na kopírovanie | UltraTextGen">
+  <meta property="og:description" content="Bezplatný generátor gotického písma — gotické znaky Unicode (fraktúra) na kopírovanie a vloženie na Instagram, Discord, TikTok a do nickov. Ihneď, bez registrácie.">
+  <meta property="og:url" content="https://ultratextgen.com/sk/goticke-pismo/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category-gothic-fonts.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Generátor gotického písma — 𝔤𝔬𝔱𝔦𝔠𝔨ý 𝔱𝔢𝔵𝔱 na kopírovanie | UltraTextGen">
+  <meta name="twitter:description" content="Bezplatný generátor gotického písma — gotické znaky Unicode (fraktúra) na kopírovanie a vloženie do sociálnych sietí, na Discord a do nickov.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category-gothic-fonts.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "sk",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Čo je generátor gotického písma a ako funguje?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Prevádza písmená, ktoré napíšeš, na gotické znaky Unicode (𝔱𝔞𝔨é 𝔞𝔨𝔬 𝔱𝔦𝔢𝔱𝔬) — ozajstné znaky z rodiny fraktúry, nie písmo ani obrázok. Keďže ide o obyčajné textové znaky, môžeš ich skopírovať a vložiť všade, kde je povolený text: do bia, popisov, komentárov, nickov a správ. Viac v našom sprievodcovi o tom, ako funguje písmo Unicode."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Funguje gotický text na Instagrame, Discorde, TikToku a v ďalších aplikáciách?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Áno. Bio, popisy, komentáre, názvy kanálov na Discorde aj správy na chate gotické znaky bez problémov prijmú, pretože ide o obyčajný Unicode. Skvele sa hodí do nickov a profilov s goth, metalovou alebo stredovekou náladou. Pozor: niektoré polia s @používateľským menom neštandardné znaky filtrujú — v samotnom handle je nutné zostať pri obyčajnom texte, ale v biu a popisoch gotika funguje bez problémov."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Čím sa líši gotika (fraktúra) od tučnej gotiky?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Sú to dva varianty toho istého štýlu. Obyčajná fraktúra (𝔤𝔬𝔱𝔦𝔨𝔞) je tenšia a klasickejšia, kým tučná gotika (𝖌𝖔𝖙𝖎𝖐𝖆) má silnejšie, výraznejšie ťahy a lepšie vyzerá v krátkych titulkoch a nickoch. Vo výsledkoch nižšie nájdeš oba varianty — stačí kliknúť na ten, ktorý k tvojmu návrhu sedí, a skopírovať."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Môžem písať slovenské znaky (á, ä, č, ď, é, í, ĺ, ľ, ň, ó, ô, ŕ, š, ť, ú, ý, ž) gotickým písmom?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Gotika Unicode pokrýva A–Z a a–z, preto slovenské znaky ako á, č, ľ, š, ť, ž nemajú vlastnú gotickú podobu a zostávajú obyčajné. Pre jednotný gotický efekt ich môžeš nahradiť základnými písmenami (a, c, l, s, t, z) — mení to však pravopis — alebo ich nechať v normálnej podobe, čo pri krátkom texte, nicku alebo titulku obvykle aj tak vyzerá dobre."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Je generátor gotického písma zadarmo?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Áno, plne zadarmo a bez registrácie. Píš, kopíruj a vkladaj, koľkokrát chceš — nie je tu žiadny limit ani skryté náklady."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Prečo sa niektoré gotické písmená zobrazujú ako štvorčeky alebo vyzerajú inak?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Prázdny štvorček (▯) znamená, že zariadenie nemá zodpovedajúci glyf pre daný gotický znak — týka sa to väčšinou starších systémov. Navyše pár veľkých písmen fraktúry (C, H, I, R, Z) pochádza z iného bloku Unicode a vyzerá inak než zvyšok abecedy — to je normálne. Vyber v takom prípade tučný variant gotiky alebo zariadenie aktualizuj; viac v článku o tom, prečo sa písmo zobrazuje ako štvorčeky."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "inLanguage": "sk",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Domov", "item": "https://ultratextgen.com/sk/" },
+    { "@type": "ListItem", "position": 2, "name": "Gotické písmo", "item": "https://ultratextgen.com/sk/goticke-pismo/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Generátor gotického písma",
+  "alternateName": ["Gotické písmo","Gotický text","Gotika na kopírovanie","Fraktúra Unicode","Gotické písmená","Generátor gotiky","Gotické písmo","Blackletter po slovensky"],
+  "url": "https://ultratextgen.com/sk/goticke-pismo/",
+  "inLanguage": "sk",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "EUR"
+  },
+  "description": "Bezplatný generátor gotického písma: preveď text na gotické znaky Unicode (fraktúra a tučná gotika) na kopírovanie a vloženie na Instagram, Discord, TikTok, do nickov a návrhov tetovania.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/sk/">Domov</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Gotické písmo</span>
+</nav>
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/category-gothic-fonts.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+  <!-- Hero -->
+  <section class="hero">
+    <div class="hero-inner">
+      <div class="hero-card">
+        <h1 class="hero-headline">Generátor gotického písma</h1>
+        <p class="hero-tagline">Premeň ľubovoľný text na 𝔤𝔬𝔱𝔦𝔠𝔨é 𝔭í𝔰𝔪𝔬 na kopírovanie a vloženie — temné,
+          ozdobné písmená Unicode (fraktúra a tučná gotika) do bia, nickov a titulkov. Zadarmo, ihneď, bez registrácie.</p>
+        <div class="input-wrapper">
+          <textarea class="main-input" id="mainInput" placeholder="Napíš text, slovo alebo meno…" maxlength="500" autofocus></textarea>
+          <span class="char-count"><span id="charCount">0</span>/500</span>
+        </div>
+
+        <!-- Decoration Selector -->
+        <div class="decoration-section">
+          <div class="decoration-label">
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"></path>
+            </svg>
+            Pridaj symboly okolo výsledku
+          </div>
+          <div class="decoration-tabs">
+            <button class="decoration-tab active" data-deco-tab="symbols">Symboly</button>
+            <button class="decoration-tab" data-deco-tab="frames">Rámčeky</button>
+            <button class="decoration-tab" data-deco-tab="dividers">Oddeľovače</button>
+            <button class="decoration-tab" data-deco-tab="minimal">Minimalistické</button>
+            <button class="decoration-tab" data-deco-tab="emojis">Emoji</button>
+          </div>
+          <div class="decoration-grid" id="decorationGrid"></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Main Content -->
+  <main class="container">
+
+    <section class="editorial-section">
+      <span class="article-section-label">Gotické písmo Unicode</span>
+      <h2>Gotický text na kopírovanie — do bia, nickov a na tetovanie</h2>
+      <p>Tieto písmená nie sú písmo ani obrázok, ale ozajstné <strong>znaky Unicode</strong> z rodiny fraktúry. Dodaj
+        svojmu biu goth náladu, vytvor temný nick alebo priprav nápis v stredovekom či metalovom štýle — gotika
+        skvele sadne aj na návrhy tetovania. Napíš text vyššie, klikni na <strong>Kopírovať</strong> a vlož
+        gotické písmo tam, kam chceš.</p>
+    </section>
+
+    <!-- Category Tabs (populated by script.js) -->
+    <div class="category-section">
+      <div class="category-tabs" id="categoryTabs"></div>
+    </div>
+
+    <!-- Results -->
+    <div class="results-grid" id="resultsGrid"></div>
+
+    <section class="editorial-section">
+      <span class="article-section-label">Súvisiace</span>
+      <p>Spoj gotiku s <a href="/sk/tucne-pismo/">tučným písmom</a>,
+        <a href="/library/aesthetic-symbols/">ozdobami</a> alebo <a href="/library/invisible-character/">neviditeľným znakom</a>
+        pre čisté medzery. Na návrhy tetovania sa hodí <a href="/usecase/tattoo-fonts/">generátor písma na tetovanie</a>,
+        a na zvislé sadzby — <a href="/usecase/vertical-text/">zvislý text</a>.</p>
+    </section>
+  </main>
+
+  <!-- Footer + FAQ -->
+  <footer class="footer">
+    <div class="footer-inner">
+<div class="faq-section" id="gothic-faq">
+
+<h2 class="faq-category">Generátor gotického písma — FAQ</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Čo je generátor gotického písma a ako funguje?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Prevádza písmená, ktoré napíšeš, na gotické znaky Unicode (𝔱𝔞𝔨é 𝔞𝔨𝔬 𝔱𝔦𝔢𝔱𝔬) — ozajstné znaky z rodiny fraktúry, nie písmo ani obrázok. Keďže ide o obyčajné textové znaky, môžeš ich skopírovať a vložiť všade, kde je povolený text: do bia, popisov, komentárov, nickov a správ. Viac v našom <a href="/guide/how-unicode-fonts-work/">sprievodcovi o tom, ako funguje písmo Unicode</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Funguje gotický text na Instagrame, Discorde, TikToku a v ďalších aplikáciách?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Áno. Bio, popisy, komentáre, názvy kanálov na Discorde aj správy na chate gotické znaky bez problémov prijmú, pretože ide o obyčajný Unicode. Skvele sa hodí do nickov a profilov s goth, metalovou alebo stredovekou náladou. Pozor: niektoré polia s <strong>@používateľským menom</strong> neštandardné znaky filtrujú — v samotnom handle je nutné zostať pri obyčajnom texte, ale v biu a popisoch gotika funguje bez problémov.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Čím sa líši gotika (fraktúra) od tučnej gotiky?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Sú to dva varianty toho istého štýlu. Obyčajná fraktúra (𝔤𝔬𝔱𝔦𝔨𝔞) je tenšia a klasickejšia, kým tučná gotika (𝖌𝖔𝖙𝖎𝖐𝖆) má silnejšie, výraznejšie ťahy a lepšie vyzerá v krátkych titulkoch a nickoch. Vo výsledkoch nižšie nájdeš oba varianty — stačí kliknúť na ten, ktorý k tvojmu návrhu sedí, a skopírovať.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Môžem písať slovenské znaky (á, ä, č, ď, é, í, ĺ, ľ, ň, ó, ô, ŕ, š, ť, ú, ý, ž) gotickým písmom?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Gotika Unicode pokrýva A–Z a a–z, preto slovenské znaky ako á, č, ľ, š, ť, ž nemajú vlastnú gotickú podobu a zostávajú obyčajné. Pre jednotný gotický efekt ich môžeš nahradiť základnými písmenami (<strong>a, c, l, s, t, z</strong>) — mení to však pravopis — alebo ich nechať v normálnej podobe, čo pri krátkom texte, nicku alebo titulku obvykle aj tak vyzerá dobre.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Je generátor gotického písma zadarmo?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Áno, plne zadarmo a bez registrácie. Píš, kopíruj a vkladaj, koľkokrát chceš — nie je tu žiadny limit ani skryté náklady.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Prečo sa niektoré gotické písmená zobrazujú ako štvorčeky alebo vyzerajú inak?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Prázdny štvorček (▯) znamená, že zariadenie nemá zodpovedajúci glyf pre daný gotický znak — týka sa to väčšinou starších systémov. Navyše pár veľkých písmen fraktúry (C, H, I, R, Z) pochádza z iného bloku Unicode a vyzerá inak než zvyšok abecedy — to je normálne. Vyber v takom prípade tučný variant gotiky alebo zariadenie aktualizuj; viac v článku o tom, <a href="/guide/why-fonts-show-as-boxes/">prečo sa písmo zobrazuje ako štvorčeky</a>.
+  </div>
+</div>
+
+</div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Výber jazyka">
+      <a class="lang-option" href="/category/gothic-fonts/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/sk/goticke-pismo/" hreflang="sk">SK</a>
+    </div>
+
+    </div>
+  </footer>
+
+  <div class="copy-toast" id="copyToast">Skopírované!</div>
+
+  <script>
+    window.UTG_FAMILY = "gothic";
+    window.UTG_DEMO_TEXT = "gotické písmo\ngotický text";
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/script.js" defer></script>
+  <script src="/footer.js" defer></script>
+</body></html>

--- a/sk/index.html
+++ b/sk/index.html
@@ -1,0 +1,1019 @@
+<!DOCTYPE html><html lang="sk" dir="ltr"><head>
+  <meta name="yandex-verification" content="aa326290e0338f4f">
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title data-i18n="meta.title">Ozdobné písmo a štýlový text na kopírovanie — písmená na Instagram, TikTok a prezývky</title>
+<meta name="description" data-i18n-content="meta.description" content="Generátor ozdobného písma, estetických písmen a štýlového textu na kopírovanie. Tučné, kurzíva, gotika, bublinkové, Zalgo a symboly — vlož do bia na Instagrame, do popisu na TikToku, do herného nicku alebo na Discord. Zadarmo, bez účtu.">
+
+<link rel="canonical" href="https://ultratextgen.com/sk/">
+
+<link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/">
+<link rel="alternate" hreflang="en" href="https://ultratextgen.com/">
+<link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/">
+<link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/">
+<link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/">
+<link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/">
+<link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/">
+<link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/">
+<link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/">
+<link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/">
+<link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/">
+<link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/">
+<link rel="alternate" hreflang="sv" href="https://ultratextgen.com/sv/">
+<link rel="alternate" hreflang="no" href="https://ultratextgen.com/no/">
+<link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/">
+<link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/">
+<link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/">
+<link rel="alternate" hreflang="ar" href="https://ultratextgen.com/ar/">
+<link rel="alternate" hreflang="cs" href="https://ultratextgen.com/cs/">
+<link rel="alternate" hreflang="sk" href="https://ultratextgen.com/sk/">
+<link rel="alternate" hreflang="hr" href="https://ultratextgen.com/hr/">
+<link rel="alternate" hreflang="bs" href="https://ultratextgen.com/bs/">
+<link rel="alternate" hreflang="sr" href="https://ultratextgen.com/sr/">
+<link rel="alternate" hreflang="ro" href="https://ultratextgen.com/ro/">
+
+<meta name="robots" content="index, follow">
+
+<meta property="og:site_name" content="UltraTextGen">
+<meta property="og:title" content="Ozdobné písmo a štýlový text na kopírovanie — písmená na Instagram, TikTok a prezývky">
+<meta property="og:description" content="Generátor ozdobného písma, estetických písmen a štýlového textu na kopírovanie. Tučné, kurzíva, gotika, bublinkové, Zalgo a symboly — vlož do bia na Instagrame, do popisu na TikToku, do herného nicku alebo na Discord.">
+<meta property="og:url" content="https://ultratextgen.com/sk/">
+<meta property="og:type" content="website">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/generator-ladnych-czcionek-preview.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Ozdobné písmo a štýlový text na kopírovanie — písmená na Instagram, TikTok a prezývky">
+<meta name="twitter:description" content="Generátor ozdobného písma, estetických písmen a štýlového textu na kopírovanie. Tučné, kurzíva, gotika, bublinkové, Zalgo a symboly — vlož do bia na Instagrame, do popisu na TikToku, do herného nicku alebo na Discord.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/generator-ladnych-czcionek-preview.png">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/style.css">
+
+ <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+[
+  {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/",
+    "inLanguage": "sk",
+    "description": "Rýchly a prehľadný generátor textu Unicode pre bio na sociálnych sieťach, popisy a používateľské mená.",
+    "potentialAction": {
+      "@type": "SearchAction",
+      "target": {
+        "@type": "EntryPoint",
+        "urlTemplate": "https://ultratextgen.com/?q={search_term_string}"
+      },
+      "query-input": "required name=search_term_string"
+    }
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com",
+    "logo": "https://ultratextgen.com/logo.png",
+    "sameAs": [
+      "https://www.youtube.com/@UltraTextGen",
+      "https://www.facebook.com/profile.php?id=61588587387596",
+      "https://www.linkedin.com/company/71290348/",
+      "https://x.com/UltraTextGen"
+    ]
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "WebApplication",
+    "name": "UltraTextGen",
+    "alternateName": ["Generátor písma Unicode", "Generátor ozdobného textu", "Menič písma", "Písmo na kopírovanie a vkladanie"],
+    "url": "https://ultratextgen.com/sk/",
+    "inLanguage": "sk",
+    "applicationCategory": "UtilitiesApplication",
+    "operatingSystem": "All",
+    "browserRequirements": "Requires JavaScript",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "description": "Okamžite generuj štýlové písmo Unicode pre Instagram, TikTok, X, WhatsApp a Discord. Kopíruj a vkladaj textové štýly do bia na sieťach, používateľských mien a príspevkov."
+  }
+]
+</script>
+
+
+
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "sk",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Čo je UltraTextGen a čo sa tu vlastne deje?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Je to bezplatný generátor písmen — napíšeš obyčajný text a my ho prevedieme na štylizované znaky Unicode, ktoré vyzerajú ako ozdobné písmo. Hlavná vec: sú to ozajstné znaky , nie stučnenie z Wordu alebo markdown z Discordu. Preto fungujú všade, kam sa dá napísať obyčajný text — v biu na Instagrame, v nicku, v komentári, v e-maile, v statuse na WhatsAppe. Príklad Napíšeš „ahoj\" → dostaneš 𝗮𝗵𝗼𝗷 (tučné), 𝘢𝘩𝘰𝘫 (kurzíva), 𝒶𝒽ℴ𝒿 (kaligrafia) alebo ⓐⓗⓞⓙ (bublinkové). Všetko jedným kliknutím."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Ako skopírovať ozdobné písmená za 5 sekúnd?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "1. Napíšeš alebo vložíš text do poľa hore. 2. Štýly sa hneď objavia pod ním — tučné, kurzíva, gotika, bublinkové a ešte pár desiatok ďalších. 3. Keď chceš, pridaj ozdoby — rámčeky, hviezdičky, šípky. 4. Klikneš na „Kopírovať\" pri tom, ktorý ti sedí, a vložíš, kam len chceš. A je to. Bez registrácie, bez inštalácie apky. Funguje rovnako na počítači aj na telefóne."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Zadarmo? Bez limitov, bez účtu?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Áno, celé je to 100% zadarmo . Žiadny účet, žiadny denný limit, žiadne vodoznaky, žiadny háčik. Môžeš cez to prehnať celú knižku a nič sa nestane."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Ako dostať štýlový text do bia na Instagrame?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Instagram nemá žiadny panel na formátovanie, ale prijíma Unicode — takže všetko, čo u nás vygeneruješ, ti v biu naskočí bez problémov. Ako na to 1. Napíš, čo chceš mať v biu (napríklad meno, hashtag, krátky popis). 2. Vyber štýl — tučné a kurzíva fungujú na väčšine zariadení najlepšie. 3. Skopíruj výsledok a vlož ho v „Upraviť profil → Bio\" v aplikácii. Tip: keď chceš ozdobiť, pridaj rámček typu ⋆｡˚ alebo hviezdičku ✦ po strane — vyzerá to dobre a nekradne to pozornosť zvyšku bia."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Fungujú písmená v popisoch na TikToku?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Áno — TikTok vykresľuje Unicode v popisoch, popisoch profilu aj komentároch. Najlepšie sa osvedčí tučné , kurzíva , bublinkové a kapitálky . Štýly s kopou ozdôb sa pri dlhých popisoch občas orežú, tak si pre istotu príspevok skontroluj v náhľade pred zverejnením."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Dá sa spraviť nick do hry alebo na Discord?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Jasné — to je asi najčastejší dôvod, prečo ľudia na takéto generátory chodia. Discord, Roblox, Steam, Minecraft, väčšina hier prijíma Unicode v nicku. Príklad Obyčajný nick: „DarkWolf\" Po štylizácii: „𝔇𝔞𝔯𝔨𝔚𝔬𝔩𝔣\" (gotika), „ⒹⓐⓡⓚⓌⓞⓛⓕ\" (bublinkové) alebo „๖ۣۜDarkWolf\" (s ozdobou po strane). Pozor: niektoré hry majú filtre a exotické znaky neprijmú. Keď jeden štýl neprejde, daj iný — tučné a kurzíva prejdú takmer všade."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Funguje to v statuse na WhatsAppe, na Telegrame a v Messengeri?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Áno — WhatsApp, Telegram, Messenger, Signal, iMessage. Čokoľvek prijíma obyčajný text, prijme aj písmená Unicode. Vložíš ich do statusu alebo do správy a vyzerajú ako ozdobné písmo. K WhatsAppu ešte dodám: ak ti ide len o stučnenie, môžeš použiť ich vlastnú syntax ( *text* spraví tučné). Ale Unicode funguje všade — aj tam, kde to WhatsApp nepodporuje, napríklad v názve kontaktu."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "A v predmete e-mailu alebo v životopise?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Tu Unicode odvedie najväčšiu prácu. Predmet e-mailu je obyčajný text, takže stučnenie z Outlooku odpadá. Ale „𝗙𝗮𝗸𝘁𝘂𝗿𝗮 — 𝗣𝗢𝗭𝗢𝗥\" už v príjemcovej schránke pôsobí silnejšie. V životopise dokáže jemne stučnené meno v hlavičke pritiahnuť pohľad personalistu. Len to nepreháňaj — celý životopis v gotike nepôsobí profesionálne."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Aké štýly písmen mám na výber?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Veľa. Vážne veľa. V skratke: Základné Tučné (bold), kurzíva, kaligrafia (script), gotika, bublinkové (v kolieskach), kapitálky, prečiarknuté, podčiarknuté, dvojito ťahané (double struck). Zábavné Text hore nohami, zrkadlovo obrátený, Zalgo (glitch s čiarkami nad písmenami), text v štvorčekoch, v zátvorkách, fullwidth (rozhádzaný). Doplnky Rámčeky okolo textu, hviezdičky, srdiečka, šípky, oddeľovače, vlajky, emoji — dajú sa na štýl písmen navrstviť. Z času na čas pribúdajú nové — oplatí sa pridať si stránku do záložiek."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Môžem spojiť viac štýlov naraz?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Áno — a to je najväčšia prednosť UltraTextGenu. Môžeš navrstviť napríklad bublinkové + Zalgo , gotiku + hore nohami alebo kapitálky + podčiarknutie a potom to celé uzavrieť do rámčeka alebo hviezdičky. Príklad „ahoj\" → vyberieš gotiku → pridáš rámček s hviezdičkami → vyjde: ★彡[ 𝔞𝔥𝔬𝔧 ]彡★ Čím viac experimentuješ, tým zaujímavejšie veci vzniknú. Odporúčam začať jedným štýlom a pridať jednu ozdobu — nie všetko naraz."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Čo je Zalgo a tie divné čiarky nad písmenami?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Zalgo je taký „prekliaty\", glitchový štýl — nad a pod každé písmeno naletí kopa diakritických znamienok. Vyzerá to, akoby sa text rozpadal alebo bol z hororu. Príklad „ahoj\" → a̷̢h̴̢ơ̷j̴̜ Najčastejšie to vídavaš v temných biách na Instagrame, v halloweenskych memoch, v herných klanoch, ktoré chcú vyzerať hrozivo, alebo keď si z toho niekto robí srandu."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Kde brať pekné symboly, hviezdičky a srdiečka?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Všetko, čo máš v sekcii „Ozdoby\" pod textovým poľom, môžeš kopírovať zvlášť — aj bez písania textu. Jednoducho ako samostatné znaky do bia, nicku alebo príspevku. — Estetické symboly : ✦ ✧ ⋆ ｡ ☆ ♡ ❀ ✿ — Rámčeky a obruby : ╭─▸ │ ╰─▸ alebo ★彡[ ]彡★ — Šípky : → ⇨ ➤ ⟶ — Minimalistické oddeľovače : · ⋅ ─ • — Vlajky a emoji . Najčastejšie sa používajú v estetických biách na Instagrame a Pintereste — hodia sa úplne ku všetkému, od citátov po zoznamy záujmov."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "A slovenské znaky? Funguje to s á, ä, č, ď, é, í, ĺ, ľ, ň, ó, ô, ŕ, š, ť, ú, ý, ž?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Krátko: záleží na štýle. Unicode má štylizované varianty pre základnú abecedu A–Z, takže a , c , e , s , z sa v pohode premenia napríklad na tučné. Ale pre á , č , ľ , š , ť , ž štylizované verzie existujú len v časti štýlov (hlavne tučné, kurzíva, kapitálky). Keď štýl nemá verziu pre slovenský znak s diakritikou, zostane v pôvodnej podobe — text je stále čitateľný, slovenské písmená s mäkčeňmi a dĺžňami jednoducho vyzerajú „obyčajnejšie\" než zvyšok. Pre nicky bez diakritiky to nie je žiadny problém. Pre celé vety v slovenčine odporúčam tučné , kurzívu alebo monospace — tie si s našou abecedou poradia najlepšie."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Prečo sa niekomu zobrazujú štvorčeky namiesto písmen?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Pretože systémové písmo na strane príjemcu daný znak Unicode neobsahuje. Nie je to problém s tvojím textom — jeho telefón alebo aplikácia jednoducho ten konkrétny znak v sade nemá. Drž sa tučných , kurzívy a bublinkových — tie majú najširšiu podporu. Veľmi exotické štýly (fullwidth, štvorčeky) sa na starších Androidoch alebo v niektorých e-mailových klientoch môžu zobraziť ako □."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Instagram mi v nicku orezal časť znakov — čo teraz?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Instagram má filter na pole používateľské meno (čiže @login) — berie len písmená, číslice, bodky a podčiarkovníky. Sem štylizované písmená nevložíš. Ale do poľa „Meno\" (zobrazované meno) a do bia áno — a tam prejde väčšina štýlov. Keď sa jeden neuloží, daj iný. Tučné obvykle prejde bez problémov."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Sú nejaké znaky, ktoré sa vôbec nedajú previesť?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Štandardné písmená (A–Z, a–z), číslice a základná interpunkcia sa prevedú bez problémov. Niektoré vzácne symboly alebo špeciálne znaky nemajú v Unicode štylizované náprotivky — potom zostanú v pôvodnej podobe. Nič sa nerozbije, text je stále na kopírovanie."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Ukladá sa môj text niekam?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Nie. Celý prevod písmen prebieha v tvojom prehliadači — nič neputuje na naše servery, nič sa neukladá, nič sa nesleduje. Skopírovaný text je čistý Unicode, bez skrytých znakov, bez akýchkoľvek identifikátorov."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Je bezpečné vkladať tieto písmená kamkoľvek?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Áno — sú to štandardné znaky Unicode, rovnaké ako tie, ktoré používa celý internet. Nič vnútri, žiadne skripty, žiadne skryté formátovanie, žiadne kódy. Pokojne ich vlož do životopisu, do pracovného e-mailu, do bia na LinkedIne — kam chceš."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Funguje to na telefóne?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Áno — stránka sa plne prispôsobí mobilu. iPhone, Android, tablet — všetko klape. Napíšeš text, klikneš, skopíruje sa do schránky, vložíš v aplikácii. Bez inštalácie čohokoľvek z obchodu."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Čím sa líšite od iných generátorov písmen?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Konkrétne: — Jedna z najväčších zbierok štýlov Ultra — tučné, kurzíva, gotika, bublinkové a ešte pár desiatok ďalších. — Kombinovanie štýlov — väčšina generátorov ti dá jeden štýl naraz, my dovolíme vrstviť. — Ozdoby jedným kliknutím — rámčeky, hviezdičky, oddeľovače bez lepenia znak po znaku. — Stránky pre konkrétne platformy — Instagram, TikTok, Discord. Ukazujeme tam len štýly, ktoré v danej apke fungujú. — Rýchlo a bez vyskakovacích okien — žiadne captchy, žiadne „prijať všetko\" pred každým kliknutím."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Pribúdajú nové štýly?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Áno, pravidelne. Z času na čas naskočia nové varianty, ozdoby a rámčeky. Najjednoduchšie je uložiť si stránku do záložiek alebo sa sem raz za čas vrátiť."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Ako nájsť presne ten štýl, ktorý hľadám?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Tri cesty: Podľa štýlu — kategórie hore: tučné, kurzíva, gotika, bublinkové, prečiarknuté, hore nohami a ďalšie. Podľa platformy — pozri podstránku pre Instagram, TikTok, Discord — tam sú len štýly, ktoré na danej platforme fungujú. Podľa cieľa — sekcia využitia má nástroje ušité na konkrétnu potrebu: titulok na LinkedIn, komentáre, text s emoji."
+      }
+    }
+  ]
+}
+</script>
+</head>
+
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer=""></script>
+
+  <!-- Hero Section -->
+  <section class="hero">
+    <div class="hero-inner">
+      <div class="hero-card">
+        <h1 class="hero-headline" data-i18n="hero.title">Ozdobné písmo a štýlové písmená na kopírovanie</h1>
+        <p class="hero-tagline" data-i18n="hero.subtitle">Napíš text, vyber štýl — tučné, kurzíva, gotika, bublinkové alebo s ozdobami. Vlož do bia na Instagrame, do herného nicku, do statusu na WhatsAppe alebo do popisu na TikToku. Bez aplikácie, bez prihlasovania.</p>
+        <div class="input-wrapper">
+          <textarea class="main-input" id="mainInput" placeholder="Napíš text..." data-i18n-placeholder="ui.placeholder" maxlength="500" autofocus=""></textarea>
+          <button class="input-clear-btn" id="inputClearBtn" aria-label="Clear input" hidden="">✕</button>
+          <span class="char-count" id="charCountWrapper" hidden=""><span id="charCount">0</span>/500</span>
+        </div>
+
+        <!-- Decoration Selector -->
+        <div class="decoration-section">
+          <div class="decoration-label">
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"></path>
+            </svg>
+            <span data-i18n="decorations.label">Pridaj ozdoby k textu</span>
+       </div>
+    <div class="decoration-tabs">
+    <button class="decoration-tab active" data-deco-tab="symbols" data-i18n="decorations.tabs.symbols">Symboly</button>
+    <button class="decoration-tab" data-deco-tab="frames" data-i18n="decorations.tabs.frames">Rámčeky</button>
+    <button class="decoration-tab" data-deco-tab="dividers" data-i18n="decorations.tabs.dividers">Oddeľovače</button>
+    <button class="decoration-tab" data-deco-tab="arrows" data-i18n="decorations.tabs.arrows">Šípky</button>
+    <button class="decoration-tab" data-deco-tab="minimal" data-i18n="decorations.tabs.minimal">Minimalistické</button>
+    <button class="decoration-tab" data-deco-tab="emojis" data-i18n="decorations.tabs.emojis">Emoji</button>
+    <button class="decoration-tab" data-deco-tab="flags" data-i18n="decorations.tabs.flags">Vlajky</button>
+      </div>
+          <div class="decoration-grid" id="decorationGrid"></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Main Content -->
+  <main class="container">
+    <!-- Category Tabs -->
+    <div class="category-section">
+      <div class="category-tabs" id="categoryTabs">
+        <!-- Tabs will be dynamically loaded from fonts.json -->
+      </div>
+    </div>
+
+    <!-- Results -->
+    <div class="results-grid" id="resultsGrid"></div>
+  </main>
+
+  <!-- How To: Ako skopírovať ozdobné písmená -->
+  <section class="editorial-section">
+    <h2>Písmená a písmenká na kopírovanie — ako to funguje</h2>
+    <p class="editorial-intro">Ozdobné <strong>písmená na kopírovanie</strong> zvládneš za pár sekúnd — bez inštalácie aplikácie a bez zakladania účtu. Napíšeš text a generátor ho prevedie na desiatky štýlov pekných písmen, pripravených na kopírovanie a vloženie.</p>
+    <div class="steps-grid">
+      <div class="step-card">
+        <div class="step-number">1</div>
+        <h3>Napíš text</h3>
+        <p>Napíš meno, slovo alebo celú vetu do poľa úplne hore. Môžeš tiež vložiť niečo, čo už máš skopírované.</p>
+      </div>
+      <div class="step-card">
+        <div class="step-number">2</div>
+        <h3>Vyber štýl písmen</h3>
+        <p>Pekné písmená sa objavia hneď — tučné, kurzíva, kaligrafia, gotika, bublinkové a kapitálky. Výber zúžiš kategóriou hore.</p>
+      </div>
+      <div class="step-card">
+        <div class="step-number">3</div>
+        <h3>Skopíruj a vlož</h3>
+        <p>Klikneš na „Kopírovať", vložíš do bia na Instagrame, herného nicku, statusu na WhatsAppe alebo popisu na TikToku. Štýl sa nestratí.</p>
+      </div>
+    </div>
+    <p class="u-mt-15 u-text-center">Rovnaké kroky fungujú pre <strong>ozdobné písma na kopírovanie</strong>, ozdobné písmená aj estetické písmená — rovnako na počítači aj na telefóne.</p>
+  </section>
+
+  <!-- Abeceda ozdobných písmen A–Z -->
+  <section class="editorial-section abc-section" aria-label="Abeceda ozdobných písmen na kopírovanie">
+    <h2>Ozdobné písmená A–Z na kopírovanie</h2>
+    <p>Celá abeceda — veľké písmená (A–Z), malé písmená (a–z) aj číslice (0–9) — v najčastejšie používaných štýloch ozdobných písmen. Napíš niečo do generátora hore a klikni na „Kopírovať", aby si vzal celé slovo v danom štýle, alebo označ písmená z tabuľky a skopíruj ich sám.</p>
+
+    <div class="abc-list">
+      <div class="abc-row">
+        <span class="abc-name">Tučné</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝗔𝗕𝗖𝗗𝗘𝗙𝗚𝗛𝗜𝗝𝗞𝗟𝗠𝗡𝗢𝗣𝗤𝗥𝗦𝗧𝗨𝗩𝗪𝗫𝗬𝗭</span>
+          <span class="abc-line">𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇</span>
+          <span class="abc-line">𝟬𝟭𝟮𝟯𝟰𝟱𝟲𝟳𝟴𝟵</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Kurzíva</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝘈𝘉𝘊𝘋𝘌𝘍𝘎𝘏𝘐𝘑𝘒𝘓𝘔𝘕𝘖𝘗𝘘𝘙𝘚𝘛𝘜𝘝𝘞𝘟𝘠𝘡</span>
+          <span class="abc-line">𝘢𝘣𝘤𝘥𝘦𝘧𝘨𝘩𝘪𝘫𝘬𝘭𝘮𝘯𝘰𝘱𝘲𝘳𝘴𝘵𝘶𝘷𝘸𝘹𝘺𝘻</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Kaligrafia</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵</span>
+          <span class="abc-line">𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Kaligrafia tučná</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩</span>
+          <span class="abc-line">𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Gotika</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝔄𝔅ℭ𝔇𝔈𝔉𝔊ℌℑ𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔ℜ𝔖𝔗𝔘𝔙𝔚𝔛𝔜ℨ</span>
+          <span class="abc-line">𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Bublinkové</span>
+        <div class="abc-lines">
+          <span class="abc-line">ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ</span>
+          <span class="abc-line">ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ</span>
+          <span class="abc-line">⓪①②③④⑤⑥⑦⑧⑨</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Kapitálky</span>
+        <div class="abc-lines">
+          <span class="abc-line">ᴀʙᴄᴅᴇꜰɢʜɪᴊᴋʟᴍɴᴏᴘqʀsᴛᴜᴠᴡxʏᴢ</span>
+          <span class="abc-line">ᴀʙᴄᴅᴇꜰɢʜɪᴊᴋʟᴍɴᴏᴘqʀsᴛᴜᴠᴡxʏᴢ</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+    </div>
+    <p class="u-mt-15">Hľadáš konkrétny rez? Pozri <a href="/sk/tucne-pismo/">tučné písmená</a>, <a href="/sk/goticke-pismo/">gotické písmená na kopírovanie</a> alebo <a href="/category/cursive-fonts/">písané písmená a kurzívu</a> — každá kategória ukazuje len jeden štýl, od veľkých po malé písmená.</p>
+  </section>
+
+  <!-- Ozdoby a symboly na kopírovanie -->
+  <section class="editorial-section glyph-section" aria-label="Ozdoby a symboly na kopírovanie">
+    <h2>Ozdoby a symboly na kopírovanie</h2>
+    <p class="editorial-intro">Hotové <strong>ozdoby textu na kopírovanie</strong> — hviezdičky, srdiečka, rámčeky, šípky a oddeľovače. Klikni na ľubovoľný znak a skopíruj ho, alebo ich pridaj automaticky k textu cez záložky <strong>Symboly</strong>, <strong>Rámčeky</strong> a <strong>Oddeľovače</strong> v generátore hore.</p>
+    <div class="glyph-group">
+      <h3>Hviezdičky a záblesky</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="✦">✦</button>
+        <button class="glyph-copy" type="button" data-text="✧">✧</button>
+        <button class="glyph-copy" type="button" data-text="⋆">⋆</button>
+        <button class="glyph-copy" type="button" data-text="✩">✩</button>
+        <button class="glyph-copy" type="button" data-text="★">★</button>
+        <button class="glyph-copy" type="button" data-text="☆">☆</button>
+        <button class="glyph-copy" type="button" data-text="✰">✰</button>
+        <button class="glyph-copy" type="button" data-text="⊹">⊹</button>
+        <button class="glyph-copy" type="button" data-text="࿐">࿐</button>
+        <button class="glyph-copy" type="button" data-text="˚">˚</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Srdiečka</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="♡">♡</button>
+        <button class="glyph-copy" type="button" data-text="♥">♥</button>
+        <button class="glyph-copy" type="button" data-text="❤">❤</button>
+        <button class="glyph-copy" type="button" data-text="❥">❥</button>
+        <button class="glyph-copy" type="button" data-text="❣">❣</button>
+        <button class="glyph-copy" type="button" data-text="ღ">ღ</button>
+        <button class="glyph-copy" type="button" data-text="ꨄ">ꨄ</button>
+        <button class="glyph-copy" type="button" data-text="ஐ">ஐ</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Mesiac a obloha</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="☾">☾</button>
+        <button class="glyph-copy" type="button" data-text="☽">☽</button>
+        <button class="glyph-copy" type="button" data-text="☁">☁</button>
+        <button class="glyph-copy" type="button" data-text="✶">✶</button>
+        <button class="glyph-copy" type="button" data-text="⍣">⍣</button>
+        <button class="glyph-copy" type="button" data-text="ꕥ">ꕥ</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Kvety</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="❀">❀</button>
+        <button class="glyph-copy" type="button" data-text="✿">✿</button>
+        <button class="glyph-copy" type="button" data-text="⚘">⚘</button>
+        <button class="glyph-copy" type="button" data-text="✾">✾</button>
+        <button class="glyph-copy" type="button" data-text="❁">❁</button>
+        <button class="glyph-copy" type="button" data-text="ꕤ">ꕤ</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Rámčeky a ornamenty</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="꧁">꧁</button>
+        <button class="glyph-copy" type="button" data-text="꧂">꧂</button>
+        <button class="glyph-copy" type="button" data-text="༺">༺</button>
+        <button class="glyph-copy" type="button" data-text="༻">༻</button>
+        <button class="glyph-copy" type="button" data-text="⟡">⟡</button>
+        <button class="glyph-copy" type="button" data-text="❪">❪</button>
+        <button class="glyph-copy" type="button" data-text="❫">❫</button>
+        <button class="glyph-copy" type="button" data-text="★彡">★彡</button>
+        <button class="glyph-copy" type="button" data-text="彡★">彡★</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Šípky</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="→">→</button>
+        <button class="glyph-copy" type="button" data-text="⇨">⇨</button>
+        <button class="glyph-copy" type="button" data-text="➤">➤</button>
+        <button class="glyph-copy" type="button" data-text="⟶">⟶</button>
+        <button class="glyph-copy" type="button" data-text="➳">➳</button>
+        <button class="glyph-copy" type="button" data-text="↬">↬</button>
+        <button class="glyph-copy" type="button" data-text="⇢">⇢</button>
+        <button class="glyph-copy" type="button" data-text="↳">↳</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Oddeľovače</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="·">·</button>
+        <button class="glyph-copy" type="button" data-text="•">•</button>
+        <button class="glyph-copy" type="button" data-text="◦">◦</button>
+        <button class="glyph-copy" type="button" data-text="➛">➛</button>
+        <button class="glyph-copy" type="button" data-text="⟢">⟢</button>
+        <button class="glyph-copy" type="button" data-text="—">—</button>
+        <button class="glyph-copy" type="button" data-text="☰">☰</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Kaomoji (tváre)</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="(◍•ᴗ•◍)">(◍•ᴗ•◍)</button>
+        <button class="glyph-copy" type="button" data-text="(｡♥‿♥｡)">(｡♥‿♥｡)</button>
+        <button class="glyph-copy" type="button" data-text="ʕ•ᴥ•ʔ">ʕ•ᴥ•ʔ</button>
+        <button class="glyph-copy" type="button" data-text="(＾▽＾)">(＾▽＾)</button>
+        <button class="glyph-copy" type="button" data-text="٩(◕‿◕)۶">٩(◕‿◕)۶</button>
+      </div>
+    </div>
+  </section>
+
+  <!-- Popular Use Cases -->
+  <section class="editorial-section">
+    <h2 data-i18n="useCases.title">Na čo to ľudia najčastejšie používajú</h2>
+    <div class="tips-grid">
+      <a class="tip-card" href="/usecase/linkedin-headline/" aria-label="Titulok na LinkedIne">
+        <div class="tip-icon">💼</div>
+        <h3 data-i18n="useCases.items.0.title">Titulok na LinkedIne</h3>
+        <p data-i18n="useCases.items.0.description">Vynikni vo vyhľadávaní na LinkedIne — tučný alebo jemne ozdobený titulok zaberie skôr, než niekto stihne odscrollovať ďalej.</p>
+      </a>
+      <a class="tip-card" href="/usecase/comment-font/" aria-label="Komentáre pod príspevkami">
+        <div class="tip-icon">💬</div>
+        <h3 data-i18n="useCases.items.1.title">Komentáre pod príspevkami</h3>
+        <p data-i18n="useCases.items.1.description">Štýlové komentáre na Instagrame, YouTube aj TikToku — okom ich zachytíš ľahšie než stovky obyčajných pod populárnym príspevkom.</p>
+      </a>
+      <a class="tip-card" href="/usecase/text-to-emoji/" aria-label="Text zapísaný v emoji">
+        <div class="tip-icon">😊</div>
+        <h3 data-i18n="useCases.items.2.title">Text zapísaný v emoji</h3>
+        <p data-i18n="useCases.items.2.description">Premeň nápis na sekvenciu písmen-emoji — kreatívne bio, story, skupinové chaty alebo čisto pre zábavu s kamarátmi.</p>
+      </a>
+      <a class="tip-card" href="/usecase/tattoo-fonts/" aria-label="Písmo na tetovanie">
+        <div class="tip-icon">🖤</div>
+        <h3>Písmo na tetovanie</h3>
+        <p>Vyskúšaj si meno alebo nápis v kaligrafii, gotike a kurzíve — skôr, než pôjde pod ihlu.</p>
+      </a>
+      <a class="tip-card" href="/usecase/zalgo-text/" aria-label="Generátor textu Zalgo">
+        <div class="tip-icon">👻</div>
+        <h3>Pokrútené písmená Zalgo</h3>
+        <p>Glitchový text s čiarkami nad a pod písmenami — hodí sa k halloweenskym memom, temným biám a herným klanom, ktoré chcú vyzerať hrozivo.</p>
+      </a>
+    </div>
+    <p class="u-mt-15 u-text-center"><a class="cat-cta" href="/usecase/" data-i18n="useCases.viewAll">Zobraziť ďalšie využitie →</a></p>
+  </section>
+
+  <!-- Popular Guides -->
+  <section class="editorial-section">
+    <h2 data-i18n="guides.title">Pozri si návody</h2>
+    <div class="tips-grid">
+      <a class="tip-card" href="/guide/the-rhetoric-of-fonts/" aria-label="Rétorika písma">
+        <div class="tip-icon">📚</div>
+        <h3 data-i18n="guides.items.0.title">Rétorika písma</h3>
+        <p data-i18n="guides.items.0.description">Prečo jedno písmo budí dôveru a druhé vyzerá ako spam — čiže ako typografia ovplyvňuje to, čo pri čítaní cítime.</p>
+      </a>
+      <a class="tip-card" href="/guide/personal-branding-through-typography/" aria-label="Osobná značka cez typografiu">
+        <div class="tip-icon">🎨</div>
+        <h3 data-i18n="guides.items.1.title">Osobná značka cez typografiu</h3>
+        <p data-i18n="guides.items.1.description">Ako vybrať písmená, ktoré ladia s tvojím vibom a zostanú divákovi v hlave — či už ide o LinkedIn, Instagram alebo Discord.</p>
+      </a>
+      <a class="tip-card" href="/guide/stop-the-scroll-with-font-variation/" aria-label="Zastav skrolovanie — pohraj sa s písmom">
+        <div class="tip-icon">📱</div>
+        <h3 data-i18n="guides.items.2.title">Zastav skrolovanie — pohraj sa s písmom</h3>
+        <p data-i18n="guides.items.2.description">Prečo sa ľudia zastavia pri príspevkoch s iným štýlom textu a ako to využiť na zvýšenie dosahov.</p>
+      </a>
+    </div>
+    <p class="u-mt-15 u-text-center"><a class="cat-cta" href="/guide/" data-i18n="guides.viewAll">Všetky návody →</a></p>
+  </section>
+
+  <!-- FAQ Section -->
+  <section class="faq-section-wrapper" aria-label="Frequently asked questions">
+    <div class="faq-inner">
+
+<!-- Písmená a ozdoby na kopírovanie -->
+<h2 class="faq-category">Písmená a ozdoby na kopírovanie</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span>Kde nájdem pekné písmená na kopírovanie?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer">Priamo tu. Napíšeš text do poľa hore a pekné písmená — <strong>tučné</strong>, <strong>kurzíva</strong>, <strong>gotika</strong>, <strong>bublinkové</strong> a ešte pár desiatok ďalších — sa hneď objavia pod ním. Klikneš na „Kopírovať" a vložíš, kam chceš.
+    <br><br>
+    Máš tu aj hotovú <strong>abecedu A–Z na kopírovanie</strong> v obľúbených štýloch — veľké písmená, malé písmená aj číslice — ktorú si môžeš vziať aj bez písania čohokoľvek.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span>Čo sú ozdoby na kopírovanie a kde ich hľadať?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer">Ozdoby sú malé symboly, ktorými zdobíš text — hviezdičky ✦, srdiečka ♡, rámčeky ꧁꧂, šípky → a oddeľovače.
+    <br><br>
+    V sekcii <strong>„Ozdoby a symboly na kopírovanie"</strong> klikneš na ľubovoľný znak a skopíruješ ho zvlášť. <strong>Ozdoby textu</strong> môžeš tiež pridať automaticky k celému nápisu — cez záložky <strong>Symboly</strong>, <strong>Rámčeky</strong> a <strong>Oddeľovače</strong> nad poľom na písanie.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span>Máte pekné a estetické písma na kopírovanie?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer">Áno — od minimalistických, rozhádzaných <strong>estetických písem na kopírovanie</strong> po ozdobné písmená so symbolmi. Napíšeš text a všetky štýly pekných písem sa objavia naraz. Celé je to zadarmo a pripravené na kopírovanie jedným kliknutím, rovnako na telefóne aj na počítači.</div>
+</div>
+
+
+<!-- Prvé otázky -->
+<h2 class="faq-category" data-i18n="faq.categories.0.title">Prvé otázky</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.0.items.0.question">Čo je UltraTextGen a čo sa tu vlastne deje?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.0.items.0.answer">Je to bezplatný generátor písmen — napíšeš obyčajný text a my ho prevedieme na štylizované znaky Unicode, ktoré vyzerajú ako ozdobné písmo.
+    <br><br>
+    Hlavná vec: sú to <strong>ozajstné znaky</strong>, nie stučnenie z Wordu alebo markdown z Discordu. Preto fungujú všade, kam sa dá napísať obyčajný text — v biu na Instagrame, v nicku, v komentári, v e-maile, v statuse na WhatsAppe.
+    <br><br>
+    <strong>Príklad</strong><br>
+    Napíšeš „ahoj" → dostaneš 𝗮𝗵𝗼𝗷 (tučné), 𝘢𝘩𝘰𝘫 (kurzíva), 𝒶𝒽ℴ𝒿 (kaligrafia) alebo ⓐⓗⓞⓙ (bublinkové). Všetko jedným kliknutím.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.0.items.1.question">Ako skopírovať ozdobné písmená za 5 sekúnd?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.0.items.1.answer">1. Napíšeš alebo vložíš text do poľa hore.<br>
+    2. Štýly sa hneď objavia pod ním — tučné, kurzíva, gotika, bublinkové a ešte pár desiatok ďalších.<br>
+    3. Keď chceš, pridaj ozdoby — rámčeky, hviezdičky, šípky.<br>
+    4. Klikneš na „Kopírovať" pri tom, ktorý ti sedí, a vložíš, kam len chceš.
+    <br><br>
+    A je to. Bez registrácie, bez inštalácie apky. Funguje rovnako na počítači aj na telefóne.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.0.items.2.question">Zadarmo? Bez limitov, bez účtu?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.0.items.2.answer">Áno, celé je to <strong>100% zadarmo</strong>. Žiadny účet, žiadny denný limit, žiadne vodoznaky, žiadny háčik. Môžeš cez to prehnať celú knižku a nič sa nestane.</div>
+</div>
+
+
+<!-- Instagram, TikTok, Discord -->
+<h2 class="faq-category" data-i18n="faq.categories.1.title">Instagram, TikTok, Discord — kam to vložiť</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.1.items.0.question">Ako dostať štýlový text do bia na Instagrame?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.1.items.0.answer">Instagram nemá žiadny panel na formátovanie, ale prijíma Unicode — takže všetko, čo u nás vygeneruješ, ti v biu naskočí bez problémov.
+    <br><br>
+    <strong>Ako na to</strong><br>
+    1. Napíš, čo chceš mať v biu (napríklad meno, hashtag, krátky popis).<br>
+    2. Vyber štýl — tučné a kurzíva fungujú na väčšine zariadení najlepšie.<br>
+    3. Skopíruj výsledok a vlož ho v „Upraviť profil → Bio" v aplikácii.
+    <br><br>
+    Tip: keď chceš ozdobiť, pridaj rámček typu ⋆｡˚ alebo hviezdičku ✦ po strane — vyzerá to dobre a nekradne to pozornosť zvyšku bia.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.1.items.1.question">Fungujú písmená v popisoch na TikToku?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.1.items.1.answer">Áno — TikTok vykresľuje Unicode v popisoch, popisoch profilu aj komentároch. Najlepšie sa osvedčí <strong>tučné</strong>, <strong>kurzíva</strong>, <strong>bublinkové</strong> a <strong>kapitálky</strong>. Štýly s kopou ozdôb sa pri dlhých popisoch občas orežú, tak si pre istotu príspevok skontroluj v náhľade pred zverejnením.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.1.items.2.question">Dá sa spraviť nick do hry alebo na Discord?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.1.items.2.answer">Jasné — to je asi najčastejší dôvod, prečo ľudia na takéto generátory chodia. Discord, Roblox, Steam, Minecraft, väčšina hier prijíma Unicode v nicku.
+    <br><br>
+    <strong>Príklad</strong><br>
+    Obyčajný nick: „DarkWolf"<br>
+    Po štylizácii: „𝔇𝔞𝔯𝔨𝔚𝔬𝔩𝔣" (gotika), „ⒹⓐⓡⓚⓌⓞⓛⓕ" (bublinkové) alebo „๖ۣۜDarkWolf" (s ozdobou po strane).
+    <br><br>
+    <strong>Pozor:</strong> niektoré hry majú filtre a exotické znaky neprijmú. Keď jeden štýl neprejde, daj iný — tučné a kurzíva prejdú takmer všade.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.1.items.3.question">Funguje to v statuse na WhatsAppe, na Telegrame a v Messengeri?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.1.items.3.answer">Áno — WhatsApp, Telegram, Messenger, Signal, iMessage. Čokoľvek prijíma obyčajný text, prijme aj písmená Unicode. Vložíš ich do statusu alebo do správy a vyzerajú ako ozdobné písmo.
+    <br><br>
+    K WhatsAppu ešte dodám: ak ti ide len o stučnenie, môžeš použiť ich vlastnú syntax (<code>*text*</code> spraví tučné). Ale Unicode funguje všade — aj tam, kde to WhatsApp nepodporuje, napríklad v názve kontaktu.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.1.items.4.question">A v predmete e-mailu alebo v životopise?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.1.items.4.answer">Tu Unicode odvedie najväčšiu prácu. Predmet e-mailu je obyčajný text, takže stučnenie z Outlooku odpadá. Ale „𝗙𝗮𝗸𝘁𝘂𝗿𝗮 — 𝗣𝗢𝗭𝗢𝗥" už v príjemcovej schránke pôsobí silnejšie.
+    <br><br>
+    V životopise dokáže jemne stučnené meno v hlavičke pritiahnuť pohľad personalistu. Len to nepreháňaj — celý životopis v gotike nepôsobí profesionálne.</div>
+</div>
+
+
+<!-- Štýly, písmená a ozdoby -->
+<h2 class="faq-category" data-i18n="faq.categories.2.title">Štýly, písmená a ozdoby</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.2.items.0.question">Aké štýly písmen mám na výber?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.2.items.0.answer">Veľa. Vážne veľa. V skratke:
+    <br><br>
+    <strong>Základné</strong><br>
+    Tučné (bold), kurzíva, kaligrafia (script), gotika, bublinkové (v kolieskach), kapitálky, prečiarknuté, podčiarknuté, dvojito ťahané (double struck).
+    <br><br>
+    <strong>Zábavné</strong><br>
+    Text hore nohami, zrkadlovo obrátený, Zalgo (glitch s čiarkami nad písmenami), text v štvorčekoch, v zátvorkách, fullwidth (rozhádzaný).
+    <br><br>
+    <strong>Doplnky</strong><br>
+    Rámčeky okolo textu, hviezdičky, srdiečka, šípky, oddeľovače, vlajky, emoji — dajú sa na štýl písmen navrstviť.
+    <br><br>
+    Z času na čas pribúdajú nové — oplatí sa pridať si stránku do záložiek.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.2.items.1.question">Môžem spojiť viac štýlov naraz?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.2.items.1.answer">Áno — a to je najväčšia prednosť UltraTextGenu. Môžeš navrstviť napríklad <strong>bublinkové + Zalgo</strong>, <strong>gotiku + hore nohami</strong> alebo <strong>kapitálky + podčiarknutie</strong> a potom to celé uzavrieť do rámčeka alebo hviezdičky.
+    <br><br>
+    <strong>Príklad</strong><br>
+    „ahoj" → vyberieš gotiku → pridáš rámček s hviezdičkami → vyjde: ★彡[ 𝔞𝔥𝔬𝔧 ]彡★
+    <br><br>
+    Čím viac experimentuješ, tým zaujímavejšie veci vzniknú. Odporúčam začať jedným štýlom a pridať jednu ozdobu — nie všetko naraz.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.2.items.2.question">Čo je Zalgo a tie divné čiarky nad písmenami?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.2.items.2.answer">Zalgo je taký „prekliaty", glitchový štýl — nad a pod každé písmeno naletí kopa diakritických znamienok. Vyzerá to, akoby sa text rozpadal alebo bol z hororu.
+    <br><br>
+    <strong>Príklad</strong><br>
+    „ahoj" → a̷̢h̴̢ơ̷j̴̜
+    <br><br>
+    Najčastejšie to vídavaš v temných biách na Instagrame, v halloweenskych memoch, v herných klanoch, ktoré chcú vyzerať hrozivo, alebo keď si z toho niekto robí srandu.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.2.items.3.question">Kde brať pekné symboly, hviezdičky a srdiečka?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.2.items.3.answer">Všetko, čo máš v sekcii „Ozdoby" pod textovým poľom, môžeš kopírovať zvlášť — aj bez písania textu. Jednoducho ako samostatné znaky do bia, nicku alebo príspevku.
+    <br><br>
+    — <strong>Estetické symboly</strong>: ✦ ✧ ⋆ ｡ ☆ ♡ ❀ ✿<br>
+    — <strong>Rámčeky a obruby</strong>: ╭─▸ │ ╰─▸ alebo ★彡[ ]彡★<br>
+    — <strong>Šípky</strong>: → ⇨ ➤ ⟶<br>
+    — <strong>Minimalistické oddeľovače</strong>: ·  ⋅  ─  •<br>
+    — <strong>Vlajky a emoji</strong>.
+    <br><br>
+    Najčastejšie sa používajú v estetických biách na Instagrame a Pintereste — hodia sa úplne ku všetkému, od citátov po zoznamy záujmov.</div>
+</div>
+
+
+<!-- Slovenské znaky, kompatibilita -->
+<h2 class="faq-category" data-i18n="faq.categories.3.title">Slovenské znaky, kompatibilita, problémy</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.3.items.0.question">A slovenské znaky? Funguje to s á, ä, č, ď, é, í, ĺ, ľ, ň, ó, ô, ŕ, š, ť, ú, ý, ž?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.3.items.0.answer"><strong>Krátko:</strong> záleží na štýle.
+    <br><br>
+    Unicode má štylizované varianty pre základnú abecedu A–Z, takže <em>a</em>, <em>c</em>, <em>e</em>, <em>s</em>, <em>z</em> sa v pohode premenia napríklad na tučné. Ale pre <em>á</em>, <em>č</em>, <em>ľ</em>, <em>š</em>, <em>ť</em>, <em>ž</em> štylizované verzie existujú len v časti štýlov (hlavne tučné, kurzíva, kapitálky).
+    <br><br>
+    Keď štýl nemá verziu pre slovenský znak s diakritikou, zostane v pôvodnej podobe — text je stále čitateľný, slovenské písmená s mäkčeňmi a dĺžňami jednoducho vyzerajú „obyčajnejšie" než zvyšok. Pre nicky bez diakritiky to nie je žiadny problém. Pre celé vety v slovenčine odporúčam <strong>tučné</strong>, <strong>kurzívu</strong> alebo <strong>monospace</strong> — tie si s našou abecedou poradia najlepšie.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.3.items.1.question">Prečo sa niekomu zobrazujú štvorčeky namiesto písmen?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.3.items.1.answer">Pretože systémové písmo na strane príjemcu daný znak Unicode neobsahuje. Nie je to problém s tvojím textom — jeho telefón alebo aplikácia jednoducho ten konkrétny znak v sade nemá.
+    <br><br>
+    Drž sa <strong>tučných</strong>, <strong>kurzívy</strong> a <strong>bublinkových</strong> — tie majú najširšiu podporu. Veľmi exotické štýly (fullwidth, štvorčeky) sa na starších Androidoch alebo v niektorých e-mailových klientoch môžu zobraziť ako □.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.3.items.2.question">Instagram mi v nicku orezal časť znakov — čo teraz?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.3.items.2.answer">Instagram má filter na pole <strong>používateľské meno</strong> (čiže @login) — berie len písmená, číslice, bodky a podčiarkovníky. Sem štylizované písmená nevložíš.
+    <br><br>
+    Ale do poľa <strong>„Meno"</strong> (zobrazované meno) a do <strong>bia</strong> áno — a tam prejde väčšina štýlov. Keď sa jeden neuloží, daj iný. Tučné obvykle prejde bez problémov.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.3.items.3.question">Sú nejaké znaky, ktoré sa vôbec nedajú previesť?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.3.items.3.answer">Štandardné písmená (A–Z, a–z), číslice a základná interpunkcia sa prevedú bez problémov. Niektoré vzácne symboly alebo špeciálne znaky nemajú v Unicode štylizované náprotivky — potom zostanú v pôvodnej podobe. Nič sa nerozbije, text je stále na kopírovanie.</div>
+</div>
+
+
+<!-- Bezpečnosť, súkromie, telefón -->
+<h2 class="faq-category" data-i18n="faq.categories.4.title">Bezpečnosť, súkromie, telefón</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.4.items.0.question">Ukladá sa môj text niekam?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.4.items.0.answer">Nie. Celý prevod písmen prebieha <strong>v tvojom prehliadači</strong> — nič neputuje na naše servery, nič sa neukladá, nič sa nesleduje. Skopírovaný text je čistý Unicode, bez skrytých znakov, bez akýchkoľvek identifikátorov.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.4.items.1.question">Je bezpečné vkladať tieto písmená kamkoľvek?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.4.items.1.answer">Áno — sú to štandardné znaky Unicode, rovnaké ako tie, ktoré používa celý internet. Nič vnútri, žiadne skripty, žiadne skryté formátovanie, žiadne kódy. Pokojne ich vlož do životopisu, do pracovného e-mailu, do bia na LinkedIne — kam chceš.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.4.items.2.question">Funguje to na telefóne?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.4.items.2.answer">Áno — stránka sa plne prispôsobí mobilu. iPhone, Android, tablet — všetko klape. Napíšeš text, klikneš, skopíruje sa do schránky, vložíš v aplikácii. Bez inštalácie čohokoľvek z obchodu.</div>
+</div>
+
+
+<!-- Čím sa líšime -->
+<h2 class="faq-category" data-i18n="faq.categories.5.title">Čím sa líšime</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.5.items.0.question">Čím sa líšite od iných generátorov písmen?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.5.items.0.answer">Konkrétne:
+    <br><br>
+    — <strong>Jedna z najväčších zbierok</strong> štýlov Ultra — tučné, kurzíva, gotika, bublinkové a ešte pár desiatok ďalších.<br>
+    — <strong>Kombinovanie štýlov</strong> — väčšina generátorov ti dá jeden štýl naraz, my dovolíme vrstviť.<br>
+    — <strong>Ozdoby jedným kliknutím</strong> — rámčeky, hviezdičky, oddeľovače bez lepenia znak po znaku.<br>
+    — <strong>Stránky pre konkrétne platformy</strong> — Instagram, TikTok, Discord. Ukazujeme tam len štýly, ktoré v danej apke fungujú.<br>
+    — <strong>Rýchlo a bez vyskakovacích okien</strong> — žiadne captchy, žiadne „prijať všetko" pred každým kliknutím.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.5.items.1.question">Pribúdajú nové štýly?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.5.items.1.answer">Áno, pravidelne. Z času na čas naskočia nové varianty, ozdoby a rámčeky. Najjednoduchšie je uložiť si stránku do záložiek alebo sa sem raz za čas vrátiť.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.5.items.2.question">Ako nájsť presne ten štýl, ktorý hľadám?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.5.items.2.answer">Tri cesty:
+    <br><br>
+    <strong>Podľa štýlu</strong> — kategórie hore: tučné, kurzíva, gotika, bublinkové, prečiarknuté, hore nohami a ďalšie.<br>
+    <strong>Podľa platformy</strong> — pozri podstránku pre Instagram, TikTok, Discord — tam sú len štýly, ktoré na danej platforme fungujú.<br>
+    <strong>Podľa cieľa</strong> — sekcia využitia má nástroje ušité na konkrétnu potrebu: titulok na LinkedIn, komentáre, text s emoji.</div>
+</div>
+    </div>
+  </section>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-inner">
+      <!-- Language Switcher -->
+      <div class="lang-switcher" role="navigation" aria-label="Language switcher">
+        <a class="lang-option" href="/" hreflang="en">EN</a>
+        <a class="lang-option active" href="/sk/" hreflang="sk">SK</a>
+        <a class="lang-option" href="/cs/" hreflang="cs">CS</a>
+        <a class="lang-option" href="/es/" hreflang="es">ES</a>
+        <a class="lang-option" href="/fr/" hreflang="fr">FR</a>
+        <a class="lang-option" href="/pt/" hreflang="pt">PT</a>
+        <a class="lang-option" href="/de/" hreflang="de">DE</a>
+        <a class="lang-option" href="/id/" hreflang="id">ID</a>
+        <a class="lang-option" href="/it/" hreflang="it">IT</a>
+        <a class="lang-option" href="/nl/" hreflang="nl">NL</a>
+        <a class="lang-option" href="/tr/" hreflang="tr">TR</a>
+        <a class="lang-option" href="/pl/" hreflang="pl">PL</a>
+        <a class="lang-option" href="/vi/" hreflang="vi">VI</a>
+        <a class="lang-option" href="/sv/" hreflang="sv">SV</a>
+        <a class="lang-option" href="/no/" hreflang="no">NO</a>
+        <a class="lang-option" href="/ja/" hreflang="ja">JA</a>
+        <a class="lang-option" href="/th/" hreflang="th">TH</a>
+        <a class="lang-option" href="/ru/" hreflang="ru">RU</a>
+        <a class="lang-option" href="/ar/" hreflang="ar">AR</a>
+      </div>
+    </div>
+  </footer>
+
+  <div class="copy-toast" id="copyToast">Copied!</div>
+
+  <script src="/styles.js" defer=""></script>
+<script src="/renderer.js" defer=""></script>
+<script src="/script.js" defer=""></script>
+<script src="/i18n.js" defer=""></script>
+
+
+
+
+<script src="/footer.js" defer=""></script>
+
+
+</body></html>

--- a/sk/kurziva/index.html
+++ b/sk/kurziva/index.html
@@ -1,0 +1,299 @@
+<!DOCTYPE html><html lang="sk"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZGVh");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Generátor kurzívy — 𝘬𝘶𝘳𝘻í𝘷𝘢 na kopírovanie | UltraTextGen</title>
+  <meta name="description" content="Bezplatný generátor kurzívy: preveď text na sklonené písmená Unicode na kopírovanie a vloženie — do bia na Instagrame, na WhatsApp, TikTok, Discord a LinkedIn. Ihneď, bez registrácie.">
+  <link rel="canonical" href="https://ultratextgen.com/sk/kurziva/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/category/italic-fonts/">
+  <link rel="alternate" hreflang="sk" href="https://ultratextgen.com/sk/kurziva/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/category/italic-fonts/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Generátor kurzívy — 𝘬𝘶𝘳𝘻í𝘷𝘢 na kopírovanie | UltraTextGen">
+  <meta property="og:description" content="Bezplatný generátor kurzívy — sklonené písmená Unicode na kopírovanie a vloženie na Instagram, TikTok, WhatsApp, Discord a LinkedIn. Ihneď, bez registrácie.">
+  <meta property="og:url" content="https://ultratextgen.com/sk/kurziva/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category-italic-fonts.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Generátor kurzívy — 𝘬𝘶𝘳𝘻í𝘷𝘢 na kopírovanie | UltraTextGen">
+  <meta name="twitter:description" content="Bezplatný generátor kurzívy — sklonené písmená Unicode na kopírovanie a vloženie na sociálnych sieťach, v chatoch a nickoch.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category-italic-fonts.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "sk",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Ako vytvoriť kurzívu na kopírovanie a vloženie?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Napíš text do poľa hore a generátor ho hneď ukáže kurzívou (𝘵𝘢𝘬é 𝘢𝘬𝘰 𝘵𝘪𝘦𝘵𝘰) — sú to ozajstné znaky Unicode, nie nainštalované písmo ani obrázok. Keďže ide o obyčajné textové znaky, môžeš ich skopírovať a vložiť všade, kde sa dá napísať text: do bia, popisov, komentárov a správ. Viac v našom sprievodcovi o tom, ako funguje písmo Unicode."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Funguje kurzíva Unicode na Instagrame, WhatsAppe, TikToku a LinkedIne?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Áno. Bio, popisy, komentáre aj správy na chate tieto znaky bez problémov prijmú. Hlavne na LinkedIne a X, kde natívna kurzíva chýba, sklonené písmo Unicode umožňuje zvýrazniť najdôležitejšie slová. Pozor: niektoré polia používateľského mena (@) takéto znaky odfiltrujú — v samotnom logine zostaň pri obyčajnom texte, ale v biu kurzíva funguje skvele."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Podporuje kurzíva slovenské znaky (á, ä, č, ľ, š, ž)?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Kurzíva Unicode pokrýva základnú abecedu A–Z a číslice 0–9, preto slovenská diakritika (á, ä, č, ď, é, í, ĺ, ľ, ň, ó, ô, ŕ, š, ť, ú, ý, ž) nemá vlastnú sklonenú podobu a zostáva obyčajnými písmenami uprostred slova (napr. „ľalia“ vyjde ako ľ𝘢𝘭𝘪𝘢). Pre nicky a krátke heslá bez diakritiky vyzerá kurzíva perfektne; v dlhšom texte je najbezpečnejšie voliť slová, ktoré ju neobsahujú."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Je generátor kurzívy zadarmo?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Áno, plne zadarmo a bez registrácie. Píš, kopíruj a vkladaj, koľkokrát chceš — nie je tu žiadny limit ani skryté poplatky."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Prečo sa niektoré písmená kurzívy zobrazujú ako prázdne štvorčeky?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Prázdny štvorček (▯) znamená, že zariadenie príjemcu nemá glyf pre daný sklonený znak — najčastejšie ide o starší telefón alebo počítač. Vyber jednoduchší variant kurzívy alebo zariadenie aktualizuj — viac v texte o tom, prečo sa písmo zobrazuje ako štvorčeky."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Ovplyvňuje kurzíva Unicode čitateľnosť a dosah?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Sklonené znaky Unicode pekne priťahujú pohľad a skvele slúžia v heslách, titulkoch a výzvach na akciu na sociálnych sieťach. Používaj ich cielene — krátky akcent kurzívou, zvyšok obyčajným textom. V obsahu na vlastnom webe je lepšie použiť sklonenie cez CSS, aby vyhľadávače čítali bežné slová; v textových poliach sociálnych sietí je ideálna kurzíva Unicode. Pri dlhších úsekoch nezabudni na prístupnosť."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "inLanguage": "sk",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Domov", "item": "https://ultratextgen.com/sk/" },
+    { "@type": "ListItem", "position": 2, "name": "Kurzíva", "item": "https://ultratextgen.com/sk/kurziva/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Generátor kurzívy",
+  "alternateName": ["Kurzíva na kopírovanie","Sklonené písmo","Sklonené písmená","Kurzíva Unicode","Písmo kurzíva","Text kurzívou","Kurzíva online"],
+  "url": "https://ultratextgen.com/sk/kurziva/",
+  "inLanguage": "sk",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "EUR"
+  },
+  "description": "Bezplatný generátor kurzívy: prevádza text na sklonené písmená Unicode na kopírovanie a vloženie na Instagram, TikTok, WhatsApp, Discord, LinkedIn a do nickov.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/sk/">Domov</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Kurzíva</span>
+</nav>
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/category-italic-fonts.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+  <!-- Hero -->
+  <section class="hero">
+    <div class="hero-inner">
+      <div class="hero-card">
+        <h1 class="hero-headline">Generátor kurzívy</h1>
+        <p class="hero-tagline">Premeň ľubovoľný text na 𝘬𝘶𝘳𝘻í𝘷𝘶 na kopírovanie a vloženie — elegantné,
+          sklonené písmená Unicode do bia, nickov a titulkov. Zadarmo, ihneď, bez registrácie.</p>
+        <div class="input-wrapper">
+          <textarea class="main-input" id="mainInput" placeholder="Napíš text, slovo alebo meno…" maxlength="500" autofocus></textarea>
+          <span class="char-count"><span id="charCount">0</span>/500</span>
+        </div>
+
+        <!-- Decoration Selector -->
+        <div class="decoration-section">
+          <div class="decoration-label">
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"></path>
+            </svg>
+            Pridaj symboly okolo výsledku
+          </div>
+          <div class="decoration-tabs">
+            <button class="decoration-tab active" data-deco-tab="symbols">Symboly</button>
+            <button class="decoration-tab" data-deco-tab="frames">Rámčeky</button>
+            <button class="decoration-tab" data-deco-tab="dividers">Oddeľovače</button>
+            <button class="decoration-tab" data-deco-tab="minimal">Minimalistické</button>
+            <button class="decoration-tab" data-deco-tab="emojis">Emoji</button>
+          </div>
+          <div class="decoration-grid" id="decorationGrid"></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Main Content -->
+  <main class="container">
+
+    <section class="editorial-section">
+      <span class="article-section-label">Kurzíva Unicode</span>
+      <h2>Kurzíva na kopírovanie — do bia, nickov a titulkov</h2>
+      <p>Tieto písmená nie sú nainštalované písmo ani obrázok, ale ozajstné <strong>znaky Unicode</strong>. Zvýrazni
+        kľúčové slovo v biu, sprav sklonený nick alebo zariaď, aby titulok na LinkedIne a X priťahoval pohľad — všade tam,
+        kde natívna kurzíva chýba. Napíš text vyššie, klikni na <strong>Kopírovať</strong> a vlož kurzívu tam, kam chceš.</p>
+    </section>
+
+    <!-- Category Tabs (populated by script.js) -->
+    <div class="category-section">
+      <div class="category-tabs" id="categoryTabs"></div>
+    </div>
+
+    <!-- Results -->
+    <div class="results-grid" id="resultsGrid"></div>
+
+    <section class="editorial-section">
+      <span class="article-section-label">Súvisiace</span>
+      <p>Spoj kurzívu s <a href="/sk/pismo-pre-discord/">písmom na Discord</a>,
+        <a href="/sk/">písmenami na kopírovanie</a> alebo
+        <a href="/library/invisible-character/">neviditeľným znakom</a> pre čisté medzery. Na tetovanie je
+        <a href="/usecase/tattoo-fonts/">generátor písma na tetovanie</a>, a na zvislé sadzby —
+        <a href="/usecase/vertical-text/">zvislý text</a>.</p>
+    </section>
+  </main>
+
+  <!-- Footer + FAQ -->
+  <footer class="footer">
+    <div class="footer-inner">
+<div class="faq-section" id="faq">
+
+<h2 class="faq-category">Generátor kurzívy — FAQ</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Ako vytvoriť kurzívu na kopírovanie a vloženie?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Napíš text do poľa hore a generátor ho hneď ukáže kurzívou (𝘵𝘢𝘬é 𝘢𝘬𝘰 𝘵𝘪𝘦𝘵𝘰) — sú to ozajstné znaky Unicode, nie nainštalované písmo ani obrázok. Keďže ide o obyčajné textové znaky, môžeš ich skopírovať a vložiť všade, kde sa dá napísať text: do bia, popisov, komentárov a správ. Viac v našom <a href="/guide/how-unicode-fonts-work/">sprievodcovi o tom, ako funguje písmo Unicode</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Funguje kurzíva Unicode na Instagrame, WhatsAppe, TikToku a LinkedIne?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Áno. Bio, popisy, komentáre aj správy na chate tieto znaky bez problémov prijmú. Hlavne na LinkedIne a X, kde natívna kurzíva chýba, sklonené písmo Unicode umožňuje zvýrazniť najdôležitejšie slová. Pozor: niektoré <strong>polia používateľského mena (@)</strong> takéto znaky odfiltrujú — v samotnom logine zostaň pri obyčajnom texte, ale v biu kurzíva funguje skvele.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Podporuje kurzíva slovenské znaky (á, ä, č, ľ, š, ž)?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Kurzíva Unicode pokrýva základnú abecedu A–Z a číslice 0–9, preto slovenská diakritika (á, ä, č, ď, é, í, ĺ, ľ, ň, ó, ô, ŕ, š, ť, ú, ý, ž) nemá vlastnú sklonenú podobu a zostáva obyčajnými písmenami uprostred slova (napr. „ľalia“ vyjde ako ľ𝘢𝘭𝘪𝘢). Pre nicky a krátke heslá <strong>bez diakritiky</strong> vyzerá kurzíva perfektne; v dlhšom texte je najbezpečnejšie voliť slová, ktoré ju neobsahujú.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Je generátor kurzívy zadarmo?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Áno, plne zadarmo a bez registrácie. Píš, kopíruj a vkladaj, koľkokrát chceš — nie je tu žiadny limit ani skryté poplatky.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Prečo sa niektoré písmená kurzívy zobrazujú ako prázdne štvorčeky?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Prázdny štvorček (▯) znamená, že zariadenie príjemcu nemá glyf pre daný sklonený znak — najčastejšie ide o starší telefón alebo počítač. Vyber jednoduchší variant kurzívy alebo zariadenie aktualizuj — viac v texte o tom, <a href="/guide/why-fonts-show-as-boxes/">prečo sa písmo zobrazuje ako štvorčeky</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Ovplyvňuje kurzíva Unicode čitateľnosť a dosah?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Sklonené znaky Unicode pekne priťahujú pohľad a skvele slúžia v heslách, titulkoch a výzvach na akciu na sociálnych sieťach. Používaj ich cielene — krátky akcent kurzívou, zvyšok obyčajným textom. V obsahu na vlastnom webe je lepšie použiť sklonenie cez CSS, aby vyhľadávače čítali bežné slová; v textových poliach sociálnych sietí je ideálna kurzíva Unicode. Pri dlhších úsekoch nezabudni na <a href="/guide/fancy-fonts-accessibility-guide/">prístupnosť</a>.
+  </div>
+</div>
+
+</div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Výber jazyka">
+      <a class="lang-option" href="/category/italic-fonts/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/sk/kurziva/" hreflang="sk">SK</a>
+    </div>
+
+    </div>
+  </footer>
+
+  <div class="copy-toast" id="copyToast">Skopírované!</div>
+
+  <script>
+    window.UTG_FAMILY = "italic";
+    window.UTG_DEMO_TEXT = "kurzíva online\nštýlový text";
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/script.js" defer></script>
+  <script src="/footer.js" defer></script>
+</body></html>

--- a/sk/male-pismo/index.html
+++ b/sk/male-pismo/index.html
@@ -1,0 +1,299 @@
+<!DOCTYPE html><html lang="sk"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZGVh");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Generátor malého písma — ᴍᴀʟé ᴘísᴍᴏ a kapitálky na kopírovanie | UltraTextGen</title>
+  <meta name="description" content="Bezplatný generátor malého písma: preveď text na malý text Unicode a kapitálky na kopírovanie a vloženie — do bia na Instagrame, Discorde, TikToku, X a do nickov. Ihneď, bez registrácie.">
+  <link rel="canonical" href="https://ultratextgen.com/sk/male-pismo/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/category/small-text/">
+  <link rel="alternate" hreflang="sk" href="https://ultratextgen.com/sk/male-pismo/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/category/small-text/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Generátor malého písma — ᴍᴀʟé ᴘísᴍᴏ a kapitálky na kopírovanie | UltraTextGen">
+  <meta property="og:description" content="Bezplatný generátor malého písma — malý text Unicode a kapitálky na kopírovanie a vloženie na Instagram, TikTok, Discord a X. Ihneď, bez registrácie.">
+  <meta property="og:url" content="https://ultratextgen.com/sk/male-pismo/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category-small-text.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Generátor malého písma — ᴍᴀʟé ᴘísᴍᴏ a kapitálky na kopírovanie | UltraTextGen">
+  <meta name="twitter:description" content="Bezplatný generátor malého písma — malý text Unicode a kapitálky na kopírovanie a vloženie do sociálnych sietí, chatov a nickov.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category-small-text.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "sk",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Čo je malé písmo a ako funguje generátor malého písma?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Generátor prevádza písmená, ktoré napíšeš, na menšie znaky Unicode — kapitálky (ᴍᴀʟé ᴘísᴍᴏ) aj malý text v hornom a dolnom indexe. Sú to ozajstné znaky, nie písmo ani obrázok, preto ich môžeš skopírovať a vložiť všade, kde je povolený text: do bia, popisov, komentárov a správ. Viac v našom sprievodcovi o tom, ako funguje písmo Unicode."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Funguje malé písmo na Discorde, Instagrame, TikToku a X?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Áno. Bio, popisy, komentáre aj správy na chate malý text obvykle bez problémov prijmú. Dobre sa hodí ako druhoplánový, jemný popis pod nickom alebo decentný podpis, ktorý nekričí tak ako veľké tučné písmo. Kompatibilita ale závisí od štýlu a zariadenia — najlepšie výsledok vlož a pozri sa, ako vyzerá v danej aplikácii."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Čím sa líšia kapitálky od malého textu v hornom indexe?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Kapitálky sú malé verzálky (ᴋᴀᴘɪᴛáʟᴋʏ) — písmená majú tvar veľkých písmen, ale výšku malých, takže text zostáva čitateľný a elegantný. Malý text v hornom indexe (ᵗᵃᵏᵉᵗᵒ) alebo dolnom je ešte drobnejší a jemne nadvihnutý alebo znížený, preto sa skvele hodí na krátke ozdobné akcenty. Na dlhšie frázy obvykle lepšie vyzerajú kapitálky."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Môžem písať slovenské znaky (á, ä, č, ď, é, í, ĺ, ľ, ň, ó, ô, ŕ, š, ť, ú, ý, ž) malým písmom?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Malé varianty Unicode pokrývajú hlavne A–Z a časť číslic, preto slovenské znaky ako á, č, ľ, š, ť, ž nemajú vlastnú malú podobu a zostávajú v normálnej veľkosti. Pre jednotný efekt ich môžeš nahradiť základnými písmenami (a, c, l, s, t, z) — mení to však pravopis — alebo ich nechať bez zmeny, čo pri krátkom nicku alebo podpise obvykle aj tak vyzerá dobre."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Je generátor malého písma zadarmo?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Áno, plne zadarmo a bez registrácie. Píš, kopíruj a vkladaj, koľkokrát chceš — nie je tu žiadny limit ani skryté náklady. Všetko beží v prehliadači, takže nič neinštaluješ."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Prečo sa niektoré malé písmená zobrazujú ako štvorčeky a ovplyvňujú čitateľnosť?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Prázdny štvorček (▯) znamená, že zariadenie nemá zodpovedajúci glyf pre daný malý znak — týka sa to väčšinou starších systémov. Vyber v takom prípade jednoduchší štýl (napr. kapitálky) alebo zariadenie aktualizuj; viac v článku o tom, prečo sa písmo zobrazuje ako štvorčeky. Pamätaj tiež, že veľmi malý text sa horšie číta — používaj ho na krátke frázy a najdôležitejšie informácie nechaj obyčajným textom kvôli prístupnosti."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "inLanguage": "sk",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Domov", "item": "https://ultratextgen.com/sk/" },
+    { "@type": "ListItem", "position": 2, "name": "Malé písmo", "item": "https://ultratextgen.com/sk/male-pismo/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Generátor malého písma",
+  "alternateName": ["Malé písmo","Malý text","Generátor malého písma","Kapitálky","Malé písmená na kopírovanie","Malý text Unicode","Drobný text","Malé nápisy"],
+  "url": "https://ultratextgen.com/sk/male-pismo/",
+  "inLanguage": "sk",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "EUR"
+  },
+  "description": "Bezplatný generátor malého písma: preveď text na malý text Unicode a kapitálky na kopírovanie a vloženie na Instagram, TikTok, Discord, X a do nickov.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/sk/">Domov</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Malé písmo</span>
+</nav>
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/category-small-text.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+  <!-- Hero -->
+  <section class="hero">
+    <div class="hero-inner">
+      <div class="hero-card">
+        <h1 class="hero-headline">Generátor malého písma</h1>
+        <p class="hero-tagline">Premeň ľubovoľný text na ᴍᴀʟé ᴘísᴍᴏ a kapitálky na kopírovanie a vloženie — jemné,
+          drobné znaky Unicode do bia, nickov a podpisov. Zadarmo, ihneď, bez registrácie.</p>
+        <div class="input-wrapper">
+          <textarea class="main-input" id="mainInput" placeholder="Napíš text, slovo alebo meno…" maxlength="500" autofocus></textarea>
+          <span class="char-count"><span id="charCount">0</span>/500</span>
+        </div>
+
+        <!-- Decoration Selector -->
+        <div class="decoration-section">
+          <div class="decoration-label">
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"></path>
+            </svg>
+            Pridaj symboly okolo výsledku
+          </div>
+          <div class="decoration-tabs">
+            <button class="decoration-tab active" data-deco-tab="symbols">Symboly</button>
+            <button class="decoration-tab" data-deco-tab="frames">Rámčeky</button>
+            <button class="decoration-tab" data-deco-tab="dividers">Oddeľovače</button>
+            <button class="decoration-tab" data-deco-tab="minimal">Minimalistické</button>
+            <button class="decoration-tab" data-deco-tab="emojis">Emoji</button>
+          </div>
+          <div class="decoration-grid" id="decorationGrid"></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Main Content -->
+  <main class="container">
+
+    <section class="editorial-section">
+      <span class="article-section-label">Malý text Unicode</span>
+      <h2>Malé písmo na kopírovanie — do bia, nickov a podpisov</h2>
+      <p>Tieto písmená nie sú písmo ani obrázok, ale ozajstné <strong>znaky Unicode</strong>. Pridaj jemný popis
+        pod nick, napíš meno elegantnými <strong>kapitálkami</strong> alebo vpleť drobný text v hornom indexe
+        tam, kde by veľké tučné písmo bolo priveľmi krikľavé. Napíš text vyššie, klikni na <strong>Kopírovať</strong>
+        a vlož malé písmo, kam chceš.</p>
+    </section>
+
+    <!-- Category Tabs (populated by script.js) -->
+    <div class="category-section">
+      <div class="category-tabs" id="categoryTabs"></div>
+    </div>
+
+    <!-- Results -->
+    <div class="results-grid" id="resultsGrid"></div>
+
+    <section class="editorial-section">
+      <span class="article-section-label">Súvisiace</span>
+      <p>Spoj malé písmo s <a href="/sk/tucne-pismo/">tučným písmom</a>,
+        <a href="/library/aesthetic-symbols/">ozdobami</a> alebo <a href="/library/invisible-character/">neviditeľným znakom</a>
+        pre čisté medzery. Pozri tiež <a href="/sk/">písmená na kopírovanie</a>,
+        a na zvislé sadzby — <a href="/usecase/vertical-text/">zvislý text</a>.</p>
+    </section>
+  </main>
+
+  <!-- Footer + FAQ -->
+  <footer class="footer">
+    <div class="footer-inner">
+<div class="faq-section" id="small-faq">
+
+<h2 class="faq-category">Generátor malého písma — FAQ</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Čo je malé písmo a ako funguje generátor malého písma?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Generátor prevádza písmená, ktoré napíšeš, na menšie znaky Unicode — kapitálky (ᴍᴀʟé ᴘísᴍᴏ) aj malý text v hornom a dolnom indexe. Sú to ozajstné znaky, nie písmo ani obrázok, preto ich môžeš skopírovať a vložiť všade, kde je povolený text: do bia, popisov, komentárov a správ. Viac v našom <a href="/guide/how-unicode-fonts-work/">sprievodcovi o tom, ako funguje písmo Unicode</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Funguje malé písmo na Discorde, Instagrame, TikToku a X?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Áno. Bio, popisy, komentáre aj správy na chate malý text obvykle bez problémov prijmú. Dobre sa hodí ako druhoplánový, jemný popis pod nickom alebo decentný podpis, ktorý nekričí tak ako veľké tučné písmo. Kompatibilita ale závisí od štýlu a zariadenia — najlepšie výsledok vlož a pozri sa, ako vyzerá v danej aplikácii.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Čím sa líšia kapitálky od malého textu v hornom indexe?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Kapitálky sú malé verzálky (ᴋᴀᴘɪᴛáʟᴋʏ) — písmená majú tvar veľkých písmen, ale výšku malých, takže text zostáva čitateľný a elegantný. Malý text v hornom indexe (ᵗᵃᵏᵉᵗᵒ) alebo dolnom je ešte drobnejší a jemne nadvihnutý alebo znížený, preto sa skvele hodí na krátke ozdobné akcenty. Na dlhšie frázy obvykle lepšie vyzerajú <strong>kapitálky</strong>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Môžem písať slovenské znaky (á, ä, č, ď, é, í, ĺ, ľ, ň, ó, ô, ŕ, š, ť, ú, ý, ž) malým písmom?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Malé varianty Unicode pokrývajú hlavne A–Z a časť číslic, preto slovenské znaky ako á, č, ľ, š, ť, ž nemajú vlastnú malú podobu a zostávajú v normálnej veľkosti. Pre jednotný efekt ich môžeš nahradiť základnými písmenami (<strong>a, c, l, s, t, z</strong>) — mení to však pravopis — alebo ich nechať bez zmeny, čo pri krátkom nicku alebo podpise obvykle aj tak vyzerá dobre.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Je generátor malého písma zadarmo?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Áno, plne zadarmo a bez registrácie. Píš, kopíruj a vkladaj, koľkokrát chceš — nie je tu žiadny limit ani skryté náklady. Všetko beží v prehliadači, takže nič neinštaluješ.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Prečo sa niektoré malé písmená zobrazujú ako štvorčeky a ovplyvňujú čitateľnosť?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Prázdny štvorček (▯) znamená, že zariadenie nemá zodpovedajúci glyf pre daný malý znak — týka sa to väčšinou starších systémov. Vyber v takom prípade jednoduchší štýl (napr. kapitálky) alebo zariadenie aktualizuj; viac v článku o tom, <a href="/guide/why-fonts-show-as-boxes/">prečo sa písmo zobrazuje ako štvorčeky</a>. Pamätaj tiež, že veľmi malý text sa horšie číta — používaj ho na krátke frázy a najdôležitejšie informácie nechaj obyčajným textom kvôli <a href="/guide/fancy-fonts-accessibility-guide/">prístupnosti</a>.
+  </div>
+</div>
+
+</div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Výber jazyka">
+      <a class="lang-option" href="/category/small-text/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/sk/male-pismo/" hreflang="sk">SK</a>
+    </div>
+
+    </div>
+  </footer>
+
+  <div class="copy-toast" id="copyToast">Skopírované!</div>
+
+  <script>
+    window.UTG_FAMILY = "small-text";
+    window.UTG_DEMO_TEXT = "malé písmo\nmalý text";
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/script.js" defer></script>
+  <script src="/footer.js" defer></script>
+</body></html>

--- a/sk/pismo-pre-discord/index.html
+++ b/sk/pismo-pre-discord/index.html
@@ -1,0 +1,302 @@
+<!DOCTYPE html><html lang="sk"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Písmo pre Discord: písmená do nicku a bia (bez Nitra) | UltraTextGen</title>
+  <meta name="description" content="Písmo pre Discord zadarmo: preveď meno na 𝘁𝘂č𝗻é, 𝓴𝓾𝓻𝔃𝓲𝓿𝓾 alebo 𝔤𝔬𝔱𝔦𝔨𝔲 a vlož do nicku, do sekcie „O mne“ a na chat. Písmo pre Discord bez Nitra.">
+  <link rel="canonical" href="https://ultratextgen.com/sk/pismo-pre-discord/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/discord/">
+  <link rel="alternate" hreflang="sk" href="https://ultratextgen.com/sk/pismo-pre-discord/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/discord/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Písmo pre Discord: písmená do nicku a bia (bez Nitra)">
+  <meta property="og:description" content="Generátor písma pre Discord: napíš meno a vlož štýlové písmeno do nicku, do „O mne“, do názvu kanála a do statusu. Tučné, kurzíva a gotika — bez Nitra.">
+  <meta property="og:url" content="https://ultratextgen.com/sk/pismo-pre-discord/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/pl-czcionki-discord.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Písmo pre Discord: písmená do nicku a bia (bez Nitra)">
+  <meta name="twitter:description" content="Tučné, kurzíva, gotika a bublinkové pripravené na vloženie do nicku a „O mne“ na Discorde — bez Nitra.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/pl-czcionki-discord.png">
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+  <link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Generátor písma pre Discord",
+  "alternateName": ["Písmo pre Discord", "Písmo na Discord", "Písmená pre Discord", "Generátor nicku na Discord"],
+  "url": "https://ultratextgen.com/sk/pismo-pre-discord/",
+  "inLanguage": "sk",
+  "applicationCategory": "UtilitiesApplication",
+  "operatingSystem": "Any",
+  "description": "Generátor písma pre Discord: prevedie tvoje meno na štylizované písmená — tučné, kurzívu, gotiku, bublinkové, elegantné a kapitálky — na vloženie do nicku, do „O mne“, do názvu kanála a do statusu, bez nutnosti mať Nitro.",
+  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "EUR" }
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "sk",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Ako zmeniť písmo v nicku na Discorde?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Napíš svoje meno do poľa hore na stránke. Hneď sa objaví desiatky písem pre Discord — tučné, kurzíva, gotické, bublinkové, kapitálky. Klikni na „Kopírovať“ pri tom, ktoré sa ti páči, otvor Discord, prejdi do Nastavenia používateľa a vlož ho do zobrazovaného mena, alebo klikni pravým tlačidlom na serveri a zmeň prezývku na tomto serveri. Keďže ide o znaky Unicode, štýlové písmeno sa vloží do poľa bez akéhokoľvek pluginu." }
+    },
+    {
+      "@type": "Question",
+      "name": "Je na písmo na Discorde potrebné Nitro?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Nie. Písmená z tohto generátora sú obyčajné znaky Unicode, rovnaké ako z klávesnice, len s iným vzhľadom — preto sa vložia do zobrazovaného mena, do prezývky na serveri, do sekcie „O mne“, do názvu kanála a do správ bez akéhokoľvek Nitra. Nitro je potrebné len na platené doplnky, ako sú farby a prechod v mene (Display Name Styles), nie na samotný štýlový text." }
+    },
+    {
+      "@type": "Question",
+      "name": "Fungujú písma v používateľskom mene (@) na Discorde?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Nie. Používateľské meno (unikátne @ používané na pozvánky medzi priateľov) prijíma len malé písmená a až z, číslice, bodku a podčiarkovník — žiadne štýlové písmo, medzery, emoji ani symboly. Písmo pre Discord funguje v zobrazovanom mene, v serverovej prezývke, v sekcii „O mne“, v názve kanála a na chate. Ak chceš štýl v mene, použi zobrazované meno, nie login @." }
+    },
+    {
+      "@type": "Question",
+      "name": "Čím sa líši formátovanie Discordu (**tučné**) od písem Unicode?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Sú to dve rôzne veci. Markdown Discordu (**tučné**, *kurzíva*, `kód`) formátuje text len vnútri správ na chate a zmizne, keď ho skúsiš použiť v mene alebo v biu. Písma Unicode z tejto stránky sú samotný oštýlovaný znak, takže fungujú všade — v nicku, v „O mne“, v názve kanála, v statuse aj na chate. Praktické pravidlo: v bežnej správe použi Markdown, a na oštýlovanie nicku alebo bia použi písmo Unicode." }
+    },
+    {
+      "@type": "Question",
+      "name": "Ako spraviť ozdobný nick na Discord s rámčekmi a symbolmi?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Vyber písmo na meno (gotika a bublinkové vychádzajú najlepšie) a obklop ho rámčekmi a symbolmi v štýle ꧁༒ ༒꧂. Na tejto stránke je mriežka hotových nickov s rámčekmi — klikni a skopíruj a vlož do prezývky na serveri. Môžeš tiež napísať svoje meno hore, nasadiť písmo a použiť záložky Symboly a Rámčeky, aby si si vzhľad doladil pred skopírovaním." }
+    },
+    {
+      "@type": "Question",
+      "name": "Prečo sa písmená na Discorde zobrazujú ako štvorčeky?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Pretože zariadenie toho, kto si to prezerá, nemá písmo, ktoré daný znak vykreslí — obvykle ide o starší telefón alebo počítač. Nie je to chyba stránky ani tvojho kopírovania. Základné štýly — tučné, kurzíva, gotika, bublinkové a kapitálky — sú najbezpečnejšie a zobrazia sa správne takmer všade. Ak niekto nahlási štvorček (□), prepni na jeden z týchto štýlov." }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "inLanguage": "sk",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Domov", "item": "https://ultratextgen.com/sk/" },
+    { "@type": "ListItem", "position": 2, "name": "Písmo pre Discord", "item": "https://ultratextgen.com/sk/pismo-pre-discord/" }
+  ]
+}
+</script>
+</head>
+<body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<script src="/header.js"></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/sk/">Domov</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Písmo pre Discord</span>
+</nav>
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pl-czcionki-discord.svg" width="1200" height="340" loading="lazy" alt="">
+</figure>
+
+<section class="hero">
+  <div class="hero-inner">
+    <div class="hero-card">
+      <h1 class="hero-headline">Písmo pre Discord: písmená do nicku a bia</h1>
+      <p class="hero-tagline">Napíš svoje meno a hneď ho uvidíš v desiatkach písem pre Discord — tučné, kurzíva, gotické, bublinkové a kapitálky. Skopíruješ a vložíš do nicku, do serverovej prezývky, do sekcie „O mne“, do názvu kanála a na chat. Všetko zadarmo a <strong>bez Nitra</strong>.</p>
+      <div class="input-wrapper">
+        <textarea class="main-input" id="mainInput" placeholder="Napíš meno alebo text..." maxlength="500" autofocus=""></textarea>
+        <span class="char-count"><span id="charCount">0</span>/500</span>
+      </div>
+      <div class="decoration-section">
+        <div class="decoration-label">Pridaj symboly a rámčeky k výsledku</div>
+        <div class="decoration-tabs">
+          <button class="decoration-tab active" data-deco-tab="symbols">Symboly</button>
+          <button class="decoration-tab" data-deco-tab="frames">Rámčeky</button>
+          <button class="decoration-tab" data-deco-tab="dividers">Oddeľovače</button>
+          <button class="decoration-tab" data-deco-tab="arrows">Šípky</button>
+          <button class="decoration-tab" data-deco-tab="minimal">Minimalistické</button>
+          <button class="decoration-tab" data-deco-tab="emojis">Emoji</button>
+        </div>
+        <div class="decoration-grid" id="decorationGrid"></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<main class="container">
+  <div class="category-section"><div class="category-tabs" id="categoryTabs"></div></div>
+  <div class="results-grid" id="resultsGrid"></div>
+
+  <!-- Ako to funguje -->
+  <section class="editorial-section">
+    <h2>Písmo pre Discord: ako to funguje</h2>
+    <p class="editorial-intro"><strong>Písmo pre Discord</strong> z tejto stránky nie je nainštalované písmo ani obrázok — sú to <strong>znaky Unicode</strong>, ozajstné písmená, rovnaké ako z klávesnice, len s iným vzhľadom (𝗔, 𝘈, 𝓐, 𝔄). Keďže Discord prijíma Unicode takmer v každom textovom poli, štýlové písmeno sa vloží rovno do tvojho <strong>zobrazovaného mena</strong>, do <strong>serverovej prezývky</strong>, do sekcie <strong>„O mne“</strong>, do <strong>názvu kanála</strong>, do <strong>statusu</strong> a dokonca aj do <strong>správ</strong> — bez Nitra, pluginu alebo aplikácie navyše.</p>
+    <div class="block-example">
+      <strong>Príklad:</strong> „adam“ → 𝗮𝗱𝗮𝗺 (tučné), 𝘢𝘥𝘢𝘮 (kurzíva), 𝓪𝓭𝓪𝓶 (ozdobná kurzíva), 𝔞𝔡𝔞𝔪 (gotické), ⓐⓓⓐⓜ (bublinkové), ᴀᴅᴀᴍ (kapitálky)
+    </div>
+    <p>Používa sa to za pár sekúnd: napíšeš meno do poľa hore, generátor ukáže ten istý text v mnohých <strong>písmach pre Discord</strong>, klikneš na „Kopírovať“ a vložíš v aplikácii. Chceš len holé písmená abecedy? Sú hneď pod tým. A ak chceš prechádzať ešte viac rezov, plný generátor nájdeš na stránke s <a href="/sk/">písmenami na kopírovanie</a>.</p>
+  </section>
+
+  <!-- Abeceda A-Z -->
+  <section class="editorial-section glyph-section">
+    <h2>Abeceda písem pre Discord (A–Z na kopírovanie)</h2>
+    <p class="editorial-intro">Celá abeceda v štýloch, ktoré sa v nickoch a biách na Discorde objavujú najčastejšie. Klikni na daný riadok a skopíruj celú abecedu v tom štýle, alebo napíš svoje meno hore a vezmi si vlastné slovo rovno oštýlované.</p>
+    <div class="alpha-list">
+      <div class="alpha-row">
+        <span class="alpha-label">Tučné</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝗔𝗕𝗖𝗗𝗘𝗙𝗚𝗛𝗜𝗝𝗞𝗟𝗠𝗡𝗢𝗣𝗤𝗥𝗦𝗧𝗨𝗩𝗪𝗫𝗬𝗭 𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇" aria-label="Kopírovať tučnú abecedu">𝗔𝗕𝗖𝗗𝗘𝗙𝗚𝗛𝗜𝗝𝗞𝗟𝗠𝗡𝗢𝗣𝗤𝗥𝗦𝗧𝗨𝗩𝗪𝗫𝗬𝗭 · 𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Kurzíva</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩 𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃" aria-label="Kopírovať abecedu kurzívou">𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩 · 𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Elegantné</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵 𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏" aria-label="Kopírovať elegantnú abecedu">𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵 · 𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Gotické</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝔄𝔅ℭ𝔇𝔈𝔉𝔊ℌℑ𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔ℜ𝔖𝔗𝔘𝔙𝔚𝔛𝔜ℨ 𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷" aria-label="Kopírovať gotickú abecedu">𝔄𝔅ℭ𝔇𝔈𝔉𝔊ℌℑ𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔ℜ𝔖𝔗𝔘𝔙𝔚𝔛𝔜ℨ · 𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Bublinkové</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ" aria-label="Kopírovať bublinkovú abecedu">ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ · ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Kapitálky</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="ᴀʙᴄᴅᴇꜰɢʜɪᴊᴋʟᴍɴᴏᴘqʀsᴛᴜᴠᴡxʏᴢ" aria-label="Kopírovať abecedu v kapitálkach">ᴀ ʙ ᴄ ᴅ ᴇ ꜰ ɢ ʜ ɪ ᴊ ᴋ ʟ ᴍ ɴ ᴏ ᴘ q ʀ s ᴛ ᴜ ᴠ ᴡ x ʏ ᴢ</button>
+      </div>
+    </div>
+    <p class="uname-note">Poznámka o slovenských znakoch: tieto písma Unicode pokrývajú základnú abecedu A–Z. Slovenská diakritika (á, ä, č, ď, é, í, ĺ, ľ, ň, ó, ô, ŕ, š, ť, ú, ý, ž) vo väčšine štýlov zostáva obyčajnými písmenami uprostred oštýlovaného slova — preto napr. „adam“ vyjde perfektne, kým „ľuboš“ ukáže ľ ako obyčajné písmeno. Pre nicky bez diakritiky to vyzerá skvele a pre dlhšie texty sú najbezpečnejšie tučné a kurzíva.</p>
+    <p class="u-mt-15">Chceš sa zahryznúť do jedného štýlu? Celú abecedu a varianty každého rezu nájdeš na stránke s <a href="/sk/">písmenami na kopírovanie</a>, a hviezdičky a rámčeky do nicku — v <a href="/library/aesthetic-symbols/">ozdobách</a>.</p>
+  </section>
+
+  <!-- Písmo do nicku a O mne -->
+  <section class="editorial-section">
+    <h2>Písmo do nicku a sekcie „O mne“ na Discorde</h2>
+    <p class="editorial-intro">Najrýchlejší spôsob, ako vypichnúť profil, je nasadiť písmo na <strong>zobrazované meno</strong> a zvlášť ho poskladať v sekcii <strong>„O mne“</strong> (bio profilu). Discord prijíma Unicode v oboch poliach — a k tomu môžeš mať <strong>inú prezývku na každom serveri</strong>, takže na hernom serveri používaš gotiku a na serveri s kamarátmi kurzívu, všetko pod tým istým účtom.</p>
+    <p class="uname-note">Ako vložiť:</p>
+    <div class="block-example">
+      — <strong>Zobrazované meno:</strong> Nastavenia používateľa › Profil › uprav zobrazované meno a vlož písmo<br>
+      — <strong>Serverová prezývka:</strong> klikni pravým na svojom mene na serveri › Upraviť profil servera › vlož štýlovú prezývku<br>
+      — <strong>„O mne“:</strong> Nastavenia používateľa › Profil › pole „O mne“ › vlož text<br>
+      — <strong>Názov kanála:</strong> ak si administrátor, uprav kanál a vlož písmo do názvu
+    </div>
+    <p>Rada od niekoho, kto profily skladá denne: oštýluj samotné meno a zvyšok „O mne“ nechaj obyčajným textom — celý efekt robí ten kontrast. Keď je všetko ozdobné, nič nepriťahuje pohľad. Pre jednotlivé hviezdičky a trblietky do bia pozri stránku s <a href="/library/aesthetic-symbols/">ozdobami na kopírovanie</a>.</p>
+  </section>
+
+  <!-- Markdown vs Unicode -->
+  <section class="editorial-section">
+    <h2>Markdown Discordu vs písma Unicode — kedy čo použiť</h2>
+    <p class="editorial-intro">Discord má <strong>dva spôsoby</strong>, ako sa pohrať s textom, a oplatí sa ich nepliesť. Jeden je natívne <strong>formátovanie Markdown</strong>, druhý sú <strong>písma Unicode</strong> z tejto stránky. Slúžia na rôzne veci.</p>
+    <div class="block-example">
+      — <strong>Markdown (natívny):</strong> <code>**tučné**</code> → <strong>tučné</strong>, <code>*kurzíva*</code> → <em>kurzíva</em>, <code>__podčiarknutie__</code>, <code>~~prečiarknutie~~</code>, <code>`kód`</code>. Funguje len <strong>vnútri správ</strong> na chate a zmizne, keď to skúsiš v mene alebo v biu.<br>
+      — <strong>Písma Unicode (táto stránka):</strong> 𝘁𝘂č𝗻é, 𝓴𝓾𝓻𝔃𝓲𝓿𝓪, 𝔤𝔬𝔱𝔦𝔨𝔞. Je to samotný oštýlovaný znak, takže funguje <strong>všade</strong> — v nicku, v „O mne“, v názve kanála, v statuse aj na chate.
+    </div>
+    <p>Praktické pravidlo: na naformátovanie bežnej <strong>správy</strong> (stučniť slovo uprostred vety) použi Markdown Discordu — je čistejší. Na oštýlovanie <strong>nicku, bia alebo názvu kanála</strong> použi písmo Unicode, pretože Markdown tam nezafunguje. A dôležité varovanie: nič z toho nefunguje v <strong>používateľskom mene (@)</strong>, ktoré prijíma len malé písmená a až z, číslice, bodku a podčiarkovník — žiadne písmo, medzery ani emoji. Ak chceš štýl v mene, správnym poľom je zobrazované meno, nie login @.</p>
+  </section>
+
+  <!-- Ozdobné nicky s rámčekmi -->
+  <section class="editorial-section">
+    <h2>Ozdobné nicky na Discord s rámčekmi a symbolmi</h2>
+    <p class="editorial-intro">Nicky, ktoré na Discorde urobia najväčší dojem, kombinujú výrazné písmo (gotika alebo bublinkové) s rámčekmi a symbolmi po oboch stranách, v štýle ꧁༒ ༒꧂. Klikni a skopíruj a vlož do prezývky na serveri — potom vymeň za svoje meno.</p>
+    <div class="uname-grid">
+      <button class="uname-chip symbol-tile" data-symbol="꧁༒𝕯𝖆𝖗𝖐༒꧂" aria-label="Kopírovať nick">꧁༒𝕯𝖆𝖗𝖐༒꧂</button>
+      <button class="uname-chip symbol-tile" data-symbol="꧁༒𝕶𝖆𝖈𝖕𝖊𝖗༒꧂" aria-label="Kopírovať nick">꧁༒𝕶𝖆𝖈𝖕𝖊𝖗༒꧂</button>
+      <button class="uname-chip symbol-tile" data-symbol="★彡ᴋᴜʙᴀ彡★" aria-label="Kopírovať nick">★彡ᴋᴜʙᴀ彡★</button>
+      <button class="uname-chip symbol-tile" data-symbol="⋆˚࿔ 𝓏𝓊𝓏𝒾𝒶 𝜗𝜚˚⋆" aria-label="Kopírovať nick">⋆˚࿔ 𝓏𝓊𝓏𝒾𝒶 𝜗𝜚˚⋆</button>
+      <button class="uname-chip symbol-tile" data-symbol="꧁✿𝓞𝓵𝓪✿꧂" aria-label="Kopírovať nick">꧁✿𝓞𝓵𝓪✿꧂</button>
+      <button class="uname-chip symbol-tile" data-symbol="✧˖°𝕁𝕦𝕝𝕚𝕒°˖✧" aria-label="Kopírovať nick">✧˖°𝕁𝕦𝕝𝕚𝕒°˖✧</button>
+      <button class="uname-chip symbol-tile" data-symbol="⛧🖤 𝔩𝔲𝔨𝔞𝔰 🖤⛧" aria-label="Kopírovať nick">⛧🖤 𝔩𝔲𝔨𝔞𝔰 🖤⛧</button>
+      <button class="uname-chip symbol-tile" data-symbol="「 ᴍᴀᴛᴇᴜsᴢ 」" aria-label="Kopírovať nick">「 ᴍᴀᴛᴇᴜsᴢ 」</button>
+      <button class="uname-chip symbol-tile" data-symbol="༺ 𝕾𝖍𝖆𝖉𝖔𝖜 ༻" aria-label="Kopírovať nick">༺ 𝕾𝖍𝖆𝖉𝖔𝖜 ༻</button>
+      <button class="uname-chip symbol-tile" data-symbol="⋆｡˚ⓝⓐⓣⓘⓐ˚｡⋆" aria-label="Kopírovať nick">⋆｡˚ⓝⓐⓣⓘⓐ˚｡⋆</button>
+    </div>
+    <p class="u-mt-15">Chceš celú sadu hotových rámčekov, hviezdičiek a oddeľovačov na zostavenie vlastného nicku? Kompletná paleta je na stránke s <a href="/library/aesthetic-symbols/">ozdobami na kopírovanie</a> — tie isté znaky sa vložia do prezývky tvojho servera na Discorde.</p>
+  </section>
+
+  <!-- Kde funguje + štvorčeky -->
+  <section class="editorial-section">
+    <h2>Kde funguje písmo na Discorde (a poznámka o štvorčekoch)</h2>
+    <p class="editorial-intro">Keďže to, čo kopíruješ, je čistý Unicode, písmená pre Discord sa vložia prakticky do každého textového poľa aplikácie:</p>
+    <div class="block-example">
+      — <strong>Zobrazované meno</strong> a <strong>serverová prezývka</strong> (zvlášť na každom serveri)<br>
+      — <strong>„O mne“</strong> (bio tvojho profilu)<br>
+      — <strong>Názov kanála</strong> (ak máš oprávnenie administrátora)<br>
+      — <strong>Vlastný status</strong> a <strong>správy</strong> na chate<br>
+      — <strong>Názov servera</strong> (ak si jeho vlastník)
+    </div>
+    <p>Jediné miesto, kde to <strong>ne</strong>funguje, je <strong>používateľské meno (@)</strong>, zámerne obmedzené na malé písmená, číslice, bodku a podčiarkovník. Okrem toho úprimná poznámka: ak je zariadenie toho, kto si to prezerá, veľmi staré, časť vzácnejších štýlov sa môže zobraziť ako <strong>štvorčeky (□)</strong> — to je chýbajúce písmo na jeho zariadení, nie problém s tvojím textom. Keď sa držíš základných štýlov (tučné, kurzíva, gotika, bublinkové, kapitálky), takmer nikdy sa to nestane. A pamätaj: nič z toho nevyžaduje <strong>Nitro</strong> — Nitro vstupuje len pri farbe a prechode v mene, nie pri samotnom štýlovom texte. Na prázdne riadky v „O mne“ sa hodí <a href="/library/invisible-character/">neviditeľný znak</a>.</p>
+  </section>
+
+  <!-- Related -->
+  <section class="editorial-section">
+    <span class="article-section-label">Súvisiace stránky</span>
+    <div class="compare-grid">
+      <a href="/sk/" class="compare-card variant-muted u-no-underline">
+        <h4>Ozdobné písmená</h4>
+        <p>Desiatky štýlov písmen na oštýlovanie mena, než ho vložíš na Discord.</p>
+      </a>
+      <a href="/sk/" class="compare-card variant-muted u-no-underline">
+        <h4>Písmená na kopírovanie</h4>
+        <p>Celá abeceda v mnohých rezoch — bold, kurzíva, gotika a bublinkové.</p>
+      </a>
+      <a href="/library/aesthetic-symbols/" class="compare-card variant-muted u-no-underline">
+        <h4>Ozdoby na kopírovanie</h4>
+        <p>Hviezdičky, srdiečka, rámčeky a oddeľovače na ozdobenie nicku a „O mne“.</p>
+      </a>
+      <a href="/library/invisible-character/" class="compare-card variant-muted u-no-underline">
+        <h4>Neviditeľný znak</h4>
+        <p>Prázdna medzera na čisté riadky v biu a prázdne nicky na Discorde.</p>
+      </a>
+    </div>
+  </section>
+</main>
+
+<footer class="footer">
+  <div class="footer-inner">
+    <h2 class="faq-category">Najčastejšie otázky o písme pre Discord</h2>
+    <div class="faq-item"><button class="faq-question" type="button">Ako zmeniť písmo v nicku na Discorde?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Napíš svoje meno do poľa hore na stránke. Hneď sa objaví desiatky písem pre Discord — tučné, kurzíva, gotické, bublinkové, kapitálky. Klikni na „Kopírovať“ pri tom, ktoré sa ti páči, otvor Discord, prejdi do Nastavenia používateľa a vlož ho do zobrazovaného mena, alebo klikni pravým tlačidlom na serveri a zmeň prezývku na tomto serveri. Keďže ide o znaky Unicode, štýlové písmeno sa vloží do poľa bez akéhokoľvek pluginu.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Je na písmo na Discorde potrebné Nitro?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Nie. Písmená z tohto generátora sú obyčajné znaky Unicode, rovnaké ako z klávesnice, len s iným vzhľadom — preto sa vložia do zobrazovaného mena, do prezývky na serveri, do sekcie „O mne“, do názvu kanála a do správ bez akéhokoľvek Nitra. Nitro je potrebné len na platené doplnky, ako sú farby a prechod v mene (Display Name Styles), nie na samotný štýlový text.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Fungujú písma v používateľskom mene (@) na Discorde?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Nie. Používateľské meno (unikátne @ používané na pozvánky medzi priateľov) prijíma len malé písmená a až z, číslice, bodku a podčiarkovník — žiadne štýlové písmo, medzery, emoji ani symboly. Písmo pre Discord funguje v zobrazovanom mene, v serverovej prezývke, v sekcii „O mne“, v názve kanála a na chate. Ak chceš štýl v mene, použi zobrazované meno, nie login @.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Čím sa líši formátovanie Discordu (**tučné**) od písem Unicode?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Sú to dve rôzne veci. Markdown Discordu (**tučné**, *kurzíva*, `kód`) formátuje text len vnútri správ na chate a zmizne, keď ho skúsiš použiť v mene alebo v biu. Písma Unicode z tejto stránky sú samotný oštýlovaný znak, takže fungujú všade — v nicku, v „O mne“, v názve kanála, v statuse aj na chate. Praktické pravidlo: v bežnej správe použi Markdown, a na oštýlovanie nicku alebo bia použi písmo Unicode.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Ako spraviť ozdobný nick na Discord s rámčekmi a symbolmi?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Vyber písmo na meno (gotika a bublinkové vychádzajú najlepšie) a obklop ho rámčekmi a symbolmi v štýle ꧁༒ ༒꧂. Na tejto stránke je mriežka hotových nickov s rámčekmi — klikni a skopíruj a vlož do prezývky na serveri. Môžeš tiež napísať svoje meno hore, nasadiť písmo a použiť záložky Symboly a Rámčeky, aby si si vzhľad doladil pred skopírovaním.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Prečo sa písmená na Discorde zobrazujú ako štvorčeky?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Pretože zariadenie toho, kto si to prezerá, nemá písmo, ktoré daný znak vykreslí — obvykle ide o starší telefón alebo počítač. Nie je to chyba stránky ani tvojho kopírovania. Základné štýly — tučné, kurzíva, gotika, bublinkové a kapitálky — sú najbezpečnejšie a zobrazia sa správne takmer všade. Ak niekto nahlási štvorček (□), prepni na jeden z týchto štýlov.</div></div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Výber jazyka">
+      <a class="lang-option" href="/discord/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/sk/pismo-pre-discord/" hreflang="sk">SK</a>
+    </div>
+  </div>
+</footer>
+
+<div class="copy-toast" id="copyToast">Skopírované!</div>
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/styles.js"></script>
+<script src="/renderer.js"></script>
+<script src="/script.js" defer=""></script>
+<script src="/symbol-explorer.js"></script>
+<script src="/footer.js"></script>
+</body></html>

--- a/sk/pismo-pre-instagram/index.html
+++ b/sk/pismo-pre-instagram/index.html
@@ -1,0 +1,310 @@
+<!DOCTYPE html><html lang="sk"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Písmo pre Instagram: ozdobné písmená do bia a popisov | UltraTextGen</title>
+  <meta name="description" content="Písmo pre Instagram zadarmo: preveď text na 𝘁𝘂č𝗻é, 𝘬𝘶𝘳𝘻í𝘷𝘶 alebo 𝓴𝓪𝓵𝓲𝓰𝓻𝓪𝓯𝓲𝓾 a vlož do bia, do mena profilu, do popisu a do komentárov. Ozdobné písmená pre Instagram — bez aplikácie.">
+  <link rel="canonical" href="https://ultratextgen.com/sk/pismo-pre-instagram/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/instagram/">
+  <link rel="alternate" hreflang="sk" href="https://ultratextgen.com/sk/pismo-pre-instagram/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/instagram/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Písmo pre Instagram: ozdobné písmená do bia a popisov">
+  <meta property="og:description" content="Generátor písma pre Instagram: napíš text a vlož štýlové písmeno do bia, do mena profilu, do popisu a do komentárov. Tučné, kurzíva, kaligrafia a gotika — bez aplikácie.">
+  <meta property="og:url" content="https://ultratextgen.com/sk/pismo-pre-instagram/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/pl-czcionki-na-instagram.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Písmo pre Instagram: ozdobné písmená do bia a popisov">
+  <meta name="twitter:description" content="Tučné, kurzíva, kaligrafia a gotika pripravené na vloženie do bia a mena profilu na Instagrame — bez aplikácie.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/pl-czcionki-na-instagram.png">
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+  <link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Generátor písma pre Instagram",
+  "alternateName": ["Písmo pre Instagram", "Písmo na Instagram", "Ozdobné písmená pre Instagram", "Písmo do bia na Instagram", "Generátor písma na IG", "Fonty na Instagram", "Písmená pre Instagram"],
+  "url": "https://ultratextgen.com/sk/pismo-pre-instagram/",
+  "inLanguage": "sk",
+  "applicationCategory": "UtilitiesApplication",
+  "operatingSystem": "Any",
+  "description": "Generátor písma pre Instagram: prevedie tvoj text na štylizované písmená — tučné, kurzívu, kaligrafiu, gotiku, bublinkové a kapitálky — na vloženie do bia, do mena profilu, do popisu príspevku, do komentárov a do Stories, bez sťahovania aplikácie.",
+  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "EUR" }
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "sk",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Ako zmeniť písmo v biu na Instagrame?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Napíš svoj text do poľa hore na stránke. Hneď sa objaví desiatky písem pre Instagram — tučné, kurzíva, kaligrafia, gotika, bublinkové a kapitálky. Klikni na „Kopírovať“ pri tom, ktoré sa ti páči, otvor Instagram, prejdi do Upraviť profil a vlož ho do poľa Bio. Keďže ide o znaky Unicode, štýlové písmeno sa vloží do poľa bez akejkoľvek aplikácie alebo klávesnice navyše." }
+    },
+    {
+      "@type": "Question",
+      "name": "Ako spraviť iné písmo v mene profilu na Instagrame?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Skopíruj tu vybrané písmo a vlož ho do poľa „Meno“ v Upraviť profil — to je ten tučný názov hore na profile, nie login @. Instagram v tomto poli prijíma Unicode, takže sa štýlové písmeno zobrazí správne. Len pamätaj, že Instagram povoľuje meniť Meno obmedzene často v krátkom čase (obvykle dvakrát za 14 dní), takže vlož rovno hotový štýl." }
+    },
+    {
+      "@type": "Question",
+      "name": "Dá sa použiť ozdobné písmo v používateľskom mene (@) na Instagrame?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Nie. Používateľské meno (login @, ktorý je v tvojom odkaze a slúži na označovanie) prijíma len malé písmená a až z, číslice, bodku a podčiarkovník — žiadne štýlové písmo, medzery, emoji ani symboly. Písmo pre Instagram funguje v mene profilu (Meno), v biu, v popisoch a v komentároch. Ak chceš štýl v mene, použi pole Meno, nie login @." }
+    },
+    {
+      "@type": "Question",
+      "name": "Fungujú písma v popisoch príspevkov a v komentároch na Instagrame?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Áno. Keďže ide o obyčajné znaky Unicode, štýlové písmeno vložíš do popisu fotky aj reelu, do komentárov, do textu v Stories a do správ na Directe. Funguje to rovnako v aplikácii na telefóne aj vo verzii v prehliadači. Jediné pole, ktoré to neprijíma, je login @ (používateľské meno)." }
+    },
+    {
+      "@type": "Question",
+      "name": "Škodí štýlové písmo v biu zobrazovaniu vo vyhľadávaní na Instagrame?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Môže uškodiť, ak oštýluješ všetko. Vyhľadávanie a čítačky obrazovky lepšie rozumejú obyčajnému textu, takže je najlepšie oštýlovať len meno alebo jedno krátke heslo a dôležité kľúčové slová — čím sa zaoberáš, tvoje mesto, tvoju niku — nechať obyčajným písmom. Profil potom vyzerá pekne a stále sa ľahko nájde." }
+    },
+    {
+      "@type": "Question",
+      "name": "Prečo sa písmo na Instagrame zobrazuje ako štvorček?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Pretože zariadenie toho, kto si to prezerá, nemá písmo, ktoré daný znak vykreslí — obvykle ide o starší telefón alebo počítač. Nie je to chyba stránky ani tvojho kopírovania. Základné štýly — tučné, kurzíva, kaligrafia, gotika, bublinkové a kapitálky — sú najbezpečnejšie a zobrazia sa správne takmer všade. Ak uvidíš štvorček (□), prepni na jeden z týchto štýlov." }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "inLanguage": "sk",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Domov", "item": "https://ultratextgen.com/sk/" },
+    { "@type": "ListItem", "position": 2, "name": "Písmo pre Instagram", "item": "https://ultratextgen.com/sk/pismo-pre-instagram/" }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/sk/">Domov</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Písmo pre Instagram</span>
+</nav>
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pl-czcionki-na-instagram.svg" width="1200" height="340" loading="lazy" alt="">
+</figure>
+
+<section class="hero">
+  <div class="hero-inner">
+    <div class="hero-card">
+      <h1 class="hero-headline">Písmo pre Instagram: ozdobné písmená do bia a popisov</h1>
+      <p class="hero-tagline">Napíš text a hneď ho uvidíš v desiatkach písem pre Instagram — tučné, kurzíva, kaligrafia, gotika, bublinkové a kapitálky. Skopíruješ a vložíš do bia, do mena profilu, do popisu príspevku a do komentárov. Všetko zadarmo a <strong>bez aplikácie</strong>.</p>
+      <div class="input-wrapper">
+        <textarea class="main-input" id="mainInput" placeholder="Napíš text do bia alebo popisu..." maxlength="500" autofocus=""></textarea>
+        <span class="char-count"><span id="charCount">0</span>/500</span>
+      </div>
+      <div class="decoration-section">
+        <div class="decoration-label">Pridaj symboly a rámčeky k výsledku</div>
+        <div class="decoration-tabs">
+          <button class="decoration-tab active" data-deco-tab="symbols">Symboly</button>
+          <button class="decoration-tab" data-deco-tab="frames">Rámčeky</button>
+          <button class="decoration-tab" data-deco-tab="dividers">Oddeľovače</button>
+          <button class="decoration-tab" data-deco-tab="arrows">Šípky</button>
+          <button class="decoration-tab" data-deco-tab="minimal">Minimalistické</button>
+          <button class="decoration-tab" data-deco-tab="emojis">Emoji</button>
+        </div>
+        <div class="decoration-grid" id="decorationGrid"></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<main class="container">
+  <div class="category-section"><div class="category-tabs" id="categoryTabs"></div></div>
+  <div class="results-grid" id="resultsGrid"></div>
+
+  <!-- Ako to funguje -->
+  <section class="editorial-section">
+    <h2>Písmo pre Instagram: ako to funguje</h2>
+    <p class="editorial-intro"><strong>Písmo pre Instagram</strong> z tejto stránky nie je nainštalované písmo ani obrázok — sú to <strong>znaky Unicode</strong>, ozajstné písmená, rovnaké ako z klávesnice, len s iným vzhľadom (𝗔, 𝘈, 𝓐, 𝔄). Keďže Instagram prijíma Unicode takmer v každom textovom poli, štýlové písmeno sa vloží rovno do tvojho <strong>bia</strong>, do <strong>mena profilu</strong>, do <strong>popisu príspevku</strong>, do <strong>komentárov</strong>, do textu v <strong>Stories</strong> aj do správ na <strong>Directe</strong> — bez aplikácie, pluginu alebo klávesnice navyše.</p>
+    <div class="block-example">
+      <strong>Príklad:</strong> „tereza“ → 𝘁𝗲𝗿𝗲𝘇𝗮 (tučné), 𝘵𝘦𝘳𝘦𝘻𝘢 (kurzíva), 𝓉𝑒𝓇𝑒𝓏𝒶 (kaligrafia), 𝔱𝔢𝔯𝔢𝔷𝔞 (gotické), ⓣⓔⓡⓔⓩⓐ (bublinkové), ᴛᴇʀᴇᴢᴀ (kapitálky)
+    </div>
+    <p>Používa sa to za pár sekúnd: napíšeš text do poľa hore, generátor ho ukáže v mnohých <strong>písmach pre Instagram</strong>, klikneš na „Kopírovať“ a vložíš v aplikácii. Chceš len holé písmená abecedy? Sú hneď pod tým. A ak chceš prechádzať ešte viac rezov, plný generátor nájdeš na stránke s <a href="/sk/">písmenami na kopírovanie</a>.</p>
+  </section>
+
+  <!-- Abeceda A-Z -->
+  <section class="editorial-section glyph-section">
+    <h2>Abeceda písem pre Instagram (A–Z na kopírovanie)</h2>
+    <p class="editorial-intro">Celá abeceda v štýloch, ktoré sa v biu a popisoch na Instagrame objavujú najčastejšie. Klikni na daný riadok a skopíruj celú abecedu v tom štýle, alebo napíš svoj text hore a vezmi si vlastné slovo rovno oštýlované.</p>
+    <div class="alpha-list">
+      <div class="alpha-row">
+        <span class="alpha-label">Tučné</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝗔𝗕𝗖𝗗𝗘𝗙𝗚𝗛𝗜𝗝𝗞𝗟𝗠𝗡𝗢𝗣𝗤𝗥𝗦𝗧𝗨𝗩𝗪𝗫𝗬𝗭 𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇" aria-label="Kopírovať tučnú abecedu">𝗔𝗕𝗖𝗗𝗘𝗙𝗚𝗛𝗜𝗝𝗞𝗟𝗠𝗡𝗢𝗣𝗤𝗥𝗦𝗧𝗨𝗩𝗪𝗫𝗬𝗭 · 𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Kurzíva</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩 𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃" aria-label="Kopírovať abecedu kurzívou">𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩 · 𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Elegantné</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵 𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏" aria-label="Kopírovať elegantnú abecedu">𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵 · 𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Gotické</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝔄𝔅ℭ𝔇𝔈𝔉𝔊ℌℑ𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔ℜ𝔖𝔗𝔘𝔙𝔚𝔛𝔜ℨ 𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷" aria-label="Kopírovať gotickú abecedu">𝔄𝔅ℭ𝔇𝔈𝔉𝔊ℌℑ𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔ℜ𝔖𝔗𝔘𝔙𝔚𝔛𝔜ℨ · 𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Bublinkové</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ" aria-label="Kopírovať bublinkovú abecedu">ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ · ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Kapitálky</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="ᴀʙᴄᴅᴇꜰɢʜɪᴊᴋʟᴍɴᴏᴘqʀsᴛᴜᴠᴡxʏᴢ" aria-label="Kopírovať abecedu v kapitálkach">ᴀ ʙ ᴄ ᴅ ᴇ ꜰ ɢ ʜ ɪ ᴊ ᴋ ʟ ᴍ ɴ ᴏ ᴘ q ʀ s ᴛ ᴜ ᴠ ᴡ x ʏ ᴢ</button>
+      </div>
+    </div>
+    <p class="uname-note">Poznámka o slovenských znakoch: tieto písma Unicode pokrývajú základnú abecedu A–Z. Slovenská diakritika (á, ä, č, ď, é, í, ĺ, ľ, ň, ó, ô, ŕ, š, ť, ú, ý, ž) vo väčšine štýlov zostáva obyčajnými písmenami uprostred oštýlovaného slova — preto napr. „klara“ vyjde perfektne, kým „žofia“ ukáže ž ako obyčajné písmeno. Do bia a mien bez diakritiky to vyzerá skvele a do dlhších popisov sú najbezpečnejšie tučné a kurzíva.</p>
+    <p class="u-mt-15">Chceš sa zahryznúť do jedného štýlu? Celú abecedu a varianty každého rezu nájdeš na stránke s <a href="/sk/">písmenami na kopírovanie</a>, a najobľúbenejšia do bia na Instagrame je <a href="/sk/kurziva/">kurzíva</a>.</p>
+  </section>
+
+  <!-- Písmo do bia a mena -->
+  <section class="editorial-section">
+    <h2>Písmo do bia a mena profilu na Instagrame</h2>
+    <p class="editorial-intro">Najrýchlejší spôsob, ako vypichnúť profil, je nasadiť písmo na <strong>meno profilu</strong> (pole „Meno“) a zvlášť ho poskladať v <strong>biu</strong>. Sú to dve rôzne polia — „Meno“ je ten tučný názov hore na profile a bio je popis pod ním. Instagram prijíma Unicode v oboch, ale <strong>nie v logine @</strong>.</p>
+    <p class="uname-note">Ako vložiť:</p>
+    <div class="block-example">
+      — <strong>Meno profilu:</strong> Upraviť profil › pole „Meno“ › vlož štýlové písmo<br>
+      — <strong>Bio:</strong> Upraviť profil › pole „Bio“ › vlož text (môžeš kombinovať viac štýlov v samostatných riadkoch)<br>
+      — <strong>Popis príspevku / reelu:</strong> pri pridávaní príspevku vlož písmo do poľa popisu<br>
+      — <strong>Komentáre a Direct:</strong> vlož štýlové písmeno rovno do poľa komentára alebo správy
+    </div>
+    <p>Rada od niekoho, kto profily skladá denne: oštýluj samotné meno alebo jedno heslo a zvyšok bia nechaj obyčajným textom — celý efekt robí ten kontrast. Keď je všetko ozdobné, nič nepriťahuje pohľad. Dôležitý detail: Instagram povoľuje meniť pole „Meno“ len obmedzene často v krátkom čase, takže vlož rovno hotový štýl. Pre jednotlivé hviezdičky a trblietky do bia pozri stránku s <a href="/library/aesthetic-symbols/">ozdobami na kopírovanie</a>.</p>
+  </section>
+
+  <!-- Kde funguje a kde nie -->
+  <section class="editorial-section">
+    <h2>Kam vložíš písmo na Instagrame (a kam nie)</h2>
+    <p class="editorial-intro">Keďže to, čo kopíruješ, je čistý Unicode, písmená pre Instagram sa vložia prakticky do každého textového poľa aplikácie:</p>
+    <div class="block-example">
+      — <strong>Meno profilu</strong> a <strong>bio</strong><br>
+      — <strong>Popisy príspevkov</strong> a <strong>reelov</strong><br>
+      — <strong>Komentáre</strong> pod príspevkami<br>
+      — <strong>Text v Stories</strong> a <strong>poznámky (Notes)</strong><br>
+      — <strong>Správy na Directe</strong>
+    </div>
+    <p>Jediné miesto, kde to <strong>ne</strong>funguje, je <strong>používateľské meno (login @)</strong> — Instagram ho zámerne obmedzuje na malé písmená a až z, číslice, bodku a podčiarkovník, takže žiadne štýlové písmo, medzera ani emoji tam neprejde. Okrem toho úprimná poznámka: ak je zariadenie toho, kto si to prezerá, veľmi staré, časť vzácnejších štýlov sa môže zobraziť ako <strong>štvorčeky (□)</strong> — to je chýbajúce písmo na jeho zariadení, nie problém s tvojím textom. Keď sa držíš základných štýlov (tučné, kurzíva, kaligrafia, gotika, bublinkové, kapitálky), takmer nikdy sa to nestane. Na čisté prázdne riadky v biu sa hodí <a href="/library/invisible-character/">neviditeľný znak</a>.</p>
+  </section>
+
+  <!-- Ozdobné bio se symboly -->
+  <section class="editorial-section">
+    <h2>Ozdobné bio a mená na Instagram so symbolmi</h2>
+    <p class="editorial-intro">Mená a riadky bia, ktoré na Instagrame urobia najväčší dojem, kombinujú jemné písmo (kaligrafia alebo kurzíva) s hviezdičkami a symbolmi po oboch stranách, v štýle ⋆˚₊‧ ‧₊˚⋆. Klikni a skopíruj, potom vlož do poľa „Meno“ alebo do bia — potom vymeň za svoje slovo.</p>
+    <div class="uname-grid">
+      <button class="uname-chip symbol-tile" data-symbol="⋆˚₊‧ 𝓏𝑜𝓈𝒾𝒶 ‧₊˚⋆" aria-label="Kopírovať meno">⋆˚₊‧ 𝓏𝑜𝓈𝒾𝒶 ‧₊˚⋆</button>
+      <button class="uname-chip symbol-tile" data-symbol="✿ 𝓸𝓵𝓪 ✿" aria-label="Kopírovať meno">✿ 𝓸𝓵𝓪 ✿</button>
+      <button class="uname-chip symbol-tile" data-symbol="꒰ঌ 𝒷𝒶𝓈𝒾𝒶 ໒꒱" aria-label="Kopírovať meno">꒰ঌ 𝒷𝒶𝓈𝒾𝒶 ໒꒱</button>
+      <button class="uname-chip symbol-tile" data-symbol="⋆｡˚ 𝓴𝓪𝓼𝓲𝓪 ˚｡⋆" aria-label="Kopírovať meno">⋆｡˚ 𝓴𝓪𝓼𝓲𝓪 ˚｡⋆</button>
+      <button class="uname-chip symbol-tile" data-symbol="✧˖° 𝓶𝓪𝓳𝓪 °˖✧" aria-label="Kopírovať meno">✧˖° 𝓶𝓪𝓳𝓪 °˖✧</button>
+      <button class="uname-chip symbol-tile" data-symbol="ᯓ★ 𝓌𝒾𝓀𝓉𝑜𝓇𝒾𝒶 ★" aria-label="Kopírovať meno">ᯓ★ 𝓌𝒾𝓀𝓉𝑜𝓇𝒾𝒶 ★</button>
+      <button class="uname-chip symbol-tile" data-symbol="˚ʚ 𝒶𝓃𝒾𝒶 ɞ˚" aria-label="Kopírovať meno">˚ʚ 𝒶𝓃𝒾𝒶 ɞ˚</button>
+      <button class="uname-chip symbol-tile" data-symbol="⊹ ࣪ ˖ 𝓃𝒶𝓉𝒶𝓁𝒾𝒶 ˖ ࣪ ⊹" aria-label="Kopírovať meno">⊹ ࣪ ˖ 𝓃𝒶𝓉𝒶𝓁𝒾𝒶 ˖ ࣪ ⊹</button>
+      <button class="uname-chip symbol-tile" data-symbol="⟡ 𝓵𝓮𝓷𝓪 ⟡" aria-label="Kopírovať meno">⟡ 𝓵𝓮𝓷𝓪 ⟡</button>
+      <button class="uname-chip symbol-tile" data-symbol="๑ 𝓳𝓾𝓵𝓴𝓪 ๑" aria-label="Kopírovať meno">๑ 𝓳𝓾𝓵𝓴𝓪 ๑</button>
+    </div>
+    <p class="u-mt-15">Chceš celú sadu hotových hviezdičiek, srdiečok a oddeľovačov na zostavenie vlastného bia? Kompletná paleta je na stránke s <a href="/library/aesthetic-symbols/">ozdobami na kopírovanie</a> — tie isté znaky sa vložia do mena aj do bia na Instagrame.</p>
+  </section>
+
+  <!-- Vyhľadávanie a štvorčeky -->
+  <section class="editorial-section">
+    <h2>Písmo a vyhľadávanie na Instagrame (a poznámka o štvorčekoch)</h2>
+    <p class="editorial-intro">Štylizovaný text vyzerá skvele, ale má jeden háčik: vyhľadávanie na Instagrame a čítačky obrazovky zaobchádzajú so znakmi Unicode inak než s obyčajnými písmenami. Ak oštýluješ celé bio, tvoje kľúčové slová môžu horšie vyskakovať vo vyhľadávaní.</p>
+    <div class="block-example">
+      — <strong>Dobrá prax:</strong> oštýluj meno alebo krátke heslo, zvyšok nechaj obyčajným textom<br>
+      — <strong>Nechaj obyčajným písmom:</strong> čím sa zaoberáš, mesto, niku, slová, podľa ktorých ťa hľadajú<br>
+      — <strong>Príklad:</strong> 𝓶𝓪𝓳𝓪 𝓴𝓸𝔀𝓪𝓵𝓼𝓴𝓪 (kaligrafia) + „svadobné fotografie · Bratislava“ obyčajným písmom
+    </div>
+    <p>Druhá vec sú <strong>štvorčeky (□)</strong>: keď niekto vidí namiesto písmen prázdny obdĺžnik, znamená to, že jeho zariadenie nemá písmo, ktoré daný znak vykreslí — obvykle veľmi starý telefón. Nie je to problém s tvojím textom ani s kopírovaním. Keď sa držíš základných štýlov, takmer nikdy sa to nestane. Na prázdne riadky a medzery v biu sa hodí <a href="/library/invisible-character/">neviditeľný znak</a>, a výraznejší, temný štýl na meno nájdeš v <a href="/sk/goticke-pismo/">gotickom písme</a>.</p>
+  </section>
+
+  <!-- Related -->
+  <section class="editorial-section">
+    <span class="article-section-label">Súvisiace stránky</span>
+    <div class="compare-grid">
+      <a href="/sk/" class="compare-card variant-muted u-no-underline">
+        <h4>Písmená na kopírovanie</h4>
+        <p>Celá abeceda v mnohých rezoch — tučné, kurzíva, kaligrafia a bublinkové.</p>
+      </a>
+      <a href="/sk/kurziva/" class="compare-card variant-muted u-no-underline">
+        <h4>Kurzíva</h4>
+        <p>Ozdobná, ručne písaná kurzíva — najčastejšia voľba do bia na Instagrame.</p>
+      </a>
+      <a href="/library/aesthetic-symbols/" class="compare-card variant-muted u-no-underline">
+        <h4>Ozdoby na kopírovanie</h4>
+        <p>Hviezdičky, srdiečka, rámčeky a oddeľovače na ozdobenie mena a bia.</p>
+      </a>
+      <a href="/library/invisible-character/" class="compare-card variant-muted u-no-underline">
+        <h4>Neviditeľný znak</h4>
+        <p>Prázdna medzera na čisté riadky a odsadenie v biu na Instagrame.</p>
+      </a>
+      <a href="/sk/goticke-pismo/" class="compare-card variant-muted u-no-underline">
+        <h4>Gotické písmo</h4>
+        <p>Temné, výrazné písmená na meno profilu s charakterom.</p>
+      </a>
+    </div>
+  </section>
+</main>
+
+<footer class="footer">
+  <div class="footer-inner">
+    <h2 class="faq-category">Najčastejšie otázky o písme pre Instagram</h2>
+    <div class="faq-item"><button class="faq-question" type="button">Ako zmeniť písmo v biu na Instagrame?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Napíš svoj text do poľa hore na stránke. Hneď sa objaví desiatky písem pre Instagram — tučné, kurzíva, kaligrafia, gotika, bublinkové a kapitálky. Klikni na „Kopírovať“ pri tom, ktoré sa ti páči, otvor Instagram, prejdi do Upraviť profil a vlož ho do poľa Bio. Keďže ide o znaky Unicode, štýlové písmeno sa vloží do poľa bez akejkoľvek aplikácie alebo klávesnice navyše.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Ako spraviť iné písmo v mene profilu na Instagrame?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Skopíruj tu vybrané písmo a vlož ho do poľa „Meno“ v Upraviť profil — to je ten tučný názov hore na profile, nie login @. Instagram v tomto poli prijíma Unicode, takže sa štýlové písmeno zobrazí správne. Len pamätaj, že Instagram povoľuje meniť Meno obmedzene často v krátkom čase (obvykle dvakrát za 14 dní), takže vlož rovno hotový štýl.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Dá sa použiť ozdobné písmo v používateľskom mene (@) na Instagrame?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Nie. Používateľské meno (login @, ktorý je v tvojom odkaze a slúži na označovanie) prijíma len malé písmená a až z, číslice, bodku a podčiarkovník — žiadne štýlové písmo, medzery, emoji ani symboly. Písmo pre Instagram funguje v mene profilu (Meno), v biu, v popisoch a v komentároch. Ak chceš štýl v mene, použi pole Meno, nie login @.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Fungujú písma v popisoch príspevkov a v komentároch na Instagrame?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Áno. Keďže ide o obyčajné znaky Unicode, štýlové písmeno vložíš do popisu fotky aj reelu, do komentárov, do textu v Stories a do správ na Directe. Funguje to rovnako v aplikácii na telefóne aj vo verzii v prehliadači. Jediné pole, ktoré to neprijíma, je login @ (používateľské meno).</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Škodí štýlové písmo v biu zobrazovaniu vo vyhľadávaní na Instagrame?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Môže uškodiť, ak oštýluješ všetko. Vyhľadávanie a čítačky obrazovky lepšie rozumejú obyčajnému textu, takže je najlepšie oštýlovať len meno alebo jedno krátke heslo a dôležité kľúčové slová — čím sa zaoberáš, tvoje mesto, tvoju niku — nechať obyčajným písmom. Profil potom vyzerá pekne a stále sa ľahko nájde.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Prečo sa písmo na Instagrame zobrazuje ako štvorček?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Pretože zariadenie toho, kto si to prezerá, nemá písmo, ktoré daný znak vykreslí — obvykle ide o starší telefón alebo počítač. Nie je to chyba stránky ani tvojho kopírovania. Základné štýly — tučné, kurzíva, kaligrafia, gotika, bublinkové a kapitálky — sú najbezpečnejšie a zobrazia sa správne takmer všade. Ak uvidíš štvorček (□), prepni na jeden z týchto štýlov.</div></div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Výber jazyka">
+      <a class="lang-option" href="/instagram/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/sk/pismo-pre-instagram/" hreflang="sk">SK</a>
+    </div>
+  </div>
+</footer>
+
+<div class="copy-toast" id="copyToast">Skopírované!</div>
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script>window.UTG_PREVIEW_PLATFORM='instagram';window.UTG_SHOW_PLATFORMS=true;window.UTG_DEMO_TEXT='tereza aesthetic\nodkaz v biu ⬇';</script>
+<script src="/styles.js"></script>
+<script src="/renderer.js"></script>
+<script src="/script.js" defer=""></script>
+<script src="/symbol-explorer.js"></script>
+<script src="/footer.js" defer></script>
+</body></html>

--- a/sk/tucne-pismo/index.html
+++ b/sk/tucne-pismo/index.html
@@ -1,0 +1,299 @@
+<!DOCTYPE html><html lang="sk"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZGVh");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Generátor tučného písma — 𝐭𝐮č𝐧é 𝐩í𝐬𝐦𝐨 na kopírovanie | UltraTextGen</title>
+  <meta name="description" content="Bezplatný generátor tučného písma: preveď text na tučné znaky Unicode na kopírovanie a vloženie — do bia na Instagrame, na WhatsApp, TikTok, Discord, LinkedIn a do nickov. Ihneď, bez registrácie.">
+  <link rel="canonical" href="https://ultratextgen.com/sk/tucne-pismo/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/category/bold-fonts/">
+  <link rel="alternate" hreflang="sk" href="https://ultratextgen.com/sk/tucne-pismo/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/category/bold-fonts/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Generátor tučného písma — 𝐭𝐮č𝐧é 𝐩í𝐬𝐦𝐨 na kopírovanie | UltraTextGen">
+  <meta property="og:description" content="Bezplatný generátor tučného písma — tučné znaky Unicode na kopírovanie a vloženie na Instagram, TikTok, WhatsApp, Discord a LinkedIn. Ihneď, bez registrácie.">
+  <meta property="og:url" content="https://ultratextgen.com/sk/tucne-pismo/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category-bold-fonts.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Generátor tučného písma — 𝐭𝐮č𝐧é 𝐩í𝐬𝐦𝐨 na kopírovanie | UltraTextGen">
+  <meta name="twitter:description" content="Bezplatný generátor tučného písma — tučné znaky Unicode na kopírovanie a vloženie do sociálnych sietí, chatov a nickov.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category-bold-fonts.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "sk",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Čo je generátor tučného písma a ako funguje?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Prevádza písmená, ktoré napíšeš, na tučné znaky Unicode (𝐭𝐚𝐤é 𝐚𝐤𝐨 𝐭𝐢𝐞𝐭𝐨) — ozajstné znaky, nie písmo ani obrázok. Keďže ide o obyčajné textové znaky, môžeš ich skopírovať a vložiť všade, kde je povolený text: do bia, popisov, komentárov a správ. Viac v našom sprievodcovi o tom, ako funguje písmo Unicode."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Funguje tučné písmo na Instagrame, WhatsAppe, TikToku a LinkedIne?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Áno. Bio, popisy, komentáre aj správy na chate tieto znaky bez problémov prijmú. Hlavne na LinkedIne a X, kde natívne stučnenie chýba, tučné písmo Unicode zaistí, že najdôležitejšie časti vyniknú. Pozor: niektoré polia s @používateľským menom tieto znaky filtrujú — v samotnom handle je nutné zostať pri obyčajnom texte, ale v biu tučné písmo funguje skvele."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Môžem písať slovenské znaky (á, ä, č, ď, é, í, ĺ, ľ, ň, ó, ô, ŕ, š, ť, ú, ý, ž) tučným písmom?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Tučné písmo Unicode pokrýva A–Z a 0–9, preto slovenské znaky ako á, č, ľ, š, ť, ž nemajú vlastnú tučnú podobu a zostávajú obyčajné. Pre plne tučný efekt ich môžeš nahradiť základnými písmenami (a, c, l, s, t, z) — mení to však pravopis — alebo ich nechať v normálnej hrúbke, čo pri krátkom texte obvykle aj tak vyzerá dobre."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Je generátor tučného písma zadarmo?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Áno, plne zadarmo a bez registrácie. Píš, kopíruj a vkladaj, koľkokrát chceš — nie je tu žiadny limit ani skryté náklady."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Prečo sa niektoré znaky zobrazujú ako prázdne štvorčeky?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Prázdny štvorček (▯) znamená, že zariadenie nemá zodpovedajúci glyf pre daný tučný znak. Týka sa to väčšinou starších systémov. Vyber jednoduchší tučný štýl alebo zariadenie aktualizuj — viac v článku o tom, prečo sa písmo zobrazuje ako štvorčeky."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Ovplyvňuje tučný text Unicode čitateľnosť a dosahy?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Tučné znaky Unicode priťahujú pohľad vo feede a skvele slúžia ako háčiky, titulky a CTA na sociálnych sieťach. Používaj ich cielene — krátke tučné akcenty, zvyšok obyčajným textom. Pre obsah na webe je lepšie použiť stučnenie cez CSS, aby vyhľadávače čítali text ako bežné slová. Pre textové polia na sociálnych sieťach je tučné písmo Unicode ideálne riešenie. Nezabudni na prístupnosť, keď formátuješ dlhšie úseky."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "inLanguage": "sk",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Domov", "item": "https://ultratextgen.com/sk/" },
+    { "@type": "ListItem", "position": 2, "name": "Tučné písmo", "item": "https://ultratextgen.com/sk/tucne-pismo/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Generátor tučného písma",
+  "alternateName": ["Tučné písmo","Tučný text","Tučné písmená","Generátor tučného textu","Tučné písmo na kopírovanie","Tučný text Unicode","Bold na kopírovanie"],
+  "url": "https://ultratextgen.com/sk/tucne-pismo/",
+  "inLanguage": "sk",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "EUR"
+  },
+  "description": "Bezplatný generátor tučného písma: preveď text na tučné znaky Unicode na kopírovanie a vloženie na Instagram, TikTok, WhatsApp, Discord, LinkedIn a do nickov.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/sk/">Domov</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Tučné písmo</span>
+</nav>
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/category-bold-fonts.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+  <!-- Hero -->
+  <section class="hero">
+    <div class="hero-inner">
+      <div class="hero-card">
+        <h1 class="hero-headline">Generátor tučného písma</h1>
+        <p class="hero-tagline">Premeň ľubovoľný text na 𝐭𝐮č𝐧ý 𝐭𝐞𝐱𝐭 na kopírovanie a vloženie — výrazné,
+          pohľad priťahujúce znaky Unicode do bia, nickov a titulkov. Zadarmo, ihneď, bez registrácie.</p>
+        <div class="input-wrapper">
+          <textarea class="main-input" id="mainInput" placeholder="Napíš text, slovo alebo meno…" maxlength="500" autofocus></textarea>
+          <span class="char-count"><span id="charCount">0</span>/500</span>
+        </div>
+
+        <!-- Decoration Selector -->
+        <div class="decoration-section">
+          <div class="decoration-label">
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"></path>
+            </svg>
+            Pridaj symboly okolo výsledku
+          </div>
+          <div class="decoration-tabs">
+            <button class="decoration-tab active" data-deco-tab="symbols">Symboly</button>
+            <button class="decoration-tab" data-deco-tab="frames">Rámčeky</button>
+            <button class="decoration-tab" data-deco-tab="dividers">Oddeľovače</button>
+            <button class="decoration-tab" data-deco-tab="minimal">Minimalistické</button>
+            <button class="decoration-tab" data-deco-tab="emojis">Emoji</button>
+          </div>
+          <div class="decoration-grid" id="decorationGrid"></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Main Content -->
+  <main class="container">
+
+    <section class="editorial-section">
+      <span class="article-section-label">Tučné písmo Unicode</span>
+      <h2>Tučný text na kopírovanie — do bia, nickov a titulkov</h2>
+      <p>Tieto písmená nie sú písmo ani obrázok, ale ozajstné <strong>znaky Unicode</strong>. Zvýrazni kľúčové slovo
+        vo svojom biu, vytvor tučný nick alebo zariaď, aby titulok na LinkedIne a X priťahoval pohľad — všade tam,
+        kde natívne stučnenie chýba. Napíš text vyššie, klikni na <strong>Kopírovať</strong> a vlož tučné
+        písmo tam, kam chceš.</p>
+    </section>
+
+    <!-- Category Tabs (populated by script.js) -->
+    <div class="category-section">
+      <div class="category-tabs" id="categoryTabs"></div>
+    </div>
+
+    <!-- Results -->
+    <div class="results-grid" id="resultsGrid"></div>
+
+    <section class="editorial-section">
+      <span class="article-section-label">Súvisiace</span>
+      <p>Spoj tučné písmo s <a href="/sk/pismo-pre-discord/">písmom na Discord</a>,
+        <a href="/library/aesthetic-symbols/">ozdobami</a> alebo <a href="/library/invisible-character/">neviditeľným znakom</a>
+        pre čisté medzery. Na body art máme <a href="/usecase/tattoo-fonts/">generátor písma na tetovanie</a>,
+        a na zvislé sadzby — <a href="/usecase/vertical-text/">zvislý text</a>.</p>
+    </section>
+  </main>
+
+  <!-- Footer + FAQ -->
+  <footer class="footer">
+    <div class="footer-inner">
+<div class="faq-section" id="bold-faq">
+
+<h2 class="faq-category">Generátor tučného písma — FAQ</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Čo je generátor tučného písma a ako funguje?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Prevádza písmená, ktoré napíšeš, na tučné znaky Unicode (𝐭𝐚𝐤é 𝐚𝐤𝐨 𝐭𝐢𝐞𝐭𝐨) — ozajstné znaky, nie písmo ani obrázok. Keďže ide o obyčajné textové znaky, môžeš ich skopírovať a vložiť všade, kde je povolený text: do bia, popisov, komentárov a správ. Viac v našom <a href="/guide/how-unicode-fonts-work/">sprievodcovi o tom, ako funguje písmo Unicode</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Funguje tučné písmo na Instagrame, WhatsAppe, TikToku a LinkedIne?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Áno. Bio, popisy, komentáre aj správy na chate tieto znaky bez problémov prijmú. Hlavne na LinkedIne a X, kde natívne stučnenie chýba, tučné písmo Unicode zaistí, že najdôležitejšie časti vyniknú. Pozor: niektoré polia s <strong>@používateľským menom</strong> tieto znaky filtrujú — v samotnom handle je nutné zostať pri obyčajnom texte, ale v biu tučné písmo funguje skvele.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Môžem písať slovenské znaky (á, ä, č, ď, é, í, ĺ, ľ, ň, ó, ô, ŕ, š, ť, ú, ý, ž) tučným písmom?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Tučné písmo Unicode pokrýva A–Z a 0–9, preto slovenské znaky ako á, č, ľ, š, ť, ž nemajú vlastnú tučnú podobu a zostávajú obyčajné. Pre plne tučný efekt ich môžeš nahradiť základnými písmenami (<strong>a, c, l, s, t, z</strong>) — mení to však pravopis — alebo ich nechať v normálnej hrúbke, čo pri krátkom texte obvykle aj tak vyzerá dobre.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Je generátor tučného písma zadarmo?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Áno, plne zadarmo a bez registrácie. Píš, kopíruj a vkladaj, koľkokrát chceš — nie je tu žiadny limit ani skryté náklady.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Prečo sa niektoré znaky zobrazujú ako prázdne štvorčeky?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Prázdny štvorček (▯) znamená, že zariadenie nemá zodpovedajúci glyf pre daný tučný znak. Týka sa to väčšinou starších systémov. Vyber jednoduchší tučný štýl alebo zariadenie aktualizuj — viac v článku o tom, <a href="/guide/why-fonts-show-as-boxes/">prečo sa písmo zobrazuje ako štvorčeky</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Ovplyvňuje tučný text Unicode čitateľnosť a dosahy?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Tučné znaky Unicode priťahujú pohľad vo feede a skvele slúžia ako háčiky, titulky a CTA na sociálnych sieťach. Používaj ich cielene — krátke tučné akcenty, zvyšok obyčajným textom. Pre obsah na webe je lepšie použiť stučnenie cez CSS, aby vyhľadávače čítali text ako bežné slová. Pre textové polia na sociálnych sieťach je tučné písmo Unicode ideálne riešenie. Nezabudni na <a href="/guide/fancy-fonts-accessibility-guide/">prístupnosť</a>, keď formátuješ dlhšie úseky.
+  </div>
+</div>
+
+</div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Výber jazyka">
+      <a class="lang-option" href="/category/bold-fonts/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/sk/tucne-pismo/" hreflang="sk">SK</a>
+    </div>
+
+    </div>
+  </footer>
+
+  <div class="copy-toast" id="copyToast">Skopírované!</div>
+
+  <script>
+    window.UTG_FAMILY = "bold";
+    window.UTG_DEMO_TEXT = "tučné písmo\ntučný text";
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/script.js" defer></script>
+  <script src="/footer.js" defer></script>
+</body></html>

--- a/sr/fontovi-za-discord/index.html
+++ b/sr/fontovi-za-discord/index.html
@@ -1,0 +1,301 @@
+<!DOCTYPE html><html lang="sr"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Fontovi za Discord: Slova za Nadimak i Bio (Bez Nitra) | UltraTextGen</title>
+  <meta name="description" content="Fontovi za Discord besplatno: pretvori ime u 𝗽𝗼𝗱𝗲𝗯𝗹𝗷𝗮𝗻𝗼, 𝓴𝓾𝓻𝔃𝓲𝓿 ili 𝔤𝔬𝔱𝔦𝔠𝔲 i nalepi u nadimak, u odeljak „O meni” i u chat. Fontovi za Discord bez Nitra.">
+  <link rel="canonical" href="https://ultratextgen.com/sr/fontovi-za-discord/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/discord/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/discord/">
+  <link rel="alternate" hreflang="sr" href="https://ultratextgen.com/sr/fontovi-za-discord/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Fontovi za Discord: Slova za Nadimak i Bio (Bez Nitra)">
+  <meta property="og:description" content="Generator fontova za Discord: upiši ime i nalepi stilizovano slovo u nadimak, u „O meni”, u naziv kanala i u status. Podebljano, kurziv i gotica — bez Nitra.">
+  <meta property="og:url" content="https://ultratextgen.com/sr/fontovi-za-discord/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/discord.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Fontovi za Discord: Slova za Nadimak i Bio (Bez Nitra)">
+  <meta name="twitter:description" content="Podebljano, kurziv, gotica i balončasta spremni za lepljenje u nadimak i „O meni” na Discordu — bez Nitra.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/discord.png">
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+  <link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Generator Fontova za Discord",
+  "alternateName": ["Fontovi za Discord", "Fontovi na Discordu", "Slova za Discord", "Generator Nadimka za Discord"],
+  "url": "https://ultratextgen.com/sr/fontovi-za-discord/",
+  "applicationCategory": "UtilitiesApplication",
+  "operatingSystem": "Any",
+  "description": "Generator fontova za Discord: pretvara tvoje ime u stilizovana slova — podebljano, kurziv, goticu, balončasta, elegantna i kapitalke — za lepljenje u nadimak, u „O meni”, u naziv kanala i u status, bez potrebe za Nitrom.",
+  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "RSD" }
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "sr-Latn",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Kako promeniti font u nadimku na Discordu?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Upiši svoje ime u polje na vrhu stranice. Odmah će se pojaviti desetine fontova za Discord — podebljano, kurziv, gotička, balončasta, kapitalke. Klikni „Kopiraj” kod onog koji ti se sviđa, otvori Discord, uđi u Korisnička podešavanja i nalepi ga u prikazano ime, ili desnim klikom na serveru promeni nadimak na tom serveru. Budući da su to Unicode znakovi, stilizovano slovo se lepi u polje bez ikakvog dodatka." }
+    },
+    {
+      "@type": "Question",
+      "name": "Treba li za fontove na Discordu Nitro?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Ne. Slova iz ovog generatora obični su Unicode znakovi, isti kao sa tastature, samo drugačijeg izgleda — zato se lepe u prikazano ime, u nadimak na serveru, u odeljak „O meni”, u naziv kanala i u poruke bez ikakvog Nitra. Nitro je potreban samo za plaćene dodatke, poput boja i gradijenta u imenu (Display Name Styles), a ne za sam stilizovani tekst." }
+    },
+    {
+      "@type": "Question",
+      "name": "Rade li fontovi u korisničkom imenu (@) na Discordu?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Ne. Korisničko ime (jedinstveni @ koji se koristi za pozivnice prijateljima) prima samo mala slova od a do z, brojke, tačku i podvlaku — bez stilskih fontova, razmaka, emojija ili simbola. Fontovi za Discord rade u prikazanom imenu, u nadimku na serveru, u odeljku „O meni”, u nazivu kanala i u chatu. Ako želiš stil u imenu, koristi prikazano ime, a ne @login." }
+    },
+    {
+      "@type": "Question",
+      "name": "Po čemu se razlikuje Discordovo oblikovanje (**podebljanje**) od Unicode fontova?",
+      "acceptedAnswer": { "@type": "Answer", "text": "To su dve različite stvari. Discordov Markdown (**podebljanje**, *kurziv*, `kod`) oblikuje tekst samo unutar poruka u chatu i nestane kad ga pokušaš upotrebiti u imenu ili u biju. Unicode fontovi sa ove stranice sam su stilizovani znak, pa rade svuda — u nadimku, u „O meni”, u nazivu kanala, u statusu i u chatu. Praktično pravilo: u običnoj poruci koristi Markdown, a da stilizuješ nadimak ili bio, koristi Unicode font." }
+    },
+    {
+      "@type": "Question",
+      "name": "Kako napraviti ukrasni nadimak za Discord s okvirima i simbolima?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Odaberi font za ime (gotica i balončasta izlaze najbolje) i okruži ga okvirima te simbolima u stilu ꧁༒ ༒꧂. Na ovoj stranici je mreža gotovih nadimaka s okvirima — klikni za kopiranje i nalepi u nadimak na serveru. Možeš i da upišeš svoje ime na vrhu, staviti font i upotrebiti kartice Simboli i Okviri da dotjeraš izgled pre kopiranja." }
+    },
+    {
+      "@type": "Question",
+      "name": "Zašto se slova na Discordu prikazuju kao kvadratići?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Zato što uređaj osobe koja to gleda nema font koji crta taj znak — obično je to stariji telefon ili računar. To nije greška stranice ni tvog kopiranja. Osnovni stilovi — podebljano, kurziv, gotica, balončasta i kapitalke — najsigurniji su i prikazuju se ispravno gotovo svuda. Ako neko prijavi kvadratić (□), zameni jednim od tih stilova." }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "inLanguage": "sr-Latn",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Početna", "item": "https://ultratextgen.com/sr/" },
+    { "@type": "ListItem", "position": 2, "name": "Fontovi za Discord", "item": "https://ultratextgen.com/sr/fontovi-za-discord/" }
+  ]
+}
+</script>
+</head>
+<body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<script src="/header.js"></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/sr/">Početna</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Fontovi za Discord</span>
+</nav>
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/discord.svg" width="1200" height="340" loading="lazy" alt="">
+</figure>
+
+<section class="hero">
+  <div class="hero-inner">
+    <div class="hero-card">
+      <h1 class="hero-headline">Fontovi za Discord: slova za nadimak i bio</h1>
+      <p class="hero-tagline">Upiši svoje ime i vidi ga odmah u desetinama fontova za Discord — podebljano, kurziv, gotička, balončasta i kapitalke. Kopiraš i lepiš u nadimak, u nadimak na serveru, u odeljak „O meni”, u naziv kanala i u chat. Sve besplatno i <strong>bez Nitra</strong>.</p>
+      <div class="input-wrapper">
+        <textarea class="main-input" id="mainInput" placeholder="Upiši ime ili tekst..." maxlength="500" autofocus=""></textarea>
+        <span class="char-count"><span id="charCount">0</span>/500</span>
+      </div>
+      <div class="decoration-section">
+        <div class="decoration-label">Dodaj simbole i okvire rezultatu</div>
+        <div class="decoration-tabs">
+          <button class="decoration-tab active" data-deco-tab="symbols">Simboli</button>
+          <button class="decoration-tab" data-deco-tab="frames">Okviri</button>
+          <button class="decoration-tab" data-deco-tab="dividers">Razdelnici</button>
+          <button class="decoration-tab" data-deco-tab="arrows">Strelice</button>
+          <button class="decoration-tab" data-deco-tab="minimal">Minimalni</button>
+          <button class="decoration-tab" data-deco-tab="emojis">Emoji</button>
+        </div>
+        <div class="decoration-grid" id="decorationGrid"></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<main class="container">
+  <div class="category-section"><div class="category-tabs" id="categoryTabs"></div></div>
+  <div class="results-grid" id="resultsGrid"></div>
+
+  <!-- Kako to radi -->
+  <section class="editorial-section">
+    <h2>Fontovi za Discord: kako to radi</h2>
+    <p class="editorial-intro"><strong>Fontovi za Discord</strong> sa ove stranice nisu instalirani font ni slika — to su <strong>Unicode znakovi</strong>, prava slova, ista kao sa tastature, samo drugačijeg izgleda (𝗔, 𝘈, 𝓐, 𝔄). Budući da Discord prihvata Unicode u gotovo svakom tekstualnom polju, stilizovano slovo lepi se ravno u tvoje <strong>prikazano ime</strong>, u <strong>nadimak na serveru</strong>, u odeljak <strong>„O meni”</strong>, u <strong>naziv kanala</strong>, u <strong>status</strong> pa i u <strong>poruke</strong> — bez Nitra, dodatka ili posebne aplikacije.</p>
+    <div class="block-example">
+      <strong>Primer:</strong> „marko” → 𝗺𝗮𝗿𝗸𝗼 (podebljano), 𝘮𝘢𝘳𝘬𝘰 (kurziv), 𝓶𝓪𝓻𝓴𝓸 (ukrasni kurziv), 𝔪𝔞𝔯𝔨𝔬 (gotička), ⓜⓐⓡⓚⓞ (balončasta), ᴍᴀʀᴋᴏ (kapitalke)
+    </div>
+    <p>Koristi se u nekoliko sekundi: upišeš ime u polje na vrhu, generator prikaže isti tekst u brojnim <strong>fontovima za Discord</strong>, klikneš „Kopiraj” i nalepiš u aplikaciji. Želiš samo gola slova abecede? Odmah su ispod. A ako radije pregledavaš još rezova, potpuni generator naći ćeš na <a href="/sr/">glavnoj stranici sa slovima za kopiranje</a>.</p>
+  </section>
+
+  <!-- Abeceda A-Z -->
+  <section class="editorial-section glyph-section">
+    <h2>Abeceda fontova za Discord (A–Z za kopiranje)</h2>
+    <p class="editorial-intro">Cela abeceda u stilovima koji se najčešće pojavljuju u nadimcima i biju na Discordu. Klikni redak da kopiraš celu abecedu u tom stilu, ili upiši svoje ime na vrhu i uzmi sopstvenu reč odmah stilizovanu.</p>
+    <div class="alpha-list">
+      <div class="alpha-row">
+        <span class="alpha-label">Podebljano</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝗔𝗕𝗖𝗗𝗘𝗙𝗚𝗛𝗜𝗝𝗞𝗟𝗠𝗡𝗢𝗣𝗤𝗥𝗦𝗧𝗨𝗩𝗪𝗫𝗬𝗭 𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇" aria-label="Kopiraj podebljanu abecedu">𝗔𝗕𝗖𝗗𝗘𝗙𝗚𝗛𝗜𝗝𝗞𝗟𝗠𝗡𝗢𝗣𝗤𝗥𝗦𝗧𝗨𝗩𝗪𝗫𝗬𝗭 · 𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Kurziv</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩 𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃" aria-label="Kopiraj abecedu u kurzivu">𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩 · 𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Elegantno</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵 𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏" aria-label="Kopiraj elegantnu abecedu">𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵 · 𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Gotička</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝔄𝔅ℭ𝔇𝔈𝔉𝔊ℌℑ𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔ℜ𝔖𝔗𝔘𝔙𝔚𝔛𝔜ℨ 𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷" aria-label="Kopiraj gotičku abecedu">𝔄𝔅ℭ𝔇𝔈𝔉𝔊ℌℑ𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔ℜ𝔖𝔗𝔘𝔙𝔚𝔛𝔜ℨ · 𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Balončasta</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ" aria-label="Kopiraj balončastu abecedu">ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ · ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Kapitalke</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="ᴀʙᴄᴅᴇꜰɢʜɪᴊᴋʟᴍɴᴏᴘqʀsᴛᴜᴠᴡxʏᴢ" aria-label="Kopiraj abecedu u kapitalkama">ᴀ ʙ ᴄ ᴅ ᴇ ꜰ ɢ ʜ ɪ ᴊ ᴋ ʟ ᴍ ɴ ᴏ ᴘ q ʀ s ᴛ ᴜ ᴠ ᴡ x ʏ ᴢ</button>
+      </div>
+    </div>
+    <p class="uname-note">Napomena o srpskim znakovima: ovi Unicode fontovi obuhvataju osnovnu abecedu A–Z. Srpske kvačice (č, ć, đ, š, ž) u većini stilova ostaju obična slova usred stilizovane reči — pa npr. „željko” izađe kao ž𝓮𝓵𝓳𝓴𝓸. Za nadimke bez kvačica izgleda idealno, a za duže tekstove najsigurniji su podebljano i kurziv.</p>
+    <p class="u-mt-15">Želiš se udubiti u jedan stil? Celu abecedu i varijante svakog reza naći ćeš na <a href="/sr/">glavnoj stranici sa slovima za kopiranje</a>, a zvezdice i okvire za nadimak — u <a href="/library/aesthetic-symbols/">ukrasnim simbolima</a>.</p>
+  </section>
+
+  <!-- Fontovi za nadimak i O meni -->
+  <section class="editorial-section">
+    <h2>Fontovi za nadimak i odeljak „O meni” na Discordu</h2>
+    <p class="editorial-intro">Najbrži način da istakneš profil jest staviti font na <strong>prikazano ime</strong> i zasebno u odeljak <strong>„O meni”</strong> (bio profila). Discord prihvata Unicode u oba polja — a uz to možeš da imaš <strong>drugačiji nadimak na svakom serveru</strong>, pa na gaming serveru koristiš goticu, a na serveru sa prijateljima kurziv, sve pod istim nalogom.</p>
+    <p class="uname-note">Kako nalepiti:</p>
+    <div class="block-example">
+      — <strong>Prikazano ime:</strong> Korisnička podešavanja › Profil › uredi prikazano ime i nalepi font<br>
+      — <strong>Nadimak na serveru:</strong> desni klik na svom imenu na serveru › Uredi profil servera › nalepi stilizovani nadimak<br>
+      — <strong>„O meni”:</strong> Korisnička podešavanja › Profil › polje „O meni” › nalepi tekst<br>
+      — <strong>Naziv kanala:</strong> ako si administrator, uredi kanal i nalepi font u naziv
+    </div>
+    <p>Savet od nekoga tko svakodnevno slaže profile: stilizuj samo ime, a ostatak „O meni” ostavi običnim tekstom — kontrast čini ceo efekat. Kad je sve ukrašeno, ništa ne privlači pogled. Za pojedinačne zvezdice i sjaj u biju svrati na stranicu s <a href="/library/aesthetic-symbols/">ukrasnim simbolima za kopiranje</a>.</p>
+  </section>
+
+  <!-- Markdown vs Unicode -->
+  <section class="editorial-section">
+    <h2>Discordov Markdown vs Unicode fontovi — kad šta upotrebiti</h2>
+    <p class="editorial-intro">Discord ima <strong>dva načina</strong> za petljanje po tekstu i vredi ih ne mešati. Jedan je izvorno <strong>Markdown oblikovanje</strong>, drugi su <strong>Unicode fontovi</strong> sa ove stranice. Služe za različite stvari.</p>
+    <div class="block-example">
+      — <strong>Markdown (izvorni):</strong> <code>**podebljanje**</code> → <strong>podebljanje</strong>, <code>*kurziv*</code> → <em>kurziv</em>, <code>__podcrtavanje__</code>, <code>~~precrtavanje~~</code>, <code>`kod`</code>. Radi samo <strong>unutar poruka</strong> u chatu i nestane kad ga pokušaš u imenu ili u biju.<br>
+      — <strong>Unicode fontovi (ova stranica):</strong> 𝗽𝗼𝗱𝗲𝗯𝗹𝗷𝗮𝗻𝗼, 𝓴𝓾𝓻𝔃𝓲𝓿, 𝔤𝔬𝔱𝔦𝔠𝔞. To je sam stilizovani znak, pa radi <strong>svuda</strong> — u nadimku, u „O meni”, u nazivu kanala, u statusu i u chatu.
+    </div>
+    <p>Praktično pravilo: da oblikuješ običnu <strong>poruku</strong> (podebljaš reč usred rečenice), koristi Discordov Markdown — čišći je. Da stilizuješ <strong>nadimak, bio ili naziv kanala</strong>, koristi Unicode font, jer Markdown tu neće raditi. I važno upozorenje: ništa od toga ne radi u <strong>korisničkom imenu (@)</strong>, koje prima samo mala slova od a do z, brojke, tačku i podvlaku — nikakav font, razmak ni emoji. Ako želiš stil u imenu, pravo polje je prikazano ime, a ne @login.</p>
+  </section>
+
+  <!-- Ukrasni nadimci s okvirima -->
+  <section class="editorial-section">
+    <h2>Ukrasni nadimci za Discord s okvirima i simbolima</h2>
+    <p class="editorial-intro">Nadimci koji najviše ostavljaju dojam na Discordu spajaju snažan font (goticu ili balončasta) s okvirima i simbolima sa obe strane, u stilu ꧁༒ ༒꧂. Klikni za kopiranje i nalepi u nadimak na serveru — potom zameni svojim imenom.</p>
+    <div class="uname-grid">
+      <button class="uname-chip symbol-tile" data-symbol="꧁༒𝕯𝖆𝖗𝖐༒꧂" aria-label="Kopiraj nadimak">꧁༒𝕯𝖆𝖗𝖐༒꧂</button>
+      <button class="uname-chip symbol-tile" data-symbol="꧁༒𝕸𝖆𝖗𝖐𝖔༒꧂" aria-label="Kopiraj nadimak">꧁༒𝕸𝖆𝖗𝖐𝖔༒꧂</button>
+      <button class="uname-chip symbol-tile" data-symbol="★彡ʟᴜᴋᴀ彡★" aria-label="Kopiraj nadimak">★彡ʟᴜᴋᴀ彡★</button>
+      <button class="uname-chip symbol-tile" data-symbol="⋆˚࿔ 𝓏𝒶𝓇𝒶 𝜗𝜚˚⋆" aria-label="Kopiraj nadimak">⋆˚࿔ 𝓏𝒶𝓇𝒶 𝜗𝜚˚⋆</button>
+      <button class="uname-chip symbol-tile" data-symbol="꧁✿𝓝𝓲𝓴𝓪✿꧂" aria-label="Kopiraj nadimak">꧁✿𝓝𝓲𝓴𝓪✿꧂</button>
+      <button class="uname-chip symbol-tile" data-symbol="✧˖°ℙ𝕖𝕥𝕣𝕒°˖✧" aria-label="Kopiraj nadimak">✧˖°ℙ𝕖𝕥𝕣𝕒°˖✧</button>
+      <button class="uname-chip symbol-tile" data-symbol="⛧🖤 𝔩𝔲𝔨𝔞 🖤⛧" aria-label="Kopiraj nadimak">⛧🖤 𝔩𝔲𝔨𝔞 🖤⛧</button>
+      <button class="uname-chip symbol-tile" data-symbol="「 ᴍᴀᴛᴇᴏ 」" aria-label="Kopiraj nadimak">「 ᴍᴀᴛᴇᴏ 」</button>
+      <button class="uname-chip symbol-tile" data-symbol="༺ 𝕾𝖍𝖆𝖉𝖔𝖜 ༻" aria-label="Kopiraj nadimak">༺ 𝕾𝖍𝖆𝖉𝖔𝖜 ༻</button>
+      <button class="uname-chip symbol-tile" data-symbol="⋆｡˚ⓝⓘⓝⓐ˚｡⋆" aria-label="Kopiraj nadimak">⋆｡˚ⓝⓘⓝⓐ˚｡⋆</button>
+    </div>
+    <p class="u-mt-15">Želiš celi set gotovih okvira, zvezdica i razdelnika da složiš sopstveni nadimak? Cela paleta je na stranici s <a href="/library/aesthetic-symbols/">ukrasnim simbolima za kopiranje</a> — isti se znakovi lepe u nadimak tvog servera na Discordu.</p>
+  </section>
+
+  <!-- Gde radi + kvadratići -->
+  <section class="editorial-section">
+    <h2>Gde rade fontovi na Discordu (i napomena o kvadratićima)</h2>
+    <p class="editorial-intro">Budući da je ono što kopiraš čisti Unicode, slova za Discord lepe se praktički u svako tekstualno polje aplikacije:</p>
+    <div class="block-example">
+      — <strong>Prikazano ime</strong> i <strong>nadimak na serveru</strong> (zaseban na svakom serveru)<br>
+      — <strong>„O meni”</strong> (bio tvog profila)<br>
+      — <strong>Naziv kanala</strong> (ako imaš administratorska prava)<br>
+      — <strong>Prilagođeni status</strong> i <strong>poruke</strong> u chatu<br>
+      — <strong>Naziv servera</strong> (ako si njegov vlasnik)
+    </div>
+    <p>Jedino mesto gde to <strong>ne</strong> radi jest <strong>korisničko ime (@)</strong>, namerno ograničeno na mala slova, brojke, tačku i podvlaku. Uz to iskrena napomena: ako je uređaj osobe koja to gleda vrlo star, deo rjeđih stilova može se prikazati kao <strong>kvadratići (□)</strong> — to je font koji nedostaje na njezinu uređaju, a ne problem sa tvojim tekstom. Držiš li se osnovnih stilova (podebljano, kurziv, gotica, balončasta, kapitalke) to se gotovo nikad ne dešava. I zapamti: ništa od toga ne traži <strong>Nitro</strong> — Nitro ulazi samo kod boje i gradijenta u imenu, ne kod samog stilizovanog teksta. Za prazne redove u „O meni” dobro će doći <a href="/library/invisible-character/">nevidljivi znak</a>.</p>
+  </section>
+
+  <!-- Related -->
+  <section class="editorial-section">
+    <span class="article-section-label">Povezane stranice</span>
+    <div class="compare-grid">
+      <a href="/sr/" class="compare-card variant-muted u-no-underline">
+        <h4>Lepa Slova</h4>
+        <p>Desetci stilova slova za stilizovanje imena pre nego što ga nalepiš na Discord.</p>
+      </a>
+      <a href="/sr/" class="compare-card variant-muted u-no-underline">
+        <h4>Slova za Kopiranje</h4>
+        <p>Cela abeceda u brojnim rezovima — bold, kurziv, gotica i balončasta.</p>
+      </a>
+      <a href="/library/aesthetic-symbols/" class="compare-card variant-muted u-no-underline">
+        <h4>Ukrasni Simboli za Kopiranje</h4>
+        <p>Zvezdice, srca, okviri i razdelnici za ukrašavanje nadimka i „O meni”.</p>
+      </a>
+      <a href="/library/invisible-character/" class="compare-card variant-muted u-no-underline">
+        <h4>Nevidljivi Znak</h4>
+        <p>Prazan razmak za čiste redove u biju i prazne nazive na Discordu.</p>
+      </a>
+    </div>
+  </section>
+</main>
+
+<footer class="footer">
+  <div class="footer-inner">
+    <h2 class="faq-category">Najčešća pitanja o fontovima za Discord</h2>
+    <div class="faq-item"><button class="faq-question" type="button">Kako promeniti font u nadimku na Discordu?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Upiši svoje ime u polje na vrhu stranice. Odmah će se pojaviti desetine fontova za Discord — podebljano, kurziv, gotička, balončasta, kapitalke. Klikni „Kopiraj” kod onog koji ti se sviđa, otvori Discord, uđi u Korisnička podešavanja i nalepi ga u prikazano ime, ili desnim klikom na serveru promeni nadimak na tom serveru. Budući da su to Unicode znakovi, stilizovano slovo se lepi u polje bez ikakvog dodatka.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Treba li za fontove na Discordu Nitro?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Ne. Slova iz ovog generatora obični su Unicode znakovi, isti kao sa tastature, samo drugačijeg izgleda — zato se lepe u prikazano ime, u nadimak na serveru, u odeljak „O meni”, u naziv kanala i u poruke bez ikakvog Nitra. Nitro je potreban samo za plaćene dodatke, poput boja i gradijenta u imenu (Display Name Styles), a ne za sam stilizovani tekst.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Rade li fontovi u korisničkom imenu (@) na Discordu?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Ne. Korisničko ime (jedinstveni @ koji se koristi za pozivnice prijateljima) prima samo mala slova od a do z, brojke, tačku i podvlaku — bez stilskih fontova, razmaka, emojija ili simbola. Fontovi za Discord rade u prikazanom imenu, u nadimku na serveru, u odeljku „O meni”, u nazivu kanala i u chatu. Ako želiš stil u imenu, koristi prikazano ime, a ne @login.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Po čemu se razlikuje Discordovo oblikovanje (**podebljanje**) od Unicode fontova?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">To su dve različite stvari. Discordov Markdown (**podebljanje**, *kurziv*, `kod`) oblikuje tekst samo unutar poruka u chatu i nestane kad ga pokušaš upotrebiti u imenu ili u biju. Unicode fontovi sa ove stranice sam su stilizovani znak, pa rade svuda — u nadimku, u „O meni”, u nazivu kanala, u statusu i u chatu. Praktično pravilo: u običnoj poruci koristi Markdown, a da stilizuješ nadimak ili bio, koristi Unicode font.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Kako napraviti ukrasni nadimak za Discord s okvirima i simbolima?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Odaberi font za ime (gotica i balončasta izlaze najbolje) i okruži ga okvirima te simbolima u stilu ꧁༒ ༒꧂. Na ovoj stranici je mreža gotovih nadimaka s okvirima — klikni za kopiranje i nalepi u nadimak na serveru. Možeš i da upišeš svoje ime na vrhu, staviti font i upotrebiti kartice Simboli i Okviri da dotjeraš izgled pre kopiranja.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Zašto se slova na Discordu prikazuju kao kvadratići?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Zato što uređaj osobe koja to gleda nema font koji crta taj znak — obično je to stariji telefon ili računar. To nije greška stranice ni tvog kopiranja. Osnovni stilovi — podebljano, kurziv, gotica, balončasta i kapitalke — najsigurniji su i prikazuju se ispravno gotovo svuda. Ako neko prijavi kvadratić (□), zameni jednim od tih stilova.</div></div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Odabir jezika">
+      <a class="lang-option" href="/discord/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/sr/fontovi-za-discord/" hreflang="sr">SR</a>
+    </div>
+  </div>
+</footer>
+
+<div class="copy-toast" id="copyToast">Kopirano!</div>
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/styles.js"></script>
+<script src="/renderer.js"></script>
+<script src="/script.js" defer=""></script>
+<script src="/symbol-explorer.js"></script>
+<script src="/footer.js"></script>
+</body></html>

--- a/sr/fontovi-za-instagram/index.html
+++ b/sr/fontovi-za-instagram/index.html
@@ -1,0 +1,310 @@
+<!DOCTYPE html><html lang="sr"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Fontovi za Instagram: lepa slova za bio i opise | UltraTextGen</title>
+  <meta name="description" content="Fontovi za Instagram besplatno: pretvori tekst u 𝗽𝗼𝗱𝗲𝗯𝗹𝗷𝗮𝗻𝗼, 𝘬𝘶𝘳𝘻𝘪𝘷 ili 𝓴𝓪𝓵𝓲𝓰𝓻𝓪𝓯𝓲𝓳𝓾 i nalepi u bio, u ime profila, u opis i u komentare. Lepa slova za Instagram — bez aplikacije.">
+  <link rel="canonical" href="https://ultratextgen.com/sr/fontovi-za-instagram/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/instagram/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/instagram/">
+  <link rel="alternate" hreflang="sr" href="https://ultratextgen.com/sr/fontovi-za-instagram/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Fontovi za Instagram: lepa slova za bio i opise">
+  <meta property="og:description" content="Generator fontova za Instagram: upiši tekst i nalepi stilizovano slovo u bio, u ime profila, u opis i u komentare. Podebljano, kurziv, kaligrafija i gotica — bez aplikacije.">
+  <meta property="og:url" content="https://ultratextgen.com/sr/fontovi-za-instagram/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/instagram.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Fontovi za Instagram: lepa slova za bio i opise">
+  <meta name="twitter:description" content="Podebljano, kurziv, kaligrafija i gotica spremni za lepljenje u bio i ime profila na Instagramu — bez aplikacije.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/instagram.png">
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+  <link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Generator Fontova za Instagram",
+  "alternateName": ["Fontovi za Instagram", "Fontovi za Instu", "Lepa slova za Instagram", "Fontovi za bio na Instagramu", "Generator fontova za IG", "Slova za Instagram"],
+  "url": "https://ultratextgen.com/sr/fontovi-za-instagram/",
+  "inLanguage": "sr-Latn",
+  "applicationCategory": "UtilitiesApplication",
+  "operatingSystem": "Any",
+  "description": "Generator fontova za Instagram: pretvara tvoj tekst u stilizovana slova — podebljano, kurziv, kaligrafiju, goticu, balončasta i kapitalke — za lepljenje u bio, u ime profila, u opis objave, u komentare i u Priče, bez preuzimanja aplikacije.",
+  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "RSD" }
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "sr-Latn",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Kako promeniti font u biju na Instagramu?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Upiši svoj tekst u polje na vrhu stranice. Odmah će se pojaviti desetine fontova za Instagram — podebljano, kurziv, kaligrafija, gotica, balončasta i kapitalke. Klikni „Kopiraj” kod onog koji ti se sviđa, otvori Instagram, uđi u Uredi profil i nalepi ga u polje Bio. Budući da su to Unicode znakovi, stilizovano slovo se lepi u polje bez ikakve aplikacije ni dodatne tastature." }
+    },
+    {
+      "@type": "Question",
+      "name": "Kako napraviti drugačiji font u imenu profila na Instagramu?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Kopiraj ovde odabrani font i nalepi ga u polje „Ime” u Uredi profil — to je ono podebljano ime na vrhu profila, a ne @login. Instagram prihvata Unicode u tom polju, pa se stilizovano slovo prikazuje ispravno. Samo imaj na umu da Instagram dozvoljava promenu Imena ograničen broj puta u kratkom periodu (obično dvaput u 14 dana), pa nalepi odmah gotov stil." }
+    },
+    {
+      "@type": "Question",
+      "name": "Može li se koristiti ukrasni font u korisničkom imenu (@) na Instagramu?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Ne. Korisničko ime (@login koji je u tvom linku i služi za označavanje) prima samo mala slova od a do z, brojke, tačku i podvlaku — bez stilskih fontova, razmaka, emojija ili simbola. Fontovi za Instagram rade u imenu profila (Ime), u biju, u opisima i u komentarima. Ako želiš stil u imenu, koristi polje Ime, a ne @login." }
+    },
+    {
+      "@type": "Question",
+      "name": "Rade li fontovi u opisima objava i u komentarima na Instagramu?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Da. Budući da su to obični Unicode znakovi, stilizovano slovo lepiš u opis fotografije i reela, u komentare, u tekst u Pričama i u poruke na Directu. Radi jednako u aplikaciji na telefonu i u verziji za pregledač. Jedino polje koje to ne prima jest @login (korisničko ime)." }
+    },
+    {
+      "@type": "Question",
+      "name": "Šteti li stilizovani font u biju prikazu u pretrazi na Instagramu?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Može štetiti ako sve stilizuješ. Pretraga i čitači ekrana bolje razumiju običan tekst, pa je najbolje stilizujeti samo ime ili jednu kratku frazu, a važne ključne reči — čime se baviš, tvoj grad, tvoja niša — ostaviti običnim fontom. Tada profil izgleda lepo i i dalje ga je lako pronaći." }
+    },
+    {
+      "@type": "Question",
+      "name": "Zašto se font na Instagramu prikazuje kao kvadratić?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Zato što uređaj osobe koja to gleda nema font koji crta taj znak — obično je to stariji telefon ili računar. To nije greška stranice ni tvog kopiranja. Osnovni stilovi — podebljano, kurziv, kaligrafija, gotica, balončasta i kapitalke — najsigurniji su i prikazuju se ispravno gotovo svuda. Ako vidiš kvadratić (□), zameni jednim od tih stilova." }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "inLanguage": "sr-Latn",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Početna", "item": "https://ultratextgen.com/sr/" },
+    { "@type": "ListItem", "position": 2, "name": "Fontovi za Instagram", "item": "https://ultratextgen.com/sr/fontovi-za-instagram/" }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/sr/">Početna</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Fontovi za Instagram</span>
+</nav>
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/instagram.svg" width="1200" height="340" loading="lazy" alt="">
+</figure>
+
+<section class="hero">
+  <div class="hero-inner">
+    <div class="hero-card">
+      <h1 class="hero-headline">Fontovi za Instagram: lepa slova za bio i opise</h1>
+      <p class="hero-tagline">Upiši tekst i vidi ga odmah u desetinama fontova za Instagram — podebljano, kurziv, kaligrafija, gotica, balončasta i kapitalke. Kopiraš i lepiš u bio, u ime profila, u opis objave i u komentare. Sve besplatno i <strong>bez aplikacije</strong>.</p>
+      <div class="input-wrapper">
+        <textarea class="main-input" id="mainInput" placeholder="Upiši tekst za bio ili opis..." maxlength="500" autofocus=""></textarea>
+        <span class="char-count"><span id="charCount">0</span>/500</span>
+      </div>
+      <div class="decoration-section">
+        <div class="decoration-label">Dodaj simbole i okvire rezultatu</div>
+        <div class="decoration-tabs">
+          <button class="decoration-tab active" data-deco-tab="symbols">Simboli</button>
+          <button class="decoration-tab" data-deco-tab="frames">Okviri</button>
+          <button class="decoration-tab" data-deco-tab="dividers">Razdelnici</button>
+          <button class="decoration-tab" data-deco-tab="arrows">Strelice</button>
+          <button class="decoration-tab" data-deco-tab="minimal">Minimalni</button>
+          <button class="decoration-tab" data-deco-tab="emojis">Emoji</button>
+        </div>
+        <div class="decoration-grid" id="decorationGrid"></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<main class="container">
+  <div class="category-section"><div class="category-tabs" id="categoryTabs"></div></div>
+  <div class="results-grid" id="resultsGrid"></div>
+
+  <!-- Kako to radi -->
+  <section class="editorial-section">
+    <h2>Fontovi za Instagram: kako to radi</h2>
+    <p class="editorial-intro"><strong>Fontovi za Instagram</strong> sa ove stranice nisu instalirani font ni slika — to su <strong>Unicode znakovi</strong>, prava slova, ista kao sa tastature, samo drugačijeg izgleda (𝗔, 𝘈, 𝓐, 𝔄). Budući da Instagram prihvata Unicode u gotovo svakom tekstualnom polju, stilizovano slovo lepi se ravno u tvoj <strong>bio</strong>, u <strong>ime profila</strong>, u <strong>opis objave</strong>, u <strong>komentare</strong>, u tekst u <strong>Pričama</strong> i u poruke na <strong>Directu</strong> — bez aplikacije, dodatka ili posebne tastature.</p>
+    <div class="block-example">
+      <strong>Primer:</strong> „ana” → 𝗮𝗻𝗮 (podebljano), 𝘢𝘯𝘢 (kurziv), 𝒶𝓃𝒶 (kaligrafija), 𝔞𝔫𝔞 (gotička), ⓐⓝⓐ (balončasta), ᴀɴᴀ (kapitalke)
+    </div>
+    <p>Koristi se u nekoliko sekundi: upišeš tekst u polje na vrhu, generator ga prikaže u brojnim <strong>fontovima za Instagram</strong>, klikneš „Kopiraj” i nalepiš u aplikaciji. Želiš samo gola slova abecede? Odmah su ispod. A ako radije pregledavaš još rezova, potpuni generator naći ćeš na <a href="/sr/">glavnoj stranici sa slovima za kopiranje</a>.</p>
+  </section>
+
+  <!-- Abeceda A-Z -->
+  <section class="editorial-section glyph-section">
+    <h2>Abeceda fontova za Instagram (A–Z za kopiranje)</h2>
+    <p class="editorial-intro">Cela abeceda u stilovima koji se najčešće pojavljuju u biju i opisima na Instagramu. Klikni redak da kopiraš celu abecedu u tom stilu, ili upiši svoj tekst na vrhu i uzmi sopstvenu reč odmah stilizovanu.</p>
+    <div class="alpha-list">
+      <div class="alpha-row">
+        <span class="alpha-label">Podebljano</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝗔𝗕𝗖𝗗𝗘𝗙𝗚𝗛𝗜𝗝𝗞𝗟𝗠𝗡𝗢𝗣𝗤𝗥𝗦𝗧𝗨𝗩𝗪𝗫𝗬𝗭 𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇" aria-label="Kopiraj podebljanu abecedu">𝗔𝗕𝗖𝗗𝗘𝗙𝗚𝗛𝗜𝗝𝗞𝗟𝗠𝗡𝗢𝗣𝗤𝗥𝗦𝗧𝗨𝗩𝗪𝗫𝗬𝗭 · 𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Kurziv</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩 𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃" aria-label="Kopiraj abecedu u kurzivu">𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩 · 𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Elegantno</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵 𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏" aria-label="Kopiraj elegantnu abecedu">𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵 · 𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Gotička</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="𝔄𝔅ℭ𝔇𝔈𝔉𝔊ℌℑ𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔ℜ𝔖𝔗𝔘𝔙𝔚𝔛𝔜ℨ 𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷" aria-label="Kopiraj gotičku abecedu">𝔄𝔅ℭ𝔇𝔈𝔉𝔊ℌℑ𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔ℜ𝔖𝔗𝔘𝔙𝔚𝔛𝔜ℨ · 𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Balončasta</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ" aria-label="Kopiraj balončastu abecedu">ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ · ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ</button>
+      </div>
+      <div class="alpha-row">
+        <span class="alpha-label">Kapitalke</span>
+        <button class="glyph-copy alpha-glyphs" type="button" data-text="ᴀʙᴄᴅᴇꜰɢʜɪᴊᴋʟᴍɴᴏᴘqʀsᴛᴜᴠᴡxʏᴢ" aria-label="Kopiraj abecedu u kapitalkama">ᴀ ʙ ᴄ ᴅ ᴇ ꜰ ɢ ʜ ɪ ᴊ ᴋ ʟ ᴍ ɴ ᴏ ᴘ q ʀ s ᴛ ᴜ ᴠ ᴡ x ʏ ᴢ</button>
+      </div>
+    </div>
+    <p class="uname-note">Napomena o srpskim znakovima: ovi Unicode fontovi obuhvataju osnovnu abecedu A–Z. Srpske kvačice (č, ć, đ, š, ž) u većini stilova ostaju obična slova usred stilizovane reči — pa npr. „ana” izađe savršeno, a „nataša” prikaže š kao obično slovo. Za bio i imena bez kvačica izgleda savršeno, a za duže opise najsigurniji su podebljano i kurziv.</p>
+    <p class="u-mt-15">Želiš se udubiti u jedan stil? Celu abecedu i varijante svakog reza naći ćeš na <a href="/sr/">glavnoj stranici sa slovima za kopiranje</a>, a najpopularniji za bio na Instagramu je <a href="/sr/kurziv/">kurziv</a>.</p>
+  </section>
+
+  <!-- Fontovi za bio i ime -->
+  <section class="editorial-section">
+    <h2>Fontovi za bio i ime profila na Instagramu</h2>
+    <p class="editorial-intro">Najbrži način da istakneš profil jest staviti font na <strong>ime profila</strong> (polje „Ime”) i zasebno u <strong>bio</strong>. To su dva različita polja — „Ime” je ono podebljano ime na vrhu profila, a bio je opis ispod njega. Instagram prihvata Unicode u oba, ali <strong>ne u @loginu</strong>.</p>
+    <p class="uname-note">Kako nalepiti:</p>
+    <div class="block-example">
+      — <strong>Ime profila (Ime):</strong> Uredi profil › polje „Ime” › nalepi stilizovani font<br>
+      — <strong>Bio:</strong> Uredi profil › polje „Bio” › nalepi tekst (možeš da spajaš više stilova u zasebnim redovima)<br>
+      — <strong>Opis objave / reela:</strong> pri dodavanju objave nalepi font u polje opisa<br>
+      — <strong>Komentari i Direct:</strong> nalepi stilizovano slovo ravno u polje komentara ili poruke
+    </div>
+    <p>Savet od nekoga tko svakodnevno slaže profile: stilizuj samo ime ili jednu frazu, a ostatak bija ostavi običnim tekstom — kontrast čini ceo efekat. Kad je sve ukrašeno, ništa ne privlači pogled. Važan detalj: Instagram dozvoljava promenu polja „Ime” samo ograničen broj puta u kratkom periodu, pa nalepi odmah gotov stil. Za pojedinačne zvezdice i sjaj u biju svrati na stranicu s <a href="/library/aesthetic-symbols/">ukrasnim simbolima za kopiranje</a>.</p>
+  </section>
+
+  <!-- Gde radi i gde ne -->
+  <section class="editorial-section">
+    <h2>Gde ćeš nalepiti fontove na Instagramu (a gde ne)</h2>
+    <p class="editorial-intro">Budući da je ono što kopiraš čisti Unicode, slova za Instagram lepe se praktički u svako tekstualno polje aplikacije:</p>
+    <div class="block-example">
+      — <strong>Ime profila (Ime)</strong> i <strong>bio</strong><br>
+      — <strong>Opisi objava</strong> i <strong>reelova</strong><br>
+      — <strong>Komentari</strong> ispod objava<br>
+      — <strong>Tekst u Pričama</strong> i <strong>bilješke (Notes)</strong><br>
+      — <strong>Poruke na Directu</strong>
+    </div>
+    <p>Jedino mesto gde to <strong>ne</strong> radi jest <strong>korisničko ime (@login)</strong> — Instagram ga namerno ograničava na mala slova od a do z, brojke, tačku i podvlaku, pa nikakav stilizovani font, razmak ni emoji tu ne prolazi. Uz to iskrena napomena: ako je uređaj osobe koja to gleda vrlo star, deo rjeđih stilova može se prikazati kao <strong>kvadratići (□)</strong> — to je font koji nedostaje na njezinu uređaju, a ne problem sa tvojim tekstom. Držiš li se osnovnih stilova (podebljano, kurziv, kaligrafija, gotica, balončasta, kapitalke) to se gotovo nikad ne dešava. Za čiste prazne redove u biju dobro će doći <a href="/library/invisible-character/">nevidljivi znak</a>.</p>
+  </section>
+
+  <!-- Ukrasni bio sa simbolima -->
+  <section class="editorial-section">
+    <h2>Ukrasni bio i imena za Instagram sa simbolima</h2>
+    <p class="editorial-intro">Imena i redovi bija koji najviše ostavljaju dojam na Instagramu spajaju nežan font (kaligrafiju ili kurziv) sa zvezdicama i simbolima sa obe strane, u stilu ⋆˚₊‧ ‧₊˚⋆. Klikni za kopiranje i nalepi u polje „Ime” ili u bio — potom zameni svojom rečju.</p>
+    <div class="uname-grid">
+      <button class="uname-chip symbol-tile" data-symbol="⋆˚₊‧ 𝒶𝓃𝒶 ‧₊˚⋆" aria-label="Kopiraj ime">⋆˚₊‧ 𝒶𝓃𝒶 ‧₊˚⋆</button>
+      <button class="uname-chip symbol-tile" data-symbol="✿ 𝓶𝓪𝓳𝓪 ✿" aria-label="Kopiraj ime">✿ 𝓶𝓪𝓳𝓪 ✿</button>
+      <button class="uname-chip symbol-tile" data-symbol="꒰ঌ 𝓃𝒾𝓀𝒶 ໒꒱" aria-label="Kopiraj ime">꒰ঌ 𝓃𝒾𝓀𝒶 ໒꒱</button>
+      <button class="uname-chip symbol-tile" data-symbol="⋆｡˚ 𝓮𝓶𝓪 ˚｡⋆" aria-label="Kopiraj ime">⋆｡˚ 𝓮𝓶𝓪 ˚｡⋆</button>
+      <button class="uname-chip symbol-tile" data-symbol="✧˖° 𝓵𝓾𝓬𝓲𝓳𝓪 °˖✧" aria-label="Kopiraj ime">✧˖° 𝓵𝓾𝓬𝓲𝓳𝓪 °˖✧</button>
+      <button class="uname-chip symbol-tile" data-symbol="ᯓ★ 𝓅ℯ𝓉𝓇𝒶 ★" aria-label="Kopiraj ime">ᯓ★ 𝓅ℯ𝓉𝓇𝒶 ★</button>
+      <button class="uname-chip symbol-tile" data-symbol="˚ʚ 𝓁𝒶𝓃𝒶 ɞ˚" aria-label="Kopiraj ime">˚ʚ 𝓁𝒶𝓃𝒶 ɞ˚</button>
+      <button class="uname-chip symbol-tile" data-symbol="⊹ ࣪ ˖ 𝓀𝓁𝒶𝓇𝒶 ˖ ࣪ ⊹" aria-label="Kopiraj ime">⊹ ࣪ ˖ 𝓀𝓁𝒶𝓇𝒶 ˖ ࣪ ⊹</button>
+      <button class="uname-chip symbol-tile" data-symbol="⟡ 𝓲𝓿𝓪 ⟡" aria-label="Kopiraj ime">⟡ 𝓲𝓿𝓪 ⟡</button>
+      <button class="uname-chip symbol-tile" data-symbol="๑ 𝓼𝓪𝓻𝓪 ๑" aria-label="Kopiraj ime">๑ 𝓼𝓪𝓻𝓪 ๑</button>
+    </div>
+    <p class="u-mt-15">Želiš celi set gotovih zvezdica, srca i razdelnika da složiš sopstveni bio? Cela paleta je na stranici s <a href="/library/aesthetic-symbols/">ukrasnim simbolima za kopiranje</a> — isti se znakovi lepe u ime i u bio na Instagramu.</p>
+  </section>
+
+  <!-- Pretraga i kvadratići -->
+  <section class="editorial-section">
+    <h2>Fontovi i pretraga na Instagramu (i napomena o kvadratićima)</h2>
+    <p class="editorial-intro">Stilizovani tekst izgleda sjajno, ali ima jednu kvaku: pretraga Instagrama i čitači ekrana tretiraju Unicode znakove drugačije od običnih slova. Ako stilizuješ celi bio, tvoje ključne reči mogu slabije iskakati u pretrazi.</p>
+    <div class="block-example">
+      — <strong>Dobra praksa:</strong> stilizuj ime ili kratku frazu, ostalo ostavi običnim tekstom<br>
+      — <strong>Ostavi običnim fontom:</strong> čime se baviš, grad, niša, reči po kojima te traže<br>
+      — <strong>Primer:</strong> 𝓶𝓪𝓳𝓪 𝓴𝓸𝓿𝓪č𝓲ć (kaligrafija) + „venčana fotografija · Beograd” običnim fontom
+    </div>
+    <p>Druga stvar su <strong>kvadratići (□)</strong>: kad neko na mestu slova vidi prazan pravougaonik, to znači da njegov uređaj nema font koji crta taj znak — obično vrlo star telefon. To nije problem sa tvojim tekstom ni s kopiranjem. Držiš li se osnovnih stilova, to se gotovo nikad ne dešava. Za prazne redove i razmake u biju dobro će doći <a href="/library/invisible-character/">nevidljivi znak</a>, a snažniji, taman stil za ime naći ćeš u <a href="/sr/goticka-slova/">gotičkim slovima</a>.</p>
+  </section>
+
+  <!-- Related -->
+  <section class="editorial-section">
+    <span class="article-section-label">Povezane stranice</span>
+    <div class="compare-grid">
+      <a href="/sr/" class="compare-card variant-muted u-no-underline">
+        <h4>Slova za Kopiranje</h4>
+        <p>Cela abeceda u brojnim rezovima — podebljano, kurziv, kaligrafija i balončasta.</p>
+      </a>
+      <a href="/sr/kurziv/" class="compare-card variant-muted u-no-underline">
+        <h4>Kurziv</h4>
+        <p>Ukrasni, rukopisni kurziv — najčešći izbor za bio na Instagramu.</p>
+      </a>
+      <a href="/library/aesthetic-symbols/" class="compare-card variant-muted u-no-underline">
+        <h4>Ukrasni Simboli za Kopiranje</h4>
+        <p>Zvezdice, srca, okviri i razdelnici za ukrašavanje imena i bija.</p>
+      </a>
+      <a href="/library/invisible-character/" class="compare-card variant-muted u-no-underline">
+        <h4>Nevidljivi Znak</h4>
+        <p>Prazan razmak za čiste redove i odmake u biju na Instagramu.</p>
+      </a>
+      <a href="/sr/goticka-slova/" class="compare-card variant-muted u-no-underline">
+        <h4>Gotička Slova</h4>
+        <p>Tamna, snažna slova za ime profila s karakterom.</p>
+      </a>
+    </div>
+  </section>
+</main>
+
+<footer class="footer">
+  <div class="footer-inner">
+    <h2 class="faq-category">Najčešća pitanja o fontovima za Instagram</h2>
+    <div class="faq-item"><button class="faq-question" type="button">Kako promeniti font u biju na Instagramu?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Upiši svoj tekst u polje na vrhu stranice. Odmah će se pojaviti desetine fontova za Instagram — podebljano, kurziv, kaligrafija, gotica, balončasta i kapitalke. Klikni „Kopiraj” kod onog koji ti se sviđa, otvori Instagram, uđi u Uredi profil i nalepi ga u polje Bio. Budući da su to Unicode znakovi, stilizovano slovo se lepi u polje bez ikakve aplikacije ni dodatne tastature.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Kako napraviti drugačiji font u imenu profila na Instagramu?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Kopiraj ovde odabrani font i nalepi ga u polje „Ime” u Uredi profil — to je ono podebljano ime na vrhu profila, a ne @login. Instagram prihvata Unicode u tom polju, pa se stilizovano slovo prikazuje ispravno. Samo imaj na umu da Instagram dozvoljava promenu Imena ograničen broj puta u kratkom periodu (obično dvaput u 14 dana), pa nalepi odmah gotov stil.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Može li se koristiti ukrasni font u korisničkom imenu (@) na Instagramu?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Ne. Korisničko ime (@login koji je u tvom linku i služi za označavanje) prima samo mala slova od a do z, brojke, tačku i podvlaku — bez stilskih fontova, razmaka, emojija ili simbola. Fontovi za Instagram rade u imenu profila (Ime), u biju, u opisima i u komentarima. Ako želiš stil u imenu, koristi polje Ime, a ne @login.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Rade li fontovi u opisima objava i u komentarima na Instagramu?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Da. Budući da su to obični Unicode znakovi, stilizovano slovo lepiš u opis fotografije i reela, u komentare, u tekst u Pričama i u poruke na Directu. Radi jednako u aplikaciji na telefonu i u verziji za pregledač. Jedino polje koje to ne prima jest @login (korisničko ime).</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Šteti li stilizovani font u biju prikazu u pretrazi na Instagramu?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Može štetiti ako sve stilizuješ. Pretraga i čitači ekrana bolje razumiju običan tekst, pa je najbolje stilizujeti samo ime ili jednu kratku frazu, a važne ključne reči — čime se baviš, tvoj grad, tvoja niša — ostaviti običnim fontom. Tada profil izgleda lepo i i dalje ga je lako pronaći.</div></div>
+    <div class="faq-item"><button class="faq-question" type="button">Zašto se font na Instagramu prikazuje kao kvadratić?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Zato što uređaj osobe koja to gleda nema font koji crta taj znak — obično je to stariji telefon ili računar. To nije greška stranice ni tvog kopiranja. Osnovni stilovi — podebljano, kurziv, kaligrafija, gotica, balončasta i kapitalke — najsigurniji su i prikazuju se ispravno gotovo svuda. Ako vidiš kvadratić (□), zameni jednim od tih stilova.</div></div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Odabir jezika">
+      <a class="lang-option" href="/instagram/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/sr/fontovi-za-instagram/" hreflang="sr">SR</a>
+    </div>
+  </div>
+</footer>
+
+<div class="copy-toast" id="copyToast">Kopirano!</div>
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script>window.UTG_PREVIEW_PLATFORM='instagram';window.UTG_SHOW_PLATFORMS=true;window.UTG_DEMO_TEXT='ana aesthetic\nlink u biju ⬇';</script>
+<script src="/styles.js"></script>
+<script src="/renderer.js"></script>
+<script src="/script.js" defer=""></script>
+<script src="/symbol-explorer.js"></script>
+<script src="/footer.js" defer></script>
+</body></html>

--- a/sr/goticka-slova/index.html
+++ b/sr/goticka-slova/index.html
@@ -1,0 +1,299 @@
+<!DOCTYPE html><html lang="sr"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZGVh");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Generator Gotičkih Slova — 𝔤𝔬𝔱𝔦𝔠𝔞 za kopiranje | UltraTextGen</title>
+  <meta name="description" content="Besplatan generator gotičkih slova: pretvori tekst u gotičke Unicode znakove (fraktura) za kopiranje i lepljenje — u bio na Instagramu, Discord, TikTok, nadimke i skice tetovaža. Odmah, bez registracije.">
+  <link rel="canonical" href="https://ultratextgen.com/sr/goticka-slova/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/category/gothic-fonts/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/category/gothic-fonts/">
+  <link rel="alternate" hreflang="sr" href="https://ultratextgen.com/sr/goticka-slova/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Generator Gotičkih Slova — 𝔤𝔬𝔱𝔦𝔠𝔞 za kopiranje | UltraTextGen">
+  <meta property="og:description" content="Besplatan generator gotičkih slova — gotički Unicode znakovi (fraktura) za kopiranje i lepljenje na Instagram, Discord, TikTok i u nadimke. Odmah, bez registracije.">
+  <meta property="og:url" content="https://ultratextgen.com/sr/goticka-slova/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category-gothic-fonts.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Generator Gotičkih Slova — 𝔤𝔬𝔱𝔦𝔠𝔞 za kopiranje | UltraTextGen">
+  <meta name="twitter:description" content="Besplatan generator gotičkih slova — gotički Unicode znakovi (fraktura) za kopiranje i lepljenje na društvene mreže, Discord i u nadimke.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category-gothic-fonts.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "sr-Latn",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Šta je generator gotičkih slova i kako radi?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Pretvara slova koja upišeš u gotičke Unicode znakove (𝔭𝔬𝔭𝔲𝔱 𝔬𝔳𝔦𝔥) — prave znakove iz porodice frakture, a ne font ni sliku. Budući da su to obični tekstualni znakovi, možeš da ih kopiraš i nalepiš svuda gde je dozvoljen tekst: u bio, opise, komentare, nadimke i poruke. Više u našem vodiču o tome kako rade Unicode fontovi."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Radi li gotički tekst na Instagramu, Discordu, TikToku i u drugim aplikacijama?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da. Bio, opisi, komentari, nazivi kanala na Discordu i poruke na chatu bez problema primaju gotičke znakove jer je to običan Unicode. Sjajno se pokaže u nadimcima i profilima goth, metal ili srednjovjekovnog ugođaja. Napomena: neka polja s @korisničkim imenom filtriraju nestandardne znakove — u samom handleu treba ostati na običnom tekstu, ali u biju i opisima gotica radi bez prepreka."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Po čemu se razlikuje gotica (fraktura) od podebljane gotice?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "To su dve varijante istog stila. Obična fraktura (𝔤𝔬𝔱𝔦𝔠𝔞) tanja je i klasičnija, a podebljana gotica (𝖌𝖔𝖙𝖎𝖈𝖆) ima deblje, snažnije poteze i bolje izgleda u kratkim naslovima i nadimcima. U rezultatima ispod naći ćeš obe varijante — dovoljno je kliknuti onu koja odgovara tvom projektu i kopirati."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Mogu li pisati srpske znakove (č, ć, đ, š, ž) gotičkim slovima?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Unicode gotica obuhvata A–Z i a–z, pa srpski znakovi poput č, ć, đ, š, ž nemaju sopstveni gotički oblik i ostaju obični. Za dosledan gotički efekat možeš da ih zameniš osnovnim slovima (c, d, s, z) — to menja pravopis — ili ih ostaviti u normalnom obliku, što u kratkom tekstu, nadimku ili naslovu obično ionako izgleda dobro."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Je li generator gotičkih slova besplatan?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da, potpuno besplatan i bez registracije. Upisuj, kopiraj i lepi koliko god puta želiš — nema ograničenja ni skrivenih troškova."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Zašto se neka gotička slova prikazuju kao kvadratići ili izgledaju drugačije?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Prazni kvadratić (▯) znači da uređaj nema odgovarajući glif za taj gotički znak — to se obično odnosi na starije sisteme. Osim toga, nekoliko velikih slova frakture (C, H, I, R, Z) dolazi iz drugog Unicode bloka i izgleda drugačije od ostatka abecede — to je normalno. Odaberi tada podebljanu varijantu gotice ili ažuriraj uređaj; više u članku o tome zašto se fontovi prikazuju kao kvadratići."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "inLanguage": "sr-Latn",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Početna", "item": "https://ultratextgen.com/sr/" },
+    { "@type": "ListItem", "position": 2, "name": "Gotička slova", "item": "https://ultratextgen.com/sr/goticka-slova/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Generator Gotičkih Slova",
+  "alternateName": ["Gotička slova","Gotički tekst","Gotica za kopiranje","Unicode fraktura","Gotička slova za tetovažu","Generator gotice","Gotički font","Blackletter na srpskom"],
+  "url": "https://ultratextgen.com/sr/goticka-slova/",
+  "inLanguage": "sr-Latn",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "RSD"
+  },
+  "description": "Besplatan generator gotičkih slova: pretvori tekst u gotičke Unicode znakove (fraktura i podebljana gotica) za kopiranje i lepljenje na Instagram, Discord, TikTok, u nadimke i skice tetovaža.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/sr/">Početna</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Gotička slova</span>
+</nav>
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/category-gothic-fonts.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+  <!-- Hero -->
+  <section class="hero">
+    <div class="hero-inner">
+      <div class="hero-card">
+        <h1 class="hero-headline">Generator Gotičkih Slova</h1>
+        <p class="hero-tagline">Pretvori bilo koji tekst u 𝔤𝔬𝔱𝔦𝔠𝔲 za kopiranje i lepljenje — mračna,
+          ukrasna Unicode slova (fraktura i podebljana gotica) za bio, nadimke i naslove. Besplatno, odmah, bez registracije.</p>
+        <div class="input-wrapper">
+          <textarea class="main-input" id="mainInput" placeholder="Upiši tekst, reč ili ime…" maxlength="500" autofocus></textarea>
+          <span class="char-count"><span id="charCount">0</span>/500</span>
+        </div>
+
+        <!-- Decoration Selector -->
+        <div class="decoration-section">
+          <div class="decoration-label">
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"></path>
+            </svg>
+            Dodaj simbole oko rezultata
+          </div>
+          <div class="decoration-tabs">
+            <button class="decoration-tab active" data-deco-tab="symbols">Simboli</button>
+            <button class="decoration-tab" data-deco-tab="frames">Okviri</button>
+            <button class="decoration-tab" data-deco-tab="dividers">Razdelnici</button>
+            <button class="decoration-tab" data-deco-tab="minimal">Minimalni</button>
+            <button class="decoration-tab" data-deco-tab="emojis">Emoji</button>
+          </div>
+          <div class="decoration-grid" id="decorationGrid"></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Main Content -->
+  <main class="container">
+
+    <section class="editorial-section">
+      <span class="article-section-label">Gotička Unicode slova</span>
+      <h2>Gotički tekst za kopiranje — za bio, nadimke i tetovaže</h2>
+      <p>Ova slova nisu font ni slika, nego pravi <strong>Unicode znakovi</strong> iz porodice frakture. Daj
+        svom biju goth ugođaj, napravi mračan nadimak ili pripremi natpis u srednjovjekovnom ili metal stilu — gotica
+        sjajno paše i uz skice tetovaža. Upiši tekst iznad, klikni <strong>Kopiraj</strong> i nalepi
+        gotička slova gde god želiš.</p>
+    </section>
+
+    <!-- Category Tabs (populated by script.js) -->
+    <div class="category-section">
+      <div class="category-tabs" id="categoryTabs"></div>
+    </div>
+
+    <!-- Results -->
+    <div class="results-grid" id="resultsGrid"></div>
+
+    <section class="editorial-section">
+      <span class="article-section-label">Povezano</span>
+      <p>Spoji goticu s <a href="/sr/podebljana-slova/">podebljanim slovima</a>,
+        <a href="/library/aesthetic-symbols/">ukrasnim simbolima</a> ili <a href="/library/invisible-character/">nevidljivim znakom</a>
+        za čiste razmake. Za skice tetovaža dobro će doći <a href="/usecase/tattoo-fonts/">generator fontova za tetovažu</a>,
+        a za okomite rasporede — <a href="/usecase/vertical-text/">okomiti tekst</a>.</p>
+    </section>
+  </main>
+
+  <!-- Footer + FAQ -->
+  <footer class="footer">
+    <div class="footer-inner">
+<div class="faq-section" id="gothic-faq">
+
+<h2 class="faq-category">Generator Gotičkih Slova — FAQ</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Šta je generator gotičkih slova i kako radi?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Pretvara slova koja upišeš u gotičke Unicode znakove (𝔭𝔬𝔭𝔲𝔱 𝔬𝔳𝔦𝔥) — prave znakove iz porodice frakture, a ne font ni sliku. Budući da su to obični tekstualni znakovi, možeš da ih kopiraš i nalepiš svuda gde je dozvoljen tekst: u bio, opise, komentare, nadimke i poruke. Više u našem <a href="/guide/how-unicode-fonts-work/">vodiču o tome kako rade Unicode fontovi</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Radi li gotički tekst na Instagramu, Discordu, TikToku i u drugim aplikacijama?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Da. Bio, opisi, komentari, nazivi kanala na Discordu i poruke na chatu bez problema primaju gotičke znakove jer je to običan Unicode. Sjajno se pokaže u nadimcima i profilima goth, metal ili srednjovjekovnog ugođaja. Napomena: neka polja s <strong>@korisničkim imenom</strong> filtriraju nestandardne znakove — u samom handleu treba ostati na običnom tekstu, ali u biju i opisima gotica radi bez prepreka.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Po čemu se razlikuje gotica (fraktura) od podebljane gotice?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    To su dve varijante istog stila. Obična fraktura (𝔤𝔬𝔱𝔦𝔠𝔞) tanja je i klasičnija, a podebljana gotica (𝖌𝖔𝖙𝖎𝖈𝖆) ima deblje, snažnije poteze i bolje izgleda u kratkim naslovima i nadimcima. U rezultatima ispod naći ćeš obe varijante — dovoljno je kliknuti onu koja odgovara tvom projektu i kopirati.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Mogu li pisati srpske znakove (č, ć, đ, š, ž) gotičkim slovima?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Unicode gotica obuhvata A–Z i a–z, pa srpski znakovi poput č, ć, đ, š, ž nemaju sopstveni gotički oblik i ostaju obični. Za dosledan gotički efekat možeš da ih zameniš osnovnim slovima (<strong>c, d, s, z</strong>) — to menja pravopis — ili ih ostaviti u normalnom obliku, što u kratkom tekstu, nadimku ili naslovu obično ionako izgleda dobro.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Je li generator gotičkih slova besplatan?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Da, potpuno besplatan i bez registracije. Upisuj, kopiraj i lepi koliko god puta želiš — nema ograničenja ni skrivenih troškova.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Zašto se neka gotička slova prikazuju kao kvadratići ili izgledaju drugačije?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Prazni kvadratić (▯) znači da uređaj nema odgovarajući glif za taj gotički znak — to se obično odnosi na starije sisteme. Osim toga, nekoliko velikih slova frakture (C, H, I, R, Z) dolazi iz drugog Unicode bloka i izgleda drugačije od ostatka abecede — to je normalno. Odaberi tada podebljanu varijantu gotice ili ažuriraj uređaj; više u članku o tome, <a href="/guide/why-fonts-show-as-boxes/">zašto se fontovi prikazuju kao kvadratići</a>.
+  </div>
+</div>
+
+</div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Odabir jezika">
+      <a class="lang-option" href="/category/gothic-fonts/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/sr/goticka-slova/" hreflang="sr">SR</a>
+    </div>
+
+    </div>
+  </footer>
+
+  <div class="copy-toast" id="copyToast">Kopirano!</div>
+
+  <script>
+    window.UTG_FAMILY = "gothic";
+    window.UTG_DEMO_TEXT = "gotička slova\ngotički tekst";
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/script.js" defer></script>
+  <script src="/footer.js" defer></script>
+</body></html>

--- a/sr/index.html
+++ b/sr/index.html
@@ -1,0 +1,1021 @@
+<!DOCTYPE html><html lang="sr" dir="ltr"><head>
+  <meta name="yandex-verification" content="aa326290e0338f4f">
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title data-i18n="meta.title">Lepi Fontovi i Stilizovana Slova za Kopiranje — Slova za Instagram, TikTok i Nadimke</title>
+<meta name="description" data-i18n-content="meta.description" content="Generator lepih fontova, estetskih slova i stilizovanog teksta za kopiranje. Podebljano, kurziv, gotica, balončasta, Zalgo i simboli — nalepi u instagram bio, u opis na TikToku, u nadimak u igri ili na Discord. Besplatno, bez naloga.">
+
+<link rel="canonical" href="https://ultratextgen.com/sr/">
+
+<link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/">
+<link rel="alternate" hreflang="en" href="https://ultratextgen.com/">
+<link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/">
+<link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/">
+<link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/">
+<link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/">
+<link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/">
+<link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/">
+<link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/">
+<link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/">
+<link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/">
+<link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/">
+<link rel="alternate" hreflang="sv" href="https://ultratextgen.com/sv/">
+<link rel="alternate" hreflang="no" href="https://ultratextgen.com/no/">
+<link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/">
+<link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/">
+<link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/">
+<link rel="alternate" hreflang="ar" href="https://ultratextgen.com/ar/">
+<link rel="alternate" hreflang="hr" href="https://ultratextgen.com/hr/">
+<link rel="alternate" hreflang="cs" href="https://ultratextgen.com/cs/">
+<link rel="alternate" hreflang="sk" href="https://ultratextgen.com/sk/">
+<link rel="alternate" hreflang="bs" href="https://ultratextgen.com/bs/">
+<link rel="alternate" hreflang="sr" href="https://ultratextgen.com/sr/">
+<link rel="alternate" hreflang="ro" href="https://ultratextgen.com/ro/">
+<link rel="alternate" hreflang="sr-ME" href="https://ultratextgen.com/hr/">
+<link rel="alternate" hreflang="bs-ME" href="https://ultratextgen.com/hr/">
+
+<meta name="robots" content="index, follow">
+
+<meta property="og:site_name" content="UltraTextGen">
+<meta property="og:title" content="Lepi Fontovi i Stilizovana Slova za Kopiranje — Slova za Instagram, TikTok i Nadimke">
+<meta property="og:description" content="Generator lepih fontova, estetskih slova i stilizovanog teksta za kopiranje. Podebljano, kurziv, gotica, balončasta, Zalgo i simboli — nalepi u instagram bio, u opis na TikToku, u nadimak u igri ili na Discord.">
+<meta property="og:url" content="https://ultratextgen.com/sr/">
+<meta property="og:type" content="website">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/fancy-text-generator-preview.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Lepi Fontovi i Stilizovana Slova za Kopiranje — Slova za Instagram, TikTok i Nadimke">
+<meta name="twitter:description" content="Generator lepih fontova, estetskih slova i stilizovanog teksta za kopiranje. Podebljano, kurziv, gotica, balončasta, Zalgo i simboli — nalepi u instagram bio, u opis na TikToku, u nadimak u igri ili na Discord.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/fancy-text-generator-preview.png">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/style.css">
+
+ <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+[
+  {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/sr/",
+    "inLanguage": "sr-Latn",
+    "description": "Brz i pregledan generator Unicode teksta za bio na društvenim mrežama, opise i korisnička imena.",
+    "potentialAction": {
+      "@type": "SearchAction",
+      "target": {
+        "@type": "EntryPoint",
+        "urlTemplate": "https://ultratextgen.com/sr/?q={search_term_string}"
+      },
+      "query-input": "required name=search_term_string"
+    }
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com",
+    "logo": "https://ultratextgen.com/logo.png",
+    "sameAs": [
+      "https://www.youtube.com/@UltraTextGen",
+      "https://www.facebook.com/profile.php?id=61588587387596",
+      "https://www.linkedin.com/company/71290348/",
+      "https://x.com/UltraTextGen"
+    ]
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "WebApplication",
+    "name": "UltraTextGen",
+    "alternateName": ["Generator Unicode fontova", "Generator lepog teksta", "Menjač fontova", "Fontovi za kopiranje i lepljenje"],
+    "url": "https://ultratextgen.com/sr/",
+    "inLanguage": "sr-Latn",
+    "applicationCategory": "UtilitiesApplication",
+    "operatingSystem": "All",
+    "browserRequirements": "Requires JavaScript",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "description": "Generiši stilizovani Unicode tekst u trenu za Instagram, TikTok, X, WhatsApp i Discord. Kopiraj i nalepi stilove teksta za bio, korisnička imena i objave."
+  }
+]
+</script>
+
+
+
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "sr-Latn",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Šta je UltraTextGen i šta se tu zapravo dešava?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "To je besplatan generator slova — upišeš običan tekst, a mi ga pretvaramo u stilizovane Unicode znakove koji izgledaju kao lep font. Najvažnije: to su pravi znakovi , a ne podebljanje iz Worda ni markdown sa Discorda. Zato rade svuda gde se može upisati običan tekst — u instagram bio, u nadimak, u komentar, u mejl, u WhatsApp status. Primer Upišeš „bok\" → dobiješ 𝗯𝗼𝗸 (podebljano), 𝘣𝘰𝘬 (kurziv), 𝒷ℴ𝓀 (kaligrafija) ili ⓑⓞⓚ (balončasta). Sve jednim klikom."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Kako kopirati lepa slova u 5 sekundi?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "1. Upišeš ili nalepiš tekst u polje na vrhu. 2. Stilovi se pojave odmah ispod — bold, kurziv, gotica, balončasta i još desetak drugih. 3. Ako želiš, dodaj ukrase — okvire, zvezdice, strelice. 4. Klikneš „Kopiraj\" kod onog koji ti odgovara i nalepiš gde god želiš. To je to. Bez registracije, bez instaliranja aplikacije. Radi jednako na računaru i na telefonu."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Besplatno? Bez ograničenja, bez naloga?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da, sve je 100% besplatno . Bez naloga, bez dnevnog ograničenja, bez vodenih žigova, bez kvake. Možeš kroz to da propustiš celu knjigu i ništa se neće desiti."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Kako ubaciti stilizovani tekst u bio na Instagramu?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Instagram nema nikakvu alatnu traku za oblikovanje, ali prihvata Unicode — dakle sve što ovde generišeš uredno uleti u bio. Kako to napraviti 1. Upiši ono što želiš u biju (npr. ime, hashtag, kratak opis). 2. Odaberi stil — podebljano i kurziv rade najbolje na većini uređaja. 3. Kopiraj rezultat i nalepi u „Uredi profil → Bio\" u aplikaciji. Savet: ako želiš da ukrasiš, dodaj okvir tipa ⋆｡˚ ili zvezdicu ✦ sa strane — izgleda dobro, a ne krade pažnju ostatku bija."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Rade li slova u opisima na TikToku?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da — TikTok prikazuje Unicode u opisima, opisima profila i komentarima. Najbolje se pokažu podebljano , kurziv , balončasta i kapitalke . Stilovi sa puno ukrasa znaju da se odrežu kod dugih opisa, pa za svaki slučaj proveri objavu u pregledu pre objavljivanja."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Može li se napraviti nadimak za igru ili za Discord?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Naravno — to je verovatno najčešći razlog zbog kojeg ljudi dolaze na ovakve generatore. Discord, Roblox, Steam, Minecraft, većina igara prihvata Unicode u nadimcima. Primer Obični nadimak: „DarkWolf\" Nakon stilizovanja: „𝔇𝔞𝔯𝔨𝔚𝔬𝔩𝔣\" (gotica), „ⒹⓐⓡⓚⓌⓞⓛⓕ\" (balončasta) ili „๖ۣۜDarkWolf\" (sa ukrasom sa strane). Napomena: neke igre imaju filtre i neće primiti egzotične znakove. Ako jedan stil ne prolazi, uzmi drugi — bold i kurziv obično prolaze svuda."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Radi li u WhatsApp statusu, na Telegramu i u Messengeru?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da — WhatsApp, Telegram, Messenger, Signal, iMessage. Sve što prima običan tekst prima i Unicode slova. Nalepiš u status ili u poruku i izgleda kao ukrasan font. Za WhatsApp dodajem: ako ti treba samo podebljanje, možeš da koristiš njihovu sopstvenu sintaksu (`*tekst*` daje bold). Ali Unicode radi svuda — i onde gde ga WhatsApp ne podržava, npr. u imenu kontakta."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "A u naslovu mejla ili u biografiji?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Tu Unicode odradi najviše. Naslov mejla je običan tekst, pa podebljanje iz Outlooka otpada. Ali „𝗥𝗮č𝘂𝗻 — 𝗵𝗶𝘁𝗻𝗼\" već izgleda snažnije u sandučiću primaoca. U biografiji blago podebljano ime u zaglavlju zna da privuče pogled poslodavca. Samo nemoj da preteruješ — cela biografija u gotici ne izgleda profesionalno."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Koje stilove slova imam na izbor?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Puno. Zaista puno. Ukratko: Osnovni Podebljano (bold), kurziv, kaligrafija (script), gotica, balončasta (u kružićima), kapitalke, precrtano, podcrtano, double struck. Zabavni Tekst naopako, ogledalno, Zalgo (glitch sa crticama nad slovima), tekst u kvadratićima, u zagradama, fullwidth (razmaknuti). Dodaci Okviri oko teksta, zvezdice, srca, strelice, razdelnici, zastave, emoji — sve to možeš da nasloniš na stil slova. S vremena na vreme dolaze novi — vredi dodati stranicu u obeleživače."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Mogu li spojiti više stilova odjednom?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da — i to je najveća prednost UltraTextGena. Možeš da nasloniš npr. balončasta + Zalgo , gotica + naopako ili kapitalke + podcrtano , a onda sve to da zatvoriš u okvir ili zvezdicu. Primer „bok\" → odabereš goticu → dodaš okvir sa zvezdicama → izađe: ★彡[ 𝔟𝔬𝔨 ]彡★ Što više eksperimentišeš, to zanimljivije stvari izlaze. Preporučujem da kreneš sa jednim stilom i dodaš jedan ukras — ne sve odjednom."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Šta je Zalgo i te čudne crtice nad slovima?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Zalgo je onakav „ukleti\", glitchani stil — nad i pod svakim slovom naleti gomila dijakritičkih znakova. Izgleda kao da se tekst raspada ili kao da je iz horora. Primer „bok\" → b̷̢o̴̢k̷̛ Najčešće to viđaš u mračnim biojevima na Instagramu, u halloweenskim memovima, u gaming klanovima koji žele da izgledaju opasno ili kad neko od toga pravi foru."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Odakle uzeti lepe simbole, zvezdice i srca?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Sve što imaš u odeljku „Ukrasi\" ispod tekstualnog polja možeš kopirati zasebno — čak i bez upisivanja teksta. Naprosto kao zasebne znakove za bio, nadimak ili objavu. — Estetski simboli : ✦ ✧ ⋆ ｡ ☆ ♡ ❀ ✿ — Okviri i obrubi : ╭─▸ │ ╰─▸ ili ★彡[ ]彡★ — Strelice : → ⇨ ➤ ⟶ — Minimalni razdelnici : · ⋅ ─ • — Zastave i emoji . Najčešće se koriste u estetskim biojevima na Instagramu i Pinterestu — pašu uz sve, od citata do spiska interesovanja."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "A srpski znakovi? Radi li sa č, ć, đ, š, ž?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ukratko: zavisi od stila. Unicode ima stilizovane varijante za osnovnu abecedu A–Z, pa se c , s , z bez problema pretvore npr. u podebljano. Ali za č , ć , đ , š , ž stilizovane verzije postoje samo u delu stilova (uglavnom bold, kurziv, kapitalke). Ako stil nema verziju za srpski znak, on ostaje u izvornom obliku — tekst je i dalje čitljiv, srpsko slovo naprosto izgleda „običnije\" od ostatka. Za nadimke bez kvačica to nije nikakav problem. Za cele rečenice na srpskom preporučujem bold , kurziv ili monospace — oni se najbolje snalaze sa našom abecedom. Napomena i za digrafe: dž, lj i nj su samo dva obična slova jedno do drugog, pa se svako stilizuje zasebno."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Zašto se nekome prikazuju kvadratići umesto slova?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Zato što sistemski font na strani primaoca ne sadrži zadati Unicode znak. To nije problem sa tvojim tekstom — naprosto njegov telefon ili aplikacija nema taj konkretni znak u kompletu. Drži se bolda , kurziva i balončaste — imaju najširu podršku. Vrlo egzotični stilovi (fullwidth, kvadratići) mogu da se prikažu kao □ na starijim Androidima ili u nekim mejl klijentima."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Instagram mi je izrezao deo znakova u nadimku — šta sad?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Instagram ima filter na polju korisničko ime (dakle @login) — prima samo slova, brojke, tačke i podvlake. Tu stilizovana slova ne možeš da nalepiš. Ali u polju „Ime\" (prikazano ime) i u biju može — i tu prolazi većina stilova. Ako se jedan ne sačuva, uzmi drugi. Bold obično prolazi bez problema."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Postoje li znakovi koji se uopšte ne mogu pretvoriti?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Standardna slova (A–Z, a–z), brojke i osnovni interpunkcijski znakovi pretvaraju se bez problema. Neki retki simboli ili posebni znakovi nemaju stilizovane parnjake u Unicodeu — tada ostaju u izvorniku. Ništa se ne kvari, tekst je i dalje za kopiranje."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Čuva li se moj tekst negde?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ne. Cela pretvorba slova dešava se u tvom pregledaču — ništa ne ide na naše servere, ništa se ne čuva, ništa se ne prati. Kopirani tekst je čisti Unicode, bez skrivenih znakova, bez ikakvih identifikatora."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Je li sigurno lepiti ova slova bilo gde?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da — to su standardni Unicode znakovi, isti kakve koristi ceo internet. Ništa unutra, bez skripti, bez skrivenog oblikovanja, bez kodova. Slobodno lepi u biografiju, u poslovni mejl, u bio na LinkedInu — gde god želiš."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Radi li na telefonu?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da — stranica se u potpunosti prilagođava telefonu. iPhone, Android, tablet — sve štima. Upišeš tekst, klikneš, kopira se u privremenu memoriju, nalepiš u aplikaciji. Bez instaliranja ičega iz prodavnice."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Po čemu se razlikujete od drugih generatora slova?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Konkretno: — Jedna od većih kolekcija Ultra stilova — bold, kurziv, gotica, balončasta i još desetak drugih. — Spajanje stilova — većina generatora daje ti jedan stil odjednom, mi dozvoljavamo naslanjanje. — Ukrasi jednim klikom — okviri, zvezdice, razdelnici bez lepljenja znak po znak. — Stranice za konkretne platforme — Instagram, TikTok, Discord. Onde prikazujemo samo stilove koji na toj aplikaciji rade. — Brzo i bez iskačućih prozora — bez captcha, bez „prihvati sve\" pre svakog klika."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Dolaze li novi stilovi?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da, redovno. S vremena na vreme upadnu nove varijante, ukrasi i okviri. Najlakše je zapamtiti stranicu ili svratiti povremeno."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Kako pronaći tačno onaj stil koji tražim?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Tri puta: Po stilu — kategorije na vrhu: bold, kurziv, gotica, balončasta, precrtano, naopako i još. Po platformi — svrati na podstranicu za Instagram, TikTok, Discord — onde su samo stilovi koji se na toj platformi pokažu. Po cilju — odeljak s primenama ima alate prilagođene konkretnoj potrebi: naslov na LinkedInu, komentari, tekst sa emojijima."
+      }
+    }
+  ]
+}
+</script>
+</head>
+
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer=""></script>
+
+  <!-- Hero Section -->
+  <section class="hero">
+    <div class="hero-inner">
+      <div class="hero-card">
+        <h1 class="hero-headline" data-i18n="hero.title">Lepi Fontovi i Stilizovana Slova za Kopiranje</h1>
+        <p class="hero-tagline" data-i18n="hero.subtitle">Upiši tekst, odaberi stil — podebljano, kurziv, gotica, balončasta ili sa ukrasima. Ubaci u instagram bio, u nadimak u igri, u WhatsApp status ili u opis pod TikTokom. Bez aplikacije, bez prijave.</p>
+        <div class="input-wrapper">
+          <textarea class="main-input" id="mainInput" placeholder="Upiši tekst..." data-i18n-placeholder="ui.placeholder" maxlength="500" autofocus=""></textarea>
+          <button class="input-clear-btn" id="inputClearBtn" aria-label="Clear input" hidden="">✕</button>
+          <span class="char-count" id="charCountWrapper" hidden=""><span id="charCount">0</span>/500</span>
+        </div>
+
+        <!-- Decoration Selector -->
+        <div class="decoration-section">
+          <div class="decoration-label">
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"></path>
+            </svg>
+            <span data-i18n="decorations.label">Dodaj ukrase tekstu</span>
+       </div>
+    <div class="decoration-tabs">
+    <button class="decoration-tab active" data-deco-tab="symbols" data-i18n="decorations.tabs.symbols">Simboli</button>
+    <button class="decoration-tab" data-deco-tab="frames" data-i18n="decorations.tabs.frames">Okviri</button>
+    <button class="decoration-tab" data-deco-tab="dividers" data-i18n="decorations.tabs.dividers">Razdelnici</button>
+    <button class="decoration-tab" data-deco-tab="arrows" data-i18n="decorations.tabs.arrows">Strelice</button>
+    <button class="decoration-tab" data-deco-tab="minimal" data-i18n="decorations.tabs.minimal">Minimalni</button>
+    <button class="decoration-tab" data-deco-tab="emojis" data-i18n="decorations.tabs.emojis">Emoji</button>
+    <button class="decoration-tab" data-deco-tab="flags" data-i18n="decorations.tabs.flags">Zastave</button>
+      </div>
+          <div class="decoration-grid" id="decorationGrid"></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Main Content -->
+  <main class="container">
+    <!-- Category Tabs -->
+    <div class="category-section">
+      <div class="category-tabs" id="categoryTabs">
+        <!-- Tabs will be dynamically loaded from fonts.json -->
+      </div>
+    </div>
+
+    <!-- Results -->
+    <div class="results-grid" id="resultsGrid"></div>
+  </main>
+
+  <!-- How To: Kako kopirati lepa slova -->
+  <section class="editorial-section">
+    <h2>Slova i slovca za kopiranje — kako to radi</h2>
+    <p class="editorial-intro">Lepa <strong>slova za kopiranje</strong> napraviš u nekoliko sekundi — bez instaliranja aplikacije i bez otvaranja naloga. Upišeš tekst, a generator ga pretvara u desetke stilova lepih slova, spremnih za kopiranje i lepljenje.</p>
+    <div class="steps-grid">
+      <div class="step-card">
+        <div class="step-number">1</div>
+        <h3>Upiši tekst</h3>
+        <p>Upiši ime, reč ili celu rečenicu u polje na samom vrhu. Možeš i nalepiti nešto što već imaš kopirano.</p>
+      </div>
+      <div class="step-card">
+        <div class="step-number">2</div>
+        <h3>Odaberi stil slova</h3>
+        <p>Lepa slova pojave se odmah — podebljano, kurziv, kaligrafija, gotica, balončasta i kapitalke. Suzi izbor kategorijom na vrhu.</p>
+      </div>
+      <div class="step-card">
+        <div class="step-number">3</div>
+        <h3>Kopiraj i nalepi</h3>
+        <p>Klikneš „Kopiraj", nalepiš u instagram bio, nadimak u igri, WhatsApp status ili opis na TikToku. Stil se ne gubi.</p>
+      </div>
+    </div>
+    <p class="u-mt-15 u-text-center">Isti koraci vrede za <strong>lepe fontove za kopiranje</strong>, ukrasna slova i estetska slovca — jednako na računaru i na telefonu.</p>
+  </section>
+
+  <!-- Abeceda lepih slova A–Z -->
+  <section class="editorial-section abc-section" aria-label="Abeceda lepih slova za kopiranje">
+    <h2>Lepa slova A–Z za kopiranje</h2>
+    <p>Cela abeceda — velika slova (A–Z), mala slova (a–z) i brojke (0–9) — u najčešće korištenim stilovima lepih slova. Upiši nešto u generator na vrhu i klikni „Kopiraj" da uzmeš celu reč u danom stilu, ili označi slova iz tablice i kopiraj sam.</p>
+
+    <div class="abc-list">
+      <div class="abc-row">
+        <span class="abc-name">Podebljano</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝗔𝗕𝗖𝗗𝗘𝗙𝗚𝗛𝗜𝗝𝗞𝗟𝗠𝗡𝗢𝗣𝗤𝗥𝗦𝗧𝗨𝗩𝗪𝗫𝗬𝗭</span>
+          <span class="abc-line">𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇</span>
+          <span class="abc-line">𝟬𝟭𝟮𝟯𝟰𝟱𝟲𝟳𝟴𝟵</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Kurziv</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝘈𝘉𝘊𝘋𝘌𝘍𝘎𝘏𝘐𝘑𝘒𝘓𝘔𝘕𝘖𝘗𝘘𝘙𝘚𝘛𝘜𝘝𝘞𝘟𝘠𝘡</span>
+          <span class="abc-line">𝘢𝘣𝘤𝘥𝘦𝘧𝘨𝘩𝘪𝘫𝘬𝘭𝘮𝘯𝘰𝘱𝘲𝘳𝘴𝘵𝘶𝘷𝘸𝘹𝘺𝘻</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Kaligrafija</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵</span>
+          <span class="abc-line">𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Kaligrafija podebljana</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩</span>
+          <span class="abc-line">𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Gotica</span>
+        <div class="abc-lines">
+          <span class="abc-line">𝔄𝔅ℭ𝔇𝔈𝔉𝔊ℌℑ𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔ℜ𝔖𝔗𝔘𝔙𝔚𝔛𝔜ℨ</span>
+          <span class="abc-line">𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Balončasta</span>
+        <div class="abc-lines">
+          <span class="abc-line">ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ</span>
+          <span class="abc-line">ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ</span>
+          <span class="abc-line">⓪①②③④⑤⑥⑦⑧⑨</span>
+        </div>
+      </div>
+      <div class="abc-row">
+        <span class="abc-name">Kapitalke</span>
+        <div class="abc-lines">
+          <span class="abc-line">ᴀʙᴄᴅᴇꜰɢʜɪᴊᴋʟᴍɴᴏᴘqʀsᴛᴜᴠᴡxʏᴢ</span>
+          <span class="abc-line">ᴀʙᴄᴅᴇꜰɢʜɪᴊᴋʟᴍɴᴏᴘqʀsᴛᴜᴠᴡxʏᴢ</span>
+          <span class="abc-line">0123456789</span>
+        </div>
+      </div>
+    </div>
+    <p class="u-mt-15">Tražiš određeni rez? Zaviri u <a href="/sr/podebljana-slova/">podebljana slova</a>, <a href="/sr/goticka-slova/">gotička slova za kopiranje</a> ili <a href="/sr/kurziv/">kurziv i rukopisna slova</a> — svaka kategorija prikazuje samo jedan stil, od velikih do malih slova.</p>
+  </section>
+
+  <!-- Ukrasi i simboli za kopiranje -->
+  <section class="editorial-section glyph-section" aria-label="Ukrasi i simboli za kopiranje">
+    <h2>Ukrasi i simboli za kopiranje</h2>
+    <p class="editorial-intro">Gotovi <strong>ukrasi teksta za kopiranje</strong> — zvezdice, srca, okviri, strelice i razdelnici. Klikni bilo koji znak da ga kopiraš, ili ih automatski dodaj tekstu preko kartica <strong>Simboli</strong>, <strong>Okviri</strong> i <strong>Razdelnici</strong> u generatoru na vrhu.</p>
+    <div class="glyph-group">
+      <h3>Zvezdice i bleskovi</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="✦">✦</button>
+        <button class="glyph-copy" type="button" data-text="✧">✧</button>
+        <button class="glyph-copy" type="button" data-text="⋆">⋆</button>
+        <button class="glyph-copy" type="button" data-text="✩">✩</button>
+        <button class="glyph-copy" type="button" data-text="★">★</button>
+        <button class="glyph-copy" type="button" data-text="☆">☆</button>
+        <button class="glyph-copy" type="button" data-text="✰">✰</button>
+        <button class="glyph-copy" type="button" data-text="⊹">⊹</button>
+        <button class="glyph-copy" type="button" data-text="࿐">࿐</button>
+        <button class="glyph-copy" type="button" data-text="˚">˚</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Srca</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="♡">♡</button>
+        <button class="glyph-copy" type="button" data-text="♥">♥</button>
+        <button class="glyph-copy" type="button" data-text="❤">❤</button>
+        <button class="glyph-copy" type="button" data-text="❥">❥</button>
+        <button class="glyph-copy" type="button" data-text="❣">❣</button>
+        <button class="glyph-copy" type="button" data-text="ღ">ღ</button>
+        <button class="glyph-copy" type="button" data-text="ꨄ">ꨄ</button>
+        <button class="glyph-copy" type="button" data-text="ஐ">ஐ</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Mesec i nebo</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="☾">☾</button>
+        <button class="glyph-copy" type="button" data-text="☽">☽</button>
+        <button class="glyph-copy" type="button" data-text="☁">☁</button>
+        <button class="glyph-copy" type="button" data-text="✶">✶</button>
+        <button class="glyph-copy" type="button" data-text="⍣">⍣</button>
+        <button class="glyph-copy" type="button" data-text="ꕥ">ꕥ</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Cveće</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="❀">❀</button>
+        <button class="glyph-copy" type="button" data-text="✿">✿</button>
+        <button class="glyph-copy" type="button" data-text="⚘">⚘</button>
+        <button class="glyph-copy" type="button" data-text="✾">✾</button>
+        <button class="glyph-copy" type="button" data-text="❁">❁</button>
+        <button class="glyph-copy" type="button" data-text="ꕤ">ꕤ</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Okviri i ornamenti</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="꧁">꧁</button>
+        <button class="glyph-copy" type="button" data-text="꧂">꧂</button>
+        <button class="glyph-copy" type="button" data-text="༺">༺</button>
+        <button class="glyph-copy" type="button" data-text="༻">༻</button>
+        <button class="glyph-copy" type="button" data-text="⟡">⟡</button>
+        <button class="glyph-copy" type="button" data-text="❪">❪</button>
+        <button class="glyph-copy" type="button" data-text="❫">❫</button>
+        <button class="glyph-copy" type="button" data-text="★彡">★彡</button>
+        <button class="glyph-copy" type="button" data-text="彡★">彡★</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Strelice</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="→">→</button>
+        <button class="glyph-copy" type="button" data-text="⇨">⇨</button>
+        <button class="glyph-copy" type="button" data-text="➤">➤</button>
+        <button class="glyph-copy" type="button" data-text="⟶">⟶</button>
+        <button class="glyph-copy" type="button" data-text="➳">➳</button>
+        <button class="glyph-copy" type="button" data-text="↬">↬</button>
+        <button class="glyph-copy" type="button" data-text="⇢">⇢</button>
+        <button class="glyph-copy" type="button" data-text="↳">↳</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Razdelnici</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="·">·</button>
+        <button class="glyph-copy" type="button" data-text="•">•</button>
+        <button class="glyph-copy" type="button" data-text="◦">◦</button>
+        <button class="glyph-copy" type="button" data-text="➛">➛</button>
+        <button class="glyph-copy" type="button" data-text="⟢">⟢</button>
+        <button class="glyph-copy" type="button" data-text="—">—</button>
+        <button class="glyph-copy" type="button" data-text="☰">☰</button>
+      </div>
+    </div>
+    <div class="glyph-group">
+      <h3>Kaomoji (smeškovi)</h3>
+      <div class="glyph-grid">
+        <button class="glyph-copy" type="button" data-text="(◍•ᴗ•◍)">(◍•ᴗ•◍)</button>
+        <button class="glyph-copy" type="button" data-text="(｡♥‿♥｡)">(｡♥‿♥｡)</button>
+        <button class="glyph-copy" type="button" data-text="ʕ•ᴥ•ʔ">ʕ•ᴥ•ʔ</button>
+        <button class="glyph-copy" type="button" data-text="(＾▽＾)">(＾▽＾)</button>
+        <button class="glyph-copy" type="button" data-text="٩(◕‿◕)۶">٩(◕‿◕)۶</button>
+      </div>
+    </div>
+  </section>
+
+  <!-- Popular Use Cases -->
+  <section class="editorial-section">
+    <h2 data-i18n="useCases.title">Za šta ljudi ovo najčešće koriste</h2>
+    <div class="tips-grid">
+      <a class="tip-card" href="/usecase/linkedin-headline/" aria-label="Naslov na LinkedInu">
+        <div class="tip-icon">💼</div>
+        <h3 data-i18n="useCases.items.0.title">Naslov na LinkedInu</h3>
+        <p data-i18n="useCases.items.0.description">Istakni se u pretrazi na LinkedInu — podebljan ili blago ukrašen naslov odradi svoje pre nego što neko stigne da skroluje dalje.</p>
+      </a>
+      <a class="tip-card" href="/usecase/comment-font/" aria-label="Komentari ispod objava">
+        <div class="tip-icon">💬</div>
+        <h3 data-i18n="useCases.items.1.title">Komentari ispod objava</h3>
+        <p data-i18n="useCases.items.1.description">Stilizovani komentari na Instagramu, YouTubeu i TikToku — lakše ih je uočiti nego stotine običnih ispod popularne objave.</p>
+      </a>
+      <a class="tip-card" href="/usecase/text-to-emoji/" aria-label="Tekst ispisan u emojijima">
+        <div class="tip-icon">😊</div>
+        <h3 data-i18n="useCases.items.2.title">Tekst ispisan u emojijima</h3>
+        <p data-i18n="useCases.items.2.description">Pretvori natpis u niz slova od emojija — kreativan bio, story, grupni chat ili čisto za zezanje sa prijateljima.</p>
+      </a>
+      <a class="tip-card" href="/usecase/tattoo-fonts/" aria-label="Fontovi za tetovažu">
+        <div class="tip-icon">🖤</div>
+        <h3>Fontovi za tetovažu</h3>
+        <p>Proveri ime ili natpis u kurzivu, gotici i italicu — pre nego što ode pod iglu.</p>
+      </a>
+      <a class="tip-card" href="/usecase/zalgo-text/" aria-label="Generator Zalgo teksta">
+        <div class="tip-icon">👻</div>
+        <h3>Iskrivljena Zalgo slova</h3>
+        <p>Glitchani tekst sa crticama nad i pod slovima — paše uz halloweenske memove, mračne biojeve i gaming klanove koji žele da izgledaju opasno.</p>
+      </a>
+    </div>
+    <p class="u-mt-15 u-text-center"><a class="cat-cta" href="/usecase/" data-i18n="useCases.viewAll">Pogledaj više primena →</a></p>
+  </section>
+
+  <!-- Popular Guides -->
+  <section class="editorial-section">
+    <h2 data-i18n="guides.title">Svrati na vodiče</h2>
+    <div class="tips-grid">
+      <a class="tip-card" href="/guide/the-rhetoric-of-fonts/" aria-label="Retorika fontova">
+        <div class="tip-icon">📚</div>
+        <h3 data-i18n="guides.items.0.title">Retorika fontova</h3>
+        <p data-i18n="guides.items.0.description">Zašto jedan font budi poverenje, a drugi izgleda kao spam — odnosno kako tipografija utiče na ono što osećamo dok čitamo.</p>
+      </a>
+      <a class="tip-card" href="/guide/personal-branding-through-typography/" aria-label="Osobni brend kroz tipografiju">
+        <div class="tip-icon">🎨</div>
+        <h3 data-i18n="guides.items.1.title">Osobni brend kroz tipografiju</h3>
+        <p data-i18n="guides.items.1.description">Kako odabrati slova koja odgovaraju tvom vibeu i ostaju u pamćenju — bilo da je reč o LinkedInu, Instagramu ili Discordu.</p>
+      </a>
+      <a class="tip-card" href="/guide/stop-the-scroll-with-font-variation/" aria-label="Zaustavi skrolovanje igrom fontova">
+        <div class="tip-icon">📱</div>
+        <h3 data-i18n="guides.items.2.title">Zaustavi skrolovanje igrom fontova</h3>
+        <p data-i18n="guides.items.2.description">Zašto se ljudi zaustavljaju kod objava s drugačijim stilom teksta i kako to iskoristiti da podigneš doseg.</p>
+      </a>
+    </div>
+    <p class="u-mt-15 u-text-center"><a class="cat-cta" href="/guide/" data-i18n="guides.viewAll">Svi vodiči →</a></p>
+  </section>
+
+  <!-- FAQ Section -->
+  <section class="faq-section-wrapper" aria-label="Frequently asked questions">
+    <div class="faq-inner">
+
+<!-- Slova i ukrasi za kopiranje -->
+<h2 class="faq-category">Slova i ukrasi za kopiranje</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span>Gde ću naći lepa slova za kopiranje?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer">Na ovoj stranici. Upišeš tekst u polje na vrhu, a lepa slova — <strong>podebljano</strong>, <strong>kurziv</strong>, <strong>gotica</strong>, <strong>balončasta</strong> i još desetak drugih — pojave se odmah ispod. Klikneš „Kopiraj" i nalepiš gde želiš.
+    <br><br>
+    Imaš i gotovu <strong>abecedu A–Z za kopiranje</strong> u popularnim stilovima — velika slova, mala slova i brojke — koju možeš uzeti čak i bez upisivanja ičega.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span>Šta su ukrasi za kopiranje i gde ih tražiti?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer">Ukrasi su mali simboli kojima dekorišeš tekst — zvezdice ✦, srca ♡, okviri ꧁꧂, strelice → i razdelnici.
+    <br><br>
+    U odeljku <strong>„Ukrasi i simboli za kopiranje"</strong> klikneš bilo koji znak da ga kopiraš zasebno. Možeš i automatski dodati <strong>ukrase tekstu</strong> celom natpisu — na karticama <strong>Simboli</strong>, <strong>Okviri</strong> i <strong>Razdelnici</strong> iznad polja za upisivanje.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span>Imate li lepe i estetske fontove za kopiranje?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer">Da — od minimalističkih, razmaknutih <strong>estetskih fontova za kopiranje</strong> do ukrasnih slova sa simbolima. Upišeš tekst, a svi se stilovi lepih fontova pojave odjednom. Sve je besplatno i spremno za kopiranje jednim klikom, jednako na telefonu i na računaru.</div>
+</div>
+
+
+<!-- Prva pitanja -->
+<h2 class="faq-category" data-i18n="faq.categories.0.title">Prva pitanja</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.0.items.0.question">Šta je UltraTextGen i šta se tu zapravo dešava?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.0.items.0.answer">To je besplatan generator slova — upišeš običan tekst, a mi ga pretvaramo u stilizovane Unicode znakove koji izgledaju kao lep font.
+    <br><br>
+    Najvažnije: to su <strong>pravi znakovi</strong>, a ne podebljanje iz Worda ni markdown sa Discorda. Zato rade svuda gde se može upisati običan tekst — u instagram bio, u nadimak, u komentar, u mejl, u WhatsApp status.
+    <br><br>
+    <strong>Primer</strong><br>
+    Upišeš „bok" → dobiješ 𝗯𝗼𝗸 (podebljano), 𝘣𝘰𝘬 (kurziv), 𝒷ℴ𝓀 (kaligrafija) ili ⓑⓞⓚ (balončasta). Sve jednim klikom.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.0.items.1.question">Kako kopirati lepa slova u 5 sekundi?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.0.items.1.answer">1. Upišeš ili nalepiš tekst u polje na vrhu.<br>
+    2. Stilovi se pojave odmah ispod — bold, kurziv, gotica, balončasta i još desetak drugih.<br>
+    3. Ako želiš, dodaj ukrase — okvire, zvezdice, strelice.<br>
+    4. Klikneš „Kopiraj" kod onog koji ti odgovara i nalepiš gde god želiš.
+    <br><br>
+    To je to. Bez registracije, bez instaliranja aplikacije. Radi jednako na računaru i na telefonu.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.0.items.2.question">Besplatno? Bez ograničenja, bez naloga?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.0.items.2.answer">Da, sve je <strong>100% besplatno</strong>. Bez naloga, bez dnevnog ograničenja, bez vodenih žigova, bez kvake. Možeš kroz to da propustiš celu knjigu i ništa se neće desiti.</div>
+</div>
+
+
+<!-- Instagram, TikTok, Discord -->
+<h2 class="faq-category" data-i18n="faq.categories.1.title">Instagram, TikTok, Discord — gde to nalepiti</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.1.items.0.question">Kako ubaciti stilizovani tekst u bio na Instagramu?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.1.items.0.answer">Instagram nema nikakvu alatnu traku za oblikovanje, ali prihvata Unicode — dakle sve što ovde generišeš uredno uleti u bio.
+    <br><br>
+    <strong>Kako to napraviti</strong><br>
+    1. Upiši ono što želiš u biju (npr. ime, hashtag, kratak opis).<br>
+    2. Odaberi stil — podebljano i kurziv rade najbolje na većini uređaja.<br>
+    3. Kopiraj rezultat i nalepi u „Uredi profil → Bio" u aplikaciji.
+    <br><br>
+    Savet: ako želiš da ukrasiš, dodaj okvir tipa ⋆｡˚ ili zvezdicu ✦ sa strane — izgleda dobro, a ne krade pažnju ostatku bija.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.1.items.1.question">Rade li slova u opisima na TikToku?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.1.items.1.answer">Da — TikTok prikazuje Unicode u opisima, opisima profila i komentarima. Najbolje se pokažu <strong>podebljano</strong>, <strong>kurziv</strong>, <strong>balončasta</strong> i <strong>kapitalke</strong>. Stilovi sa puno ukrasa znaju da se odrežu kod dugih opisa, pa za svaki slučaj proveri objavu u pregledu pre objavljivanja.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.1.items.2.question">Može li se napraviti nadimak za igru ili za Discord?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.1.items.2.answer">Naravno — to je verovatno najčešći razlog zbog kojeg ljudi dolaze na ovakve generatore. Discord, Roblox, Steam, Minecraft, većina igara prihvata Unicode u nadimcima.
+    <br><br>
+    <strong>Primer</strong><br>
+    Obični nadimak: „DarkWolf"<br>
+    Nakon stilizovanja: „𝔇𝔞𝔯𝔨𝔚𝔬𝔩𝔣" (gotica), „ⒹⓐⓡⓚⓌⓞⓛⓕ" (balončasta) ili „๖ۣۜDarkWolf" (sa ukrasom sa strane).
+    <br><br>
+    <strong>Napomena:</strong> neke igre imaju filtre i neće primiti egzotične znakove. Ako jedan stil ne prolazi, uzmi drugi — bold i kurziv obično prolaze svuda.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.1.items.3.question">Radi li u WhatsApp statusu, na Telegramu i u Messengeru?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.1.items.3.answer">Da — WhatsApp, Telegram, Messenger, Signal, iMessage. Sve što prima običan tekst prima i Unicode slova. Nalepiš u status ili u poruku i izgleda kao ukrasan font.
+    <br><br>
+    Za WhatsApp dodajem: ako ti treba samo podebljanje, možeš da koristiš njihovu sopstvenu sintaksu (`*tekst*` daje bold). Ali Unicode radi svuda — i onde gde ga WhatsApp ne podržava, npr. u imenu kontakta.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.1.items.4.question">A u naslovu mejla ili u biografiji?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.1.items.4.answer">Tu Unicode odradi najviše. Naslov mejla je običan tekst, pa podebljanje iz Outlooka otpada. Ali „𝗥𝗮č𝘂𝗻 — 𝗵𝗶𝘁𝗻𝗼" već izgleda snažnije u sandučiću primaoca.
+    <br><br>
+    U biografiji blago podebljano ime u zaglavlju zna da privuče pogled poslodavca. Samo nemoj da preteruješ — cela biografija u gotici ne izgleda profesionalno.</div>
+</div>
+
+
+<!-- Stilovi, slova i ukrasi -->
+<h2 class="faq-category" data-i18n="faq.categories.2.title">Stilovi, slova i ukrasi</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.2.items.0.question">Koje stilove slova imam na izbor?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.2.items.0.answer">Puno. Zaista puno. Ukratko:
+    <br><br>
+    <strong>Osnovni</strong><br>
+    Podebljano (bold), kurziv, kaligrafija (script), gotica, balončasta (u kružićima), kapitalke, precrtano, podcrtano, double struck.
+    <br><br>
+    <strong>Zabavni</strong><br>
+    Tekst naopako, ogledalno, Zalgo (glitch sa crticama nad slovima), tekst u kvadratićima, u zagradama, fullwidth (razmaknuti).
+    <br><br>
+    <strong>Dodaci</strong><br>
+    Okviri oko teksta, zvezdice, srca, strelice, razdelnici, zastave, emoji — sve to možeš da nasloniš na stil slova.
+    <br><br>
+    S vremena na vreme dolaze novi — vredi dodati stranicu u obeleživače.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.2.items.1.question">Mogu li spojiti više stilova odjednom?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.2.items.1.answer">Da — i to je najveća prednost UltraTextGena. Možeš da nasloniš npr. <strong>balončasta + Zalgo</strong>, <strong>gotica + naopako</strong> ili <strong>kapitalke + podcrtano</strong>, a onda sve to da zatvoriš u okvir ili zvezdicu.
+    <br><br>
+    <strong>Primer</strong><br>
+    „bok" → odabereš goticu → dodaš okvir sa zvezdicama → izađe: ★彡[ 𝔟𝔬𝔨 ]彡★
+    <br><br>
+    Što više eksperimentišeš, to zanimljivije stvari izlaze. Preporučujem da kreneš sa jednim stilom i dodaš jedan ukras — ne sve odjednom.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.2.items.2.question">Šta je Zalgo i te čudne crtice nad slovima?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.2.items.2.answer">Zalgo je onakav „ukleti", glitchani stil — nad i pod svakim slovom naleti gomila dijakritičkih znakova. Izgleda kao da se tekst raspada ili kao da je iz horora.
+    <br><br>
+    <strong>Primer</strong><br>
+    „bok" → b̷̢o̴̢k̷̛
+    <br><br>
+    Najčešće to viđaš u mračnim biojevima na Instagramu, u halloweenskim memovima, u gaming klanovima koji žele da izgledaju opasno ili kad neko od toga pravi foru.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.2.items.3.question">Odakle uzeti lepe simbole, zvezdice i srca?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.2.items.3.answer">Sve što imaš u odeljku „Ukrasi" ispod tekstualnog polja možeš kopirati zasebno — čak i bez upisivanja teksta. Naprosto kao zasebne znakove za bio, nadimak ili objavu.
+    <br><br>
+    — <strong>Estetski simboli</strong>: ✦ ✧ ⋆ ｡ ☆ ♡ ❀ ✿<br>
+    — <strong>Okviri i obrubi</strong>: ╭─▸ │ ╰─▸ ili ★彡[ ]彡★<br>
+    — <strong>Strelice</strong>: → ⇨ ➤ ⟶<br>
+    — <strong>Minimalni razdelnici</strong>: ·  ⋅  ─  •<br>
+    — <strong>Zastave i emoji</strong>.
+    <br><br>
+    Najčešće se koriste u estetskim biojevima na Instagramu i Pinterestu — pašu uz sve, od citata do spiska interesovanja.</div>
+</div>
+
+
+<!-- Srpski znakovi, kompatibilnost -->
+<h2 class="faq-category" data-i18n="faq.categories.3.title">Srpski znakovi, kompatibilnost, problemi</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.3.items.0.question">A srpski znakovi? Radi li sa č, ć, đ, š, ž?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.3.items.0.answer"><strong>Ukratko:</strong> zavisi od stila.
+    <br><br>
+    Unicode ima stilizovane varijante za osnovnu abecedu A–Z, pa se <em>c</em>, <em>s</em>, <em>z</em> bez problema pretvore npr. u podebljano. Ali za <em>č</em>, <em>ć</em>, <em>đ</em>, <em>š</em>, <em>ž</em> stilizovane verzije postoje samo u delu stilova (uglavnom bold, kurziv, kapitalke).
+    <br><br>
+    Ako stil nema verziju za srpski znak, on ostaje u izvornom obliku — tekst je i dalje čitljiv, srpsko slovo naprosto izgleda „običnije" od ostatka. Za nadimke bez kvačica to nije nikakav problem. Za cele rečenice na srpskom preporučujem <strong>bold</strong>, <strong>kurziv</strong> ili <strong>monospace</strong> — oni se najbolje snalaze sa našom abecedom. Napomena i za digrafe: dž, lj i nj su samo dva obična slova jedno do drugog, pa se svako stilizuje zasebno.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.3.items.1.question">Zašto se nekome prikazuju kvadratići umesto slova?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.3.items.1.answer">Zato što sistemski font na strani primaoca ne sadrži zadati Unicode znak. To nije problem sa tvojim tekstom — naprosto njegov telefon ili aplikacija nema taj konkretni znak u kompletu.
+    <br><br>
+    Drži se <strong>bolda</strong>, <strong>kurziva</strong> i <strong>balončaste</strong> — imaju najširu podršku. Vrlo egzotični stilovi (fullwidth, kvadratići) mogu da se prikažu kao □ na starijim Androidima ili u nekim mejl klijentima.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.3.items.2.question">Instagram mi je izrezao deo znakova u nadimku — šta sad?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.3.items.2.answer">Instagram ima filter na polju <strong>korisničko ime</strong> (dakle @login) — prima samo slova, brojke, tačke i podvlake. Tu stilizovana slova ne možeš da nalepiš.
+    <br><br>
+    Ali u polju <strong>„Ime"</strong> (prikazano ime) i u <strong>biju</strong> može — i tu prolazi većina stilova. Ako se jedan ne sačuva, uzmi drugi. Bold obično prolazi bez problema.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.3.items.3.question">Postoje li znakovi koji se uopšte ne mogu pretvoriti?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.3.items.3.answer">Standardna slova (A–Z, a–z), brojke i osnovni interpunkcijski znakovi pretvaraju se bez problema. Neki retki simboli ili posebni znakovi nemaju stilizovane parnjake u Unicodeu — tada ostaju u izvorniku. Ništa se ne kvari, tekst je i dalje za kopiranje.</div>
+</div>
+
+
+<!-- Sigurnost, privatnost, telefon -->
+<h2 class="faq-category" data-i18n="faq.categories.4.title">Sigurnost, privatnost, telefon</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.4.items.0.question">Čuva li se moj tekst negde?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.4.items.0.answer">Ne. Cela pretvorba slova dešava se <strong>u tvom pregledaču</strong> — ništa ne ide na naše servere, ništa se ne čuva, ništa se ne prati. Kopirani tekst je čisti Unicode, bez skrivenih znakova, bez ikakvih identifikatora.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.4.items.1.question">Je li sigurno lepiti ova slova bilo gde?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.4.items.1.answer">Da — to su standardni Unicode znakovi, isti kakve koristi ceo internet. Ništa unutra, bez skripti, bez skrivenog oblikovanja, bez kodova. Slobodno lepi u biografiju, u poslovni mejl, u bio na LinkedInu — gde god želiš.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.4.items.2.question">Radi li na telefonu?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.4.items.2.answer">Da — stranica se u potpunosti prilagođava telefonu. iPhone, Android, tablet — sve štima. Upišeš tekst, klikneš, kopira se u privremenu memoriju, nalepiš u aplikaciji. Bez instaliranja ičega iz prodavnice.</div>
+</div>
+
+
+<!-- Po čemu se razlikujemo -->
+<h2 class="faq-category" data-i18n="faq.categories.5.title">Po čemu se razlikujemo</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.5.items.0.question">Po čemu se razlikujete od drugih generatora slova?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.5.items.0.answer">Konkretno:
+    <br><br>
+    — <strong>Jedna od većih kolekcija</strong> Ultra stilova — bold, kurziv, gotica, balončasta i još desetak drugih.<br>
+    — <strong>Spajanje stilova</strong> — većina generatora daje ti jedan stil odjednom, mi dozvoljavamo naslanjanje.<br>
+    — <strong>Ukrasi jednim klikom</strong> — okviri, zvezdice, razdelnici bez lepljenja znak po znak.<br>
+    — <strong>Stranice za konkretne platforme</strong> — Instagram, TikTok, Discord. Onde prikazujemo samo stilove koji na toj aplikaciji rade.<br>
+    — <strong>Brzo i bez iskačućih prozora</strong> — bez captcha, bez „prihvati sve" pre svakog klika.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.5.items.1.question">Dolaze li novi stilovi?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.5.items.1.answer">Da, redovno. S vremena na vreme upadnu nove varijante, ukrasi i okviri. Najlakše je zapamtiti stranicu ili svratiti povremeno.</div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    <span data-i18n="faq.categories.5.items.2.question">Kako pronaći tačno onaj stil koji tražim?</span>
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <div class="faq-answer" data-i18n-html="faq.categories.5.items.2.answer">Tri puta:
+    <br><br>
+    <strong>Po stilu</strong> — kategorije na vrhu: bold, kurziv, gotica, balončasta, precrtano, naopako i još.<br>
+    <strong>Po platformi</strong> — svrati na podstranicu za Instagram, TikTok, Discord — onde su samo stilovi koji se na toj platformi pokažu.<br>
+    <strong>Po cilju</strong> — odeljak s primenama ima alate prilagođene konkretnoj potrebi: naslov na LinkedInu, komentari, tekst sa emojijima.</div>
+</div>
+    </div>
+  </section>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-inner">
+      <!-- Language Switcher -->
+      <div class="lang-switcher" role="navigation" aria-label="Language switcher">
+        <a class="lang-option" href="/" hreflang="en">EN</a>
+        <a class="lang-option" href="/es/" hreflang="es">ES</a>
+        <a class="lang-option" href="/fr/" hreflang="fr">FR</a>
+        <a class="lang-option" href="/pt/" hreflang="pt">PT</a>
+        <a class="lang-option" href="/de/" hreflang="de">DE</a>
+        <a class="lang-option" href="/id/" hreflang="id">ID</a>
+        <a class="lang-option" href="/it/" hreflang="it">IT</a>
+        <a class="lang-option" href="/nl/" hreflang="nl">NL</a>
+        <a class="lang-option" href="/tr/" hreflang="tr">TR</a>
+        <a class="lang-option" href="/pl/" hreflang="pl">PL</a>
+        <a class="lang-option" href="/hr/" hreflang="hr">HR</a>
+        <a class="lang-option active" href="/sr/" hreflang="sr">SR</a>
+        <a class="lang-option" href="/vi/" hreflang="vi">VI</a>
+        <a class="lang-option" href="/sv/" hreflang="sv">SV</a>
+        <a class="lang-option" href="/no/" hreflang="no">NO</a>
+        <a class="lang-option" href="/ja/" hreflang="ja">JA</a>
+        <a class="lang-option" href="/th/" hreflang="th">TH</a>
+        <a class="lang-option" href="/ru/" hreflang="ru">RU</a>
+        <a class="lang-option" href="/ar/" hreflang="ar">AR</a>
+      </div>
+    </div>
+  </footer>
+
+  <div class="copy-toast" id="copyToast">Copied!</div>
+
+  <script src="/styles.js" defer=""></script>
+<script src="/renderer.js" defer=""></script>
+<script src="/script.js" defer=""></script>
+<script src="/i18n.js" defer=""></script>
+
+
+
+
+<script src="/footer.js" defer=""></script>
+
+
+</body></html>

--- a/sr/kurziv/index.html
+++ b/sr/kurziv/index.html
@@ -1,0 +1,299 @@
+<!DOCTYPE html><html lang="sr"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZGVh");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Generator Kurziva — 𝘬𝘶𝘳𝘻𝘪𝘷 za kopiranje | UltraTextGen</title>
+  <meta name="description" content="Besplatan generator kurziva: pretvori tekst u ukošena Unicode slova za kopiranje i lepljenje — u bio na Instagramu, WhatsApp, TikTok, Discord i LinkedIn. Odmah, bez registracije.">
+  <link rel="canonical" href="https://ultratextgen.com/sr/kurziv/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/category/italic-fonts/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/category/italic-fonts/">
+  <link rel="alternate" hreflang="sr" href="https://ultratextgen.com/sr/kurziv/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Generator Kurziva — 𝘬𝘶𝘳𝘻𝘪𝘷 za kopiranje | UltraTextGen">
+  <meta property="og:description" content="Besplatan generator kurziva — ukošena Unicode slova za kopiranje i lepljenje na Instagram, TikTok, WhatsApp, Discord i LinkedIn. Odmah, bez registracije.">
+  <meta property="og:url" content="https://ultratextgen.com/sr/kurziv/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category-italic-fonts.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Generator Kurziva — 𝘬𝘶𝘳𝘻𝘪𝘷 za kopiranje | UltraTextGen">
+  <meta name="twitter:description" content="Besplatan generator kurziva — ukošena Unicode slova za kopiranje i lepljenje na društvene mreže, chatove i u nadimke.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category-italic-fonts.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "sr-Latn",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Kako napraviti kurziv za kopiranje i lepljenje?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Upiši tekst u polje na vrhu, a generator će ga odmah prikazati u kurzivu (𝘱𝘰𝘱𝘶𝘵 𝘰𝘷𝘰𝘨𝘢) — to su pravi Unicode znakovi, a ne instalirani font ni slika. Budući da su obični tekstualni znakovi, možeš da ih kopiraš i nalepiš svuda gde se može upisati tekst: u bio, opise, komentare i poruke. Više u našem vodiču o tome kako rade Unicode fontovi."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Radi li Unicode kurziv na Instagramu, WhatsAppu, TikToku i LinkedInu?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da. Bio, opisi, komentari i poruke na chatu primaju te znakove bez problema. Naročito na LinkedInu i X-u, gde nema izvornog kurziva, ukošeni Unicode font omogućuje da istakneš najvažnije reči. Napomena: neka polja korisničkog imena (@) filtriraju takve znakove — za sam login ostavi običan tekst, ali u biju kurziv radi sjajno."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Podržava li kurziv srpske znakove (č, ć, đ, š, ž)?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Unicode kurziv obuhvata osnovnu abecedu A–Z i brojke 0–9, pa srpske kvačice (č, ć, đ, š, ž) nemaju sopstveni ukošeni oblik i ostaju obična slova usred reči (npr. „šuma” izađe kao š𝘶𝘮𝘢). Za nadimke i kratke natpise bez kvačica izgleda idealno; u dužem tekstu najsigurnije je birati reči koje ih ne sadrže."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Je li generator kurziva besplatan?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da, potpuno besplatan i bez registracije. Upisuj, kopiraj i lepi koliko god puta želiš — nema nikakvog ograničenja ni skrivenih troškova."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Zašto se neka slova kurziva prikazuju kao prazni kvadratići?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Prazni kvadratić (▯) znači da uređaj primaoca nema glif za taj ukošeni znak — najčešće je to stariji telefon ili računar. Odaberi jednostavniju varijantu kurziva ili ažuriraj uređaj — više u tekstu o tome zašto se fontovi prikazuju kao kvadratići."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Utiče li Unicode kurziv na čitljivost i doseg?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ukošeni Unicode znakovi lepo privlače pogled i sjajno rade u sloganima, naslovima i pozivima na akciju na društvenim mrežama. Koristi ih namerno — kratak naglasak u kurzivu, ostalo običnim tekstom. Za sadržaj na sopstvenoj web-stranici bolje je koristiti CSS ukošenje da pretraživači čitaju normalne reči; u tekstualnim poljima društvenih mreža idealan je Unicode kurziv. Kod dužih delova vodi računa o pristupačnosti."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "inLanguage": "sr-Latn",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Početna", "item": "https://ultratextgen.com/sr/" },
+    { "@type": "ListItem", "position": 2, "name": "Kurziv", "item": "https://ultratextgen.com/sr/kurziv/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Generator Kurziva",
+  "alternateName": ["Kurziv za kopiranje","Ukošeni font","Ukošena slova","Unicode kurziv","Kurzivni font","Tekst u kurzivu","Kurziv online"],
+  "url": "https://ultratextgen.com/sr/kurziv/",
+  "inLanguage": "sr-Latn",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "RSD"
+  },
+  "description": "Besplatan generator kurziva: pretvara tekst u ukošena Unicode slova za kopiranje i lepljenje na Instagram, TikTok, WhatsApp, Discord, LinkedIn i u nadimke.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/sr/">Početna</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Kurziv</span>
+</nav>
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/category-italic-fonts.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+  <!-- Hero -->
+  <section class="hero">
+    <div class="hero-inner">
+      <div class="hero-card">
+        <h1 class="hero-headline">Generator Kurziva</h1>
+        <p class="hero-tagline">Pretvori bilo koji tekst u 𝘬𝘶𝘳𝘻𝘪𝘷 za kopiranje i lepljenje — elegantna,
+          ukošena Unicode slova za bio, nadimke i naslove. Besplatno, odmah, bez registracije.</p>
+        <div class="input-wrapper">
+          <textarea class="main-input" id="mainInput" placeholder="Upiši tekst, reč ili ime…" maxlength="500" autofocus></textarea>
+          <span class="char-count"><span id="charCount">0</span>/500</span>
+        </div>
+
+        <!-- Decoration Selector -->
+        <div class="decoration-section">
+          <div class="decoration-label">
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"></path>
+            </svg>
+            Dodaj simbole oko rezultata
+          </div>
+          <div class="decoration-tabs">
+            <button class="decoration-tab active" data-deco-tab="symbols">Simboli</button>
+            <button class="decoration-tab" data-deco-tab="frames">Okviri</button>
+            <button class="decoration-tab" data-deco-tab="dividers">Razdelnici</button>
+            <button class="decoration-tab" data-deco-tab="minimal">Minimalni</button>
+            <button class="decoration-tab" data-deco-tab="emojis">Emoji</button>
+          </div>
+          <div class="decoration-grid" id="decorationGrid"></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Main Content -->
+  <main class="container">
+
+    <section class="editorial-section">
+      <span class="article-section-label">Unicode kurziv</span>
+      <h2>Kurziv za kopiranje — za bio, nadimke i naslove</h2>
+      <p>Ova slova nisu instalirani font ni slika, nego pravi <strong>Unicode znakovi</strong>. Istakni
+        ključnu reč u biju, napravi ukošen nadimak ili učini da naslov na LinkedInu i X-u privlači pogled — svuda onde,
+        gde nema izvornog kurziva. Upiši tekst iznad, klikni <strong>Kopiraj</strong> i nalepi kurziv gde god želiš.</p>
+    </section>
+
+    <!-- Category Tabs (populated by script.js) -->
+    <div class="category-section">
+      <div class="category-tabs" id="categoryTabs"></div>
+    </div>
+
+    <!-- Results -->
+    <div class="results-grid" id="resultsGrid"></div>
+
+    <section class="editorial-section">
+      <span class="article-section-label">Povezano</span>
+      <p>Spoji kurziv s <a href="/sr/fontovi-za-discord/">fontovima za Discord</a>,
+        <a href="/sr/">slovima za kopiranje</a> ili
+        <a href="/library/invisible-character/">nevidljivim znakom</a> za čiste razmake. Za tetovaže tu je
+        <a href="/usecase/tattoo-fonts/">generator fontova za tetovažu</a>, a za okomite rasporede —
+        <a href="/usecase/vertical-text/">okomiti tekst</a>.</p>
+    </section>
+  </main>
+
+  <!-- Footer + FAQ -->
+  <footer class="footer">
+    <div class="footer-inner">
+<div class="faq-section" id="faq">
+
+<h2 class="faq-category">Generator Kurziva — FAQ</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Kako napraviti kurziv za kopiranje i lepljenje?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Upiši tekst u polje na vrhu, a generator će ga odmah prikazati u kurzivu (𝘱𝘰𝘱𝘶𝘵 𝘰𝘷𝘰𝘨𝘢) — to su pravi Unicode znakovi, a ne instalirani font ni slika. Budući da su obični tekstualni znakovi, možeš da ih kopiraš i nalepiš svuda gde se može upisati tekst: u bio, opise, komentare i poruke. Više u našem <a href="/guide/how-unicode-fonts-work/">vodiču o tome kako rade Unicode fontovi</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Radi li Unicode kurziv na Instagramu, WhatsAppu, TikToku i LinkedInu?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Da. Bio, opisi, komentari i poruke na chatu primaju te znakove bez problema. Naročito na LinkedInu i X-u, gde nema izvornog kurziva, ukošeni Unicode font omogućuje da istakneš najvažnije reči. Napomena: neka <strong>polja korisničkog imena (@)</strong> filtriraju takve znakove — za sam login ostavi običan tekst, ali u biju kurziv radi sjajno.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Podržava li kurziv srpske znakove (č, ć, đ, š, ž)?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Unicode kurziv obuhvata osnovnu abecedu A–Z i brojke 0–9, pa srpske kvačice (č, ć, đ, š, ž) nemaju sopstveni ukošeni oblik i ostaju obična slova usred reči (npr. „šuma” izađe kao š𝘶𝘮𝘢). Za nadimke i kratke natpise <strong>bez kvačica</strong> izgleda idealno; u dužem tekstu najsigurnije je birati reči koje ih ne sadrže.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Je li generator kurziva besplatan?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Da, potpuno besplatan i bez registracije. Upisuj, kopiraj i lepi koliko god puta želiš — nema nikakvog ograničenja ni skrivenih troškova.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Zašto se neka slova kurziva prikazuju kao prazni kvadratići?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Prazni kvadratić (▯) znači da uređaj primaoca nema glif za taj ukošeni znak — najčešće je to stariji telefon ili računar. Odaberi jednostavniju varijantu kurziva ili ažuriraj uređaj — više u tekstu o tome, <a href="/guide/why-fonts-show-as-boxes/">zašto se fontovi prikazuju kao kvadratići</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Utiče li Unicode kurziv na čitljivost i doseg?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Ukošeni Unicode znakovi lepo privlače pogled i sjajno rade u sloganima, naslovima i pozivima na akciju na društvenim mrežama. Koristi ih namerno — kratak naglasak u kurzivu, ostalo običnim tekstom. Za sadržaj na sopstvenoj web-stranici bolje je koristiti CSS ukošenje da pretraživači čitaju normalne reči; u tekstualnim poljima društvenih mreža idealan je Unicode kurziv. Kod dužih delova vodi računa o <a href="/guide/fancy-fonts-accessibility-guide/">pristupačnosti</a>.
+  </div>
+</div>
+
+</div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Odabir jezika">
+      <a class="lang-option" href="/category/italic-fonts/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/sr/kurziv/" hreflang="sr">SR</a>
+    </div>
+
+    </div>
+  </footer>
+
+  <div class="copy-toast" id="copyToast">Kopirano!</div>
+
+  <script>
+    window.UTG_FAMILY = "italic";
+    window.UTG_DEMO_TEXT = "kurziv online\nstilizovani tekst";
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/script.js" defer></script>
+  <script src="/footer.js" defer></script>
+</body></html>

--- a/sr/mala-slova/index.html
+++ b/sr/mala-slova/index.html
@@ -1,0 +1,299 @@
+<!DOCTYPE html><html lang="sr"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZGVh");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Generator Malih Slova — ᴍᴀʟᴀ sʟᴏᴠᴀ i kapitalke za kopiranje | UltraTextGen</title>
+  <meta name="description" content="Besplatan generator malih slova: pretvori tekst u mali Unicode tekst i kapitalke za kopiranje i lepljenje — u bio na Instagramu, Discordu, TikToku, X-u i nadimke. Odmah, bez registracije.">
+  <link rel="canonical" href="https://ultratextgen.com/sr/mala-slova/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/category/small-text/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/category/small-text/">
+  <link rel="alternate" hreflang="sr" href="https://ultratextgen.com/sr/mala-slova/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Generator Malih Slova — ᴍᴀʟᴀ sʟᴏᴠᴀ i kapitalke za kopiranje | UltraTextGen">
+  <meta property="og:description" content="Besplatan generator malih slova — mali Unicode tekst i kapitalke za kopiranje i lepljenje na Instagram, TikTok, Discord i X. Odmah, bez registracije.">
+  <meta property="og:url" content="https://ultratextgen.com/sr/mala-slova/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category-small-text.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Generator Malih Slova — ᴍᴀʟᴀ sʟᴏᴠᴀ i kapitalke za kopiranje | UltraTextGen">
+  <meta name="twitter:description" content="Besplatan generator malih slova — mali Unicode tekst i kapitalke za kopiranje i lepljenje na društvene mreže, chatove i u nadimke.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category-small-text.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "sr-Latn",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Šta su mala slova i kako radi generator malih slova?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Generator pretvara slova koja upišeš u manje Unicode znakove — kapitalke (ᴍᴀʟᴀ sʟᴏᴠᴀ) te mali tekst u gornjem i donjem indeksu. To su pravi znakovi, a ne font ni slika, pa ih možeš kopirati i nalepiti svuda gde je dozvoljen tekst: u bio, opise, komentare i poruke. Više u našem vodiču o tome kako rade Unicode fontovi."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Rade li mala slova na Discordu, Instagramu, TikToku i X-u?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da. Bio, opisi, komentari i poruke na chatu obično bez problema primaju mali tekst. Dobro se pokaže kao pomoćni, suptilan opis ispod nadimka ili nežan potpis koji ne viče kao velik podebljan font. Kompatibilnost ipak zavisi od stila i uređaja — najbolje je nalepiti rezultat i proveriti kako izgleda u danoj aplikaciji."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Po čemu se razlikuju kapitalke od malog teksta u gornjem indeksu?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Kapitalke su mala verzalna slova (ᴋᴀᴘɪᴛᴀʟᴋᴇ) — slova imaju oblik velikih, ali visinu malih, pa tekst ostaje čitljiv i elegantan. Mali tekst u gornjem indeksu (ᵗᵃᵏᵒ) ili donjem još je sitniji i lagano podignut ili spušten, pa je sjajan za kratke ukrasne naglaske. Za duže fraze obično bolje izgledaju kapitalke."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Mogu li pisati srpske znakove (č, ć, đ, š, ž) malim slovima?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Male Unicode varijante obuhvataju uglavnom A–Z i deo brojki, pa srpski znakovi poput č, ć, đ, š, ž nemaju sopstveni mali oblik i ostaju u normalnoj veličini. Za ujednačen efekat možeš da ih zameniš osnovnim slovima (c, d, s, z) — to menja pravopis — ili ih ostaviti nepromenjene, što u kratkom nadimku ili potpisu obično ionako izgleda dobro."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Je li generator malih slova besplatan?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da, potpuno besplatan i bez registracije. Upisuj, kopiraj i lepi koliko god puta želiš — nema ograničenja ni skrivenih troškova. Sve radi u pregledaču, pa ništa ne instaliraš."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Zašto se neka mala slova prikazuju kao kvadratići i utiču li na čitljivost?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Prazni kvadratić (▯) znači da uređaj nema odgovarajući glif za taj mali znak — to se obično odnosi na starije sisteme. Odaberi tada jednostavniji stil (npr. kapitalke) ili ažuriraj uređaj; više u članku o tome zašto se fontovi prikazuju kao kvadratići. Imaj i na umu da se vrlo mali tekst teže čita — koristi ga za kratke fraze, a najvažnije informacije ostavi običnim tekstom zbog pristupačnosti."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "inLanguage": "sr-Latn",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Početna", "item": "https://ultratextgen.com/sr/" },
+    { "@type": "ListItem", "position": 2, "name": "Mala slova", "item": "https://ultratextgen.com/sr/mala-slova/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Generator Malih Slova",
+  "alternateName": ["Mala slova","Mali tekst","Generator malih slova","Kapitalke","Mala slova za kopiranje","Mali Unicode tekst","Sitni tekst","Mali natpisi"],
+  "url": "https://ultratextgen.com/sr/mala-slova/",
+  "inLanguage": "sr-Latn",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "RSD"
+  },
+  "description": "Besplatan generator malih slova: pretvori tekst u mali Unicode tekst i kapitalke za kopiranje i lepljenje na Instagram, TikTok, Discord, X i u nadimke.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/sr/">Početna</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Mala slova</span>
+</nav>
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/category-small-text.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+  <!-- Hero -->
+  <section class="hero">
+    <div class="hero-inner">
+      <div class="hero-card">
+        <h1 class="hero-headline">Generator Malih Slova</h1>
+        <p class="hero-tagline">Pretvori bilo koji tekst u ᴍᴀʟᴀ sʟᴏᴠᴀ i kapitalke za kopiranje i lepljenje — suptilni,
+          sitni Unicode znakovi za bio, nadimke i potpise. Besplatno, odmah, bez registracije.</p>
+        <div class="input-wrapper">
+          <textarea class="main-input" id="mainInput" placeholder="Upiši tekst, reč ili ime…" maxlength="500" autofocus></textarea>
+          <span class="char-count"><span id="charCount">0</span>/500</span>
+        </div>
+
+        <!-- Decoration Selector -->
+        <div class="decoration-section">
+          <div class="decoration-label">
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"></path>
+            </svg>
+            Dodaj simbole oko rezultata
+          </div>
+          <div class="decoration-tabs">
+            <button class="decoration-tab active" data-deco-tab="symbols">Simboli</button>
+            <button class="decoration-tab" data-deco-tab="frames">Okviri</button>
+            <button class="decoration-tab" data-deco-tab="dividers">Razdelnici</button>
+            <button class="decoration-tab" data-deco-tab="minimal">Minimalni</button>
+            <button class="decoration-tab" data-deco-tab="emojis">Emoji</button>
+          </div>
+          <div class="decoration-grid" id="decorationGrid"></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Main Content -->
+  <main class="container">
+
+    <section class="editorial-section">
+      <span class="article-section-label">Mali Unicode tekst</span>
+      <h2>Mala slova za kopiranje — za bio, nadimke i potpise</h2>
+      <p>Ova slova nisu font ni slika, nego pravi <strong>Unicode znakovi</strong>. Dodaj suptilan opis
+        ispod nadimka, ispiši ime elegantnim <strong>kapitalkama</strong> ili upleti sitan tekst u gornjem indeksu
+        onde gde bi velik podebljan font bio previše napadan. Upiši tekst iznad, klikni <strong>Kopiraj</strong>
+        i nalepi mala slova gde god želiš.</p>
+    </section>
+
+    <!-- Category Tabs (populated by script.js) -->
+    <div class="category-section">
+      <div class="category-tabs" id="categoryTabs"></div>
+    </div>
+
+    <!-- Results -->
+    <div class="results-grid" id="resultsGrid"></div>
+
+    <section class="editorial-section">
+      <span class="article-section-label">Povezano</span>
+      <p>Spoji mala slova s <a href="/sr/podebljana-slova/">podebljanim slovima</a>,
+        <a href="/library/aesthetic-symbols/">ukrasnim simbolima</a> ili <a href="/library/invisible-character/">nevidljivim znakom</a>
+        za čiste razmake. Pogledaj i <a href="/sr/">slova za kopiranje</a>,
+        a za okomite rasporede — <a href="/usecase/vertical-text/">okomiti tekst</a>.</p>
+    </section>
+  </main>
+
+  <!-- Footer + FAQ -->
+  <footer class="footer">
+    <div class="footer-inner">
+<div class="faq-section" id="small-faq">
+
+<h2 class="faq-category">Generator Malih Slova — FAQ</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Šta su mala slova i kako radi generator malih slova?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Generator pretvara slova koja upišeš u manje Unicode znakove — kapitalke (ᴍᴀʟᴀ sʟᴏᴠᴀ) te mali tekst u gornjem i donjem indeksu. To su pravi znakovi, a ne font ni slika, pa ih možeš kopirati i nalepiti svuda gde je dozvoljen tekst: u bio, opise, komentare i poruke. Više u našem <a href="/guide/how-unicode-fonts-work/">vodiču o tome kako rade Unicode fontovi</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Rade li mala slova na Discordu, Instagramu, TikToku i X-u?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Da. Bio, opisi, komentari i poruke na chatu obično bez problema primaju mali tekst. Dobro se pokaže kao pomoćni, suptilan opis ispod nadimka ili nežan potpis koji ne viče kao velik podebljan font. Kompatibilnost ipak zavisi od stila i uređaja — najbolje je nalepiti rezultat i proveriti kako izgleda u danoj aplikaciji.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Po čemu se razlikuju kapitalke od malog teksta u gornjem indeksu?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Kapitalke su mala verzalna slova (ᴋᴀᴘɪᴛᴀʟᴋᴇ) — slova imaju oblik velikih, ali visinu malih, pa tekst ostaje čitljiv i elegantan. Mali tekst u gornjem indeksu (ᵗᵃᵏᵒ) ili donjem još je sitniji i lagano podignut ili spušten, pa je sjajan za kratke ukrasne naglaske. Za duže fraze obično bolje izgledaju <strong>kapitalke</strong>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Mogu li pisati srpske znakove (č, ć, đ, š, ž) malim slovima?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Male Unicode varijante obuhvataju uglavnom A–Z i deo brojki, pa srpski znakovi poput č, ć, đ, š, ž nemaju sopstveni mali oblik i ostaju u normalnoj veličini. Za ujednačen efekat možeš da ih zameniš osnovnim slovima (<strong>c, d, s, z</strong>) — to menja pravopis — ili ih ostaviti nepromenjene, što u kratkom nadimku ili potpisu obično ionako izgleda dobro.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Je li generator malih slova besplatan?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Da, potpuno besplatan i bez registracije. Upisuj, kopiraj i lepi koliko god puta želiš — nema ograničenja ni skrivenih troškova. Sve radi u pregledaču, pa ništa ne instaliraš.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Zašto se neka mala slova prikazuju kao kvadratići i utiču li na čitljivost?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Prazni kvadratić (▯) znači da uređaj nema odgovarajući glif za taj mali znak — to se obično odnosi na starije sisteme. Odaberi tada jednostavniji stil (npr. kapitalke) ili ažuriraj uređaj; više u članku o tome, <a href="/guide/why-fonts-show-as-boxes/">zašto se fontovi prikazuju kao kvadratići</a>. Imaj i na umu da se vrlo mali tekst teže čita — koristi ga za kratke fraze, a najvažnije informacije ostavi običnim tekstom zbog <a href="/guide/fancy-fonts-accessibility-guide/">pristupačnosti</a>.
+  </div>
+</div>
+
+</div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Odabir jezika">
+      <a class="lang-option" href="/category/small-text/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/sr/mala-slova/" hreflang="sr">SR</a>
+    </div>
+
+    </div>
+  </footer>
+
+  <div class="copy-toast" id="copyToast">Kopirano!</div>
+
+  <script>
+    window.UTG_FAMILY = "small-text";
+    window.UTG_DEMO_TEXT = "mala slova\nmali tekst";
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/script.js" defer></script>
+  <script src="/footer.js" defer></script>
+</body></html>

--- a/sr/podebljana-slova/index.html
+++ b/sr/podebljana-slova/index.html
@@ -1,0 +1,299 @@
+<!DOCTYPE html><html lang="sr"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZGVh");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Generator Podebljanih Slova — 𝐩𝐨𝐝𝐞𝐛𝐥𝐣𝐚𝐧𝐚 𝐬𝐥𝐨𝐯𝐚 za kopiranje | UltraTextGen</title>
+  <meta name="description" content="Besplatan generator podebljanih slova: pretvori tekst u podebljane Unicode znakove za kopiranje i lepljenje — u bio na Instagramu, WhatsApp, TikTok, Discord, LinkedIn i nadimke. Odmah, bez registracije.">
+  <link rel="canonical" href="https://ultratextgen.com/sr/podebljana-slova/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/category/bold-fonts/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/category/bold-fonts/">
+  <link rel="alternate" hreflang="sr" href="https://ultratextgen.com/sr/podebljana-slova/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Generator Podebljanih Slova — 𝐩𝐨𝐝𝐞𝐛𝐥𝐣𝐚𝐧𝐚 𝐬𝐥𝐨𝐯𝐚 za kopiranje | UltraTextGen">
+  <meta property="og:description" content="Besplatan generator podebljanih slova — podebljani Unicode znakovi za kopiranje i lepljenje na Instagram, TikTok, WhatsApp, Discord i LinkedIn. Odmah, bez registracije.">
+  <meta property="og:url" content="https://ultratextgen.com/sr/podebljana-slova/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category-bold-fonts.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Generator Podebljanih Slova — 𝐩𝐨𝐝𝐞𝐛𝐥𝐣𝐚𝐧𝐚 𝐬𝐥𝐨𝐯𝐚 za kopiranje | UltraTextGen">
+  <meta name="twitter:description" content="Besplatan generator podebljanih slova — podebljani Unicode znakovi za kopiranje i lepljenje na društvene mreže, chatove i u nadimke.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category-bold-fonts.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "sr-Latn",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Šta je generator podebljanih slova i kako radi?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Pretvara slova koja upišeš u podebljane Unicode znakove (𝐩𝐨𝐩𝐮𝐭 𝐨𝐯𝐢𝐡) — prave znakove, a ne font ni sliku. Budući da su to obični tekstualni znakovi, možeš da ih kopiraš i nalepiš svuda gde je dozvoljen tekst: u bio, opise, komentare i poruke. Više u našem vodiču o tome kako rade Unicode fontovi."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Rade li podebljana slova na Instagramu, WhatsAppu, TikToku i LinkedInu?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da. Bio, opisi, komentari i poruke na chatu bez problema primaju te znakove. Naročito na LinkedInu i X-u, gde nema izvornog podebljanja, podebljana Unicode slova čine da se najvažniji delovi istaknu. Napomena: neka polja s @korisničkim imenom filtriraju te znakove — u samom handleu treba ostati na običnom tekstu, ali u biju podebljana slova rade sjajno."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Mogu li pisati srpske znakove (č, ć, đ, š, ž) podebljanim slovima?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Unicode podebljanje obuhvata A–Z i 0–9, pa srpski znakovi poput č, ć, đ, š, ž nemaju sopstveni podebljani oblik i ostaju obični. Za potpuno podebljan efekat možeš da ih zameniš osnovnim slovima (c, d, s, z) — to menja pravopis — ili ih ostaviti u normalnoj debljini, što u kratkom tekstu obično ionako izgleda dobro. Najbolje se sa našom abecedom snalaze bold, kurziv i monospace."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Je li generator podebljanih slova besplatan?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Da, potpuno besplatan i bez registracije. Upisuj, kopiraj i lepi koliko god puta želiš — nema ograničenja ni skrivenih troškova."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Zašto se neki znakovi prikazuju kao prazni kvadratići?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Prazni kvadratić (▯) znači da uređaj nema odgovarajući glif za taj podebljani znak. To se obično odnosi na starije sisteme. Odaberi jednostavniji podebljani stil ili ažuriraj uređaj — više u članku o tome zašto se fontovi prikazuju kao kvadratići."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Utiče li podebljani Unicode tekst na čitljivost i doseg?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Podebljani Unicode znakovi privlače pogled u feedu i sjajno rade kao hook, naslov i CTA na društvenim mrežama. Koristi ih namerno — kratki podebljani naglasci, ostalo običnim tekstom. Za sadržaj na web-stranici bolje je koristiti CSS podebljanje da pretraživači čitaju tekst kao obične reči. Za tekstualna polja na društvenim mrežama Unicode podebljanje je idealno rješenje. Vodi računa o pristupačnosti kad oblikuješ duže delove."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "inLanguage": "sr-Latn",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Početna", "item": "https://ultratextgen.com/sr/" },
+    { "@type": "ListItem", "position": 2, "name": "Podebljana slova", "item": "https://ultratextgen.com/sr/podebljana-slova/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Generator Podebljanih Slova",
+  "alternateName": ["Podebljana slova","Podebljani tekst","Bold slova","Generator podebljanog teksta","Podebljana slova za kopiranje","Podebljani Unicode tekst","Bold za kopiranje"],
+  "url": "https://ultratextgen.com/sr/podebljana-slova/",
+  "inLanguage": "sr-Latn",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "RSD"
+  },
+  "description": "Besplatan generator podebljanih slova: pretvori tekst u podebljane Unicode znakove za kopiranje i lepljenje na Instagram, TikTok, WhatsApp, Discord, LinkedIn i u nadimke.",
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/sr/">Početna</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Podebljana slova</span>
+</nav>
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/category-bold-fonts.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+  <!-- Hero -->
+  <section class="hero">
+    <div class="hero-inner">
+      <div class="hero-card">
+        <h1 class="hero-headline">Generator Podebljanih Slova</h1>
+        <p class="hero-tagline">Pretvori bilo koji tekst u 𝐩𝐨𝐝𝐞𝐛𝐥𝐣𝐚𝐧𝐢 𝐭𝐞𝐤𝐬𝐭 za kopiranje i lepljenje — snažni,
+          uočljivi Unicode znakovi za bio, nadimke i naslove. Besplatno, odmah, bez registracije.</p>
+        <div class="input-wrapper">
+          <textarea class="main-input" id="mainInput" placeholder="Upiši tekst, reč ili ime…" maxlength="500" autofocus></textarea>
+          <span class="char-count"><span id="charCount">0</span>/500</span>
+        </div>
+
+        <!-- Decoration Selector -->
+        <div class="decoration-section">
+          <div class="decoration-label">
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"></path>
+            </svg>
+            Dodaj simbole oko rezultata
+          </div>
+          <div class="decoration-tabs">
+            <button class="decoration-tab active" data-deco-tab="symbols">Simboli</button>
+            <button class="decoration-tab" data-deco-tab="frames">Okviri</button>
+            <button class="decoration-tab" data-deco-tab="dividers">Razdelnici</button>
+            <button class="decoration-tab" data-deco-tab="minimal">Minimalni</button>
+            <button class="decoration-tab" data-deco-tab="emojis">Emoji</button>
+          </div>
+          <div class="decoration-grid" id="decorationGrid"></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Main Content -->
+  <main class="container">
+
+    <section class="editorial-section">
+      <span class="article-section-label">Podebljana Unicode slova</span>
+      <h2>Podebljani tekst za kopiranje — za bio, nadimke i naslove</h2>
+      <p>Ova slova nisu font ni slika, nego pravi <strong>Unicode znakovi</strong>. Istakni ključnu reč
+        u svom biju, napravi podebljan nadimak ili učini da naslov na LinkedInu i X-u privlači pogled — svuda onde,
+        gde nema izvornog podebljanja. Upiši tekst iznad, klikni <strong>Kopiraj</strong> i nalepi podebljana
+        slova gde god želiš.</p>
+    </section>
+
+    <!-- Category Tabs (populated by script.js) -->
+    <div class="category-section">
+      <div class="category-tabs" id="categoryTabs"></div>
+    </div>
+
+    <!-- Results -->
+    <div class="results-grid" id="resultsGrid"></div>
+
+    <section class="editorial-section">
+      <span class="article-section-label">Povezano</span>
+      <p>Spoji podebljana slova s <a href="/sr/fontovi-za-discord/">fontovima za Discord</a>,
+        <a href="/library/aesthetic-symbols/">ukrasnim simbolima</a> ili <a href="/library/invisible-character/">nevidljivim znakom</a>
+        za čiste razmake. Za body art imamo <a href="/usecase/tattoo-fonts/">generator fontova za tetovažu</a>,
+        a za okomite rasporede — <a href="/usecase/vertical-text/">okomiti tekst</a>.</p>
+    </section>
+  </main>
+
+  <!-- Footer + FAQ -->
+  <footer class="footer">
+    <div class="footer-inner">
+<div class="faq-section" id="bold-faq">
+
+<h2 class="faq-category">Generator Podebljanih Slova — FAQ</h2>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Šta je generator podebljanih slova i kako radi?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Pretvara slova koja upišeš u podebljane Unicode znakove (𝐩𝐨𝐩𝐮𝐭 𝐨𝐯𝐢𝐡) — prave znakove, a ne font ni sliku. Budući da su to obični tekstualni znakovi, možeš da ih kopiraš i nalepiš svuda gde je dozvoljen tekst: u bio, opise, komentare i poruke. Više u našem <a href="/guide/how-unicode-fonts-work/">vodiču o tome kako rade Unicode fontovi</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Rade li podebljana slova na Instagramu, WhatsAppu, TikToku i LinkedInu?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Da. Bio, opisi, komentari i poruke na chatu bez problema primaju te znakove. Naročito na LinkedInu i X-u, gde nema izvornog podebljanja, podebljana Unicode slova čine da se najvažniji delovi istaknu. Napomena: neka polja s <strong>@korisničkim imenom</strong> filtriraju te znakove — u samom handleu treba ostati na običnom tekstu, ali u biju podebljana slova rade sjajno.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Mogu li pisati srpske znakove (č, ć, đ, š, ž) podebljanim slovima?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Unicode podebljanje obuhvata A–Z i 0–9, pa srpski znakovi poput č, ć, đ, š, ž nemaju sopstveni podebljani oblik i ostaju obični. Za potpuno podebljan efekat možeš da ih zameniš osnovnim slovima (<strong>c, d, s, z</strong>) — to menja pravopis — ili ih ostaviti u normalnoj debljini, što u kratkom tekstu obično ionako izgleda dobro. Najbolje se sa našom abecedom snalaze bold, kurziv i monospace.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Je li generator podebljanih slova besplatan?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Da, potpuno besplatan i bez registracije. Upisuj, kopiraj i lepi koliko god puta želiš — nema ograničenja ni skrivenih troškova.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Zašto se neki znakovi prikazuju kao prazni kvadratići?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Prazni kvadratić (▯) znači da uređaj nema odgovarajući glif za taj podebljani znak. To se obično odnosi na starije sisteme. Odaberi jednostavniji podebljani stil ili ažuriraj uređaj — više u članku o tome, <a href="/guide/why-fonts-show-as-boxes/">zašto se fontovi prikazuju kao kvadratići</a>.
+  </div>
+</div>
+
+<div class="faq-item">
+  <button class="faq-question" type="button">
+    Utiče li podebljani Unicode tekst na čitljivost i doseg?
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+  </button>
+  <div class="faq-answer">
+    Podebljani Unicode znakovi privlače pogled u feedu i sjajno rade kao hook, naslov i CTA na društvenim mrežama. Koristi ih namerno — kratki podebljani naglasci, ostalo običnim tekstom. Za sadržaj na web-stranici bolje je koristiti CSS podebljanje da pretraživači čitaju tekst kao obične reči. Za tekstualna polja na društvenim mrežama Unicode podebljanje je idealno rješenje. Vodi računa o <a href="/guide/fancy-fonts-accessibility-guide/">pristupačnosti</a> kad oblikuješ duže delove.
+  </div>
+</div>
+
+</div>
+
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Odabir jezika">
+      <a class="lang-option" href="/category/bold-fonts/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/sr/podebljana-slova/" hreflang="sr">SR</a>
+    </div>
+
+    </div>
+  </footer>
+
+  <div class="copy-toast" id="copyToast">Kopirano!</div>
+
+  <script>
+    window.UTG_FAMILY = "bold";
+    window.UTG_DEMO_TEXT = "podebljana slova\npodebljani tekst";
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/script.js" defer></script>
+  <script src="/footer.js" defer></script>
+</body></html>


### PR DESCRIPTION
## Summary
Adds full internationalization support for five new languages: Bosnian (bs), Croatian (hr), Czech (cs), Romanian (ro), and Serbian (sr). This includes translated landing pages, category pages, locale configuration files, and sitemap entries.

## Key Changes

- **New locale files**: Added `locales/{bs,cs,hr,ro,sr}.json` with complete UI translations for each language
- **Landing pages**: Created `{bs,cs,hr,ro,sr}/index.html` with language-specific metadata, titles, and descriptions
- **Category pages**: Generated category-specific pages for each locale:
  - Discord fonts (`fontovi-za-discord/`, `pismo-pro-discord/`, `fonturi-pentru-discord/`)
  - Instagram fonts (`fontovi-za-instagram/`, `pismo-pro-instagram/`, `fonturi-pentru-instagram/`)
  - Gothic text (`goticka-slova/`, `goticke-pismo/`, `scriere-gotica/`)
  - Italic/cursive (`kurziv/`, `kurziva/`, `text-cursiv/`)
  - Small text (`mala-slova/`, `male-pismo/`, `text-mic/`)
  - Bold text (`podebljana-slova/`, `tucne-pismo/`, `text-ingrosat/`)
- **Sitemap updates**: Added all new locale pages to `sitemap.xml` with appropriate priority and change frequency
- **i18n configuration**: Updated `i18n.js` and `scripts/prerender-i18n.js` to include the five new languages in the supported locales list

## Implementation Details

- All new HTML pages follow the existing template structure with proper `lang` attributes and hreflang alternates
- Locale JSON files contain complete translations for meta tags, hero section, category descriptions, and UI elements
- Each locale's pages include proper canonical URLs and language alternates for SEO
- Sitemap entries use consistent lastmod date (2026-07-09) and appropriate priority levels (0.8 for home, 0.7 for category pages)
- No changes to core functionality or styling—this is purely content and configuration expansion

https://claude.ai/code/session_01FEAbrEVveRCacJ5MPnydWY