### PR TITLE
feat: add sight word tracing worksheets landing page

### DIFF
--- a/printables/index.html
+++ b/printables/index.html
@@ -47,7 +47,8 @@
       { "@type": "ListItem", "position": 5, "name": "Cursive Alphabet & Practice Sheets", "url": "https://ultratextgen.com/printables/cursive-alphabet/" },
       { "@type": "ListItem", "position": 6, "name": "Calligraphy Alphabet & Practice Sheets", "url": "https://ultratextgen.com/printables/calligraphy-alphabet/" },
       { "@type": "ListItem", "position": 7, "name": "Printable Block Letters & Stencils", "url": "https://ultratextgen.com/printables/block-letters/" },
-      { "@type": "ListItem", "position": 8, "name": "Name Tracing Worksheets", "url": "https://ultratextgen.com/printables/name-tracing/" }
+      { "@type": "ListItem", "position": 8, "name": "Name Tracing Worksheets", "url": "https://ultratextgen.com/printables/name-tracing/" },
+      { "@type": "ListItem", "position": 9, "name": "Sight Word Tracing Worksheets", "url": "https://ultratextgen.com/printables/sight-word-tracing/" }
     ]
   }
 }
@@ -193,6 +194,13 @@
           <h3>Name Tracing Worksheets</h3>
           <p>Type any name and print a handwriting worksheet: a solid model row, faded rows to trace, and blank lines for practice. Great for preschool and kindergarten.</p>
           <span class="printable-card-cta">Open name tracing →</span>
+        </a>
+
+        <a class="printable-card" href="/printables/sight-word-tracing/">
+          <span class="printable-card-art" aria-hidden="true">the·said</span>
+          <h3>Sight Word Tracing Worksheets</h3>
+          <p>Tap a common Dolch-style sight word or type your own, dial the tracing difficulty, and print a free practice sheet. Reading-stage presets from Pre-K to Grade 2+.</p>
+          <span class="printable-card-cta">Open sight word tracing →</span>
         </a>
 
       </div>

--- a/printables/sight-word-tracing/index.html
+++ b/printables/sight-word-tracing/index.html
@@ -6,24 +6,24 @@
   'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
   })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
   <!-- End Google Tag Manager -->
-  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZGVh");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
   <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handwriting Worksheet Generator — Adjustable Dotted Tracing | UltraTextGen</title>
-  <meta name="description" content="Make your own handwriting worksheet: type any name or words, then dial the difficulty from bold dotted letters to faded ghosts to blank lines. Age presets for Pre-K to Grade 2. Free, no sign-up — print or download PNG.">
-  <link rel="canonical" href="https://ultratextgen.com/printables/handwriting-worksheet-generator/">
-  <meta property="og:title" content="Handwriting Worksheet Generator — Adjustable Dotted Tracing | UltraTextGen">
-  <meta property="og:description" content="Build a custom handwriting worksheet and dial the difficulty as a child improves — bold dotted, fine dotted, dashed, faded, or blank. Age presets included. Free, print or PNG.">
-  <meta property="og:url" content="https://ultratextgen.com/printables/handwriting-worksheet-generator/">
+  <title>Sight Word Tracing Worksheets — Free Printable Dolch Word Practice | UltraTextGen</title>
+  <meta name="description" content="Free sight word tracing worksheets: tap a common sight word or type your own, dial the difficulty from bold dotted letters to a blank line, and print or download a PNG. Pre-K to Grade 2, no sign-up.">
+  <link rel="canonical" href="https://ultratextgen.com/printables/sight-word-tracing/">
+  <meta property="og:title" content="Sight Word Tracing Worksheets — Free Printable Dolch Word Practice | UltraTextGen">
+  <meta property="og:description" content="Tap a common sight word or type your own, dial the tracing difficulty, and print or download a PNG. Free sight word practice sheets for Pre-K to Grade 2.">
+  <meta property="og:url" content="https://ultratextgen.com/printables/sight-word-tracing/">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://ultratextgen.com/assets/og/category.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
   <meta property="og:image:type" content="image/png">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Handwriting Worksheet Generator — Adjustable Dotted Tracing | UltraTextGen">
-  <meta name="twitter:description" content="Make your own handwriting worksheet and increase the difficulty as a child improves — from bold dotted letters to blank lines.">
+  <meta name="twitter:title" content="Sight Word Tracing Worksheets — Free Printable Dolch Word Practice | UltraTextGen">
+  <meta name="twitter:description" content="Tap a common sight word or type your own, dial the tracing difficulty, and print or download a PNG. Free sight word practice sheets.">
   <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -37,7 +37,7 @@
   "itemListElement": [
     { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ultratextgen.com/" },
     { "@type": "ListItem", "position": 2, "name": "Printables", "item": "https://ultratextgen.com/printables/" },
-    { "@type": "ListItem", "position": 3, "name": "Handwriting Worksheet Generator", "item": "https://ultratextgen.com/printables/handwriting-worksheet-generator/" }
+    { "@type": "ListItem", "position": 3, "name": "Sight Word Tracing", "item": "https://ultratextgen.com/printables/sight-word-tracing/" }
   ]
 }
 </script>
@@ -46,13 +46,13 @@
 {
   "@context": "https://schema.org",
   "@type": "WebApplication",
-  "name": "Handwriting Worksheet Generator",
-  "url": "https://ultratextgen.com/printables/handwriting-worksheet-generator/",
+  "name": "Sight Word Tracing Worksheets",
+  "url": "https://ultratextgen.com/printables/sight-word-tracing/",
   "applicationCategory": "EducationalApplication",
   "operatingSystem": "Any",
   "browserRequirements": "Requires JavaScript. Runs entirely in the browser.",
   "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
-  "description": "Create a custom handwriting practice worksheet from any name or words and adjust the tracing difficulty — bold dotted, fine dotted, dashed, faded, faint, or blank — with age presets from Pre-K to Grade 2. Prints or downloads as PNG, rendered client-side."
+  "description": "Create a sight word tracing worksheet from any common sight word — tap a Dolch-style sample word or type your own — and adjust the tracing difficulty from bold dotted to blank line, with reading-stage presets from Pre-K to Grade 2. Prints or downloads as PNG, rendered client-side."
 }
 </script>
 
@@ -63,34 +63,34 @@
   "mainEntity": [
     {
       "@type": "Question",
-      "name": "How do I make my own handwriting worksheet?",
+      "name": "What are sight words?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Type a name or a few words, tap an age preset or a difficulty level, then click Print the worksheet. The sheet includes a solid model row, several rows at your chosen difficulty to trace, and blank ruled lines for free practice. You can also download it as a PNG."
+        "text": "Sight words are common words — like \"the\", \"said\", and \"was\" — that early readers are taught to recognize instantly, without sounding them out. Many classrooms use the Dolch or Fry word lists, which group these high-frequency words by reading stage from Pre-K through third grade."
       }
     },
     {
       "@type": "Question",
-      "name": "How do the difficulty levels work?",
+      "name": "How do I make a sight word tracing worksheet?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "The seven levels get gradually harder: solid model, bold dotted, fine dotted, dashed, faded ghost, faint guide, and blank line. Each level combines three things a teacher thinks about — stroke thickness, how close the dots sit, and how dark the letters are — so one control cleanly raises or lowers the challenge."
+        "text": "Tap one of the sample sight words or type your own into the box, choose a difficulty level from bold dotted letters to a blank line, then click Print the worksheet. The sheet includes a solid model row, several rows to trace, and blank ruled lines for writing the word from memory. You can also download it as a PNG."
       }
     },
     {
       "@type": "Question",
-      "name": "What difficulty is right for my child's age?",
+      "name": "Which sight words should my child practice first?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "As a starting point: Pre-K works well with bold dotted letters, Kindergarten with fine dotted, Grade 1 with dashed, and Grade 2 and up with a faint guide before writing solo. Use the age presets to jump to a sensible level, then nudge up a notch as the child gets more confident."
+        "text": "Start with short, very common words like \"the\", \"and\", \"a\", and \"said\", then work up to longer ones like \"little\", \"friend\", and \"where\". The reading-stage buttons — Pre-K through Grade 2+ — jump the tracing difficulty to a sensible starting point for each stage."
       }
     },
     {
       "@type": "Question",
-      "name": "Is the handwriting worksheet generator free?",
+      "name": "Is the sight word tracing worksheet generator free?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes — completely free, with no sign-up, watermark, or limit. Everything is generated in your browser, so you can make as many worksheets as you like for any name, word, or difficulty."
+        "text": "Yes — completely free, with no sign-up, watermark, or limit. Everything is generated in your browser, so you can make as many sight word worksheets as you like."
       }
     }
   ]
@@ -111,17 +111,16 @@
   <span class="breadcrumb-separator">›</span>
   <a href="/printables/">Printables</a>
   <span class="breadcrumb-separator">›</span>
-  <span class="breadcrumb-current">Handwriting Worksheet Generator</span>
+  <span class="breadcrumb-current">Sight Word Tracing</span>
 </nav>
 
   <section class="hero">
     <div class="hero-inner" style="max-width:820px;">
-      <h1 class="hero-headline">Handwriting Worksheet Generator</h1>
+      <h1 class="hero-headline">Sight Word Tracing Worksheets</h1>
       <p class="hero-tagline">
-        Make your own handwriting worksheet in seconds. Type any name or words, tap a
-        difficulty level from bold dotted letters to a blank line, and watch the sheet
-        build live. Great for Pre-K to Grade 2 — and adult handwriting practice.
-        Free, no sign-up, print or save a PDF/PNG.
+        Tap a common sight word or type your own, dial the difficulty from bold dotted
+        letters to a blank line, and watch the sheet build live. Reading-stage presets
+        from Pre-K to Grade 2+. Free, no sign-up, print or save a PDF/PNG.
       </p>
     </div>
   </section>
@@ -130,26 +129,45 @@
 
     <!-- Generator studio (primary) -->
     <section class="bubble-alphabet" aria-labelledby="ptGenHeading">
-      <h2 id="ptGenHeading">Build your worksheet</h2>
-      <p class="bubble-az-intro">Type a name or words, tap a difficulty level, and the sheet builds live on the right. Print it, save a PDF, or download a PNG — free, no sign-up.</p>
+      <h2 id="ptGenHeading">Build a sight word worksheet</h2>
+      <p class="bubble-az-intro">Tap a sample sight word below or type your own, choose a difficulty level, and the sheet builds live on the right. Print it, save a PDF, or download a PNG — free, no sign-up.</p>
 
       <div class="pt-studio">
         <!-- Controls -->
         <div class="pt-studio-controls">
           <div class="pt-field">
-            <label class="pt-field-label" for="pt-gen-input">Name or words to practice</label>
+            <label class="pt-field-label" for="pt-gen-input">Sight word to practice</label>
             <div class="input-wrapper">
-              <input type="text" class="main-input pt-gen-input" id="pt-gen-input" placeholder="Type a name or words… e.g. Emma" maxlength="42" autocomplete="off">
+              <input type="text" class="main-input pt-gen-input" id="pt-gen-input" placeholder="Type a sight word… e.g. said" maxlength="42" autocomplete="off">
+            </div>
+            <div class="quickfill">
+              <span class="quickfill-label">Try</span>
+              <button type="button" data-fill="the">the</button>
+              <button type="button" data-fill="and">and</button>
+              <button type="button" data-fill="said">said</button>
+              <button type="button" data-fill="was">was</button>
+              <button type="button" data-fill="you">you</button>
+              <button type="button" data-fill="are">are</button>
+              <button type="button" data-fill="see">see</button>
+              <button type="button" data-fill="like">like</button>
+              <button type="button" data-fill="come">come</button>
+              <button type="button" data-fill="play">play</button>
+              <button type="button" data-fill="little">little</button>
+              <button type="button" data-fill="look">look</button>
+              <button type="button" data-fill="here">here</button>
+              <button type="button" data-fill="funny">funny</button>
+              <button type="button" data-fill="blue">blue</button>
+              <button type="button" data-fill="friend">friend</button>
             </div>
           </div>
 
           <div class="pt-field">
-            <span class="pt-field-label">Start by age <span class="pt-field-opt">— optional shortcut</span></span>
-            <div class="pt-segment" id="pt-gen-presets" role="group" aria-label="Age preset">
-              <button type="button" class="pt-gen-preset" data-level="2" aria-pressed="false">Pre-K <small>bold dotted</small></button>
-              <button type="button" class="pt-gen-preset" data-level="3" aria-pressed="false">Kindergarten <small>fine dotted</small></button>
-              <button type="button" class="pt-gen-preset" data-level="4" aria-pressed="false">Grade 1 <small>dashed</small></button>
-              <button type="button" class="pt-gen-preset" data-level="6" aria-pressed="false">Grade 2+ <small>faint guide</small></button>
+            <span class="pt-field-label">Reading stage <span class="pt-field-opt">— optional shortcut</span></span>
+            <div class="pt-segment" id="pt-gen-presets" role="group" aria-label="Reading stage preset">
+              <button type="button" class="pt-gen-preset" data-level="2" aria-pressed="false">Pre-K <small>Dolch pre-primer</small></button>
+              <button type="button" class="pt-gen-preset" data-level="3" aria-pressed="false">Kindergarten <small>Dolch primer</small></button>
+              <button type="button" class="pt-gen-preset" data-level="4" aria-pressed="false">Grade 1 <small>Dolch 1st grade</small></button>
+              <button type="button" class="pt-gen-preset" data-level="6" aria-pressed="false">Grade 2+ <small>Dolch 2nd grade+</small></button>
             </div>
           </div>
 
@@ -239,78 +257,78 @@
       </div>
     </section>
 
-    <!-- How difficulty works (crawlable explainer; the ladder above is interactive) -->
-    <section class="editorial-section" aria-labelledby="ptLadderHeading">
-      <h2 id="ptLadderHeading">How the difficulty works</h2>
-      <p>Every difficulty level combines three things a teacher thinks about — how <strong>thick</strong>
-        the guide is, how <strong>close</strong> the dots sit, and how <strong>dark</strong> the letters
-        are — so one tap cleanly raises or lowers the challenge. The seven levels run from a
-        <strong>solid model</strong> to trace on top, through <strong>bold dotted</strong>,
-        <strong>fine dotted</strong>, <strong>dashed</strong>, <strong>faded ghost</strong> and
-        <strong>faint guide</strong>, all the way to a <strong>blank ruled line</strong> for writing from
-        memory. Start easy and move up a single notch as a child’s control improves.</p>
-      <p>Not sure where to start? As a rule of thumb, <strong>Pre-K</strong> does well with bold dotted,
-        <strong>Kindergarten</strong> with fine dotted, <strong>Grade 1</strong> with dashed, and
-        <strong>Grade 2 and up</strong> with a faint guide before writing solo. Adults relearning
-        penmanship often start at faded ghost and drop to a blank line. The age buttons jump to a
-        sensible level — then fine-tune with the ladder.</p>
-      <p>Want a ready-made sheet instead of building one? Grab a
-        <a href="/printables/name-tracing/">name tracing worksheet</a>, practice common high-frequency
-        words with <a href="/printables/sight-word-tracing/">sight word tracing worksheets</a>, try the
-        <a href="/printables/cursive-alphabet/">cursive practice sheets</a>, or browse all
+    <!-- What are sight words (crawlable explainer) -->
+    <section class="editorial-section" aria-labelledby="ptSightHeading">
+      <h2 id="ptSightHeading">What are sight words, and why trace them?</h2>
+      <p><strong>Sight words</strong> are the small set of very common words — <strong>the</strong>,
+        <strong>said</strong>, <strong>was</strong>, <strong>you</strong>, <strong>are</strong> — that
+        show up so often in early reading that kids are taught to recognize them instantly, by sight,
+        rather than sounding them out letter by letter. Many classrooms build this list from the
+        <strong>Dolch</strong> or <strong>Fry</strong> word lists, which group high-frequency words by
+        reading stage from Pre-K through third grade. Tracing a sight word while saying it out loud
+        connects the shape of the word to its sound, which helps it stick as an instantly-recognized
+        whole rather than a word to decode every time.</p>
+      <p>Not sure where to start? As a rule of thumb, <strong>Pre-K</strong> works well with bold dotted
+        letters on short words like "a" and "the", <strong>Kindergarten</strong> with fine dotted,
+        <strong>Grade 1</strong> with dashed, and <strong>Grade 2 and up</strong> with a faint guide
+        before writing the word solo. The reading-stage buttons jump to a sensible level — then
+        fine-tune with the difficulty ladder above.</p>
+      <p>Want the same tool for a name instead of a sight word? Try the general-purpose
+        <a href="/printables/handwriting-worksheet-generator/">handwriting worksheet generator</a>, grab a
+        <a href="/printables/name-tracing/">name tracing worksheet</a>, or browse all
         <a href="/printables/">printable letters &amp; alphabets</a>.</p>
     </section>
   </main>
 
   <footer class="footer">
     <div class="footer-inner">
-      <h2 class="faq-category">Handwriting Worksheet Generator — FAQ</h2>
+      <h2 class="faq-category">Sight Word Tracing Worksheets — FAQ</h2>
 
       <div class="faq-item">
         <button class="faq-question" type="button">
-          How do I make my own handwriting worksheet?
+          What are sight words?
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
         </button>
         <div class="faq-answer">
-          Type a name or a few words, tap an age preset or a difficulty level, then click
-          <strong>Print the worksheet</strong>. The sheet includes a solid model row, several rows at your
-          chosen difficulty to trace, and blank ruled lines for free practice. You can also download it as a PNG.
+          Sight words are common words — like "the", "said", and "was" — that early readers are taught to
+          recognize instantly, without sounding them out. Many classrooms use the Dolch or Fry word lists,
+          which group these high-frequency words by reading stage from Pre-K through third grade.
         </div>
       </div>
 
       <div class="faq-item">
         <button class="faq-question" type="button">
-          How do the difficulty levels work?
+          How do I make a sight word tracing worksheet?
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
         </button>
         <div class="faq-answer">
-          The seven levels get gradually harder: solid model, bold dotted, fine dotted,
-          dashed, faded ghost, faint guide, and blank line. Each level combines three things a teacher thinks about —
-          stroke thickness, how close the dots sit, and how dark the letters are — so one control cleanly raises or
-          lowers the challenge.
+          Tap one of the sample sight words or type your own into the box, choose a difficulty level from
+          bold dotted letters to a blank line, then click <strong>Print the worksheet</strong>. The sheet
+          includes a solid model row, several rows to trace, and blank ruled lines for writing the word
+          from memory. You can also download it as a PNG.
         </div>
       </div>
 
       <div class="faq-item">
         <button class="faq-question" type="button">
-          What difficulty is right for my child's age?
+          Which sight words should my child practice first?
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
         </button>
         <div class="faq-answer">
-          As a starting point: Pre-K works well with bold dotted letters, Kindergarten with fine dotted, Grade 1 with
-          dashed, and Grade 2 and up with a faint guide before writing solo. Use the age presets to jump to a sensible
-          level, then nudge up a notch as the child gets more confident.
+          Start with short, very common words like "the", "and", "a", and "said", then work up to longer
+          ones like "little", "friend", and "where". The reading-stage buttons — Pre-K through Grade 2+ —
+          jump the tracing difficulty to a sensible starting point for each stage.
         </div>
       </div>
 
       <div class="faq-item">
         <button class="faq-question" type="button">
-          Is the handwriting worksheet generator free?
+          Is the sight word tracing worksheet generator free?
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
         </button>
         <div class="faq-answer">
-          Yes — completely free, with no sign-up, watermark, or limit. Everything is generated in your browser, so you
-          can make as many worksheets as you like for any name, word, or difficulty.
+          Yes — completely free, with no sign-up, watermark, or limit. Everything is generated in your
+          browser, so you can make as many sight word worksheets as you like.
         </div>
       </div>
 
@@ -322,18 +340,34 @@
 
   <script>
     window.UTG_PRINTABLE = {
-      key: "handwriting-worksheet-generator",
+      key: "sight-word-tracing",
       render: "outline",
       noun: "tracing",
-      pngPrefix: "handwriting",
+      pngPrefix: "sight-word",
       font: "Quicksand, 'Plus Jakarta Sans', sans-serif",
       charset: "alnum",
-      genDemo: "Emma"
+      genDemo: "said"
     };
   </script>
   <script src="/styles.js" defer></script>
   <script src="/renderer.js" defer></script>
   <script src="/js/printables/printablesEngine.js" defer></script>
+
+  <!-- Quick-fill sight word chips -->
+  <script>
+    (function () {
+      "use strict";
+      const input = document.getElementById("pt-gen-input");
+      if (!input) return;
+      document.querySelectorAll(".quickfill [data-fill]").forEach((btn) => {
+        btn.addEventListener("click", () => {
+          input.value = btn.dataset.fill;
+          input.dispatchEvent(new Event("input", { bubbles: true }));
+          input.focus();
+        });
+      });
+    })();
+  </script>
 
   <!-- FAQ toggle -->
   <script>

--- a/styles.js
+++ b/styles.js
@@ -167,6 +167,11 @@ const PRINTABLE_PAGES = {
     title: 'Handwriting Worksheet Generator',
     description: 'Make a custom handwriting worksheet and dial the tracing difficulty — dotted, dashed, faded, or blank — with age presets from Pre-K to Grade 2.'
   },
+  'sight-word-tracing': {
+    slug: 'sight-word-tracing',
+    title: 'Sight Word Tracing Worksheets',
+    description: 'Tap a common Dolch-style sight word or type your own, dial the tracing difficulty, and print a free sight word practice sheet — reading-stage presets from Pre-K to Grade 2+.'
+  },
   'alphabet-coloring-pages': {
     slug: 'alphabet-coloring-pages',
     title: 'Alphabet Coloring Pages',


### PR DESCRIPTION
## Summary
- New page `/printables/sight-word-tracing/`, reusing the existing `handwriting-worksheet-generator` studio verbatim (no engine changes) with copy/meta reframed around "sight word tracing" / Dolch word-list intent.
- Lowest-confidence, cheapest item in this batch (thin content vertical, no forum thread found) — shipped for sweep completeness with minimal build cost, per the plan.
- Adds a 16-word quick-fill chip row (the/and/said/was/...) feeding the existing word input, reusing the `.quickfill` pattern already used on the Old English page.

## Test plan
- [x] Verified in real Chromium: "the"/"said"/"friend" all render, resize, and print/PNG-export cleanly through the unmodified generator engine
- [x] Confirmed reading-stage presets (Pre-K · Dolch pre-primer → Grade 2+ · Dolch 2nd grade+) and difficulty ladder both update correctly
- [x] Dark mode verified with no new CSS needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZveMqYHJ4XNHYaGon7Uet)_