### PR TITLE
Refine meta descriptions for FF and ML nickname generators

### DIFF
--- a/id/usecase/nama-ff-keren/index.html
+++ b/id/usecase/nama-ff-keren/index.html
@@ -14,7 +14,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Nama FF Keren: Simbol Payung ꧁꧂ &amp; Generator Nickname Free Fire</title>
-  <meta name="description" content="Bikin nama FF keren dengan simbol payung ꧁༒꧂, mahkota, dan katakana. Ketik nama kamu, salin, tempel ke Free Fire. Ada kumpulan nama FF cowok, cewek, pro, old, dan yang belum dipakai — gratis, tanpa aplikasi.">
+  <meta name="description" content="Bikin nama FF keren dengan simbol payung ꧁༒꧂, mahkota, dan katakana. Ketik nama kamu, salin, tempel ke Free Fire. Ada kumpulan nama FF pro, old, dan yang belum dipakai — gratis, tanpa aplikasi.">
   <link rel="canonical" href="https://ultratextgen.com/id/usecase/nama-ff-keren/">
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/usecase/free-fire-name-generator/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/usecase/nama-ff-keren/">

--- a/id/usecase/nama-ml-keren/index.html
+++ b/id/usecase/nama-ml-keren/index.html
@@ -14,7 +14,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Nama ML Keren: Font Aesthetic &amp; Simbol Nickname Mobile Legends</title>
-  <meta name="description" content="Bikin nama ML keren dengan font aesthetic, simbol ꧁꧂, dan small caps buat nickname Mobile Legends. Ketik nama kamu, salin, tempel — ada kumpulan nama ML cowok, cewek (girl), dan squad. Gratis, tanpa aplikasi.">
+  <meta name="description" content="Bikin nama ML keren dengan font aesthetic, simbol ꧁꧂, dan small caps buat nickname Mobile Legends. Ketik nama kamu, salin, tempel — plus kumpulan nama ML aesthetic siap pakai. Gratis, tanpa aplikasi.">
   <link rel="canonical" href="https://ultratextgen.com/id/usecase/nama-ml-keren/">
 
   <meta property="og:image" content="https://ultratextgen.com/assets/og/id-usecase-nama-ml-keren.png">


### PR DESCRIPTION
## Summary
Updated meta descriptions for the Free Fire and Mobile Legends nickname generator pages to improve clarity and SEO messaging. Removed gender-specific category references and replaced them with more inclusive, feature-focused language.

## Changes
- **Nama FF Keren** (`id/usecase/nama-ff-keren/index.html`): Removed "cowok, cewek" (male, female) category mentions from meta description. Simplified to focus on core features (umbrella symbols, crowns, katakana) and key name collections (pro, old, unused).

- **Nama ML Keren** (`id/usecase/nama-ml-keren/index.html`): Replaced "cowok, cewek (girl), dan squad" category list with "aesthetic siap pakai" (ready-to-use aesthetic names). Maintains feature focus while broadening appeal beyond gender-specific segmentation.

## Rationale
These changes align the meta descriptions with a more inclusive, feature-driven positioning while maintaining keyword relevance for search. The descriptions now emphasize the generator's core value (easy customization + ready-made collections) rather than demographic categories.

https://claude.ai/code/session_012tyvSJ1Z9dW8tHxtS3djqX