### PR TITLE
docs: weekly infrastructure review 2026-07-10

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,7 @@ workflow that produces it.
 | **Guide** (articles) | `/guide/` | `Article` | [`guide-content-workflow.md`](./guide-content-workflow.md) | `data/library_opportunities.csv` (`page_type=guide`) + `guide-opportunity-map-<date>.md` | ❌ none (hand-built) | ⚠️ workflow + backlog, no generator |
 | **Printables** (bubble/cursive/block/tracing/coloring sheets) | `/printables/` | `WebApplication` (+ `CollectionPage` hub) | [`coloring-sheet-generator-strategy.md`](./coloring-sheet-generator-strategy.md) (strategy) + `CLAUDE.md` scope note | `library_opportunities.csv` (`page_type=printables`, added 2026-07-09 — other-language/other-script backlog) | ❌ none (hand-built, on `js/printables/printablesEngine.js`) | ⚠️ backlog + strategy, no generator |
 | **Platform** (social-network generators) | `/discord/`, `/instagram/`, `/x/`, … | `WebApplication` | ❌ undocumented | ❌ none | ❌ none | ❌ undocumented |
+| **Root pages** (homepage, 404, legal) | `index.html`, `_root.html`, `404.html`, `about/`, `contact/`, `privacy/`, `terms/`, site icons | `WebSite` (homepage) | ❌ undocumented | ❌ none | ❌ none (hand-built) | ❌ undocumented |
 
 **Only the Library lane is structurally complete** (discovery → scouting →
 research → volume → score → dedupe → spec → generate → validate → PR). The
@@ -58,7 +59,8 @@ These run across page types rather than producing a type.
 | Image backlinks (embeddable images / widgets) | `/embed/` widget pages (no generator yet) | [`image-backlink-strategy.md`](./image-backlink-strategy.md) (decision doc) | ad hoc |
 | **Visual & printable assets** (in-browser SVG/PNG output mode) | `js/curved/curvedText.js` + `curvedTextController.js` (curved/arc tool → `/curved-text/`); `js/bubble/bubbleExplorer.js` (printable bubble letters, per-letter + A–Z); `js/cursive/cursivePageController.js` + `cursiveData.js` (cursive practice sheets) | [`jtbd-principles.md`](./jtbd-principles.md) §10 (output modes) + `CLAUDE.md` scope note | per feature (demand-gated) |
 | Collection-copy audit | `audit_library_opportunities.py` (+ explorer, see workflow §5) | ⚠️ workflow §5; [`emoji-combination-taxonomy.md`](./emoji-combination-taxonomy.md) for combo taxonomy | per batch |
-| i18n / localization | `prerender-i18n.js` (+ `de/`, `es/`, `fr/`, `id/`, `it/`, `nl/`, `pl/`, `pt/`, `tl/`, `tr/`, `vi/`, `locales/`, `README.*.md`) | ❌ none | as needed |
+| i18n / localization | `prerender-i18n.js` (+ `de/`, `es/`, `fr/`, `id/`, `it/`, `nl/`, `no/`, `pl/`, `pt/`, `sv/`, `tl/`, `tr/`, `vi/`, `locales/`, `README.*.md`) | ❌ none | as needed |
+| Ads / monetization (Journey ads deployment) | `scripts/check-ads.js` (CI: `ads-check.yml`), `scripts/update-ads-txt.sh` (CI: `update-ads-txt.yml`, daily sync of `ads.txt` from Journey), tag injected site-wide via `header.js` | ❌ none | as needed + daily `ads.txt` sync |
 | ↳ Printables × i18n (not yet wired together) | n/a — `/printables/` pages have no `data-i18n` attributes / locale-JSON keys yet | `library_opportunities.csv` `OPP-0803` (scoping note: German/Spanish/French native-query volume for alphabet printables outweighs the English long-tail) | needs scoping pass |
 | CSS audit | `audit-css.js` | ❌ none (CI-only) | CI (`css-audit.yml`) |
 | GTM check | `check-gtm.js` | ❌ none (CI-only) | CI (`gtm-check.yml`) |
@@ -78,6 +80,8 @@ These run across page types rather than producing a type.
 | `gtm-check.yml` | on `pull_request` | `check-gtm.js` (GTM snippet present) |
 | `image-assets-check.yml` | on `pull_request` (HTML/`assets/og`/`assets/hero`/`assets/pinterest` paths) | `check-image-assets.py` (PR #315) |
 | `schedule-cache-removal.yml` | annual (Apr 10) + manual | cache maintenance |
+| `ads-check.yml` | on `pull_request` (HTML/`header.js`/`package.json`/`scripts/check-ads.js`) | `check-ads.js` (Journey ads tag deployed site-wide, PR #366) |
+| `update-ads-txt.yml` | daily 00:30 UTC + manual | refresh `ads.txt` from Journey (`update-ads-txt.sh`, PR #368) |
 
 ### Scheduled routines (Claude Code on the web)
 
@@ -119,7 +123,11 @@ here so they aren't lost. Update as they're closed or new ones appear.
    received content expansions in PRs #302, #310, and #312, and PR #312
    introduced a localized usecase sub-namespace (`/id/usecase/`) with no
    governing workflow — the i18n governing doc and namespace definition are
-   overdue.
+   overdue. **Update (2026-07-10):** two more locales shipped this week —
+   Swedish `/sv/` (PR #396) and Norwegian `/no/` (PR #397) — and neither
+   prefix was in `LANE_RULES`, so both PRs surfaced as unclassified; both
+   prefixes are now added. The locale count (12+ and growing weekly) makes
+   the missing i18n governing doc the most pressing item in this gap.
 5. **Platform pages lane is undocumented** — the eleven social-network generator
    pages (`/discord/`, `/instagram/`, `/x/`, …) receive active SEO updates
    (`alternateName`: PR #277; FAQ structured data: PR #290) but have no
@@ -132,11 +140,13 @@ here so they aren't lost. Update as they're closed or new ones appear.
    `assets/pinterest/` root rather than a named board subdirectory — these
    should be moved to `assets/pinterest/<board>/` and wired into the upload
    pipeline. Migrate both per `docs/pinterest-pin-generation.md`.
-7. **Homepage (`index.html`, `_root.html`) has no lane or owner.** It isn't a
-   page type in the table above, so edits to it (PRs #310, #330, #331 this
-   week) never resolve to a lane — the digest classifier has no rule for it,
-   and inventing one (e.g. folding it into "Docs" or "Core JS") would misrepresent
-   what changed. Needs a decision: its own row, or explicit non-lane status.
+7. ~~**Homepage (`index.html`, `_root.html`) has no lane or owner.**~~ **Closed
+   (2026-07-10)** — given its own row in the page-type table ("Root pages":
+   `index.html`, `_root.html`, `404.html`, `about/`, `contact/`, `privacy/`,
+   `terms/`, site icons) and matching `LANE_RULES` entries, resolving repeated
+   unclassified signal across PRs #365, #367, #369, #372, #384, #389, #396,
+   #397. It's still hand-built with no generator or governing doc — that
+   remains open, tracked the same as the other undocumented lanes above.
 8. **Visual/printable output mode has principles but no pipeline.** The second
    output mode ([`jtbd-principles.md`](./jtbd-principles.md) §10) is live across
    three surfaces — the curved/arc tool (`/curved-text/`), printable bubble
@@ -150,6 +160,13 @@ here so they aren't lost. Update as they're closed or new ones appear.
    is still absent from the page-type table. Decide: promote to a full lane
    (shared export util + a governing doc) or keep it a principle-governed
    cross-cutting track.
+9. **New this week: Ads / monetization track has no governing doc.** PRs
+   #366–#368 stood up Journey ads as a real operational track — site-wide tag
+   injection via `header.js`, a CI gate (`ads-check.yml` / `check-ads.js`),
+   and a daily `ads.txt` sync (`update-ads-txt.yml` / `update-ads-txt.sh`) —
+   replacing Google AdSense. Added to the operational-tracks table this
+   review; no strategy/decision doc exists yet (e.g. why Journey over
+   AdSense, revenue-share terms, page exclusions). Flagging so it isn't lost.
 
 ---
 

--- a/scripts/weekly_pr_digest.py
+++ b/scripts/weekly_pr_digest.py
@@ -35,6 +35,17 @@ LANE_RULES = [
     ("usecase/", "Usecase pages"),
     ("guide/", "Guide pages"),
     ("curved-text/", "Visual & printable assets"),
+    # Root-level site-wide pages (homepage, legal, 404, site icons) — no
+    # dedicated page-type namespace; see docs/README.md Known gaps.
+    ("index.html", "Root pages"),
+    ("_root.html", "Root pages"),
+    ("404.html", "Root pages"),
+    ("about/", "Root pages"),
+    ("contact/", "Root pages"),
+    ("privacy/", "Root pages"),
+    ("terms/", "Root pages"),
+    ("favicon.ico", "Root pages"),
+    ("apple-touch-icon.png", "Root pages"),
     ("discord/", "Platform pages"),
     ("facebook/", "Platform pages"),
     ("instagram/", "Platform pages"),
@@ -55,6 +66,7 @@ LANE_RULES = [
     ("scripts/", "Scripts / tooling"),
     ("docs/", "Docs"),
     ("CLAUDE.md", "Docs"),
+    ("README", "Docs"),  # README.md + locale variants (README.<lang>.md)
     ("style.css", "Styling"),
     ("symbol-explorer", "Symbol explorer"),
     ("renderer.js", "Core JS"),
@@ -62,6 +74,11 @@ LANE_RULES = [
     ("script.js", "Core JS"),
     ("header.js", "Core JS"),
     ("fonts.json", "Core JS"),
+    ("gothic-tools.js", "Core JS"),
+    ("accent-notice.js", "Core JS"),
+    ("i18n.js", "Core JS"),
+    ("ads.txt", "Ads / monetization"),
+    (".gitignore", "CI / automation"),
     # Visual/printable output modules (must precede the generic "js/" rule).
     ("js/curved/", "Visual & printable assets"),
     ("js/bubble/", "Visual & printable assets"),
@@ -83,6 +100,8 @@ LANE_RULES = [
     ("tl/", "i18n"),
     ("tr/", "i18n"),
     ("vi/", "i18n"),
+    ("sv/", "i18n"),
+    ("no/", "i18n"),
 ]
 
 # A lane label used when no rule matched any of a PR's files. These are the


### PR DESCRIPTION
## Summary

Weekly infrastructure review per `docs/README.md` § [Weekly infrastructure review](https://github.com/ychowdhrey/ultratextgen/blob/main/docs/README.md#weekly-infrastructure-review). Input: `docs/infra-review/latest.md` (2026-06-29 → 2026-07-06, the most recent automated digest — next digest runs Monday). 31 of its PRs were flagged "Unclassified — possible new lane (signal!)"; I fetched each one's changed files and diffed them against the current `LANE_RULES` to find the actual unmatched paths.

- **Close Known gap #7** ("Homepage has no lane or owner") by adding a **Root pages** page-type row (`index.html`, `_root.html`, `404.html`, `about/`, `contact/`, `privacy/`, `terms/`, site icons). This gap had recurred across 8 PRs this week alone (#365, #367, #369, #372, #384, #389, #396, #397).
- **Add a new "Ads / monetization" operational track** for the Journey ads rollout (PRs #366–#368: site-wide tag injection via `header.js`, `ads-check.yml` CI gate, daily `ads.txt` sync) — no governing doc exists yet, so it's also logged as a new Known gap (#9).
- **Teach `LANE_RULES`** the specific paths causing this week's unclassified signal: the Root pages set above, `README.md` + its locale variants, three more root-level core scripts (`gothic-tools.js`, `accent-notice.js`, `i18n.js`), `ads.txt`, `.gitignore`, and two locale prefixes that shipped this week but were missing from the i18n rule list (`sv/` Swedish PR #396, `no/` Norwegian PR #397).
- Noted the growing i18n locale count against the existing i18n governing-doc gap.
- Most of the other "Unclassified" PRs in the digest already match current `LANE_RULES` (the digest was generated against an earlier snapshot mid-week) — no action needed there.

Diff is small and additive, as the process requires. **Not merging** — for human review per the golden rule in the process doc.

## Test plan

- [x] Ran `classify_paths()` against sample paths from every new/changed `LANE_RULES` entry (root pages, icons, README variants, new core JS files, `ads.txt`, `.gitignore`, `sv/`/`no/`) to confirm matches and no collisions with existing prefixes (`category/`, `js/`, `usecase/`, etc.)
- [ ] Human review of the new "Root pages" and "Ads / monetization" lane decisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKJKHsDHQGAkGDzuszHMks

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKJKHsDHQGAkGDzuszHMks)_