### PR TITLE
feat: stroke-direction trace overlay for handwriting worksheets

### DIFF
--- a/js/printables/printablesEngine.js
+++ b/js/printables/printablesEngine.js
@@ -31,6 +31,11 @@
  *   #pt-practice-print   button: print ruled practice sheet
  *   #pt-name-input       name / word field  (+ #pt-name-print, #pt-name-png,
  *                        #pt-name-preview, #pt-name-rows)
+ *   #pt-stroke-toggle    checkbox: overlay a numbered start-dot + direction
+ *                        arrows on traceable letters (off by default). Reads
+ *                        window.UTG_STROKE_DIRECTION_DATA (js/printables/
+ *                        strokeDirectionData.js) — a page must load that
+ *                        script for the toggle to draw anything.
  *   #pt-print-root       hidden print surface (REQUIRED to print)
  */
 (function () {
@@ -72,6 +77,7 @@
     namePng: $("#pt-name-png"),
     namePreview: $("#pt-name-preview"),
     nameRows: $("#pt-name-rows"),
+    strokeToggle: $("#pt-stroke-toggle"),
     // Difficulty generator (handwriting-worksheet-generator)
     genInput: $("#pt-gen-input"),
     genPreview: $("#pt-gen-preview"),
@@ -193,6 +199,7 @@
     text.setAttribute("paint-order", "stroke");
     text.textContent = ch;
     svg.appendChild(text);
+    if (o.overlay) addStrokeOverlay(svg, ch);
     return svg;
   }
 
@@ -230,6 +237,7 @@
     }
     text.textContent = word;
     svg.appendChild(text);
+    if (o.overlay) addWordStrokeOverlay(svg, word, fontSize, spacing, 112, "central", w);
     return svg;
   }
 
@@ -244,6 +252,154 @@
       return p;
     }
     return outlineSVG(ch);
+  }
+
+  /* ---------------------------------------------------------------
+     Stroke-direction overlay ("Show stroke direction" toggle)
+     ---------------------------------------------------------------
+     Occupational-therapy guidance: tracing without a numbered start-dot and
+     a direction arrow can teach poor motor plans. window.UTG_STROKE_DIRECTION_DATA
+     (js/printables/strokeDirectionData.js) hand-authors, per letter, a
+     numbered start-dot + 1-4 short arrow strokes in the SAME 200x240 /
+     font-size-210 / x=100,y=128 / dominant-baseline:central coordinate
+     space that outlineSVG() already draws letters in — so for a single
+     letter (outlineSVG) the overlay drops straight on top with no math.
+     For a whole traced word/name (wordOutlineSVG, traceWordSVG) the word is
+     still rendered as ONE unbroken <text> node exactly as before — visual
+     output is byte-for-byte unchanged when the toggle is off — and the
+     overlay is added as a separate layer whose per-letter groups are placed
+     using Canvas-measured advance widths (the same "measure with a hidden
+     canvas" technique already used elsewhere in this file, e.g. wordPNG).
+     Off by default; gated entirely on the optional #pt-stroke-toggle mount,
+     so pages that don't add it are completely unaffected. SVG only — PNG
+     downloads intentionally don't include the overlay.
+     --------------------------------------------------------------- */
+
+  const STROKE_COLOR = "#2451c9";     // legible on white, distinct from the ink-black glyph
+  const STROKE_BASELINE_UNIT_Y = 200; // where the type baseline falls inside outlineSVG's own
+                                       // 200x240 / font-size-210 / central-baseline box
+  let strokeOverlayUid = 0;
+  let strokeMeasureCtx = null;
+
+  function strokeOverlayOn() { return !!(el.strokeToggle && el.strokeToggle.checked); }
+
+  function strokeDataFor(ch) {
+    const table = window.UTG_STROKE_DIRECTION_DATA;
+    return (table && table[ch]) ? table[ch] : null;
+  }
+
+  // Numbered start-dot + direction arrow for every stroke of one letter,
+  // drawn directly into `parent`'s own coordinate space (the 200x240 unit
+  // box, or a <g> already transformed into an equivalent local box).
+  function addStrokeOverlay(parent, ch) {
+    const data = strokeDataFor(ch);
+    if (!data || !data.strokes || !data.strokes.length) return;
+    const uid = "ptsd" + (++strokeOverlayUid);
+    const g = svgMake("g", { class: "pt-stroke-overlay", "aria-hidden": "true" }, parent);
+    const defs = svgMake("defs", null, g);
+    const markerId = "ptArrow" + uid;
+    // markerUnits defaults to "strokeWidth", which would silently multiply
+    // markerWidth/Height by the path's stroke-width below (6x) — pin it to
+    // userSpaceOnUse so the arrowhead size stays fixed and predictable.
+    const marker = svgMake("marker", {
+      id: markerId, viewBox: "0 0 10 10", refX: 8, refY: 5, markerUnits: "userSpaceOnUse",
+      markerWidth: 20, markerHeight: 20, orient: "auto"
+    }, defs);
+    svgMake("path", { d: "M0,0 L10,5 L0,10 Z", fill: STROKE_COLOR }, marker);
+
+    data.strokes.forEach((d, i) => {
+      svgMake("path", {
+        d: d, fill: "none", stroke: STROKE_COLOR,
+        "stroke-width": 6, "stroke-linecap": "round", "stroke-linejoin": "round",
+        "marker-end": "url(#" + markerId + ")", opacity: 0.9
+      }, g);
+      const m = /M\s*([\d.\-]+)[,\s]+([\d.\-]+)/.exec(d);
+      if (!m) return;
+      const sx = parseFloat(m[1]), sy = parseFloat(m[2]);
+      svgMake("circle", { cx: sx, cy: sy, r: 11, fill: "#ffffff", stroke: STROKE_COLOR, "stroke-width": 2.5 }, g);
+      const label = svgMake("text", {
+        x: sx, y: sy + 0.5, "text-anchor": "middle", "dominant-baseline": "central",
+        "font-family": "'Plus Jakarta Sans', sans-serif", "font-weight": 700,
+        "font-size": 13, fill: STROKE_COLOR
+      }, g);
+      label.textContent = String(i + 1);
+    });
+  }
+
+  function getStrokeMeasureCtx() {
+    if (!strokeMeasureCtx) strokeMeasureCtx = document.createElement("canvas").getContext("2d");
+    return strokeMeasureCtx;
+  }
+
+  // Per-character center-x offsets (0-based, left edge at 0) for `word` when
+  // rendered at `fontPx`, using the SAME technique wordPNG/genWordPNG already
+  // use to size text on Canvas — real per-glyph advance widths, reconciled
+  // so they sum to the actual measured word width (covers minor
+  // kerning/rounding drift between the per-char and whole-word measurements).
+  function charAdvanceCenters(word, fontPx) {
+    const ctx = getStrokeMeasureCtx();
+    ctx.font = "700 " + fontPx + "px " + FONT;
+    const chars = [...String(word)];
+    const widths = chars.map((c) => ctx.measureText(c).width);
+    const rawTotal = widths.reduce((a, b) => a + b, 0) || 1;
+    const measuredTotal = ctx.measureText(word).width;
+    const scale = measuredTotal / rawTotal;
+    let x = 0;
+    const centers = chars.map((c, i) => {
+      const w = widths[i] * scale;
+      const cx = x + w / 2;
+      x += w; // any letter-spacing gap is added by the caller, not here
+      return { ch: c, cx: cx };
+    });
+    return { centers: centers, total: measuredTotal };
+  }
+
+  // Draws one letter's stroke overlay, scaled + translated from its 200x240
+  // authoring box into a destination slot centered at (cx, anchorY) with an
+  // em-size of `emPx`. `mode` picks which point of the authoring box maps to
+  // (cx, anchorY): "central" (box center, matching wordOutlineSVG's own
+  // dominant-baseline:central text) or "alphabetic" (the type baseline,
+  // matching traceWordSVG's default alphabetic-baseline text).
+  function letterOverlayCell(parent, ch, cx, anchorY, emPx, mode) {
+    if (!strokeDataFor(ch)) return;
+    const scale = emPx / 210;
+    const anchorUnitY = mode === "alphabetic" ? STROKE_BASELINE_UNIT_Y : 128;
+    const tx = cx - 100 * scale;
+    const ty = anchorY - anchorUnitY * scale;
+    const g = svgMake("g", { transform: "translate(" + tx.toFixed(2) + "," + ty.toFixed(2) + ") scale(" + scale.toFixed(4) + ")" }, parent);
+    addStrokeOverlay(g, ch);
+  }
+
+  // Overlays every letter of a word/name rendered as a single centered
+  // <text> (wordOutlineSVG / traceWordSVG) without touching that <text>
+  // node itself. `spacingPx` mirrors the `letter-spacing` attribute those
+  // functions may set so the overlay tracks the same extra gaps.
+  function addWordStrokeOverlay(svg, word, fontPx, spacingPx, anchorY, mode, totalW) {
+    const measured = charAdvanceCenters(word, fontPx);
+    const extra = spacingPx ? spacingPx * (measured.centers.length - 1) : 0;
+    const fullWidth = measured.total + extra;
+    let runningExtra = 0;
+    const leftEdge = totalW / 2 - fullWidth / 2;
+    measured.centers.forEach((c, i) => {
+      const cx = leftEdge + c.cx + runningExtra;
+      if (spacingPx) runningExtra += spacingPx;
+      if (!/[A-Za-z]/.test(c.ch)) return;
+      letterOverlayCell(svg, c.ch, cx, anchorY, fontPx, mode);
+    });
+  }
+
+  const STROKE_TOGGLE_LS_KEY = "utg-pt-stroke-overlay";
+
+  function initStrokeToggle() {
+    if (!el.strokeToggle) return;
+    try {
+      if (localStorage.getItem(STROKE_TOGGLE_LS_KEY) === "1") el.strokeToggle.checked = true;
+    } catch (e) { /* noop — storage unavailable, default unchecked */ }
+    el.strokeToggle.addEventListener("change", () => {
+      try { localStorage.setItem(STROKE_TOGGLE_LS_KEY, el.strokeToggle.checked ? "1" : "0"); } catch (e) { /* noop */ }
+      if (el.nameInput || el.namePreview) renderNamePreview();
+      if (el.genInput || el.genPreview) renderGenPreview();
+    });
   }
 
   /* ---------------------------------------------------------------
@@ -569,8 +725,9 @@
      --------------------------------------------------------------- */
 
   function buildPracticeSheet() {
+    const overlayOn = strokeOverlayOn();
     const sheet = document.createElement("div");
-    sheet.className = "cursive-print-sheet";
+    sheet.className = "cursive-print-sheet" + (overlayOn ? " pt-stroke-on" : "");
     CHARS.forEach((ch) => {
       const row = document.createElement("div");
       row.className = "cursive-print-row";
@@ -582,7 +739,9 @@
         model.textContent = renderGlyph(ch.toUpperCase()) + " " + renderGlyph(ch.toLowerCase());
         trace.textContent = renderGlyph(ch.toUpperCase()) + " " + renderGlyph(ch.toLowerCase());
       } else {
-        model.appendChild(outlineSVG(ch, { small: true }));
+        // Model column only ever shows the uppercase letter (CHARS is A-Z +
+        // 0-9), so the overlay's uppercase coverage lines up exactly here.
+        model.appendChild(outlineSVG(ch, { small: true, overlay: overlayOn }));
         model.classList.add("pt-model-svg");
         trace.textContent = /[0-9]/.test(ch) ? ch : (ch + " " + ch.toLowerCase());
       }
@@ -615,7 +774,7 @@
       p.textContent = renderGlyph(name);
       el.namePreview.appendChild(p);
     } else {
-      el.namePreview.appendChild(wordOutlineSVG(name, { solid: false }));
+      el.namePreview.appendChild(wordOutlineSVG(name, { solid: false, overlay: strokeOverlayOn() }));
     }
   }
 
@@ -645,7 +804,7 @@
       span.textContent = renderGlyph(name);
       row.appendChild(span);
     } else {
-      row.appendChild(wordOutlineSVG(name, { solid: kind === "model" }));
+      row.appendChild(wordOutlineSVG(name, { solid: kind === "model", overlay: strokeOverlayOn() }));
     }
     return row;
   }
@@ -743,6 +902,7 @@
       if (spec.opacity != null && spec.opacity !== 1) t.setAttribute("opacity", String(spec.opacity));
       t.textContent = word;
       svg.appendChild(t);
+      if (o.overlay) addWordStrokeOverlay(svg, word, TRACE_FONT_SIZE, 0, TRACE_BASE, "alphabetic", w);
     }
     return svg;
   }
@@ -802,7 +962,7 @@
   function genRow(word, level) {
     const row = document.createElement("div");
     row.className = "pt-gen-row";
-    row.appendChild(traceWordSVG(word, level, { guides: true }));
+    row.appendChild(traceWordSVG(word, level, { guides: true, overlay: strokeOverlayOn() }));
     return row;
   }
 
@@ -1270,6 +1430,7 @@
      --------------------------------------------------------------- */
 
   function init() {
+    initStrokeToggle();
     buildStrip();
     buildAlphabetGrid();
     initGenerator();

--- a/js/printables/strokeDirectionData.js
+++ b/js/printables/strokeDirectionData.js
@@ -1,0 +1,257 @@
+/*
+ * strokeDirectionData.js — per-letter stroke-order overlay data for the
+ * printables engine's "Show stroke direction" toggle (js/printables/
+ * printablesEngine.js). Occupational-therapy handwriting sources note that
+ * tracing without a numbered start-dot + directional arrow can teach poor
+ * motor plans, so each entry below marks where a pencil starts and which
+ * way each stroke travels, based on conventional US manuscript
+ * (print-handwriting) stroke order.
+ *
+ * This is intentionally a *schematic* guide, not a trace of the rendered
+ * glyph's exact outline — the letters are drawn with a real system/Google
+ * font via SVG <text>, so there is no vector path data to reverse-engineer.
+ * Coordinates are hand-authored against the SAME 200×240 viewBox / 210px
+ * font-size / x=100,y=128 / dominant-baseline:central recipe that
+ * printablesEngine.js's outlineSVG() uses to draw a single letter, so the
+ * dot/arrow positions line up with the rendered glyph without any
+ * per-context math. (printablesEngine.js also reuses these same coordinates,
+ * scaled, to overlay letters inside a whole traced word/name.)
+ *
+ * Calibration reference for that box (font-weight 700, sans-serif):
+ *   cap top      ~ y 55        x-height top ~ y 88
+ *   ascender top ~ y 52        baseline     ~ y 198-200
+ *   descender bottom ~ y 236-238            center x = 100
+ *
+ * Each letter is a small array of `strokes` — 1-4 SVG path `d` strings in
+ * stroke order. The FIRST point of each path (its "M x,y") is where the
+ * numbered start-dot for that stroke is drawn; the path's end is where the
+ * direction arrowhead is drawn. Pure data, no logic — read by
+ * printablesEngine.js. Exposes window.UTG_STROKE_DIRECTION_DATA only.
+ *
+ * Coverage: full A-Z and a-z (52 letters). Digits are intentionally out of
+ * scope for this pass (optional per the feature spec) — the overlay is a
+ * silent no-op for any character without an entry here.
+ */
+(function () {
+  "use strict";
+
+  window.UTG_STROKE_DIRECTION_DATA = {
+
+    /* ---------------------------------------------------------------
+       Uppercase A-Z
+       --------------------------------------------------------------- */
+
+    A: { strokes: [
+      "M100,55 L42,198",
+      "M110,80 L158,198",
+      "M66,140 L134,140"
+    ] },
+    B: { strokes: [
+      "M45,55 L45,172",
+      "M69,69 L45,55 C118,55 118,122 45,127 C118,132 118,193 45,198"
+    ] },
+    C: { strokes: [
+      "M150,75 C125,52 70,52 48,100 C28,145 55,193 150,196"
+    ] },
+    D: { strokes: [
+      "M45,55 L45,172",
+      "M69,69 L45,55 C132,55 152,90 152,127 C152,164 132,198 45,198"
+    ] },
+    E: { strokes: [
+      "M45,55 L45,198",
+      "M71,55 L155,55",
+      "M45,127 L135,127",
+      "M45,198 L155,198"
+    ] },
+    F: { strokes: [
+      "M45,55 L45,198",
+      "M71,55 L155,55",
+      "M45,127 L135,127"
+    ] },
+    G: { strokes: [
+      "M150,75 C125,52 70,52 48,100 C28,148 58,198 110,198 C140,198 148,178 150,128",
+      "M100,150 L136,150"
+    ] },
+    H: { strokes: [
+      "M45,55 L45,198",
+      "M155,55 L155,198",
+      "M45,127 L155,127"
+    ] },
+    I: { strokes: [
+      "M100,55 L100,198"
+    ] },
+    J: { strokes: [
+      "M120,55 L120,165 C120,190 100,198 75,193"
+    ] },
+    K: { strokes: [
+      "M45,55 L45,198",
+      "M155,55 L45,130",
+      "M65,118 L155,198"
+    ] },
+    L: { strokes: [
+      "M45,55 L45,198",
+      "M45,198 L150,198"
+    ] },
+    M: { strokes: [
+      "M25,55 L25,198",
+      "M42,75 L100,140 L175,55",
+      "M175,55 L175,198"
+    ] },
+    N: { strokes: [
+      "M40,55 L40,198",
+      "M57,75 L160,198",
+      "M160,55 L160,172"
+    ] },
+    O: { strokes: [
+      "M100,55 C60,55 45,90 45,127 C45,164 60,198 100,198 C140,198 155,164 155,127 C155,90 140,55 100,55"
+    ] },
+    P: { strokes: [
+      "M45,55 L45,198",
+      "M69,69 L45,55 C130,55 140,75 140,95 C140,118 122,127 45,127"
+    ] },
+    Q: { strokes: [
+      "M100,55 C60,55 45,90 45,127 C45,164 60,198 100,198 C140,198 155,164 155,127 C155,90 140,55 100,55",
+      "M110,155 L162,205"
+    ] },
+    R: { strokes: [
+      "M45,55 L45,198",
+      "M69,69 L45,55 C130,55 140,75 140,95 C140,118 122,127 45,127",
+      "M85,127 L155,198"
+    ] },
+    S: { strokes: [
+      "M145,75 C145,58 120,50 95,52 C65,55 50,70 50,88 C50,110 75,118 100,127 C125,136 150,145 150,167 C150,188 130,198 100,198 C75,198 55,190 50,175"
+    ] },
+    T: { strokes: [
+      "M45,55 L155,55",
+      "M100,55 L100,198"
+    ] },
+    U: { strokes: [
+      "M45,55 L45,150 C45,180 68,198 100,198 C132,198 155,180 155,150 L155,55"
+    ] },
+    V: { strokes: [
+      "M40,55 L100,198 L160,55"
+    ] },
+    W: { strokes: [
+      "M25,55 L65,198 L100,120 L135,198 L175,55"
+    ] },
+    X: { strokes: [
+      "M42,55 L158,198",
+      "M158,55 L42,198"
+    ] },
+    Y: { strokes: [
+      "M42,55 L100,130",
+      "M158,55 L100,130 L100,198"
+    ] },
+    Z: { strokes: [
+      "M45,55 L155,55",
+      "M155,55 L45,198",
+      "M45,198 L155,198"
+    ] },
+
+    /* ---------------------------------------------------------------
+       Lowercase a-z
+       --------------------------------------------------------------- */
+
+    a: { strokes: [
+      "M140,100 C140,86 120,84 105,86 C72,90 55,112 55,143 C55,174 75,193 103,193 C125,193 138,180 140,155 L140,100",
+      "M165,65 L140,88 L140,198"
+    ] },
+    b: { strokes: [
+      "M45,52 L45,198",
+      "M45,140 C100,130 145,140 145,168 C145,188 122,198 90,198 C65,198 48,190 45,175"
+    ] },
+    c: { strokes: [
+      "M150,100 C135,90 110,86 95,88 C68,92 55,110 55,143 C55,172 72,190 98,190 C118,190 138,182 148,168"
+    ] },
+    d: { strokes: [
+      "M155,52 L155,198",
+      "M155,140 C140,128 115,124 98,127 C70,132 55,150 55,163 C55,182 78,198 108,198 C130,198 148,188 155,172"
+    ] },
+    e: { strokes: [
+      "M58,132 L142,132",
+      "M142,132 C142,105 122,88 98,88 C68,88 55,110 55,143 C55,172 75,190 100,190 C122,190 138,180 145,168"
+    ] },
+    f: { strokes: [
+      "M120,52 C120,52 90,52 85,75 L75,198",
+      "M55,110 L115,110"
+    ] },
+    g: { strokes: [
+      "M140,88 C140,80 125,86 108,88 C80,92 62,110 62,143 C62,168 80,186 105,186 C125,186 140,175 140,155 L140,90",
+      "M140,150 L140,215 C140,232 122,238 100,236"
+    ] },
+    h: { strokes: [
+      "M45,52 L45,198",
+      "M45,135 C65,115 100,110 118,125 C132,137 132,155 132,198"
+    ] },
+    i: { strokes: [
+      "M100,60 L100,64",
+      "M100,90 L100,198"
+    ] },
+    j: { strokes: [
+      "M118,60 L118,64",
+      "M118,90 L118,215 C118,232 100,238 80,236"
+    ] },
+    k: { strokes: [
+      "M45,52 L45,198",
+      "M130,90 L55,145",
+      "M75,133 L135,198"
+    ] },
+    l: { strokes: [
+      "M100,52 L100,198"
+    ] },
+    m: { strokes: [
+      "M45,90 L45,198",
+      "M45,120 C65,100 95,98 108,115 C118,128 118,145 118,198",
+      "M118,120 C138,100 168,98 178,115 C188,128 188,145 188,198"
+    ] },
+    n: { strokes: [
+      "M45,90 L45,198",
+      "M45,135 C65,115 100,110 118,125 C132,137 132,155 132,198"
+    ] },
+    o: { strokes: [
+      "M100,88 C130,88 145,110 145,143 C145,172 128,190 100,190 C72,190 55,172 55,143 C55,110 70,88 100,88"
+    ] },
+    p: { strokes: [
+      "M45,90 L45,236",
+      "M45,140 C100,130 145,140 145,168 C145,188 122,198 90,198 C65,198 48,190 45,175"
+    ] },
+    q: { strokes: [
+      "M140,90 C140,80 125,86 108,88 C80,92 62,110 62,143 C62,168 80,186 105,186 C125,186 140,175 140,155 L140,90",
+      "M140,150 L140,236"
+    ] },
+    r: { strokes: [
+      "M55,90 L55,198",
+      "M55,120 C68,100 95,92 115,98"
+    ] },
+    s: { strokes: [
+      "M135,100 C130,90 112,86 95,88 C75,90 60,98 60,112 C60,128 78,133 100,140 C122,147 145,153 145,172 C145,188 125,198 100,198 C80,198 62,192 55,180"
+    ] },
+    t: { strokes: [
+      "M78,58 L78,175 C78,190 88,198 105,196",
+      "M50,110 L112,110"
+    ] },
+    u: { strokes: [
+      "M55,90 L55,165 C55,183 70,190 88,190 C105,190 118,182 122,168",
+      "M122,90 L122,198"
+    ] },
+    v: { strokes: [
+      "M48,90 L100,198 L152,90"
+    ] },
+    w: { strokes: [
+      "M40,90 L68,198 L100,135 L132,198 L160,90"
+    ] },
+    x: { strokes: [
+      "M52,90 L148,198",
+      "M148,90 L52,198"
+    ] },
+    y: { strokes: [
+      "M52,90 L100,180",
+      "M148,90 L100,180 L88,215 C82,230 65,236 50,233"
+    ] },
+    z: { strokes: [
+      "M55,90 L145,90",
+      "M145,90 L55,198",
+      "M55,198 L145,198"
+    ] }
+  };
+})();

--- a/printables/handwriting-worksheet-generator/index.html
+++ b/printables/handwriting-worksheet-generator/index.html
@@ -220,7 +220,12 @@
               <input type="checkbox" id="pt-gen-model" checked>
               Solid model row on top
             </label>
+            <label class="pt-check" for="pt-stroke-toggle">
+              <input type="checkbox" id="pt-stroke-toggle">
+              Show stroke direction
+            </label>
           </div>
+          <p class="pt-stroke-toggle-hint">Stroke direction adds a numbered start dot and arrows to each letter, showing which way to draw it.</p>
         </div>
 
         <!-- Live preview -->
@@ -332,6 +337,7 @@
   </script>
   <script src="/styles.js" defer></script>
   <script src="/renderer.js" defer></script>
+  <script src="/js/printables/strokeDirectionData.js" defer></script>
   <script src="/js/printables/printablesEngine.js" defer></script>
 
   <!-- FAQ toggle -->

--- a/printables/name-tracing/index.html
+++ b/printables/name-tracing/index.html
@@ -112,6 +112,14 @@
 
   <main class="container">
 
+    <div class="pt-stroke-toggle-row">
+      <label class="pt-check" for="pt-stroke-toggle">
+        <input type="checkbox" id="pt-stroke-toggle">
+        Show stroke direction
+      </label>
+      <span class="pt-stroke-toggle-hint">Adds a numbered start dot and arrows to every traced letter, showing which way to draw each stroke — on by choice, since kids at different stages need different guidance.</span>
+    </div>
+
     <!-- Name worksheet (primary) -->
     <section class="bubble-alphabet" aria-labelledby="ptNameHeading">
       <h2 id="ptNameHeading">Make a name tracing worksheet</h2>
@@ -253,6 +261,7 @@
   </script>
   <script src="/styles.js" defer></script>
   <script src="/renderer.js" defer></script>
+  <script src="/js/printables/strokeDirectionData.js" defer></script>
   <script src="/js/printables/printablesEngine.js" defer></script>
 
   <!-- FAQ toggle -->

--- a/style.css
+++ b/style.css
@@ -5302,6 +5302,25 @@ html[dir="rtl"] .rtl-flip { display: inline-block; transform: scaleX(-1); }
 /* Practice-sheet model cell that holds an outline SVG (outline mode) */
 .pt-model-svg .bubble-outline { width: 84px; height: auto; }
 
+/* "Show stroke direction" toggle (js/printables/printablesEngine.js +
+   js/printables/strokeDirectionData.js). Off by default; when on, the
+   practice-sheet model column widens so the numbered dot + arrows stay
+   legible at print size instead of shrinking with the 84px default cell. */
+.pt-stroke-toggle-row {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  margin: 0.85rem 0 0.25rem;
+  padding: 0.65rem 0.9rem;
+  border: 1px solid var(--border-light);
+  border-radius: 10px;
+  background: var(--bg-white);
+}
+.pt-stroke-toggle-hint { font-size: 0.78rem; color: var(--text-muted); }
+.cursive-print-sheet.pt-stroke-on .cursive-print-row { grid-template-columns: 170px 90px 1fr; }
+.cursive-print-sheet.pt-stroke-on .pt-model-svg .bubble-outline { width: 150px; }
+
 /* ---- Print surfaces for the shared engine ---- */
 #pt-print-root { display: none; }
 .bubble-print-single { text-align: center; }


### PR DESCRIPTION
## Summary
- Adds an off-by-default "Show stroke direction" toggle to `/printables/name-tracing/` and `/printables/handwriting-worksheet-generator/`, overlaying a numbered start-dot + directional arrow on each traced letter.
- Occupational-therapy sources note that tracing worksheets without a start-dot/direction cue can teach poor motor plans — this closes that gap without changing default behavior for existing traffic.
- New `js/printables/strokeDirectionData.js` hand-authors stroke order for all 52 letters (full A–Z and a–z), modeled on the existing `js/cursive/cursiveData.js` pattern.

## Blast radius note (read before merging)
This PR touches the **shared** `outlineSVG`/`wordOutlineSVG` functions in `js/printables/printablesEngine.js`, which every printables page uses (bubble-letters, block-letters, cursive-alphabet, calligraphy-alphabet, coloring-page-maker, name-tracing, handwriting-worksheet-generator). I reviewed the diff specifically for this risk: every overlay call is gated behind an explicit `opts.overlay` flag that only the two target pages ever pass (via a checkbox with no `checked` attribute, so off by default), and every other page's calls to these functions are unchanged and never pass that flag — confirmed no behavior change is possible on pages without the toggle.

## Test plan
- [x] Verified toggle off produces zero overlay DOM nodes (no regression) on both target pages
- [x] Verified toggle on produces expected overlay on practice sheets, name worksheets, and the generator; spot-checked b/d/p/q and all multi-stroke letters via a full 52-letter QA pass
- [x] Rendered an actual print PDF and rasterized at 300 DPI to confirm arrows/dots stay legible at true print resolution, not just on-screen
- [x] Smoke-tested bubble-letters, block-letters, cursive-alphabet, calligraphy-alphabet, and coloring-page-maker (all share this engine file) — no regressions
- [x] Two bugs found and fixed during testing: overlapping start-dots on several letters where two strokes began at the same point, and an SVG marker-scaling bug that inflated arrowheads ~6× and merged nearby endpoints into a "star" artifact (most visible on lowercase `a`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZveMqYHJ4XNHYaGon7Uet)_