### PR TITLE
Launch Korean (ko) — symbol-only footprint (10 pages)

### DIFF
--- a/ar/library/emoji-combos/index.html
+++ b/ar/library/emoji-combos/index.html
@@ -17,10 +17,13 @@
 <meta name="description" content="مجموعات إيموجي جاهزة للنسخ واللصق. تركيبات رموز حسب الأجواء: كيوت، حب، نجوم وليل، فصول، احتفال وأكثر. انقر على أي تركيبة لنسخها والصقها مباشرة في انستقرام وتيك توك وواتساب و X.">
 
 <link rel="canonical" href="https://ultratextgen.com/ar/library/emoji-combos/">
-<link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/emoji-combos/">
-<link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/emoji-combos/">
-<link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/emoji-combos/">
-<link rel="alternate" hreflang="ar" href="https://ultratextgen.com/ar/library/emoji-combos/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/emoji-combos/">
+  <link rel="alternate" hreflang="ar" href="https://ultratextgen.com/ar/library/emoji-combos/">
+  <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/emoji-combos/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/imoji-johap/">
+  <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/emoji-combos/">
+  <link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/emoji-combos/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/emoji-combos/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/library-emoji-combos.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">

--- a/ar/library/kaomoji/index.html
+++ b/ar/library/kaomoji/index.html
@@ -24,6 +24,7 @@
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/kaomoji/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/kaomoji/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/text-faces-kaomoji/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/imotikon/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/kaomoji/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/kaomoji/">
   <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/kaomoji/">

--- a/ar/library/special-characters/index.html
+++ b/ar/library/special-characters/index.html
@@ -17,10 +17,13 @@
 <meta name="description" content="الرموز والأحرف الخاصة رموز للنسخ. زخارف لطيفة من لمعان وقلوب ونجوم وأسهم وأقواس زخرفية وعلامات موسيقية مرتبة حسب الفئة. يكفي أن تنقر لتنسخ الرمز وتستخدمه مباشرة في سيرتك على إنستغرام أو اسمك في الألعاب.">
 
 <link rel="canonical" href="https://ultratextgen.com/ar/library/special-characters/">
-<link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/special-characters/">
-<link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/special-characters/">
-<link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/special-characters/">
-<link rel="alternate" hreflang="ar" href="https://ultratextgen.com/ar/library/special-characters/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/special-characters/">
+  <link rel="alternate" hreflang="ar" href="https://ultratextgen.com/ar/library/special-characters/">
+  <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/special-characters/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/">
+  <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/special-characters/">
+  <link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/special-characters/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/special-characters/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/library-special-characters.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">

--- a/de/library/herz-symbole/index.html
+++ b/de/library/herz-symbole/index.html
@@ -23,6 +23,7 @@
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-love/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-cuore/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/heart-symbols/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/hateu-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-serca/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-de-coracao/">
   <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/serdechki/">

--- a/de/library/kaomoji/index.html
+++ b/de/library/kaomoji/index.html
@@ -24,6 +24,7 @@
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/kaomoji/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/kaomoji/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/text-faces-kaomoji/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/imotikon/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/kaomoji/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/kaomoji/">
   <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/kaomoji/">

--- a/de/library/pfeil-symbole/index.html
+++ b/de/library/pfeil-symbole/index.html
@@ -22,6 +22,7 @@
   <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/simbolos-de-flechas/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-panah/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/arrow-symbols/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/hwasalpyo-giho/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/setas/">
   <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/ki-tu-mui-ten/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/arrow-symbols/">

--- a/de/library/stern-symbole/index.html
+++ b/de/library/stern-symbole/index.html
@@ -23,6 +23,7 @@
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-bintang/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-stella/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/star-symbols/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/byeol-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-gwiazdek/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-de-estrela/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/yildiz-sembolleri/">

--- a/es/library/kaomoji/index.html
+++ b/es/library/kaomoji/index.html
@@ -24,6 +24,7 @@
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/kaomoji/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/kaomoji/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/text-faces-kaomoji/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/imotikon/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/kaomoji/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/kaomoji/">
   <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/kaomoji/">

--- a/es/library/simbolos-discord/index.html
+++ b/es/library/simbolos-discord/index.html
@@ -22,6 +22,7 @@
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles-discord/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-discord/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-discord/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/discord-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-discord/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-discord/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/discord-sembolleri/">

--- a/es/library/simbolos-roblox/index.html
+++ b/es/library/simbolos-roblox/index.html
@@ -22,6 +22,7 @@
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles-roblox/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-roblox/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-roblox/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/roblox-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-roblox/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-roblox/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/roblox-sembolleri/">

--- a/es/library/simbolos-y2k/index.html
+++ b/es/library/simbolos-y2k/index.html
@@ -22,6 +22,7 @@
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles-y2k/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-y2k/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-y2k/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/y2k-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-y2k/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-y2k/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/y2k-sembolleri/">

--- a/es/simbolos-aesthetic/index.html
+++ b/es/simbolos-aesthetic/index.html
@@ -4,6 +4,7 @@
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-aesthetic/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/aesthetic-symbols/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/gamseong-giho/">
   <link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/library/speciale-tekens/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/estetik-semboller/">

--- a/es/simbolos-de-corazon/index.html
+++ b/es/simbolos-de-corazon/index.html
@@ -5,6 +5,7 @@
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-love/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-cuore/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/heart-symbols/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/hateu-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-serca/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-de-coracao/">
   <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/serdechki/">

--- a/es/simbolos-de-estrella/index.html
+++ b/es/simbolos-de-estrella/index.html
@@ -23,6 +23,7 @@
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-bintang/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-stella/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/star-symbols/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/byeol-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-gwiazdek/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-de-estrela/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/yildiz-sembolleri/">
@@ -515,6 +516,7 @@
       <a class="lang-option" href="/id/library/simbol-bintang/" hreflang="id">ID</a>
       <a class="lang-option" href="/it/library/simboli-stella/" hreflang="it">IT</a>
       <a class="lang-option" href="/ja/library/star-symbols/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/byeol-giho/" hreflang="ko">KO</a>
       <a class="lang-option" href="/pl/library/symbole-gwiazdek/" hreflang="pl">PL</a>
       <a class="lang-option" href="/pt/library/simbolos-de-estrela/" hreflang="pt">PT</a>
       <a class="lang-option" href="/tr/library/yildiz-sembolleri/" hreflang="tr">TR</a>

--- a/es/simbolos-de-flechas/index.html
+++ b/es/simbolos-de-flechas/index.html
@@ -22,6 +22,7 @@
   <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/simbolos-de-flechas/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-panah/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/arrow-symbols/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/hwasalpyo-giho/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/setas/">
   <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/ki-tu-mui-ten/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/arrow-symbols/">

--- a/fr/library/symboles-discord/index.html
+++ b/fr/library/symboles-discord/index.html
@@ -22,6 +22,7 @@
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles-discord/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-discord/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-discord/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/discord-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-discord/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-discord/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/discord-sembolleri/">
@@ -641,6 +642,7 @@
       <a class="lang-option active" href="/fr/library/symboles-discord/" hreflang="fr">FR</a>
       <a class="lang-option" href="/id/library/simbol-discord/" hreflang="id">ID</a>
       <a class="lang-option" href="/it/library/simboli-discord/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ko/library/discord-giho/" hreflang="ko">KO</a>
       <a class="lang-option" href="/pl/library/symbole-discord/" hreflang="pl">PL</a>
       <a class="lang-option" href="/pt/library/simbolos-discord/" hreflang="pt">PT</a>
       <a class="lang-option" href="/tr/library/discord-sembolleri/" hreflang="tr">TR</a>

--- a/fr/library/symboles-roblox/index.html
+++ b/fr/library/symboles-roblox/index.html
@@ -22,6 +22,7 @@
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles-roblox/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-roblox/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-roblox/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/roblox-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-roblox/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-roblox/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/roblox-sembolleri/">
@@ -431,6 +432,7 @@
       <a class="lang-option active" href="/fr/library/symboles-roblox/" hreflang="fr">FR</a>
       <a class="lang-option" href="/id/library/simbol-roblox/" hreflang="id">ID</a>
       <a class="lang-option" href="/it/library/simboli-roblox/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ko/library/roblox-giho/" hreflang="ko">KO</a>
       <a class="lang-option" href="/pl/library/symbole-roblox/" hreflang="pl">PL</a>
       <a class="lang-option" href="/pt/library/simbolos-roblox/" hreflang="pt">PT</a>
       <a class="lang-option" href="/tr/library/roblox-sembolleri/" hreflang="tr">TR</a>

--- a/fr/library/symboles-y2k/index.html
+++ b/fr/library/symboles-y2k/index.html
@@ -22,6 +22,7 @@
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles-y2k/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-y2k/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-y2k/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/y2k-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-y2k/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-y2k/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/y2k-sembolleri/">
@@ -771,6 +772,7 @@
       <a class="lang-option active" href="/fr/library/symboles-y2k/" hreflang="fr">FR</a>
       <a class="lang-option" href="/id/library/simbol-y2k/" hreflang="id">ID</a>
       <a class="lang-option" href="/it/library/simboli-y2k/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ko/library/y2k-giho/" hreflang="ko">KO</a>
       <a class="lang-option" href="/pl/library/symbole-y2k/" hreflang="pl">PL</a>
       <a class="lang-option" href="/pt/library/simbolos-y2k/" hreflang="pt">PT</a>
       <a class="lang-option" href="/tr/library/y2k-sembolleri/" hreflang="tr">TR</a>

--- a/fr/library/symboles/index.html
+++ b/fr/library/symboles/index.html
@@ -18,6 +18,7 @@
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-aesthetic/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/aesthetic-symbols/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/gamseong-giho/">
   <link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/library/speciale-tekens/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/estetik-semboller/">
@@ -348,6 +349,7 @@
       <a class="lang-option active" href="/fr/library/symboles/" hreflang="fr">FR</a>
       <a class="lang-option" href="/id/library/simbol-aesthetic/" hreflang="id">ID</a>
       <a class="lang-option" href="/ja/library/aesthetic-symbols/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/gamseong-giho/" hreflang="ko">KO</a>
       <a class="lang-option" href="/nl/library/speciale-tekens/" hreflang="nl">NL</a>
       <a class="lang-option" href="/pt/library/simbolos/" hreflang="pt">PT</a>
       <a class="lang-option" href="/tr/library/estetik-semboller/" hreflang="tr">TR</a>

--- a/id/library/kaomoji/index.html
+++ b/id/library/kaomoji/index.html
@@ -24,6 +24,7 @@
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/kaomoji/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/kaomoji/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/text-faces-kaomoji/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/imotikon/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/kaomoji/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/kaomoji/">
   <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/kaomoji/">

--- a/id/library/simbol-aesthetic/index.html
+++ b/id/library/simbol-aesthetic/index.html
@@ -22,6 +22,7 @@
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-aesthetic/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/aesthetic-symbols/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/gamseong-giho/">
   <link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/library/speciale-tekens/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/estetik-semboller/">

--- a/id/library/simbol-bintang/index.html
+++ b/id/library/simbol-bintang/index.html
@@ -23,6 +23,7 @@
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-bintang/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-stella/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/star-symbols/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/byeol-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-gwiazdek/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-de-estrela/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/yildiz-sembolleri/">

--- a/id/library/simbol-discord/index.html
+++ b/id/library/simbol-discord/index.html
@@ -22,6 +22,7 @@
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles-discord/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-discord/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-discord/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/discord-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-discord/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-discord/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/discord-sembolleri/">

--- a/id/library/simbol-love/index.html
+++ b/id/library/simbol-love/index.html
@@ -23,6 +23,7 @@
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-love/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-cuore/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/heart-symbols/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/hateu-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-serca/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-de-coracao/">
   <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/serdechki/">

--- a/id/library/simbol-panah/index.html
+++ b/id/library/simbol-panah/index.html
@@ -22,6 +22,7 @@
   <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/simbolos-de-flechas/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-panah/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/arrow-symbols/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/hwasalpyo-giho/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/setas/">
   <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/ki-tu-mui-ten/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/arrow-symbols/">

--- a/id/library/simbol-roblox/index.html
+++ b/id/library/simbol-roblox/index.html
@@ -22,6 +22,7 @@
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles-roblox/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-roblox/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-roblox/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/roblox-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-roblox/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-roblox/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/roblox-sembolleri/">

--- a/id/library/simbol-y2k/index.html
+++ b/id/library/simbol-y2k/index.html
@@ -22,6 +22,7 @@
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles-y2k/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-y2k/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-y2k/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/y2k-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-y2k/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-y2k/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/y2k-sembolleri/">

--- a/it/library/kaomoji/index.html
+++ b/it/library/kaomoji/index.html
@@ -24,6 +24,7 @@
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/kaomoji/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/kaomoji/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/text-faces-kaomoji/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/imotikon/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/kaomoji/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/kaomoji/">
   <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/kaomoji/">
@@ -633,6 +634,7 @@
       <a class="lang-option" href="/id/library/kaomoji/" hreflang="id">ID</a>
       <a class="lang-option active" href="/it/library/kaomoji/" hreflang="it">IT</a>
       <a class="lang-option" href="/ja/library/text-faces-kaomoji/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/imotikon/" hreflang="ko">KO</a>
       <a class="lang-option" href="/pl/library/kaomoji/" hreflang="pl">PL</a>
       <a class="lang-option" href="/pt/library/kaomoji/" hreflang="pt">PT</a>
       <a class="lang-option" href="/ru/library/kaomoji/" hreflang="ru">RU</a>

--- a/it/library/simboli-cuore/index.html
+++ b/it/library/simboli-cuore/index.html
@@ -23,6 +23,7 @@
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-love/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-cuore/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/heart-symbols/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/hateu-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-serca/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-de-coracao/">
   <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/serdechki/">
@@ -471,6 +472,7 @@
       <a class="lang-option" href="/id/library/simbol-love/" hreflang="id">ID</a>
       <a class="lang-option active" href="/it/library/simboli-cuore/" hreflang="it">IT</a>
       <a class="lang-option" href="/ja/library/heart-symbols/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/hateu-giho/" hreflang="ko">KO</a>
       <a class="lang-option" href="/pl/library/symbole-serca/" hreflang="pl">PL</a>
       <a class="lang-option" href="/pt/library/simbolos-de-coracao/" hreflang="pt">PT</a>
       <a class="lang-option" href="/ru/library/serdechki/" hreflang="ru">RU</a>

--- a/it/library/simboli-discord/index.html
+++ b/it/library/simboli-discord/index.html
@@ -22,6 +22,7 @@
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles-discord/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-discord/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-discord/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/discord-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-discord/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-discord/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/discord-sembolleri/">
@@ -646,6 +647,7 @@
       <a class="lang-option" href="/fr/library/symboles-discord/" hreflang="fr">FR</a>
       <a class="lang-option" href="/id/library/simbol-discord/" hreflang="id">ID</a>
       <a class="lang-option active" href="/it/library/simboli-discord/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ko/library/discord-giho/" hreflang="ko">KO</a>
       <a class="lang-option" href="/pl/library/symbole-discord/" hreflang="pl">PL</a>
       <a class="lang-option" href="/pt/library/simbolos-discord/" hreflang="pt">PT</a>
       <a class="lang-option" href="/tr/library/discord-sembolleri/" hreflang="tr">TR</a>

--- a/it/library/simboli-roblox/index.html
+++ b/it/library/simboli-roblox/index.html
@@ -22,6 +22,7 @@
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles-roblox/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-roblox/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-roblox/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/roblox-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-roblox/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-roblox/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/roblox-sembolleri/">
@@ -432,6 +433,7 @@
       <a class="lang-option" href="/fr/library/symboles-roblox/" hreflang="fr">FR</a>
       <a class="lang-option" href="/id/library/simbol-roblox/" hreflang="id">ID</a>
       <a class="lang-option active" href="/it/library/simboli-roblox/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ko/library/roblox-giho/" hreflang="ko">KO</a>
       <a class="lang-option" href="/pl/library/symbole-roblox/" hreflang="pl">PL</a>
       <a class="lang-option" href="/pt/library/simbolos-roblox/" hreflang="pt">PT</a>
       <a class="lang-option" href="/tr/library/roblox-sembolleri/" hreflang="tr">TR</a>

--- a/it/library/simboli-stella/index.html
+++ b/it/library/simboli-stella/index.html
@@ -23,6 +23,7 @@
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-bintang/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-stella/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/star-symbols/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/byeol-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-gwiazdek/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-de-estrela/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/yildiz-sembolleri/">
@@ -532,6 +533,7 @@
       <a class="lang-option" href="/id/library/simbol-bintang/" hreflang="id">ID</a>
       <a class="lang-option active" href="/it/library/simboli-stella/" hreflang="it">IT</a>
       <a class="lang-option" href="/ja/library/star-symbols/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/byeol-giho/" hreflang="ko">KO</a>
       <a class="lang-option" href="/pl/library/symbole-gwiazdek/" hreflang="pl">PL</a>
       <a class="lang-option" href="/pt/library/simbolos-de-estrela/" hreflang="pt">PT</a>
       <a class="lang-option" href="/tr/library/yildiz-sembolleri/" hreflang="tr">TR</a>

--- a/it/library/simboli-y2k/index.html
+++ b/it/library/simboli-y2k/index.html
@@ -22,6 +22,7 @@
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles-y2k/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-y2k/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-y2k/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/y2k-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-y2k/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-y2k/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/y2k-sembolleri/">
@@ -748,6 +749,7 @@
       <a class="lang-option" href="/fr/library/symboles-y2k/" hreflang="fr">FR</a>
       <a class="lang-option" href="/id/library/simbol-y2k/" hreflang="id">ID</a>
       <a class="lang-option active" href="/it/library/simboli-y2k/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ko/library/y2k-giho/" hreflang="ko">KO</a>
       <a class="lang-option" href="/pl/library/symbole-y2k/" hreflang="pl">PL</a>
       <a class="lang-option" href="/pt/library/simbolos-y2k/" hreflang="pt">PT</a>
       <a class="lang-option" href="/tr/library/y2k-sembolleri/" hreflang="tr">TR</a>

--- a/ja/library/aesthetic-symbols/index.html
+++ b/ja/library/aesthetic-symbols/index.html
@@ -22,6 +22,7 @@
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-aesthetic/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/aesthetic-symbols/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/gamseong-giho/">
   <link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/library/speciale-tekens/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/estetik-semboller/">

--- a/ja/library/arrow-symbols/index.html
+++ b/ja/library/arrow-symbols/index.html
@@ -22,6 +22,7 @@
   <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/simbolos-de-flechas/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-panah/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/arrow-symbols/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/hwasalpyo-giho/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/setas/">
   <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/ki-tu-mui-ten/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/arrow-symbols/">

--- a/ja/library/emoji-combos/index.html
+++ b/ja/library/emoji-combos/index.html
@@ -17,11 +17,13 @@
 <meta name="description" content="かわいい絵文字の組み合わせをコピペで。量産型・シンプル・韓国っぽ・推し活・季節・誕生日まで、雰囲気別にコンボを一覧化。クリックするだけでコピーして、インスタやLINE、Xにそのまま貼れます。">
 
 <link rel="canonical" href="https://ultratextgen.com/ja/library/emoji-combos/">
-<link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/emoji-combos/">
-<link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/emoji-combos/">
-<link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/emoji-combos/">
-<link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/emoji-combos/">
-<link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/emoji-combos/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/emoji-combos/">
+  <link rel="alternate" hreflang="ar" href="https://ultratextgen.com/ar/library/emoji-combos/">
+  <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/emoji-combos/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/imoji-johap/">
+  <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/emoji-combos/">
+  <link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/emoji-combos/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/emoji-combos/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/library-emoji-combos.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">

--- a/ja/library/heart-symbols/index.html
+++ b/ja/library/heart-symbols/index.html
@@ -23,6 +23,7 @@
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-love/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-cuore/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/heart-symbols/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/hateu-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-serca/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-de-coracao/">
   <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/serdechki/">

--- a/ja/library/special-characters/index.html
+++ b/ja/library/special-characters/index.html
@@ -17,11 +17,13 @@
 <meta name="description" content="かわいい特殊文字をコピペで。キラキラ・ハート・星・矢印・飾り括弧・音符まで、ジャンル別に一覧化。クリックするだけでコピーできて、インスタのプロフィールやゲームの名前にそのまま使えます。">
 
 <link rel="canonical" href="https://ultratextgen.com/ja/library/special-characters/">
-<link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/special-characters/">
-<link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/special-characters/">
-<link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/special-characters/">
-<link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/special-characters/">
-<link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/special-characters/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/special-characters/">
+  <link rel="alternate" hreflang="ar" href="https://ultratextgen.com/ar/library/special-characters/">
+  <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/special-characters/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/">
+  <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/special-characters/">
+  <link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/special-characters/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/special-characters/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/library-special-characters.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">

--- a/ja/library/star-symbols/index.html
+++ b/ja/library/star-symbols/index.html
@@ -23,6 +23,7 @@
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-bintang/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-stella/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/star-symbols/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/byeol-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-gwiazdek/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-de-estrela/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/yildiz-sembolleri/">

--- a/ja/library/text-faces-kaomoji/index.html
+++ b/ja/library/text-faces-kaomoji/index.html
@@ -24,6 +24,7 @@
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/kaomoji/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/kaomoji/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/text-faces-kaomoji/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/imotikon/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/kaomoji/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/kaomoji/">
   <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/kaomoji/">

--- a/ko/index.html
+++ b/ko/index.html
@@ -1,0 +1,604 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>특수문자 모음 — 닉네임·프로필 꾸미기 복사 붙여넣기</title>
+<meta name="description" content="닉네임과 프로필을 꾸미는 특수문자 모음. 별·하트·화살표·꾸밈 괄호부터 감성 기호까지 종류별로 정리했습니다. 클릭 한 번으로 복사해서 인스타 바이오, 디스코드, 게임 닉네임에 바로 붙여넣으세요.">
+
+<link rel="canonical" href="https://ultratextgen.com/ko/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/special-characters/">
+  <link rel="alternate" hreflang="ar" href="https://ultratextgen.com/ar/library/special-characters/">
+  <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/special-characters/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/">
+  <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/special-characters/">
+  <link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/special-characters/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/special-characters/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/library-special-characters.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="특수문자 모음 — 닉네임·프로필 꾸미기 복사 붙여넣기">
+<meta name="twitter:description" content="닉네임과 프로필을 꾸미는 특수문자 모음. 별·하트·화살표·꾸밈 괄호까지 클릭 한 번으로 복사해서 인스타, 디스코드, 게임 닉네임에 바로 붙여넣으세요.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/library-special-characters.png">
+<meta property="og:title" content="특수문자 모음 — 닉네임·프로필 꾸미기 복사 붙여넣기">
+<meta property="og:description" content="닉네임과 프로필을 꾸미는 특수문자 모음. 별·하트·화살표·꾸밈 괄호까지 클릭 한 번으로 복사해서 인스타, 디스코드, 게임 닉네임에 바로 붙여넣으세요.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://ultratextgen.com/ko/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "name": "특수문자 모음 — 닉네임·프로필 꾸미기 복사 붙여넣기",
+  "description": "닉네임과 프로필을 꾸미는 특수문자 모음. 별·하트·화살표·꾸밈 괄호부터 감성 기호까지 종류별로 정리한 복사 붙여넣기 특수문자 페이지입니다.",
+  "url": "https://ultratextgen.com/ko/",
+  "inLanguage": "ko",
+  "isPartOf": {
+    "@type": "WebSite",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  }
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "홈",
+      "item": "https://ultratextgen.com/ko/"
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "ko",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "특수문자란 무엇인가요?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "키보드로 바로 입력하기 어려운, 유니코드에 들어 있는 기호와 문자를 말합니다. ✧ ♡ ⋆ ꒰꒱ 같은 감성 꾸밈부터 화살표, 음표, 괄호까지 모두 이미지가 아니라 텍스트라서, 복사해서 프로필이나 닉네임에 그대로 붙여넣을 수 있습니다."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "특수문자는 어디에 쓸 수 있나요?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "인스타그램 바이오와 이름, 카카오톡 상태메시지, 디스코드 닉네임과 서버명, 트위터(X), 틱톡, 게임 아이디와 닉네임까지 텍스트를 입력할 수 있는 곳이면 거의 어디서나 쓸 수 있습니다."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "특수문자가 네모(□)로 보이는 이유는 무엇인가요?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "오래된 기기나 일부 앱에는 최신 유니코드 문자를 표시할 글꼴이 없어서 네모(□)로 보일 수 있습니다. 복사가 잘못된 것이 아니라 표시 문제이며, 문자 자체는 정상적으로 전달됩니다. ♡ ☆ ✧ ✿ 처럼 오래된 기본 기호는 거의 모든 환경에서 제대로 보이므로, 화려한 기호를 쓸 때는 올리기 전에 휴대폰에서 확인해 보세요."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "무료로 사용할 수 있나요?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "네, 완전 무료입니다. 특수문자는 유니코드 표준 문자라서 저작권 걱정 없이 원하는 만큼 복사해서 자유롭게 쓸 수 있습니다."
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <span class="breadcrumb-current">홈</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">특수문자 모음 (닉네임·프로필 꾸미기)</h1>
+    <p class="hero-tagline">닉네임과 프로필을 꾸미는 특수문자를 종류별로 정리했습니다. 별·하트·화살표·꾸밈 괄호부터 감성 기호까지 — 클릭 한 번이면 복사되어 인스타 바이오, 디스코드, 게임 닉네임에 바로 붙여넣을 수 있습니다.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/library-special-characters.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>특수문자는 키보드로 바로 치기 어려운 유니코드 기호입니다. ✧ ♡ ⋆ ꒰꒱ 같은 감성 꾸밈도, → ↳ ⇢ 같은 화살표도 모두 이미지가 아니라 '문자'입니다. 그래서 복사만 하면 인스타 바이오, 카카오톡 상태메시지, 디스코드 닉네임, 게임 아이디까지 텍스트가 들어가는 곳이면 어디에나 붙여넣을 수 있습니다.</p>
+    <p>사용법은 간단합니다. 줄 구분에 ✦ 를 넣고, 이름을 ꒰ ꒱ 로 감싸고, 목록 앞에 ➤ 를 붙이면 그것만으로 완성도가 달라집니다. 아래 종류에서 원하는 기호를 찾아 클릭(탭)하면 바로 복사됩니다.</p>
+    <p>참고로 한글은 유니코드 '폰트' 변환(볼드·이탤릭 등)이 되지 않습니다. 그 스타일 변환은 영문 알파벳에만 적용되므로, 한글 닉네임은 이렇게 어느 언어에서나 통하는 특수문자로 꾸미는 것이 정답입니다.</p>
+  </div>
+</section>
+
+<!-- QUICK PICK -->
+<section class="mood-explainers" id="quick-pick">
+  <span class="article-section-label">빠른 선택</span>
+  <h2>인기 특수문자</h2>
+  <p class="section-lead is-spaced">가장 많이 쓰는 기본부터. 클릭하면 복사됩니다.</p>
+  <div class="flag-rows symbol-pick-grid">
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="✧" aria-label="✧ 복사">✧</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="♡" aria-label="♡ 복사">♡</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="⋆" aria-label="⋆ 복사">⋆</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="✿" aria-label="✿ 복사">✿</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="☾" aria-label="☾ 복사">☾</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="∞" aria-label="∞ 복사">∞</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="꒰꒱" aria-label="꒰꒱ 복사">꒰꒱</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="➤" aria-label="➤ 복사">➤</button></div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- 별·반짝임 -->
+<section class="mood-explainers" id="sparkle">
+  <span class="article-section-label">별·반짝임</span>
+  <h2>별·반짝임 특수문자</h2>
+  <p class="u-secondary-tight">프로필 줄 구분이나 이름 양옆 꾸밈에.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✧" aria-label="✧ 복사">✧</button>
+      <span class="flag-label">흰 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✦" aria-label="✦ 복사">✦</button>
+      <span class="flag-label">검은 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⋆" aria-label="⋆ 복사">⋆</button>
+      <span class="flag-label">작은 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✩" aria-label="✩ 복사">✩</button>
+      <span class="flag-label">별 윤곽</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊹" aria-label="⊹ 복사">⊹</button>
+      <span class="flag-label">반짝임</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❂" aria-label="❂ 복사">❂</button>
+      <span class="flag-label">여덟 갈래 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="₊" aria-label="₊ 복사">₊</button>
+      <span class="flag-label">작은 플러스</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="˚" aria-label="˚ 복사">˚</button>
+      <span class="flag-label">고리점</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- 하트 -->
+<section class="mood-explainers" id="hearts">
+  <span class="article-section-label">하트</span>
+  <h2>하트 특수문자</h2>
+  <p class="u-secondary-tight">이모지 하트보다 담백하고 감성적인 텍스트 하트.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♡" aria-label="♡ 복사">♡</button>
+      <span class="flag-label">흰 하트</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♥" aria-label="♥ 복사">♥</button>
+      <span class="flag-label">검은 하트</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❦" aria-label="❦ 복사">❦</button>
+      <span class="flag-label">꽃 하트</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❧" aria-label="❧ 복사">❧</button>
+      <span class="flag-label">돌아간 꽃 하트</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❥" aria-label="❥ 복사">❥</button>
+      <span class="flag-label">기울인 하트</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❣" aria-label="❣ 복사">❣</button>
+      <span class="flag-label">하트 느낌표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ꨄ" aria-label="ꨄ 복사">ꨄ</button>
+      <span class="flag-label">레트로 하트</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- 무한·영원 -->
+<section class="mood-explainers" id="infinity">
+  <span class="article-section-label">무한·영원</span>
+  <h2>무한·영원 특수문자</h2>
+  <p class="u-secondary-tight">끝없음, 반복, 영원을 뜻하는 기호.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="∞" aria-label="∞ 복사">∞</button>
+      <span class="flag-label">무한대</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♾️" aria-label="♾️ 복사">♾️</button>
+      <span class="flag-label">무한 이모지</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⧜" aria-label="⧜ 복사">⧜</button>
+      <span class="flag-label">불완전 무한</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⧝" aria-label="⧝ 복사">⧝</button>
+      <span class="flag-label">묶인 무한</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⟳" aria-label="⟳ 복사">⟳</button>
+      <span class="flag-label">시계방향 화살</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🔁" aria-label="🔁 복사">🔁</button>
+      <span class="flag-label">반복 버튼</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🔂" aria-label="🔂 복사">🔂</button>
+      <span class="flag-label">한 곡 반복</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- 화살표 -->
+<section class="mood-explainers" id="arrows">
+  <span class="article-section-label">화살표</span>
+  <h2>화살표 특수문자</h2>
+  <p class="u-secondary-tight">링크 유도나 목록 앞머리에.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="→" aria-label="→ 복사">→</button>
+      <span class="flag-label">오른쪽 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⇢" aria-label="⇢ 복사">⇢</button>
+      <span class="flag-label">점선 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="↳" aria-label="↳ 복사">↳</button>
+      <span class="flag-label">꺾인 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="➤" aria-label="➤ 복사">➤</button>
+      <span class="flag-label">삼각 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="➛" aria-label="➛ 복사">➛</button>
+      <span class="flag-label">둥근 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⟶" aria-label="⟶ 복사">⟶</button>
+      <span class="flag-label">긴 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⇝" aria-label="⇝ 복사">⇝</button>
+      <span class="flag-label">물결 화살표</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- 꾸밈 괄호 -->
+<section class="mood-explainers" id="brackets">
+  <span class="article-section-label">괄호·감싸기</span>
+  <h2>꾸밈 괄호 특수문자</h2>
+  <p class="u-secondary-tight">이름이나 제목을 감싸 시선을 모으는 꾸밈에.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="【 】" aria-label="【 】 복사">【 】</button>
+      <span class="flag-label">먹칠 괄호</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="『 』" aria-label="『 』 복사">『 』</button>
+      <span class="flag-label">겹낫표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="〖 〗" aria-label="〖 〗 복사">〖 〗</button>
+      <span class="flag-label">흰 먹칠 괄호</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="꧁ ꧂" aria-label="꧁ ꧂ 복사">꧁ ꧂</button>
+      <span class="flag-label">화려한 꾸밈</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="༺ ༻" aria-label="༺ ༻ 복사">༺ ༻</button>
+      <span class="flag-label">오리엔탈</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="≪ ≫" aria-label="≪ ≫ 복사">≪ ≫</button>
+      <span class="flag-label">겹화살괄호</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❝ ❞" aria-label="❝ ❞ 복사">❝ ❞</button>
+      <span class="flag-label">따옴표</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- 감성 기호 -->
+<section class="mood-explainers" id="aesthetic-standalone">
+  <span class="article-section-label">감성 기호</span>
+  <h2>감성 특수문자 (단독 기호)</h2>
+  <p class="u-secondary-tight">바이오, 닉네임, 감성 텍스트에 많이 쓰이는 꾸밈 유니코드.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✿" aria-label="✿ 복사">✿</button>
+      <span class="flag-label">검은 꽃</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☾" aria-label="☾ 복사">☾</button>
+      <span class="flag-label">하현달</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☽" aria-label="☽ 복사">☽</button>
+      <span class="flag-label">상현달</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="༄" aria-label="༄ 복사">༄</button>
+      <span class="flag-label">티베트 장식</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="꒰ ꒱" aria-label="꒰ ꒱ 복사">꒰ ꒱</button>
+      <span class="flag-label">둥근 꾸밈 괄호</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="Ɛ" aria-label="Ɛ 복사">Ɛ</button>
+      <span class="flag-label">뒤집힌 3 (Ɛ)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="Я" aria-label="Я 복사">Я</button>
+      <span class="flag-label">뒤집힌 R (Я)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="и" aria-label="и 복사">и</button>
+      <span class="flag-label">뒤집힌 N (и)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="※" aria-label="※ 복사">※</button>
+      <span class="flag-label">참고 표시</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☙" aria-label="☙ 복사">☙</button>
+      <span class="flag-label">꽃 장식 불릿</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- 저작권·오피스 -->
+<section class="mood-explainers" id="legal-office">
+  <span class="article-section-label">저작권·오피스</span>
+  <h2>저작권·오피스 특수문자</h2>
+  <p class="u-secondary-tight">저작권·상표·문서용 조판 기호.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="©" aria-label="© 복사">©</button>
+      <span class="flag-label">저작권</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="®" aria-label="® 복사">®</button>
+      <span class="flag-label">등록상표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="™" aria-label="™ 복사">™</button>
+      <span class="flag-label">상표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="§" aria-label="§ 복사">§</button>
+      <span class="flag-label">조항 기호</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="¶" aria-label="¶ 복사">¶</button>
+      <span class="flag-label">단락 기호</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="†" aria-label="† 복사">†</button>
+      <span class="flag-label">단검표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="№" aria-label="№ 복사">№</button>
+      <span class="flag-label">번호 기호</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- 희귀 유니코드 -->
+<section class="mood-explainers" id="rare-unicode">
+  <span class="article-section-label">희귀 유니코드</span>
+  <h2>희귀 유니코드 특수문자</h2>
+  <p class="u-secondary-tight">기술·기호 블록에서 나온 잘 안 쓰이는 이색 문자.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⌘" aria-label="⌘ 복사">⌘</button>
+      <span class="flag-label">커맨드 키</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⌥" aria-label="⌥ 복사">⌥</button>
+      <span class="flag-label">옵션 키</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⇧" aria-label="⇧ 복사">⇧</button>
+      <span class="flag-label">시프트 키</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⏎" aria-label="⏎ 복사">⏎</button>
+      <span class="flag-label">리턴 기호</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚜" aria-label="⚜ 복사">⚜</button>
+      <span class="flag-label">플뢰르 드 리스</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="℞" aria-label="℞ 복사">℞</button>
+      <span class="flag-label">처방 기호</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⏻" aria-label="⏻ 복사">⏻</button>
+      <span class="flag-label">전원 기호</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- COLLECTIONS -->
+<section class="mood-explainers" id="symbol-collections">
+  <span class="article-section-label">기호 세트</span>
+  <h2>바로 쓰는 꾸밈 세트</h2>
+  <p class="u-secondary-block">이미 조합해 둔 꾸밈 세트입니다. 클릭 한 번으로 복사해서 이름이나 상태메시지에 붙여넣으세요.</p>
+  <div id="symbolCollectionsContainer"></div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- KOREAN HUB LINKS -->
+<section class="editorial-section" id="korean-hub">
+  <span class="article-section-label">한국어 특수문자 모음</span>
+  <h2>다른 특수문자 라이브러리</h2>
+  <p class="section-lead">용도별로 더 많은 한국어 특수문자 모음을 준비했습니다. 하트, 이모티콘, 디스코드 기호를 따로 모아 두었으니 필요한 곳으로 이동하세요.</p>
+  <div class="compare-grid">
+    <a href="/ko/library/hateu-giho/" class="compare-card variant-muted u-no-underline">
+      <h4>하트 기호 모음</h4>
+      <p>♡ ♥ ❥ ꨄ 같은 텍스트 하트 특수문자. 프로필과 닉네임 꾸미기에 딱.</p>
+    </a>
+    <a href="/ko/library/imotikon/" class="compare-card variant-muted u-no-underline">
+      <h4>이모티콘 모음</h4>
+      <p>ㅇㅅㅇ ⸜(´꒳`)⸝ 같은 텍스트 이모티콘. 감정별로 복사해서 바로 사용.</p>
+    </a>
+    <a href="/ko/library/discord-giho/" class="compare-card variant-muted u-no-underline">
+      <h4>디스코드 특수문자</h4>
+      <p>디스코드 닉네임·서버명·채널명을 꾸미는 특수문자와 기호 모음.</p>
+    </a>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- FAQ -->
+<section class="editorial-section" id="faq">
+  <span class="article-section-label">자주 묻는 질문</span>
+  <h2>특수문자 자주 묻는 질문</h2>
+  <details class="faq-item">
+    <summary class="faq-question">특수문자란 무엇인가요?</summary>
+    <p class="faq-answer">키보드로 바로 입력하기 어려운, 유니코드에 들어 있는 기호와 문자를 말합니다. ✧ ♡ ⋆ ꒰꒱ 같은 감성 꾸밈부터 화살표, 음표, 괄호까지 모두 이미지가 아니라 텍스트라서, 복사해서 프로필이나 닉네임에 그대로 붙여넣을 수 있습니다.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">특수문자는 어디에 쓸 수 있나요?</summary>
+    <p class="faq-answer">인스타그램 바이오와 이름, 카카오톡 상태메시지, 디스코드 닉네임과 서버명, 트위터(X), 틱톡, 게임 아이디와 닉네임까지 텍스트를 입력할 수 있는 곳이면 거의 어디서나 쓸 수 있습니다.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">특수문자가 네모(□)로 보이는 이유는 무엇인가요?</summary>
+    <p class="faq-answer">오래된 기기나 일부 앱에는 최신 유니코드 문자를 표시할 글꼴이 없어서 네모(□)로 보일 수 있습니다. 복사가 잘못된 것이 아니라 표시 문제이며, 문자 자체는 정상적으로 전달됩니다. ♡ ☆ ✧ ✿ 처럼 오래된 기본 기호는 거의 모든 환경에서 제대로 보이므로, 화려한 기호를 쓸 때는 올리기 전에 휴대폰에서 확인해 보세요.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">무료로 사용할 수 있나요?</summary>
+    <p class="faq-answer">네, 완전 무료입니다. 특수문자는 유니코드 표준 문자라서 저작권 걱정 없이 원하는 만큼 복사해서 자유롭게 쓸 수 있습니다.</p>
+  </details>
+</section>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">관련 페이지</span>
+  <div class="compare-grid">
+    <a href="/ko/library/hateu-giho/" class="compare-card variant-muted u-no-underline">
+      <h4>하트 기호 모음</h4>
+      <p>텍스트 하트 특수문자를 감성별로 정리. 클릭해서 복사하세요.</p>
+    </a>
+    <a href="/ko/library/imotikon/" class="compare-card variant-muted u-no-underline">
+      <h4>이모티콘 모음</h4>
+      <p>귀여운 텍스트 이모티콘을 감정별로. 복사해서 바로 사용.</p>
+    </a>
+    <a href="/library/special-characters/" class="compare-card variant-muted u-no-underline">
+      <h4>Special Characters (English)</h4>
+      <p>The full English special-characters reference with every symbol family.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    { name: "반짝임 꾸밈 세트", flags: ["✧","⋆","⊹","₊"], defaultFormat: "inline" },
+    { name: "감성 세트", flags: ["꒰ ꒱","☾","✿","♡"], defaultFormat: "inline" },
+    { name: "이름 꾸밈 세트", flags: ["【 】","꧁ ꧂","༺ ༻","❝ ❞"], defaultFormat: "inline" },
+    { name: "줄 구분 세트", flags: ["✦","·","☾","➛"], defaultFormat: "inline" }
+  ];
+
+  ns.buildGrids("symbolCollectionsContainer", GROUPS);
+  if (ns.parseTwemoji) ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/ko/library/byeol-giho/index.html
+++ b/ko/library/byeol-giho/index.html
@@ -1,0 +1,592 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>별 기호 ★ 모음 — 복사해서 쓰는 별 특수문자와 반짝임 이모지</title>
+<meta name="description" content="별 기호와 반짝임 특수문자, 별 이모지를 모양·용도별로 한눈에. 클릭 한 번으로 복사되어 인스타 프로필·닉네임·디스코드 이름 꾸미기에 그대로 붙여 쓸 수 있습니다.">
+
+<link rel="canonical" href="https://ultratextgen.com/ko/library/byeol-giho/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/star-symbols/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/library/stern-symbole/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/simbolos-de-estrella/">
+  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-bintang/">
+  <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-stella/">
+  <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/star-symbols/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/byeol-giho/">
+  <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-gwiazdek/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-de-estrela/">
+  <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/yildiz-sembolleri/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/star-symbols/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/library-star-symbols.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="별 기호 ★ 모음 — 복사해서 쓰는 별 특수문자와 반짝임 이모지">
+<meta name="twitter:description" content="별 기호·반짝임 특수문자·별 이모지를 모양별로 한눈에. 클릭하면 바로 복사됩니다.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/library-star-symbols.png">
+<meta property="og:title" content="별 기호 ★ 모음 — 복사해서 쓰는 별 특수문자와 반짝임 이모지">
+<meta property="og:description" content="별 기호·반짝임 특수문자·별 이모지를 모양·용도별로 정리했습니다. 클릭 한 번으로 복사되어 인스타 프로필·닉네임 꾸미기에 그대로 붙여 쓸 수 있습니다.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/ko/library/byeol-giho/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "name": "별 기호 ★ 복사 모음",
+  "inLanguage": "ko",
+  "description": "별 기호·반짝임 특수문자·별 이모지를 모양과 용도별로 정리한 복사·붙여넣기 모음입니다. 기본 별, 다각형 별, 별표, 반짝임, 별점, 프로필 꾸미기 데코까지 클릭 한 번으로 복사할 수 있습니다.",
+  "url": "https://ultratextgen.com/ko/library/byeol-giho/",
+  "isPartOf": {
+    "@type": "WebSite",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  }
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "홈",
+      "item": "https://ultratextgen.com/ko/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "별 기호",
+      "item": "https://ultratextgen.com/ko/library/byeol-giho/"
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "ko",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "별 기호란 무엇인가요?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "★ ☆ ✦ ✧ ⋆ 처럼 별 모양을 본뜬 유니코드 문자를 말합니다. ⭐ 🌟 ✨ 같은 컬러 별 이모지와 달리, ★ ☆ ✦ 는 주변 글자와 같은 색으로 표시되는 흑백 텍스트 기호라서 과하지 않고 깔끔한 감성 꾸미기에 잘 어울립니다. 모두 이미지가 아닌 '문자'이기 때문에 복사해서 붙여넣기만 하면 됩니다."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "별 기호는 어디에 쓸 수 있나요?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "인스타 프로필·닉네임, X(트위터) 이름과 글, 틱톡, 디스코드 이름, 카카오톡 상태메시지, 게임 아이디·닉네임까지 텍스트를 입력할 수 있는 곳이면 거의 어디든 쓸 수 있습니다. 이름 양옆을 ˚₊‧⭐‧₊˚ 로 감싸거나 구분선에 ✦ ｡ ✧ ｡ ✦ 를 넣는 방식이 많이 쓰입니다."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "별 이모지(⭐)와 텍스트 별 기호(★)는 무엇이 다른가요?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "⭐ 🌟 ✨ 는 이모지라서 기기마다 컬러로 크게 표시되어 눈에 잘 띕니다. ★ ☆ ✦ ⋆ 는 유니코드 기호 문자로, 주변 글자와 같은 색·크기로 표시되어 차분하고 통일감 있는 감성 꾸미기에 어울립니다. 강조하고 싶을 때는 이모지, 깔끔하게 정리하고 싶을 때는 텍스트 기호를 쓰는 식으로 나눠 쓰면 좋습니다."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "한글도 이런 별 폰트처럼 꾸밀 수 있나요?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "유니코드 '폰트'(볼드·이탤릭 등)는 알파벳과 숫자만 변환할 수 있어 한글 자체는 모양을 바꿀 수 없습니다. 대신 별 기호는 언어와 상관없이 쓸 수 있으므로, 한글 닉네임이나 프로필 앞뒤에 ★ ⋆ ✦ 를 붙여 꾸미는 방식으로 활용하면 됩니다. 예: ⋆｡˚ 별빛닉네임 ˚｡⋆"
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "별 기호가 □(네모)나 '?'로 표시돼요",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "오래된 기기나 일부 앱은 최신 유니코드 기호·이모지를 지원하는 폰트가 없어서 □(두부 문자)로 보일 수 있습니다. ★ ☆ ✦ ⭐ ✨ 같은 기본 별은 거의 모든 환경에서 정상적으로 표시되므로, 복잡한 기호를 쓸 때는 올리기 전에 휴대폰에서 표시를 한 번 확인하는 것이 안전합니다."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "무료인가요? 저작권 문제는 없나요?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "네, 완전 무료입니다. 별 기호는 유니코드 표준 문자라서 저작권 걱정 없이 몇 번이든 자유롭게 복사해서 쓸 수 있습니다. 회원가입도 필요 없습니다."
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/ko/">홈</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">별 기호</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">별 기호 ★ 모음 (복사용)</h1>
+    <p class="hero-tagline">별 기호·반짝임 특수문자·별 이모지를 모양과 용도별로 정리했습니다. 기본 별부터 다각형 별, 별표, 반짝임, 별점, 프로필 꾸미기 데코까지 — 클릭 한 번으로 복사되어 인스타 프로필·닉네임·디스코드 이름에 그대로 붙여 쓸 수 있습니다.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/library-star-symbols.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>별 기호는 키보드로는 바로 칠 수 없는 유니코드 별 문자와 이모지입니다. ⭐ ✨ 🌟 같은 컬러 별 이모지도, ★ ☆ ✦ ⋆ 같은 흑백 텍스트 별도 모두 이미지가 아닌 '문자'입니다. 그래서 복사해서 붙여넣기만 하면 인스타 프로필, X 이름, 틱톡, 디스코드 이름, 게임 아이디까지 텍스트가 들어가는 곳이면 어디든 쓸 수 있습니다.</p>
+    <p>참고로 유니코드 '폰트'는 알파벳·숫자만 바꿀 수 있어 한글 자체는 모양을 바꿀 수 없습니다. 대신 별 기호는 언어를 가리지 않으니, 한글 닉네임이나 프로필 앞뒤에 ⋆｡˚ 처럼 붙여서 감성 있게 꾸미면 됩니다. 아래에서 모양별로 골라 클릭(탭)하면 바로 복사됩니다.</p>
+    <p>알파벳까지 예쁘게 바꾸고 싶다면 <a href="/ko/">폰트 변환 도구</a>와 함께 쓰는 것을 추천합니다.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- BASIC STARS -->
+<section class="mood-explainers" id="basic-stars">
+  <span class="article-section-label">기본 별</span>
+  <h2>기본 별 기호</h2>
+  <p>다섯 꼭짓점 별과 그 외곽선·원 안·그림자 변형들. 유니코드 딩뱃(Dingbats)과 기타 기호 블록에서 가져온 대표적인 별 문자입니다.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="★" aria-label="★ 복사">★</button>
+      <span class="flag-label">검은 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☆" aria-label="☆ 복사">☆</button>
+      <span class="flag-label">흰 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✦" aria-label="✦ 복사">✦</button>
+      <span class="flag-label">네 꼭짓점</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✧" aria-label="✧ 복사">✧</button>
+      <span class="flag-label">네 꼭짓점(흰)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✡" aria-label="✡ 복사">✡</button>
+      <span class="flag-label">다윗의 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✩" aria-label="✩ 복사">✩</button>
+      <span class="flag-label">외곽선 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✪" aria-label="✪ 복사">✪</button>
+      <span class="flag-label">원 안의 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✫" aria-label="✫ 복사">✫</button>
+      <span class="flag-label">가운데 뚫린 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✬" aria-label="✬ 복사">✬</button>
+      <span class="flag-label">가운데 검은 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✭" aria-label="✭ 복사">✭</button>
+      <span class="flag-label">외곽선 검은 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✮" aria-label="✮ 복사">✮</button>
+      <span class="flag-label">굵은 외곽선</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✯" aria-label="✯ 복사">✯</button>
+      <span class="flag-label">바람개비 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✰" aria-label="✰ 복사">✰</button>
+      <span class="flag-label">그림자 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⭑" aria-label="⭑ 복사">⭑</button>
+      <span class="flag-label">작은 검은 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⭒" aria-label="⭒ 복사">⭒</button>
+      <span class="flag-label">작은 흰 별</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- MULTI-POINTED STARS -->
+<section class="mood-explainers" id="multi-stars">
+  <span class="article-section-label">다각형 별</span>
+  <h2>여러 꼭짓점 별 기호</h2>
+  <p>여섯·여덟·열두 꼭짓점 등 꼭짓점이 많은 별과 바람개비·직선형 변형들. 딩뱃 블록에서 가져왔습니다.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✴" aria-label="✴ 복사">✴</button>
+      <span class="flag-label">여덟 꼭짓점</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✵" aria-label="✵ 복사">✵</button>
+      <span class="flag-label">여덟 바람개비</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✶" aria-label="✶ 복사">✶</button>
+      <span class="flag-label">여섯 꼭짓점</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✷" aria-label="✷ 복사">✷</button>
+      <span class="flag-label">여덟 직선형</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✸" aria-label="✸ 복사">✸</button>
+      <span class="flag-label">굵은 직선형</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✹" aria-label="✹ 복사">✹</button>
+      <span class="flag-label">열두 꼭짓점</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🔯" aria-label="🔯 복사">🔯</button>
+      <span class="flag-label">가운데 점 육각별</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- STAR EMOJIS -->
+<section class="mood-explainers" id="star-emojis">
+  <span class="article-section-label">별 이모지</span>
+  <h2>별 이모지</h2>
+  <p>빛나는 별, 별똥별, 반짝임 등 이모지 스타일의 별 문자입니다. 대부분의 환경에서 컬러 그림 문자로 표시됩니다.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⭐" aria-label="⭐ 복사">⭐</button>
+      <span class="flag-label">별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌟" aria-label="🌟 복사">🌟</button>
+      <span class="flag-label">빛나는 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💫" aria-label="💫 복사">💫</button>
+      <span class="flag-label">어지러운 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✨" aria-label="✨ 복사">✨</button>
+      <span class="flag-label">반짝임</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌠" aria-label="🌠 복사">🌠</button>
+      <span class="flag-label">별똥별</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- CELESTIAL STARS -->
+<section class="mood-explainers" id="celestial-stars">
+  <span class="article-section-label">천체 별</span>
+  <h2>천체·밤하늘 별 기호</h2>
+  <p>천문·밤하늘 맥락에서 쓰이는 별 관련 기호들입니다.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☪" aria-label="☪ 복사">☪</button>
+      <span class="flag-label">별과 초승달</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⍟" aria-label="⍟ 복사">⍟</button>
+      <span class="flag-label">원 안 별(APL)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚝" aria-label="⚝ 복사">⚝</button>
+      <span class="flag-label">외곽선 흰 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌃" aria-label="🌃 복사">🌃</button>
+      <span class="flag-label">별이 뜬 밤</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- ASTERISKS & SPARKLES -->
+<section class="mood-explainers" id="asterisks">
+  <span class="article-section-label">별표 · 반짝임</span>
+  <h2>별표와 반짝임 기호</h2>
+  <p>별표(애스터리스크) 변형과 애스터리즘, 반짝임 기호들. 일반 문장부호 블록과 딩뱃 블록에서 가져왔습니다.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⁂" aria-label="⁂ 복사">⁂</button>
+      <span class="flag-label">애스터리즘</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⁑" aria-label="⁑ 복사">⁑</button>
+      <span class="flag-label">두 개의 별표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✱" aria-label="✱ 복사">✱</button>
+      <span class="flag-label">굵은 별표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✲" aria-label="✲ 복사">✲</button>
+      <span class="flag-label">가운데 뚫린 별표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✳" aria-label="✳ 복사">✳</button>
+      <span class="flag-label">여덟 살 별표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✺" aria-label="✺ 복사">✺</button>
+      <span class="flag-label">열여섯 꼭짓점</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✻" aria-label="✻ 복사">✻</button>
+      <span class="flag-label">물방울 살 별표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✼" aria-label="✼ 복사">✼</button>
+      <span class="flag-label">가운데 뚫린 물방울</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✽" aria-label="✽ 복사">✽</button>
+      <span class="flag-label">굵은 물방울 별표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❇" aria-label="❇ 복사">❇</button>
+      <span class="flag-label">반짝임 기호</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- RATING STARS -->
+<section class="mood-explainers" id="rating-stars">
+  <span class="article-section-label">별점</span>
+  <h2>별점·리뷰용 별 기호</h2>
+  <p>리뷰·후기·평점에 바로 쓰는 별점 조합입니다. 한 줄 전체를 눌러 5점 별점을 통째로 복사하거나, 꽉 찬 별·반쪽 별·빈 별을 하나씩 골라 직접 조합할 수도 있습니다.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="★★★★★" aria-label="별 5점 복사">★★★★★</button>
+      <span class="flag-label">별 다섯</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="★★★★☆" aria-label="별 4점 복사">★★★★☆</button>
+      <span class="flag-label">별 넷</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="★★★☆☆" aria-label="별 3점 복사">★★★☆☆</button>
+      <span class="flag-label">별 셋</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="★★☆☆☆" aria-label="별 2점 복사">★★☆☆☆</button>
+      <span class="flag-label">별 둘</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="★☆☆☆☆" aria-label="별 1점 복사">★☆☆☆☆</button>
+      <span class="flag-label">별 하나</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⭐⭐⭐⭐⭐" aria-label="별 이모지 5점 복사">⭐⭐⭐⭐⭐</button>
+      <span class="flag-label">이모지 다섯</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⯨" aria-label="⯨ 복사">⯨</button>
+      <span class="flag-label">반쪽 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⯪" aria-label="⯪ 복사">⯪</button>
+      <span class="flag-label">반쪽 별(오른쪽)</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- BIO DECORATIONS -->
+<section class="mood-explainers" id="bio-decorations">
+  <span class="article-section-label">프로필 꾸미기</span>
+  <h2>감성 별 프로필 데코</h2>
+  <p>인스타 프로필, 닉네임, 감성 프로필에 바로 쓰는 별 클러스터와 반짝임 테두리입니다. 한 세트를 누르면 데코 전체가 한 번에 복사됩니다.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="˚｡⋆｡˚" aria-label="잔잔한 반짝임 데코 복사">˚｡⋆｡˚</button>
+      <span class="flag-label">잔잔한 반짝임</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⋆⭒˚｡⋆" aria-label="작은 별 반짝임 데코 복사">⋆⭒˚｡⋆</button>
+      <span class="flag-label">작은 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="˚₊‧⭐‧₊˚" aria-label="별을 감싼 데코 복사">˚₊‧⭐‧₊˚</button>
+      <span class="flag-label">감싼 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✦ ｡ ✧ ｡ ✦" aria-label="네 꼭짓점 별 구분선 복사">✦ ｡ ✧ ｡ ✦</button>
+      <span class="flag-label">별 구분선</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⋆｡‧˚ʚ★ɞ˚‧｡⋆" aria-label="별 날개 데코 복사">⋆｡‧˚ʚ★ɞ˚‧｡⋆</button>
+      <span class="flag-label">별 날개</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="★彡" aria-label="별똥별 꼬리 데코 복사">★彡</button>
+      <span class="flag-label">별 꼬리</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✮⋆˙" aria-label="반짝임 포인트 데코 복사">✮⋆˙</button>
+      <span class="flag-label">반짝임 포인트</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="｡ﾟ⭐｡ﾟ" aria-label="빛나는 별 데코 복사">｡ﾟ⭐｡ﾟ</button>
+      <span class="flag-label">빛나는 별</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- COLLECTIONS -->
+<section class="mood-explainers" id="star-collections">
+  <span class="article-section-label">별 세트</span>
+  <h2>그대로 쓰는 별 데코·별점 세트</h2>
+  <p class="u-secondary-block">조합해 둔 별 데코, 별 꼬리, 별점 줄입니다. 클릭 한 번으로 세트를 통째로 복사해서 프로필·캡션·닉네임·리뷰에 바로 붙여 쓸 수 있습니다.</p>
+  <div id="starCollectionsContainer"></div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- FAQ -->
+<section class="editorial-section" id="faq">
+  <span class="article-section-label">FAQ</span>
+  <h2>별 기호 자주 묻는 질문</h2>
+  <details class="faq-item">
+    <summary class="faq-question">별 기호란 무엇인가요?</summary>
+    <p class="faq-answer">★ ☆ ✦ ✧ ⋆ 처럼 별 모양을 본뜬 유니코드 문자를 말합니다. ⭐ 🌟 ✨ 같은 컬러 별 이모지와 달리, ★ ☆ ✦ 는 주변 글자와 같은 색으로 표시되는 흑백 텍스트 기호라서 과하지 않고 깔끔한 감성 꾸미기에 잘 어울립니다. 모두 이미지가 아닌 '문자'이기 때문에 복사해서 붙여넣기만 하면 됩니다.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">별 기호는 어디에 쓸 수 있나요?</summary>
+    <p class="faq-answer">인스타 프로필·닉네임, X(트위터) 이름과 글, 틱톡, 디스코드 이름, 카카오톡 상태메시지, 게임 아이디·닉네임까지 텍스트를 입력할 수 있는 곳이면 거의 어디든 쓸 수 있습니다. 이름 양옆을 ˚₊‧⭐‧₊˚ 로 감싸거나 구분선에 ✦ ｡ ✧ ｡ ✦ 를 넣는 방식이 많이 쓰입니다.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">별 이모지(⭐)와 텍스트 별 기호(★)는 무엇이 다른가요?</summary>
+    <p class="faq-answer">⭐ 🌟 ✨ 는 이모지라서 기기마다 컬러로 크게 표시되어 눈에 잘 띕니다. ★ ☆ ✦ ⋆ 는 유니코드 기호 문자로, 주변 글자와 같은 색·크기로 표시되어 차분하고 통일감 있는 감성 꾸미기에 어울립니다. 강조하고 싶을 때는 이모지, 깔끔하게 정리하고 싶을 때는 텍스트 기호를 쓰는 식으로 나눠 쓰면 좋습니다.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">한글도 이런 별 폰트처럼 꾸밀 수 있나요?</summary>
+    <p class="faq-answer">유니코드 '폰트'(볼드·이탤릭 등)는 알파벳과 숫자만 변환할 수 있어 한글 자체는 모양을 바꿀 수 없습니다. 대신 별 기호는 언어와 상관없이 쓸 수 있으므로, 한글 닉네임이나 프로필 앞뒤에 ★ ⋆ ✦ 를 붙여 꾸미는 방식으로 활용하면 됩니다. 예: ⋆｡˚ 별빛닉네임 ˚｡⋆</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">별 기호가 □(네모)나 '?'로 표시돼요</summary>
+    <p class="faq-answer">오래된 기기나 일부 앱은 최신 유니코드 기호·이모지를 지원하는 폰트가 없어서 □(두부 문자)로 보일 수 있습니다. ★ ☆ ✦ ⭐ ✨ 같은 기본 별은 거의 모든 환경에서 정상적으로 표시되므로, 복잡한 기호를 쓸 때는 올리기 전에 휴대폰에서 표시를 한 번 확인하는 것이 안전합니다.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">무료인가요? 저작권 문제는 없나요?</summary>
+    <p class="faq-answer">네, 완전 무료입니다. 별 기호는 유니코드 표준 문자라서 저작권 걱정 없이 몇 번이든 자유롭게 복사해서 쓸 수 있습니다. 회원가입도 필요 없습니다.</p>
+  </details>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>기호만이 아니라 글자 자체도 바꿀 수 있어요</h3>
+  <p>별 기호로 꾸몄다면, 이번엔 알파벳을 𝓒𝓾𝓽𝓮 한 필기체나 𝗕𝗼𝗹𝗱 한 굵은 글씨로. UltraTextGen이면 영문·숫자를 100가지가 넘는 감성 유니코드 폰트로 순식간에 바꿀 수 있습니다. 무료이고 회원가입도 필요 없습니다.</p>
+  <a href="/ko/" class="cta-btn">폰트 변환 열기 →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">관련 페이지</span>
+  <div class="compare-grid">
+    <a href="/ko/library/hateu-giho/" class="compare-card variant-muted u-no-underline">
+      <h4>하트 기호 모음</h4>
+      <p>♥ ♡ ❥ 부터 컬러 하트 이모지까지, 하트 특수문자를 스타일별로 복사. 프로필·닉네임 꾸미기에.</p>
+    </a>
+    <a href="/ko/library/imoji-johap/" class="compare-card variant-muted u-no-underline">
+      <h4>이모지 조합</h4>
+      <p>감성·귀여운 이모지 조합 모음. 프로필과 캡션에 바로 붙여 쓰는 조합을 클릭 한 번으로 복사.</p>
+    </a>
+    <a href="/ko/library/imotikon/" class="compare-card variant-muted u-no-underline">
+      <h4>이모티콘 모음</h4>
+      <p>ㅋ 카오모지·텍스트 이모티콘을 감정별로 복사. 채팅과 댓글에 그대로 쓰는 특수문자 얼굴.</p>
+    </a>
+    <a href="/ko/" class="compare-card variant-muted u-no-underline">
+      <h4>폰트 변환</h4>
+      <p>영문·숫자를 굵은 글씨·필기체·고딕 등 감성 폰트로 복사해서 변환.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    { name: "반짝임 프로필 테두리", flags: ["⋆","˚","✦","✧","✦","˚","⋆"], defaultFormat: "inline" },
+    { name: "별똥별 꼬리", flags: ["｡˚⋆★彡"], defaultFormat: "inline" },
+    { name: "별빛 닉네임 태그", flags: ["✩","｡","✫","｡","✩"], defaultFormat: "inline" },
+    { name: "별점 다섯 줄", flags: ["★★★★★"], defaultFormat: "inline" },
+    { name: "반짝임 포인트 묶음", flags: ["✮","⋆","˙","⭒","˙","⋆","✮"], defaultFormat: "inline" },
+    { name: "밤하늘 캡션 글로우", flags: ["˚","₊","‧","🌟","‧","₊","˚"], defaultFormat: "inline" }
+  ];
+
+  ns.buildGrids("starCollectionsContainer", GROUPS);
+  ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/ko/library/discord-giho/index.html
+++ b/ko/library/discord-giho/index.html
@@ -1,0 +1,656 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>디스코드 특수문자 ▸ 복사 — 채널·서버·닉네임 꾸미기 기호 모음</title>
+<meta name="description" content="디스코드 특수문자를 복사해서 채널 이름, 서버 이름, 닉네임, 프로필을 꾸며보세요. 화살표 ▸ ➤, 구분선 ┊ │, 별 ✦, 하트 ♡ 등 어디서나 깨지지 않는 유니코드 기호를 한 번에 복사할 수 있습니다.">
+
+<link rel="canonical" href="https://ultratextgen.com/ko/library/discord-giho/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/discord-symbols/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/library/simbolos-discord/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles-discord/">
+  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-discord/">
+  <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-discord/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/discord-giho/">
+  <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-discord/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-discord/">
+  <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/discord-sembolleri/">
+  <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/ki-tu-discord/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/discord-symbols/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/library-discord-symbols.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="디스코드 특수문자 ▸ 복사 — 채널·서버·닉네임 꾸미기 기호 모음">
+<meta name="twitter:description" content="디스코드 특수문자를 복사해서 채널·서버 이름, 닉네임, 프로필을 꾸며보세요. 화살표·구분선·별·하트 등 깨지지 않는 유니코드 기호 모음.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/library-discord-symbols.png">
+<meta property="og:title" content="디스코드 특수문자 ▸ 복사 — 채널·서버·닉네임 꾸미기 기호 모음">
+<meta property="og:description" content="디스코드 특수문자를 복사해서 채널 이름, 서버 이름, 닉네임, 프로필을 꾸며보세요. 화살표·구분선·별·하트 등 어디서나 깨지지 않는 유니코드 기호를 한 번에 복사할 수 있습니다.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/ko/library/discord-giho/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "inLanguage": "ko",
+  "name": "디스코드 특수문자 모음 (복사·붙여넣기)",
+  "alternateName": ["디스코드 특수문자", "디스코드 기호", "디코 특수문자", "디스코드 채널 특수문자", "디스코드 닉네임 특수문자", "디스코드 서버 꾸미기 기호"],
+  "description": "디스코드 채널 이름, 서버 이름, 닉네임, 프로필을 꾸밀 수 있는 유니코드 특수문자 모음. 화살표, 구분선, 별, 하트, 괄호 프레임 등을 카테고리별로 정리했고 클릭 한 번으로 복사할 수 있습니다.",
+  "url": "https://ultratextgen.com/ko/library/discord-giho/"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "홈",
+      "item": "https://ultratextgen.com/ko/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "디스코드 특수문자",
+      "item": "https://ultratextgen.com/ko/library/discord-giho/"
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "ko",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "디스코드 특수문자를 쓰려면 니트로(Nitro)가 필요한가요?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "아니요. 이 페이지의 기호는 모두 표준 유니코드 문자라서 니트로가 없는 무료 계정에서도 그대로 사용할 수 있습니다. 니트로는 커스텀·움직이는 이모지, 더 큰 파일 업로드, 프로필 추가 기능을 제공하지만, 텍스트 기호나 유니코드 폰트에는 니트로가 전혀 필요하지 않습니다."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "디스코드 닉네임이나 프로필에 특수문자를 어떻게 넣나요?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "기호를 눌러 복사한 다음, 디스코드의 표시 이름(별명), 자기소개(About Me), 서버 별명, 서버 이름, 또는 메시지 입력창에 붙여넣으면 됩니다. 다만 로그인용 사용자명(username) 칸은 소문자·숫자·밑줄(_)·마침표(.)만 허용하므로, 특수문자는 사용자명이 아니라 표시 이름에 넣어야 합니다."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "디스코드 채널 이름에도 특수문자를 쓸 수 있나요?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "부분적으로 가능합니다. 채널 이름은 자동으로 소문자로 바뀌고 띄어쓰기는 하이픈(-)으로 바뀌지만, ⊹ ➤ │ ⌗ 같은 여러 유니코드 기호와 구분선은 채널 목록과 카테고리를 정리하는 접두사나 구분자로 잘 작동합니다. 지원 여부가 기기마다 다를 수 있으니 PC와 모바일에서 모두 확인해 보세요."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "일부 디스코드 특수문자가 네모(□)로 보이는 이유는 무엇인가요?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "네모(두부, □)로 보인다면 상대방의 기기나 앱 버전에 해당 문자를 표시할 글리프(글꼴 모양)가 없다는 뜻입니다. 별·하트·점·박스 구분선처럼 널리 지원되는 기호는 거의 모든 환경에서 잘 보이지만, 드문 문자는 그렇지 않을 수 있습니다. 상대방에게 깨져 보인다면 더 흔한 기호로 바꿔 주세요."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "한글 닉네임을 볼드체나 이탤릭체로 바꿀 수 있나요?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "아니요. 유니코드의 볼드·이탤릭 같은 '폰트 변환'은 알파벳(A–Z)과 숫자만 지원하고 한글(가–힣)은 지원하지 않습니다. 그래서 한글 닉네임은 글자 모양 자체를 바꾸는 대신, 이 페이지의 특수문자로 앞뒤를 감싸거나 사이에 구분 기호를 넣어 꾸미는 것이 가장 자연스러운 방법입니다."
+      }
+    }
+  ]
+}
+</script>
+
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/ko/">홈</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">디스코드 특수문자</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">디스코드 특수문자 (복사·붙여넣기)</h1>
+    <p class="hero-tagline">디스코드 채널 이름, 서버 이름, 닉네임, 프로필을 꾸밀 수 있는 특수문자 모음입니다. 화살표 ▸ ➤, 구분선 ┊ │, 별 ✦, 하트 ♡, 괄호 프레임까지 — 어디서나 깨지지 않는 유니코드 기호를 클릭 한 번으로 복사하세요.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/library-discord-symbols.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>디스코드는 닉네임, 자기소개, 서버 이름에서 대부분의 유니코드 문자를 지원하지만, 실제로 어떻게 보이는지는 기기와 이모지 버전에 따라 조금씩 다릅니다. 이 페이지에는 디스코드 커뮤니티에서 가장 많이 쓰이는 꾸미기 기호들 — 채널 접두사와 구분선부터 반짝이는 별, 괄호 프레임, 하트 조합까지 — 을 모아 두었습니다. 모든 타일은 기호 하나 또는 바로 붙여넣을 수 있는 조합을 복사합니다.</p>
+    <p>참고로 한글(가–힣)은 유니코드 볼드·이탤릭 같은 '폰트 변환'이 적용되지 않습니다. 그래서 한글 닉네임은 글자 모양을 바꾸는 대신, 아래 특수문자로 이름의 앞뒤를 감싸거나 사이에 구분 기호를 넣어 꾸미는 방식이 가장 잘 어울립니다. 아래에서 골라 클릭(탭)하면 바로 복사됩니다.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- CHANNEL & CATEGORY SYMBOLS -->
+<section class="mood-explainers" id="channel-category-symbols">
+  <span class="article-section-label">채널·카테고리 기호</span>
+  <h2>디스코드 채널·카테고리 기호</h2>
+  <p>서버의 채널과 카테고리 헤더를 정리하기 위한 접두사 아이콘과 구분선입니다. 채널 이름 앞에 붙여넣어 채널 목록을 묶고 꾸며 보세요.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⌗" aria-label="⌗ 복사">⌗</button>
+      <span class="flag-label">뷰데이터 사각형 (해시태그 느낌)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="➤" aria-label="➤ 복사">➤</button>
+      <span class="flag-label">채널 화살촉</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="▸" aria-label="▸ 복사">▸</button>
+      <span class="flag-label">작은 오른쪽 삼각형</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="│" aria-label="│ 복사">│</button>
+      <span class="flag-label">세로 막대</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊹" aria-label="⊹ 복사">⊹</button>
+      <span class="flag-label">직교 십자</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="╭" aria-label="╭ 복사">╭</button>
+      <span class="flag-label">좌상단 곡선</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="╰" aria-label="╰ 복사">╰</button>
+      <span class="flag-label">좌하단 곡선</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="↳" aria-label="↳ 복사">↳</button>
+      <span class="flag-label">아래로 꺾인 오른쪽 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⋆" aria-label="⋆ 복사">⋆</button>
+      <span class="flag-label">별표(스타 연산자)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="◜" aria-label="◜ 복사">◜</button>
+      <span class="flag-label">좌상단 호</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❥" aria-label="❥ 복사">❥</button>
+      <span class="flag-label">하트 불릿</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="┊" aria-label="┊ 복사">┊</button>
+      <span class="flag-label">점선 세로 구분선</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 1 -->
+<section class="mood-explainers" id="decorative-dots">
+  <span class="article-section-label">장식용 점·악센트</span>
+  <h2>장식용 점과 악센트</h2>
+  <p>디스코드 감성 프로필에서 인기 있는 작은 악센트와 점 문자입니다.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="࣪" aria-label="࣪ 복사">࣪</button>
+      <span class="flag-label">감성 점</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="݁" aria-label="݁ 복사">݁</button>
+      <span class="flag-label">결합용 점</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊹" aria-label="⊹ 복사">⊹</button>
+      <span class="flag-label">직교 십자</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⋆" aria-label="⋆ 복사">⋆</button>
+      <span class="flag-label">육각 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✦" aria-label="✦ 복사">✦</button>
+      <span class="flag-label">검은 사각 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✧" aria-label="✧ 복사">✧</button>
+      <span class="flag-label">흰 사각 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="◌" aria-label="◌ 복사">◌</button>
+      <span class="flag-label">결합용 원</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="◎" aria-label="◎ 복사">◎</button>
+      <span class="flag-label">과녁(불스아이)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⩩" aria-label="⩩ 복사">⩩</button>
+      <span class="flag-label">유사·동등 기호</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="๑" aria-label="๑ 복사">๑</button>
+      <span class="flag-label">태국 문자 꼬 까이</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="໒" aria-label="໒ 복사">໒</button>
+      <span class="flag-label">라오 문자 로 링</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="᭡" aria-label="᭡ 복사">᭡ </button>
+      <span class="flag-label">발리 음악 기호</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ᥫ" aria-label="ᥫ 복사">ᥫ</button>
+      <span class="flag-label">림부 문자 A</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="➤" aria-label="➤ 복사">➤</button>
+      <span class="flag-label">검은 오른쪽 화살촉</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 2 -->
+<section class="mood-explainers" id="hearts-discord">
+  <span class="article-section-label">디스코드 프로필용 하트</span>
+  <h2>디스코드 프로필용 하트</h2>
+  <p>디스코드 닉네임과 자기소개에서 깔끔하게 표시되는 하트 기호와 변형들입니다.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♡" aria-label="♡ 복사">♡</button>
+      <span class="flag-label">흰 하트(트럼프)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♥" aria-label="♥ 복사">♥</button>
+      <span class="flag-label">검은 하트(트럼프)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❥" aria-label="❥ 복사">❥</button>
+      <span class="flag-label">기울어진 하트 불릿</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❣" aria-label="❣ 복사">❣</button>
+      <span class="flag-label">하트 느낌표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❤︎" aria-label="❤︎ 복사">❤︎</button>
+      <span class="flag-label">텍스트 하트(모노)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ෆ" aria-label="ෆ 복사">ෆ</button>
+      <span class="flag-label">싱할라 문자 (하트 모양)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓆩♡𓆪" aria-label="𓆩♡𓆪 복사">𓆩♡𓆪</button>
+      <span class="flag-label">이집트 하트 프레임(조합)</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 3 -->
+<section class="mood-explainers" id="frames-brackets">
+  <span class="article-section-label">프레임·괄호</span>
+  <h2>프레임과 괄호</h2>
+  <p>디스코드 닉네임과 자기소개에서 텍스트를 감쌀 때 쓰는 괄호·프레임 문자입니다.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="꒰" aria-label="꒰ 복사">꒰</button>
+      <span class="flag-label">장식 여는 괄호</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="꒱" aria-label="꒱ 복사">꒱</button>
+      <span class="flag-label">장식 닫는 괄호</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⌗" aria-label="⌗ 복사">⌗</button>
+      <span class="flag-label">뷰데이터 사각형</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="〔" aria-label="〔 복사">〔</button>
+      <span class="flag-label">거북 등딱지 여는 괄호</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="〕" aria-label="〕 복사">〕</button>
+      <span class="flag-label">거북 등딱지 닫는 괄호</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="「" aria-label="「 복사">「</button>
+      <span class="flag-label">여는 낫표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="」" aria-label="」 복사">」</button>
+      <span class="flag-label">닫는 낫표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="『" aria-label="『 복사">『</button>
+      <span class="flag-label">여는 겹낫표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="』" aria-label="』 복사">』</button>
+      <span class="flag-label">닫는 겹낫표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⌜" aria-label="⌜ 복사">⌜</button>
+      <span class="flag-label">좌상단 모서리</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⌝" aria-label="⌝ 복사">⌝</button>
+      <span class="flag-label">우상단 모서리</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⌞" aria-label="⌞ 복사">⌞</button>
+      <span class="flag-label">좌하단 모서리</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⌟" aria-label="⌟ 복사">⌟</button>
+      <span class="flag-label">우하단 모서리</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❪" aria-label="❪ 복사">❪</button>
+      <span class="flag-label">납작한 여는 괄호</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❫" aria-label="❫ 복사">❫</button>
+      <span class="flag-label">납작한 닫는 괄호</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="▬" aria-label="▬ 복사">▬</button>
+      <span class="flag-label">검은 직사각형</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="▭" aria-label="▭ 복사">▭</button>
+      <span class="flag-label">흰 직사각형</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 4 -->
+<section class="mood-explainers" id="stars-sparkles">
+  <span class="article-section-label">별·반짝임</span>
+  <h2>별과 반짝임</h2>
+  <p>디스코드 닉네임, 서버 이름, 채널 꾸미기에 어울리는 별·반짝임 기호입니다.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="★" aria-label="★ 복사">★</button>
+      <span class="flag-label">검은 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☆" aria-label="☆ 복사">☆</button>
+      <span class="flag-label">흰 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✦" aria-label="✦ 복사">✦</button>
+      <span class="flag-label">검은 사각 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✧" aria-label="✧ 복사">✧</button>
+      <span class="flag-label">흰 사각 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✩" aria-label="✩ 복사">✩</button>
+      <span class="flag-label">외곽선 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⋆" aria-label="⋆ 복사">⋆</button>
+      <span class="flag-label">육각 별표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✨" aria-label="✨ 복사">✨</button>
+      <span class="flag-label">반짝임 이모지</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𖤐" aria-label="𖤐 복사">𖤐</button>
+      <span class="flag-label">검은 태양</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⭒" aria-label="⭒ 복사">⭒</button>
+      <span class="flag-label">외곽선 작은 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⭑" aria-label="⭑ 복사">⭑</button>
+      <span class="flag-label">작은 별</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 5 -->
+<section class="mood-explainers" id="dividers">
+  <span class="article-section-label">구분선</span>
+  <h2>구분선</h2>
+  <p>디스코드 자기소개나 서버 설명에서 구역을 나눌 때 쓰는 한 글자 구분선입니다.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="・" aria-label="・ 복사">・</button>
+      <span class="flag-label">가운뎃점(가타카나)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊹" aria-label="⊹ 복사">⊹</button>
+      <span class="flag-label">직교 십자</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❀" aria-label="❀ 복사">❀</button>
+      <span class="flag-label">흰 꽃(플뢰레트)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⌒" aria-label="⌒ 복사">⌒</button>
+      <span class="flag-label">호(아크)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="━" aria-label="━ 복사">━</button>
+      <span class="flag-label">굵은 가로선</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="┈" aria-label="┈ 복사">┈</button>
+      <span class="flag-label">가는 4점 점선(가로)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="┊" aria-label="┊ 복사">┊</button>
+      <span class="flag-label">가는 4점 점선(세로)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⌇" aria-label="⌇ 복사">⌇</button>
+      <span class="flag-label">물결선</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="─" aria-label="─ 복사">─</button>
+      <span class="flag-label">가는 가로선</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="╌" aria-label="╌ 복사">╌</button>
+      <span class="flag-label">가는 2점 점선</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="┄" aria-label="┄ 복사">┄</button>
+      <span class="flag-label">가는 3점 점선</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 6 -->
+<section class="mood-explainers" id="combo-templates">
+  <span class="article-section-label">기호 조합</span>
+  <h2>기호 조합 템플릿</h2>
+  <p>바로 붙여넣을 수 있는 디스코드 프로필 템플릿입니다. 타일을 누르면 조합 전체가 복사됩니다.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="꒰ ✦ ꒱" aria-label="꒰ ✦ ꒱ 복사">꒰ ✦ ꒱</button>
+      <span class="flag-label">괄호·별·괄호</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⋆˚࿔" aria-label="⋆˚࿔ 복사">⋆˚࿔</button>
+      <span class="flag-label">반짝임 링</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="★ ⩩ 𓂃 ✦" aria-label="★ ⩩ 𓂃 ✦ 복사">★ ⩩ 𓂃 ✦</button>
+      <span class="flag-label">별 조합</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊹ ♡ ⊹" aria-label="⊹ ♡ ⊹ 복사">⊹ ♡ ⊹</button>
+      <span class="flag-label">십자로 감싼 하트</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓆩♡𓆪" aria-label="𓆩♡𓆪 복사">𓆩♡𓆪</button>
+      <span class="flag-label">이집트 하트 프레임</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="꒰꒱ ⊹" aria-label="꒰꒱ ⊹ 복사">꒰꒱ ⊹</button>
+      <span class="flag-label">장식 괄호·십자</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- COLLECTIONS -->
+<section class="mood-explainers" id="discord-collections">
+  <span class="article-section-label">디스코드 세트</span>
+  <h2>바로 쓰는 디스코드 프로필·채널 조합 세트</h2>
+  <p class="u-secondary-block">닉네임, 자기소개, 서버 이름, 채널에 그대로 붙여넣을 수 있는 완성형 디스코드 조합입니다. 클릭 한 번으로 조합 전체가 복사됩니다.</p>
+  <div id="discordCollectionsContainer"></div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- FAQ -->
+<section class="editorial-section" id="faq">
+  <span class="article-section-label">FAQ</span>
+  <h2>디스코드 특수문자, 자주 묻는 질문</h2>
+  <details class="faq-item">
+    <summary class="faq-question">디스코드 특수문자를 쓰려면 니트로(Nitro)가 필요한가요?</summary>
+    <p class="faq-answer">아니요. 이 페이지의 기호는 모두 표준 유니코드 문자라서 니트로가 없는 무료 계정에서도 그대로 사용할 수 있습니다. 니트로는 커스텀·움직이는 이모지, 더 큰 파일 업로드, 프로필 추가 기능을 제공하지만, 텍스트 기호나 유니코드 폰트에는 니트로가 전혀 필요하지 않습니다.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">디스코드 닉네임이나 프로필에 특수문자를 어떻게 넣나요?</summary>
+    <p class="faq-answer">기호를 눌러 복사한 다음, 디스코드의 표시 이름(별명), 자기소개(About Me), 서버 별명, 서버 이름, 또는 메시지 입력창에 붙여넣으면 됩니다. 다만 로그인용 사용자명(username) 칸은 소문자·숫자·밑줄(_)·마침표(.)만 허용하므로, 특수문자는 사용자명이 아니라 표시 이름에 넣어야 합니다.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">디스코드 채널 이름에도 특수문자를 쓸 수 있나요?</summary>
+    <p class="faq-answer">부분적으로 가능합니다. 채널 이름은 자동으로 소문자로 바뀌고 띄어쓰기는 하이픈(-)으로 바뀌지만, ⊹ ➤ │ ⌗ 같은 여러 유니코드 기호와 구분선은 채널 목록과 카테고리를 정리하는 접두사나 구분자로 잘 작동합니다. 지원 여부가 기기마다 다를 수 있으니 PC와 모바일에서 모두 확인해 보세요.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">일부 디스코드 특수문자가 네모(□)로 보이는 이유는 무엇인가요?</summary>
+    <p class="faq-answer">네모(두부, □)로 보인다면 상대방의 기기나 앱 버전에 해당 문자를 표시할 글리프(글꼴 모양)가 없다는 뜻입니다. 별·하트·점·박스 구분선처럼 널리 지원되는 기호는 거의 모든 환경에서 잘 보이지만, 드문 문자는 그렇지 않을 수 있습니다. 상대방에게 깨져 보인다면 더 흔한 기호로 바꿔 주세요.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">한글 닉네임을 볼드체나 이탤릭체로 바꿀 수 있나요?</summary>
+    <p class="faq-answer">아니요. 유니코드의 볼드·이탤릭 같은 '폰트 변환'은 알파벳(A–Z)과 숫자만 지원하고 한글(가–힣)은 지원하지 않습니다. 그래서 한글 닉네임은 글자 모양 자체를 바꾸는 대신, 이 페이지의 특수문자로 앞뒤를 감싸거나 사이에 구분 기호를 넣어 꾸미는 것이 가장 자연스러운 방법입니다.</p>
+  </details>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>알파벳은 유니코드 폰트로 바꿔 보세요</h3>
+  <p>닉네임의 영문 부분(예: ID, 게임 닉네임)을 함께 꾸미고 싶다면 폰트 변환 도구로 볼드·필기체 스타일을 만들어 이 기호들과 조합해 보세요. 무료이고 가입도 필요 없습니다.</p>
+  <a href="/ko/" class="cta-btn">폰트 변환 도구 열기 →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">관련 페이지</span>
+  <div class="compare-grid">
+    <a href="/ko/library/hateu-giho/" class="compare-card variant-muted u-no-underline">
+      <h4>하트 기호</h4>
+      <p>모든 하트 이모지와 유니코드 하트 문자를 복사·붙여넣기.</p>
+    </a>
+    <a href="/ko/library/byeol-giho/" class="compare-card variant-muted u-no-underline">
+      <h4>별·반짝임 기호</h4>
+      <p>별, 반짝임, 빛나는 장식 문자를 프로필 꾸미기용으로.</p>
+    </a>
+    <a href="/ko/library/imotikon/" class="compare-card variant-muted u-no-underline">
+      <h4>이모티콘·얼굴 문자</h4>
+      <p>디스코드에서도 잘 보이는 텍스트 얼굴과 일본식 이모티콘.</p>
+    </a>
+    <a href="/ko/library/imoji-johap/" class="compare-card variant-muted u-no-underline">
+      <h4>이모지 조합</h4>
+      <p>귀여운 이모지 조합 모음 — 감성·심플·계절별로 복사 OK.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    { name: "디스코드 채널 구분선", flags: ["━━━┈┈┈━━━"], defaultFormat: "inline" },
+    { name: "별·괄호 닉네임 조합", flags: ["꒰","✦","⊹","✧","꒱"], defaultFormat: "inline" },
+    { name: "하트 프레임 프로필 조합", flags: ["𓆩♡𓆪"], defaultFormat: "inline" },
+    { name: "반짝임 프로필 악센트", flags: ["⋆","˚","⊹","✦","⊹","˚","⋆"], defaultFormat: "inline" },
+    { name: "낫표 채널 이름", flags: ["「","✧","・","✧","」"], defaultFormat: "inline" },
+    { name: "점 서버 구분선", flags: ["・","⊹","┈","┈","⊹","・"], defaultFormat: "inline" }
+  ];
+
+  ns.buildGrids("discordCollectionsContainer", GROUPS);
+  ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/ko/library/gamseong-giho/index.html
+++ b/ko/library/gamseong-giho/index.html
@@ -1,0 +1,559 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>감성 특수문자 · 예쁜 기호 모음 — 프로필 · 닉네임 꾸미기 복사</title>
+<meta name="description" content="감성 특수문자와 예쁜 기호를 종류별로 모았습니다. 반짝이·하트·꽃·구분선·괄호 기호를 클릭 한 번으로 복사해서 인스타 프로필, 닉네임, 디스코드 상태 메시지 꾸미기에 바로 붙여넣으세요.">
+
+<link rel="canonical" href="https://ultratextgen.com/ko/library/gamseong-giho/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/aesthetic-symbols/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/simbolos-aesthetic/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles/">
+  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-aesthetic/">
+  <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/aesthetic-symbols/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/gamseong-giho/">
+  <link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/library/speciale-tekens/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos/">
+  <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/estetik-semboller/">
+  <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/ki-tu-dac-biet/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/aesthetic-symbols/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/library-aesthetic-symbols.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="감성 특수문자 · 예쁜 기호 모음 — 프로필 · 닉네임 꾸미기 복사">
+<meta name="twitter:description" content="감성 특수문자와 예쁜 기호를 종류별로 모았습니다. 클릭 한 번으로 복사해서 인스타 프로필, 닉네임, 디스코드 꾸미기에 바로 사용하세요.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/library-aesthetic-symbols.png">
+<meta property="og:title" content="감성 특수문자 · 예쁜 기호 모음 — 프로필 · 닉네임 꾸미기 복사">
+<meta property="og:description" content="감성 특수문자와 예쁜 기호를 종류별로 모았습니다. 반짝이·하트·꽃·구분선·괄호 기호를 클릭 한 번으로 복사해서 프로필과 닉네임 꾸미기에 사용하세요.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/ko/library/gamseong-giho/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "ko",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "감성 특수문자가 뭔가요?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "⋆ ✦ ✧ ♡ ❀ ୨୧ ʚɞ 처럼 키보드로는 바로 칠 수 없는 유니코드 기호들을 말합니다. 반짝이, 하트, 꽃, 구분선, 괄호 같은 작고 예쁜 기호로, 인스타 프로필이나 닉네임을 감성적으로 꾸밀 때 자주 쓰입니다. 이미지가 아니라 전부 문자이기 때문에 복사해서 붙여넣기만 하면 됩니다."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "감성 특수문자는 어디에 쓸 수 있나요?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "인스타 프로필과 이름, 소개글, X(트위터) 닉네임, 틱톡, 디스코드 상태 메시지·닉네임, 카카오톡 상태메시지, 게임 아이디까지 텍스트를 입력할 수 있는 곳이면 거의 어디서나 사용할 수 있습니다. 이름 양옆을 ⋆｡˚ ⟡ ˚｡⋆ 로 감싸거나 구분선에 ✦──✦ 를 넣는 식으로 많이 씁니다."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "한글도 특수문자 폰트로 바꿀 수 있나요?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "아니요. 굵게·기울임 같은 유니코드 폰트 변환은 알파벳(A–Z)과 숫자에만 적용되고, 한글(가나다)에는 대응하는 유니코드 글자가 없어서 모양을 바꿀 수 없습니다. 그래서 한글 닉네임을 꾸밀 때는 글자 자체를 바꾸는 대신, 이 페이지의 기호를 이름 앞뒤에 붙여서 감성을 더하는 방식이 정답입니다. 이 기호들은 언어와 상관없이 어디서나 그대로 표시됩니다."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "기호가 □(네모)나 물음표로 보여요.",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "오래된 기기나 일부 앱은 최신 유니코드 기호를 지원하는 폰트가 없어서 □(두부)로 표시되기도 합니다. ⋆ ✦ ♡ ❀ 같은 기본 기호는 대부분의 환경에서 잘 보이니, 특이한 기호를 쓸 때는 올리기 전에 메모장이나 스마트폰에서 어떻게 보이는지 먼저 확인하는 것이 안전합니다."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "무료인가요? 저작권 문제는 없나요?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "네, 완전 무료입니다. 감성 특수문자는 유니코드 표준 문자라서 저작권 걱정 없이 몇 번이든 자유롭게 복사해서 쓸 수 있습니다. 회원가입도 필요 없습니다."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "홈",
+      "item": "https://ultratextgen.com/ko/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "감성 특수문자",
+      "item": "https://ultratextgen.com/ko/library/gamseong-giho/"
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "name": "감성 특수문자 · 예쁜 기호 모음",
+  "description": "감성 특수문자·예쁜 기호를 반짝이, 하트, 꽃, 구분선, 괄호 등 종류별로 모아 클릭 한 번으로 복사할 수 있는 페이지입니다. 인스타 프로필, 닉네임, 디스코드 꾸미기에 바로 사용할 수 있습니다.",
+  "url": "https://ultratextgen.com/ko/library/gamseong-giho/",
+  "inLanguage": "ko",
+  "isPartOf": {
+    "@type": "WebSite",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  }
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/ko/">홈</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">감성 특수문자</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">감성 특수문자 · 예쁜 기호 모음</h1>
+    <p class="hero-tagline">인스타 프로필, 닉네임, 디스코드 상태 메시지를 꾸미기 위한 감성 유니코드 기호 모음입니다. 반짝이·하트·꽃·구분선·괄호 기호를 종류별로 정리했어요. 기호를 클릭(터치)하면 바로 복사됩니다.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/library-aesthetic-symbols.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>감성 특수문자는 키보드로는 바로 칠 수 없는 유니코드 기호를 말합니다. ⋆ ✦ ♡ ❀ ୨୧ 처럼 작고 예쁜 기호들로, 인스타·틱톡·핀터레스트·디스코드·트위터(X)에서 프로필과 닉네임, 소개글을 꾸밀 때 두루 쓰입니다. 이미지가 아니라 전부 「문자」이기 때문에, 복사해서 붙여넣기만 하면 어디서든 그대로 표시됩니다.</p>
+    <p>참고로 <strong>한글(가나다)은 굵게·기울임 같은 유니코드 폰트로 바꿀 수 없습니다.</strong> 폰트 변환은 알파벳과 숫자에만 적용되기 때문이에요. 그래서 한글 닉네임을 꾸밀 때는 글자 모양을 바꾸는 대신, 이 페이지의 기호를 이름 앞뒤에 붙이는 방식이 가장 자연스럽습니다. 아래에서 원하는 기호를 찾아 클릭해서 복사해 보세요.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- QUICK PICK -->
+<section class="mood-explainers" id="quick-pick">
+  <span class="article-section-label">빠른 선택</span>
+  <h2>가장 많이 쓰는 감성 기호</h2>
+  <p class="section-lead is-spaced">몇 개만 빠르게 필요하다면 여기서 시작하세요. 기호를 클릭하면 바로 복사됩니다.</p>
+  <div class="flag-rows symbol-pick-grid">
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="⋆" aria-label="⋆ 복사">⋆</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="✦" aria-label="✦ 복사">✦</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="✧" aria-label="✧ 복사">✧</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="⊹" aria-label="⊹ 복사">⊹</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="࣪" aria-label="࣪ 복사">࣪</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="݁" aria-label="݁ 복사">݁</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="❀" aria-label="❀ 복사">❀</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="♡" aria-label="♡ 복사">♡</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="♥" aria-label="♥ 복사">♥</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="✿" aria-label="✿ 복사">✿</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="❁" aria-label="❁ 복사">❁</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="୨୧" aria-label="୨୧ 복사">୨୧</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="ʚɞ" aria-label="ʚɞ 복사">ʚɞ</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="𐙚" aria-label="𐙚 복사">𐙚</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="⋆˚࿔" aria-label="⋆˚࿔ 복사">⋆˚࿔</button></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile symbol-pick-tile" data-symbol="⩩" aria-label="⩩ 복사">⩩</button></div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SPARKLE -->
+<section class="mood-explainers" id="sparkle-symbols">
+  <span class="article-section-label">반짝이 기호</span>
+  <h2>반짝이 · 별 기호</h2>
+  <p class="u-secondary-tight">감성 프로필과 닉네임에서 가장 많이 쓰이는 반짝이·별 기호. 이름 앞뒤에 하나만 붙여도 분위기가 확 살아납니다.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✧" aria-label="✧ 복사">✧</button>
+      <span class="flag-label">흰 사각별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="・" aria-label="・ 복사">・</button>
+      <span class="flag-label">가운뎃점(가타카나)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="゚" aria-label="゚ 복사">゚</button>
+      <span class="flag-label">반탁점</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊹" aria-label="⊹ 복사">⊹</button>
+      <span class="flag-label">직교 십자</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="₊" aria-label="₊ 복사">₊</button>
+      <span class="flag-label">작은 플러스</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="˚" aria-label="˚ 복사">˚</button>
+      <span class="flag-label">위 고리</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✦" aria-label="✦ 복사">✦</button>
+      <span class="flag-label">검은 사각별</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- HEART -->
+<section class="mood-explainers" id="heart-symbols">
+  <span class="article-section-label">하트 기호</span>
+  <h2>하트 감성 기호</h2>
+  <p class="u-secondary-tight">주변 글자와 같은 색으로 표시되는 모노톤 하트 기호. 절제된 감성으로 프로필을 꾸미기 좋습니다.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♡" aria-label="♡ 복사">♡</button>
+      <span class="flag-label">흰 하트</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❥" aria-label="❥ 복사">❥</button>
+      <span class="flag-label">기울인 하트 불릿</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="꒰" aria-label="꒰ 복사">꒰</button>
+      <span class="flag-label">장식 왼쪽 괄호</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="꒱" aria-label="꒱ 복사">꒱</button>
+      <span class="flag-label">장식 오른쪽 괄호</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="᯽" aria-label="᯽ 복사">᯽</button>
+      <span class="flag-label">바탁 문자 빈두</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ɞ" aria-label="ɞ 복사">ɞ</button>
+      <span class="flag-label">반전 열린 e</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- NATURE / FLOWER -->
+<section class="mood-explainers" id="flower-symbols">
+  <span class="article-section-label">꽃 · 자연 기호</span>
+  <h2>꽃 · 자연 감성 기호</h2>
+  <p class="u-secondary-tight">부드러운 감성 프로필과 소개글에 어울리는 꽃·자연 기호.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❀" aria-label="❀ 복사">❀</button>
+      <span class="flag-label">흰 꽃무늬</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✿" aria-label="✿ 복사">✿</button>
+      <span class="flag-label">검은 꽃무늬</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☘" aria-label="☘ 복사">☘</button>
+      <span class="flag-label">세잎클로버</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚘" aria-label="⚘ 복사">⚘</button>
+      <span class="flag-label">꽃</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✾" aria-label="✾ 복사">✾</button>
+      <span class="flag-label">여섯잎 꽃무늬</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓆸" aria-label="𓆸 복사">𓆸</button>
+      <span class="flag-label">이집트 연꽃</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓂃" aria-label="𓂃 복사">𓂃</button>
+      <span class="flag-label">상형문자 깃털</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- DIVIDER -->
+<section class="mood-explainers" id="divider-symbols">
+  <span class="article-section-label">구분선 기호</span>
+  <h2>구분선 · 화살표 감성 기호</h2>
+  <p class="u-secondary-tight">소개글을 정돈해 주는 구분선과 라인 패턴. 문단 사이나 이름 아래에 넣어 보세요.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="──" aria-label="── 복사">──</button>
+      <span class="flag-label">두 줄 선</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✦──✦" aria-label="✦──✦ 복사">✦──✦</button>
+      <span class="flag-label">별-선-별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="╌╌╌" aria-label="╌╌╌ 복사">╌╌╌</button>
+      <span class="flag-label">가는 점선</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="∘∘∘" aria-label="∘∘∘ 복사">∘∘∘</button>
+      <span class="flag-label">고리 점</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊱" aria-label="⊱ 복사">⊱</button>
+      <span class="flag-label">뒤따름 기호</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊰" aria-label="⊰ 복사">⊰</button>
+      <span class="flag-label">앞섬 기호</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- BRACKET -->
+<section class="mood-explainers" id="bracket-symbols">
+  <span class="article-section-label">괄호 · 테두리 기호</span>
+  <h2>괄호 · 테두리 감성 기호</h2>
+  <p class="u-secondary-tight">닉네임이나 소개글의 제목을 감싸기 좋은 일본어·CJK 괄호 기호.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="【" aria-label="【 복사">【</button>
+      <span class="flag-label">검은 렌즈형 괄호(왼쪽)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="】" aria-label="】 복사">】</button>
+      <span class="flag-label">검은 렌즈형 괄호(오른쪽)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="「" aria-label="「 복사">「</button>
+      <span class="flag-label">홑낫표(왼쪽)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="」" aria-label="」 복사">」</button>
+      <span class="flag-label">홑낫표(오른쪽)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="『" aria-label="『 복사">『</button>
+      <span class="flag-label">겹낫표(왼쪽)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="』" aria-label="』 복사">』</button>
+      <span class="flag-label">겹낫표(오른쪽)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="〖" aria-label="〖 복사">〖</button>
+      <span class="flag-label">흰 렌즈형 괄호(왼쪽)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="〗" aria-label="〗 복사">〗</button>
+      <span class="flag-label">흰 렌즈형 괄호(오른쪽)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="〔" aria-label="〔 복사">〔</button>
+      <span class="flag-label">거북등 괄호(왼쪽)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="〕" aria-label="〕 복사">〕</button>
+      <span class="flag-label">거북등 괄호(오른쪽)</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- WHISPER / MINIMAL -->
+<section class="mood-explainers" id="whisper-symbols">
+  <span class="article-section-label">미니멀 · 위스퍼</span>
+  <h2>미니멀 · 위스퍼 감성 기호</h2>
+  <p class="u-secondary-tight">핀터레스트풍의 조용한 감성. 거의 보이지 않을 만큼 작은 점과 악센트, 아치형 기호입니다. 상당수는 앞 글자에 붙는 결합 문자(Unicode 'Mn')라, 메모장에서 먼저 어떻게 보이는지 확인해 보세요.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ׂ" aria-label="ׂ 복사">◌ׂ</button>
+      <span class="flag-label">히브리 신 점</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ׅ" aria-label="ׅ 복사">◌ׅ</button>
+      <span class="flag-label">히브리 아래 점</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="݂" aria-label="݂ 복사">◌݂</button>
+      <span class="flag-label">아랍 아래 점</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="֯" aria-label="֯ 복사">◌֯</button>
+      <span class="flag-label">히브리 라페</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="̥" aria-label="̥ 복사">◌̥</button>
+      <span class="flag-label">아래 결합 고리</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ᣟ" aria-label="ᣟ 복사">ᣟ</button>
+      <span class="flag-label">캐나다 음절 마무리</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="◎" aria-label="◎ 복사">◎</button>
+      <span class="flag-label">과녁 원</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="๑" aria-label="๑ 복사">๑</button>
+      <span class="flag-label">태국 문자 꼬까이</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⌒" aria-label="⌒ 복사">⌒</button>
+      <span class="flag-label">아치</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="╮" aria-label="╮ 복사">╮</button>
+      <span class="flag-label">아치(위-왼쪽)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="╭" aria-label="╭ 복사">╭</button>
+      <span class="flag-label">아치(아래-오른쪽)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ꔫ" aria-label="ꔫ 복사">ꔫ</button>
+      <span class="flag-label">바이 문자 핑</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- COLLECTIONS -->
+<section class="mood-explainers" id="gamseong-collections">
+  <span class="article-section-label">감성 세트</span>
+  <h2>그대로 붙여넣는 감성 꾸미기 세트</h2>
+  <p class="u-secondary-block">조합이 끝난 감성 기호 세트입니다. 클릭 한 번으로 통째로 복사해서 프로필·닉네임·소개글에 바로 붙여넣으세요.</p>
+  <div id="gamseongCollectionsContainer"></div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- FAQ -->
+<section class="editorial-section" id="faq">
+  <span class="article-section-label">FAQ</span>
+  <h2>감성 특수문자 자주 묻는 질문</h2>
+  <details class="faq-item">
+    <summary class="faq-question">감성 특수문자가 뭔가요?</summary>
+    <p class="faq-answer">⋆ ✦ ✧ ♡ ❀ ୨୧ ʚɞ 처럼 키보드로는 바로 칠 수 없는 유니코드 기호들을 말합니다. 반짝이, 하트, 꽃, 구분선, 괄호 같은 작고 예쁜 기호로, 인스타 프로필이나 닉네임을 감성적으로 꾸밀 때 자주 쓰입니다. 이미지가 아니라 전부 문자이기 때문에 복사해서 붙여넣기만 하면 됩니다.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">감성 특수문자는 어디에 쓸 수 있나요?</summary>
+    <p class="faq-answer">인스타 프로필과 이름, 소개글, X(트위터) 닉네임, 틱톡, 디스코드 상태 메시지·닉네임, 카카오톡 상태메시지, 게임 아이디까지 텍스트를 입력할 수 있는 곳이면 거의 어디서나 사용할 수 있습니다. 이름 양옆을 ⋆｡˚ ⟡ ˚｡⋆ 로 감싸거나 구분선에 ✦──✦ 를 넣는 식으로 많이 씁니다.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">한글도 특수문자 폰트로 바꿀 수 있나요?</summary>
+    <p class="faq-answer">아니요. 굵게·기울임 같은 유니코드 폰트 변환은 알파벳(A–Z)과 숫자에만 적용되고, 한글(가나다)에는 대응하는 유니코드 글자가 없어서 모양을 바꿀 수 없습니다. 그래서 한글 닉네임을 꾸밀 때는 글자 자체를 바꾸는 대신, 이 페이지의 기호를 이름 앞뒤에 붙여서 감성을 더하는 방식이 정답입니다. 이 기호들은 언어와 상관없이 어디서나 그대로 표시됩니다.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">기호가 □(네모)나 물음표로 보여요.</summary>
+    <p class="faq-answer">오래된 기기나 일부 앱은 최신 유니코드 기호를 지원하는 폰트가 없어서 □(두부)로 표시되기도 합니다. ⋆ ✦ ♡ ❀ 같은 기본 기호는 대부분의 환경에서 잘 보이니, 특이한 기호를 쓸 때는 올리기 전에 메모장이나 스마트폰에서 어떻게 보이는지 먼저 확인하는 것이 안전합니다.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">무료인가요? 저작권 문제는 없나요?</summary>
+    <p class="faq-answer">네, 완전 무료입니다. 감성 특수문자는 유니코드 표준 문자라서 저작권 걱정 없이 몇 번이든 자유롭게 복사해서 쓸 수 있습니다. 회원가입도 필요 없습니다.</p>
+  </details>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>알파벳 닉네임은 폰트까지 바꿔 보세요</h3>
+  <p>한글은 기호로 꾸미고, 영문 이름은 𝓒𝓾𝓽𝓮 한 필기체나 𝗕𝗼𝗹𝗱 한 굵은 글씨로. UltraTextGen은 영문·숫자를 100가지가 넘는 감성 유니코드 폰트로 한 번에 변환해 줍니다. 무료이고 회원가입도 필요 없습니다.</p>
+  <a href="/ko/" class="cta-btn">폰트 변환 열기 →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">관련 페이지</span>
+  <div class="compare-grid">
+    <a href="/ko/library/hateu-giho/" class="compare-card variant-muted u-no-underline">
+      <h4>하트 기호 모음</h4>
+      <p>♡ ♥ ❥ 부터 컬러 하트 이모지까지, 하트 기호를 종류별로 복사.</p>
+    </a>
+    <a href="/ko/library/byeol-giho/" class="compare-card variant-muted u-no-underline">
+      <h4>별 · 반짝이 기호</h4>
+      <p>★ ✩ ✧ ⋆ 별과 반짝이 기호로 프로필과 닉네임을 꾸미기.</p>
+    </a>
+    <a href="/ko/library/imotikon/" class="compare-card variant-muted u-no-underline">
+      <h4>이모티콘 모음</h4>
+      <p>(⁠｡⁠•̀⁠ᴗ⁠-⁠)✧ 같은 텍스트 이모티콘을 감정별로 복사.</p>
+    </a>
+    <a href="/ko/library/discord-giho/" class="compare-card variant-muted u-no-underline">
+      <h4>디스코드 특수문자</h4>
+      <p>디스코드 닉네임·상태 메시지에 어울리는 기호와 꾸미기 세트.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    { name: "부드러운 반짝이 소개글", flags: ["⊹","˚","₊","✧","₊","˚","⊹"], defaultFormat: "inline" },
+    { name: "하트 이름 감싸기", flags: ["୨୧","♡","ʚɞ","♡","୨୧"], defaultFormat: "inline" },
+    { name: "꽃무늬 세트", flags: ["❀","✿","❁","✾","❀"], defaultFormat: "inline" },
+    { name: "별-선 구분선", flags: ["✦──✦"], defaultFormat: "inline" },
+    { name: "미니멀 점 악센트", flags: ["⊰","∘","⋆","✦","⋆","∘","⊱"], defaultFormat: "inline" },
+    { name: "몽환적 닉네임 태그", flags: ["⋆˚࿔","✧","˚","⋆"], defaultFormat: "inline" }
+  ];
+
+  ns.buildGrids("gamseongCollectionsContainer", GROUPS);
+  ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/ko/library/hateu-giho/index.html
+++ b/ko/library/hateu-giho/index.html
@@ -1,0 +1,511 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>하트 기호 ♥ 모음 — 복사해서 쓰는 하트 특수문자·이모지</title>
+<meta name="description" content="하트 기호와 하트 이모지, 유니코드 하트 문자를 색상·스타일별로 모았습니다. 클릭 한 번으로 복사해서 인스타 프로필, 닉네임, 디스코드 특수문자로 바로 붙여넣으세요.">
+
+<link rel="canonical" href="https://ultratextgen.com/ko/library/hateu-giho/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/heart-symbols/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/library/herz-symbole/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/simbolos-de-corazon/">
+  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-love/">
+  <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-cuore/">
+  <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/heart-symbols/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/hateu-giho/">
+  <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-serca/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-de-coracao/">
+  <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/serdechki/">
+  <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/kalp-sembolleri/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/heart-symbols/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/library-heart-symbols.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="하트 기호 ♥ 모음 — 복사해서 쓰는 하트 특수문자·이모지">
+<meta name="twitter:description" content="하트 기호와 하트 이모지, 유니코드 하트 문자를 색상·스타일별로 모았습니다. 클릭 한 번으로 복사할 수 있어요.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/library-heart-symbols.png">
+<meta property="og:title" content="하트 기호 ♥ 모음 — 복사해서 쓰는 하트 특수문자·이모지">
+<meta property="og:description" content="하트 기호와 하트 이모지, 유니코드 하트 문자를 색상·스타일별로 모았습니다. 클릭 한 번으로 복사해서 인스타 프로필과 닉네임에 바로 붙여넣으세요.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/ko/library/hateu-giho/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "name": "하트 기호 복사 모음",
+  "inLanguage": "ko",
+  "url": "https://ultratextgen.com/ko/library/hateu-giho/",
+  "description": "하트 기호·하트 이모지·유니코드 하트 문자를 무료로 복사하세요. 빨강·핑크 등 색상 하트부터 깨진 하트, 장식 하트, 텍스트 하트 기호까지 색상·스타일별로 정리해, 클릭 한 번으로 인스타·엑스·디스코드 프로필과 닉네임에 붙여넣을 수 있습니다."
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "ko",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "하트 기호란 무엇인가요?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "♥ ♡ ❥ ❦ ❧ 처럼 하트 모양을 본뜬 유니코드 문자를 말합니다. 💕 💖 같은 컬러 하트 이모지와 달리, 주변 글자와 같은 색으로 표시되는 흑백 텍스트 하트도 있어 과하지 않고 깔끔한 장식으로 쓰기 좋습니다. 모두 이미지가 아니라 문자이기 때문에 복사해서 붙여넣기만 하면 됩니다."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "하트 기호는 어디에 쓸 수 있나요?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "인스타 프로필과 이름, 엑스(옛 트위터)의 이름·게시글, 틱톡, 디스코드, 카카오톡 상태메시지, 게임 아이디·닉네임까지 텍스트를 입력할 수 있는 곳이라면 거의 어디서나 쓸 수 있습니다. 닉네임 양옆을 ♡ ♡ 로 감싸거나, 구분선으로 ⋆｡˚♡˚｡⋆ 를 넣는 것이 대표적인 닉네임 꾸미기 방법입니다."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "하트 이모지(💕)와 텍스트 하트(♡)는 무엇이 다른가요?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "💕 💖 ❤ 는 이모지라 기기마다 컬러로 크게 표시되어 눈에 잘 띕니다. ♥ ♡ ❥ 는 유니코드 특수문자라서 주변 글자와 같은 색·크기로 표시되어 은은하고 통일감 있는 감성 프로필 느낌을 줍니다. 눈에 띄게 하고 싶으면 이모지, 깔끔하게 정리하고 싶으면 텍스트 하트 기호를 쓰는 식으로 골라 쓰면 됩니다."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "컬러 하트 이모지에는 어떤 색이 있나요?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "❤ 빨강, 🧡 주황, 💛 노랑, 💚 초록, 💙 파랑, 💜 보라, 🖤 검정, 🤍 흰색, 🤎 갈색에 더해 🩷 분홍, 🩵 하늘색, 🩶 회색 같은 새 색상도 있습니다. 색마다 의미를 담거나 🌈 와 나란히 놓아 무지개로 꾸미는 것도 인기가 많습니다."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "하트 기호가 □(네모)나 '?'로 표시돼요",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "오래된 기기나 일부 앱은 최신 유니코드 기호·이모지를 지원하는 글꼴이 없어서 □(네모)로 표시될 수 있습니다. ♥ ♡ ❤ 💕 같은 기본 하트는 거의 모든 환경에서 제대로 보이므로, 특이한 기호를 쓸 때는 게시 전에 휴대폰에서 표시를 한 번 확인하면 안전합니다."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "무료인가요? 저작권은 괜찮나요?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "네, 완전히 무료입니다. 하트 기호는 유니코드 표준 문자라서 저작권 걱정 없이 몇 번이든 자유롭게 복사해서 쓸 수 있습니다. 회원가입도 필요 없습니다."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "홈",
+      "item": "https://ultratextgen.com/ko/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "하트 기호",
+      "item": "https://ultratextgen.com/ko/library/hateu-giho/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/ko/">홈</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">하트 기호</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">하트 기호 ♥ 복사 모음</h1>
+    <p class="hero-tagline">하트 이모지·유니코드 하트 문자·사랑을 나타내는 기호를 색상과 스타일별로 모았습니다. 빨강·핑크 컬러 하트부터 깨진 하트, 텍스트 하트 기호까지 — 클릭 한 번으로 복사해서 인스타 프로필과 닉네임 꾸미기에 바로 붙여넣으세요.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/library-heart-symbols.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>하트 기호는 키보드로는 바로 입력하기 어려운 유니코드 하트 문자와 이모지입니다. ❤ 💕 💖 같은 화려한 컬러 하트 이모지도, ♥ ♡ ❥ ❦ 같은 흑백 텍스트 하트도 모두 이미지가 아닌 '문자'입니다. 그래서 복사해서 붙여넣기만 하면 인스타 프로필, 엑스 이름, 틱톡, 디스코드, 게임 아이디까지 텍스트가 들어가는 곳이면 어디든 특수문자로 쓸 수 있습니다.</p>
+    <p>쓰는 법은 간단합니다. 닉네임을 ♡ ♡ 로 감싸거나, 구분선으로 ⋆｡˚♡˚｡⋆ 를 넣거나, 캡션 앞에 ❤ 하나만 놓아도 프로필의 완성도가 눈에 띄게 올라갑니다. 색상·스타일별로 정리해 두었으니 아래에서 골라 클릭(탭)해 복사하세요.</p>
+    <p>알파벳 자체도 예쁘게 꾸미고 싶다면 <a href="/ko/">폰트 변환 도구</a>와 함께 쓰는 것을 추천합니다.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- PRIDE / RAINBOW HEARTS (featured sub-group) -->
+<section class="mood-explainers" id="pride-rainbow-hearts">
+  <span class="article-section-label">무지개·프라이드</span>
+  <h2>무지개·프라이드 하트</h2>
+  <p class="u-secondary-tight">무지개와 컬러 하트를 나란히 놓은 대표 조합입니다. 다양성·응원·프라이드 게시글에서 자주 쓰여요. 하나씩 복사해도 되고, 한 줄로 묶어서 써도 됩니다.</p>
+  <div class="flag-rows">
+    <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="🌈" aria-label="🌈 복사">🌈</button><span class="flag-label">무지개</span></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="❤" aria-label="❤ 복사">❤</button><span class="flag-label">빨강</span></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="🧡" aria-label="🧡 복사">🧡</button><span class="flag-label">주황</span></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="💛" aria-label="💛 복사">💛</button><span class="flag-label">노랑</span></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="💚" aria-label="💚 복사">💚</button><span class="flag-label">초록</span></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="💙" aria-label="💙 복사">💙</button><span class="flag-label">파랑</span></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="💜" aria-label="💜 복사">💜</button><span class="flag-label">보라</span></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="🤎" aria-label="🤎 복사">🤎</button><span class="flag-label">갈색</span></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="🖤" aria-label="🖤 복사">🖤</button><span class="flag-label">검정</span></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="🤍" aria-label="🤍 복사">🤍</button><span class="flag-label">흰색</span></div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- COLOR HEARTS -->
+<section class="mood-explainers" id="color-hearts">
+  <span class="article-section-label">컬러 하트</span>
+  <h2>컬러 하트 이모지</h2>
+  <p>모든 기본 색상이 갖춰진 하트 이모지입니다. 색상마다 서로 다른 유니코드 이모지로 되어 있어요.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❤" aria-label="❤ 복사">❤</button>
+      <span class="flag-label">빨강</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧡" aria-label="🧡 복사">🧡</button>
+      <span class="flag-label">주황</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💛" aria-label="💛 복사">💛</button>
+      <span class="flag-label">노랑</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💚" aria-label="💚 복사">💚</button>
+      <span class="flag-label">초록</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💙" aria-label="💙 복사">💙</button>
+      <span class="flag-label">파랑</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💜" aria-label="💜 복사">💜</button>
+      <span class="flag-label">보라</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🖤" aria-label="🖤 복사">🖤</button>
+      <span class="flag-label">검정</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🤍" aria-label="🤍 복사">🤍</button>
+      <span class="flag-label">흰색</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🤎" aria-label="🤎 복사">🤎</button>
+      <span class="flag-label">갈색</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🩷" aria-label="🩷 복사">🩷</button>
+      <span class="flag-label">분홍</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🩵" aria-label="🩵 복사">🩵</button>
+      <span class="flag-label">하늘색</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🩶" aria-label="🩶 복사">🩶</button>
+      <span class="flag-label">회색</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- DECORATED HEARTS -->
+<section class="mood-explainers" id="decorated-hearts">
+  <span class="article-section-label">장식 하트</span>
+  <h2>장식이 있는 하트 이모지</h2>
+  <p>화살표·리본·반짝임 같은 장식이 붙은 하트, 그리고 움직임이 느껴지는 하트 이모지입니다.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💕" aria-label="💕 복사">💕</button>
+      <span class="flag-label">두 개의 하트</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💞" aria-label="💞 복사">💞</button>
+      <span class="flag-label">도는 하트</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💓" aria-label="💓 복사">💓</button>
+      <span class="flag-label">두근거리는 하트</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💗" aria-label="💗 복사">💗</button>
+      <span class="flag-label">커지는 하트</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💖" aria-label="💖 복사">💖</button>
+      <span class="flag-label">반짝이는 하트</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💘" aria-label="💘 복사">💘</button>
+      <span class="flag-label">화살 하트</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💝" aria-label="💝 복사">💝</button>
+      <span class="flag-label">리본 하트</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💟" aria-label="💟 복사">💟</button>
+      <span class="flag-label">하트 장식</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❣" aria-label="❣ 복사">❣</button>
+      <span class="flag-label">하트 느낌표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❤️‍🔥" aria-label="❤️‍🔥 복사">❤️‍🔥</button>
+      <span class="flag-label">불타는 하트</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❤️‍🩹" aria-label="❤️‍🩹 복사">❤️‍🩹</button>
+      <span class="flag-label">치유되는 하트</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- BROKEN & SPECIAL -->
+<section class="mood-explainers" id="special-hearts">
+  <span class="article-section-label">특별한 하트</span>
+  <h2>깨진 하트·특별한 하트</h2>
+  <p>이별과 상실을 나타내는 깨진 하트 이모지입니다.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💔" aria-label="💔 복사">💔</button>
+      <span class="flag-label">깨진 하트</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- LOVE & AFFECTION -->
+<section class="mood-explainers" id="love-affection">
+  <span class="article-section-label">사랑·연애 이모지</span>
+  <h2>사랑·연애를 담은 이모지</h2>
+  <p>러브레터부터 커플 기호까지, 사랑과 로맨스, 애정을 전하는 하트 모티프 이모지입니다.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💌" aria-label="💌 복사">💌</button>
+      <span class="flag-label">러브레터</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💑" aria-label="💑 복사">💑</button>
+      <span class="flag-label">하트 커플</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💏" aria-label="💏 복사">💏</button>
+      <span class="flag-label">키스</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💒" aria-label="💒 복사">💒</button>
+      <span class="flag-label">결혼식</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="😍" aria-label="😍 복사">😍</button>
+      <span class="flag-label">하트 눈</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🥰" aria-label="🥰 복사">🥰</button>
+      <span class="flag-label">하트에 둘러싸인 미소</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="😘" aria-label="😘 복사">😘</button>
+      <span class="flag-label">뽀뽀 날리기</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- UNICODE HEARTS -->
+<section class="mood-explainers" id="unicode-hearts">
+  <span class="article-section-label">유니코드 하트</span>
+  <h2>유니코드 하트 문자</h2>
+  <p>여러 유니코드 블록에서 온 대표적인 하트 문자입니다. 텍스트 하트, 꽃 하트, 활자 장식 등이 있어요.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♥" aria-label="♥ 복사">♥</button>
+      <span class="flag-label">검은 하트(카드)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♡" aria-label="♡ 복사">♡</button>
+      <span class="flag-label">흰 하트(카드)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❥" aria-label="❥ 복사">❥</button>
+      <span class="flag-label">기울어진 하트</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❦" aria-label="❦ 복사">❦</button>
+      <span class="flag-label">꽃 하트</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❧" aria-label="❧ 복사">❧</button>
+      <span class="flag-label">꽃 하트(뒤집힘)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☙" aria-label="☙ 복사">☙</button>
+      <span class="flag-label">반전 꽃 하트</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🫀" aria-label="🫀 복사">🫀</button>
+      <span class="flag-label">심장(해부학)</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- COLLECTIONS -->
+<section class="mood-explainers" id="heart-collections">
+  <span class="article-section-label">하트 세트</span>
+  <h2>바로 쓰는 하트 꾸미기 세트</h2>
+  <p class="u-secondary-block">미리 조합해 둔 하트 꾸미기 세트입니다. 클릭 한 번으로 통째로 복사해서 프로필·캡션·닉네임에 그대로 붙여넣으세요.</p>
+  <div id="heartCollectionsContainer"></div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- FAQ -->
+<section class="editorial-section" id="faq">
+  <span class="article-section-label">FAQ</span>
+  <h2>하트 기호 자주 묻는 질문</h2>
+  <details class="faq-item">
+    <summary class="faq-question">하트 기호란 무엇인가요?</summary>
+    <p class="faq-answer">♥ ♡ ❥ ❦ ❧ 처럼 하트 모양을 본뜬 유니코드 문자를 말합니다. 💕 💖 같은 컬러 하트 이모지와 달리, 주변 글자와 같은 색으로 표시되는 흑백 텍스트 하트도 있어 과하지 않고 깔끔한 장식으로 쓰기 좋습니다. 모두 이미지가 아니라 문자이기 때문에 복사해서 붙여넣기만 하면 됩니다.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">하트 기호는 어디에 쓸 수 있나요?</summary>
+    <p class="faq-answer">인스타 프로필과 이름, 엑스(옛 트위터)의 이름·게시글, 틱톡, 디스코드, 카카오톡 상태메시지, 게임 아이디·닉네임까지 텍스트를 입력할 수 있는 곳이라면 거의 어디서나 쓸 수 있습니다. 닉네임 양옆을 ♡ ♡ 로 감싸거나, 구분선으로 ⋆｡˚♡˚｡⋆ 를 넣는 것이 대표적인 닉네임 꾸미기 방법입니다.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">하트 이모지(💕)와 텍스트 하트(♡)는 무엇이 다른가요?</summary>
+    <p class="faq-answer">💕 💖 ❤ 는 이모지라 기기마다 컬러로 크게 표시되어 눈에 잘 띕니다. ♥ ♡ ❥ 는 유니코드 특수문자라서 주변 글자와 같은 색·크기로 표시되어 은은하고 통일감 있는 감성 프로필 느낌을 줍니다. 눈에 띄게 하고 싶으면 이모지, 깔끔하게 정리하고 싶으면 텍스트 하트 기호를 쓰는 식으로 골라 쓰면 됩니다.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">컬러 하트 이모지에는 어떤 색이 있나요?</summary>
+    <p class="faq-answer">❤ 빨강, 🧡 주황, 💛 노랑, 💚 초록, 💙 파랑, 💜 보라, 🖤 검정, 🤍 흰색, 🤎 갈색에 더해 🩷 분홍, 🩵 하늘색, 🩶 회색 같은 새 색상도 있습니다. 색마다 의미를 담거나 🌈 와 나란히 놓아 무지개로 꾸미는 것도 인기가 많습니다.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">하트 기호가 □(네모)나 '?'로 표시돼요</summary>
+    <p class="faq-answer">오래된 기기나 일부 앱은 최신 유니코드 기호·이모지를 지원하는 글꼴이 없어서 □(네모)로 표시될 수 있습니다. ♥ ♡ ❤ 💕 같은 기본 하트는 거의 모든 환경에서 제대로 보이므로, 특이한 기호를 쓸 때는 게시 전에 휴대폰에서 표시를 한 번 확인하면 안전합니다.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">무료로 쓸 수 있나요? 저작권은 괜찮나요?</summary>
+    <p class="faq-answer">네, 완전히 무료입니다. 하트 기호는 유니코드 표준 문자라서 저작권 걱정 없이 몇 번이든 자유롭게 복사해서 쓸 수 있습니다. 회원가입도 필요 없습니다.</p>
+  </details>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>기호만이 아니라, 글자 자체도 바꿀 수 있어요</h3>
+  <p>하트 기호로 꾸몄다면, 다음은 알파벳을 𝓒𝓾𝓽𝓮 한 필기체나 𝗕𝗼𝗹𝗱 한 굵은 글씨로. UltraTextGen이면 영문·숫자를 100가지가 넘는 예쁜 유니코드 폰트로 순식간에 변환할 수 있습니다. 무료·회원가입 불필요.</p>
+  <a href="/ko/" class="cta-btn">폰트 변환 열기 →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">관련 페이지</span>
+  <div class="compare-grid">
+    <a href="/ko/library/imotikon/" class="compare-card variant-muted u-no-underline">
+      <h4>이모티콘 모음</h4>
+      <p>텍스트로 만든 감정 이모티콘을 종류별로 복사. 프로필과 채팅 꾸미기에.</p>
+    </a>
+    <a href="/library/star-symbols/" class="compare-card variant-muted u-no-underline">
+      <h4>별 기호 모음</h4>
+      <p>별과 반짝임 문자를 다양한 유니코드 스타일로. 프로필 장식에 잘 어울려요.</p>
+    </a>
+    <a href="/library/sparkle-symbols/" class="compare-card variant-muted u-no-underline">
+      <h4>반짝임 기호 모음</h4>
+      <p>반짝임·글리터 계열 장식 기호를 종류별로 복사. 닉네임 꾸미기에.</p>
+    </a>
+    <a href="/ko/" class="compare-card variant-muted u-no-underline">
+      <h4>폰트 변환</h4>
+      <p>영문·숫자를 굵은 글씨·필기체 등 예쁜 폰트로 복사해서 변환.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    { name: "무지개 하트 줄", flags: ["❤","🧡","💛","💚","💙","💜"], defaultFormat: "inline" },
+    { name: "부드러운 하트 테두리", flags: ["⋆｡˚♡˚｡⋆"], defaultFormat: "inline" },
+    { name: "파스텔 하트 세 개", flags: ["🩷","🤍","🩵"], defaultFormat: "inline" },
+    { name: "흰 하트 닉네임 장식", flags: ["♡","˚","♡","˚","♡"], defaultFormat: "inline" },
+    { name: "반짝 러브 조합", flags: ["💕","˖","💖","˖","💞"], defaultFormat: "inline" },
+    { name: "꽃 하트 구분선", flags: ["❦","˚","｡","♡","｡","˚","❧"], defaultFormat: "inline" }
+  ];
+
+  ns.buildGrids("heartCollectionsContainer", GROUPS);
+  ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/ko/library/hwasalpyo-giho/index.html
+++ b/ko/library/hwasalpyo-giho/index.html
@@ -1,0 +1,739 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>화살표 기호 → ← ➤ 모음 — 복사해서 쓰는 특수문자 화살표</title>
+<meta name="description" content="화살표 기호와 화살표 특수문자를 방향·스타일별로 모았습니다. → ← ↑ ↓ ➤ ➜ ⇒ 같은 기호를 클릭 한 번으로 복사해 인스타 프로필, 닉네임, 디스코드에 바로 붙여넣으세요.">
+
+<link rel="canonical" href="https://ultratextgen.com/ko/library/hwasalpyo-giho/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/arrow-symbols/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/library/pfeil-symbole/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/simbolos-de-flechas/">
+  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-panah/">
+  <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/arrow-symbols/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/hwasalpyo-giho/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/setas/">
+  <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/ki-tu-mui-ten/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/arrow-symbols/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/library-arrow-symbols.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="화살표 기호 → ← ➤ 모음 — 복사해서 쓰는 특수문자 화살표">
+<meta name="twitter:description" content="화살표 기호·화살표 특수문자를 방향·스타일별로 모았습니다. 클릭 한 번으로 복사해 프로필이나 닉네임에 바로 붙여넣으세요.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/library-arrow-symbols.png">
+<meta property="og:title" content="화살표 기호 → ← ➤ 모음 — 복사해서 쓰는 특수문자 화살표">
+<meta property="og:description" content="화살표 기호와 화살표 특수문자를 방향·스타일별로 모아 클릭 한 번으로 복사할 수 있습니다. 인스타 프로필, 닉네임, 디스코드에 바로 붙여넣으세요.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/ko/library/hwasalpyo-giho/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "ko",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "화살표 기호는 무엇인가요?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "→ ← ↑ ↓ ➤ ➜ ⇒ 처럼 방향을 나타내는 유니코드 문자들을 화살표 기호라고 합니다. 그림이 아니라 문자이기 때문에 키보드로 바로 입력할 수는 없지만, 복사해서 붙여넣으면 어디서든 쓸 수 있습니다. 색이 입혀진 ➡️ 같은 화살표 이모지와 달리, → ➤ 같은 기호는 주변 글자와 같은 색으로 표시되어 깔끔하고 차분한 느낌을 줍니다."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "화살표 기호는 어디에 쓸 수 있나요?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "인스타그램 프로필과 소개글, X(트위터) 이름과 게시글, 틱톡, 디스코드, 카카오톡 상태메시지, 게임 닉네임과 아이디까지 텍스트를 입력할 수 있는 곳이면 대부분 사용할 수 있습니다. 닉네임 앞에 ➤ 를 붙이거나, 항목을 → 로 연결해 「전 → 후」처럼 흐름을 표현하는 방식이 인기 있습니다."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "화살표 기호와 화살표 이모지(➡️)는 무엇이 다른가요?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "➡️ ⬅️ ⬆️ 는 이모지라 기기마다 색과 큰 크기로 표시되어 눈에 잘 띕니다. → ← ➤ ⇒ 는 유니코드 기호 문자로, 주변 글자와 같은 색·크기로 표시되어 통일감 있고 담백한 느낌을 줍니다. 강조하고 싶을 때는 이모지, 깔끔하게 정리하고 싶을 때는 기호 문자를 쓰는 것을 추천합니다."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "화살표 기호가 □(네모)나 물음표로 표시돼요",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "오래된 기기나 일부 앱은 최신 유니코드 기호에 대응하는 폰트가 없어서 □(두부)로 보일 수 있습니다. → ← ↑ ↓ ➤ ⇒ 같은 기본 화살표는 거의 모든 환경에서 제대로 표시되므로, 화려한 기호를 쓸 때는 게시 전에 휴대폰에서 표시 상태를 한번 확인해 보세요."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "무료인가요? 저작권은 괜찮은가요?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "네, 완전히 무료입니다. 화살표 기호는 유니코드 표준 문자라서 저작권 걱정 없이 몇 번이든 자유롭게 복사해서 쓸 수 있습니다. 회원가입도 필요하지 않습니다."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "홈",
+      "item": "https://ultratextgen.com/ko/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "화살표 기호",
+      "item": "https://ultratextgen.com/ko/library/hwasalpyo-giho/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/ko/">홈</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">화살표 기호</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">화살표 기호 모음 (복사용)</h1>
+    <p class="hero-tagline">방향을 나타내는 화살표 특수문자를 스타일별로 모았습니다. → ← ↑ ↓ 같은 기본 화살표부터 굵은 화살표, 이중 화살표, 곡선 화살표, 삼각형 포인터, 화살표 이모지까지 — 클릭 한 번으로 복사해 인스타 프로필이나 닉네임에 바로 붙여넣으세요.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/library-arrow-symbols.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>화살표 기호는 키보드로는 바로 치기 어려운 유니코드 문자입니다. → ← ➤ ➜ ⇒ 같은 기호도, ➡️ ⬅️ 같은 화살표 이모지도 모두 그림이 아니라 「문자」예요. 그래서 복사해서 붙여넣기만 하면 인스타 프로필, X 이름, 틱톡, 디스코드, 게임 아이디까지 텍스트가 들어가는 곳이면 어디든 쓸 수 있습니다.</p>
+    <p>쓰는 법은 간단합니다. 닉네임 앞에 ➤ 를 붙이거나, 항목을 → 로 이어 「Before → After」 흐름을 만들거나, 목록 앞머리를 » ‣ ▸ 로 꾸미면 됩니다. 아래에 방향·스타일별로 정리해 두었으니 원하는 기호를 클릭(탭)해서 복사하세요.</p>
+    <p>알파벳 자체도 멋있게 바꾸고 싶다면 <a href="/ko/">폰트 변환 도구</a>와 함께 쓰는 것을 추천합니다.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SIMPLE DIRECTIONAL -->
+<section class="mood-explainers" id="simple-directional">
+  <span class="article-section-label">기본 방향</span>
+  <h2>기본 방향 화살표</h2>
+  <p class="u-secondary-tight">여덟 방향을 모두 가리키는 가장 기본적인 유니코드 화살표입니다.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="→" aria-label="→ 복사">→</button>
+      <span class="flag-label">오른쪽 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="←" aria-label="← 복사">←</button>
+      <span class="flag-label">왼쪽 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="↑" aria-label="↑ 복사">↑</button>
+      <span class="flag-label">위쪽 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="↓" aria-label="↓ 복사">↓</button>
+      <span class="flag-label">아래쪽 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="↗" aria-label="↗ 복사">↗</button>
+      <span class="flag-label">오른쪽 위</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="↘" aria-label="↘ 복사">↘</button>
+      <span class="flag-label">오른쪽 아래</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="↙" aria-label="↙ 복사">↙</button>
+      <span class="flag-label">왼쪽 아래</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="↖" aria-label="↖ 복사">↖</button>
+      <span class="flag-label">왼쪽 위</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="↔" aria-label="↔ 복사">↔</button>
+      <span class="flag-label">좌우 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="↕" aria-label="↕ 복사">↕</button>
+      <span class="flag-label">상하 화살표</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- BOLD & HEAVY -->
+<section class="mood-explainers" id="bold-heavy">
+  <span class="article-section-label">굵은 화살표</span>
+  <h2>굵고 진한 화살표 기호</h2>
+  <p class="u-secondary-tight">두껍고 존재감 있는 화살표로, 강조나 콜투액션(CTA) 문구에 어울립니다.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="➜" aria-label="➜ 복사">➜</button>
+      <span class="flag-label">둥근 굵은 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="➝" aria-label="➝ 복사">➝</button>
+      <span class="flag-label">중간 오른쪽 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⟶" aria-label="⟶ 복사">⟶</button>
+      <span class="flag-label">긴 오른쪽 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="➡" aria-label="➡ 복사">➡</button>
+      <span class="flag-label">오른쪽 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⬅" aria-label="⬅ 복사">⬅</button>
+      <span class="flag-label">왼쪽 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⬆" aria-label="⬆ 복사">⬆</button>
+      <span class="flag-label">위쪽 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⬇" aria-label="⬇ 복사">⬇</button>
+      <span class="flag-label">아래쪽 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="➔" aria-label="➔ 복사">➔</button>
+      <span class="flag-label">진한 오른쪽 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="➙" aria-label="➙ 복사">➙</button>
+      <span class="flag-label">점선 화살표</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- DOUBLE & FORMAL -->
+<section class="mood-explainers" id="double-formal">
+  <span class="article-section-label">이중·수학 화살표</span>
+  <h2>이중 화살표 · 격식 있는 화살표 기호</h2>
+  <p class="u-secondary-tight">이중선 화살표와 수학용 화살표. 논리, 문서, 격식 있는 글쓰기에 어울립니다.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⇒" aria-label="⇒ 복사">⇒</button>
+      <span class="flag-label">이중 오른쪽 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⇐" aria-label="⇐ 복사">⇐</button>
+      <span class="flag-label">이중 왼쪽 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⇑" aria-label="⇑ 복사">⇑</button>
+      <span class="flag-label">이중 위쪽 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⇓" aria-label="⇓ 복사">⇓</button>
+      <span class="flag-label">이중 아래쪽 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⇔" aria-label="⇔ 복사">⇔</button>
+      <span class="flag-label">이중 좌우 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⟹" aria-label="⟹ 복사">⟹</button>
+      <span class="flag-label">긴 이중 오른쪽</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⟸" aria-label="⟸ 복사">⟸</button>
+      <span class="flag-label">긴 이중 왼쪽</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⇕" aria-label="⇕ 복사">⇕</button>
+      <span class="flag-label">이중 상하 화살표</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- CURVED & RETURN -->
+<section class="mood-explainers" id="curved-return">
+  <span class="article-section-label">곡선·되돌리기</span>
+  <h2>곡선 · 되돌리기 화살표 기호</h2>
+  <p class="u-secondary-tight">답장, 되돌리기(undo), 새로고침, 순환에 쓰이는 곡선·회전 화살표입니다.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="↩" aria-label="↩ 복사">↩</button>
+      <span class="flag-label">되돌아가기 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="↪" aria-label="↪ 복사">↪</button>
+      <span class="flag-label">오른쪽 곡선 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="↺" aria-label="↺ 복사">↺</button>
+      <span class="flag-label">반시계 방향</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="↻" aria-label="↻ 복사">↻</button>
+      <span class="flag-label">시계 방향</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⤴" aria-label="⤴ 복사">⤴</button>
+      <span class="flag-label">위로 꺾인 곡선</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⤵" aria-label="⤵ 복사">⤵</button>
+      <span class="flag-label">아래로 꺾인 곡선</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="↶" aria-label="↶ 복사">↶</button>
+      <span class="flag-label">반시계 (위)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="↷" aria-label="↷ 복사">↷</button>
+      <span class="flag-label">시계 (위)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🔃" aria-label="🔃 복사">🔃</button>
+      <span class="flag-label">시계 방향 세로 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🔄" aria-label="🔄 복사">🔄</button>
+      <span class="flag-label">반시계 방향 화살표</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- TRIANGLE & POINTER -->
+<section class="mood-explainers" id="triangle-pointer">
+  <span class="article-section-label">삼각형·포인터</span>
+  <h2>삼각형 · 포인터 화살표 기호</h2>
+  <p class="u-secondary-tight">불릿(목록 앞머리), 재생 버튼, 메뉴 표시에 어울리는 삼각형·포인터 기호입니다.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="▶" aria-label="▶ 복사">▶</button>
+      <span class="flag-label">오른쪽 삼각형</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="◀" aria-label="◀ 복사">◀</button>
+      <span class="flag-label">왼쪽 삼각형</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="▲" aria-label="▲ 복사">▲</button>
+      <span class="flag-label">위쪽 삼각형</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="▼" aria-label="▼ 복사">▼</button>
+      <span class="flag-label">아래쪽 삼각형</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="►" aria-label="► 복사">►</button>
+      <span class="flag-label">오른쪽 포인터</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="◄" aria-label="◄ 복사">◄</button>
+      <span class="flag-label">왼쪽 포인터</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="➤" aria-label="➤ 복사">➤</button>
+      <span class="flag-label">오른쪽 화살촉</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‣" aria-label="‣ 복사">‣</button>
+      <span class="flag-label">삼각 불릿</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="›" aria-label="› 복사">›</button>
+      <span class="flag-label">오른쪽 홑화살괄호</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‹" aria-label="‹ 복사">‹</button>
+      <span class="flag-label">왼쪽 홑화살괄호</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⏩" aria-label="⏩ 복사">⏩</button>
+      <span class="flag-label">빨리 감기</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⏪" aria-label="⏪ 복사">⏪</button>
+      <span class="flag-label">되감기</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⏫" aria-label="⏫ 복사">⏫</button>
+      <span class="flag-label">위로 빠르게</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⏬" aria-label="⏬ 복사">⏬</button>
+      <span class="flag-label">아래로 빠르게</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- THIN & MINIMAL -->
+<section class="mood-explainers" id="thin-minimal">
+  <span class="article-section-label">얇은·미니멀</span>
+  <h2>얇고 심플한 화살표 기호</h2>
+  <p class="u-secondary-tight">가벼운 화살괄호와 미니멀한 방향 문자. 닉네임 장식이나 구분선에 잘 어울립니다.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="«" aria-label="« 복사">«</button>
+      <span class="flag-label">왼쪽 겹화살괄호</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="»" aria-label="» 복사">»</button>
+      <span class="flag-label">오른쪽 겹화살괄호</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‹" aria-label="‹ 복사">‹</button>
+      <span class="flag-label">왼쪽 홑화살괄호</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="›" aria-label="› 복사">›</button>
+      <span class="flag-label">오른쪽 홑화살괄호</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="˂" aria-label="˂ 복사">˂</button>
+      <span class="flag-label">작은 왼쪽 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="˃" aria-label="˃ 복사">˃</button>
+      <span class="flag-label">작은 오른쪽 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="˄" aria-label="˄ 복사">˄</button>
+      <span class="flag-label">작은 위쪽 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="˅" aria-label="˅ 복사">˅</button>
+      <span class="flag-label">작은 아래쪽 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⟵" aria-label="⟵ 복사">⟵</button>
+      <span class="flag-label">긴 왼쪽 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⟶" aria-label="⟶ 복사">⟶</button>
+      <span class="flag-label">긴 오른쪽 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⟷" aria-label="⟷ 복사">⟷</button>
+      <span class="flag-label">긴 좌우 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⟸" aria-label="⟸ 복사">⟸</button>
+      <span class="flag-label">긴 왼쪽 이중 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⟹" aria-label="⟹ 복사">⟹</button>
+      <span class="flag-label">긴 오른쪽 이중 화살표</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- EMOJI ARROWS -->
+<section class="mood-explainers" id="emoji-arrows">
+  <span class="article-section-label">화살표 이모지</span>
+  <h2>화살표 이모지</h2>
+  <p class="u-secondary-tight">SNS와 메시지에서 눈에 잘 띄는 컬러 화살표 이모지와 방향 아이콘입니다.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⬆️" aria-label="⬆️ 복사">⬆️</button>
+      <span class="flag-label">위쪽 화살표 이모지</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⬇️" aria-label="⬇️ 복사">⬇️</button>
+      <span class="flag-label">아래쪽 화살표 이모지</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="➡️" aria-label="➡️ 복사">➡️</button>
+      <span class="flag-label">오른쪽 화살표 이모지</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⬅️" aria-label="⬅️ 복사">⬅️</button>
+      <span class="flag-label">왼쪽 화살표 이모지</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="↕️" aria-label="↕️ 복사">↕️</button>
+      <span class="flag-label">상하 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="↔️" aria-label="↔️ 복사">↔️</button>
+      <span class="flag-label">좌우 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="↩️" aria-label="↩️ 복사">↩️</button>
+      <span class="flag-label">되돌아가기 이모지</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="↪️" aria-label="↪️ 복사">↪️</button>
+      <span class="flag-label">오른쪽 곡선 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🔄" aria-label="🔄 복사">🔄</button>
+      <span class="flag-label">반시계 방향</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🔃" aria-label="🔃 복사">🔃</button>
+      <span class="flag-label">시계 방향</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🔀" aria-label="🔀 복사">🔀</button>
+      <span class="flag-label">셔플</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🔁" aria-label="🔁 복사">🔁</button>
+      <span class="flag-label">반복</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🔂" aria-label="🔂 복사">🔂</button>
+      <span class="flag-label">한 곡 반복</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🔙" aria-label="🔙 복사">🔙</button>
+      <span class="flag-label">BACK 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🔚" aria-label="🔚 복사">🔚</button>
+      <span class="flag-label">END 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🔛" aria-label="🔛 복사">🔛</button>
+      <span class="flag-label">ON! 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🔜" aria-label="🔜 복사">🔜</button>
+      <span class="flag-label">SOON 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🔝" aria-label="🔝 복사">🔝</button>
+      <span class="flag-label">TOP 화살표</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- RIGHT ARROW VARIANTS -->
+<section class="mood-explainers" id="right-arrow-variants">
+  <span class="article-section-label">오른쪽 화살표</span>
+  <h2>오른쪽 화살표 종류 모음</h2>
+  <p>가장 많이 복사되는 오른쪽 화살표를 한곳에 모았습니다 — 얇은 것, 굵은 것, 이중, 곡선, 장식형까지. 「다음」, 「계속」, CTA 문구에 특히 자주 쓰입니다.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="→" aria-label="오른쪽 화살표 → 복사">→</button>
+      <span class="flag-label">기본</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⇒" aria-label="이중 오른쪽 화살표 ⇒ 복사">⇒</button>
+      <span class="flag-label">이중</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⟶" aria-label="긴 오른쪽 화살표 ⟶ 복사">⟶</button>
+      <span class="flag-label">긴 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="➡" aria-label="검은 오른쪽 화살표 ➡ 복사">➡</button>
+      <span class="flag-label">검은 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="➜" aria-label="둥근 굵은 화살표 ➜ 복사">➜</button>
+      <span class="flag-label">둥근 굵은</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="➤" aria-label="오른쪽 화살촉 ➤ 복사">➤</button>
+      <span class="flag-label">화살촉</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="➛" aria-label="제도용 오른쪽 화살표 ➛ 복사">➛</button>
+      <span class="flag-label">제도용</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="➠" aria-label="진한 점선 오른쪽 화살표 ➠ 복사">➠</button>
+      <span class="flag-label">점선 굵은</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="➢" aria-label="입체 오른쪽 화살촉 ➢ 복사">➢</button>
+      <span class="flag-label">입체 화살촉</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⮕" aria-label="넓은 검은 오른쪽 화살표 ⮕ 복사">⮕</button>
+      <span class="flag-label">넓은 검은</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="↪" aria-label="갈고리 오른쪽 화살표 ↪ 복사">↪</button>
+      <span class="flag-label">갈고리형</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="↦" aria-label="막대에서 나온 오른쪽 화살표 ↦ 복사">↦</button>
+      <span class="flag-label">막대에서</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- NAVIGATION & UI ARROWS -->
+<section class="mood-explainers" id="navigation-ui-arrows">
+  <span class="article-section-label">내비게이션·UI</span>
+  <h2>내비게이션 · UI에서 쓰는 화살표</h2>
+  <p>메뉴, 이동경로(breadcrumb), 슬라이드, 버튼에 자주 쓰이는 화살표입니다. 각 타일에 보통 어떤 용도로 쓰이는지 표시해 두었으니 상황에 맞는 기호를 골라 복사하세요.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="›" aria-label="이동경로 구분자로 쓰는 › 복사">›</button>
+      <span class="flag-label">이동경로 ›</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‹" aria-label="뒤로 표시로 쓰는 ‹ 복사">‹</button>
+      <span class="flag-label">뒤로 ‹</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="▸" aria-label="메뉴 항목용 작은 오른쪽 삼각형 ▸ 복사">▸</button>
+      <span class="flag-label">메뉴 항목 ▸</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="▾" aria-label="드롭다운용 작은 아래쪽 삼각형 ▾ 복사">▾</button>
+      <span class="flag-label">드롭다운 ▾</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="▴" aria-label="접기용 작은 위쪽 삼각형 ▴ 복사">▴</button>
+      <span class="flag-label">접기 ▴</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⟩" aria-label="다음 컨트롤용 오른쪽 꺾쇠 ⟩ 복사">⟩</button>
+      <span class="flag-label">다음 ⟩</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⟨" aria-label="이전 컨트롤용 왼쪽 꺾쇠 ⟨ 복사">⟨</button>
+      <span class="flag-label">이전 ⟨</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="▶" aria-label="재생 컨트롤용 오른쪽 삼각형 ▶ 복사">▶</button>
+      <span class="flag-label">재생 ▶</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⤓" aria-label="다운로드·맨아래로 이동용 화살표 ⤓ 복사">⤓</button>
+      <span class="flag-label">다운로드 ⤓</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="↑" aria-label="맨 위로 이동용 위쪽 화살표 ↑ 복사">↑</button>
+      <span class="flag-label">맨 위로 ↑</span>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>기호만이 아니라, 글자 자체도 바꿀 수 있어요</h3>
+  <p>화살표로 꾸몄다면, 다음은 알파벳을 𝗕𝗼𝗹𝗱 한 굵은 글씨나 𝓒𝓾𝓻𝓼𝓲𝓿𝓮 한 필기체로. UltraTextGen이면 영문·숫자를 100가지 이상의 멋진 유니코드 폰트로 순식간에 변환할 수 있습니다. 무료·회원가입 불필요.</p>
+  <a href="/ko/" class="cta-btn">폰트 변환 열기 →</a>
+</div>
+
+<!-- FAQ -->
+<section class="editorial-section" id="faq">
+  <span class="article-section-label">FAQ</span>
+  <h2>화살표 기호 자주 묻는 질문</h2>
+  <details class="faq-item">
+    <summary class="faq-question">화살표 기호는 무엇인가요?</summary>
+    <p class="faq-answer">→ ← ↑ ↓ ➤ ➜ ⇒ 처럼 방향을 나타내는 유니코드 문자들을 화살표 기호라고 합니다. 그림이 아니라 문자이기 때문에 키보드로 바로 입력할 수는 없지만, 복사해서 붙여넣으면 어디서든 쓸 수 있습니다. 색이 입혀진 ➡️ 같은 화살표 이모지와 달리, → ➤ 같은 기호는 주변 글자와 같은 색으로 표시되어 깔끔하고 차분한 느낌을 줍니다.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">화살표 기호는 어디에 쓸 수 있나요?</summary>
+    <p class="faq-answer">인스타그램 프로필과 소개글, X(트위터) 이름과 게시글, 틱톡, 디스코드, 카카오톡 상태메시지, 게임 닉네임과 아이디까지 텍스트를 입력할 수 있는 곳이면 대부분 사용할 수 있습니다. 닉네임 앞에 ➤ 를 붙이거나, 항목을 → 로 연결해 「전 → 후」처럼 흐름을 표현하는 방식이 인기 있습니다.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">화살표 기호와 화살표 이모지(➡️)는 무엇이 다른가요?</summary>
+    <p class="faq-answer">➡️ ⬅️ ⬆️ 는 이모지라 기기마다 색과 큰 크기로 표시되어 눈에 잘 띕니다. → ← ➤ ⇒ 는 유니코드 기호 문자로, 주변 글자와 같은 색·크기로 표시되어 통일감 있고 담백한 느낌을 줍니다. 강조하고 싶을 때는 이모지, 깔끔하게 정리하고 싶을 때는 기호 문자를 쓰는 것을 추천합니다.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">화살표 기호가 □(네모)나 물음표로 표시돼요</summary>
+    <p class="faq-answer">오래된 기기나 일부 앱은 최신 유니코드 기호에 대응하는 폰트가 없어서 □(두부)로 보일 수 있습니다. → ← ↑ ↓ ➤ ⇒ 같은 기본 화살표는 거의 모든 환경에서 제대로 표시되므로, 화려한 기호를 쓸 때는 게시 전에 휴대폰에서 표시 상태를 한번 확인해 보세요.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">무료인가요? 저작권은 괜찮은가요?</summary>
+    <p class="faq-answer">네, 완전히 무료입니다. 화살표 기호는 유니코드 표준 문자라서 저작권 걱정 없이 몇 번이든 자유롭게 복사해서 쓸 수 있습니다. 회원가입도 필요하지 않습니다.</p>
+  </details>
+</section>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">관련 페이지</span>
+  <div class="compare-grid">
+    <a href="/ko/library/hateu-giho/" class="compare-card variant-muted u-no-underline">
+      <h4>하트 기호 모음</h4>
+      <p>♥ ♡ ❤ 💕 같은 하트 기호와 하트 이모지를 색·스타일별로 복사. 프로필과 닉네임 장식에.</p>
+    </a>
+    <a href="/ko/library/imotikon/" class="compare-card variant-muted u-no-underline">
+      <h4>이모티콘 모음</h4>
+      <p>ㅋㅋ 표정부터 귀여운 텍스트 이모티콘까지 복사해서 바로 쓰는 문자 이모티콘.</p>
+    </a>
+    <a href="/ko/library/imoji-johap/" class="compare-card variant-muted u-no-underline">
+      <h4>이모지 조합</h4>
+      <p>감성·양산형 이모지 조합 모음. 프로필·캡션·닉네임에 그대로 복사해서 붙여넣기.</p>
+    </a>
+    <a href="/ko/" class="compare-card variant-muted u-no-underline">
+      <h4>폰트 변환</h4>
+      <p>영문·숫자를 굵은 글씨, 필기체, 고딕 등 멋진 유니코드 폰트로 복사 변환.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/ko/library/imoji-johap/index.html
+++ b/ko/library/imoji-johap/index.html
@@ -1,0 +1,764 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>이모지 조합 — 프로필·닉네임에 바로 쓰는 감성 이모지 세트 (복붙)</title>
+<meta name="description" content="감성 이모지 조합 100종 이상을 복사·붙여넣기로. 소녀 감성, 코티지코어, 밤하늘, Y2K 등 인스타 프로필·닉네임·캡션·디스코드 상태 메시지에 딱 맞는 이모지 세트를 탭 한 번으로 복사하세요.">
+
+<link rel="canonical" href="https://ultratextgen.com/ko/library/imoji-johap/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/emoji-combos/">
+  <link rel="alternate" hreflang="ar" href="https://ultratextgen.com/ar/library/emoji-combos/">
+  <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/emoji-combos/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/imoji-johap/">
+  <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/emoji-combos/">
+  <link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/emoji-combos/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/emoji-combos/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/library-emoji-combos.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="이모지 조합 — 프로필·닉네임에 바로 쓰는 감성 이모지 세트 (복붙)">
+<meta name="twitter:description" content="감성 이모지 조합 100종 이상. 소녀 감성, 코티지코어, 밤하늘, Y2K 등 인스타·디스코드에 딱 맞는 이모지 세트를 탭 한 번으로 복사하세요.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/library-emoji-combos.png">
+<meta property="og:title" content="이모지 조합 — 프로필·닉네임에 바로 쓰는 감성 이모지 세트 (복붙)">
+<meta property="og:description" content="감성 이모지 조합 100종 이상을 복사·붙여넣기로. 소녀 감성, 코티지코어, 밤하늘, Y2K 등 인스타 프로필·닉네임·캡션에 딱 맞는 이모지 세트를 탭 한 번으로 복사하세요.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/ko/library/imoji-johap/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "name": "이모지 조합 — 감성 이모지 세트 모음 (복붙)",
+  "inLanguage": "ko",
+  "url": "https://ultratextgen.com/ko/library/imoji-johap/",
+  "description": "감성 이모지 조합 100종 이상을 복사·붙여넣기로. 소녀 감성, 코티지코어, 밤하늘, Y2K, 그런지, 카와이 등 무드별로 정리한 이모지 세트를 탭 한 번으로 통째로 복사해 인스타 프로필·닉네임·캡션·디스코드 상태 메시지에 바로 붙여넣을 수 있습니다."
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "ko",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "이모지 조합이란 무엇인가요?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "이모지 조합은 하나의 분위기를 공유하는 이모지 몇 개를 짧게 엮은 세트입니다. 예를 들어 소녀 감성 프로필에는 🎀🌸✨, 몽환적인 밤 테마에는 🌙⭐☁️ 처럼요. 이모지 하나만 쓰는 것과 달리, 조합은 통째로 복사해서 붙여넣도록 만들어져 인스타 프로필이나 닉네임, 틱톡 캡션, 디스코드 상태 메시지를 한 번에 꾸밀 수 있습니다."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "아이폰이나 안드로이드에서 이모지 조합을 어떻게 복사하나요?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "아이폰과 안드로이드 모두, 이 페이지에서 원하는 조합을 탭하기만 하면 자동으로 클립보드에 복사됩니다. 앱 설치나 회원가입은 필요 없습니다. 그다음 인스타·틱톡·디스코드나 아무 입력창을 열고 붙여넣을 위치를 길게 눌러 '붙여넣기'를 누르세요. 모든 조합은 하나의 문자열로 복사되므로 한 번의 붙여넣기로 분위기가 통째로 들어갑니다."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "이모지 조합이 인스타·디스코드·틱톡에서도 되나요?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "네. 이 조합들은 표준 유니코드 이모지라서 인스타 프로필·캡션, 틱톡 캡션·닉네임, 디스코드 상태 메시지·채팅, 스냅챗, 왓츠앱은 물론 텍스트를 붙여넣을 수 있는 거의 모든 곳에서 제대로 표시됩니다. 아주 오래된 기기에서는 최신 이모지 일부가 네모(□)로 보일 수 있지만, 인기 있는 조합은 어디서나 잘 나옵니다."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "나만의 이모지 조합은 어떻게 만드나요?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "먼저 분위기를 정하고 그 무드를 공유하는 이모지 3~5개를 엮으세요. 부드러운 감성이라면 리본·꽃·반짝임(🎀🌸✨), 밤하늘이라면 달·별·구름(🌙⭐☁️)처럼요. 이모지 사이에 ✦ ⋆ ° 같은 텍스트 기호를 넣으면 손으로 꾸민 듯한 느낌이 납니다. 아래 섹션의 개별 이모지와 기호를 탭해서 나만의 조합을 만들고 복사해 보세요."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "홈",
+      "item": "https://ultratextgen.com/ko/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "이모지 조합",
+      "item": "https://ultratextgen.com/ko/library/imoji-johap/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/ko/">홈</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">이모지 조합</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">이모지 조합 (복붙)</h1>
+    <p class="hero-tagline">인스타 프로필·닉네임 꾸미기에 바로 쓰는 감성 이모지 조합 100종 이상 — 소녀 감성, 코티지코어, 밤하늘, Y2K 등 무드별로 정리했습니다. 원하는 조합을 탭하면 세트 전체가 한 번에 복사돼요.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/library-emoji-combos.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p><strong>이모지 조합</strong>은 하나의 분위기를 공유하는 이모지를 짧게 엮은 세트입니다. 소녀 감성 프로필의 🎀🌸✨, 몽환적인 밤 테마의 🌙⭐☁️ 처럼요. 인스타 프로필, 틱톡 캡션, 디스코드 상태 메시지, 닉네임에 순식간에 감성을 입히는 가장 빠른 방법입니다. 아래에서 무드별로 정리한 100종 이상의 조합을 둘러보고, <strong>원하는 조합을 탭해서 세트 전체를 복사</strong>한 뒤 프로필에 그대로 붙여넣으세요. 앱 설치도, 회원가입도 필요 없습니다.</p>
+    <p>한글은 유니코드 '폰트'(굵게·기울임 등)로 스타일을 바꿀 수 없지만, 이모지와 특수문자는 언어와 상관없이 어디서나 똑같이 표시됩니다. 그래서 닉네임 꾸미기나 프로필 감성 연출에는 이모지 조합과 <a href="/ko/library/hateu-giho/">하트 기호</a>, <a href="/ko/library/imotikon/">이모티콘</a> 같은 특수문자가 특히 잘 어울립니다.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- COMBOS BY AESTHETIC -->
+<section class="editorial-section" id="combos-by-aesthetic">
+  <span class="article-section-label">무드별로 찾기</span>
+  <h2>무드별 이모지 조합</h2>
+  <p class="u-secondary-block">무드별로 정리한 감성 이모지 조합입니다. 원하는 조합을 탭하면 문자열 전체가 복사되고, 프로필·캡션·닉네임·상태 메시지에 바로 붙여넣을 수 있습니다. 바로가기: <a href="#combo-soft-girl">소녀 감성</a>, <a href="#combo-cottagecore">코티지코어</a>, <a href="#combo-night-sky">밤하늘</a>, <a href="#combo-y2k">Y2K</a>, <a href="#combo-grunge">그런지</a>, <a href="#combo-kawaii">카와이</a>.</p>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SOFT GIRL -->
+<section class="mood-explainers" id="combo-soft-girl">
+  <span class="article-section-label">소녀 감성</span>
+  <h2>소녀 감성 &amp; 코켓 조합</h2>
+  <p class="u-secondary-tight">리본, 연분홍, 앙증맞은 하트로 부드럽고 사랑스러운 프로필을 완성하세요.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🎀🌸✨" aria-label="리본 &amp; 꽃 조합 복사">🎀🌸✨</button>
+      <span class="flag-label">리본 &amp; 꽃</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🩰🤍🦢" aria-label="발레 화이트 조합 복사">🩰🤍🦢</button>
+      <span class="flag-label">발레 화이트</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌷💗🎀" aria-label="튤립 크러시 조합 복사">🌷💗🎀</button>
+      <span class="flag-label">튤립 크러시</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🍓🥛🤍" aria-label="딸기 우유 조합 복사">🍓🥛🤍</button>
+      <span class="flag-label">딸기 우유</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🎀💋🪞" aria-label="러블리 미러 조합 복사">🎀💋🪞</button>
+      <span class="flag-label">러블리 미러</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌸🦋🤍" aria-label="소프트 나비 조합 복사">🌸🦋🤍</button>
+      <span class="flag-label">소프트 나비</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💗🪞🎀" aria-label="핑크 미러 조합 복사">💗🪞🎀</button>
+      <span class="flag-label">핑크 미러</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🍰🩷🫧" aria-label="스위트 버블 조합 복사">🍰🩷🫧</button>
+      <span class="flag-label">스위트 버블</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- COTTAGECORE -->
+<section class="mood-explainers" id="combo-cottagecore">
+  <span class="article-section-label">코티지코어</span>
+  <h2>코티지코어 조합</h2>
+  <p class="u-secondary-tight">버섯, 꿀, 들판의 작은 동물들로 포근한 시골 감성을 담았습니다.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🍄🌿🧺" aria-label="숲속 바구니 조합 복사">🍄🌿🧺</button>
+      <span class="flag-label">숲속 바구니</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌷🐝🍯" aria-label="꿀 정원 조합 복사">🌷🐝🍯</button>
+      <span class="flag-label">꿀 정원</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🍃🐚🤎" aria-label="흙길 산책 조합 복사">🍃🐚🤎</button>
+      <span class="flag-label">흙길 산책</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧺🍓🌼" aria-label="딸기 따기 조합 복사">🧺🍓🌼</button>
+      <span class="flag-label">딸기 따기</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🍄🐌🌧️" aria-label="비 오는 숲 조합 복사">🍄🐌🌧️</button>
+      <span class="flag-label">비 오는 숲</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌾🐑☁️" aria-label="목장의 하루 조합 복사">🌾🐑☁️</button>
+      <span class="flag-label">목장의 하루</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕯️📖🍂" aria-label="고요한 저녁 조합 복사">🕯️📖🍂</button>
+      <span class="flag-label">고요한 저녁</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌻🐝🌾" aria-label="햇살 들판 조합 복사">🌻🐝🌾</button>
+      <span class="flag-label">햇살 들판</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- NIGHT SKY -->
+<section class="mood-explainers" id="combo-night-sky">
+  <span class="article-section-label">밤하늘</span>
+  <h2>밤하늘 &amp; 별자리 조합</h2>
+  <p class="u-secondary-tight">달과 별, 구름으로 몽환적인 밤 테마를 연출하세요.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌙⭐☁️" aria-label="몽환의 밤 조합 복사">🌙⭐☁️</button>
+      <span class="flag-label">몽환의 밤</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✦⋆｡˚🌙" aria-label="별빛 조합 복사">✦⋆｡˚🌙</button>
+      <span class="flag-label">별빛</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌌🔭✨" aria-label="별 관측 조합 복사">🌌🔭✨</button>
+      <span class="flag-label">별 관측</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌙🤍🌠" aria-label="소원 별 조합 복사">🌙🤍🌠</button>
+      <span class="flag-label">소원 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⭐🪐💫" aria-label="코스믹 조합 복사">⭐🪐💫</button>
+      <span class="flag-label">코스믹</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌃🌙⭐" aria-label="도시의 밤 조합 복사">🌃🌙⭐</button>
+      <span class="flag-label">도시의 밤</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☾⋆⁺₊✧" aria-label="초승달 글로우 조합 복사">☾⋆⁺₊✧</button>
+      <span class="flag-label">초승달 글로우</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌙🦉🕯️" aria-label="밤의 부엉이 조합 복사">🌙🦉🕯️</button>
+      <span class="flag-label">밤의 부엉이</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- Y2K -->
+<section class="mood-explainers" id="combo-y2k">
+  <span class="article-section-label">Y2K</span>
+  <h2>Y2K 조합</h2>
+  <p class="u-secondary-tight">CD, 나비, 디스코 반짝임으로 2000년대 초반 사이버 감성을 살렸습니다.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💿🦋⚡" aria-label="사이버 디스크 조합 복사">💿🦋⚡</button>
+      <span class="flag-label">사이버 디스크</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🪩💖💿" aria-label="디스코 팝 조합 복사">🪩💖💿</button>
+      <span class="flag-label">디스코 팝</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✨💗🦋" aria-label="글리터 윙 조합 복사">✨💗🦋</button>
+      <span class="flag-label">글리터 윙</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⭐🌐💜" aria-label="웹 스타 조합 복사">⭐🌐💜</button>
+      <span class="flag-label">웹 스타</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💋💅✨" aria-label="글램 조합 복사">💋💅✨</button>
+      <span class="flag-label">글램</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦋🫧💿" aria-label="버블 디스크 조합 복사">🦋🫧💿</button>
+      <span class="flag-label">버블 디스크</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚡🛹🤍" aria-label="스케이터 조합 복사">⚡🛹🤍</button>
+      <span class="flag-label">스케이터</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌈🪩💫" aria-label="레이브 조합 복사">🌈🪩💫</button>
+      <span class="flag-label">레이브</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- GRUNGE -->
+<section class="mood-explainers" id="combo-grunge">
+  <span class="article-section-label">그런지</span>
+  <h2>그런지 &amp; 다크 조합</h2>
+  <p class="u-secondary-tight">체인, 시든 장미, 연기로 어둡고 무드 있는 얼터 감성을 담았습니다.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🖤⛓️🌑" aria-label="다크 체인 조합 복사">🖤⛓️🌑</button>
+      <span class="flag-label">다크 체인</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🥀🖤🕸️" aria-label="시든 장미 조합 복사">🥀🖤🕸️</button>
+      <span class="flag-label">시든 장미</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛓️🦇🌫️" aria-label="연기와 박쥐 조합 복사">⛓️🦇🌫️</button>
+      <span class="flag-label">연기와 박쥐</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕷️🖤🥀" aria-label="거미 장미 조합 복사">🕷️🖤🥀</button>
+      <span class="flag-label">거미 장미</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌧️🖤⚡" aria-label="폭풍 조합 복사">🌧️🖤⚡</button>
+      <span class="flag-label">폭풍</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🥀⛓️🤍" aria-label="페이디드 조합 복사">🥀⛓️🤍</button>
+      <span class="flag-label">페이디드</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🔪🖤💀" aria-label="엣지 조합 복사">🔪🖤💀</button>
+      <span class="flag-label">엣지</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌑🐍🖤" aria-label="베놈 조합 복사">🌑🐍🖤</button>
+      <span class="flag-label">베놈</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- KAWAII -->
+<section class="mood-explainers" id="combo-kawaii">
+  <span class="article-section-label">카와이</span>
+  <h2>카와이 조합</h2>
+  <p class="u-secondary-tight">동글동글 파스텔 톤의 귀여운 아이템으로 큐트한 프로필을 완성하세요.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🍡🌸🐰" aria-label="당고 토끼 조합 복사">🍡🌸🐰</button>
+      <span class="flag-label">당고 토끼</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧸🍓💕" aria-label="테디 베리 조합 복사">🧸🍓💕</button>
+      <span class="flag-label">테디 베리</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐰🎀🍙" aria-label="토끼 간식 조합 복사">🐰🎀🍙</button>
+      <span class="flag-label">토끼 간식</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🍓🐻🤍" aria-label="베리 베어 조합 복사">🍓🐻🤍</button>
+      <span class="flag-label">베리 베어</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌸🍡🐣" aria-label="봄 병아리 조합 복사">🌸🍡🐣</button>
+      <span class="flag-label">봄 병아리</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧁🐰💗" aria-label="컵케이크 조합 복사">🧁🐰💗</button>
+      <span class="flag-label">컵케이크</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🍮🐱🌸" aria-label="푸딩 고양이 조합 복사">🍮🐱🌸</button>
+      <span class="flag-label">푸딩 고양이</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐥🌼🤍" aria-label="소프트 병아리 조합 복사">🐥🌼🤍</button>
+      <span class="flag-label">소프트 병아리</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- FAIRYCORE -->
+<section class="mood-explainers" id="combo-fairycore">
+  <span class="article-section-label">페어리코어</span>
+  <h2>페어리코어 조합</h2>
+  <p class="u-secondary-tight">요정, 버섯, 무당벌레로 몽글몽글한 숲속 판타지를 담았습니다.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧚🍄🌿" aria-label="요정의 고리 조합 복사">🧚🍄🌿</button>
+      <span class="flag-label">요정의 고리</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦋🌸🍃" aria-label="플러터 조합 복사">🦋🌸🍃</button>
+      <span class="flag-label">플러터</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧚‍♀️✨🌷" aria-label="요정의 가루 조합 복사">🧚‍♀️✨🌷</button>
+      <span class="flag-label">요정의 가루</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🍃🐞🌼" aria-label="무당벌레 조합 복사">🍃🐞🌼</button>
+      <span class="flag-label">무당벌레</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌙🧚🍄" aria-label="밤의 요정 조합 복사">🌙🧚🍄</button>
+      <span class="flag-label">밤의 요정</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦋🌿💫" aria-label="숲의 마법 조합 복사">🦋🌿💫</button>
+      <span class="flag-label">숲의 마법</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐌🍄🌧️" aria-label="작은 세계 조합 복사">🐌🍄🌧️</button>
+      <span class="flag-label">작은 세계</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌸🧚🤍" aria-label="꽃 요정 조합 복사">🌸🧚🤍</button>
+      <span class="flag-label">꽃 요정</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- DARK ACADEMIA -->
+<section class="mood-explainers" id="combo-dark-academia">
+  <span class="article-section-label">다크 아카데미아</span>
+  <h2>다크 아카데미아 조합</h2>
+  <p class="u-secondary-tight">책, 촛불, 잉크로 학구적이고 클래식한 무드를 연출하세요.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="📚🕯️🖋️" aria-label="밤샘 공부 조합 복사">📚🕯️🖋️</button>
+      <span class="flag-label">밤샘 공부</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🖤📖☕" aria-label="늦은 독서 조합 복사">🖤📖☕</button>
+      <span class="flag-label">늦은 독서</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕯️📜🪶" aria-label="오래된 편지 조합 복사">🕯️📜🪶</button>
+      <span class="flag-label">오래된 편지</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🏛️📚🤎" aria-label="도서관 조합 복사">🏛️📚🤎</button>
+      <span class="flag-label">도서관</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☕📖🍂" aria-label="가을 독서 조합 복사">☕📖🍂</button>
+      <span class="flag-label">가을 독서</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🖋️📜🕯️" aria-label="필사본 조합 복사">🖋️📜🕯️</button>
+      <span class="flag-label">필사본</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦉📚🌙" aria-label="밤의 학자 조합 복사">🦉📚🌙</button>
+      <span class="flag-label">밤의 학자</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🤎📖🕰️" aria-label="타임리스 조합 복사">🤎📖🕰️</button>
+      <span class="flag-label">타임리스</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- OCEAN -->
+<section class="mood-explainers" id="combo-ocean">
+  <span class="article-section-label">바다</span>
+  <h2>바다 &amp; 해변 조합</h2>
+  <p class="u-secondary-tight">파도, 조개, 돌고래로 상쾌한 해변 감성을 담았습니다.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌊🐚🤍" aria-label="바닷가 조합 복사">🌊🐚🤍</button>
+      <span class="flag-label">바닷가</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐬🌊💙" aria-label="돌고래 조합 복사">🐬🌊💙</button>
+      <span class="flag-label">돌고래</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🏝️🌴☀️" aria-label="섬의 하루 조합 복사">🏝️🌴☀️</button>
+      <span class="flag-label">섬의 하루</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐚🧜‍♀️💦" aria-label="인어 조합 복사">🐚🧜‍♀️💦</button>
+      <span class="flag-label">인어</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌊⛱️🩵" aria-label="해변 블루 조합 복사">🌊⛱️🩵</button>
+      <span class="flag-label">해변 블루</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐠🪸🌊" aria-label="산호초 조합 복사">🐠🪸🌊</button>
+      <span class="flag-label">산호초</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦀🏖️🐚" aria-label="조수 웅덩이 조합 복사">🦀🏖️🐚</button>
+      <span class="flag-label">조수 웅덩이</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌅🌊🤍" aria-label="아침 서핑 조합 복사">🌅🌊🤍</button>
+      <span class="flag-label">아침 서핑</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- LOVE -->
+<section class="mood-explainers" id="combo-love">
+  <span class="article-section-label">사랑</span>
+  <h2>사랑 &amp; 하트 조합</h2>
+  <p class="u-secondary-tight">핑크, 리본, 하트로 커플·짝사랑·소녀 감성 프로필을 꾸며 보세요.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💗💕💞" aria-label="하트비트 조합 복사">💗💕💞</button>
+      <span class="flag-label">하트비트</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🤍🫶🎀" aria-label="손하트 &amp; 리본 조합 복사">🤍🫶🎀</button>
+      <span class="flag-label">손하트 &amp; 리본</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💌💋💗" aria-label="러브 레터 조합 복사">💌💋💗</button>
+      <span class="flag-label">러브 레터</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🩷💕🌷" aria-label="스위트하트 조합 복사">🩷💕🌷</button>
+      <span class="flag-label">스위트하트</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❤️‍🔥💋🌹" aria-label="패션 조합 복사">❤️‍🔥💋🌹</button>
+      <span class="flag-label">패션</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💝💗🦢" aria-label="선물 백조 조합 복사">💝💗🦢</button>
+      <span class="flag-label">선물 백조</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓆩♡𓆪" aria-label="감싼 하트 조합 복사">𓆩♡𓆪</button>
+      <span class="flag-label">감싼 하트</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌹💞💌" aria-label="로맨스 조합 복사">🌹💞💌</button>
+      <span class="flag-label">로맨스</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- STAPLES -->
+<section class="mood-explainers" id="aesthetic-staples">
+  <span class="article-section-label">기본 아이템</span>
+  <h2>감성 이모지 기본 아이템</h2>
+  <p class="u-secondary-tight">거의 모든 감성 조합에 등장하는 핵심 이모지 — 반짝임, 리본, 나비, 부드러운 하늘 요소들입니다.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✨" aria-label="반짝임 복사">✨</button>
+      <span class="flag-label">반짝임</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌸" aria-label="벚꽃 복사">🌸</button>
+      <span class="flag-label">벚꽃</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🎀" aria-label="리본 복사">🎀</button>
+      <span class="flag-label">리본</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦋" aria-label="나비 복사">🦋</button>
+      <span class="flag-label">나비</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☁️" aria-label="구름 복사">☁️</button>
+      <span class="flag-label">구름</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌷" aria-label="튤립 복사">🌷</button>
+      <span class="flag-label">튤립</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💫" aria-label="반짝이는 별 복사">💫</button>
+      <span class="flag-label">반짝이는 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🍓" aria-label="딸기 복사">🍓</button>
+      <span class="flag-label">딸기</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌙" aria-label="초승달 복사">🌙</button>
+      <span class="flag-label">초승달</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🫧" aria-label="비눗방울 복사">🫧</button>
+      <span class="flag-label">비눗방울</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SYMBOL ACCENTS -->
+<section class="mood-explainers" id="symbol-accents">
+  <span class="article-section-label">기호 악센트</span>
+  <h2>조합에 넣는 특수문자 악센트</h2>
+  <p class="u-secondary-tight">이모지 사이에 끼워 넣으면 손으로 꾸민 듯한 느낌을 주는 텍스트 기호입니다. 닉네임 꾸미기에 특히 좋아요.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♡" aria-label="흰 하트 복사">♡</button>
+      <span class="flag-label">흰 하트</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☆" aria-label="흰 별 복사">☆</button>
+      <span class="flag-label">흰 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✧" aria-label="흰 사각별 복사">✧</button>
+      <span class="flag-label">흰 사각별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✦" aria-label="검은 사각별 복사">✦</button>
+      <span class="flag-label">검은 사각별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❀" aria-label="흰 꽃 복사">❀</button>
+      <span class="flag-label">흰 꽃</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✿" aria-label="검은 꽃 복사">✿</button>
+      <span class="flag-label">검은 꽃</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⋆" aria-label="별 연산자 복사">⋆</button>
+      <span class="flag-label">작은 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="°" aria-label="도 기호 복사">°</button>
+      <span class="flag-label">도(°) 기호</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- FAQ -->
+<section class="editorial-section" id="faq">
+  <span class="article-section-label">FAQ</span>
+  <h2>이모지 조합 자주 묻는 질문</h2>
+  <details class="faq-item">
+    <summary class="faq-question">이모지 조합이란 무엇인가요?</summary>
+    <p class="faq-answer">이모지 조합은 하나의 분위기를 공유하는 이모지 몇 개를 짧게 엮은 세트입니다. 예를 들어 소녀 감성 프로필에는 🎀🌸✨, 몽환적인 밤 테마에는 🌙⭐☁️ 처럼요. 이모지 하나만 쓰는 것과 달리, 조합은 통째로 복사해서 붙여넣도록 만들어져 인스타 프로필이나 닉네임, 틱톡 캡션, 디스코드 상태 메시지를 한 번에 꾸밀 수 있습니다.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">아이폰이나 안드로이드에서 이모지 조합을 어떻게 복사하나요?</summary>
+    <p class="faq-answer">아이폰과 안드로이드 모두, 이 페이지에서 원하는 조합을 탭하기만 하면 자동으로 클립보드에 복사됩니다. 앱 설치나 회원가입은 필요 없습니다. 그다음 인스타·틱톡·디스코드나 아무 입력창을 열고 붙여넣을 위치를 길게 눌러 '붙여넣기'를 누르세요. 모든 조합은 하나의 문자열로 복사되므로 한 번의 붙여넣기로 분위기가 통째로 들어갑니다.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">이모지 조합이 인스타·디스코드·틱톡에서도 되나요?</summary>
+    <p class="faq-answer">네. 이 조합들은 표준 유니코드 이모지라서 인스타 프로필·캡션, 틱톡 캡션·닉네임, 디스코드 상태 메시지·채팅, 스냅챗, 왓츠앱은 물론 텍스트를 붙여넣을 수 있는 거의 모든 곳에서 제대로 표시됩니다. 아주 오래된 기기에서는 최신 이모지 일부가 네모(□)로 보일 수 있지만, 인기 있는 조합은 어디서나 잘 나옵니다.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">나만의 이모지 조합은 어떻게 만드나요?</summary>
+    <p class="faq-answer">먼저 분위기를 정하고 그 무드를 공유하는 이모지 3~5개를 엮으세요. 부드러운 감성이라면 리본·꽃·반짝임(🎀🌸✨), 밤하늘이라면 달·별·구름(🌙⭐☁️)처럼요. 이모지 사이에 ✦ ⋆ ° 같은 텍스트 기호를 넣으면 손으로 꾸민 듯한 느낌이 납니다. 위 섹션의 개별 이모지와 기호를 탭해서 나만의 조합을 만들고 복사해 보세요.</p>
+  </details>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>이모지로 꾸몄다면, 영문 닉네임도 폰트로</h3>
+  <p>한글은 유니코드 폰트로 스타일을 바꿀 수 없지만, 영문·숫자라면 UltraTextGen으로 굵게·필기체 등 100종 이상의 유니코드 폰트로 한 번에 변환할 수 있습니다. 무료이고 가입도 필요 없어요.</p>
+  <a href="/ko/" class="cta-btn">폰트 변환 열기 →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">관련 페이지</span>
+  <div class="compare-grid">
+    <a href="/ko/library/hateu-giho/" class="compare-card variant-muted u-no-underline">
+      <h4>하트 기호</h4>
+      <p>♥ ♡ ❥ 부터 컬러 하트 이모지까지, 프로필·닉네임 꾸미기용 하트를 복붙하세요.</p>
+    </a>
+    <a href="/ko/library/imotikon/" class="compare-card variant-muted u-no-underline">
+      <h4>이모티콘</h4>
+      <p>(｡•́︿•̀｡) 같은 텍스트 이모티콘(카오모지)을 감정별로 복사할 수 있습니다.</p>
+    </a>
+    <a href="/ko/library/discord-giho/" class="compare-card variant-muted u-no-underline">
+      <h4>디스코드 특수문자</h4>
+      <p>디스코드 닉네임·상태 메시지에 어울리는 특수문자와 기호 모음.</p>
+    </a>
+    <a href="/ko/" class="compare-card variant-muted u-no-underline">
+      <h4>폰트 변환</h4>
+      <p>영문·숫자를 굵게·필기체 등 감성 유니코드 폰트로 복붙 변환.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (ns && ns.parseTwemoji) ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/ko/library/imotikon/index.html
+++ b/ko/library/imotikon/index.html
@@ -1,0 +1,793 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>이모티콘 특수문자 모음 — 복사해서 쓰는 텍스트 얼굴 (｡•́‿•̀｡)</title>
+<meta name="description" content="(◕‿◕) ¯\_(ツ)_/¯ 같은 텍스트 이모티콘(카오모지)과 ㅋㅋ ㅠㅠ 한글 자모 이모티콘을 감정별로 모았어요. 클릭 한 번으로 복사해서 인스타·디스코드 프로필, 닉네임, 카톡, 댓글에 바로 붙여넣기.">
+
+<link rel="canonical" href="https://ultratextgen.com/ko/library/imotikon/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/text-faces-kaomoji/">
+  <link rel="alternate" hreflang="ar" href="https://ultratextgen.com/ar/library/kaomoji/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/library/kaomoji/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/library/kaomoji/">
+  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/kaomoji/">
+  <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/kaomoji/">
+  <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/text-faces-kaomoji/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/imotikon/">
+  <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/kaomoji/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/kaomoji/">
+  <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/kaomoji/">
+  <link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/kaomoji/">
+  <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/kaomoji/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/text-faces-kaomoji/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/library-text-faces-kaomoji.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="이모티콘 특수문자 모음 — 복사해서 쓰는 텍스트 얼굴 (｡•́‿•̀｡)">
+<meta name="twitter:description" content="(◕‿◕) ¯\_(ツ)_/¯ 같은 텍스트 이모티콘과 ㅋㅋ ㅠㅠ 한글 자모 이모티콘을 감정별로 모았어요. 클릭 한 번으로 복사.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/library-text-faces-kaomoji.png">
+<meta property="og:title" content="이모티콘 특수문자 모음 — 복사해서 쓰는 텍스트 얼굴 (｡•́‿•̀｡)">
+<meta property="og:description" content="(◕‿◕) ¯\_(ツ)_/¯ 같은 텍스트 이모티콘(카오모지)과 ㅋㅋ ㅠㅠ 한글 자모 이모티콘을 감정별로 모았어요. 클릭 한 번으로 복사해서 인스타·디스코드 프로필과 닉네임에 붙여넣기.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/ko/library/imotikon/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "name": "이모티콘 특수문자 모음 (텍스트 얼굴 · 카오모지)",
+  "alternateName": ["이모티콘 특수문자", "텍스트 이모티콘", "카오모지 복사", "얼굴 특수문자", "ㅋㅋ ㅠㅠ 이모티콘", "일본식 이모티콘", "닉네임 이모티콘"],
+  "url": "https://ultratextgen.com/ko/library/imotikon/",
+  "inLanguage": "ko",
+  "description": "(◕‿◕) ¯\\_(ツ)_/¯ (｡•́︿•̀｡) 같은 텍스트 이모티콘(카오모지)과 ㅋㅋ ㅠㅠ 한글 자모 이모티콘을 기쁨·슬픔·귀여움·화남 등 감정별로 정리했어요. 그림이 아니라 유니코드 문자라서, 클릭 한 번으로 복사해 인스타·디스코드 프로필과 닉네임, 카톡, 댓글에 그대로 붙여넣을 수 있습니다.",
+  "isPartOf": {
+    "@type": "WebSite",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  }
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "홈",
+      "item": "https://ultratextgen.com/ko/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "이모티콘 특수문자",
+      "item": "https://ultratextgen.com/ko/library/imotikon/"
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "ko",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "이모티콘 특수문자가 뭔가요?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "(◕‿◕), ¯\\_(ツ)_/¯, (｡•́︿•̀｡) 처럼 키보드 기호와 유니코드 문자를 조합해 만든 작은 '텍스트 얼굴'이에요. 일본에서는 카오모지(顔文字)라고 부릅니다. 😀 같은 이모지(그림 문자)와 달리 옆으로 눕히지 않고 똑바로 세워서 읽기 때문에 눈·입·팔이 한눈에 보여요. 전부 그림이 아니라 문자라서 복사해서 붙여넣기만 하면 어디서나 그대로 표시됩니다."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "이모티콘 특수문자는 어디에 쓸 수 있나요?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "인스타 프로필·소개, 디스코드 닉네임과 채팅, 카카오톡, 트위터(X), 틱톡, 유튜브 댓글, 게임 아이디까지 텍스트를 입력할 수 있는 곳이면 거의 어디서나 붙여넣을 수 있어요. 닉네임 꾸미기용으로 이름 양옆을 ꒰ ꒱ 로 감싸거나 문장 끝에 (๑˃ᴗ˂)ﻭ 를 붙이는 식으로 많이 씁니다."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "ㅋㅋ, ㅠㅠ 같은 한글 이모티콘도 이모티콘 특수문자인가요?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "네. ㅋㅋ(웃음), ㅠㅠ·ㅜㅜ(울음), ㅎㅎ, ㄷㄷ(덜덜), ㅇㅇ 처럼 한글 자음·모음(자모)만으로 감정을 표현하는 것도 한국식 텍스트 이모티콘이에요. 일본식 카오모지가 얼굴 모양을 그린다면, 한글 자모 이모티콘은 소리와 느낌을 자모로 나타낸다는 점이 다릅니다. 이 페이지에는 두 가지를 모두 정리해 두었어요."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "이모티콘과 이모지(😀)는 뭐가 다른가요?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "이모지는 기기의 이모지 폰트로 그려지는 컬러 그림 문자 하나(😀)이고, 텍스트 이모티콘은 (≧◡≦) 처럼 평범한 문자들을 조합해 똑바로 세워 읽는 얼굴이에요. 텍스트 이모티콘은 미묘한 감정을 더 자유롭게 표현할 수 있고, 표준 유니코드 문자로 만들어져 어느 기기에서든 같은 모양으로 보입니다."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "무료인가요? 저작권은 괜찮나요?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "네, 완전 무료예요. 이모티콘 특수문자는 유니코드 표준 문자라서 저작권 걱정 없이 몇 번이든 자유롭게 복사해 쓸 수 있고, 회원가입도 필요 없습니다."
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/ko/">홈</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">이모티콘 특수문자</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">이모티콘 특수문자 모음 (복사·붙여넣기)</h1>
+    <p class="hero-tagline">(◕‿◕) ¯\_(ツ)_/¯ 같은 텍스트 이모티콘(카오모지)과 ㅋㅋ ㅠㅠ 한글 자모 이모티콘을 감정별로 정리했어요. 기쁨·슬픔·귀여움·화남·졸림까지 — 원하는 얼굴을 클릭하면 바로 복사됩니다. 인스타·디스코드 프로필, 닉네임 꾸미기, 카톡, 댓글에 그대로 붙여넣으세요.</p>
+  </div>
+</section>
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>이모티콘 특수문자는 키보드 기호와 유니코드 문자를 조합해 만든 작은 '텍스트 얼굴'이에요. 일본에서 시작돼 <em>카오모지</em>(顔文字, "얼굴 문자")라고도 불립니다. 😀 같은 이모지(그림 문자)와 달리 옆으로 눕히지 않고 똑바로 세워서 읽기 때문에 눈·입, 심지어 팔까지 한눈에 알아볼 수 있어요. 서양식 <code>:-)</code> 이모티콘이 옆으로 누워 있다면, <code>(◕‿◕)</code> 같은 카오모지는 정면을 바라봅니다.</p>
+    <p>여기 있는 이모티콘은 전부 그림이나 이모지 폰트가 아니라 순수한 유니코드 <strong>문자</strong>예요. 그래서 복사해서 붙여넣기만 하면 인스타 프로필, 디스코드 닉네임, 카카오톡, 트위터(X), 틱톡, 유튜브 댓글, 게임 아이디까지 텍스트가 들어가는 곳이면 어디서나 깨지지 않고 그대로 표시됩니다. 닉네임 꾸미기용으로 이름 양옆을 <code>꒰ ꒱</code> 로 감싸거나 문장 끝에 얼굴 하나만 붙여도 분위기가 확 살아나요.</p>
+    <p>한국에서는 이런 일본식 얼굴 이모티콘과 함께, <code>ㅋㅋ</code>(웃음)·<code>ㅠㅠ</code>(울음)처럼 <strong>한글 자모</strong>만으로 감정을 나타내는 이모티콘도 많이 씁니다. 아래 마지막 섹션에 한글 자모 이모티콘도 따로 모아 두었으니 함께 확인해 보세요. 감정별로 정리했으니, 아래에서 마음에 드는 얼굴을 클릭(탭)해서 복사하면 됩니다.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- HAPPY & POSITIVE -->
+<section class="mood-explainers" id="happy-positive">
+  <span class="article-section-label">기쁨 · 긍정</span>
+  <h2>기쁘고 신나는 이모티콘</h2>
+  <p class="u-secondary-tight">밝고 즐거운 분위기의 텍스트 얼굴. 기분 좋은 메시지나 신난 리액션에 잘 어울려요.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="◕‿◕" aria-label="◕‿◕ 복사">◕‿◕</button>
+      <span class="flag-label">웃는 얼굴</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(◠‿◠)" aria-label="(◠‿◠) 복사">(◠‿◠)</button>
+      <span class="flag-label">미소</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="╰(▔∀▔)╯" aria-label="╰(▔∀▔)╯ 복사">╰(▔∀▔)╯</button>
+      <span class="flag-label">신난 춤</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(✿◠‿◠)" aria-label="(✿◠‿◠) 복사">(✿◠‿◠)</button>
+      <span class="flag-label">꽃 미소</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ヽ(•‿•)ノ" aria-label="ヽ(•‿•)ノ 복사">ヽ(•‿•)ノ</button>
+      <span class="flag-label">만세</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(^▽^)" aria-label="(^▽^) 복사">(^▽^)</button>
+      <span class="flag-label">활짝 웃음</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(≧◡≦)" aria-label="(≧◡≦) 복사">(≧◡≦)</button>
+      <span class="flag-label">아주 기쁨</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="٩(◕‿◕)۶" aria-label="٩(◕‿◕)۶ 복사">٩(◕‿◕)۶</button>
+      <span class="flag-label">축하 · 환호</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SAD & UPSET -->
+<section class="mood-explainers" id="sad-upset">
+  <span class="article-section-label">슬픔 · 속상함</span>
+  <h2>슬프고 우는 이모티콘</h2>
+  <p class="u-secondary-tight">눈물, 울음, 속상한 마음을 담은 텍스트 얼굴.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="╥﹏╥" aria-label="╥﹏╥ 복사">╥﹏╥</button>
+      <span class="flag-label">우는 얼굴</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(╯︵╰,)" aria-label="(╯︵╰,) 복사">(╯︵╰,)</button>
+      <span class="flag-label">서러움</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ಥ_ಥ" aria-label="ಥ_ಥ 복사">ಥ_ಥ</button>
+      <span class="flag-label">그렁그렁한 눈</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(;﹏;)" aria-label="(;﹏;) 복사">(;﹏;)</button>
+      <span class="flag-label">흐느낌</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(T_T)" aria-label="(T_T) 복사">(T_T)</button>
+      <span class="flag-label">엉엉</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(｡•́︿•̀｡)" aria-label="(｡•́︿•̀｡) 복사">(｡•́︿•̀｡)</button>
+      <span class="flag-label">시무룩</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SHRUG & CONFUSION -->
+<section class="mood-explainers" id="shrug-confusion">
+  <span class="article-section-label">글쎄 · 당황</span>
+  <h2>어깨 으쓱 · 멍한 이모티콘</h2>
+  <p class="u-secondary-tight">"몰라~", 당황, 무표정을 나타내는 텍스트 얼굴.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="¯\_(ツ)_/¯" aria-label="¯\_(ツ)_/¯ 복사">¯\_(ツ)_/¯</button>
+      <span class="flag-label">어깨 으쓱 (몰라)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ಠ_ಠ" aria-label="ಠ_ಠ 복사">ಠ_ಠ</button>
+      <span class="flag-label">못마땅한 눈빛</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(⊙_⊙)" aria-label="(⊙_⊙) 복사">(⊙_⊙)</button>
+      <span class="flag-label">동그란 눈</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(°ロ°)!" aria-label="(°ロ°)! 복사">(°ロ°)!</button>
+      <span class="flag-label">깜짝 놀람</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(￣_￣|||)" aria-label="(￣_￣|||) 복사">(￣_￣|||)</button>
+      <span class="flag-label">식은땀 · 어색</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(¬_¬)" aria-label="(¬_¬) 복사">(¬_¬)</button>
+      <span class="flag-label">째려봄</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- LOVE & AFFECTION -->
+<section class="mood-explainers" id="love-affection">
+  <span class="article-section-label">사랑 · 애정</span>
+  <h2>사랑 · 애정 이모티콘</h2>
+  <p class="u-secondary-tight">설렘과 애정을 담은 텍스트 얼굴.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(♥ω♥)" aria-label="(♥ω♥) 복사">(♥ω♥)</button>
+      <span class="flag-label">하트 눈</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(◍•ᴗ•◍)❤" aria-label="(◍•ᴗ•◍)❤ 복사">(◍•ᴗ•◍)❤</button>
+      <span class="flag-label">사랑스러운 얼굴</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(≧◡≦)" aria-label="(≧◡≦) 복사">(≧◡≦)</button>
+      <span class="flag-label">행복 만끽</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(✿ ♥‿♥)" aria-label="(✿ ♥‿♥) 복사">(✿ ♥‿♥)</button>
+      <span class="flag-label">꽃과 하트</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(⁄ ⁄•⁄ω⁄•⁄ ⁄)" aria-label="(⁄ ⁄•⁄ω⁄•⁄ ⁄) 복사">(⁄ ⁄•⁄ω⁄•⁄ ⁄)</button>
+      <span class="flag-label">부끄부끄</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♡(˃͈ દ ˂͈ ༶ )" aria-label="♡(˃͈ દ ˂͈ ༶ ) 복사">♡(˃͈ દ ˂͈ ༶ )</button>
+      <span class="flag-label">수줍은 하트 눈</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- ANIMALS & CREATURES -->
+<section class="mood-explainers" id="animals-creatures">
+  <span class="article-section-label">동물 · 캐릭터</span>
+  <h2>귀여운 동물 이모티콘</h2>
+  <p class="u-secondary-tight">메시지와 SNS에 딱 좋은 귀여운 동물 텍스트 얼굴.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ʕ•ᴥ•ʔ" aria-label="ʕ•ᴥ•ʔ 복사">ʕ•ᴥ•ʔ</button>
+      <span class="flag-label">곰</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(=^・ω・^=)" aria-label="(=^・ω・^=) 복사">(=^・ω・^=)</button>
+      <span class="flag-label">고양이</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(◕ᴗ◕✿)" aria-label="(◕ᴗ◕✿) 복사">(◕ᴗ◕✿)</button>
+      <span class="flag-label">귀여운 캐릭터</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(U ᵕ U❁)" aria-label="(U ᵕ U❁) 복사">(U ᵕ U❁)</button>
+      <span class="flag-label">토끼</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="∩｡• ᵕ •｡∩" aria-label="∩｡• ᵕ •｡∩ 복사">∩｡• ᵕ •｡∩</button>
+      <span class="flag-label">강아지</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(^•ω•^)" aria-label="(^•ω•^) 복사">(^•ω•^)</button>
+      <span class="flag-label">행복한 반려동물</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- ACTION & EXPRESSION -->
+<section class="mood-explainers" id="action-expression">
+  <span class="article-section-label">동작 · 리액션</span>
+  <h2>동작 · 리액션 이모티콘</h2>
+  <p class="u-secondary-tight">움직임, 답답함, 오버 리액션까지 표현하는 텍스트 얼굴.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ᕕ(ᐛ)ᕗ" aria-label="ᕕ(ᐛ)ᕗ 복사">ᕕ(ᐛ)ᕗ</button>
+      <span class="flag-label">신나게 달리기</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(╯°□°）╯︵ ┻━┻" aria-label="(╯°□°）╯︵ ┻━┻ 복사">(╯°□°）╯︵ ┻━┻</button>
+      <span class="flag-label">책상 엎기 (분노)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="┬─┬ノ(º_ºノ)" aria-label="┬─┬ノ(º_ºノ) 복사">┬─┬ノ(º_ºノ)</button>
+      <span class="flag-label">책상 다시 놓기</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(ノ°▽°)ノ" aria-label="(ノ°▽°)ノ 복사">(ノ°▽°)ノ</button>
+      <span class="flag-label">두 팔 번쩍</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(づ｡◕‿‿◕｡)づ" aria-label="(づ｡◕‿‿◕｡)づ 복사">(づ｡◕‿‿◕｡)づ</button>
+      <span class="flag-label">안아주기</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(ˆ_ˆ)/" aria-label="(ˆ_ˆ)/ 복사">(ˆ_ˆ)/</button>
+      <span class="flag-label">손 흔들기</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- LENNY FACES -->
+<section class="mood-explainers" id="lenny-faces">
+  <span class="article-section-label">레니 페이스 · 능글</span>
+  <h2>레니 페이스 (Lenny Face)</h2>
+  <p class="u-secondary-tight">전설의 레니 페이스와 능글맞은 · 윙크 · 팔 올린 변형들. 얼굴 하나가 통째로 복사됩니다.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="( ͡° ͜ʖ ͡°)" aria-label="( ͡° ͜ʖ ͡°) 복사">( ͡° ͜ʖ ͡°)</button>
+      <span class="flag-label">기본 레니</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="( ͠° ͟ʖ ͡°)" aria-label="( ͠° ͟ʖ ͡°) 복사">( ͠° ͟ʖ ͡°)</button>
+      <span class="flag-label">강렬한 레니</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="( ͡~ ͜ʖ ͡°)" aria-label="( ͡~ ͜ʖ ͡°) 복사">( ͡~ ͜ʖ ͡°)</button>
+      <span class="flag-label">윙크 레니</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="( ͡ʘ ͜ʖ ͡ʘ)" aria-label="( ͡ʘ ͜ʖ ͡ʘ) 복사">( ͡ʘ ͜ʖ ͡ʘ)</button>
+      <span class="flag-label">놀란 레니</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="( ͡◉ ͜ʖ ͡◉)" aria-label="( ͡◉ ͜ʖ ͡◉) 복사">( ͡◉ ͜ʖ ͡◉)</button>
+      <span class="flag-label">큰 눈 레니</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="( ͡⊙ ͜ʖ ͡⊙)" aria-label="( ͡⊙ ͜ʖ ͡⊙) 복사">( ͡⊙ ͜ʖ ͡⊙)</button>
+      <span class="flag-label">동그란 눈 레니</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="¯\_( ͡° ͜ʖ ͡°)_/¯" aria-label="¯\_( ͡° ͜ʖ ͡°)_/¯ 복사">¯\_( ͡° ͜ʖ ͡°)_/¯</button>
+      <span class="flag-label">레니 으쓱</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="( ͡° ͜ʖ ͡°)╭∩╮" aria-label="( ͡° ͜ʖ ͡°)╭∩╮ 복사">( ͡° ͜ʖ ͡°)╭∩╮</button>
+      <span class="flag-label">까칠한 레니</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="( ͡° ͜ʖ ͡°)つ──☆*:・ﾟ" aria-label="( ͡° ͜ʖ ͡°)つ──☆*:・ﾟ 복사">( ͡° ͜ʖ ͡°)つ──☆*:・ﾟ</button>
+      <span class="flag-label">마법 레니</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- LAUGHING & CRYING-LAUGHING -->
+<section class="mood-explainers" id="laughing-crying">
+  <span class="article-section-label">웃음 · 빵 터짐</span>
+  <h2>웃음 · 빵 터지는 이모티콘</h2>
+  <p class="u-secondary-tight">크게 웃거나 눈물 나게 웃는 텍스트 얼굴 — 웃겨 죽는 이모지의 카오모지 버전이에요.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(≧▽≦)" aria-label="(≧▽≦) 복사">(≧▽≦)</button>
+      <span class="flag-label">웃음</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(＾▽＾)" aria-label="(＾▽＾) 복사">(＾▽＾)</button>
+      <span class="flag-label">함박웃음</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="( ´∀｀)" aria-label="( ´∀｀) 복사">( ´∀｀)</button>
+      <span class="flag-label">호탕한 웃음</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(*≧艸≦)" aria-label="(*≧艸≦) 복사">(*≧艸≦)</button>
+      <span class="flag-label">킥킥</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ｗｗｗ" aria-label="ｗｗｗ 복사">ｗｗｗ</button>
+      <span class="flag-label">일본식 ㅋㅋㅋ</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(笑)" aria-label="(笑) 복사">(笑)</button>
+      <span class="flag-label">웃음 표시</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="＼(^o^)／" aria-label="＼(^o^)／ 복사">＼(^o^)／</button>
+      <span class="flag-label">환희</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(T▽T)" aria-label="(T▽T) 복사">(T▽T)</button>
+      <span class="flag-label">감동의 눈물</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(;´∀｀)" aria-label="(;´∀｀) 복사">(;´∀｀)</button>
+      <span class="flag-label">멋쩍은 웃음</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- COLLECTIONS -->
+<section class="mood-explainers" id="kaomoji-collections">
+  <span class="article-section-label">이모티콘 세트</span>
+  <h2>그대로 쓰는 이모티콘 세트</h2>
+  <p class="u-secondary-block">감정별로 묶어 둔 이모티콘 세트예요. 관련된 얼굴들을 클릭 한 번으로 통째로 복사해서 채팅·캡션·댓글에 붙여넣을 수 있습니다.</p>
+  <div id="kaomojiCollectionsContainer"></div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- HUG EMOTICON -->
+<section class="mood-explainers" id="hug-emoticon">
+  <span class="article-section-label">안아주기</span>
+  <h2>안아주는 이모티콘</h2>
+  <p class="u-secondary-tight">팔을 벌려 안아주는 카오모지 모음 — 텍스트로 보내는 포옹이에요.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(っ´▽｀)っ" aria-label="(っ´▽｀)っ 복사">(っ´▽｀)っ</button>
+      <span class="flag-label">다가와 안기</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊂((・▽・))⊃" aria-label="⊂((・▽・))⊃ 복사">⊂((・▽・))⊃</button>
+      <span class="flag-label">꽉 안기</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(っ◕‿◕)っ" aria-label="(っ◕‿◕)っ 복사">(っ◕‿◕)っ</button>
+      <span class="flag-label">귀여운 포옹</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⸜(｡˃ ᵕ ˂ )⸝♡" aria-label="⸜(｡˃ ᵕ ˂ )⸝♡ 복사">⸜(｡˃ ᵕ ˂ )⸝♡</button>
+      <span class="flag-label">행복한 포옹</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(つ≧▽≦)つ" aria-label="(つ≧▽≦)つ 복사">(つ≧▽≦)つ</button>
+      <span class="flag-label">신난 포옹</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- CAT EYES KAOMOJI -->
+<section class="mood-explainers" id="cat-eyes-kaomoji">
+  <span class="article-section-label">고양이 눈 · 큰 눈</span>
+  <h2>고양이 눈 · 반짝이는 눈 이모티콘</h2>
+  <p class="u-secondary-tight">크고 반짝이는 눈이 포인트인 카오모지 — 고양이 얼굴과 초롱초롱한 큰 눈 표정.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(=^‥^=)" aria-label="(=^‥^=) 복사">(=^‥^=)</button>
+      <span class="flag-label">고양이 눈</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(=｀ω´=)" aria-label="(=｀ω´=) 복사">(=｀ω´=)</button>
+      <span class="flag-label">얄미운 고양이</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(✿◕‿◕)" aria-label="(✿◕‿◕) 복사">(✿◕‿◕)</button>
+      <span class="flag-label">초롱초롱 큰 눈</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(◕ᴥ◕)" aria-label="(◕ᴥ◕) 복사">(◕ᴥ◕)</button>
+      <span class="flag-label">동그란 눈</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(ↀᴥↀ)" aria-label="(ↀᴥↀ) 복사">(ↀᴥↀ)</button>
+      <span class="flag-label">왕방울 고양이 눈</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- ANGRY & RAGE -->
+<section class="mood-explainers" id="angry-rage">
+  <span class="article-section-label">화남 · 분노</span>
+  <h2>화나고 짜증나는 이모티콘</h2>
+  <p class="u-secondary-tight">답답함, 분노, 못마땅함까지 — 살짝 치켜뜬 눈부터 책상 엎기까지.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(╬ Ò﹏Ó)" aria-label="(╬ Ò﹏Ó) 복사">(╬ Ò﹏Ó)</button>
+      <span class="flag-label">격노</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ಠ_ಠ" aria-label="ಠ_ಠ 복사">ಠ_ಠ</button>
+      <span class="flag-label">못마땅한 응시</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(# ゚Д゚)" aria-label="(# ゚Д゚) 복사">(# ゚Д゚)</button>
+      <span class="flag-label">짜증</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ヽ(`Д´)ﾉ" aria-label="ヽ(`Д´)ﾉ 복사">ヽ(`Д´)ﾉ</button>
+      <span class="flag-label">화내며 소리치기</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="눈_눈" aria-label="눈_눈 복사">눈_눈</button>
+      <span class="flag-label">째리는 눈빛 (한글)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(¬_¬)" aria-label="(¬_¬) 복사">(¬_¬)</button>
+      <span class="flag-label">시큰둥</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SLEEPY & SLEEPING -->
+<section class="mood-explainers" id="sleepy-sleeping">
+  <span class="article-section-label">졸림 · 잠</span>
+  <h2>졸리고 자는 이모티콘</h2>
+  <p class="u-secondary-tight">몽롱한 눈, 꾸벅꾸벅, 곤히 잠든 모습 — 잘 자 인사나 피곤한 리액션에 딱이에요.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(-_-) zzZ" aria-label="(-_-) zzZ 복사">(-_-) zzZ</button>
+      <span class="flag-label">자는 중</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(ᴗ˳ᴗ)" aria-label="(ᴗ˳ᴗ) 복사">(ᴗ˳ᴗ)</button>
+      <span class="flag-label">졸린 눈</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(∪。∪)。。。zzz" aria-label="(∪。∪)。。。zzz 복사">(∪。∪)。。。zzz</button>
+      <span class="flag-label">깊은 잠</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(︶.︶✽)" aria-label="(︶.︶✽) 복사">(︶.︶✽)</button>
+      <span class="flag-label">꾸벅꾸벅</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="( ˘ω˘ )" aria-label="( ˘ω˘ ) 복사">( ˘ω˘ )</button>
+      <span class="flag-label">나른함</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- MUSIC & SINGING -->
+<section class="mood-explainers" id="music-singing">
+  <span class="article-section-label">음악 · 노래</span>
+  <h2>음악 · 노래 이모티콘</h2>
+  <p class="u-secondary-tight">흥얼거리기, 노래 따라 부르기, 리듬 타기를 표현하는 카오모지.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♪(´▽｀)" aria-label="♪(´▽｀) 복사">♪(´▽｀)</button>
+      <span class="flag-label">노래 따라 부르기</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(っ˘ω˘)♪" aria-label="(っ˘ω˘)♪ 복사">(っ˘ω˘)♪</button>
+      <span class="flag-label">흥얼흥얼</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ヽ(´▽`)/♪" aria-label="ヽ(´▽`)/♪ 복사">ヽ(´▽`)/♪</button>
+      <span class="flag-label">신나게 노래</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(๑✧∀✧๑)♪" aria-label="(๑✧∀✧๑)♪ 복사">(๑✧∀✧๑)♪</button>
+      <span class="flag-label">음악에 설렘</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♪~(´ε` )" aria-label="♪~(´ε` ) 복사">♪~(´ε` )</button>
+      <span class="flag-label">휘파람</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- KOREAN JAMO EMOTICONS -->
+<section class="mood-explainers" id="hangul-jamo">
+  <span class="article-section-label">한글 자모 이모티콘</span>
+  <h2>ㅋㅋ · ㅠㅠ 한글 이모티콘</h2>
+  <p class="u-secondary-tight">한국에서만 통하는 한글 자모 이모티콘이에요. 얼굴 모양 대신, 자음·모음으로 웃음·울음·떨림 같은 느낌을 나타냅니다. 카톡·디시·트위터에서 매일 쓰는 것들이에요.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ㅋㅋㅋ" aria-label="ㅋㅋㅋ 복사">ㅋㅋㅋ</button>
+      <span class="flag-label">웃음 (ㅋㅋ)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ㅎㅎ" aria-label="ㅎㅎ 복사">ㅎㅎ</button>
+      <span class="flag-label">잔잔한 웃음</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ㅠㅠ" aria-label="ㅠㅠ 복사">ㅠㅠ</button>
+      <span class="flag-label">울음 (ㅠㅠ)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ㅜㅜ" aria-label="ㅜㅜ 복사">ㅜㅜ</button>
+      <span class="flag-label">울음 (ㅜㅜ)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ㅡㅡ" aria-label="ㅡㅡ 복사">ㅡㅡ</button>
+      <span class="flag-label">시큰둥 · 못마땅</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ㄷㄷ" aria-label="ㄷㄷ 복사">ㄷㄷ</button>
+      <span class="flag-label">덜덜 (놀람)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ㅗㅗ" aria-label="ㅗㅗ 복사">ㅗㅗ</button>
+      <span class="flag-label">비꼼</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ㅇㅇ" aria-label="ㅇㅇ 복사">ㅇㅇ</button>
+      <span class="flag-label">응응 (긍정)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ㅂㅂ" aria-label="ㅂㅂ 복사">ㅂㅂ</button>
+      <span class="flag-label">바이바이</span>
+    </div>
+  </div>
+  <p class="u-secondary-tight">얼굴형 이모티콘과 섞어 쓰면 더 생생해요. 예: <code>ㅠㅠ (｡•́︿•̀｡)</code>, <code>ㅋㅋ (≧▽≦)</code></p>
+</section>
+
+<!-- FAQ -->
+<section class="editorial-section" id="faq">
+  <span class="article-section-label">FAQ</span>
+  <h2>이모티콘 특수문자 자주 묻는 질문</h2>
+  <details class="faq-item">
+    <summary class="faq-question">이모티콘 특수문자가 뭔가요?</summary>
+    <p class="faq-answer">(◕‿◕), ¯\_(ツ)_/¯, (｡•́︿•̀｡) 처럼 키보드 기호와 유니코드 문자를 조합해 만든 작은 '텍스트 얼굴'이에요. 일본에서는 <strong>카오모지</strong>(顔文字)라고 부릅니다. 😀 같은 이모지(그림 문자)와 달리 옆으로 눕히지 않고 똑바로 세워서 읽기 때문에 눈·입·팔이 한눈에 보여요. 전부 그림이 아니라 문자라서, 복사해서 붙여넣기만 하면 어디서나 그대로 표시됩니다.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">이모티콘 특수문자는 어디에 쓸 수 있나요?</summary>
+    <p class="faq-answer">인스타 프로필·소개, 디스코드 닉네임과 채팅, 카카오톡, 트위터(X), 틱톡, 유튜브 댓글, 게임 아이디까지 텍스트를 입력할 수 있는 곳이면 거의 어디서나 붙여넣을 수 있어요. 닉네임 꾸미기용으로 이름 양옆을 <code>꒰ ꒱</code> 로 감싸거나 문장 끝에 <code>(๑˃ᴗ˂)ﻭ</code> 를 붙이는 식으로 많이 씁니다.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">ㅋㅋ, ㅠㅠ 같은 한글 이모티콘도 이모티콘 특수문자인가요?</summary>
+    <p class="faq-answer">네. <code>ㅋㅋ</code>(웃음), <code>ㅠㅠ</code>·<code>ㅜㅜ</code>(울음), <code>ㅎㅎ</code>, <code>ㄷㄷ</code>(덜덜), <code>ㅇㅇ</code> 처럼 한글 자음·모음(자모)만으로 감정을 표현하는 것도 한국식 텍스트 이모티콘이에요. 일본식 카오모지가 얼굴 모양을 그린다면, 한글 자모 이모티콘은 소리와 느낌을 자모로 나타낸다는 점이 다릅니다. 이 페이지에는 두 가지를 모두 정리해 두었어요.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">이모티콘과 이모지(😀)는 뭐가 다른가요?</summary>
+    <p class="faq-answer">이모지는 기기의 이모지 폰트로 그려지는 컬러 그림 문자 하나(😀)이고, 텍스트 이모티콘은 <code>(≧◡≦)</code> 처럼 평범한 문자들을 조합해 똑바로 세워 읽는 얼굴이에요. 텍스트 이모티콘은 미묘한 감정을 더 자유롭게 표현할 수 있고, 표준 유니코드 문자로 만들어져 어느 기기에서든 같은 모양으로 보입니다.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">무료인가요? 저작권은 괜찮나요?</summary>
+    <p class="faq-answer">네, 완전 무료예요. 이모티콘 특수문자는 유니코드 표준 문자라서 저작권 걱정 없이 몇 번이든 자유롭게 복사해 쓸 수 있고, 회원가입도 필요 없습니다.</p>
+  </details>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>이모티콘으로 꾸몄다면, 알파벳도 폰트로 바꿔보세요</h3>
+  <p>한글은 유니코드 폰트로 바꿀 수 없지만, 닉네임 속 영문·숫자는 𝓒𝓾𝓽𝓮 한 필기체나 𝗕𝗼𝗹𝗱 한 굵은 글씨로 바꿀 수 있어요. UltraTextGen이면 100종 이상의 특수문자 폰트로 한 번에 변환됩니다. 무료·가입 불필요.</p>
+  <a href="/ko/" class="cta-btn">폰트 변환 열기 →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">관련 페이지</span>
+  <div class="compare-grid">
+    <a href="/ko/library/hateu-giho/" class="compare-card variant-muted u-no-underline">
+      <h4>하트 특수문자</h4>
+      <p>♥ ♡ ❥ 부터 💕 💖 까지, 하트 기호와 하트 이모지를 스타일별로 복사.</p>
+    </a>
+    <a href="/ko/library/discord-giho/" class="compare-card variant-muted u-no-underline">
+      <h4>디스코드 특수문자</h4>
+      <p>디스코드 닉네임·상태·서버 이름 꾸미기에 쓰는 특수문자와 기호 모음.</p>
+    </a>
+    <a href="/library/face-emojis/" class="compare-card variant-muted u-no-underline">
+      <h4>얼굴 이모지</h4>
+      <p>모든 기분에 어울리는 스마일·표정·감정 이모지 모음.</p>
+    </a>
+    <a href="/ko/" class="compare-card variant-muted u-no-underline">
+      <h4>폰트 변환</h4>
+      <p>영문·숫자를 굵게·필기체·고딕 등 특수문자 폰트로 복사·변환.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    { name: "기쁨 세트", flags: ["(◠‿◠)","(^▽^)","(≧◡≦)","ヽ(•‿•)ノ"], defaultFormat: "inline" },
+    { name: "귀여운 동물 세트", flags: ["ʕ•ᴥ•ʔ","(=^・ω・^=)","(◕ᴗ◕✿)","(U ᵕ U❁)"], defaultFormat: "inline" },
+    { name: "슬픔 · 울음 세트", flags: ["(T_T)","╥﹏╥","(;﹏;)","(｡•́︿•̀｡)"], defaultFormat: "inline" },
+    { name: "으쓱 · 책상 엎기 세트", flags: ["¯\\_(ツ)_/¯","(╯°□°）╯︵ ┻━┻","┬─┬ノ(º_ºノ)"], defaultFormat: "inline" },
+    { name: "사랑 · 애정 세트", flags: ["(♥ω♥)","(◍•ᴗ•◍)❤","(✿ ♥‿♥)","(づ｡◕‿‿◕｡)づ"], defaultFormat: "inline" },
+    { name: "레니 페이스 세트", flags: ["( ͡° ͜ʖ ͡°)","( ͡~ ͜ʖ ͡°)","( ͡◉ ͜ʖ ͡◉)"], defaultFormat: "inline" },
+    { name: "한글 자모 세트", flags: ["ㅋㅋㅋ","ㅠㅠ","ㅎㅎ","ㄷㄷ"], defaultFormat: "inline" }
+  ];
+
+  ns.buildGrids("kaomojiCollectionsContainer", GROUPS);
+  ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/ko/library/roblox-giho/index.html
+++ b/ko/library/roblox-giho/index.html
@@ -1,0 +1,445 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>로블록스 특수문자 ★ — 닉네임에 넣어도 안 막히는 기호 모음 (복사 붙여넣기)</title>
+<meta name="description" content="로블록스 닉네임(디스플레이 네임)·프로필·그룹 소개에 넣어도 필터에 안 걸리는 특수문자 모음. 별·하트·꽃·반짝이 기호를 클릭 한 번으로 복사해서 바로 붙여넣으세요.">
+
+<link rel="canonical" href="https://ultratextgen.com/ko/library/roblox-giho/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/roblox-symbols/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/library/simbolos-roblox/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles-roblox/">
+  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-roblox/">
+  <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-roblox/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/roblox-giho/">
+  <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-roblox/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-roblox/">
+  <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/roblox-sembolleri/">
+  <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/ki-tu-roblox/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/roblox-symbols/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/library-roblox-symbols.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="로블록스 특수문자 ★ — 닉네임에 넣어도 안 막히는 기호 모음">
+<meta name="twitter:description" content="로블록스 닉네임·프로필·그룹 소개에 넣어도 필터에 안 걸리는 특수문자. 클릭 한 번으로 복사해서 바로 붙여넣으세요.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/library-roblox-symbols.png">
+<meta property="og:title" content="로블록스 특수문자 ★ — 닉네임에 넣어도 안 막히는 기호 모음">
+<meta property="og:description" content="로블록스 닉네임·프로필·그룹 소개에 넣어도 필터에 안 걸리는 특수문자. 클릭 한 번으로 복사해서 바로 붙여넣으세요.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/ko/library/roblox-giho/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "inLanguage": "ko",
+  "name": "로블록스 특수문자 모음 (복사 붙여넣기)",
+  "description": "로블록스 닉네임·프로필·그룹 소개에 넣어도 이름 필터에 걸리지 않는 특수문자 모음. 별·하트·꽃·반짝이 기호를 클릭 한 번으로 복사해서 바로 붙여넣을 수 있습니다.",
+  "url": "https://ultratextgen.com/ko/library/roblox-giho/",
+  "isPartOf": {
+    "@type": "WebSite",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  }
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "홈",
+      "item": "https://ultratextgen.com/ko/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "로블록스 특수문자",
+      "item": "https://ultratextgen.com/ko/library/roblox-giho/"
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "ko",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "로블록스 닉네임에는 어떤 특수문자를 쓸 수 있나요?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "★ ♡ ✦ ❀ ⋆ ✧ 처럼 한 글자짜리 유니코드 기호가 가장 안전합니다. 로블록스 이름 필터를 통과하고 게임 안에서도 제대로 표시됩니다. 반대로 잘 안 쓰이는 유니코드 영역이나 여러 글자를 이어 붙인 조합은 거절될 확률이 높습니다. 이 페이지의 '필터 통과 기호' 섹션에 있는 문자는 모두 실제로 저장이 잘 되는 것만 골랐습니다."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "로블록스는 왜 어떤 특수문자를 막나요?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "로블록스는 이름을 읽기 쉽고 안전하게 유지하려고 자동 이름·콘텐츠 필터를 돌립니다. 검증할 수 없는 문자, 즉 장식용 희귀 유니코드, 보이지 않는 문자(투명 문자), 일부 조합은 거절됩니다. 닉네임에 넣었는데 저장이 안 되면 더 단순한 한 글자짜리 기호로 바꿔 보세요."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "로블록스 닉네임에 특수문자를 어떻게 넣나요?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "이 페이지에서 기호를 클릭하면 복사됩니다. 그다음 설정 → 계정 정보 → 디스플레이 네임(또는 그룹/프로필 소개란)에 붙여넣으세요. 디스플레이 네임(닉네임)은 기호를 허용하지만, @아이디(로그인용 이름)는 영문·숫자·언더바 하나만 됩니다."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "이 로블록스 특수문자를 써도 계정에 문제가 없나요?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "네. 모두 장식용으로 쓰는 평범한 유니코드 문자일 뿐, 버그나 편법이 아닙니다. 닉네임이나 프로필에 넣어도 로블록스 규정을 어기는 게 아닙니다. 다만 기호 주변의 단어에는 콘텐츠 필터가 그대로 적용되니 이름 전체는 건전하게 유지하세요."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "한글은 왜 굵게·기울임 같은 폰트로 안 바뀌나요?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "유니코드의 굵은체·기울임체 같은 '폰트' 문자는 알파벳(A~Z)과 숫자만 커버합니다. 한글에는 대응하는 유니코드 글자가 없어서 변환되지 않습니다. 그래서 한글 닉네임은 글자 자체를 바꾸는 대신, 이 페이지의 별·하트·반짝이 같은 특수문자로 앞뒤를 꾸미는 방식이 가장 잘 통합니다."
+      }
+    }
+  ]
+}
+</script>
+
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/ko/">홈</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">로블록스 특수문자</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">로블록스 특수문자 (복사 붙여넣기)</h1>
+    <p class="hero-tagline">로블록스 닉네임·프로필·그룹 소개를 꾸밀 별·하트·꽃·반짝이 기호 모음입니다. 모두 로블록스 이름 필터를 통과하는지 확인한 문자만 골랐어요 — 클릭 한 번으로 바로 복사됩니다.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/library-roblox-symbols.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>로블록스는 닉네임(디스플레이 네임)과 프로필에 유니코드 문자를 허용하지만, 일부 특수문자는 콘텐츠 필터에 막혀 저장이 안 됩니다. 여기 모은 건 로블록스에서 실제로 잘 표시되는 안전한 기호들 — 별, 하트, 꽃, 귀여운 장식 문자입니다. 로블록스 닉네임, 그룹 소개, 프로필 꾸미기에 그대로 쓰세요.</p>
+    <p>중요한 점 하나. 한글은 유니코드 '굵은체·필기체' 폰트로 바뀌지 않습니다. 그런 폰트 문자는 알파벳과 숫자만 커버하기 때문이에요. 그래서 한글 닉네임은 글자를 바꾸는 대신, 아래 기호로 이름 앞뒤를 감싸는 방식(예: <span aria-hidden="true">✧ 닉네임 ✧</span>)이 가장 잘 통합니다. 마음에 드는 기호를 눌러 복사한 뒤 붙여넣으세요.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 1 -->
+<section class="mood-explainers" id="roblox-friendly-marks">
+  <span class="article-section-label">필터 통과 기호</span>
+  <h2>로블록스에서 안 막히는 특수문자</h2>
+  <p>아래 기호들은 로블록스 이름 필터를 안정적으로 통과하고 게임 안에서도 제대로 표시됩니다. 닉네임 꾸미기의 기본으로 쓰기 좋아요.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⋆" aria-label="⋆ 복사">⋆</button>
+      <span class="flag-label">여섯 꼭짓점 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊹" aria-label="⊹ 복사">⊹</button>
+      <span class="flag-label">직교 십자</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✦" aria-label="✦ 복사">✦</button>
+      <span class="flag-label">검은 네 꼭짓점 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✧" aria-label="✧ 복사">✧</button>
+      <span class="flag-label">흰 네 꼭짓점 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="★" aria-label="★ 복사">★</button>
+      <span class="flag-label">검은 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☆" aria-label="☆ 복사">☆</button>
+      <span class="flag-label">흰 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♡" aria-label="♡ 복사">♡</button>
+      <span class="flag-label">흰 하트</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♥" aria-label="♥ 복사">♥</button>
+      <span class="flag-label">검은 하트</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❀" aria-label="❀ 복사">❀</button>
+      <span class="flag-label">흰 꽃</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✿" aria-label="✿ 복사">✿</button>
+      <span class="flag-label">검은 꽃</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❁" aria-label="❁ 복사">❁</button>
+      <span class="flag-label">여덟 잎 꽃</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⌒" aria-label="⌒ 복사">⌒</button>
+      <span class="flag-label">호(아치)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="◌" aria-label="◌ 복사">◌</button>
+      <span class="flag-label">점선 원</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚡" aria-label="⚡ 복사">⚡</button>
+      <span class="flag-label">번개</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="•" aria-label="• 복사">•</button>
+      <span class="flag-label">가운뎃점(불릿)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ツ" aria-label="ツ 복사">ツ</button>
+      <span class="flag-label">가타카나 츠(웃는 얼굴)</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 2 -->
+<section class="mood-explainers" id="cute-decorations-roblox">
+  <span class="article-section-label">귀여운 장식</span>
+  <h2>귀여운 장식 문자</h2>
+  <p>앙증맞은 닉네임·프로필 꾸미기에 어울리는 기호들. 조합(combo)이라고 표시된 건 두 글자 이상이라 필터에 걸릴 수 있으니, 저장이 안 되면 위쪽 한 글자 기호로 바꿔 주세요.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🎀" aria-label="🎀 복사">🎀</button>
+      <span class="flag-label">리본 (이모지)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="୨୧" aria-label="୨୧ 복사">୨୧</button>
+      <span class="flag-label">코케트 물결 (조합)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ʚɞ" aria-label="ʚɞ 복사">ʚɞ</button>
+      <span class="flag-label">하트 날개 (조합)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="꒰" aria-label="꒰ 복사">꒰</button>
+      <span class="flag-label">장식 왼쪽 괄호</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="꒱" aria-label="꒱ 복사">꒱</button>
+      <span class="flag-label">장식 오른쪽 괄호</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊹" aria-label="⊹ 복사">⊹</button>
+      <span class="flag-label">직교 십자</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="๑" aria-label="๑ 복사">๑</button>
+      <span class="flag-label">타이 숫자 1</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ღ" aria-label="ღ 복사">ღ</button>
+      <span class="flag-label">조지아 문자 간(하트)</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 3 -->
+<section class="mood-explainers" id="y2k-roblox">
+  <span class="article-section-label">Y2K 감성</span>
+  <h2>Y2K 스타일 기호</h2>
+  <p>다크·사이버 Y2K 감성의 닉네임에 어울리는 기호들. 별표·십자·이집트 문양처럼 개성 있는 장식이 필요할 때 쓰세요.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♱" aria-label="♱ 복사">♱</button>
+      <span class="flag-label">동시리아 십자</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✟" aria-label="✟ 복사">✟</button>
+      <span class="flag-label">윤곽선 라틴 십자</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✮" aria-label="✮ 복사">✮</button>
+      <span class="flag-label">원 안 흰 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓆩" aria-label="𓆩 복사">𓆩</button>
+      <span class="flag-label">이집트 뱀 왼쪽</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓆪" aria-label="𓆪 복사">𓆪</button>
+      <span class="flag-label">이집트 뱀 오른쪽</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𖥔" aria-label="𖥔 복사">𖥔</button>
+      <span class="flag-label">원 안 X자</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⋆˚࿔" aria-label="⋆˚࿔ 복사">⋆˚࿔</button>
+      <span class="flag-label">반짝이 링 (조합)</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 4 -->
+<section class="mood-explainers" id="roblox-filter-note">
+  <span class="article-section-label">로블록스 필터 안내</span>
+  <h2>로블록스 콘텐츠 필터에 대하여</h2>
+  <p>로블록스는 자동 콘텐츠 필터를 돌려서 닉네임·프로필의 일부 유니코드 문자를 막을 수 있습니다. ★ ♡ ✦ ❀ ⋆ 처럼 한 글자짜리 기호가 가장 안전합니다. 여러 글자를 이어 붙인 조합이나 잘 안 쓰이는 유니코드 영역은 막히거나 지워질 확률이 높아요. 닉네임에 넣었는데 저장이 안 되면, 위쪽 '필터 통과 기호' 섹션에서 더 단순한 한 글자 기호로 바꿔 보세요.</p>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- COLLECTIONS -->
+<section class="mood-explainers" id="roblox-collections">
+  <span class="article-section-label">로블록스 세트</span>
+  <h2>닉네임·프로필에 바로 쓰는 조합</h2>
+  <p class="u-secondary-block">로블록스 닉네임, 프로필 소개, 그룹 설명에 그대로 붙여넣을 수 있는 완성형 장식 세트입니다. 클릭 한 번으로 조합 전체를 복사하세요. (여러 글자 조합은 간혹 필터에 걸릴 수 있어요.)</p>
+  <div id="robloxCollectionsContainer"></div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- FAQ -->
+<section class="editorial-section" id="faq">
+  <span class="article-section-label">자주 묻는 질문</span>
+  <h2>로블록스 특수문자, 자주 묻는 질문</h2>
+  <details class="faq-item">
+    <summary class="faq-question">로블록스 닉네임에는 어떤 특수문자를 쓸 수 있나요?</summary>
+    <p class="faq-answer">★ ♡ ✦ ❀ ⋆ ✧ 처럼 한 글자짜리 유니코드 기호가 가장 안전합니다. 로블록스 이름 필터를 통과하고 게임 안에서도 제대로 표시됩니다. 반대로 잘 안 쓰이는 유니코드 영역이나 여러 글자를 이어 붙인 조합은 거절될 확률이 높습니다. 위 '필터 통과 기호' 섹션에 있는 문자는 모두 실제로 저장이 잘 되는 것만 골랐습니다.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">로블록스는 왜 어떤 특수문자를 막나요?</summary>
+    <p class="faq-answer">로블록스는 이름을 읽기 쉽고 안전하게 유지하려고 자동 이름·콘텐츠 필터를 돌립니다. 검증할 수 없는 문자, 즉 장식용 희귀 유니코드, 보이지 않는 문자(투명 문자), 일부 조합은 거절됩니다. 닉네임에 넣었는데 저장이 안 되면 더 단순한 한 글자짜리 기호로 바꿔 보세요.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">로블록스 닉네임에 특수문자를 어떻게 넣나요?</summary>
+    <p class="faq-answer">이 페이지에서 기호를 클릭하면 복사됩니다. 그다음 설정 → 계정 정보 → 디스플레이 네임(또는 그룹/프로필 소개란)에 붙여넣으세요. 디스플레이 네임(닉네임)은 기호를 허용하지만, @아이디(로그인용 이름)는 영문·숫자·언더바 하나만 됩니다.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">이 로블록스 특수문자를 써도 계정에 문제가 없나요?</summary>
+    <p class="faq-answer">네. 모두 장식용으로 쓰는 평범한 유니코드 문자일 뿐, 버그나 편법이 아닙니다. 닉네임이나 프로필에 넣어도 로블록스 규정을 어기는 게 아닙니다. 다만 기호 주변의 단어에는 콘텐츠 필터가 그대로 적용되니 이름 전체는 건전하게 유지하세요.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">한글은 왜 굵게·기울임 같은 폰트로 안 바뀌나요?</summary>
+    <p class="faq-answer">유니코드의 굵은체·기울임체 같은 '폰트' 문자는 알파벳(A~Z)과 숫자만 커버합니다. 한글에는 대응하는 유니코드 글자가 없어서 변환되지 않습니다. 그래서 한글 닉네임은 글자 자체를 바꾸는 대신, 이 페이지의 별·하트·반짝이 같은 특수문자로 앞뒤를 꾸미는 방식이 가장 잘 통합니다.</p>
+  </details>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>기호만이 아니라, 영문 닉네임 글자도 바꿀 수 있어요</h3>
+  <p>한글은 유니코드 폰트로 바뀌지 않지만, 영문·숫자 부분은 UltraTextGen에서 굵은체·필기체 등 100가지 이상의 유니코드 폰트로 한 번에 변환할 수 있습니다. 무료이고 가입도 필요 없어요.</p>
+  <a href="/ko/" class="cta-btn">폰트 변환기 열기 →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">관련 페이지</span>
+  <div class="compare-grid">
+    <a href="/ko/library/byeol-giho/" class="compare-card variant-muted u-no-underline">
+      <h4>별 특수문자</h4>
+      <p>별·반짝이 기호 모음. 닉네임 앞뒤 꾸미기에 딱.</p>
+    </a>
+    <a href="/ko/library/hateu-giho/" class="compare-card variant-muted u-no-underline">
+      <h4>하트 특수문자</h4>
+      <p>하트 기호와 하트 이모지를 색·스타일별로 복사.</p>
+    </a>
+    <a href="/ko/library/imotikon/" class="compare-card variant-muted u-no-underline">
+      <h4>이모티콘 (얼굴 표정)</h4>
+      <p>텍스트로 만든 귀여운 얼굴 이모티콘 모음.</p>
+    </a>
+    <a href="/ko/library/imoji-johap/" class="compare-card variant-muted u-no-underline">
+      <h4>이모지 조합</h4>
+      <p>프로필·감성 문구에 어울리는 이모지 조합 모음.</p>
+    </a>
+    <a href="/ko/" class="compare-card variant-muted u-no-underline">
+      <h4>폰트 변환</h4>
+      <p>영문·숫자를 굵은체·필기체 등 유니코드 폰트로 변환.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    { name: "별 닉네임 조합", flags: ["⋆","★","✦","★","⋆"], defaultFormat: "inline" },
+    { name: "귀여운 리본 조합", flags: ["୨୧","♡","୨୧"], defaultFormat: "inline" },
+    { name: "꽃 닉네임 장식", flags: ["❀","✿","❁","✿","❀"], defaultFormat: "inline" },
+    { name: "하트 날개 조합", flags: ["⋆","ʚɞ","⋆"], defaultFormat: "inline" },
+    { name: "괄호 별 닉네임", flags: ["꒰","⊹","✧","⊹","꒱"], defaultFormat: "inline" },
+    { name: "반짝이 프로필 구분선", flags: ["⋆","☆","⊹","☆","⋆"], defaultFormat: "inline" }
+  ];
+
+  ns.buildGrids("robloxCollectionsContainer", GROUPS);
+  ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/ko/library/y2k-giho/index.html
+++ b/ko/library/y2k-giho/index.html
@@ -1,0 +1,758 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Y2K 특수문자 ✰ 감성 프로필 꾸미기 별·나비·십자가 복사</title>
+<meta name="description" content="Y2K 감성 특수문자 모음 — 별 ✰, 나비 🦋, 십자가 ♱, 반짝이 ⋆｡°✩, CD 💿 까지. 클릭 한 번으로 복사해서 인스타 프로필, 닉네임, 디스코드 이름 꾸미기에 바로 붙여넣으세요.">
+
+<link rel="canonical" href="https://ultratextgen.com/ko/library/y2k-giho/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/y2k-symbols/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/library/simbolos-y2k/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles-y2k/">
+  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-y2k/">
+  <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-y2k/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/y2k-giho/">
+  <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-y2k/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-y2k/">
+  <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/y2k-sembolleri/">
+  <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/ki-tu-y2k/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/y2k-symbols/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/library-y2k-symbols.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Y2K 특수문자 ✰ 감성 프로필 꾸미기 별·나비·십자가 복사">
+<meta name="twitter:description" content="Y2K 감성 특수문자 모음 — 별, 나비, 십자가, 반짝이, CD까지. 클릭 한 번으로 복사해서 인스타 프로필과 닉네임 꾸미기에 바로 붙여넣으세요.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/library-y2k-symbols.png">
+<meta property="og:title" content="Y2K 특수문자 ✰ 감성 프로필 꾸미기 별·나비·십자가 복사">
+<meta property="og:description" content="Y2K 감성 특수문자 모음 — 별, 나비, 십자가, 반짝이, CD까지. 클릭 한 번으로 복사해서 인스타 프로필, 닉네임, 디스코드 이름 꾸미기에 바로 붙여넣으세요.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/ko/library/y2k-giho/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "ko",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Y2K 특수문자가 뭔가요?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Y2K 특수문자는 2000년대 초반 사이버 감성을 담은 유니코드 문자예요. 반짝이 별(✦ ✮ ⋆), 고딕 십자가(♱ ✟ †), 나비(🦋), CD와 삐삐(💿 📟), 그리고 작은 먼지·반짝임 기호까지 포함됩니다. 이미지가 아니라 그냥 문자라서, 파일을 올릴 필요 없이 인스타 프로필, 닉네임, 캡션에 그대로 복사해서 붙여넣을 수 있어요."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "인스타 프로필 꾸미기에 Y2K 특수문자를 어떻게 쓰나요?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "원하는 기호나 조합을 눌러 복사한 뒤, 인스타그램에서 프로필 편집으로 들어가 이름이나 소개(bio) 칸에 붙여넣으면 돼요. 텍스트 양옆을 같은 기호로 감싸는 게 정석이에요 — 예를 들어 ♱ 내용 ♱ 이나 𓆩♡𓆪 처럼요. 단어 사이에 반짝이(✦)나 별(✮)을 하나씩 넣어도 예뻐요. 너무 많이 쓰면 지저분해 보이니 기호는 두세 개 정도로 유지하세요."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Y2K 특수문자가 틱톡이나 디스코드에서도 되나요?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "네. 여기 있는 기호는 전부 표준 유니코드라서 틱톡 닉네임·캡션·댓글, 디스코드 표시 이름·채널명·메시지에서 잘 나옵니다. 다만 폰트가 없는 오래된 기기에서는 일부 희귀한 기호가 네모(□)로 보일 수 있으니, 올리기 전에 휴대폰에서 한 번 확인하세요. 별, 하트, 십자가 같은 기본 기호가 가장 넓게 지원됩니다."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "홈",
+      "item": "https://ultratextgen.com/ko/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Y2K 특수문자",
+      "item": "https://ultratextgen.com/ko/library/y2k-giho/"
+    }
+  ]
+}
+</script>
+
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/ko/">홈</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Y2K 특수문자</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Y2K 특수문자 (감성 프로필용)</h1>
+    <p class="hero-tagline">Y2K 감성은 2000년대 초반의 사이버 향수 — 반짝이 별, 고딕 십자가, 나비, CD 광택이에요. 아래 기호를 누르면 바로 복사됩니다. 인스타 프로필, 닉네임, 디스코드 이름 꾸미기에 그대로 붙여넣으세요.</p>
+  </div>
+</section>
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Y2K 감성 특수문자는 2000년대 초반 인터넷의 향수를 담고 있어요. 나비 집게핀, 폴더폰, 글리터, 고딕 십자가, 홀로그램 CD 광택 같은 무드죠. 반짝임을 위한 별, 엣지를 위한 십자가, 부드러운 느낌을 위한 나비와 리본, 테크 시대를 담은 사이버 기호, 그리고 텍스트를 감싸는 괄호까지 — 아래 모든 기호는 복사·붙여넣기용입니다. 기호를 누르면 복사되고, 인스타 소개(bio), 틱톡 캡션, 디스코드 이름 등 유니코드 텍스트가 되는 곳이면 어디든 붙여넣을 수 있어요.</p>
+    <p>참고로 한글이나 알파벳 자체는 유니코드 "폰트"로 굵게·기울임 하기 어렵지만(그 스타일은 라틴 문자만 커버해요), 이 특수문자들은 언어와 상관없이 어디서나 똑같이 표시됩니다. 알파벳도 꾸미고 싶다면 <a href="/">UltraTextGen 폰트 변환기</a>와 함께 써보세요.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- QUICK COPY (above the fold) -->
+<section class="mood-explainers" id="quick-copy">
+  <span class="article-section-label">가장 많이 복사되는 Y2K 기호</span>
+  <h2>눌러서 복사</h2>
+  <p>Y2K 감성 특수문자 중 사람들이 제일 많이 가져가는 것들 — 별, 십자가, 나비, 반짝이, CD. 한 번 누르면 바로 복사됩니다.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✦" aria-label="✦ 복사">✦</button>
+      <span class="flag-label">반짝이 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✮" aria-label="✮ 복사">✮</button>
+      <span class="flag-label">Y2K 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♱" aria-label="♱ 복사">♱</button>
+      <span class="flag-label">십자가</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦋" aria-label="🦋 복사">🦋</button>
+      <span class="flag-label">나비</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✨" aria-label="✨ 복사">✨</button>
+      <span class="flag-label">반짝임</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💿" aria-label="💿 복사">💿</button>
+      <span class="flag-label">CD</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𖤐" aria-label="𖤐 복사">𖤐</button>
+      <span class="flag-label">검은 태양</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓆩♡𓆪" aria-label="𓆩♡𓆪 복사">𓆩♡𓆪</button>
+      <span class="flag-label">하트 프레임</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 1 -->
+<section class="mood-explainers" id="stars-sparkles">
+  <span class="article-section-label">별 &amp; 반짝이</span>
+  <h2>별 &amp; 반짝이</h2>
+  <p>Y2K 감성의 핵심 — 닉네임, 프로필, 캡션에 넣는 반짝이 별과 글리터 기호. 아무거나 눌러 복사하세요.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✦" aria-label="✦ 복사">✦</button>
+      <span class="flag-label">검은 사각별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✧" aria-label="✧ 복사">✧</button>
+      <span class="flag-label">흰 사각별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="★" aria-label="★ 복사">★</button>
+      <span class="flag-label">검은 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☆" aria-label="☆ 복사">☆</button>
+      <span class="flag-label">흰 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✮" aria-label="✮ 복사">✮</button>
+      <span class="flag-label">굵은 외곽선 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✯" aria-label="✯ 복사">✯</button>
+      <span class="flag-label">바람개비 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✩" aria-label="✩ 복사">✩</button>
+      <span class="flag-label">외곽선 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✪" aria-label="✪ 복사">✪</button>
+      <span class="flag-label">원 안 흰 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✫" aria-label="✫ 복사">✫</button>
+      <span class="flag-label">가운데 열린 검은 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✬" aria-label="✬ 복사">✬</button>
+      <span class="flag-label">가운데 검은 흰 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✭" aria-label="✭ 복사">✭</button>
+      <span class="flag-label">외곽선 검은 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✰" aria-label="✰ 복사">✰</button>
+      <span class="flag-label">그림자 흰 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⭑" aria-label="⭑ 복사">⭑</button>
+      <span class="flag-label">작은 검은 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⭒" aria-label="⭒ 복사">⭒</button>
+      <span class="flag-label">작은 흰 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⋆" aria-label="⋆ 복사">⋆</button>
+      <span class="flag-label">별 연산자</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⍟" aria-label="⍟ 복사">⍟</button>
+      <span class="flag-label">네모 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚝" aria-label="⚝ 복사">⚝</button>
+      <span class="flag-label">외곽선 흰 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✨" aria-label="✨ 복사">✨</button>
+      <span class="flag-label">반짝임 이모지</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌟" aria-label="🌟 복사">🌟</button>
+      <span class="flag-label">빛나는 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💫" aria-label="💫 복사">💫</button>
+      <span class="flag-label">어지러운 별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⭐" aria-label="⭐ 복사">⭐</button>
+      <span class="flag-label">별 이모지</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="˚" aria-label="˚ 복사">˚</button>
+      <span class="flag-label">위 고리 (먼지)</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 1B -->
+<section class="mood-explainers" id="hearts-crosses">
+  <span class="article-section-label">하트 &amp; 십자가</span>
+  <h2>하트 &amp; 십자가</h2>
+  <p>고딕 십자가와 Y2K 하트 — 2000년대 부활 감성의 핵심인 '엣지 + 부드러움' 조합.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♡" aria-label="♡ 복사">♡</button>
+      <span class="flag-label">흰 하트</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♥" aria-label="♥ 복사">♥</button>
+      <span class="flag-label">검은 하트</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❤" aria-label="❤ 복사">❤</button>
+      <span class="flag-label">빨간 하트 이모지</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🖤" aria-label="🖤 복사">🖤</button>
+      <span class="flag-label">검은 하트 이모지</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🤍" aria-label="🤍 복사">🤍</button>
+      <span class="flag-label">흰 하트 이모지</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ᥫ᭡" aria-label="ᥫ᭡ 복사">ᥫ᭡</button>
+      <span class="flag-label">늘어진 하트</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ʚ♡ɞ" aria-label="ʚ♡ɞ 복사">ʚ♡ɞ</button>
+      <span class="flag-label">날개 하트 (조합)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❦" aria-label="❦ 복사">❦</button>
+      <span class="flag-label">꽃 하트</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❧" aria-label="❧ 복사">❧</button>
+      <span class="flag-label">회전한 꽃 하트</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♱" aria-label="♱ 복사">♱</button>
+      <span class="flag-label">동시리아 십자가</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♰" aria-label="♰ 복사">♰</button>
+      <span class="flag-label">서시리아 십자가</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✟" aria-label="✟ 복사">✟</button>
+      <span class="flag-label">외곽선 라틴 십자가</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✝" aria-label="✝ 복사">✝</button>
+      <span class="flag-label">라틴 십자가</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="†" aria-label="† 복사">†</button>
+      <span class="flag-label">단검(칼표)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☦" aria-label="☦ 복사">☦</button>
+      <span class="flag-label">정교회 십자가</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛧" aria-label="⛧ 복사">⛧</button>
+      <span class="flag-label">역오각별</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𖤐" aria-label="𖤐 복사">𖤐</button>
+      <span class="flag-label">검은 태양</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 2 -->
+<section class="mood-explainers" id="tech-cyber">
+  <span class="article-section-label">테크 &amp; 사이버</span>
+  <h2>테크 &amp; 사이버 기호</h2>
+  <p>CD, 삐삐, 사이버 모티프 — 2000년대 초반 디지털 시대의 상징. Y2K 테크 감성의 정점입니다.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💿" aria-label="💿 복사">💿</button>
+      <span class="flag-label">CD 이모지</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="📀" aria-label="📀 복사">📀</button>
+      <span class="flag-label">DVD 이모지</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💾" aria-label="💾 복사">💾</button>
+      <span class="flag-label">플로피 디스크</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="📟" aria-label="📟 복사">📟</button>
+      <span class="flag-label">삐삐(호출기)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="📱" aria-label="📱 복사">📱</button>
+      <span class="flag-label">휴대폰</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💻" aria-label="💻 복사">💻</button>
+      <span class="flag-label">노트북</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🖥" aria-label="🖥 복사">🖥</button>
+      <span class="flag-label">데스크톱</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕹" aria-label="🕹 복사">🕹</button>
+      <span class="flag-label">조이스틱</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🎮" aria-label="🎮 복사">🎮</button>
+      <span class="flag-label">게임 컨트롤러</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌐" aria-label="🌐 복사">🌐</button>
+      <span class="flag-label">지구본(경선)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🛸" aria-label="🛸 복사">🛸</button>
+      <span class="flag-label">비행접시(UFO)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="📡" aria-label="📡 복사">📡</button>
+      <span class="flag-label">위성 안테나</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🔋" aria-label="🔋 복사">🔋</button>
+      <span class="flag-label">배터리</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕸" aria-label="🕸 복사">🕸</button>
+      <span class="flag-label">거미줄</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦇" aria-label="🦇 복사">🦇</button>
+      <span class="flag-label">박쥐</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚙" aria-label="⚙ 복사">⚙</button>
+      <span class="flag-label">톱니바퀴</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⌨" aria-label="⌨ 복사">⌨</button>
+      <span class="flag-label">키보드</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 3 -->
+<section class="mood-explainers" id="butterflies-bows">
+  <span class="article-section-label">나비 · 리본 · 버블</span>
+  <h2>나비, 리본, 버블</h2>
+  <p>Y2K의 부드러운 면 — 나비 집게핀, 리본, 그리고 몽글몽글한 버블 장식.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦋" aria-label="🦋 복사">🦋</button>
+      <span class="flag-label">나비 이모지</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🎀" aria-label="🎀 복사">🎀</button>
+      <span class="flag-label">리본 이모지</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🩰" aria-label="🩰 복사">🩰</button>
+      <span class="flag-label">발레 슈즈</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🫧" aria-label="🫧 복사">🫧</button>
+      <span class="flag-label">버블</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌸" aria-label="🌸 복사">🌸</button>
+      <span class="flag-label">벚꽃</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🍓" aria-label="🍓 복사">🍓</button>
+      <span class="flag-label">딸기</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ꨄ" aria-label="ꨄ 복사">ꨄ</button>
+      <span class="flag-label">말린 하트</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ᡣ𐭩" aria-label="ᡣ𐭩 복사">ᡣ𐭩</button>
+      <span class="flag-label">고양이 얼굴 (조합)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✨" aria-label="✨ 복사">✨</button>
+      <span class="flag-label">반짝임 이모지</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 3B -->
+<section class="mood-explainers" id="arrows-brackets">
+  <span class="article-section-label">화살표 &amp; 괄호</span>
+  <h2>화살표 &amp; 괄호</h2>
+  <p>텍스트를 Y2K 스타일로 감싸기 — 코너 괄호, 곡선 괄호, 그리고 소개글을 가리키고 감싸는 화살표.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="「" aria-label="「 복사">「</button>
+      <span class="flag-label">왼쪽 코너 괄호</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="」" aria-label="」 복사">」</button>
+      <span class="flag-label">오른쪽 코너 괄호</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="『" aria-label="『 복사">『</button>
+      <span class="flag-label">왼쪽 흰 코너 괄호</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="』" aria-label="』 복사">』</button>
+      <span class="flag-label">오른쪽 흰 코너 괄호</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="꒰" aria-label="꒰ 복사">꒰</button>
+      <span class="flag-label">왼쪽 곡선 괄호</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="꒱" aria-label="꒱ 복사">꒱</button>
+      <span class="flag-label">오른쪽 곡선 괄호</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⫷" aria-label="⫷ 복사">⫷</button>
+      <span class="flag-label">왼쪽 삼각 괄호</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⫸" aria-label="⫸ 복사">⫸</button>
+      <span class="flag-label">오른쪽 삼각 괄호</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="➶" aria-label="➶ 복사">➶</button>
+      <span class="flag-label">위쪽 굵은 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="➴" aria-label="➴ 복사">➴</button>
+      <span class="flag-label">아래쪽 굵은 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="↳" aria-label="↳ 복사">↳</button>
+      <span class="flag-label">갈고리 화살표</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="➤" aria-label="➤ 복사">➤</button>
+      <span class="flag-label">검은 화살촉</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☆彡" aria-label="☆彡 복사">☆彡</button>
+      <span class="flag-label">별똥별 (조합)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⌗" aria-label="⌗ 복사">⌗</button>
+      <span class="flag-label">뷰데이터 사각</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 4 -->
+<section class="mood-explainers" id="egyptian-frames">
+  <span class="article-section-label">이집트풍 프레임</span>
+  <h2>이집트풍 프레임</h2>
+  <p>상형문자를 감성 프레임 괄호로 재활용한 것 — Y2K 인터넷의 단골 조합입니다.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓆩" aria-label="𓆩 복사">𓆩</button>
+      <span class="flag-label">이집트 뱀 (왼쪽)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓆪" aria-label="𓆪 복사">𓆪</button>
+      <span class="flag-label">이집트 뱀 (오른쪽)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓆝" aria-label="𓆝 복사">𓆝</button>
+      <span class="flag-label">이집트 거북</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓍯" aria-label="𓍯 복사">𓍯</button>
+      <span class="flag-label">이집트 바구니</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓂃" aria-label="𓂃 복사">𓂃</button>
+      <span class="flag-label">이집트 깃털</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓏸" aria-label="𓏸 복사">𓏸</button>
+      <span class="flag-label">이집트 기호</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓏲" aria-label="𓏲 복사">𓏲</button>
+      <span class="flag-label">이집트 기호 2</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓆩♱𓆪" aria-label="𓆩♱𓆪 복사">𓆩♱𓆪</button>
+      <span class="flag-label">이집트 십자가 프레임 (조합)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓆩♡𓆪" aria-label="𓆩♡𓆪 복사">𓆩♡𓆪</button>
+      <span class="flag-label">이집트 하트 프레임 (조합)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓆩 ⛧ 𓆪" aria-label="𓆩 ⛧ 𓆪 복사">𓆩 ⛧ 𓆪</button>
+      <span class="flag-label">이집트 오각별 프레임 (조합)</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 5 -->
+<section class="mood-explainers" id="sparkle-dust">
+  <span class="article-section-label">먼지 &amp; 반짝임 장식</span>
+  <h2>먼지 &amp; 반짝임 장식</h2>
+  <p>Y2K 감성 조합에 레이어처럼 겹쳐 넣는 아주 작은 반짝임·먼지 기호.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𖥔" aria-label="𖥔 복사">𖥔</button>
+      <span class="flag-label">원 안 사선 십자</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊹" aria-label="⊹ 복사">⊹</button>
+      <span class="flag-label">직교 십자</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‧₊˚" aria-label="‧₊˚ 복사">‧₊˚</button>
+      <span class="flag-label">작은 반짝임 (조합)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="࣪" aria-label="࣪ 복사">࣪</button>
+      <span class="flag-label">결합 기호</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="݁" aria-label="݁ 복사">݁</button>
+      <span class="flag-label">결합 점</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 6 -->
+<section class="mood-explainers" id="y2k-combos">
+  <span class="article-section-label">Y2K 조합</span>
+  <h2>Y2K 조합 템플릿</h2>
+  <p>프로필과 닉네임에 바로 쓰는 미리 만든 Y2K 감성 조합. 아무거나 눌러 통째로 복사하세요.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♱*.ﾟ🎧⚝‧,₊˚🕷️✮𖤐📟🕸️,.♰" aria-label="♱*.ﾟ🎧⚝‧,₊˚🕷️✮𖤐📟🕸️,.♰ 복사">♱*.ﾟ🎧⚝‧,₊˚🕷️✮𖤐📟🕸️,.♰</button>
+      <span class="flag-label">Y2K 소개글 조합</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓆩♱𓆪 𖥔 ᥫ᭡ ⋆" aria-label="𓆩♱𓆪 𖥔 ᥫ᭡ ⋆ 복사">𓆩♱𓆪 𖥔 ᥫ᭡ ⋆</button>
+      <span class="flag-label">이집트 별 조합</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❦.♱ʚ♡ɞ♱❦." aria-label="❦.♱ʚ♡ɞ♱❦. 복사">❦.♱ʚ♡ɞ♱❦.</button>
+      <span class="flag-label">고딕 하트 조합</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✮⋆˙" aria-label="✮⋆˙ 복사">✮⋆˙</button>
+      <span class="flag-label">별 반짝임</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𖤐 ⛧ ✟" aria-label="𖤐 ⛧ ✟ 복사">𖤐 ⛧ ✟</button>
+      <span class="flag-label">다크 스타 크로스</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- COLLECTIONS -->
+<section class="mood-explainers" id="y2k-collections">
+  <span class="article-section-label">Y2K 세트</span>
+  <h2>그대로 쓰는 Y2K 조합 템플릿</h2>
+  <p class="u-secondary-block">소개글, 닉네임, 캡션에 바로 붙여넣을 수 있게 조합해 둔 Y2K 문자열입니다. 한 번의 클릭으로 통째로 복사하세요.</p>
+  <div id="y2kCollectionsContainer"></div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- FAQ -->
+<section class="editorial-section" id="faq">
+  <span class="article-section-label">FAQ</span>
+  <h2>Y2K 특수문자 자주 묻는 질문</h2>
+  <details class="faq-item">
+    <summary class="faq-question">Y2K 특수문자가 뭔가요?</summary>
+    <p class="faq-answer">Y2K 특수문자는 2000년대 초반 사이버 감성을 담은 유니코드 문자예요. 반짝이 별(✦ ✮ ⋆), 고딕 십자가(♱ ✟ †), 나비(🦋), CD와 삐삐(💿 📟), 그리고 작은 먼지·반짝임 기호까지 포함됩니다. 이미지가 아니라 그냥 문자라서, 파일을 올릴 필요 없이 인스타 프로필, 닉네임, 캡션에 그대로 복사해서 붙여넣을 수 있어요.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">인스타 프로필 꾸미기에 Y2K 특수문자를 어떻게 쓰나요?</summary>
+    <p class="faq-answer">원하는 기호나 조합을 눌러 복사한 뒤, 인스타그램에서 프로필 편집으로 들어가 이름이나 소개(bio) 칸에 붙여넣으면 돼요. 텍스트 양옆을 같은 기호로 감싸는 게 정석이에요 — 예를 들어 ♱ 내용 ♱ 이나 𓆩♡𓆪 처럼요. 단어 사이에 반짝이(✦)나 별(✮)을 하나씩 넣어도 예뻐요. 너무 많이 쓰면 지저분해 보이니 기호는 두세 개 정도로 유지하세요.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">Y2K 특수문자가 틱톡이나 디스코드에서도 되나요?</summary>
+    <p class="faq-answer">네. 여기 있는 기호는 전부 표준 유니코드라서 틱톡 닉네임·캡션·댓글, 디스코드 표시 이름·채널명·메시지에서 잘 나옵니다. 다만 폰트가 없는 오래된 기기에서는 일부 희귀한 기호가 네모(□)로 보일 수 있으니, 올리기 전에 휴대폰에서 한 번 확인하세요. 별, 하트, 십자가 같은 기본 기호가 가장 넓게 지원됩니다.</p>
+  </details>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>기호만이 아니라, 글자 자체도 바꿀 수 있어요</h3>
+  <p>Y2K 특수문자로 꾸몄다면, 다음은 알파벳을 𝓒𝓾𝓽𝓮 한 필기체나 𝗕𝗼𝗹𝗱 한 굵은 글씨로. UltraTextGen이면 영문·숫자를 100가지 넘는 유니코드 폰트로 순식간에 변환해요. 무료·가입 불필요.</p>
+  <a href="/" class="cta-btn">폰트 변환기 열기 →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">관련 페이지</span>
+  <div class="compare-grid">
+    <a href="/ko/library/byeol-giho/" class="compare-card variant-muted u-no-underline">
+      <h4>별 기호 모음</h4>
+      <p>별과 반짝이 기호를 스타일별로 모아 클릭 복사. 프로필과 닉네임 꾸미기에.</p>
+    </a>
+    <a href="/ko/library/hateu-giho/" class="compare-card variant-muted u-no-underline">
+      <h4>하트 기호 모음</h4>
+      <p>컬러 하트부터 텍스트 하트, 꽃 하트까지 색·스타일별로 코피페.</p>
+    </a>
+    <a href="/ko/library/hwasalpyo-giho/" class="compare-card variant-muted u-no-underline">
+      <h4>화살표 기호 모음</h4>
+      <p>다양한 방향과 스타일의 화살표 기호를 모아 클릭 한 번으로 복사.</p>
+    </a>
+    <a href="/ko/library/discord-giho/" class="compare-card variant-muted u-no-underline">
+      <h4>디스코드 특수문자</h4>
+      <p>디스코드 이름·채널·메시지에 잘 나오는 특수문자와 장식 모음.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    { name: "사이버 닉네임 조합", flags: ["✮","⋆","˚","𖤐","˚","⋆","✮"], defaultFormat: "inline" },
+    { name: "고딕 십자가 소개글 조합", flags: ["♱","✟","†","✟","♱"], defaultFormat: "inline" },
+    { name: "이집트 십자가 프레임", flags: ["𓆩♱𓆪"], defaultFormat: "inline" },
+    { name: "나비 소개글 조합", flags: ["🦋","‧₊˚","🫧","‧₊˚","🦋"], defaultFormat: "inline" },
+    { name: "다크 스타 조합", flags: ["𖤐","⛧","✯","⛧","𖤐"], defaultFormat: "inline" },
+    { name: "반짝이 먼지 구분선", flags: ["𖥔","⊹","‧₊˚","⊹","𖥔"], defaultFormat: "inline" }
+  ];
+
+  ns.buildGrids("y2kCollectionsContainer", GROUPS);
+  ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/library/aesthetic-symbols/index.html
+++ b/library/aesthetic-symbols/index.html
@@ -22,6 +22,7 @@
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-aesthetic/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/aesthetic-symbols/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/gamseong-giho/">
   <link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/library/speciale-tekens/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/estetik-semboller/">

--- a/library/arrow-symbols/index.html
+++ b/library/arrow-symbols/index.html
@@ -22,6 +22,7 @@
   <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/simbolos-de-flechas/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-panah/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/arrow-symbols/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/hwasalpyo-giho/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/setas/">
   <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/ki-tu-mui-ten/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/arrow-symbols/">

--- a/library/discord-symbols/index.html
+++ b/library/discord-symbols/index.html
@@ -22,6 +22,7 @@
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles-discord/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-discord/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-discord/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/discord-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-discord/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-discord/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/discord-sembolleri/">

--- a/library/emoji-combos/index.html
+++ b/library/emoji-combos/index.html
@@ -17,12 +17,13 @@
 <meta name="description" content="Emoji combos to copy and paste — 100+ aesthetic sets (soft girl, cottagecore, Y2K, night sky) for Instagram bios, captions &amp; usernames. Tap any combo to copy.">
 
 <link rel="canonical" href="https://ultratextgen.com/library/emoji-combos/">
-<link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/emoji-combos/">
-<link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/emoji-combos/">
-<link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/emoji-combos/">
-<link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/emoji-combos/">
-<link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/emoji-combos/">
-<link rel="alternate" hreflang="ar" href="https://ultratextgen.com/ar/library/emoji-combos/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/emoji-combos/">
+  <link rel="alternate" hreflang="ar" href="https://ultratextgen.com/ar/library/emoji-combos/">
+  <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/emoji-combos/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/imoji-johap/">
+  <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/emoji-combos/">
+  <link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/emoji-combos/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/emoji-combos/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/library-emoji-combos.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">

--- a/library/heart-symbols/index.html
+++ b/library/heart-symbols/index.html
@@ -23,6 +23,7 @@
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-love/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-cuore/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/heart-symbols/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/hateu-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-serca/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-de-coracao/">
   <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/serdechki/">

--- a/library/roblox-symbols/index.html
+++ b/library/roblox-symbols/index.html
@@ -22,6 +22,7 @@
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles-roblox/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-roblox/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-roblox/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/roblox-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-roblox/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-roblox/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/roblox-sembolleri/">

--- a/library/special-characters/index.html
+++ b/library/special-characters/index.html
@@ -17,12 +17,13 @@
 <meta name="description" content="Browse and copy unique special characters — infinity, peace, OK hand, and meaningful standalone Unicode symbols for bios and text. Click any symbol to copy it instantly.">
 
 <link rel="canonical" href="https://ultratextgen.com/library/special-characters/">
-<link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/special-characters/">
-<link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/special-characters/">
-<link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/special-characters/">
-<link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/special-characters/">
-<link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/special-characters/">
-<link rel="alternate" hreflang="ar" href="https://ultratextgen.com/ar/library/special-characters/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/special-characters/">
+  <link rel="alternate" hreflang="ar" href="https://ultratextgen.com/ar/library/special-characters/">
+  <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/special-characters/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/">
+  <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/special-characters/">
+  <link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/special-characters/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/special-characters/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/library-special-characters.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">

--- a/library/star-symbols/index.html
+++ b/library/star-symbols/index.html
@@ -23,6 +23,7 @@
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-bintang/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-stella/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/star-symbols/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/byeol-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-gwiazdek/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-de-estrela/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/yildiz-sembolleri/">

--- a/library/text-faces-kaomoji/index.html
+++ b/library/text-faces-kaomoji/index.html
@@ -24,6 +24,7 @@
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/kaomoji/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/kaomoji/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/text-faces-kaomoji/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/imotikon/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/kaomoji/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/kaomoji/">
   <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/kaomoji/">

--- a/library/y2k-symbols/index.html
+++ b/library/y2k-symbols/index.html
@@ -22,6 +22,7 @@
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles-y2k/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-y2k/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-y2k/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/y2k-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-y2k/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-y2k/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/y2k-sembolleri/">

--- a/nl/library/speciale-tekens/index.html
+++ b/nl/library/speciale-tekens/index.html
@@ -18,6 +18,7 @@
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-aesthetic/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/aesthetic-symbols/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/gamseong-giho/">
   <link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/library/speciale-tekens/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/estetik-semboller/">
@@ -337,6 +338,7 @@
       <a class="lang-option" href="/fr/library/symboles/" hreflang="fr">FR</a>
       <a class="lang-option" href="/id/library/simbol-aesthetic/" hreflang="id">ID</a>
       <a class="lang-option" href="/ja/library/aesthetic-symbols/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/gamseong-giho/" hreflang="ko">KO</a>
       <a class="lang-option active" href="/nl/library/speciale-tekens/" hreflang="nl">NL</a>
       <a class="lang-option" href="/pt/library/simbolos/" hreflang="pt">PT</a>
       <a class="lang-option" href="/tr/library/estetik-semboller/" hreflang="tr">TR</a>

--- a/pl/library/kaomoji/index.html
+++ b/pl/library/kaomoji/index.html
@@ -24,6 +24,7 @@
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/kaomoji/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/kaomoji/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/text-faces-kaomoji/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/imotikon/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/kaomoji/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/kaomoji/">
   <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/kaomoji/">

--- a/pl/library/symbole-discord/index.html
+++ b/pl/library/symbole-discord/index.html
@@ -22,6 +22,7 @@
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles-discord/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-discord/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-discord/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/discord-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-discord/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-discord/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/discord-sembolleri/">

--- a/pl/library/symbole-gwiazdek/index.html
+++ b/pl/library/symbole-gwiazdek/index.html
@@ -23,6 +23,7 @@
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-bintang/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-stella/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/star-symbols/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/byeol-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-gwiazdek/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-de-estrela/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/yildiz-sembolleri/">

--- a/pl/library/symbole-roblox/index.html
+++ b/pl/library/symbole-roblox/index.html
@@ -22,6 +22,7 @@
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles-roblox/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-roblox/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-roblox/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/roblox-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-roblox/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-roblox/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/roblox-sembolleri/">

--- a/pl/library/symbole-serca/index.html
+++ b/pl/library/symbole-serca/index.html
@@ -23,6 +23,7 @@
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-love/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-cuore/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/heart-symbols/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/hateu-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-serca/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-de-coracao/">
   <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/serdechki/">

--- a/pl/library/symbole-y2k/index.html
+++ b/pl/library/symbole-y2k/index.html
@@ -22,6 +22,7 @@
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles-y2k/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-y2k/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-y2k/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/y2k-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-y2k/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-y2k/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/y2k-sembolleri/">

--- a/pt/library/kaomoji/index.html
+++ b/pt/library/kaomoji/index.html
@@ -24,6 +24,7 @@
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/kaomoji/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/kaomoji/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/text-faces-kaomoji/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/imotikon/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/kaomoji/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/kaomoji/">
   <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/kaomoji/">

--- a/pt/library/setas/index.html
+++ b/pt/library/setas/index.html
@@ -22,6 +22,7 @@
   <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/simbolos-de-flechas/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-panah/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/arrow-symbols/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/hwasalpyo-giho/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/setas/">
   <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/ki-tu-mui-ten/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/arrow-symbols/">

--- a/pt/library/simbolos-de-coracao/index.html
+++ b/pt/library/simbolos-de-coracao/index.html
@@ -23,6 +23,7 @@
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-love/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-cuore/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/heart-symbols/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/hateu-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-serca/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-de-coracao/">
   <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/serdechki/">

--- a/pt/library/simbolos-de-estrela/index.html
+++ b/pt/library/simbolos-de-estrela/index.html
@@ -23,6 +23,7 @@
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-bintang/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-stella/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/star-symbols/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/byeol-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-gwiazdek/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-de-estrela/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/yildiz-sembolleri/">

--- a/pt/library/simbolos-discord/index.html
+++ b/pt/library/simbolos-discord/index.html
@@ -22,6 +22,7 @@
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles-discord/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-discord/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-discord/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/discord-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-discord/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-discord/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/discord-sembolleri/">

--- a/pt/library/simbolos-roblox/index.html
+++ b/pt/library/simbolos-roblox/index.html
@@ -22,6 +22,7 @@
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles-roblox/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-roblox/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-roblox/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/roblox-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-roblox/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-roblox/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/roblox-sembolleri/">

--- a/pt/library/simbolos-y2k/index.html
+++ b/pt/library/simbolos-y2k/index.html
@@ -22,6 +22,7 @@
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles-y2k/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-y2k/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-y2k/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/y2k-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-y2k/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-y2k/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/y2k-sembolleri/">

--- a/pt/library/simbolos/index.html
+++ b/pt/library/simbolos/index.html
@@ -22,6 +22,7 @@
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-aesthetic/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/aesthetic-symbols/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/gamseong-giho/">
   <link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/library/speciale-tekens/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/estetik-semboller/">

--- a/ru/library/emoji-combos/index.html
+++ b/ru/library/emoji-combos/index.html
@@ -17,11 +17,13 @@
 <meta name="description" content="Милые сочетания эмодзи, которые можно скопировать и вставить. Пастельные, минималистичные, с блёстками, в цветах биаса, по временам года и ко дню рождения — наборы по настроению. Один клик — и готово для профиля в Instagram, Telegram или X.">
 
 <link rel="canonical" href="https://ultratextgen.com/ru/library/emoji-combos/">
-<link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/emoji-combos/">
-<link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/emoji-combos/">
-<link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/emoji-combos/">
-<link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/emoji-combos/">
-<link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/emoji-combos/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/emoji-combos/">
+  <link rel="alternate" hreflang="ar" href="https://ultratextgen.com/ar/library/emoji-combos/">
+  <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/emoji-combos/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/imoji-johap/">
+  <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/emoji-combos/">
+  <link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/emoji-combos/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/emoji-combos/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/library-emoji-combos.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">

--- a/ru/library/kaomoji/index.html
+++ b/ru/library/kaomoji/index.html
@@ -24,6 +24,7 @@
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/kaomoji/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/kaomoji/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/text-faces-kaomoji/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/imotikon/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/kaomoji/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/kaomoji/">
   <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/kaomoji/">

--- a/ru/library/serdechki/index.html
+++ b/ru/library/serdechki/index.html
@@ -23,6 +23,7 @@
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-love/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-cuore/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/heart-symbols/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/hateu-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-serca/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-de-coracao/">
   <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/serdechki/">

--- a/ru/library/special-characters/index.html
+++ b/ru/library/special-characters/index.html
@@ -17,11 +17,13 @@
 <meta name="description" content="Красивые специальные символы для копирования и вставки. Блёстки, сердца, звёзды, стрелки, декоративные скобки и ноты — всё по категориям. Просто нажмите, чтобы скопировать, и вставьте в описание в Instagram или в ник в игре.">
 
 <link rel="canonical" href="https://ultratextgen.com/ru/library/special-characters/">
-<link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/special-characters/">
-<link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/special-characters/">
-<link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/special-characters/">
-<link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/special-characters/">
-<link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/special-characters/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/special-characters/">
+  <link rel="alternate" hreflang="ar" href="https://ultratextgen.com/ar/library/special-characters/">
+  <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/special-characters/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/">
+  <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/special-characters/">
+  <link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/special-characters/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/special-characters/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/library-special-characters.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1676,7 +1676,7 @@
 
   <url>
     <loc>https://ultratextgen.com/id/usecase/nama-ff-keren/</loc>
-    <lastmod>2026-07-09</lastmod>
+    <lastmod>2026-07-10</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -1711,7 +1711,7 @@
 
   <url>
     <loc>https://ultratextgen.com/id/usecase/nama-ml-keren/</loc>
-    <lastmod>2026-07-09</lastmod>
+    <lastmod>2026-07-10</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -2120,6 +2120,76 @@
     <lastmod>2026-07-09</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/ko/</loc>
+    <lastmod>2026-07-10</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/ko/library/byeol-giho/</loc>
+    <lastmod>2026-07-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/ko/library/discord-giho/</loc>
+    <lastmod>2026-07-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/ko/library/gamseong-giho/</loc>
+    <lastmod>2026-07-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/ko/library/hateu-giho/</loc>
+    <lastmod>2026-07-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/ko/library/hwasalpyo-giho/</loc>
+    <lastmod>2026-07-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/ko/library/imoji-johap/</loc>
+    <lastmod>2026-07-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/ko/library/imotikon/</loc>
+    <lastmod>2026-07-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/ko/library/roblox-giho/</loc>
+    <lastmod>2026-07-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/ko/library/y2k-giho/</loc>
+    <lastmod>2026-07-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
   </url>
 
   <url>
@@ -4217,7 +4287,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/</loc>
-    <lastmod>2026-07-09</lastmod>
+    <lastmod>2026-07-10</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -4434,7 +4504,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/coloring-page-maker/</loc>
-    <lastmod>2026-07-09</lastmod>
+    <lastmod>2026-07-10</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -4448,14 +4518,21 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/handwriting-worksheet-generator/</loc>
-    <lastmod>2026-07-09</lastmod>
+    <lastmod>2026-07-10</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/printables/name-tracing/</loc>
-    <lastmod>2026-07-09</lastmod>
+    <lastmod>2026-07-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/printables/sight-word-tracing/</loc>
+    <lastmod>2026-07-10</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>

--- a/th/library/emoji-combos/index.html
+++ b/th/library/emoji-combos/index.html
@@ -17,11 +17,13 @@
 <meta name="description" content="รวมชุดอีโมจิน่ารักให้คัดลอกวางได้ทันที ทั้งแนวพาสเทล มินิมอล โทนมุ้งมิ้ง ประกายดาว สีไบแอส ฤดูกาล ไปจนถึงวันเกิด จัดหมวดตามมู้ด แค่แตะก็คัดลอกไปวางในไบโอ IG, LINE หรือ X ได้เลย">
 
 <link rel="canonical" href="https://ultratextgen.com/th/library/emoji-combos/">
-<link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/emoji-combos/">
-<link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/emoji-combos/">
-<link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/emoji-combos/">
-<link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/emoji-combos/">
-<link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/emoji-combos/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/emoji-combos/">
+  <link rel="alternate" hreflang="ar" href="https://ultratextgen.com/ar/library/emoji-combos/">
+  <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/emoji-combos/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/imoji-johap/">
+  <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/emoji-combos/">
+  <link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/emoji-combos/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/emoji-combos/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/library-emoji-combos.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">

--- a/th/library/kaomoji/index.html
+++ b/th/library/kaomoji/index.html
@@ -24,6 +24,7 @@
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/kaomoji/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/kaomoji/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/text-faces-kaomoji/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/imotikon/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/kaomoji/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/kaomoji/">
   <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/kaomoji/">

--- a/th/library/special-characters/index.html
+++ b/th/library/special-characters/index.html
@@ -17,11 +17,13 @@
 <meta name="description" content="รวมอักขระพิเศษน่ารักคัดลอกวางได้ทันที ทั้งดาวระยิบระยับ หัวใจ ลูกศร วงเล็บตกแต่ง ไปจนถึงตัวโน้ต จัดหมวดหมู่ให้ครบ แค่คลิกก็คัดลอกได้ นำไปใส่ไบโอ Instagram หรือชื่อในเกมได้เลย">
 
 <link rel="canonical" href="https://ultratextgen.com/th/library/special-characters/">
-<link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/special-characters/">
-<link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/special-characters/">
-<link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/special-characters/">
-<link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/special-characters/">
-<link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/special-characters/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/special-characters/">
+  <link rel="alternate" hreflang="ar" href="https://ultratextgen.com/ar/library/special-characters/">
+  <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/special-characters/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/">
+  <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/special-characters/">
+  <link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/special-characters/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/special-characters/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/library-special-characters.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">

--- a/tr/library/discord-sembolleri/index.html
+++ b/tr/library/discord-sembolleri/index.html
@@ -22,6 +22,7 @@
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles-discord/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-discord/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-discord/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/discord-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-discord/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-discord/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/discord-sembolleri/">
@@ -596,6 +597,7 @@
       <a class="lang-option" href="/fr/library/symboles-discord/" hreflang="fr">FR</a>
       <a class="lang-option" href="/id/library/simbol-discord/" hreflang="id">ID</a>
       <a class="lang-option" href="/it/library/simboli-discord/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ko/library/discord-giho/" hreflang="ko">KO</a>
       <a class="lang-option" href="/pl/library/symbole-discord/" hreflang="pl">PL</a>
       <a class="lang-option" href="/pt/library/simbolos-discord/" hreflang="pt">PT</a>
       <a class="lang-option active" href="/tr/library/discord-sembolleri/" hreflang="tr">TR</a>

--- a/tr/library/estetik-semboller/index.html
+++ b/tr/library/estetik-semboller/index.html
@@ -22,6 +22,7 @@
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-aesthetic/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/aesthetic-symbols/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/gamseong-giho/">
   <link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/library/speciale-tekens/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/estetik-semboller/">
@@ -275,6 +276,7 @@
       <a class="lang-option" href="/fr/library/symboles/" hreflang="fr">FR</a>
       <a class="lang-option" href="/id/library/simbol-aesthetic/" hreflang="id">ID</a>
       <a class="lang-option" href="/ja/library/aesthetic-symbols/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/gamseong-giho/" hreflang="ko">KO</a>
       <a class="lang-option" href="/nl/library/speciale-tekens/" hreflang="nl">NL</a>
       <a class="lang-option" href="/pt/library/simbolos/" hreflang="pt">PT</a>
       <a class="lang-option active" href="/tr/library/estetik-semboller/" hreflang="tr">TR</a>

--- a/tr/library/kalp-sembolleri/index.html
+++ b/tr/library/kalp-sembolleri/index.html
@@ -24,6 +24,7 @@
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-love/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-cuore/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/heart-symbols/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/hateu-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-serca/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-de-coracao/">
   <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/serdechki/">
@@ -452,6 +453,7 @@
       <a class="lang-option" href="/id/library/simbol-love/" hreflang="id">ID</a>
       <a class="lang-option" href="/it/library/simboli-cuore/" hreflang="it">IT</a>
       <a class="lang-option" href="/ja/library/heart-symbols/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/hateu-giho/" hreflang="ko">KO</a>
       <a class="lang-option" href="/pl/library/symbole-serca/" hreflang="pl">PL</a>
       <a class="lang-option" href="/pt/library/simbolos-de-coracao/" hreflang="pt">PT</a>
       <a class="lang-option" href="/ru/library/serdechki/" hreflang="ru">RU</a>

--- a/tr/library/kaomoji/index.html
+++ b/tr/library/kaomoji/index.html
@@ -25,6 +25,7 @@
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/kaomoji/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/kaomoji/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/text-faces-kaomoji/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/imotikon/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/kaomoji/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/kaomoji/">
   <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/kaomoji/">
@@ -611,6 +612,7 @@
       <a class="lang-option" href="/id/library/kaomoji/" hreflang="id">ID</a>
       <a class="lang-option" href="/it/library/kaomoji/" hreflang="it">IT</a>
       <a class="lang-option" href="/ja/library/text-faces-kaomoji/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/imotikon/" hreflang="ko">KO</a>
       <a class="lang-option" href="/pl/library/kaomoji/" hreflang="pl">PL</a>
       <a class="lang-option" href="/pt/library/kaomoji/" hreflang="pt">PT</a>
       <a class="lang-option" href="/ru/library/kaomoji/" hreflang="ru">RU</a>

--- a/tr/library/roblox-sembolleri/index.html
+++ b/tr/library/roblox-sembolleri/index.html
@@ -23,6 +23,7 @@
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles-roblox/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-roblox/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-roblox/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/roblox-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-roblox/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-roblox/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/roblox-sembolleri/">
@@ -380,6 +381,7 @@
       <a class="lang-option" href="/fr/library/symboles-roblox/" hreflang="fr">FR</a>
       <a class="lang-option" href="/id/library/simbol-roblox/" hreflang="id">ID</a>
       <a class="lang-option" href="/it/library/simboli-roblox/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ko/library/roblox-giho/" hreflang="ko">KO</a>
       <a class="lang-option" href="/pl/library/symbole-roblox/" hreflang="pl">PL</a>
       <a class="lang-option" href="/pt/library/simbolos-roblox/" hreflang="pt">PT</a>
       <a class="lang-option active" href="/tr/library/roblox-sembolleri/" hreflang="tr">TR</a>

--- a/tr/library/y2k-sembolleri/index.html
+++ b/tr/library/y2k-sembolleri/index.html
@@ -22,6 +22,7 @@
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles-y2k/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-y2k/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-y2k/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/y2k-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-y2k/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-y2k/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/y2k-sembolleri/">
@@ -744,6 +745,7 @@
       <a class="lang-option" href="/fr/library/symboles-y2k/" hreflang="fr">FR</a>
       <a class="lang-option" href="/id/library/simbol-y2k/" hreflang="id">ID</a>
       <a class="lang-option" href="/it/library/simboli-y2k/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ko/library/y2k-giho/" hreflang="ko">KO</a>
       <a class="lang-option" href="/pl/library/symbole-y2k/" hreflang="pl">PL</a>
       <a class="lang-option" href="/pt/library/simbolos-y2k/" hreflang="pt">PT</a>
       <a class="lang-option active" href="/tr/library/y2k-sembolleri/" hreflang="tr">TR</a>

--- a/tr/library/yildiz-sembolleri/index.html
+++ b/tr/library/yildiz-sembolleri/index.html
@@ -24,6 +24,7 @@
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-bintang/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-stella/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/star-symbols/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/byeol-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-gwiazdek/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-de-estrela/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/yildiz-sembolleri/">
@@ -533,6 +534,7 @@
       <a class="lang-option" href="/id/library/simbol-bintang/" hreflang="id">ID</a>
       <a class="lang-option" href="/it/library/simboli-stella/" hreflang="it">IT</a>
       <a class="lang-option" href="/ja/library/star-symbols/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/byeol-giho/" hreflang="ko">KO</a>
       <a class="lang-option" href="/pl/library/symbole-gwiazdek/" hreflang="pl">PL</a>
       <a class="lang-option" href="/pt/library/simbolos-de-estrela/" hreflang="pt">PT</a>
       <a class="lang-option active" href="/tr/library/yildiz-sembolleri/" hreflang="tr">TR</a>

--- a/vi/ki-tu-dac-biet/index.html
+++ b/vi/ki-tu-dac-biet/index.html
@@ -18,6 +18,7 @@
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-aesthetic/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/aesthetic-symbols/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/gamseong-giho/">
   <link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/library/speciale-tekens/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/estetik-semboller/">
@@ -385,6 +386,7 @@
       <a class="lang-option" href="/fr/library/symboles/" hreflang="fr">FR</a>
       <a class="lang-option" href="/id/library/simbol-aesthetic/" hreflang="id">ID</a>
       <a class="lang-option" href="/ja/library/aesthetic-symbols/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/gamseong-giho/" hreflang="ko">KO</a>
       <a class="lang-option" href="/nl/library/speciale-tekens/" hreflang="nl">NL</a>
       <a class="lang-option" href="/pt/library/simbolos/" hreflang="pt">PT</a>
       <a class="lang-option" href="/tr/library/estetik-semboller/" hreflang="tr">TR</a>

--- a/vi/ki-tu-discord/index.html
+++ b/vi/ki-tu-discord/index.html
@@ -22,6 +22,7 @@
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles-discord/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-discord/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-discord/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/discord-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-discord/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-discord/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/discord-sembolleri/">
@@ -613,6 +614,7 @@
       <a class="lang-option" href="/fr/library/symboles-discord/" hreflang="fr">FR</a>
       <a class="lang-option" href="/id/library/simbol-discord/" hreflang="id">ID</a>
       <a class="lang-option" href="/it/library/simboli-discord/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ko/library/discord-giho/" hreflang="ko">KO</a>
       <a class="lang-option" href="/pl/library/symbole-discord/" hreflang="pl">PL</a>
       <a class="lang-option" href="/pt/library/simbolos-discord/" hreflang="pt">PT</a>
       <a class="lang-option" href="/tr/library/discord-sembolleri/" hreflang="tr">TR</a>

--- a/vi/ki-tu-mui-ten/index.html
+++ b/vi/ki-tu-mui-ten/index.html
@@ -18,6 +18,7 @@
   <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/simbolos-de-flechas/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-panah/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/arrow-symbols/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/hwasalpyo-giho/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/setas/">
   <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/ki-tu-mui-ten/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/arrow-symbols/">
@@ -1077,6 +1078,7 @@
       <a class="lang-option" href="/es/simbolos-de-flechas/" hreflang="es">ES</a>
       <a class="lang-option" href="/id/library/simbol-panah/" hreflang="id">ID</a>
       <a class="lang-option" href="/ja/library/arrow-symbols/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/hwasalpyo-giho/" hreflang="ko">KO</a>
       <a class="lang-option" href="/pt/library/setas/" hreflang="pt">PT</a>
       <a class="lang-option active" href="/vi/ki-tu-mui-ten/" hreflang="vi">VI</a>
     </div>

--- a/vi/ki-tu-roblox/index.html
+++ b/vi/ki-tu-roblox/index.html
@@ -22,6 +22,7 @@
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles-roblox/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-roblox/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-roblox/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/roblox-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-roblox/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-roblox/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/roblox-sembolleri/">
@@ -433,6 +434,7 @@
       <a class="lang-option" href="/fr/library/symboles-roblox/" hreflang="fr">FR</a>
       <a class="lang-option" href="/id/library/simbol-roblox/" hreflang="id">ID</a>
       <a class="lang-option" href="/it/library/simboli-roblox/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ko/library/roblox-giho/" hreflang="ko">KO</a>
       <a class="lang-option" href="/pl/library/symbole-roblox/" hreflang="pl">PL</a>
       <a class="lang-option" href="/pt/library/simbolos-roblox/" hreflang="pt">PT</a>
       <a class="lang-option" href="/tr/library/roblox-sembolleri/" hreflang="tr">TR</a>

--- a/vi/ki-tu-y2k/index.html
+++ b/vi/ki-tu-y2k/index.html
@@ -18,6 +18,7 @@
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles-y2k/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-y2k/">
   <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-y2k/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/y2k-giho/">
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-y2k/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-y2k/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/y2k-sembolleri/">
@@ -724,6 +725,7 @@
       <a class="lang-option" href="/fr/library/symboles-y2k/" hreflang="fr">FR</a>
       <a class="lang-option" href="/id/library/simbol-y2k/" hreflang="id">ID</a>
       <a class="lang-option" href="/it/library/simboli-y2k/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ko/library/y2k-giho/" hreflang="ko">KO</a>
       <a class="lang-option" href="/pl/library/symbole-y2k/" hreflang="pl">PL</a>
       <a class="lang-option" href="/pt/library/simbolos-y2k/" hreflang="pt">PT</a>
       <a class="lang-option" href="/tr/library/y2k-sembolleri/" hreflang="tr">TR</a>


### PR DESCRIPTION
## Summary

Launches **Korean (`ko`)** — the one genuinely untapped market left, with a large digital / aesthetic / kaomoji / K-culture audience.

**Symbol-only by design.** Hangul cannot take Unicode "font" styling (bold/italic only cover the Latin alphabet), so font-generator pages would render broken. Instead every Korean page is a **copy-paste symbol / kaomoji / emoji library** — which is *script-agnostic* and matches how Koreans actually search (닉네임 꾸미기, 프로필 특수문자, 인스타/디스코드).

### Pages (10)
| Page | Topic |
|---|---|
| `/ko/` | 특수문자 hub (special characters) |
| `library/imotikon` | 이모티콘 — kaomoji / text faces |
| `library/imoji-johap` | 이모지 조합 — emoji combos |
| `library/hateu-giho` | 하트 기호 — hearts ♥ |
| `library/byeol-giho` | 별 기호 — stars ★ |
| `library/hwasalpyo-giho` | 화살표 기호 — arrows → |
| `library/discord-giho` | 디스코드 특수문자 (proven winner) |
| `library/roblox-giho` | 로블록스 특수문자 (proven winner) |
| `library/y2k-giho` | Y2K 특수문자 |
| `library/gamseong-giho` | 감성 특수문자 — aesthetic |

## Verification
- **Structural audit: 10/10 clean** — `<html lang="ko">`, `#shared-header`, darkmode bootstrap, canonical; **no generator engine** (no `UTG_FAMILY` / `UTG_DEMO_TEXT`); symbols copied verbatim; 2-level breadcrumbs (no dead `/ko/library/` link); FAQ/WebPage `inLanguage="ko"`.
- **Render-check: 10/10** in Chromium — native Korean content loads, no page errors.
- **JSON-LD valid across all touched files**; `ko` joined 10 symbol clusters via reciprocal `hreflang`.
- Regenerated `sitemap.xml` (→ 818 URLs).

## Notes
- Deliberately **no bold/italic/platform font pages** for Korean — they'd be broken for Hangul.
- No changes to the generator engine or existing English content beyond reciprocal `hreflang` wiring.
- Branch was reset onto the latest `main` (which already contains prior localization work, squash-merged), so this is a clean single-commit PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QkQR6kdcmrco1sbNo9grUL)_