### PR TITLE
feat: add Name Puzzle Maker printable

### DIFF
--- a/js/printables/printablesEngine.js
+++ b/js/printables/printablesEngine.js
@@ -97,6 +97,14 @@
     designPreview: $("#pt-design-preview"),
     designPrint: $("#pt-design-print"),
     designPng: $("#pt-design-png"),
+    // Name puzzle maker (optional; gated on its own mounts)
+    puzzleInput: $("#pt-puzzle-input"),
+    puzzleHeading: $("#pt-puzzle-heading"),
+    puzzleBorderGroup: $("#pt-puzzle-border-group"),
+    puzzleFooter: $("#pt-puzzle-footer"),
+    puzzlePreview: $("#pt-puzzle-preview"),
+    puzzlePrint: $("#pt-puzzle-print"),
+    puzzlePng: $("#pt-puzzle-png"),
     printRoot: $("#pt-print-root")
   };
 
@@ -1228,25 +1236,29 @@
   }
 
   // Wire one swatch button group: inject each swatch preview, set the active
-  // state, and re-render on click. `field` is the designState key it drives.
-  function wireSwatchGroup(group, field, swatchFor) {
+  // state, and re-render on click. `state` is the plain object the group
+  // drives (e.g. designState / puzzleState) and `field` is its key; `onChange`
+  // re-renders whatever preview that state feeds. Generalized (rather than
+  // hardcoded to the coloring designer) so other mounts — e.g. the name
+  // puzzle maker's border picker — can reuse the exact same swatch UI.
+  function wireSwatchGroup(group, field, swatchFor, state, onChange) {
     if (!group) return;
     const buttons = $$(".pt-swatch", group);
     const preset = buttons.filter((b) => b.classList.contains("is-active"))[0] || buttons[0];
-    if (preset) designState[field] = preset.dataset.value;
+    if (preset) state[field] = preset.dataset.value;
     buttons.forEach((b) => {
       const slot = b.querySelector(".pt-swatch-art");
       if (slot) slot.appendChild(swatchFor(b.dataset.value));
       b.setAttribute("aria-checked", b === preset ? "true" : "false");
       b.classList.toggle("is-active", b === preset);
       b.addEventListener("click", () => {
-        designState[field] = b.dataset.value;
+        state[field] = b.dataset.value;
         buttons.forEach((o) => {
           const on = o === b;
           o.classList.toggle("is-active", on);
           o.setAttribute("aria-checked", on ? "true" : "false");
         });
-        renderDesignPreview();
+        onChange();
       });
     });
   }
@@ -1257,12 +1269,255 @@
     const schedule = () => { if (timer) clearTimeout(timer); timer = setTimeout(renderDesignPreview, 120); };
     el.designInput.addEventListener("input", schedule);
     if (el.designHeading) el.designHeading.addEventListener("input", schedule);
-    wireSwatchGroup(el.designFillGroup, "fill", fillSwatchSVG);
-    wireSwatchGroup(el.designBorderGroup, "border", borderSwatchSVG);
+    wireSwatchGroup(el.designFillGroup, "fill", fillSwatchSVG, designState, renderDesignPreview);
+    wireSwatchGroup(el.designBorderGroup, "border", borderSwatchSVG, designState, renderDesignPreview);
     [el.designFill, el.designBorder, el.designFooter].forEach((c) => { if (c) c.addEventListener("change", renderDesignPreview); });
     if (el.designPrint) el.designPrint.addEventListener("click", printDesign);
     if (el.designPng) el.designPng.addEventListener("click", designPNG);
     renderDesignPreview();
+  }
+
+  /* ---------------------------------------------------------------
+     Section: name puzzle maker
+     Type a name -> each letter becomes a big outline "puzzle piece" in a
+     row, with a dashed cut line between every pair of pieces, an optional
+     custom heading, an optional Name/Date footer line, and an optional
+     decorative shape-frame border. The border reuses the exact BORDER_SETS /
+     addBorderRow / borderSwatchSVG primitives the coloring-sheet designer
+     already ships — no second border system. Letters reuse outlineSVG(ch),
+     the same per-character primitive buildAlphabetGrid lays out in a grid,
+     just arranged in a single row here. Gated on #pt-puzzle-input +
+     #pt-puzzle-preview so other pages are untouched.
+     --------------------------------------------------------------- */
+
+  const PUZZLE_DEMO = CFG.puzzleDemo || CFG.nameDemo || "Alex";
+  const puzzleState = { border: "none" };
+
+  function puzzleValue() {
+    const raw = el.puzzleInput ? el.puzzleInput.value : "";
+    return (raw && raw.trim()) ? raw.trim().slice(0, 20) : PUZZLE_DEMO;
+  }
+  function puzzleHeadingText() {
+    return el.puzzleHeading ? el.puzzleHeading.value.trim().slice(0, 48) : "";
+  }
+  function puzzleBorderKey() {
+    return el.puzzleBorderGroup ? puzzleState.border : "none";
+  }
+  function puzzleBorderSym() {
+    return BORDER_SETS[puzzleBorderKey()] || "";
+  }
+  function puzzleFooterOn() {
+    return !!(el.puzzleFooter && el.puzzleFooter.checked);
+  }
+
+  // One row of symbols reusing the coloring designer's own border primitive
+  // (addBorderRow draws across a fixed 0..1000 viewBox, so a dedicated
+  // 1000x60 strip drops straight in).
+  function puzzleBorderStripSVG(symbols) {
+    const svg = svgMake("svg", { viewBox: "0 0 1000 60", class: "pt-puzzle-border-strip", "aria-hidden": "true" });
+    addBorderRow(svg, symbols, 40);
+    return svg;
+  }
+
+  function puzzleFooterRow() {
+    const row = document.createElement("div");
+    row.className = "pt-puzzle-footer-row";
+    const field = (label) => {
+      const f = document.createElement("span");
+      f.className = "pt-puzzle-footer-field";
+      const l = document.createElement("span");
+      l.textContent = label;
+      const line = document.createElement("span");
+      line.className = "pt-puzzle-footer-line";
+      f.appendChild(l); f.appendChild(line);
+      return f;
+    };
+    row.appendChild(field("Name:"));
+    row.appendChild(field("Date:"));
+    return row;
+  }
+
+  // The row of cut-apart letter pieces. Each non-space character becomes an
+  // outlineSVG(ch) piece with a dashed cut line on its trailing edge (pure
+  // CSS border, so it prints identically to the screen preview); spaces
+  // become a narrower gap column with no piece and no cut line. Column
+  // widths are set directly (not via a CSS custom property + repeat()) so
+  // any letter count — 3 or 13 — always fits the sheet width; long names
+  // just render smaller pieces instead of overflowing.
+  function puzzleRowNode(word) {
+    const row = document.createElement("div");
+    row.className = "pt-puzzle-row";
+    const cols = [];
+    [...word].forEach((rawCh) => {
+      if (rawCh === " ") {
+        const gap = document.createElement("div");
+        gap.className = "pt-puzzle-gap";
+        row.appendChild(gap);
+        cols.push("0.6fr");
+        return;
+      }
+      const ch = /[a-z]/i.test(rawCh) ? rawCh.toUpperCase() : rawCh;
+      const piece = document.createElement("div");
+      piece.className = "pt-puzzle-piece";
+      piece.appendChild(outlineSVG(ch));
+      row.appendChild(piece);
+      cols.push("1fr");
+    });
+    row.style.gridTemplateColumns = cols.join(" ");
+    return row;
+  }
+
+  // The whole puzzle as one DOM sheet — the single primitive behind both the
+  // live preview and the printed page, so what's on screen is what prints.
+  function puzzleSheetNode() {
+    const word = puzzleValue();
+    const heading = puzzleHeadingText();
+    const strip = puzzleBorderSym().split(" ").filter(Boolean);
+    const footer = puzzleFooterOn();
+
+    const sheet = document.createElement("div");
+    sheet.className = "pt-puzzle-sheet";
+
+    if (strip.length) sheet.appendChild(puzzleBorderStripSVG(strip));
+
+    const h = document.createElement("h3");
+    h.className = "pt-puzzle-heading-text";
+    h.textContent = heading || (word + "’s Name Puzzle");
+    sheet.appendChild(h);
+
+    sheet.appendChild(puzzleRowNode(word));
+
+    const cap = document.createElement("p");
+    cap.className = "pt-puzzle-caption";
+    cap.textContent = "Cut along the dashed lines to separate each letter piece.";
+    sheet.appendChild(cap);
+
+    if (footer) sheet.appendChild(puzzleFooterRow());
+    if (strip.length) sheet.appendChild(puzzleBorderStripSVG(strip));
+
+    const cred = document.createElement("p");
+    cred.className = "pt-puzzle-credit";
+    cred.textContent = "ultratextgen.com";
+    sheet.appendChild(cred);
+
+    return sheet;
+  }
+
+  function renderPuzzlePreview() {
+    if (!el.puzzlePreview) return;
+    el.puzzlePreview.innerHTML = "";
+    el.puzzlePreview.appendChild(puzzleSheetNode());
+  }
+
+  function printPuzzle() {
+    const holder = document.createElement("div");
+    holder.className = "pt-puzzle-print-holder";
+    holder.appendChild(puzzleSheetNode());
+    printWrap("", holder);
+  }
+
+  // Word -> wide PNG mirroring the sheet: border strips, heading, a row of
+  // outlined letter pieces with dashed cut lines between them, and an
+  // optional Name/Date footer. Canvas has no CSS grid, so column widths and
+  // cut-line x-positions are computed with the same weighting (space = 0.6,
+  // letter = 1) as puzzleRowNode's grid-template-columns.
+  function puzzlePNG() {
+    const word = puzzleValue();
+    const heading = puzzleHeadingText();
+    const strip = puzzleBorderSym().split(" ").filter(Boolean);
+    const footer = puzzleFooterOn();
+    withFont(() => {
+      const chars = [...word];
+      const W = Math.max(1000, chars.length * 140 + 240);
+      const H = 900;
+      const pad = 70;
+      const canvas = document.createElement("canvas");
+      canvas.width = W; canvas.height = H;
+      const ctx = canvas.getContext("2d");
+      ctx.fillStyle = "#ffffff";
+      ctx.fillRect(0, 0, W, H);
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
+      ctx.lineJoin = "round";
+
+      if (strip.length) {
+        const count = 11, gap = (W - 120) / (count - 1);
+        ctx.font = "34px " + FONT; ctx.fillStyle = "#c8ccd6";
+        for (let i = 0; i < count; i++) {
+          ctx.fillText(strip[i % strip.length], 60 + i * gap, 60);
+          ctx.fillText(strip[i % strip.length], 60 + i * gap, H - 40);
+        }
+      }
+
+      ctx.font = "700 48px " + FONT;
+      ctx.fillStyle = INK;
+      ctx.fillText(heading || (word + "’s Name Puzzle"), W / 2, 130);
+
+      const rowTop = 190, rowBottom = 620, rowH = rowBottom - rowTop;
+      const availW = W - pad * 2;
+      const weights = chars.map((c) => (c === " " ? 0.6 : 1));
+      const totalWeight = weights.reduce((a, b) => a + b, 0) || 1;
+      let x = pad;
+      const boundaries = [];
+      chars.forEach((rawCh, i) => {
+        const w = availW * (weights[i] / totalWeight);
+        if (rawCh !== " ") {
+          const ch = /[a-z]/i.test(rawCh) ? rawCh.toUpperCase() : rawCh;
+          const cx = x + w / 2, cy = rowTop + rowH / 2;
+          const fs = Math.min(rowH * 0.8, w * 0.85);
+          ctx.font = "700 " + Math.round(fs) + "px " + FONT;
+          ctx.fillStyle = "#ffffff";
+          ctx.fillText(ch, cx, cy);
+          ctx.lineWidth = Math.max(4, fs * 0.06);
+          ctx.strokeStyle = INK;
+          ctx.strokeText(ch, cx, cy);
+          if (x > pad) boundaries.push(x);
+        }
+        x += w;
+      });
+      ctx.setLineDash([12, 10]);
+      ctx.strokeStyle = "#94a3b8";
+      ctx.lineWidth = 3;
+      boundaries.forEach((bx) => {
+        ctx.beginPath();
+        ctx.moveTo(bx, rowTop); ctx.lineTo(bx, rowBottom); ctx.stroke();
+      });
+      ctx.setLineDash([]);
+
+      if (footer) {
+        ctx.textAlign = "left";
+        ctx.font = "600 30px " + FONT;
+        ctx.fillStyle = INK;
+        const fy = 700;
+        ctx.fillText("Name:", pad, fy);
+        ctx.fillText("Date:", W / 2 + 40, fy);
+        ctx.strokeStyle = "#9aa3b2"; ctx.lineWidth = 2;
+        ctx.beginPath();
+        ctx.moveTo(pad + 110, fy + 12); ctx.lineTo(W / 2 - 40, fy + 12);
+        ctx.moveTo(W / 2 + 150, fy + 12); ctx.lineTo(W - pad, fy + 12);
+        ctx.stroke();
+        ctx.textAlign = "center";
+      }
+
+      ctx.font = "22px " + FONT;
+      ctx.fillStyle = "#aeb4c0";
+      ctx.fillText("ultratextgen.com", W / 2, 860);
+
+      downloadCanvas(canvas, PNG_PREFIX + "-" + (slugify(word) || "puzzle") + ".png");
+    });
+  }
+
+  function buildPuzzle() {
+    if (!el.puzzleInput || !el.puzzlePreview) return;
+    let timer = null;
+    const schedule = () => { if (timer) clearTimeout(timer); timer = setTimeout(renderPuzzlePreview, 120); };
+    el.puzzleInput.addEventListener("input", schedule);
+    if (el.puzzleHeading) el.puzzleHeading.addEventListener("input", schedule);
+    if (el.puzzleFooter) el.puzzleFooter.addEventListener("change", renderPuzzlePreview);
+    wireSwatchGroup(el.puzzleBorderGroup, "border", borderSwatchSVG, puzzleState, renderPuzzlePreview);
+    if (el.puzzlePrint) el.puzzlePrint.addEventListener("click", printPuzzle);
+    if (el.puzzlePng) el.puzzlePng.addEventListener("click", puzzlePNG);
+    renderPuzzlePreview();
   }
 
   /* ---------------------------------------------------------------
@@ -1274,6 +1529,7 @@
     buildAlphabetGrid();
     initGenerator();
     buildDesigner();
+    buildPuzzle();
 
     if (el.practicePrint) el.practicePrint.addEventListener("click", buildPracticeSheet);
 

--- a/printables/index.html
+++ b/printables/index.html
@@ -47,7 +47,8 @@
       { "@type": "ListItem", "position": 5, "name": "Cursive Alphabet & Practice Sheets", "url": "https://ultratextgen.com/printables/cursive-alphabet/" },
       { "@type": "ListItem", "position": 6, "name": "Calligraphy Alphabet & Practice Sheets", "url": "https://ultratextgen.com/printables/calligraphy-alphabet/" },
       { "@type": "ListItem", "position": 7, "name": "Printable Block Letters & Stencils", "url": "https://ultratextgen.com/printables/block-letters/" },
-      { "@type": "ListItem", "position": 8, "name": "Name Tracing Worksheets", "url": "https://ultratextgen.com/printables/name-tracing/" }
+      { "@type": "ListItem", "position": 8, "name": "Name Tracing Worksheets", "url": "https://ultratextgen.com/printables/name-tracing/" },
+      { "@type": "ListItem", "position": 9, "name": "Name Puzzle Maker", "url": "https://ultratextgen.com/printables/name-puzzle-maker/" }
     ]
   }
 }
@@ -193,6 +194,13 @@
           <h3>Name Tracing Worksheets</h3>
           <p>Type any name and print a handwriting worksheet: a solid model row, faded rows to trace, and blank lines for practice. Great for preschool and kindergarten.</p>
           <span class="printable-card-cta">Open name tracing →</span>
+        </a>
+
+        <a class="printable-card" href="/printables/name-puzzle-maker/">
+          <span class="printable-card-art" aria-hidden="true">A┊B┊C</span>
+          <h3>Name Puzzle Maker</h3>
+          <p>Type any name to print a cut-apart puzzle — each letter as a big outline piece with dashed cut lines, plus an optional shape-frame border. Great for letter recognition and scissor practice.</p>
+          <span class="printable-card-cta">Open the name puzzle maker →</span>
         </a>
 
       </div>

--- a/printables/name-puzzle-maker/index.html
+++ b/printables/name-puzzle-maker/index.html
@@ -1,0 +1,316 @@
+<!DOCTYPE html><html lang="en"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Name Puzzle Maker — Free Printable Cut-Apart Letter Puzzle | UltraTextGen</title>
+  <meta name="description" content="Type any name to make a free printable name puzzle: each letter as a big outline piece with dashed cut lines to snip apart, plus an optional shape-frame border. No sign-up — print or download PNG.">
+  <link rel="canonical" href="https://ultratextgen.com/printables/name-puzzle-maker/">
+  <meta property="og:title" content="Name Puzzle Maker — Free Printable Cut-Apart Letter Puzzle | UltraTextGen">
+  <meta property="og:description" content="Type any name and print a puzzle — each letter as a big outline piece with dashed cut lines, plus an optional shape-frame border. Free, no sign-up.">
+  <meta property="og:url" content="https://ultratextgen.com/printables/name-puzzle-maker/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Name Puzzle Maker — Free Printable Cut-Apart Letter Puzzle | UltraTextGen">
+  <meta name="twitter:description" content="Type any name and print a puzzle — each letter as a big outline piece with dashed cut lines, plus an optional shape-frame border. Free, no sign-up.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;family=Baloo+2:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ultratextgen.com/" },
+    { "@type": "ListItem", "position": 2, "name": "Printables", "item": "https://ultratextgen.com/printables/" },
+    { "@type": "ListItem", "position": 3, "name": "Name Puzzle Maker", "item": "https://ultratextgen.com/printables/name-puzzle-maker/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Name Puzzle Maker",
+  "url": "https://ultratextgen.com/printables/name-puzzle-maker/",
+  "applicationCategory": "DesignApplication",
+  "operatingSystem": "Any (web browser)",
+  "browserRequirements": "Requires JavaScript",
+  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+  "description": "Free in-browser name puzzle maker. Type any name to generate a printable cut-apart letter puzzle — each letter as a big outline piece with dashed cut lines, an optional heading and Name/Date line, and an optional decorative shape-frame border — then print it or download a PNG. No sign-up or watermark."
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "How do I make a name puzzle?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Type a name into the box. The tool instantly lays out each letter as a big outline piece in a row, with a dashed cut line between every pair of letters. Add an optional heading, a Name/Date line, and a decorative border, then press Print puzzle or Download PNG. Print on cardstock, cut along the dashed lines, and mix up the pieces for a child to put the name back in order."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What age is a name puzzle good for?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Name puzzles suit preschool and kindergarten learners practicing letter recognition, name spelling, and early scissor and fine-motor skills. An adult usually does the cutting for younger children; older kids can cut their own pieces along the dashed lines."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I add a border or frame to the puzzle?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Pick a shape-frame border — stars, hearts, dots, flowers, or a mixed party set — and it prints as a decorative strip above and below the letter pieces. Choose None for a plain sheet."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is the name puzzle maker free?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Completely free, with no sign-up, account, or watermark. Everything is generated in your browser and nothing is uploaded. Make as many puzzles as you like for any name or short word."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What paper should I print the puzzle on?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Regular paper works, but cardstock holds up much better once the pieces are cut apart, handled, and stored. Laminating the sheet before cutting makes the pieces reusable for many practice sessions."
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/">Home</a>
+  <span class="breadcrumb-separator">›</span>
+  <a href="/printables/">Printables</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Name Puzzle Maker</span>
+</nav>
+
+  <section class="hero">
+    <div class="hero-inner" style="max-width:820px;">
+      <h1 class="hero-headline">Name Puzzle Maker</h1>
+      <p class="hero-tagline">
+        Type a name and print a puzzle — each letter becomes a big outline piece with a dashed
+        cut line to the next. Add an optional shape-frame border, then print it or download a
+        PNG. Free, no sign-up.
+      </p>
+    </div>
+  </section>
+
+  <main class="container">
+
+    <!-- Puzzle studio (primary tool) -->
+    <section class="bubble-alphabet" aria-labelledby="ptPuzzleHeading">
+      <h2 id="ptPuzzleHeading">Make a name puzzle</h2>
+      <p class="bubble-az-intro">Type a name, pick an optional border, and the puzzle builds live on the right — each letter as its own big outline piece with a dashed cut line to the next. Print it, cut along the dashed lines, and mix up the pieces to rebuild the name.</p>
+
+      <div class="pt-studio">
+        <!-- Controls -->
+        <div class="pt-studio-controls">
+          <div class="pt-field">
+            <label class="pt-field-label" for="pt-puzzle-input">Name or word</label>
+            <div class="input-wrapper">
+              <input type="text" class="main-input pt-puzzle-input" id="pt-puzzle-input" placeholder="Type a name… e.g. Alex" maxlength="20" autocomplete="off">
+            </div>
+          </div>
+
+          <div class="pt-field">
+            <label class="pt-field-label" for="pt-puzzle-heading">Heading <span class="pt-field-opt">— optional</span></label>
+            <input type="text" class="main-input pt-puzzle-input" id="pt-puzzle-heading" placeholder="e.g. Alex’s Name Puzzle" maxlength="48" autocomplete="off">
+          </div>
+
+          <div class="pt-field">
+            <span class="pt-field-label">Shape-frame border</span>
+            <div class="pt-swatches" id="pt-puzzle-border-group" role="radiogroup" aria-label="Border">
+              <button type="button" class="pt-swatch is-active" data-value="none" role="radio" aria-checked="true"><span class="pt-swatch-art"></span><span class="pt-swatch-label">None</span></button>
+              <button type="button" class="pt-swatch" data-value="stars" role="radio" aria-checked="false"><span class="pt-swatch-art"></span><span class="pt-swatch-label">Stars</span></button>
+              <button type="button" class="pt-swatch" data-value="hearts" role="radio" aria-checked="false"><span class="pt-swatch-art"></span><span class="pt-swatch-label">Hearts</span></button>
+              <button type="button" class="pt-swatch" data-value="dots" role="radio" aria-checked="false"><span class="pt-swatch-art"></span><span class="pt-swatch-label">Dots</span></button>
+              <button type="button" class="pt-swatch" data-value="flowers" role="radio" aria-checked="false"><span class="pt-swatch-art"></span><span class="pt-swatch-label">Flowers</span></button>
+              <button type="button" class="pt-swatch" data-value="party" role="radio" aria-checked="false"><span class="pt-swatch-art"></span><span class="pt-swatch-label">Party</span></button>
+            </div>
+          </div>
+
+          <div class="pt-field">
+            <label class="pt-check" for="pt-puzzle-footer">
+              <input type="checkbox" id="pt-puzzle-footer">
+              Add a name &amp; date line
+            </label>
+          </div>
+        </div>
+
+        <!-- Live preview -->
+        <div class="pt-studio-preview">
+          <div class="pt-preview-head">
+            <span class="pt-preview-tag">Live preview</span>
+            <span class="pt-preview-meta">US Letter · cut-ready</span>
+          </div>
+          <div class="pt-paper" id="pt-puzzle-preview" aria-live="polite"></div>
+          <div class="pt-preview-actions">
+            <button type="button" class="bubble-btn bubble-btn-primary" id="pt-puzzle-print">Print puzzle</button>
+            <button type="button" class="bubble-btn" id="pt-puzzle-png">Download PNG</button>
+          </div>
+          <p class="pt-preview-note">Runs entirely in your browser — nothing is uploaded. Print on cardstock so the cut pieces hold up to handling.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Editorial -->
+    <section class="editorial-section">
+      <h2>Getting the most from a name puzzle</h2>
+      <ul class="compat-list">
+        <li><span class="ts-pill-safe">Cardstock first</span> Thin paper tears at the cut lines fast — cardstock survives little hands and repeat play.</li>
+        <li><span class="ts-pill-safe">Laminate to reuse</span> Laminate before cutting and the pieces become a durable puzzle you can use for weeks.</li>
+        <li><span class="ts-pill-safe">Start in order</span> Lay the pieces left to right the first few times, then shuffle them once the name is familiar.</li>
+        <li><span class="ts-pill-safe">Keep it stored</span> A small envelope or zip pouch keeps each name's pieces together between sessions.</li>
+      </ul>
+      <p>Want the letters as a straight tracing worksheet instead of pieces to cut? Try
+        <a href="/printables/name-tracing/">name tracing worksheets</a>. Prefer a single sheet to color rather than cut apart? Use the
+        <a href="/printables/coloring-page-maker/">coloring page maker</a>. For copy-paste stylish letters to paste into a bio or caption, see the
+        <a href="/category/">font generators</a>.</p>
+    </section>
+
+    <!-- Cross-family navigation -->
+    <section class="related-pages">
+      <h2>Explore more printables</h2>
+      <div class="related-pages-grid">
+        <a href="/printables/name-tracing/" class="related-page-card">
+          <span class="related-page-label">Handwriting</span>
+          <h4>Name tracing worksheets</h4>
+        </a>
+        <a href="/printables/coloring-page-maker/" class="related-page-card">
+          <span class="related-page-label">Coloring</span>
+          <h4>Coloring page maker</h4>
+        </a>
+        <a href="/printables/alphabet-coloring-pages/" class="related-page-card">
+          <span class="related-page-label">Coloring</span>
+          <h4>Alphabet coloring pages A–Z</h4>
+        </a>
+        <a href="/printables/" class="related-page-card">
+          <span class="related-page-label">All</span>
+          <h4>Printables home</h4>
+        </a>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <h2 class="faq-category">Name Puzzle Maker — FAQ</h2>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          How do I make a name puzzle?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Type a name into the box. The tool instantly lays out each letter as a big outline piece in a row, with a dashed cut line between every pair of letters. Add an optional heading, a Name/Date line, and a decorative border, then press <strong>Print puzzle</strong> or <strong>Download PNG</strong>. Print on cardstock, cut along the dashed lines, and mix up the pieces for a child to put the name back in order.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          What age is a name puzzle good for?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Name puzzles suit preschool and kindergarten learners practicing letter recognition, name spelling, and early scissor and fine-motor skills. An adult usually does the cutting for younger children; older kids can cut their own pieces along the dashed lines.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Can I add a border or frame to the puzzle?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Yes. Pick a shape-frame border — stars, hearts, dots, flowers, or a mixed party set — and it prints as a decorative strip above and below the letter pieces. Choose <strong>None</strong> for a plain sheet.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Is the name puzzle maker free?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Completely free, with no sign-up, account, or watermark. Everything is generated in your browser and nothing is uploaded. Make as many puzzles as you like for any name or short word.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          What paper should I print the puzzle on?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Regular paper works, but cardstock holds up much better once the pieces are cut apart, handled, and stored. Laminating the sheet before cutting makes the pieces reusable for many practice sessions.
+        </div>
+      </div>
+
+    </div>
+  </footer>
+
+  <!-- Print surface (hidden on screen, isolated when printing) -->
+  <div id="pt-print-root" aria-hidden="true"></div>
+
+  <script>
+    window.UTG_PRINTABLE = {
+      key: "name-puzzle-maker",
+      render: "outline",
+      noun: "puzzle piece",
+      pngPrefix: "name-puzzle",
+      font: "'Baloo 2', 'Plus Jakarta Sans', sans-serif",
+      strokeWidth: 7,
+      nameDemo: "Alex",
+      puzzleDemo: "Alex"
+    };
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/js/printables/printablesEngine.js" defer></script>
+
+  <!-- FAQ toggle -->
+  <script>
+    document.querySelectorAll('.faq-question').forEach(function(btn) {
+      btn.addEventListener('click', function() { this.closest('.faq-item').classList.toggle('open'); });
+    });
+  </script>
+<script src="/footer.js" defer></script>
+</body></html>

--- a/style.css
+++ b/style.css
@@ -5679,6 +5679,60 @@ body.dark-mode .pt-paper { background: #fff; border-color: var(--border-light); 
 }
 
 /* ============================================================
+   Name puzzle maker — type a name -> per-letter cut-apart outline
+   pieces with dashed cut lines, an optional heading/footer line, and
+   an optional shape-frame border. Powers /printables/name-puzzle-maker/
+   via the shared engine's #pt-puzzle-* mounts. Sits inside the same
+   .pt-studio / .pt-paper / .pt-swatches shell as the coloring-page-maker
+   and reuses its border symbol set — only the puzzle-row layout below
+   is new.
+   ============================================================ */
+.pt-puzzle-input { min-height: auto; height: 54px; resize: none; }
+
+.pt-puzzle-sheet { display: flex; flex-direction: column; gap: 0.9rem; }
+.pt-puzzle-border-strip { display: block; width: 100%; height: auto; max-height: 40px; }
+.pt-puzzle-heading-text {
+  margin: 0;
+  text-align: center;
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: #1a1a2e;
+}
+
+/* Row of cut-apart letter pieces. Column widths are set inline per render
+   (see puzzleRowNode in printablesEngine.js) so any letter count fits the
+   sheet width without overflow — long names just render smaller pieces. */
+.pt-puzzle-row {
+  display: grid;
+  align-items: stretch;
+  background: #fff;
+  border: 1px solid var(--border-light);
+  border-radius: 12px;
+  overflow: hidden;
+}
+.pt-puzzle-piece {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.6rem 0.35rem;
+  border-right: 3px dashed #94a3b8;
+}
+.pt-puzzle-piece:last-child { border-right: none; }
+.pt-puzzle-piece .bubble-outline { width: 100%; height: auto; }
+.pt-puzzle-gap { min-width: 0.75rem; }
+
+.pt-puzzle-caption { margin: 0; text-align: center; font-size: 0.8rem; color: var(--text-muted); }
+.pt-puzzle-credit { margin: 0; text-align: center; font-size: 0.75rem; color: #aeb4c0; }
+
+.pt-puzzle-footer-row { display: flex; gap: 1.5rem; justify-content: center; flex-wrap: wrap; }
+.pt-puzzle-footer-field { display: inline-flex; align-items: baseline; gap: 0.5rem; font-size: 0.9rem; font-weight: 600; color: #1a1a2e; }
+.pt-puzzle-footer-line { display: inline-block; width: 180px; height: 1px; border-bottom: 2px solid #9aa3b2; }
+
+/* Print: the sheet fills the page on its own, like the coloring designer */
+.pt-puzzle-print-holder { text-align: center; }
+.pt-puzzle-print-holder .pt-puzzle-sheet { max-width: 900px; margin: 0 auto; }
+
+/* ============================================================
    Contextual decoration showcase — static, crawlable SEO block
    Injected as the final section of <main> on decorator pages.
    ============================================================ */

--- a/styles.js
+++ b/styles.js
@@ -176,6 +176,11 @@ const PRINTABLE_PAGES = {
     slug: 'coloring-page-maker',
     title: 'Coloring Page Maker',
     description: 'Type any name or word to make your own printable coloring page — heading, name-and-date line, decorative borders, and multi-color fills. Print or PNG, no sign-up.'
+  },
+  'name-puzzle-maker': {
+    slug: 'name-puzzle-maker',
+    title: 'Name Puzzle Maker',
+    description: 'Type any name to make a free printable name puzzle — each letter as a big outline piece with dashed cut lines, plus an optional shape-frame border. Print or PNG, no sign-up.'
   }
 };
 


### PR DESCRIPTION
## Summary
- New page `/printables/name-puzzle-maker/`: type a name, get a printable cut-apart puzzle — each letter as a big outline piece with dashed cut lines between them, optional decorative shape-frame border.
- Fills a gap found in research: a recurring preschool/homeschool content vertical (Teachers Pay Teachers, Pre-K Pages, Early Learning Ideas and similar sites all sell/give away "editable name puzzle" products), but no live client-side no-signup generator exists in this category — the closest competitors are static/paid products.
- Registered in `PRINTABLE_PAGES` (`styles.js`) and linked from the `/printables/` hub grid + `ItemList` JSON-LD.

## Implementation notes
- Each letter renders via the existing `outlineSVG(ch)` primitive (same one the alphabet grid uses), laid out in a row whose column widths are computed per-render so both a 3-letter and a 14-letter name stay overflow-free (verified via DOM measurements, no horizontal overflow either way).
- The shape-frame border reuses coloring-page-maker's exact border/swatch system rather than a new one — I generalized the shared `wireSwatchGroup()` helper (previously hardcoded to the coloring designer) to accept a `state`/`onChange` pair so both features share the identical swatch UI. I checked this refactor specifically: both the original coloring-page-maker call sites and the new puzzle call site were updated consistently, and the new section is fully mount-gated (`if (!el.puzzleInput || !el.puzzlePreview) return;`) so it can't affect any other printables page.
- Print/PNG reuse the engine's existing `printWrap`/`downloadCanvas`.

## Test plan
- [x] Verified in real Chromium: 3-letter and 14-letter names (no overflow), border swatch selection, custom heading, Name/Date footer toggle, print flow, PNG download, dark mode, hub page navigation
- [x] Confirmed the `wireSwatchGroup` refactor doesn't change coloring-page-maker's existing behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZveMqYHJ4XNHYaGon7Uet)_