### PR TITLE
Define printables scope boundary: text-native only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,8 @@ Copy-paste Unicode is still the front door and satisfies the job fastest. Visual
 
 **Scope note (updated):** the earlier "text-only, no image generator" boundary has been intentionally lifted. UltraTextGen now *does* generate images — but only **client-side, on demand, as SVG/PNG built with native Canvas/SVG**. This is not a reversal of the philosophy; it's the same philosophy applied to a new job.
 
+**Printables scope boundary (added 2026-07-10):** "visual asset" does not mean "any kids' worksheet." The line is **typography-native**: a printable belongs in this repo only if the thing being rendered is text — a letter, a word, a name, a phrase (bubble/cursive/block letters, coloring pages, tracing sheets, a dot-to-dot of a *name*, name puzzles, banners spelling a word). Generic worksheet/activity content that isn't fundamentally text — shape-only tracing (circle/square/triangle with no letters), pre-writing motor-skill strokes, mazes, word searches, math worksheets — is **out of scope here**, even though `printablesEngine.js` could technically render it. That demand is real but belongs to a possible future, separate property once this site is more established — do not build it under the UltraTextGen brand. Quick test: could a user type a word/name into the feature and see *that word* rendered? If no, it's not a printable for this repo.
+
 **Core philosophy**: Fast > Fancy, Clean > Clever, Useful > Impressive. **Client-side only is a hard line:** visual generation must use native SVG/Canvas in the browser — never a server-side renderer, an image-processing library, or bundled font binaries.
 
 ---
@@ -326,6 +328,10 @@ Do not add a test framework unless explicitly requested.
   built with native browser APIs, and must not bundle `.ttf`/`.otf` font binaries.
 - Do not make a visual/printable feature the *default* answer for a query that copy-paste
   Unicode already serves — visual assets are the higher-intent follow-up, gated on real demand
+- Do not build generic (non-text) worksheet/activity content under this brand — shape-only
+  tracing, mazes, word searches, math worksheets, pre-writing motor strokes with no letterform.
+  See "Printables scope boundary" above. This demand is real but tracked for a possible future,
+  separate property — not this repo.
 - Do not edit `sitemap.xml` directly
 - Do not add `var` declarations — use `const`/`let`
 - Do not use `import`/`export` ES module syntax in frontend scripts


### PR DESCRIPTION
## Summary
Added explicit scope boundary for printable/worksheet features to clarify what belongs in UltraTextGen and what should be deferred to a future, separate property. The line is **typography-native**: printables must be fundamentally about rendering text (letters, words, names, phrases) rather than generic worksheet content.

## Changes
- **CLAUDE.md (Scope note):** Added "Printables scope boundary" section documenting what is in-scope (bubble letters, cursive practice sheets, name-based activities, coloring/tracing of letterforms) and what is explicitly out-of-scope (shape-only tracing, mazes, word searches, math worksheets, pre-writing motor strokes without letterforms)
- **CLAUDE.md (Constraints):** Added constraint rule prohibiting generic non-text worksheet/activity content under the UltraTextGen brand, with guidance to track such demand for a possible future, separate property
- Included a practical test: "Could a user type a word/name into the feature and see *that word* rendered? If no, it's not a printable for this repo."

## Rationale
This clarifies the boundary between UltraTextGen's core mission (text expression and typography-based visuals) and adjacent but out-of-scope worksheet/activity generation. While `printablesEngine.js` could technically render such content, building it here would dilute the brand and create scope creep. The demand is real but should be addressed in a dedicated, separate property once the core site is more established.

https://claude.ai/code/session_01DZveMqYHJ4XNHYaGon7Uet