### PR TITLE
feat(i18n): translate remaining 6 aesthetic packs into 7 markets

### DIFF
--- a/es/library/simbolos-dreamcore-weirdcore/index.html
+++ b/es/library/simbolos-dreamcore-weirdcore/index.html
@@ -1,0 +1,419 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Símbolos Dreamcore y Weirdcore: copiar y pegar 👁 🌈 ⋆ estética surrealista</title>
+<meta name="description" content="Símbolos dreamcore y weirdcore — ojos surrealistas 👁, arcoíris 🌈, bloques glitch, puertas y combos sleepcore para publicaciones liminales. Toca cualquier símbolo para copiarlo al instante.">
+
+<link rel="canonical" href="https://ultratextgen.com/es/library/simbolos-dreamcore-weirdcore/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/library/simbolos-dreamcore-weirdcore/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/es/library/simbolos-dreamcore-weirdcore/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/es-library-simbolos-dreamcore-weirdcore.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Símbolos Dreamcore y Weirdcore: copiar y pegar 👁 🌈 ⋆ estética surrealista">
+<meta name="twitter:description" content="Símbolos dreamcore y weirdcore — ojos surrealistas 👁, arcoíris 🌈, bloques glitch, puertas y combos sleepcore para publicaciones liminales. Toca cualquier símbolo para copiarlo al instante.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/es-library-simbolos-dreamcore-weirdcore.png">
+<meta property="og:title" content="Símbolos Dreamcore y Weirdcore: copiar y pegar 👁 🌈 ⋆ estética surrealista">
+<meta property="og:description" content="Símbolos dreamcore y weirdcore — ojos surrealistas 👁, arcoíris 🌈, bloques glitch, puertas y combos sleepcore para publicaciones liminales. Toca cualquier símbolo para copiarlo al instante.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/es/library/simbolos-dreamcore-weirdcore/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Símbolos Dreamcore y Weirdcore: copiar y pegar 👁 🌈 ⋆ estética surrealista",
+  "alternateName": ["Símbolos dreamcore para copiar y pegar", "Símbolos weirdcore para copiar y pegar", "Símbolos aesthetic dreamcore", "Símbolos aesthetic weirdcore", "Símbolos de estética surrealista", "Símbolos de espacios liminales", "Símbolos de texto dreamcore", "Emojis dreamcore weirdcore"],
+  "description": "Símbolos dreamcore y weirdcore — ojos surrealistas 👁, arcoíris 🌈, bloques glitch, puertas y combos sleepcore para publicaciones liminales. Toca cualquier símbolo para copiarlo al instante.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/es-library-simbolos-dreamcore-weirdcore.png",
+  "mainEntityOfPage": "https://ultratextgen.com/es/library/simbolos-dreamcore-weirdcore/",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Inicio",
+      "item": "https://ultratextgen.com/es/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Símbolos Dreamcore y Weirdcore",
+      "item": "https://ultratextgen.com/es/library/simbolos-dreamcore-weirdcore/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/es/">Inicio</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Símbolos Dreamcore y Weirdcore</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Símbolos Dreamcore y Weirdcore</h1>
+    <p class="hero-tagline">Ojos surrealistas, puertas infinitas, bloques de estática glitch y cielos somnolientos para estéticas de espacios liminales. Toca cualquier símbolo o combo para copiarlo al instante.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/es-library-simbolos-dreamcore-weirdcore.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Dreamcore y weirdcore son estéticas de internet hermanas, construidas sobre la lógica surrealista de los sueños — cielos nostálgicos, ojos que observan, puertas hacia ninguna parte y objetos familiares ligeramente distorsionados. Estos símbolos dreamcore y weirdcore trasladan ese ambiente a texto copiable: 👁 ojos, 🌈 arcoíris, 📺 televisores viejos, bloques de sombreado para la estática y un set sleepcore para ediciones más suaves y adormecidas. Úsalos en estados de Discord, cabeceras de Tumblr, pies de foto de TikTok y descripciones de YouTube, o cógete un combo surrealista completo de abajo.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="eyes-surreal">
+  <span class="article-section-label">Ojos que observan</span>
+  <h2>Símbolos de ojos que observan</h2>
+  <p class="u-secondary-tight">Los ojos que no parpadean en el corazón de la imaginería weirdcore, desde emojis hasta jeroglíficos egipcios.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="👁" aria-label="Copiar Ojo">👁</button>
+      <span class="flag-label">Ojo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="👁️" aria-label="Copiar Ojo (estilo emoji)">👁️</button>
+      <span class="flag-label">Ojo (estilo emoji)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="👀" aria-label="Copiar Ojos">👀</button>
+      <span class="flag-label">Ojos</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓂀" aria-label="Copiar Ojo de Horus (jeroglífico egipcio)">𓂀</button>
+      <span class="flag-label">Ojo de Horus (jeroglífico egipcio)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓁹" aria-label="Copiar Ojo jeroglífico egipcio">𓁹</button>
+      <span class="flag-label">Ojo jeroglífico egipcio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="◉" aria-label="Copiar Ojo de pez">◉</button>
+      <span class="flag-label">Ojo de pez</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊙" aria-label="Copiar Operador de punto en círculo">⊙</button>
+      <span class="flag-label">Operador de punto en círculo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="👁️‍🗨️" aria-label="Copiar Ojo en bocadillo">👁️‍🗨️</button>
+      <span class="flag-label">Ojo en bocadillo</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="dream-sky">
+  <span class="article-section-label">Cielo de ensueño</span>
+  <h2>Símbolos de cielo dreamcore</h2>
+  <p class="u-secondary-tight">Arcoíris, nubes y cielos en espiral — la mitad luminosa y nostálgica de la estética.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌈" aria-label="Copiar Arcoíris">🌈</button>
+      <span class="flag-label">Arcoíris</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☁️" aria-label="Copiar Nube">☁️</button>
+      <span class="flag-label">Nube</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌙" aria-label="Copiar Luna creciente">🌙</button>
+      <span class="flag-label">Luna creciente</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⭐" aria-label="Copiar Estrella">⭐</button>
+      <span class="flag-label">Estrella</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌀" aria-label="Copiar Ciclón">🌀</button>
+      <span class="flag-label">Ciclón</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🫧" aria-label="Copiar Burbujas">🫧</button>
+      <span class="flag-label">Burbujas</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌌" aria-label="Copiar Vía Láctea">🌌</button>
+      <span class="flag-label">Vía Láctea</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💫" aria-label="Copiar Estrella mareada">💫</button>
+      <span class="flag-label">Estrella mareada</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="weirdcore-objects">
+  <span class="article-section-label">Objetos weirdcore</span>
+  <h2>Símbolos de objetos weirdcore</h2>
+  <p class="u-secondary-tight">Puertas, agujeros, espejos y televisores viejos — objetos familiares colocados donde no deberían estar.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="📺" aria-label="Copiar Televisor">📺</button>
+      <span class="flag-label">Televisor</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🚪" aria-label="Copiar Puerta">🚪</button>
+      <span class="flag-label">Puerta</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕳" aria-label="Copiar Agujero">🕳</button>
+      <span class="flag-label">Agujero</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🪞" aria-label="Copiar Espejo">🪞</button>
+      <span class="flag-label">Espejo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🛗" aria-label="Copiar Ascensor">🛗</button>
+      <span class="flag-label">Ascensor</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🎈" aria-label="Copiar Globo">🎈</button>
+      <span class="flag-label">Globo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🩹" aria-label="Copiar Tirita">🩹</button>
+      <span class="flag-label">Tirita</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧸" aria-label="Copiar Osito de peluche">🧸</button>
+      <span class="flag-label">Osito de peluche</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="sleepcore">
+  <span class="article-section-label">Sleepcore</span>
+  <h2>Símbolos sleepcore</h2>
+  <p class="u-secondary-tight">La subestética somnolienta — camas, cielos nocturnos y la suave llamada del sueño.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💤" aria-label="Copiar Zzz">💤</button>
+      <span class="flag-label">Zzz</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🛏" aria-label="Copiar Cama">🛏</button>
+      <span class="flag-label">Cama</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="😴" aria-label="Copiar Cara durmiendo">😴</button>
+      <span class="flag-label">Cara durmiendo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌃" aria-label="Copiar Noche con estrellas">🌃</button>
+      <span class="flag-label">Noche con estrellas</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕰" aria-label="Copiar Reloj de chimenea">🕰</button>
+      <span class="flag-label">Reloj de chimenea</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🥱" aria-label="Copiar Cara bostezando">🥱</button>
+      <span class="flag-label">Cara bostezando</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="glitch-static">
+  <span class="article-section-label">Glitch y estática</span>
+  <h2>Caracteres de bloque glitch y estática</h2>
+  <p class="u-secondary-tight">Caracteres Unicode de sombreado y bloque que se leen como estática de televisor y píxeles corruptos.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="░" aria-label="Copiar Sombreado claro">░</button>
+      <span class="flag-label">Sombreado claro</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="▒" aria-label="Copiar Sombreado medio">▒</button>
+      <span class="flag-label">Sombreado medio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="▓" aria-label="Copiar Sombreado oscuro">▓</button>
+      <span class="flag-label">Sombreado oscuro</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="█" aria-label="Copiar Bloque completo">█</button>
+      <span class="flag-label">Bloque completo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="▚" aria-label="Copiar Cuadrante superior izquierdo e inferior derecho">▚</button>
+      <span class="flag-label">Cuadrante superior izquierdo e inferior derecho</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⋆" aria-label="Copiar Operador estrella">⋆</button>
+      <span class="flag-label">Operador estrella</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="combo-sets">
+  <span class="article-section-label">Sets de combos</span>
+  <h2>Sets de combos dreamcore y weirdcore</h2>
+  <p class="u-secondary-block">Copia un combo surrealista completo con un clic — ojos, cielos, estática y sueño, listos para pegar en cualquier lugar.</p>
+  <div id="dreamcoreSetsContainer"></div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Dale estilo a tu texto con fuentes Unicode</h3>
+  <p>Usa UltraTextGen para convertir texto normal en negrita, cursiva, caligrafía y más de 100 estilos de fuentes Unicode — gratis y al instante.</p>
+  <a href="/es/" class="cta-btn">Abrir UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Recursos relacionados</span>
+  <div class="compare-grid">
+    <a href="/es/library/simbolos-fairycore/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos fairycore</h4>
+      <p>Hadas, setas y polvo de hada para biografías encantadas.</p>
+    </a>
+    <a href="/es/library/simbolos-y2k/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos Y2K</h4>
+      <p>Caracteres retrofuturistas de los 2000 y marcas de estética cyber.</p>
+    </a>
+    <a href="/es/simbolos-aesthetic/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos aesthetic</h4>
+      <p>La colección maestra de símbolos de texto aesthetic y separadores.</p>
+    </a>
+    <a href="/es/simbolos-de-estrella/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos de estrella</h4>
+      <p>Estrellas y brillos de todos los estilos, listos para copiar.</p>
+    </a>
+    <a href="/es/library/kaomoji/" class="compare-card variant-muted u-no-underline">
+      <h4>Kaomoji</h4>
+      <p>Caras y emoticonos japoneses para expresar cada estado de ánimo.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    {
+      name: "Cielo dreamcore",
+      flags: ["🌈", "☁️", "👁", "⭐", "🌀"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Pasillo weirdcore",
+      flags: ["🚪", "📺", "🕳", "🪞", "👁"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Deriva sleepcore",
+      flags: ["💤", "🛏", "🌙", "☁️", "😴"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Ojos que todo lo ven",
+      flags: ["👁", "𓂀", "◉", "👀", "⊙"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Barras de estática glitch",
+      flags: ["░▒▓█▓▒░", "▓▒░⋆░▒▓", "█▓▒░"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Sueño pastel",
+      flags: ["🫧", "🌈", "🪞", "💫", "☁️"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Noche liminal",
+      flags: ["🌃", "🛗", "🕰", "🌌", "🚪"],
+      defaultFormat: "inline"
+    }
+  ];
+
+  ns.buildGrids("dreamcoreSetsContainer", GROUPS);
+  if (ns.parseTwemoji) ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/es/library/simbolos-fairycore/index.html
+++ b/es/library/simbolos-fairycore/index.html
@@ -1,0 +1,386 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Símbolos fairycore ✿ hadas, setas y brillos para copiar y pegar</title>
+<meta name="description" content="Símbolos fairycore y combos de emojis para copiar y pegar — hadas 🧚, setas 🍄, brillos ✨ y delicados caracteres de flores para biografías mágicas. Toca cualquier símbolo para copiarlo al instante.">
+
+<link rel="canonical" href="https://ultratextgen.com/es/library/simbolos-fairycore/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/library/simbolos-fairycore/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/es/library/simbolos-fairycore/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/es-library-simbolos-fairycore.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Símbolos fairycore ✿ hadas, setas y brillos para copiar y pegar">
+<meta name="twitter:description" content="Símbolos fairycore y combos de emojis para copiar y pegar — hadas 🧚, setas 🍄, brillos ✨ y delicados caracteres de flores para biografías mágicas. Toca cualquier símbolo para copiarlo al instante.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/es-library-simbolos-fairycore.png">
+<meta property="og:title" content="Símbolos fairycore ✿ hadas, setas y brillos para copiar y pegar">
+<meta property="og:description" content="Símbolos fairycore y combos de emojis para copiar y pegar — hadas 🧚, setas 🍄, brillos ✨ y delicados caracteres de flores para biografías mágicas. Toca cualquier símbolo para copiarlo al instante.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/es/library/simbolos-fairycore/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Símbolos fairycore: copiar y pegar 🧚 🍄 ✨ estética de hadas",
+  "alternateName": ["Símbolos fairycore copiar y pegar", "símbolos aesthetic fairycore", "emojis fairycore", "símbolos de hadas para copiar", "símbolos fairycore cottagecore", "símbolos mágicos para copiar y pegar"],
+  "description": "Símbolos fairycore y combos de emojis para copiar y pegar — hadas 🧚, setas 🍄, brillos ✨ y delicados caracteres de flores para biografías mágicas. Toca cualquier símbolo para copiarlo al instante.",
+  "inLanguage": "es",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/es-library-simbolos-fairycore.png",
+  "mainEntityOfPage": "https://ultratextgen.com/es/library/simbolos-fairycore/",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Inicio",
+      "item": "https://ultratextgen.com/es/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Símbolos fairycore",
+      "item": "https://ultratextgen.com/es/library/simbolos-fairycore/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/es/">Inicio</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Símbolos fairycore</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Símbolos fairycore</h1>
+    <p class="hero-tagline">Hadas, setas, brillos de polvo de hada y flores del bosque para una estética encantada. Toca cualquier símbolo o combo para copiarlo al instante.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/es-library-simbolos-fairycore.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>El fairycore es una estética mágica construida en torno a hadas, bosques luminosos, corros de setas y suaves destellos dorados — piensa en jardines encantados y polvo de hada. Estos símbolos fairycore y combos de emojis capturan esa magia con hadas 🧚, setas 🍄, brillos ✨ y delicados caracteres de florecita como ✿ y ❀. Úsalos en biografías de Instagram, nombres de tableros de Pinterest, pies de foto de TikTok y secciones «sobre mí» de Discord, o copia un combo ya armado más abajo.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="fairies-magic">
+  <span class="article-section-label">Hadas y magia</span>
+  <h2>Emojis de hadas y magia</h2>
+  <p class="u-secondary-tight">La familia de emojis de hadas junto a varitas y magia con brillos.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧚" aria-label="Copiar 🧚">🧚</button>
+      <span class="flag-label">Hada</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧚‍♀️" aria-label="Copiar 🧚‍♀️">🧚‍♀️</button>
+      <span class="flag-label">Hada mujer</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧚‍♂️" aria-label="Copiar 🧚‍♂️">🧚‍♂️</button>
+      <span class="flag-label">Hada hombre</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🪄" aria-label="Copiar 🪄">🪄</button>
+      <span class="flag-label">Varita mágica</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✨" aria-label="Copiar ✨">✨</button>
+      <span class="flag-label">Brillos</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💫" aria-label="Copiar 💫">💫</button>
+      <span class="flag-label">Estrella mareada</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🔮" aria-label="Copiar 🔮">🔮</button>
+      <span class="flag-label">Bola de cristal</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="mushrooms-flora">
+  <span class="article-section-label">Setas y flora</span>
+  <h2>Setas y flora del bosque</h2>
+  <p class="u-secondary-tight">Setas, flores y las florecitas Unicode que son la base de todo diseño fairycore.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🍄" aria-label="Copiar 🍄">🍄</button>
+      <span class="flag-label">Seta</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌷" aria-label="Copiar 🌷">🌷</button>
+      <span class="flag-label">Tulipán</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌸" aria-label="Copiar 🌸">🌸</button>
+      <span class="flag-label">Flor de cerezo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌼" aria-label="Copiar 🌼">🌼</button>
+      <span class="flag-label">Flor</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✿" aria-label="Copiar ✿">✿</button>
+      <span class="flag-label">Florecita negra</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❀" aria-label="Copiar ❀">❀</button>
+      <span class="flag-label">Florecita blanca</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌿" aria-label="Copiar 🌿">🌿</button>
+      <span class="flag-label">Hierba</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🍃" aria-label="Copiar 🍃">🍃</button>
+      <span class="flag-label">Hoja al viento</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🪷" aria-label="Copiar 🪷">🪷</button>
+      <span class="flag-label">Loto</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="pixie-sparkles">
+  <span class="article-section-label">Polvo de hada</span>
+  <h2>Polvo de hada y estrellas brillantes</h2>
+  <p class="u-secondary-tight">Pequeños caracteres de estrella y brillo para crear delicados separadores de texto y acentos en el nombre de usuario.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⋆" aria-label="Copiar ⋆">⋆</button>
+      <span class="flag-label">Operador estrella</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✦" aria-label="Copiar ✦">✦</button>
+      <span class="flag-label">Estrella negra de cuatro puntas</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✧" aria-label="Copiar ✧">✧</button>
+      <span class="flag-label">Estrella blanca de cuatro puntas</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✩" aria-label="Copiar ✩">✩</button>
+      <span class="flag-label">Estrella de contorno marcado</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="˚" aria-label="Copiar ˚">˚</button>
+      <span class="flag-label">Anillo superior</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="୨୧" aria-label="Copiar ୨୧">୨୧</button>
+      <span class="flag-label">Lazo aesthetic (dígitos odia)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌟" aria-label="Copiar 🌟">🌟</button>
+      <span class="flag-label">Estrella brillante</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="garden-creatures">
+  <span class="article-section-label">Criaturas del jardín</span>
+  <h2>Criaturas del jardín encantado</h2>
+  <p class="u-secondary-tight">Mariposas, caracoles y suaves visitantes del jardín que completan la escena del jardín de hadas.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦋" aria-label="Copiar 🦋">🦋</button>
+      <span class="flag-label">Mariposa</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐌" aria-label="Copiar 🐌">🐌</button>
+      <span class="flag-label">Caracol</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐞" aria-label="Copiar 🐞">🐞</button>
+      <span class="flag-label">Mariquita</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐝" aria-label="Copiar 🐝">🐝</button>
+      <span class="flag-label">Abeja</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐇" aria-label="Copiar 🐇">🐇</button>
+      <span class="flag-label">Conejo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦢" aria-label="Copiar 🦢">🦢</button>
+      <span class="flag-label">Cisne</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕊" aria-label="Copiar 🕊">🕊</button>
+      <span class="flag-label">Paloma</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="combo-sets">
+  <span class="article-section-label">Combos</span>
+  <h2>Combos fairycore</h2>
+  <p class="u-secondary-block">Copia un combo de emojis fairycore completo con un solo clic — listo para biografías, pies de foto y nombres de tableros.</p>
+  <div id="fairycoreSetsContainer"></div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Dale estilo a tu texto con fuentes Unicode</h3>
+  <p>Usa UltraTextGen para convertir texto normal en negrita, cursiva, caligrafía y más de 100 estilos de fuentes Unicode — gratis y al instante.</p>
+  <a href="/es/" class="cta-btn">Abrir UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Recursos relacionados</span>
+  <div class="compare-grid">
+    <a href="/es/library/simbolos-cottagecore/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos cottagecore</h4>
+      <p>Setas, abejas y caracteres rústicos de vida en el campo.</p>
+    </a>
+    <a href="/es/library/simbolos-coquette/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos coquette</h4>
+      <p>Lazos, cintas y caracteres de estética femenina y suave.</p>
+    </a>
+    <a href="/es/library/simbolos-y2k/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos Y2K</h4>
+      <p>Estrellas de brillo, cruces góticas, mariposas y CDs cyber.</p>
+    </a>
+    <a href="/es/simbolos-de-estrella/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos de estrella</h4>
+      <p>Estrellas y brillos de todas las formas para tu texto aesthetic.</p>
+    </a>
+    <a href="/es/simbolos-aesthetic/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos aesthetic</h4>
+      <p>Estrellas, brillos, corazones y adornos bonitos para tu perfil.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    {
+      name: "Jardín de hadas",
+      flags: ["🧚", "🍄", "🌷", "✨", "🌿", "🦋"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Estela de polvo de hada",
+      flags: ["✨", "⋆", "˚", "✧", "🪄", "💫"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Corro de setas",
+      flags: ["🍄", "🌿", "🍄", "✨", "🍄", "🍃"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Pradera de mariposas",
+      flags: ["🦋", "🌼", "🌸", "🐝", "🍃"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Hada a la luz de la luna",
+      flags: ["🌙", "✨", "🧚", "⋆", "☁️"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Separador delicado para biografía",
+      flags: ["⋆˚✿˖°", "୨୧", "⋆˚❀˖°"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Hada de campo",
+      flags: ["🍄", "🐌", "🌷", "🧺", "🐇"],
+      defaultFormat: "inline"
+    }
+  ];
+
+  ns.buildGrids("fairycoreSetsContainer", GROUPS);
+  if (ns.parseTwemoji) ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/es/library/simbolos-goth-grunge/index.html
+++ b/es/library/simbolos-goth-grunge/index.html
@@ -1,0 +1,368 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Símbolos Goth y Grunge ♱ cruces, calaveras y dark aesthetic para copiar y pegar</title>
+<meta name="description" content="Símbolos dark aesthetic para biografías goth y grunge — cruces ♱, calaveras 💀, arañas 🕷 y dagas † para nombres de usuario y perfiles. Un toque para copiar.">
+
+<link rel="canonical" href="https://ultratextgen.com/es/library/simbolos-goth-grunge/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/library/simbolos-goth-grunge/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/es/library/simbolos-goth-grunge/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/es-library-simbolos-goth-grunge.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Símbolos Goth y Grunge ♱ cruces, calaveras y dark aesthetic para copiar y pegar">
+<meta name="twitter:description" content="Símbolos dark aesthetic para biografías goth y grunge — cruces ♱, calaveras 💀, arañas 🕷 y dagas † para nombres de usuario y perfiles. Un toque para copiar.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/es-library-simbolos-goth-grunge.png">
+<meta property="og:title" content="Símbolos Goth y Grunge ♱ cruces, calaveras y dark aesthetic para copiar y pegar">
+<meta property="og:description" content="Símbolos dark aesthetic para biografías goth y grunge — cruces ♱, calaveras 💀, arañas 🕷 y dagas † para nombres de usuario y perfiles. Un toque para copiar.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/es/library/simbolos-goth-grunge/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "inLanguage": "es",
+  "headline": "Símbolos Goth y Grunge para copiar y pegar — decoraciones de biografía dark aesthetic",
+  "alternateName": ["Símbolos goth para copiar y pegar", "símbolos dark aesthetic", "símbolos grunge copiar y pegar", "símbolos para biografía oscura", "símbolos góticos", "símbolos emo para copiar", "símbolos de texto dark aesthetic", "emojis goth para copiar y pegar"],
+  "description": "Símbolos dark aesthetic para biografías goth y grunge — cruces, calaveras, arañas, dagas y decoraciones de moda alternativa para nombres de usuario y perfiles.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/es-library-simbolos-goth-grunge.png",
+  "mainEntityOfPage": "https://ultratextgen.com/es/library/simbolos-goth-grunge/",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Inicio",
+      "item": "https://ultratextgen.com/es/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Símbolos Goth y Grunge",
+      "item": "https://ultratextgen.com/es/library/simbolos-goth-grunge/"
+    }
+  ]
+}
+</script>
+
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/es/">Inicio</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Símbolos Goth y Grunge</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Símbolos Goth y Grunge</h1>
+    <p class="hero-tagline">Símbolos dark aesthetic para biografías goth y grunge — cruces, calaveras, arañas, dagas y decoraciones de moda alternativa. Toca cualquiera para copiarlo al instante.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/es-library-simbolos-goth-grunge.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Las estéticas goth y grunge abrazan la oscuridad, el filo y la subversión — rosas negras, cruces góticas, arañas, cadenas y calaveras. Estos caracteres Unicode y emojis traducen esa energía a decoraciones de biografía y pies de foto. Funcionan en Instagram, TikTok, Discord, Tumblr y en cualquier lugar que admita Unicode.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 1 -->
+<section class="mood-explainers" id="crosses-daggers">
+  <span class="article-section-label">Cruces y dagas</span>
+  <h2>Cruces y dagas</h2>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♱" aria-label="Copiar ♱">♱</button>
+      <span class="flag-label">Cruz siríaca oriental</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="†" aria-label="Copiar †">†</button>
+      <span class="flag-label">Daga</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‡" aria-label="Copiar ‡">‡</button>
+      <span class="flag-label">Daga doble</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✟" aria-label="Copiar ✟">✟</button>
+      <span class="flag-label">Cruz latina perfilada</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🗡" aria-label="Copiar 🗡">🗡</button>
+      <span class="flag-label">Emoji de daga</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚔" aria-label="Copiar ⚔">⚔</button>
+      <span class="flag-label">Espadas cruzadas</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🔪" aria-label="Copiar 🔪">🔪</button>
+      <span class="flag-label">Emoji de cuchillo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛧" aria-label="Copiar ⛧">⛧</button>
+      <span class="flag-label">Pentagrama invertido</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𖤐" aria-label="Copiar 𖤐">𖤐</button>
+      <span class="flag-label">Sol negro</span>
+    </div>
+      <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✝" aria-label="Copiar ✝">✝</button>
+      <span class="flag-label">Cruz latina</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☥" aria-label="Copiar ☥">☥</button>
+      <span class="flag-label">Anj</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✠" aria-label="Copiar ✠">✠</button>
+      <span class="flag-label">Cruz de Malta</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☦" aria-label="Copiar ☦">☦</button>
+      <span class="flag-label">Cruz ortodoxa</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☽" aria-label="Copiar ☽">☽</button>
+      <span class="flag-label">Luna creciente</span>
+    </div>
+</div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 2 -->
+<section class="mood-explainers" id="skulls-death">
+  <span class="article-section-label">Calaveras y motivos de muerte</span>
+  <h2>Calaveras y motivos de muerte</h2>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☠" aria-label="Copiar ☠">☠</button>
+      <span class="flag-label">Calavera y tibias cruzadas</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💀" aria-label="Copiar 💀">💀</button>
+      <span class="flag-label">Emoji de calavera</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🩸" aria-label="Copiar 🩸">🩸</button>
+      <span class="flag-label">Emoji de gota de sangre</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚰" aria-label="Copiar ⚰">⚰</button>
+      <span class="flag-label">Ataúd</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🪦" aria-label="Copiar 🪦">🪦</button>
+      <span class="flag-label">Emoji de lápida</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚱" aria-label="Copiar ⚱">⚱</button>
+      <span class="flag-label">Urna funeraria</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 3 -->
+<section class="mood-explainers" id="spiders-bats">
+  <span class="article-section-label">Arañas, murciélagos y criaturas</span>
+  <h2>Arañas, murciélagos y criaturas</h2>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕷" aria-label="Copiar 🕷">🕷</button>
+      <span class="flag-label">Emoji de araña</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕸" aria-label="Copiar 🕸">🕸</button>
+      <span class="flag-label">Emoji de telaraña</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦇" aria-label="Copiar 🦇">🦇</button>
+      <span class="flag-label">Emoji de murciélago</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐍" aria-label="Copiar 🐍">🐍</button>
+      <span class="flag-label">Emoji de serpiente</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦂" aria-label="Copiar 🦂">🦂</button>
+      <span class="flag-label">Emoji de escorpión</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 4 -->
+<section class="mood-explainers" id="dark-florals">
+  <span class="article-section-label">Flores oscuras</span>
+  <h2>Flores oscuras</h2>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🥀" aria-label="Copiar 🥀">🥀</button>
+      <span class="flag-label">Emoji de flor marchita</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚘" aria-label="Copiar ⚘">⚘</button>
+      <span class="flag-label">Flor</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🖤" aria-label="Copiar 🖤">🖤</button>
+      <span class="flag-label">Emoji de corazón negro</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❦" aria-label="Copiar ❦">❦</button>
+      <span class="flag-label">Corazón floral</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❧" aria-label="Copiar ❧">❧</button>
+      <span class="flag-label">Corazón floral rotado</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓆩♱𓆪" aria-label="Copiar 𓆩♱𓆪">𓆩♱𓆪</button>
+      <span class="flag-label">Marco egipcio con cruz</span>
+    </div>
+  </div>
+  <p>Muchos símbolos goth se solapan con la estética Y2K oscura — consulta la biblioteca de <a href="/es/library/simbolos-y2k/">Símbolos Y2K</a> para estrellas de brillo, cruces góticas y marcos cyber.</p>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- COLLECTIONS -->
+<section class="mood-explainers" id="goth-grunge-collections">
+  <span class="article-section-label">Colecciones goth y grunge</span>
+  <h2>Sets de biografía dark aesthetic</h2>
+  <p class="u-secondary-block">Cadenas dark aesthetic ya armadas que puedes pegar directamente en una biografía, pie de foto o nombre de usuario — copia el combo entero con un solo clic.</p>
+  <div id="gothGrungeCollectionsContainer"></div>
+</section>
+
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Dale estilo a tu texto con fuentes Unicode</h3>
+  <p>Usa UltraTextGen para convertir texto normal en negrita, cursiva, caligrafía y más de 100 estilos de fuentes Unicode — gratis y al instante.</p>
+  <a href="/es/" class="cta-btn">Abrir UltraTextGen →</a>
+</div>
+
+
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Recursos relacionados</span>
+  <div class="compare-grid">
+    <a href="/es/library/simbolos-y2k/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos Y2K</h4>
+      <p>Decoraciones cyber y dark aesthetic de principios de los 2000.</p>
+    </a>
+    <a href="/es/simbolos-aesthetic/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos aesthetic</h4>
+      <p>Símbolos aesthetic bonitos — estrellas, brillos y adornos para tu perfil.</p>
+    </a>
+    <a href="/es/library/simbolos-coquette/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos coquette</h4>
+      <p>Lazos, corazones y adornos suaves para biografías coquette.</p>
+    </a>
+    <a href="/es/simbolos-de-corazon/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos de corazón</h4>
+      <p>Corazones negros y símbolos de amor de todos los estilos, listos para copiar.</p>
+    </a>
+    <a href="/es/simbolos-de-estrella/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos de estrella</h4>
+      <p>Estrellas oscuras y variantes decorativas de estrella.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    { name: "Separador de cruz gótica", flags: ["†","˖","♱","˖","†"], defaultFormat: "inline" },
+    { name: "Marco egipcio con cruz", flags: ["𓆩♱𓆪"], defaultFormat: "inline" },
+    { name: "Borde de dagas", flags: ["✟","·","†","‡","†","·","✟"], defaultFormat: "inline" },
+    { name: "Combo de rosa marchita", flags: ["🥀","🖤","🥀"], defaultFormat: "inline" },
+    { name: "Sendero floral oscuro", flags: ["❦","˖","🖤","˖","❧"], defaultFormat: "inline" },
+    { name: "Combo de biografía con pentagrama", flags: ["⛧","˖","𖤐","˖","⛧"], defaultFormat: "inline" }
+  ];
+
+  ns.buildGrids("gothGrungeCollectionsContainer", GROUPS);
+  ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/es/library/simbolos-kawaii-cute/index.html
+++ b/es/library/simbolos-kawaii-cute/index.html
@@ -1,0 +1,420 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Símbolos kawaii y tiernos para copiar y pegar — decoraciones aesthetic suaves</title>
+<meta name="description" content="Símbolos kawaii y tiernos para biografías, nombres de usuario y mensajes. Corazones suaves, caritas diminutas, brillos y decoraciones pastel de la estética kawaii.">
+
+<link rel="canonical" href="https://ultratextgen.com/es/library/simbolos-kawaii-cute/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/library/simbolos-kawaii-cute/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/es/library/simbolos-kawaii-cute/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/es-library-simbolos-kawaii-cute.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Símbolos kawaii y tiernos para copiar y pegar — decoraciones aesthetic suaves">
+<meta name="twitter:description" content="Símbolos kawaii y tiernos para biografías, nombres de usuario y mensajes. Corazones suaves, caritas diminutas, brillos y decoraciones pastel de la estética kawaii.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/es-library-simbolos-kawaii-cute.png">
+<meta property="og:title" content="Símbolos kawaii y tiernos para copiar y pegar — decoraciones aesthetic suaves">
+<meta property="og:description" content="Símbolos kawaii y tiernos para biografías, nombres de usuario y mensajes. Corazones suaves, caritas diminutas, brillos y decoraciones pastel de la estética kawaii.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/es/library/simbolos-kawaii-cute/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "inLanguage": "es",
+  "headline": "Símbolos kawaii y tiernos para copiar y pegar — decoraciones aesthetic suaves",
+  "alternateName": ["Símbolos kawaii copiar y pegar", "símbolos tiernos copiar y pegar", "símbolos de texto kawaii", "símbolos aesthetic tiernos", "símbolos aesthetic suaves", "decoraciones kawaii", "símbolos japoneses tiernos"],
+  "description": "Símbolos kawaii y tiernos para biografías, nombres de usuario y mensajes. Corazones suaves, caritas diminutas, brillos y decoraciones pastel de la estética kawaii.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/es-library-simbolos-kawaii-cute.png",
+  "mainEntityOfPage": "https://ultratextgen.com/es/library/simbolos-kawaii-cute/",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Inicio",
+      "item": "https://ultratextgen.com/es/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Símbolos kawaii y tiernos",
+      "item": "https://ultratextgen.com/es/library/simbolos-kawaii-cute/"
+    }
+  ]
+}
+</script>
+
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/es/">Inicio</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Símbolos kawaii y tiernos</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Símbolos kawaii y tiernos</h1>
+    <p class="hero-tagline">Corazones suaves, caritas diminutas, brillos y decoraciones pastel kawaii. Toca cualquier símbolo para copiarlo al instante en biografías, nombres de usuario y mensajes.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/es-library-simbolos-kawaii-cute.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Kawaii (かわいい) significa tierno en japonés, y la estética kawaii celebra todo lo suave, pastel y adorable. Estos caracteres Unicode y emojis capturan esa sensación: caritas diminutas, símbolos de corazón, marcas de brillo y corchetes envolventes tiernos. Úsalos en biografías, mensajes, nombres de usuario y pies de foto en Instagram, TikTok, Discord y cualquier plataforma que admita texto Unicode.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 1 -->
+<section class="mood-explainers" id="cute-hearts">
+  <span class="article-section-label">Corazones tiernos</span>
+  <h2>Corazones tiernos</h2>
+  <p>Caracteres de corazón suave para biografías kawaii y mensajes dulces.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♡" aria-label="Copiar ♡">♡</button>
+      <span class="flag-label">Corazón blanco</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ෆ" aria-label="Copiar ෆ">ෆ</button>
+      <span class="flag-label">Corazón cingalés</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❤" aria-label="Copiar ❤">❤</button>
+      <span class="flag-label">Corazón rojo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❥" aria-label="Copiar ❥">❥</button>
+      <span class="flag-label">Viñeta de corazón rotada</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ʚɞ" aria-label="Copiar ʚɞ">ʚɞ</button>
+      <span class="flag-label">Corazón con alas (combo)</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 2 -->
+<section class="mood-explainers" id="tiny-cute-faces">
+  <span class="article-section-label">Caritas tiernas</span>
+  <h2>Caritas tiernas</h2>
+  <p>Kaomoji y caritas Unicode para añadir expresiones kawaii a tus mensajes y biografías.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(˶˃ ᵕ ˂˶)" aria-label="Copiar (˶˃ ᵕ ˂˶)">(˶˃ ᵕ ˂˶)</button>
+      <span class="flag-label">Carita sonrojada (combo)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ʕ•ᴥ•ʔ" aria-label="Copiar ʕ•ᴥ•ʔ">ʕ•ᴥ•ʔ</button>
+      <span class="flag-label">Carita de oso (combo)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(づ ◕‿◕)づ" aria-label="Copiar (づ ◕‿◕)づ">(づ ◕‿◕)づ</button>
+      <span class="flag-label">Carita de abrazo (combo)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(✿◠‿◠)" aria-label="Copiar (✿◠‿◠)">(✿◠‿◠)</button>
+      <span class="flag-label">Carita de flor (combo)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="◕" aria-label="Copiar ◕">◕</button>
+      <span class="flag-label">Ojo circular grande</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="◡" aria-label="Copiar ◡">◡</button>
+      <span class="flag-label">Letra curva</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 3 -->
+<section class="mood-explainers" id="cute-wrappers">
+  <span class="article-section-label">Corchetes y marcos tiernos</span>
+  <h2>Corchetes y marcos tiernos</h2>
+  <p>Corchetes decorativos y caracteres envolventes para nombres de usuario kawaii y dar formato a tu biografía.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="꒰" aria-label="Copiar ꒰">꒰</button>
+      <span class="flag-label">Paréntesis ornamental izquierdo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="꒱" aria-label="Copiar ꒱">꒱</button>
+      <span class="flag-label">Paréntesis ornamental derecho</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="◌" aria-label="Copiar ◌">◌</button>
+      <span class="flag-label">Anillo combinante</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊂" aria-label="Copiar ⊂">⊂</button>
+      <span class="flag-label">Subconjunto de</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊃" aria-label="Copiar ⊃">⊃</button>
+      <span class="flag-label">Superconjunto de</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="୨୧" aria-label="Copiar ୨୧">୨୧</button>
+      <span class="flag-label">Onda coquette (combo)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✿" aria-label="Copiar ✿">✿</button>
+      <span class="flag-label">Florecilla negra</span>
+    </div>
+      <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ʚ" aria-label="Copiar ʚ">ʚ</button>
+      <span class="flag-label">Ala de corazón izquierda</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ɞ" aria-label="Copiar ɞ">ɞ</button>
+      <span class="flag-label">Ala de corazón derecha</span>
+    </div>
+</div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 4 -->
+<section class="mood-explainers" id="decorative-marks-kawaii">
+  <span class="article-section-label">Marcas decorativas</span>
+  <h2>Marcas decorativas</h2>
+  <p>Brillos, puntitos y pequeñas marcas de acento para dar un toque kawaii a cualquier texto.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⋆" aria-label="Copiar ⋆">⋆</button>
+      <span class="flag-label">Operador estrella de seis puntas</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊹" aria-label="Copiar ⊹">⊹</button>
+      <span class="flag-label">Cruz ortogonal</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✧" aria-label="Copiar ✧">✧</button>
+      <span class="flag-label">Estrella blanca de cuatro puntas</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⩩" aria-label="Copiar ⩩">⩩</button>
+      <span class="flag-label">Similar o igual</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="๑" aria-label="Copiar ๑">๑</button>
+      <span class="flag-label">Carácter tailandés Ko Kai</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⌒" aria-label="Copiar ⌒">⌒</button>
+      <span class="flag-label">Arco</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❀" aria-label="Copiar ❀">❀</button>
+      <span class="flag-label">Florecilla blanca</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 5 -->
+<section class="mood-explainers" id="pastel-motifs">
+  <span class="article-section-label">Motivos pastel</span>
+  <h2>Motivos pastel</h2>
+  <p>Símbolos suaves de flores y cielo para construir una estética kawaii de ensueño.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✿" aria-label="Copiar ✿">✿</button>
+      <span class="flag-label">Florecilla negra</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❀" aria-label="Copiar ❀">❀</button>
+      <span class="flag-label">Florecilla blanca</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❁" aria-label="Copiar ❁">❁</button>
+      <span class="flag-label">Florecilla de ocho pétalos</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☁" aria-label="Copiar ☁">☁</button>
+      <span class="flag-label">Nube</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☾" aria-label="Copiar ☾">☾</button>
+      <span class="flag-label">Luna creciente</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛅" aria-label="Copiar ⛅">⛅</button>
+      <span class="flag-label">Sol tras la nube</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✦" aria-label="Copiar ✦">✦</button>
+      <span class="flag-label">Estrella negra de cuatro puntas</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⋆" aria-label="Copiar ⋆">⋆</button>
+      <span class="flag-label">Operador estrella de seis puntas</span>
+    </div>
+      <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧸" aria-label="Copiar 🧸">🧸</button>
+      <span class="flag-label">Osito de peluche</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐻" aria-label="Copiar 🐻">🐻</button>
+      <span class="flag-label">Carita de oso</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐰" aria-label="Copiar 🐰">🐰</button>
+      <span class="flag-label">Carita de conejo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🎀" aria-label="Copiar 🎀">🎀</button>
+      <span class="flag-label">Lazo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌸" aria-label="Copiar 🌸">🌸</button>
+      <span class="flag-label">Flor de cerezo</span>
+    </div>
+</div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- COLLECTIONS -->
+<section class="mood-explainers" id="kawaii-collections">
+  <span class="article-section-label">Colecciones kawaii</span>
+  <h2>Sets kawaii para biografía y nombre de usuario</h2>
+  <p class="u-secondary-block">Combos kawaii listos para usar — corazones suaves, caritas diminutas y brillos pastel que puedes pegar directamente en una biografía, nombre de usuario o mensaje con un solo clic.</p>
+  <div id="kawaiiCollectionsContainer"></div>
+</section>
+
+<div class="section-divider"></div>
+
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Dale estilo a tu texto con fuentes Unicode</h3>
+  <p>Usa UltraTextGen para convertir texto normal en negrita, cursiva, caligrafía y más de 100 estilos de fuentes Unicode — gratis y al instante.</p>
+  <a href="/es/" class="cta-btn">Abrir UltraTextGen →</a>
+</div>
+
+
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Recursos relacionados</span>
+  <div class="compare-grid">
+    <a href="/es/library/simbolos-coquette/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos coquette</h4>
+      <p>Lazos, cintas y símbolos suaves y femeninos para biografías coquette.</p>
+    </a>
+    <a href="/es/library/simbolos-cottagecore/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos cottagecore</h4>
+      <p>Flores, setas y símbolos de campo para una estética cottagecore acogedora.</p>
+    </a>
+    <a href="/es/simbolos-de-corazon/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos de corazón</h4>
+      <p>Corazones y símbolos de amor de todos los colores y estilos, listos para copiar.</p>
+    </a>
+    <a href="/es/simbolos-aesthetic/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos aesthetic</h4>
+      <p>Símbolos aesthetic bonitos — estrellas, brillos, corazones y adornos para tu perfil.</p>
+    </a>
+    <a href="/es/library/kaomoji/" class="compare-card variant-muted u-no-underline">
+      <h4>Kaomoji</h4>
+      <p>Caritas japonesas y emoticonos de texto para copiar y pegar en tus mensajes.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    { name: "Combo de biografía con corazón suave", flags: ["꒰","♡","꒱","⋆","ෆ"], defaultFormat: "inline" },
+    { name: "Separador de brillos kawaii", flags: ["⊹","⋆","✧","⋆","⊹"], defaultFormat: "inline" },
+    { name: "Nombre de usuario con alas de flor", flags: ["ʚ ✿ ɞ"], defaultFormat: "inline" },
+    { name: "Borde de polvo pastel", flags: ["✦","⋆","❀","⋆","✦"], defaultFormat: "inline" },
+    { name: "Marco de biografía con carita", flags: ["(˶˃ ᵕ ˂˶)","♡"], defaultFormat: "inline" },
+    { name: "Combo de corchetes tiernos", flags: ["꒰ ♡ ꒱"], defaultFormat: "inline" }
+  ];
+
+  ns.buildGrids("kawaiiCollectionsContainer", GROUPS);
+  ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/es/library/simbolos-therian/index.html
+++ b/es/library/simbolos-therian/index.html
@@ -1,0 +1,363 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Símbolos Therian: copiar y pegar Δ theta-delta y marcas alterhuman</title>
+<meta name="description" content="Explora marcas theta-delta (θΔ), huellas, fases lunares y símbolos de animales que usa la comunidad therian y alterhuman. Toca cualquier símbolo para copiarlo al instante.">
+
+<link rel="canonical" href="https://ultratextgen.com/es/library/simbolos-therian/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/library/simbolos-therian/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/es/library/simbolos-therian/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/es-library-simbolos-therian.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Símbolos Therian: copiar y pegar Δ theta-delta y marcas alterhuman">
+<meta name="twitter:description" content="Explora marcas theta-delta (θΔ), huellas, fases lunares y símbolos de animales que usa la comunidad therian y alterhuman. Toca cualquier símbolo para copiarlo al instante.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/es-library-simbolos-therian.png">
+<meta property="og:title" content="Símbolos Therian: copiar y pegar Δ theta-delta y marcas alterhuman">
+<meta property="og:description" content="Explora marcas theta-delta (θΔ), huellas, fases lunares y símbolos de animales que usa la comunidad therian y alterhuman. Toca cualquier símbolo para copiarlo al instante.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/es/library/simbolos-therian/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "inLanguage": "es",
+  "headline": "Símbolos Therian: copiar y pegar Δ theta-delta y marcas alterhuman",
+  "alternateName": ["Símbolos therian copiar y pegar", "Símbolo theta delta copiar pegar", "Símbolos alterhuman", "Símbolos de la comunidad therian", "Signos therian", "Símbolos de huellas para copiar", "Emojis therian para copiar"],
+  "description": "Explora marcas theta-delta (θΔ), huellas, fases lunares y símbolos de animales que usa la comunidad therian y alterhuman. Toca cualquier símbolo para copiarlo al instante.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/es-library-simbolos-therian.png",
+  "mainEntityOfPage": "https://ultratextgen.com/es/library/simbolos-therian/",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Inicio",
+      "item": "https://ultratextgen.com/es/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Símbolos Therian",
+      "item": "https://ultratextgen.com/es/library/simbolos-therian/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/es/">Inicio</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Símbolos Therian</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Símbolos Therian</h1>
+    <p class="hero-tagline">La marca comunitaria theta-delta (θΔ) más los símbolos de huellas, lunas y animales de la identidad therian y alterhuman. Toca cualquier símbolo para copiarlo al instante.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/es-library-simbolos-therian.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>El símbolo therian que más gente busca es el theta-delta — las letras griegas theta (θ) y delta (Δ) combinadas —, adoptado por la comunidad de la terianthropía en 2003 como una marca de identidad compartida y respetuosa. Los therians son personas que experimentan una identificación profunda y no física con un animal, y la comunidad alterhuman más amplia usa marcas relacionadas junto con huellas, fases lunares y emojis de animales. Esta página reúne el theta-delta en sus formas Unicode más comunes junto con los símbolos de naturaleza y animales que se usan en biografías de TikTok, blogs de Tumblr y perfiles de Discord.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="theta-delta">
+  <span class="article-section-label">Theta-delta</span>
+  <h2>Marcas comunitarias theta-delta</h2>
+  <p class="u-secondary-tight">La marca theta-delta hecha con letras griegas reales — copia el par combinado o cada letra por separado.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="θΔ" aria-label="Copiar Theta-delta (marca therian)">θΔ</button>
+      <span class="flag-label">Theta-delta (marca therian)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ΘΔ" aria-label="Copiar Theta-delta mayúscula">ΘΔ</button>
+      <span class="flag-label">Theta-delta mayúscula</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="θ" aria-label="Copiar Letra griega theta minúscula">θ</button>
+      <span class="flag-label">Letra griega theta minúscula</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="Θ" aria-label="Copiar Letra griega theta mayúscula">Θ</button>
+      <span class="flag-label">Letra griega theta mayúscula</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="Δ" aria-label="Copiar Letra griega delta mayúscula">Δ</button>
+      <span class="flag-label">Letra griega delta mayúscula</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="δ" aria-label="Copiar Letra griega delta minúscula">δ</button>
+      <span class="flag-label">Letra griega delta minúscula</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ϴ" aria-label="Copiar Símbolo griego theta mayúscula">ϴ</button>
+      <span class="flag-label">Símbolo griego theta mayúscula</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ϑ" aria-label="Copiar Símbolo griego theta">ϑ</button>
+      <span class="flag-label">Símbolo griego theta</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="paw-prints">
+  <span class="article-section-label">Huellas y cánidos</span>
+  <h2>Huellas y símbolos de cánidos</h2>
+  <p class="u-secondary-tight">Huellas y los emojis de lobo, zorro y perro que más aparecen en las biografías therian.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐾" aria-label="Copiar Huellas">🐾</button>
+      <span class="flag-label">Huellas</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐺" aria-label="Copiar Lobo">🐺</button>
+      <span class="flag-label">Lobo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦊" aria-label="Copiar Zorro">🦊</button>
+      <span class="flag-label">Zorro</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐕" aria-label="Copiar Perro">🐕</button>
+      <span class="flag-label">Perro</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐈‍⬛" aria-label="Copiar Gato negro">🐈‍⬛</button>
+      <span class="flag-label">Gato negro</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦝" aria-label="Copiar Mapache">🦝</button>
+      <span class="flag-label">Mapache</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐅" aria-label="Copiar Tigre">🐅</button>
+      <span class="flag-label">Tigre</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦴" aria-label="Copiar Hueso">🦴</button>
+      <span class="flag-label">Hueso</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="wild-animals">
+  <span class="article-section-label">Animales salvajes</span>
+  <h2>Símbolos de animales salvajes y teriotipos</h2>
+  <p class="u-secondary-tight">Emojis para teriotipos comunes — desde ciervos y grandes felinos hasta aves de presa.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦌" aria-label="Copiar Ciervo">🦌</button>
+      <span class="flag-label">Ciervo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐆" aria-label="Copiar Leopardo">🐆</button>
+      <span class="flag-label">Leopardo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦅" aria-label="Copiar Águila">🦅</button>
+      <span class="flag-label">Águila</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦉" aria-label="Copiar Búho">🦉</button>
+      <span class="flag-label">Búho</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐦‍⬛" aria-label="Copiar Pájaro negro">🐦‍⬛</button>
+      <span class="flag-label">Pájaro negro</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐍" aria-label="Copiar Serpiente">🐍</button>
+      <span class="flag-label">Serpiente</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦈" aria-label="Copiar Tiburón">🦈</button>
+      <span class="flag-label">Tiburón</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐉" aria-label="Copiar Dragón">🐉</button>
+      <span class="flag-label">Dragón</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="moon-night">
+  <span class="article-section-label">Luna y noche</span>
+  <h2>Símbolos de luna y noche</h2>
+  <p class="u-secondary-tight">Fases lunares y caracteres de luna creciente — un motivo de siempre en los espacios therian y alterhuman.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌙" aria-label="Copiar Luna creciente">🌙</button>
+      <span class="flag-label">Luna creciente</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☾" aria-label="Copiar Cuarto menguante (texto)">☾</button>
+      <span class="flag-label">Cuarto menguante (texto)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☽" aria-label="Copiar Cuarto creciente (texto)">☽</button>
+      <span class="flag-label">Cuarto creciente (texto)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌕" aria-label="Copiar Luna llena">🌕</button>
+      <span class="flag-label">Luna llena</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌑" aria-label="Copiar Luna nueva">🌑</button>
+      <span class="flag-label">Luna nueva</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌒" aria-label="Copiar Luna creciente iluminante">🌒</button>
+      <span class="flag-label">Luna creciente iluminante</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="forest-nature">
+  <span class="article-section-label">Bosque y naturaleza</span>
+  <h2>Símbolos de bosque y naturaleza</h2>
+  <p class="u-secondary-tight">Caracteres de bosque y naturaleza para rematar el pie de un vídeo de quadrobics o un perfil.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌲" aria-label="Copiar Árbol de hoja perenne">🌲</button>
+      <span class="flag-label">Árbol de hoja perenne</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌿" aria-label="Copiar Hierba">🌿</button>
+      <span class="flag-label">Hierba</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🍂" aria-label="Copiar Hoja caída">🍂</button>
+      <span class="flag-label">Hoja caída</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛰" aria-label="Copiar Montaña">⛰</button>
+      <span class="flag-label">Montaña</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🪶" aria-label="Copiar Pluma">🪶</button>
+      <span class="flag-label">Pluma</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌾" aria-label="Copiar Gavilla de arroz">🌾</button>
+      <span class="flag-label">Gavilla de arroz</span>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Dale estilo a tu texto con fuentes Unicode</h3>
+  <p>Usa UltraTextGen para convertir texto normal en negrita, cursiva, caligrafía y más de 100 estilos de fuentes Unicode — gratis y al instante.</p>
+  <a href="/es/" class="cta-btn">Abrir UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Recursos relacionados</span>
+  <div class="compare-grid">
+    <a href="/es/simbolos-de-estrella/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos de estrella</h4>
+      <p>Estrellas, lunas y caracteres celestiales para copiar y pegar.</p>
+    </a>
+    <a href="/es/library/simbolos-goth-grunge/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos goth grunge</h4>
+      <p>Cruces, dagas y marcas oscuras para perfiles y biografías con actitud.</p>
+    </a>
+    <a href="/es/library/simbolos-dreamcore-weirdcore/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos dreamcore y weirdcore</h4>
+      <p>Glifos surrealistas y nostálgicos para estéticas oníricas alterhuman.</p>
+    </a>
+    <a href="/es/library/simbolos-fairycore/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos fairycore</h4>
+      <p>Hojas, flores y motivos de bosque para estéticas de naturaleza mágica.</p>
+    </a>
+    <a href="/es/simbolos-aesthetic/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos aesthetic</h4>
+      <p>Símbolos aesthetic bonitos — estrellas, brillos, corazones y adornos para tu perfil.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/es/library/simbolos-witchy-occult/index.html
+++ b/es/library/simbolos-witchy-occult/index.html
@@ -1,0 +1,763 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Símbolos Witchy y Ocultos: copiar y pegar caracteres ocultos</title>
+<meta name="description" content="Explora y copia símbolos witchy y ocultos — pentagramas, fases lunares, signos planetarios, símbolos alquímicos y otros caracteres esotéricos. Haz clic en cualquiera para copiarlo.">
+
+<link rel="canonical" href="https://ultratextgen.com/es/library/simbolos-witchy-occult/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/witchy-occult-symbols/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/library/simbolos-witchy-occult/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/witchy-occult-symbols/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/es-library-simbolos-witchy-occult.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Símbolos Witchy y Ocultos: copiar y pegar caracteres ocultos">
+<meta name="twitter:description" content="Explora y copia símbolos witchy y ocultos — pentagramas, fases lunares, signos planetarios, símbolos alquímicos y otros caracteres esotéricos. Haz clic en cualquiera para copiarlo.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/es-library-simbolos-witchy-occult.png">
+<meta property="og:title" content="Símbolos Witchy y Ocultos: copiar y pegar caracteres ocultos">
+<meta property="og:description" content="Explora y copia símbolos witchy y ocultos — pentagramas, fases lunares, signos planetarios, símbolos alquímicos y otros caracteres esotéricos. Haz clic en cualquiera para copiarlo.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/es/library/simbolos-witchy-occult/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "inLanguage": "es",
+  "headline": "Símbolos Witchy y Ocultos: copiar y pegar caracteres ocultos",
+  "alternateName": ["Símbolos ocultos para copiar y pegar", "Símbolos witchy para copiar y pegar", "Símbolos de bruja Unicode", "Símbolos mágicos para copiar y pegar", "Símbolos esotéricos para copiar y pegar", "Símbolo de pentagrama para copiar y pegar", "Emojis witchy para copiar y pegar"],
+  "description": "Explora y copia símbolos witchy y ocultos — pentagramas, fases lunares, signos planetarios, símbolos alquímicos y otros caracteres esotéricos. Haz clic en cualquiera para copiarlo.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/es-library-simbolos-witchy-occult.png",
+  "mainEntityOfPage": "https://ultratextgen.com/es/library/simbolos-witchy-occult/",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Inicio",
+      "item": "https://ultratextgen.com/es/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Símbolos Witchy y Ocultos",
+      "item": "https://ultratextgen.com/es/library/simbolos-witchy-occult/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/es/">Inicio</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Símbolos Witchy y Ocultos</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Símbolos Witchy y Ocultos</h1>
+    <p class="hero-tagline">Una colección seleccionada de pentagramas, fases lunares, símbolos planetarios, signos alquímicos y otros caracteres Unicode esotéricos. Toca cualquier símbolo para copiarlo al instante.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/es-library-simbolos-witchy-occult.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Esta biblioteca reúne símbolos Unicode asociados con la brujería, el ocultismo, la alquimia y las tradiciones esotéricas. Todos son caracteres Unicode estándar — utilizables en texto, biografías y escritura creativa. La sección de símbolos alquímicos cubre el bloque Unicode dedicado a los símbolos alquímicos (U+1F700–U+1F73F).</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="pentagrams-stars">
+  <span class="article-section-label">Pentagramas y estrellas</span>
+  <h2>Pentagramas y estrellas de cinco puntas</h2>
+  <p>Formas de estrella y pentagrama asociadas con tradiciones esotéricas y ocultas.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="★" aria-label="Copiar Estrella negra">★</button>
+      <span class="flag-label">Estrella negra</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☆" aria-label="Copiar Estrella blanca">☆</button>
+      <span class="flag-label">Estrella blanca</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚹" aria-label="Copiar Sextil">⚹</button>
+      <span class="flag-label">Sextil</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✡" aria-label="Copiar Estrella de David">✡</button>
+      <span class="flag-label">Estrella de David</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚜" aria-label="Copiar Flor de lis">⚜</button>
+      <span class="flag-label">Flor de lis</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛤" aria-label="Copiar Pentagrama">⛤</button>
+      <span class="flag-label">Pentagrama</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛥" aria-label="Copiar Pentagrama hacia la derecha">⛥</button>
+      <span class="flag-label">Pentagrama hacia la derecha</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛦" aria-label="Copiar Pentagrama hacia la izquierda">⛦</button>
+      <span class="flag-label">Pentagrama hacia la izquierda</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛧" aria-label="Copiar Pentagrama invertido">⛧</button>
+      <span class="flag-label">Pentagrama invertido</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✴" aria-label="Copiar Estrella de ocho puntas">✴</button>
+      <span class="flag-label">Estrella de ocho puntas</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✪" aria-label="Copiar Estrella blanca en círculo">✪</button>
+      <span class="flag-label">Estrella blanca en círculo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✶" aria-label="Copiar Estrella de seis puntas">✶</button>
+      <span class="flag-label">Estrella de seis puntas</span>
+    </div>
+      <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✦" aria-label="Copiar ✦">✦</button>
+      <span class="flag-label">Estrella de brillo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="◯" aria-label="Copiar ◯">◯</button>
+      <span class="flag-label">Círculo grande</span>
+    </div>
+</div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- Anchor preserved for inbound links/bookmarks; canonical content lives on /library/moon-celestial-symbols/#celestial-collections -->
+<section class="mood-explainers" id="moon-phases">
+  <span class="article-section-label">Fases lunares</span>
+  <h2>Símbolos de fases lunares</h2>
+  <p>¿Buscas el ciclo lunar completo? Encuentra estrellas y símbolos celestes en la página dedicada, listos para copiar.</p>
+  <div class="compare-grid" style="margin-top:1rem;">
+    <a href="/es/simbolos-de-estrella/" class="compare-card variant-muted u-no-underline">
+      <h4>Ver: Símbolos de estrella y celestes →</h4>
+      <p>Las ocho fases lunares Unicode (🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘) más variantes de luna creciente y oscura/clara, listas para copiar en secuencia.</p>
+    </a>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- CLASSICAL 7 PLANETS (featured sub-group) -->
+<section class="mood-explainers" id="classical-7-planets">
+  <span class="article-section-label">Los 7 planetas clásicos</span>
+  <h2>Los siete planetas clásicos (Sol → Saturno)</h2>
+  <p class="u-secondary-tight">Los siete planetas de la astrología tradicional en orden caldeo — los cuerpos visibles del cielo que conocían los astrónomos antiguos.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☉" aria-label="Copiar Sol">☉</button>
+      <span class="flag-label">Sol</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☽" aria-label="Copiar Luna">☽</button>
+      <span class="flag-label">Luna</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☿" aria-label="Copiar Mercurio">☿</button>
+      <span class="flag-label">Mercurio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♀" aria-label="Copiar Venus">♀</button>
+      <span class="flag-label">Venus</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♂" aria-label="Copiar Marte">♂</button>
+      <span class="flag-label">Marte</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♃" aria-label="Copiar Júpiter">♃</button>
+      <span class="flag-label">Júpiter</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♄" aria-label="Copiar Saturno">♄</button>
+      <span class="flag-label">Saturno</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="planetary-zodiac">
+  <span class="article-section-label">Planetarios y afines al zodiaco</span>
+  <h2>Símbolos planetarios y astrológicos</h2>
+  <p>Símbolos planetarios clásicos y glifos astrológicos con asociaciones ocultas.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☉" aria-label="Copiar Sol">☉</button>
+      <span class="flag-label">Sol</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☽" aria-label="Copiar Luna">☽</button>
+      <span class="flag-label">Luna</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☿" aria-label="Copiar Mercurio">☿</button>
+      <span class="flag-label">Mercurio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♀" aria-label="Copiar Venus">♀</button>
+      <span class="flag-label">Venus</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♁" aria-label="Copiar Tierra">♁</button>
+      <span class="flag-label">Tierra</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♂" aria-label="Copiar Marte">♂</button>
+      <span class="flag-label">Marte</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♃" aria-label="Copiar Júpiter">♃</button>
+      <span class="flag-label">Júpiter</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♄" aria-label="Copiar Saturno">♄</button>
+      <span class="flag-label">Saturno</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♅" aria-label="Copiar Urano">♅</button>
+      <span class="flag-label">Urano</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♆" aria-label="Copiar Neptuno">♆</button>
+      <span class="flag-label">Neptuno</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♇" aria-label="Copiar Plutón">♇</button>
+      <span class="flag-label">Plutón</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚸" aria-label="Copiar Luna Negra Lilith">⚸</button>
+      <span class="flag-label">Luna Negra Lilith</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚳" aria-label="Copiar Ceres">⚳</button>
+      <span class="flag-label">Ceres</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚴" aria-label="Copiar Palas">⚴</button>
+      <span class="flag-label">Palas</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚵" aria-label="Copiar Juno">⚵</button>
+      <span class="flag-label">Juno</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚶" aria-label="Copiar Vesta">⚶</button>
+      <span class="flag-label">Vesta</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="alchemical">
+  <span class="article-section-label">Alquímicos</span>
+  <h2>Símbolos alquímicos (U+1F700–U+1F73F)</h2>
+  <p>El bloque Unicode de símbolos alquímicos, con signos para elementos, procesos y sustancias usados en la alquimia histórica.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜀" aria-label="Copiar Quintaesencia">🜀</button>
+      <span class="flag-label">Quintaesencia</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜁" aria-label="Copiar Aire">🜁</button>
+      <span class="flag-label">Aire</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜂" aria-label="Copiar Fuego">🜂</button>
+      <span class="flag-label">Fuego</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜃" aria-label="Copiar Tierra">🜃</button>
+      <span class="flag-label">Tierra</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜄" aria-label="Copiar Agua">🜄</button>
+      <span class="flag-label">Agua</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜅" aria-label="Copiar Aguafuerte">🜅</button>
+      <span class="flag-label">Aguafuerte</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜆" aria-label="Copiar Agua regia">🜆</button>
+      <span class="flag-label">Agua regia</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜇" aria-label="Copiar Agua regia II">🜇</button>
+      <span class="flag-label">Agua regia II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜈" aria-label="Copiar Aqua vitae">🜈</button>
+      <span class="flag-label">Aqua vitae</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜉" aria-label="Copiar Aqua vitae II">🜉</button>
+      <span class="flag-label">Aqua vitae II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜊" aria-label="Copiar Vinagre">🜊</button>
+      <span class="flag-label">Vinagre</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜋" aria-label="Copiar Vinagre II">🜋</button>
+      <span class="flag-label">Vinagre II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜌" aria-label="Copiar Vinagre III">🜌</button>
+      <span class="flag-label">Vinagre III</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜍" aria-label="Copiar Azufre">🜍</button>
+      <span class="flag-label">Azufre</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜎" aria-label="Copiar Azufre II">🜎</button>
+      <span class="flag-label">Azufre II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜏" aria-label="Copiar Azufre III">🜏</button>
+      <span class="flag-label">Azufre III</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜐" aria-label="Copiar Sal">🜐</button>
+      <span class="flag-label">Sal</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜑" aria-label="Copiar Sal II">🜑</button>
+      <span class="flag-label">Sal II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜒" aria-label="Copiar Sal III">🜒</button>
+      <span class="flag-label">Sal III</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜓" aria-label="Copiar Sublimado de mercurio">🜓</button>
+      <span class="flag-label">Sublimado de mercurio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜔" aria-label="Copiar Sublimado de mercurio II">🜔</button>
+      <span class="flag-label">Sublimado de mercurio II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜕" aria-label="Copiar Sublimado de mercurio III">🜕</button>
+      <span class="flag-label">Sublimado de mercurio III</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜖" aria-label="Copiar Cinabrio">🜖</button>
+      <span class="flag-label">Cinabrio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜗" aria-label="Copiar Sal amoníaco">🜗</button>
+      <span class="flag-label">Sal amoníaco</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜘" aria-label="Copiar Vitriolo">🜘</button>
+      <span class="flag-label">Vitriolo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜙" aria-label="Copiar Vitriolo II">🜙</button>
+      <span class="flag-label">Vitriolo II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜚" aria-label="Copiar Oro">🜚</button>
+      <span class="flag-label">Oro</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜛" aria-label="Copiar Plata">🜛</button>
+      <span class="flag-label">Plata</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜜" aria-label="Copiar Mena de hierro">🜜</button>
+      <span class="flag-label">Mena de hierro</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜝" aria-label="Copiar Mena de hierro II">🜝</button>
+      <span class="flag-label">Mena de hierro II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜞" aria-label="Copiar Croco de hierro">🜞</button>
+      <span class="flag-label">Croco de hierro</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜟" aria-label="Copiar Régulo de hierro">🜟</button>
+      <span class="flag-label">Régulo de hierro</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜠" aria-label="Copiar Mena de cobre">🜠</button>
+      <span class="flag-label">Mena de cobre</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜡" aria-label="Copiar Mena de hierro-cobre">🜡</button>
+      <span class="flag-label">Mena de hierro-cobre</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜢" aria-label="Copiar Sublimado de cobre">🜢</button>
+      <span class="flag-label">Sublimado de cobre</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜣" aria-label="Copiar Croco de cobre">🜣</button>
+      <span class="flag-label">Croco de cobre</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜤" aria-label="Copiar Antimoniato de cobre">🜤</button>
+      <span class="flag-label">Antimoniato de cobre</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜥" aria-label="Copiar Sal de antimoniato de cobre">🜥</button>
+      <span class="flag-label">Sal de antimoniato de cobre</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜦" aria-label="Copiar Sublimado de sal de cobre">🜦</button>
+      <span class="flag-label">Sublimado de sal de cobre</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜧" aria-label="Copiar Cardenillo">🜧</button>
+      <span class="flag-label">Cardenillo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜨" aria-label="Copiar Mena de estaño">🜨</button>
+      <span class="flag-label">Mena de estaño</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜩" aria-label="Copiar Mena de plomo">🜩</button>
+      <span class="flag-label">Mena de plomo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜪" aria-label="Copiar Tierra de mena de plomo">🜪</button>
+      <span class="flag-label">Tierra de mena de plomo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜫" aria-label="Copiar Antimonio">🜫</button>
+      <span class="flag-label">Antimonio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜬" aria-label="Copiar Antimonio II">🜬</button>
+      <span class="flag-label">Antimonio II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜭" aria-label="Copiar Sublimado de antimonio">🜭</button>
+      <span class="flag-label">Sublimado de antimonio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜮" aria-label="Copiar Sal de antimonio">🜮</button>
+      <span class="flag-label">Sal de antimonio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜯" aria-label="Copiar Sublimado de sal de antimonio">🜯</button>
+      <span class="flag-label">Sublimado de sal de antimonio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜰" aria-label="Copiar Vinagre de antimonio">🜰</button>
+      <span class="flag-label">Vinagre de antimonio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜱" aria-label="Copiar Régulo de antimonio">🜱</button>
+      <span class="flag-label">Régulo de antimonio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜲" aria-label="Copiar Régulo de antimonio II">🜲</button>
+      <span class="flag-label">Régulo de antimonio II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜳" aria-label="Copiar Régulo">🜳</button>
+      <span class="flag-label">Régulo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜴" aria-label="Copiar Régulo II">🜴</button>
+      <span class="flag-label">Régulo II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜵" aria-label="Copiar Régulo III">🜵</button>
+      <span class="flag-label">Régulo III</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜶" aria-label="Copiar Régulo IV">🜶</button>
+      <span class="flag-label">Régulo IV</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜷" aria-label="Copiar Álcali">🜷</button>
+      <span class="flag-label">Álcali</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜸" aria-label="Copiar Álcali II">🜸</button>
+      <span class="flag-label">Álcali II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜹" aria-label="Copiar Marcasita">🜹</button>
+      <span class="flag-label">Marcasita</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜺" aria-label="Copiar Sal amoníaco">🜺</button>
+      <span class="flag-label">Sal amoníaco</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜻" aria-label="Copiar Arsénico">🜻</button>
+      <span class="flag-label">Arsénico</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜼" aria-label="Copiar Rejalgar">🜼</button>
+      <span class="flag-label">Rejalgar</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜽" aria-label="Copiar Rejalgar II">🜽</button>
+      <span class="flag-label">Rejalgar II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜾" aria-label="Copiar Oropimente">🜾</button>
+      <span class="flag-label">Oropimente</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜿" aria-label="Copiar Mena de bismuto">🜿</button>
+      <span class="flag-label">Mena de bismuto</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="esoteric">
+  <span class="article-section-label">Otros esotéricos</span>
+  <h2>Otros símbolos esotéricos</h2>
+  <p>Símbolos adicionales asociados con tradiciones mágicas y esotéricas.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☥" aria-label="Copiar Anj">☥</button>
+      <span class="flag-label">Anj</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☯" aria-label="Copiar Yin yang">☯</button>
+      <span class="flag-label">Yin yang</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☘" aria-label="Copiar Trébol">☘</button>
+      <span class="flag-label">Trébol</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚷" aria-label="Copiar Quirón">⚷</button>
+      <span class="flag-label">Quirón</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚰" aria-label="Copiar Ataúd">⚰</button>
+      <span class="flag-label">Ataúd</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚱" aria-label="Copiar Urna funeraria">⚱</button>
+      <span class="flag-label">Urna funeraria</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚗" aria-label="Copiar Alambique">⚗</button>
+      <span class="flag-label">Alambique</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❤" aria-label="Copiar Corazón">❤</button>
+      <span class="flag-label">Corazón</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚛" aria-label="Copiar Símbolo del átomo">⚛</button>
+      <span class="flag-label">Símbolo del átomo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚡" aria-label="Copiar Rayo">⚡</button>
+      <span class="flag-label">Rayo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♲" aria-label="Copiar Reciclaje">♲</button>
+      <span class="flag-label">Reciclaje</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☼" aria-label="Copiar Sol blanco con rayos">☼</button>
+      <span class="flag-label">Sol blanco con rayos</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☦" aria-label="Copiar Cruz ortodoxa">☦</button>
+      <span class="flag-label">Cruz ortodoxa</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☢" aria-label="Copiar Radiactivo">☢</button>
+      <span class="flag-label">Radiactivo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☣" aria-label="Copiar Riesgo biológico">☣</button>
+      <span class="flag-label">Riesgo biológico</span>
+    </div>
+      <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🔮" aria-label="Copiar 🔮">🔮</button>
+      <span class="flag-label">Bola de cristal</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧿" aria-label="Copiar 🧿">🧿</button>
+      <span class="flag-label">Amuleto nazar</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🃏" aria-label="Copiar 🃏">🃏</button>
+      <span class="flag-label">Carta del tarot</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕯️" aria-label="Copiar 🕯️">🕯️</button>
+      <span class="flag-label">Vela</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐍" aria-label="Copiar 🐍">🐍</button>
+      <span class="flag-label">Serpiente</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="∞" aria-label="Copiar ∞">∞</button>
+      <span class="flag-label">Infinito</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⟳" aria-label="Copiar ⟳">⟳</button>
+      <span class="flag-label">Flecha cíclica</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="↻" aria-label="Copiar ↻">↻</button>
+      <span class="flag-label">Flecha circular abierta</span>
+    </div>
+</div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- COLLECTIONS -->
+<section class="mood-explainers" id="witchy-collections">
+  <span class="article-section-label">Colecciones witchy</span>
+  <h2>Sets de biografía y bordes witchy</h2>
+  <p class="u-secondary-block">Cadenas witchy ya armadas que puedes pegar directamente en una biografía, pie de foto o nombre de usuario — copia el combo entero con un solo clic.</p>
+  <div id="witchyCollectionsContainer"></div>
+</section>
+
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Dale estilo a tu texto con fuentes Unicode</h3>
+  <p>Usa UltraTextGen para convertir texto normal en negrita, cursiva, caligrafía y más de 100 estilos de fuentes Unicode — gratis y al instante.</p>
+  <a href="/es/" class="cta-btn">Abrir UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Recursos relacionados</span>
+  <div class="compare-grid">
+    <a href="/es/simbolos-aesthetic/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos aesthetic</h4>
+      <p>Todas las colecciones de símbolos aesthetic con nombre en un solo lugar.</p>
+    </a>
+    <a href="/es/library/simbolos-goth-grunge/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos goth y grunge</h4>
+      <p>Cruces oscuras, calaveras y decoraciones de estética gótica.</p>
+    </a>
+    <a href="/es/library/simbolos-cottagecore/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos cottagecore</h4>
+      <p>Setas, flores silvestres y motivos terrosos de la vida rural.</p>
+    </a>
+    <a href="/es/library/simbolos-y2k/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos Y2K</h4>
+      <p>Estrellas de brillo, cruces góticas, mariposas y motivos cyber de los 2000.</p>
+    </a>
+    <a href="/es/simbolos-de-estrella/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos de estrella</h4>
+      <p>Estrellas de todos los estilos más brillos y motivos celestes, listos para copiar.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    { name: "Borde de biografía con pentagrama", flags: ["⛧","˖","⛤","˖","⛧"], defaultFormat: "inline" },
+    { name: "Combo de luna y sol", flags: ["☽","˚","✴","˚","☉"], defaultFormat: "inline" },
+    { name: "Rastro de estrellas witchy", flags: ["✶","·","✴","·","✶"], defaultFormat: "inline" },
+    { name: "Borde de luna creciente", flags: ["☽⋆ﾟ｡⋆"], defaultFormat: "inline" },
+    { name: "Combo planetario para biografía", flags: ["☽","☿","♀","♂","♃","♄"], defaultFormat: "inline" },
+    { name: "Separador de hechizo con anj", flags: ["☥","˖","⛤","˖","☥"], defaultFormat: "inline" }
+  ];
+
+  ns.buildGrids("witchyCollectionsContainer", GROUPS);
+  ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/fr/library/symboles-dreamcore-weirdcore/index.html
+++ b/fr/library/symboles-dreamcore-weirdcore/index.html
@@ -1,0 +1,426 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Symboles Dreamcore &amp; Weirdcore à Copier-Coller 👁 🌈 ⋆ Esthétique Surréaliste</title>
+<meta name="description" content="Symboles dreamcore et weirdcore — yeux surréalistes 👁, arcs-en-ciel 🌈, blocs glitch, portes et combos sleepcore pour tes posts liminaux. Touche un symbole pour le copier aussitôt.">
+
+<link rel="canonical" href="https://ultratextgen.com/fr/library/symboles-dreamcore-weirdcore/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles-dreamcore-weirdcore/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/fr/library/symboles-dreamcore-weirdcore/">
+
+<meta property="og:image" content="https://ultratextgen.com/assets/og/fr-library-symboles-dreamcore-weirdcore.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Symboles Dreamcore &amp; Weirdcore à Copier-Coller 👁 🌈 ⋆ Esthétique Surréaliste">
+<meta name="twitter:description" content="Symboles dreamcore et weirdcore — yeux surréalistes 👁, arcs-en-ciel 🌈, blocs glitch, portes et combos sleepcore pour tes posts liminaux. Touche un symbole pour le copier aussitôt.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/fr-library-symboles-dreamcore-weirdcore.png">
+<meta property="og:title" content="Symboles Dreamcore &amp; Weirdcore à Copier-Coller 👁 🌈 ⋆ Esthétique Surréaliste">
+<meta property="og:description" content="Symboles dreamcore et weirdcore — yeux surréalistes 👁, arcs-en-ciel 🌈, blocs glitch, portes et combos sleepcore pour tes posts liminaux. Touche un symbole pour le copier aussitôt.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/fr/library/symboles-dreamcore-weirdcore/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Symboles Dreamcore & Weirdcore à Copier-Coller 👁 🌈 ⋆ Esthétique Surréaliste",
+  "inLanguage": "fr",
+  "alternateName": ["Symboles Dreamcore à Copier-Coller", "Symboles Weirdcore à Copier-Coller", "Symboles Dreamcore Aesthetic", "Symboles Weirdcore Aesthetic", "Symboles Esthétique Surréaliste", "Symboles Espaces Liminaux", "Symboles Texte Dreamcore", "Emojis Dreamcore Weirdcore"],
+  "description": "Symboles dreamcore et weirdcore — yeux surréalistes 👁, arcs-en-ciel 🌈, blocs glitch, portes et combos sleepcore pour tes posts liminaux. Touche un symbole pour le copier aussitôt.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/fr-library-symboles-dreamcore-weirdcore.png",
+  "mainEntityOfPage": "https://ultratextgen.com/fr/library/symboles-dreamcore-weirdcore/",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Accueil",
+      "item": "https://ultratextgen.com/fr/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Symboles Dreamcore & Weirdcore",
+      "item": "https://ultratextgen.com/fr/library/symboles-dreamcore-weirdcore/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Fil d'Ariane">
+  <a href="/fr/">Accueil</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Symboles Dreamcore &amp; Weirdcore</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Symboles Dreamcore &amp; Weirdcore</h1>
+    <p class="hero-tagline">Yeux surréalistes, portes sans fin, blocs glitch statiques et ciels endormis pour l'esthétique des espaces liminaux. Touche un symbole ou un combo, il est copié aussitôt.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/fr-library-symboles-dreamcore-weirdcore.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Dreamcore et weirdcore sont deux esthétiques internet sœurs bâties sur la logique surréaliste des rêves — ciels nostalgiques, yeux qui observent, portes qui ne mènent nulle part et objets familiers légèrement déréglés. Ces symboles dreamcore et weirdcore traduisent cette ambiance en texte copiable : 👁 yeux, 🌈 arcs-en-ciel, 📺 vieilles télévisions, blocs d'ombrage pour la neige d'écran, et une série sleepcore pour des montages plus doux et somnolents. Utilise-les dans tes statuts Discord, tes en-têtes Tumblr, tes légendes TikTok et tes descriptions YouTube, ou récupère un combo surréaliste entier ci-dessous.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="eyes-surreal">
+  <span class="article-section-label">Yeux Qui Observent</span>
+  <h2>Symboles d'Yeux Qui Observent</h2>
+  <p class="u-secondary-tight">Les yeux qui ne clignent jamais, au cœur de l'imagerie weirdcore, de l'emoji aux hiéroglyphes égyptiens.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="👁" aria-label="Copier Œil">👁</button>
+      <span class="flag-label">Œil</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="👁️" aria-label="Copier Œil (style emoji)">👁️</button>
+      <span class="flag-label">Œil (style emoji)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="👀" aria-label="Copier Yeux">👀</button>
+      <span class="flag-label">Yeux</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓂀" aria-label="Copier Œil d'Horus (hiéroglyphe égyptien)">𓂀</button>
+      <span class="flag-label">Œil d'Horus (hiéroglyphe égyptien)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓁹" aria-label="Copier Œil Hiéroglyphe Égyptien">𓁹</button>
+      <span class="flag-label">Œil Hiéroglyphe Égyptien</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="◉" aria-label="Copier Œil-de-Poisson">◉</button>
+      <span class="flag-label">Œil-de-Poisson</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊙" aria-label="Copier Opérateur Point Cerclé">⊙</button>
+      <span class="flag-label">Opérateur Point Cerclé</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="👁️‍🗨️" aria-label="Copier Œil dans une Bulle de Dialogue">👁️‍🗨️</button>
+      <span class="flag-label">Œil dans une Bulle de Dialogue</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="dream-sky">
+  <span class="article-section-label">Ciel de Rêve</span>
+  <h2>Symboles de Ciel Dreamcore</h2>
+  <p class="u-secondary-tight">Arcs-en-ciel, nuages et ciels tourbillonnants — la moitié lumineuse et nostalgique de l'esthétique.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌈" aria-label="Copier Arc-en-Ciel">🌈</button>
+      <span class="flag-label">Arc-en-Ciel</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☁️" aria-label="Copier Nuage">☁️</button>
+      <span class="flag-label">Nuage</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌙" aria-label="Copier Croissant de Lune">🌙</button>
+      <span class="flag-label">Croissant de Lune</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⭐" aria-label="Copier Étoile">⭐</button>
+      <span class="flag-label">Étoile</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌀" aria-label="Copier Cyclone">🌀</button>
+      <span class="flag-label">Cyclone</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🫧" aria-label="Copier Bulles">🫧</button>
+      <span class="flag-label">Bulles</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌌" aria-label="Copier Voie Lactée">🌌</button>
+      <span class="flag-label">Voie Lactée</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💫" aria-label="Copier Étoiles d'Étourdissement">💫</button>
+      <span class="flag-label">Étoiles d'Étourdissement</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="weirdcore-objects">
+  <span class="article-section-label">Objets Weirdcore</span>
+  <h2>Symboles d'Objets Weirdcore</h2>
+  <p class="u-secondary-tight">Portes, trous, miroirs et vieilles télés — des objets familiers placés là où ils ne devraient pas être.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="📺" aria-label="Copier Télévision">📺</button>
+      <span class="flag-label">Télévision</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🚪" aria-label="Copier Porte">🚪</button>
+      <span class="flag-label">Porte</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕳" aria-label="Copier Trou">🕳</button>
+      <span class="flag-label">Trou</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🪞" aria-label="Copier Miroir">🪞</button>
+      <span class="flag-label">Miroir</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🛗" aria-label="Copier Ascenseur">🛗</button>
+      <span class="flag-label">Ascenseur</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🎈" aria-label="Copier Ballon">🎈</button>
+      <span class="flag-label">Ballon</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🩹" aria-label="Copier Pansement">🩹</button>
+      <span class="flag-label">Pansement</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧸" aria-label="Copier Ours en Peluche">🧸</button>
+      <span class="flag-label">Ours en Peluche</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="sleepcore">
+  <span class="article-section-label">Sleepcore</span>
+  <h2>Symboles Sleepcore</h2>
+  <p class="u-secondary-tight">La sous-esthétique somnolente — lits, ciels nocturnes et l'attraction douce du sommeil.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💤" aria-label="Copier Zzz">💤</button>
+      <span class="flag-label">Zzz</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🛏" aria-label="Copier Lit">🛏</button>
+      <span class="flag-label">Lit</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="😴" aria-label="Copier Visage Endormi">😴</button>
+      <span class="flag-label">Visage Endormi</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌃" aria-label="Copier Nuit Étoilée">🌃</button>
+      <span class="flag-label">Nuit Étoilée</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕰" aria-label="Copier Horloge de Cheminée">🕰</button>
+      <span class="flag-label">Horloge de Cheminée</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🥱" aria-label="Copier Visage qui Bâille">🥱</button>
+      <span class="flag-label">Visage qui Bâille</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="glitch-static">
+  <span class="article-section-label">Glitch &amp; Neige</span>
+  <h2>Caractères de Blocs Glitch &amp; Neige</h2>
+  <p class="u-secondary-tight">Caractères Unicode d'ombrage et de blocs qui évoquent la neige d'écran et les pixels corrompus.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="░" aria-label="Copier Ombrage Clair">░</button>
+      <span class="flag-label">Ombrage Clair</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="▒" aria-label="Copier Ombrage Moyen">▒</button>
+      <span class="flag-label">Ombrage Moyen</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="▓" aria-label="Copier Ombrage Foncé">▓</button>
+      <span class="flag-label">Ombrage Foncé</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="█" aria-label="Copier Bloc Plein">█</button>
+      <span class="flag-label">Bloc Plein</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="▚" aria-label="Copier Quadrant Haut-Gauche et Bas-Droite">▚</button>
+      <span class="flag-label">Quadrant Haut-Gauche et Bas-Droite</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⋆" aria-label="Copier Opérateur Étoile">⋆</button>
+      <span class="flag-label">Opérateur Étoile</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="combo-sets">
+  <span class="article-section-label">Séries de Combos</span>
+  <h2>Séries de Combos Dreamcore &amp; Weirdcore</h2>
+  <p class="u-secondary-block">Copie un combo surréaliste entier en un clic — yeux, ciels, neige et sommeil, prêts à coller partout.</p>
+  <div id="dreamcoreSetsContainer"></div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Transforme ton texte avec les polices Unicode</h3>
+  <p>Utilise UltraTextGen pour convertir du texte simple en gras, italique, cursive et plus de 100 autres styles de police Unicode — gratuit et instantané.</p>
+  <a href="/fr/" class="cta-btn">Ouvrir UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Pages liées</span>
+  <div class="compare-grid">
+    <a href="/fr/library/symboles-fairycore/" class="compare-card variant-muted u-no-underline">
+      <h4>Symboles Fairycore</h4>
+      <p>Fées, champignons et poussière de lutin pour des bios enchantées.</p>
+    </a>
+    <a href="/fr/library/symboles-y2k/" class="compare-card variant-muted u-no-underline">
+      <h4>Symboles Y2K</h4>
+      <p>Caractères rétro-futuristes des années 2000 et marques cyber aesthetic.</p>
+    </a>
+    <a href="/fr/library/symboles-coquette/" class="compare-card variant-muted u-no-underline">
+      <h4>Symboles Coquette</h4>
+      <p>Nœuds, rubans et caractères doux-féminins pour bios.</p>
+    </a>
+    <a href="/fr/library/symboles-cottagecore/" class="compare-card variant-muted u-no-underline">
+      <h4>Symboles Cottagecore</h4>
+      <p>Fleurs, feuilles et symboles champêtres douillets.</p>
+    </a>
+    <a href="/fr/library/symboles/" class="compare-card variant-muted u-no-underline">
+      <h4>Symboles à Copier-Coller</h4>
+      <p>Cœurs, étoiles, croix et caractères spéciaux pour bio et pseudo.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Sélecteur de langue">
+      <a class="lang-option" href="/library/dreamcore-weirdcore-symbols/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/fr/library/symboles-dreamcore-weirdcore/" hreflang="fr">FR</a>
+    </div>
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    {
+      name: "Ciel Dreamcore",
+      flags: ["🌈", "☁️", "👁", "⭐", "🌀"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Couloir Weirdcore",
+      flags: ["🚪", "📺", "🕳", "🪞", "👁"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Dérive Sleepcore",
+      flags: ["💤", "🛏", "🌙", "☁️", "😴"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Yeux qui Voient Tout",
+      flags: ["👁", "𓂀", "◉", "👀", "⊙"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Barres de Neige Glitch",
+      flags: ["░▒▓█▓▒░", "▓▒░⋆░▒▓", "█▓▒░"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Rêve Pastel",
+      flags: ["🫧", "🌈", "🪞", "💫", "☁️"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Nuit Liminale",
+      flags: ["🌃", "🛗", "🕰", "🌌", "🚪"],
+      defaultFormat: "inline"
+    }
+  ];
+
+  ns.buildGrids("dreamcoreSetsContainer", GROUPS);
+  if (ns.parseTwemoji) ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/fr/library/symboles-fairycore/index.html
+++ b/fr/library/symboles-fairycore/index.html
@@ -1,0 +1,389 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Symboles Fairycore 🧚 🍄 ✨ à Copier-Coller | Aesthetic Féerique</title>
+<meta name="description" content="Symboles et combos emoji fairycore — fées 🧚, champignons 🍄, sparkles ✨ et fleurs délicates pour des bios féeriques. Touche un symbole pour le copier aussitôt.">
+
+<link rel="canonical" href="https://ultratextgen.com/fr/library/symboles-fairycore/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/fairycore-symbols/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles-fairycore/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/fairycore-symbols/">
+
+<meta property="og:image" content="https://ultratextgen.com/assets/og/fr-library-symboles-fairycore.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Symboles Fairycore 🧚 🍄 ✨ à Copier-Coller | Aesthetic Féerique">
+<meta name="twitter:description" content="Symboles et combos emoji fairycore — fées 🧚, champignons 🍄, sparkles ✨ et fleurs délicates pour des bios féeriques. Touche un symbole pour le copier aussitôt.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/fr-library-symboles-fairycore.png">
+<meta property="og:title" content="Symboles Fairycore 🧚 🍄 ✨ à Copier-Coller | Aesthetic Féerique">
+<meta property="og:description" content="Symboles et combos emoji fairycore — fées 🧚, champignons 🍄, sparkles ✨ et fleurs délicates pour des bios féeriques. Touche un symbole pour le copier aussitôt.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/fr/library/symboles-fairycore/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Symboles Fairycore 🧚 🍄 ✨ à Copier-Coller — Aesthetic Féerique",
+  "inLanguage": "fr",
+  "alternateName": ["Symboles Fairycore à Copier-Coller", "Symboles Aesthetic Féerique", "Emoji Fairycore", "Symboles de Fée à Copier", "Symboles Fée Cottagecore", "Symboles Whimsical à Copier-Coller"],
+  "description": "Symboles et combos emoji fairycore — fées 🧚, champignons 🍄, sparkles ✨ et fleurs délicates pour des bios féeriques. Touche un symbole pour le copier aussitôt.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/fr-library-symboles-fairycore.png",
+  "mainEntityOfPage": "https://ultratextgen.com/fr/library/symboles-fairycore/",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Accueil",
+      "item": "https://ultratextgen.com/fr/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Symboles Fairycore",
+      "item": "https://ultratextgen.com/fr/library/symboles-fairycore/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Fil d'Ariane">
+  <a href="/fr/">Accueil</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Symboles Fairycore</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Symboles Fairycore</h1>
+    <p class="hero-tagline">Fées, amanites, poussière de fée scintillante et fleurs des bois pour une esthétique enchantée. Touche un symbole ou un combo, il est copié aussitôt.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/fr-library-symboles-fairycore.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Le fairycore est une esthétique féerique construite autour des fées, des forêts lumineuses, des cercles d'amanites et d'une douce brillance dorée — pense aux jardins enchantés et à la poussière de fée. Ces symboles et combos emoji fairycore capturent cette magie avec des fées 🧚, des champignons 🍄, des sparkles ✨ et des caractères florette délicats comme ✿ et ❀. Utilise-les dans une bio Instagram, un nom de tableau Pinterest, une légende TikTok ou une section à-propos Discord, ou copie un combo prêt à l'emploi ci-dessous.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="fairies-magic">
+  <span class="article-section-label">Fées &amp; Magie</span>
+  <h2>Emoji Fées &amp; Magie</h2>
+  <p class="u-secondary-tight">La famille d'emoji fée, plus les baguettes et la magie scintillante.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧚" aria-label="Copier 🧚">🧚</button>
+      <span class="flag-label">Fée</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧚‍♀️" aria-label="Copier 🧚‍♀️">🧚‍♀️</button>
+      <span class="flag-label">Fée Femme</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧚‍♂️" aria-label="Copier 🧚‍♂️">🧚‍♂️</button>
+      <span class="flag-label">Fée Homme</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🪄" aria-label="Copier 🪄">🪄</button>
+      <span class="flag-label">Baguette Magique</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✨" aria-label="Copier ✨">✨</button>
+      <span class="flag-label">Sparkles</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💫" aria-label="Copier 💫">💫</button>
+      <span class="flag-label">Étoile Étourdie</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🔮" aria-label="Copier 🔮">🔮</button>
+      <span class="flag-label">Boule de Cristal</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="mushrooms-flora">
+  <span class="article-section-label">Champignons &amp; Flore</span>
+  <h2>Champignons &amp; Flore des Bois</h2>
+  <p class="u-secondary-tight">Amanites, fleurs et florettes Unicode qui structurent chaque composition fairycore.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🍄" aria-label="Copier 🍄">🍄</button>
+      <span class="flag-label">Champignon</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌷" aria-label="Copier 🌷">🌷</button>
+      <span class="flag-label">Tulipe</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌸" aria-label="Copier 🌸">🌸</button>
+      <span class="flag-label">Fleur de Cerisier</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌼" aria-label="Copier 🌼">🌼</button>
+      <span class="flag-label">Fleur</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✿" aria-label="Copier ✿">✿</button>
+      <span class="flag-label">Florette Noire</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❀" aria-label="Copier ❀">❀</button>
+      <span class="flag-label">Florette Blanche</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌿" aria-label="Copier 🌿">🌿</button>
+      <span class="flag-label">Herbe</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🍃" aria-label="Copier 🍃">🍃</button>
+      <span class="flag-label">Feuille au Vent</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🪷" aria-label="Copier 🪷">🪷</button>
+      <span class="flag-label">Lotus</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="pixie-sparkles">
+  <span class="article-section-label">Poussière de Fée</span>
+  <h2>Poussière de Fée &amp; Étoiles Scintillantes</h2>
+  <p class="u-secondary-tight">Petits caractères d'étoile et de sparkle pour créer des séparateurs délicats et décorer tes pseudos.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⋆" aria-label="Copier ⋆">⋆</button>
+      <span class="flag-label">Opérateur Étoile</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✦" aria-label="Copier ✦">✦</button>
+      <span class="flag-label">Étoile Noire à Quatre Branches</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✧" aria-label="Copier ✧">✧</button>
+      <span class="flag-label">Étoile Blanche à Quatre Branches</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✩" aria-label="Copier ✩">✩</button>
+      <span class="flag-label">Étoile Contour Marqué</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="˚" aria-label="Copier ˚">˚</button>
+      <span class="flag-label">Rond en Chef</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="୨୧" aria-label="Copier ୨୧">୨୧</button>
+      <span class="flag-label">Nœud Aesthetic (Chiffres Odia)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌟" aria-label="Copier 🌟">🌟</button>
+      <span class="flag-label">Étoile Brillante</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="garden-creatures">
+  <span class="article-section-label">Créatures du Jardin</span>
+  <h2>Créatures du Jardin Enchanté</h2>
+  <p class="u-secondary-tight">Papillons, escargots et doux visiteurs qui complètent la scène du jardin féerique.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦋" aria-label="Copier 🦋">🦋</button>
+      <span class="flag-label">Papillon</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐌" aria-label="Copier 🐌">🐌</button>
+      <span class="flag-label">Escargot</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐞" aria-label="Copier 🐞">🐞</button>
+      <span class="flag-label">Coccinelle</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐝" aria-label="Copier 🐝">🐝</button>
+      <span class="flag-label">Abeille</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐇" aria-label="Copier 🐇">🐇</button>
+      <span class="flag-label">Lapin</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦢" aria-label="Copier 🦢">🦢</button>
+      <span class="flag-label">Cygne</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕊" aria-label="Copier 🕊">🕊</button>
+      <span class="flag-label">Colombe</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="combo-sets">
+  <span class="article-section-label">Combos</span>
+  <h2>Combos Fairycore</h2>
+  <p class="u-secondary-block">Copie un combo emoji fairycore complet en un clic — prêt pour bios, légendes et noms de tableaux.</p>
+  <div id="fairycoreSetsContainer"></div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Transforme ton texte avec les polices Unicode</h3>
+  <p>Utilise UltraTextGen pour convertir du texte simple en gras, italique, cursive et plus de 100 autres styles de police Unicode — gratuit et instantané.</p>
+  <a href="/fr/" class="cta-btn">Ouvrir UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Pages liées</span>
+  <div class="compare-grid">
+    <a href="/fr/library/symboles-cottagecore/" class="compare-card variant-muted u-no-underline">
+      <h4>Symboles Cottagecore</h4>
+      <p>Champignons, abeilles et caractères rustiques de la vie champêtre.</p>
+    </a>
+    <a href="/fr/library/symboles-coquette/" class="compare-card variant-muted u-no-underline">
+      <h4>Symboles Coquette</h4>
+      <p>Nœuds, rubans et caractères doux-féminins pour bios.</p>
+    </a>
+    <a href="/fr/library/symboles-y2k/" class="compare-card variant-muted u-no-underline">
+      <h4>Symboles Y2K</h4>
+      <p>Étoiles, papillons et glyphes cyber aesthetic des années 2000.</p>
+    </a>
+    <a href="/fr/library/symboles/" class="compare-card variant-muted u-no-underline">
+      <h4>Symboles à Copier-Coller</h4>
+      <p>Cœurs, étoiles, croix et caractères spéciaux pour bio et pseudo.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Sélecteur de langue">
+      <a class="lang-option" href="/library/fairycore-symbols/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/fr/library/symboles-fairycore/" hreflang="fr">FR</a>
+    </div>
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    {
+      name: "Jardin de Fées",
+      flags: ["🧚", "🍄", "🌷", "✨", "🌿", "🦋"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Traînée de Poussière de Fée",
+      flags: ["✨", "⋆", "˚", "✧", "🪄", "💫"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Cercle de Champignons",
+      flags: ["🍄", "🌿", "🍄", "✨", "🍄", "🍃"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Prairie aux Papillons",
+      flags: ["🦋", "🌼", "🌸", "🐝", "🍃"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Fée au Clair de Lune",
+      flags: ["🌙", "✨", "🧚", "⋆", "☁️"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Séparateur de Bio Délicat",
+      flags: ["⋆˚✿˖°", "୨୧", "⋆˚❀˖°"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Fée des Chaumières",
+      flags: ["🍄", "🐌", "🌷", "🧺", "🐇"],
+      defaultFormat: "inline"
+    }
+  ];
+
+  ns.buildGrids("fairycoreSetsContainer", GROUPS);
+  if (ns.parseTwemoji) ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/fr/library/symboles-goth-grunge/index.html
+++ b/fr/library/symboles-goth-grunge/index.html
@@ -1,0 +1,375 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Symboles Goth &amp; Grunge à Copier-Coller ♱ Décorations Dark Aesthetic | UltraTextGen</title>
+<meta name="description" content="Symboles goth et grunge à copier-coller — croix ♱, crânes 💀, araignées 🕷 et dagues † pour ta bio, ton pseudo et tes profils. Un clic pour copier.">
+
+<link rel="canonical" href="https://ultratextgen.com/fr/library/symboles-goth-grunge/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/goth-grunge-symbols/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles-goth-grunge/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/goth-grunge-symbols/">
+
+<meta property="og:image" content="https://ultratextgen.com/assets/og/fr-library-symboles-goth-grunge.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Symboles Goth &amp; Grunge à Copier-Coller ♱ Décorations Dark Aesthetic">
+<meta name="twitter:description" content="Symboles goth et grunge à copier-coller — croix ♱, crânes 💀, araignées 🕷 et dagues † pour ta bio, ton pseudo et tes profils. Un clic pour copier.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/fr-library-symboles-goth-grunge.png">
+<meta property="og:title" content="Symboles Goth &amp; Grunge à Copier-Coller ♱ Décorations Dark Aesthetic">
+<meta property="og:description" content="Symboles goth et grunge à copier-coller — croix ♱, crânes 💀, araignées 🕷 et dagues † pour ta bio, ton pseudo et tes profils. Un clic pour copier.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/fr/library/symboles-goth-grunge/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Symboles Goth & Grunge à Copier-Coller ♱ Décorations Dark Aesthetic",
+  "inLanguage": "fr",
+  "alternateName": ["Symboles Goth Copier Coller", "Symboles Dark Aesthetic", "Symboles Grunge Copier Coller", "Symboles Bio Sombre", "Symboles Gothiques", "Symboles Emo Copier Coller", "Symboles Texte Dark Aesthetic", "Emojis Goth Copier Coller"],
+  "description": "Symboles goth et grunge à copier-coller — croix ♱, crânes 💀, araignées 🕷 et dagues † pour ta bio, ton pseudo et tes profils. Un clic pour copier.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/fr-library-symboles-goth-grunge.png",
+  "mainEntityOfPage": "https://ultratextgen.com/fr/library/symboles-goth-grunge/",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Accueil",
+      "item": "https://ultratextgen.com/fr/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Symboles Goth & Grunge",
+      "item": "https://ultratextgen.com/fr/library/symboles-goth-grunge/"
+    }
+  ]
+}
+</script>
+
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Fil d'Ariane">
+  <a href="/fr/">Accueil</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Symboles Goth &amp; Grunge</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Symboles Goth &amp; Grunge</h1>
+    <p class="hero-tagline">Symboles dark aesthetic pour bios goth et grunge — croix, crânes, araignées, dagues et décorations alt fashion. Touche un symbole, il est copié aussitôt.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/fr-library-symboles-goth-grunge.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Les esthétiques goth et grunge revendiquent la noirceur, le côté edgy et la subversion — roses noires, croix gothiques, araignées, chaînes et crânes. Ces caractères Unicode et emoji traduisent cette énergie en décorations de bio et en légendes. Ça marche sur Instagram, TikTok, Discord, Tumblr et partout où l'Unicode est accepté.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 1 -->
+<section class="mood-explainers" id="crosses-daggers">
+  <span class="article-section-label">Croix &amp; Dagues</span>
+  <h2>Croix &amp; Dagues</h2>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♱" aria-label="Copier ♱">♱</button>
+      <span class="flag-label">Croix Syriaque Est</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="†" aria-label="Copier †">†</button>
+      <span class="flag-label">Dague</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‡" aria-label="Copier ‡">‡</button>
+      <span class="flag-label">Double Dague</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✟" aria-label="Copier ✟">✟</button>
+      <span class="flag-label">Croix Latine Contourée</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🗡" aria-label="Copier 🗡">🗡</button>
+      <span class="flag-label">Emoji Dague</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚔" aria-label="Copier ⚔">⚔</button>
+      <span class="flag-label">Épées Croisées</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🔪" aria-label="Copier 🔪">🔪</button>
+      <span class="flag-label">Couteau Hocho</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛧" aria-label="Copier ⛧">⛧</button>
+      <span class="flag-label">Pentagramme Inversé</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𖤐" aria-label="Copier 𖤐">𖤐</button>
+      <span class="flag-label">Soleil Noir</span>
+    </div>
+      <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✝" aria-label="Copier ✝">✝</button>
+      <span class="flag-label">Croix Latine</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☥" aria-label="Copier ☥">☥</button>
+      <span class="flag-label">Ankh</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✠" aria-label="Copier ✠">✠</button>
+      <span class="flag-label">Croix de Malte</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☦" aria-label="Copier ☦">☦</button>
+      <span class="flag-label">Croix Orthodoxe</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☽" aria-label="Copier ☽">☽</button>
+      <span class="flag-label">Croissant de Lune</span>
+    </div>
+</div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 2 -->
+<section class="mood-explainers" id="skulls-death">
+  <span class="article-section-label">Crânes &amp; Motifs Mortuaires</span>
+  <h2>Crânes &amp; Motifs Mortuaires</h2>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☠" aria-label="Copier ☠">☠</button>
+      <span class="flag-label">Tête de Mort</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💀" aria-label="Copier 💀">💀</button>
+      <span class="flag-label">Emoji Crâne</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🩸" aria-label="Copier 🩸">🩸</button>
+      <span class="flag-label">Emoji Goutte de Sang</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚰" aria-label="Copier ⚰">⚰</button>
+      <span class="flag-label">Cercueil</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🪦" aria-label="Copier 🪦">🪦</button>
+      <span class="flag-label">Emoji Pierre Tombale</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚱" aria-label="Copier ⚱">⚱</button>
+      <span class="flag-label">Urne Funéraire</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 3 -->
+<section class="mood-explainers" id="spiders-bats">
+  <span class="article-section-label">Araignées, Chauves-Souris &amp; Créatures</span>
+  <h2>Araignées, Chauves-Souris &amp; Créatures</h2>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕷" aria-label="Copier 🕷">🕷</button>
+      <span class="flag-label">Emoji Araignée</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕸" aria-label="Copier 🕸">🕸</button>
+      <span class="flag-label">Emoji Toile d'Araignée</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦇" aria-label="Copier 🦇">🦇</button>
+      <span class="flag-label">Emoji Chauve-Souris</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐍" aria-label="Copier 🐍">🐍</button>
+      <span class="flag-label">Emoji Serpent</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦂" aria-label="Copier 🦂">🦂</button>
+      <span class="flag-label">Emoji Scorpion</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 4 -->
+<section class="mood-explainers" id="dark-florals">
+  <span class="article-section-label">Floraux Sombres</span>
+  <h2>Floraux Sombres</h2>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🥀" aria-label="Copier 🥀">🥀</button>
+      <span class="flag-label">Emoji Fleur Fanée</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚘" aria-label="Copier ⚘">⚘</button>
+      <span class="flag-label">Fleur</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🖤" aria-label="Copier 🖤">🖤</button>
+      <span class="flag-label">Emoji Cœur Noir</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❦" aria-label="Copier ❦">❦</button>
+      <span class="flag-label">Cœur Floral</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❧" aria-label="Copier ❧">❧</button>
+      <span class="flag-label">Cœur Floral Pivoté</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓆩♱𓆪" aria-label="Copier 𓆩♱𓆪">𓆩♱𓆪</button>
+      <span class="flag-label">Cadre Croix Égyptien</span>
+    </div>
+  </div>
+  <p>Beaucoup de symboles goth recoupent l'esthétique Y2K — va voir la bibliothèque <a href="/fr/library/symboles-y2k/">Symboles Y2K</a> pour des croix gothiques, étoiles sombres et pentagrammes.</p>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- COLLECTIONS -->
+<section class="mood-explainers" id="goth-grunge-collections">
+  <span class="article-section-label">Collections Goth &amp; Grunge</span>
+  <h2>Sets de Bio Dark Aesthetic</h2>
+  <p class="u-secondary-block">Des chaînes dark aesthetic prêtes à coller directement dans une bio, une légende ou un pseudo — copie le combo entier en un clic.</p>
+  <div id="gothGrungeCollectionsContainer"></div>
+</section>
+
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Transforme ton texte avec les polices Unicode</h3>
+  <p>Utilise UltraTextGen pour convertir du texte simple en gras, italique, cursive et plus de 100 autres styles de police Unicode — gratuit et instantané.</p>
+  <a href="/fr/" class="cta-btn">Ouvrir UltraTextGen →</a>
+</div>
+
+
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Pages liées</span>
+  <div class="compare-grid">
+    <a href="/fr/library/symboles-y2k/" class="compare-card variant-muted u-no-underline">
+      <h4>Symboles Y2K</h4>
+      <p>Étoiles cyber, croix gothiques et décorations des années 2000.</p>
+    </a>
+    <a href="/fr/library/symboles-coquette/" class="compare-card variant-muted u-no-underline">
+      <h4>Symboles Coquette</h4>
+      <p>Nœuds, rubans et caractères doux-féminins pour bios.</p>
+    </a>
+    <a href="/fr/library/symboles-cottagecore/" class="compare-card variant-muted u-no-underline">
+      <h4>Symboles Cottagecore</h4>
+      <p>Fleurs, plantes et caractères champêtres pour bio.</p>
+    </a>
+    <a href="/fr/library/symboles-fairycore/" class="compare-card variant-muted u-no-underline">
+      <h4>Symboles Fairycore</h4>
+      <p>Sparkles, ailes et caractères féeriques pour décorer.</p>
+    </a>
+    <a href="/fr/library/symboles/" class="compare-card variant-muted u-no-underline">
+      <h4>Symboles à Copier-Coller</h4>
+      <p>Cœurs, étoiles, croix et caractères spéciaux pour bio et pseudo.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Sélecteur de langue">
+      <a class="lang-option" href="/library/goth-grunge-symbols/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/fr/library/symboles-goth-grunge/" hreflang="fr">FR</a>
+    </div>
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    { name: "Séparateur Croix Goth", flags: ["†","˖","♱","˖","†"], defaultFormat: "inline" },
+    { name: "Cadre Croix Égyptien", flags: ["𓆩♱𓆪"], defaultFormat: "inline" },
+    { name: "Bordure de Dagues", flags: ["✟","·","†","‡","†","·","✟"], defaultFormat: "inline" },
+    { name: "Combo Rose Fanée", flags: ["🥀","🖤","🥀"], defaultFormat: "inline" },
+    { name: "Traînée Florale Sombre", flags: ["❦","˖","🖤","˖","❧"], defaultFormat: "inline" },
+    { name: "Combo Bio Pentagramme", flags: ["⛧","˖","𖤐","˖","⛧"], defaultFormat: "inline" }
+  ];
+
+  ns.buildGrids("gothGrungeCollectionsContainer", GROUPS);
+  ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/fr/library/symboles-kawaii-cute/index.html
+++ b/fr/library/symboles-kawaii-cute/index.html
@@ -1,0 +1,417 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Symboles Kawaii Cute ⋆ Symboles Mignons Aesthetic à Copier-Coller | UltraTextGen</title>
+<meta name="description" content="Symboles kawaii et mignons à copier-coller — cœurs doux, petites frimousses, sparkles et décorations pastel pour ta bio, ton pseudo et tes messages. Un clic pour copier.">
+
+<link rel="canonical" href="https://ultratextgen.com/fr/library/symboles-kawaii-cute/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles-kawaii-cute/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/fr/library/symboles-kawaii-cute/">
+
+<meta property="og:image" content="https://ultratextgen.com/assets/og/fr-library-symboles-kawaii-cute.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Symboles Kawaii Cute ⋆ Symboles Mignons Aesthetic à Copier-Coller">
+<meta name="twitter:description" content="Symboles kawaii et mignons à copier-coller — cœurs doux, petites frimousses, sparkles et décorations pastel pour ta bio, ton pseudo et tes messages. Un clic pour copier.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/fr-library-symboles-kawaii-cute.png">
+<meta property="og:title" content="Symboles Kawaii Cute ⋆ Symboles Mignons Aesthetic à Copier-Coller">
+<meta property="og:description" content="Symboles kawaii et mignons à copier-coller — cœurs doux, petites frimousses, sparkles et décorations pastel pour ta bio, ton pseudo et tes messages. Un clic pour copier.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/fr/library/symboles-kawaii-cute/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Symboles Kawaii Cute ⋆ Symboles Mignons Aesthetic à Copier-Coller",
+  "inLanguage": "fr",
+  "alternateName": ["Symboles Kawaii Copier Coller", "Symboles Mignons Copier Coller", "Symboles Texte Kawaii", "Symboles Aesthetic Mignons", "Symboles Aesthetic Doux", "Décorations Kawaii", "Symboles Japonais Mignons"],
+  "description": "Symboles kawaii et mignons à copier-coller — cœurs doux, petites frimousses, sparkles et décorations pastel pour ta bio, ton pseudo et tes messages. Un clic pour copier.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/fr-library-symboles-kawaii-cute.png",
+  "mainEntityOfPage": "https://ultratextgen.com/fr/library/symboles-kawaii-cute/",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Accueil",
+      "item": "https://ultratextgen.com/fr/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Symboles Kawaii &amp; Mignons",
+      "item": "https://ultratextgen.com/fr/library/symboles-kawaii-cute/"
+    }
+  ]
+}
+</script>
+
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Fil d'Ariane">
+  <a href="/fr/">Accueil</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Symboles Kawaii &amp; Mignons</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Symboles Kawaii &amp; Mignons</h1>
+    <p class="hero-tagline">Cœurs doux, petites frimousses, sparkles et décorations kawaii pastel. Touche un symbole ci-dessous, il est copié aussitôt pour tes bios, pseudos et messages.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/fr-library-symboles-kawaii-cute.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Kawaii (かわいい) veut dire « mignon » en japonais, et l'esthétique kawaii célèbre tout ce qui est doux, pastel et adorable. Ces caractères Unicode et emoji capturent ce feeling : petites frimousses, symboles de cœur, marques de sparkle et crochets d'encadrement mignons. Utilise-les dans tes bios, messages, pseudos et légendes sur Instagram, TikTok, Discord et partout où le texte Unicode est accepté.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 1 -->
+<section class="mood-explainers" id="cute-hearts">
+  <span class="article-section-label">Cœurs Mignons</span>
+  <h2>Cœurs Mignons</h2>
+  <p>Caractères de cœur tout doux pour bios kawaii et messages tendres.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♡" aria-label="Copier ♡">♡</button>
+      <span class="flag-label">Cœur Vide</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ෆ" aria-label="Copier ෆ">ෆ</button>
+      <span class="flag-label">Lettre Cinghalaise Alpapraana Ayanna</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❤" aria-label="Copier ❤">❤</button>
+      <span class="flag-label">Cœur Rouge</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❥" aria-label="Copier ❥">❥</button>
+      <span class="flag-label">Puce Cœur Pivotée</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ʚɞ" aria-label="Copier ʚɞ">ʚɞ</button>
+      <span class="flag-label">Ailes de Cœur (combo)</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 2 -->
+<section class="mood-explainers" id="tiny-cute-faces">
+  <span class="article-section-label">Petites Frimousses Mignonnes</span>
+  <h2>Petites Frimousses Mignonnes</h2>
+  <p>Kaomoji et frimousses Unicode pour ajouter des expressions kawaii à tes messages et bios.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(˶˃ ᵕ ˂˶)" aria-label="Copier (˶˃ ᵕ ˂˶)">(˶˃ ᵕ ˂˶)</button>
+      <span class="flag-label">Frimousse Rougissante (combo)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ʕ•ᴥ•ʔ" aria-label="Copier ʕ•ᴥ•ʔ">ʕ•ᴥ•ʔ</button>
+      <span class="flag-label">Frimousse d'Ours (combo)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(づ ◕‿◕)づ" aria-label="Copier (づ ◕‿◕)づ">(づ ◕‿◕)づ</button>
+      <span class="flag-label">Frimousse Câline (combo)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(✿◠‿◠)" aria-label="Copier (✿◠‿◠)">(✿◠‿◠)</button>
+      <span class="flag-label">Frimousse Fleurie (combo)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="◕" aria-label="Copier ◕">◕</button>
+      <span class="flag-label">Grand Œil Rond</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="◡" aria-label="Copier ◡">◡</button>
+      <span class="flag-label">Lettre Courbe</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 3 -->
+<section class="mood-explainers" id="cute-wrappers">
+  <span class="article-section-label">Crochets &amp; Encadrements Mignons</span>
+  <h2>Crochets &amp; Encadrements Mignons</h2>
+  <p>Crochets décoratifs et caractères d'encadrement pour pseudos kawaii et mise en forme de bio.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="꒰" aria-label="Copier ꒰">꒰</button>
+      <span class="flag-label">Parenthèse Ornementale Gauche</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="꒱" aria-label="Copier ꒱">꒱</button>
+      <span class="flag-label">Parenthèse Ornementale Droite</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="◌" aria-label="Copier ◌">◌</button>
+      <span class="flag-label">Rond Combinant</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊂" aria-label="Copier ⊂">⊂</button>
+      <span class="flag-label">Inclus dans</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊃" aria-label="Copier ⊃">⊃</button>
+      <span class="flag-label">Contient</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="୨୧" aria-label="Copier ୨୧">୨୧</button>
+      <span class="flag-label">Vague Coquette (combo)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✿" aria-label="Copier ✿">✿</button>
+      <span class="flag-label">Fleurette Noire</span>
+    </div>
+      <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ʚ" aria-label="Copier ʚ">ʚ</button>
+      <span class="flag-label">Aile de Cœur Gauche</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ɞ" aria-label="Copier ɞ">ɞ</button>
+      <span class="flag-label">Aile de Cœur Droite</span>
+    </div>
+</div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 4 -->
+<section class="mood-explainers" id="decorative-marks-kawaii">
+  <span class="article-section-label">Marques Décoratives</span>
+  <h2>Marques Décoratives</h2>
+  <p>Sparkles, points et petites marques d'accent pour donner une touche kawaii à n'importe quel texte.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⋆" aria-label="Copier ⋆">⋆</button>
+      <span class="flag-label">Opérateur Étoile à Six Branches</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊹" aria-label="Copier ⊹">⊹</button>
+      <span class="flag-label">Croix Orthogonale</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✧" aria-label="Copier ✧">✧</button>
+      <span class="flag-label">Étoile Blanche à Quatre Branches</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⩩" aria-label="Copier ⩩">⩩</button>
+      <span class="flag-label">Similaire ou Égal</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="๑" aria-label="Copier ๑">๑</button>
+      <span class="flag-label">Caractère Thaï Ko Kai</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⌒" aria-label="Copier ⌒">⌒</button>
+      <span class="flag-label">Arc</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❀" aria-label="Copier ❀">❀</button>
+      <span class="flag-label">Fleurette Blanche</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 5 -->
+<section class="mood-explainers" id="pastel-motifs">
+  <span class="article-section-label">Motifs Pastel</span>
+  <h2>Motifs Pastel</h2>
+  <p>Symboles floraux et célestes tout doux pour bâtir une esthétique kawaii de rêve.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✿" aria-label="Copier ✿">✿</button>
+      <span class="flag-label">Fleurette Noire</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❀" aria-label="Copier ❀">❀</button>
+      <span class="flag-label">Fleurette Blanche</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❁" aria-label="Copier ❁">❁</button>
+      <span class="flag-label">Fleurette à Huit Pétales</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☁" aria-label="Copier ☁">☁</button>
+      <span class="flag-label">Nuage</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☾" aria-label="Copier ☾">☾</button>
+      <span class="flag-label">Croissant de Lune</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛅" aria-label="Copier ⛅">⛅</button>
+      <span class="flag-label">Soleil Derrière un Nuage</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✦" aria-label="Copier ✦">✦</button>
+      <span class="flag-label">Étoile Noire à Quatre Branches</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⋆" aria-label="Copier ⋆">⋆</button>
+      <span class="flag-label">Opérateur Étoile à Six Branches</span>
+    </div>
+      <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧸" aria-label="Copier 🧸">🧸</button>
+      <span class="flag-label">Ours en Peluche</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐻" aria-label="Copier 🐻">🐻</button>
+      <span class="flag-label">Tête d'Ours</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐰" aria-label="Copier 🐰">🐰</button>
+      <span class="flag-label">Tête de Lapin</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🎀" aria-label="Copier 🎀">🎀</button>
+      <span class="flag-label">Nœud Ruban</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌸" aria-label="Copier 🌸">🌸</button>
+      <span class="flag-label">Fleur de Cerisier</span>
+    </div>
+</div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- COLLECTIONS -->
+<section class="mood-explainers" id="kawaii-collections">
+  <span class="article-section-label">Collections Kawaii</span>
+  <h2>Sets Bio &amp; Pseudo Kawaii</h2>
+  <p class="u-secondary-block">Des combos kawaii prêts à l'emploi — cœurs doux, petites frimousses et sparkle pastel à coller directement dans une bio, un pseudo ou un message en un clic.</p>
+  <div id="kawaiiCollectionsContainer"></div>
+</section>
+
+<div class="section-divider"></div>
+
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Transforme ton texte avec les polices Unicode</h3>
+  <p>Utilise UltraTextGen pour convertir du texte simple en gras, italique, cursive et plus de 100 autres styles de police Unicode — gratuit et instantané.</p>
+  <a href="/fr/" class="cta-btn">Ouvrir UltraTextGen →</a>
+</div>
+
+
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Pages liées</span>
+  <div class="compare-grid">
+    <a href="/fr/library/symboles-coquette/" class="compare-card variant-muted u-no-underline">
+      <h4>Symboles Coquette</h4>
+      <p>Nœuds, rubans et caractères doux-féminins pour bios coquette.</p>
+    </a>
+    <a href="/fr/library/symboles-cottagecore/" class="compare-card variant-muted u-no-underline">
+      <h4>Symboles Cottagecore</h4>
+      <p>Fleurs, feuilles et motifs nature pour une esthétique champêtre.</p>
+    </a>
+    <a href="/fr/library/symboles-y2k/" class="compare-card variant-muted u-no-underline">
+      <h4>Symboles Y2K</h4>
+      <p>Étoiles, croix, papillons et brillance cyber des années 2000.</p>
+    </a>
+    <a href="/fr/library/symboles/" class="compare-card variant-muted u-no-underline">
+      <h4>Symboles à Copier-Coller</h4>
+      <p>Cœurs, étoiles, croix et caractères spéciaux pour bio et pseudo.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    { name: "Combo Bio Cœur Doux", flags: ["꒰","♡","꒱","⋆","ෆ"], defaultFormat: "inline" },
+    { name: "Séparateur Sparkle Kawaii", flags: ["⊹","⋆","✧","⋆","⊹"], defaultFormat: "inline" },
+    { name: "Pseudo Aile Fleurie", flags: ["ʚ ✿ ɞ"], defaultFormat: "inline" },
+    { name: "Bordure Poussière Pastel", flags: ["✦","⋆","❀","⋆","✦"], defaultFormat: "inline" },
+    { name: "Cadre Bio Frimousse", flags: ["(˶˃ ᵕ ˂˶)","♡"], defaultFormat: "inline" },
+    { name: "Combo Crochets Mignons", flags: ["꒰ ♡ ꒱"], defaultFormat: "inline" }
+  ];
+
+  ns.buildGrids("kawaiiCollectionsContainer", GROUPS);
+  ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/fr/library/symboles-therian/index.html
+++ b/fr/library/symboles-therian/index.html
@@ -1,0 +1,364 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Symboles Therian : Theta-Delta θΔ &amp; Marques Alterhumaines à Copier-Coller | UltraTextGen</title>
+<meta name="description" content="Parcours les marques theta-delta (θΔ), empreintes de pattes, phases de lune et symboles animaux utilisés par la communauté therian et alterhumaine. Touche un symbole pour le copier aussitôt.">
+
+<link rel="canonical" href="https://ultratextgen.com/fr/library/symboles-therian/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles-therian/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/fr/library/symboles-therian/">
+
+<meta property="og:image" content="https://ultratextgen.com/assets/og/fr-library-symboles-therian.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Symboles Therian : Theta-Delta θΔ &amp; Marques Alterhumaines à Copier-Coller">
+<meta name="twitter:description" content="Parcours les marques theta-delta (θΔ), empreintes de pattes, phases de lune et symboles animaux utilisés par la communauté therian et alterhumaine. Touche un symbole pour le copier aussitôt.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/fr-library-symboles-therian.png">
+<meta property="og:title" content="Symboles Therian : Theta-Delta θΔ &amp; Marques Alterhumaines à Copier-Coller">
+<meta property="og:description" content="Parcours les marques theta-delta (θΔ), empreintes de pattes, phases de lune et symboles animaux utilisés par la communauté therian et alterhumaine. Touche un symbole pour le copier aussitôt.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/fr/library/symboles-therian/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Symboles Therian : Theta-Delta θΔ & Marques Alterhumaines à Copier-Coller",
+  "inLanguage": "fr",
+  "alternateName": ["Symboles Therian Copier Coller", "Symbole Theta Delta Copier Coller", "Symboles Alterhumains", "Symboles Communauté Therian", "Signes Therian", "Symboles Empreinte de Patte Copier Coller", "Emojis Therian Copier Coller"],
+  "description": "Parcours les marques theta-delta (θΔ), empreintes de pattes, phases de lune et symboles animaux utilisés par la communauté therian et alterhumaine. Touche un symbole pour le copier aussitôt.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/fr-library-symboles-therian.png",
+  "mainEntityOfPage": "https://ultratextgen.com/fr/library/symboles-therian/",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Accueil",
+      "item": "https://ultratextgen.com/fr/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Symboles Therian",
+      "item": "https://ultratextgen.com/fr/library/symboles-therian/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Fil d'Ariane">
+  <a href="/fr/">Accueil</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Symboles Therian</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Symboles Therian</h1>
+    <p class="hero-tagline">La marque communautaire theta-delta (θΔ) accompagnée des symboles de patte, de lune et d'animaux de l'identité therian et alterhumaine. Touche un symbole, il est copié aussitôt.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/fr-library-symboles-therian.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Le symbole therian que la plupart des gens cherchent, c'est le theta-delta — les lettres grecques thêta (θ) et delta (Δ) combinées — adopté par la communauté de la thérianthropie en 2003 comme marque d'identité commune et respectueuse. Les therians sont des personnes qui vivent une identification profonde et non physique à un animal, et la communauté alterhumaine plus large utilise des marques apparentées aux côtés des empreintes de pattes, des phases de lune et des emojis d'animaux. Cette page rassemble le theta-delta dans ses formes Unicode courantes ainsi que les symboles de nature et d'animaux utilisés dans les bios TikTok, les blogs Tumblr et les profils Discord.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="theta-delta">
+  <span class="article-section-label">Theta-Delta</span>
+  <h2>Marques Communautaires Theta-Delta</h2>
+  <p class="u-secondary-tight">La marque theta-delta construite à partir de vraies lettres grecques — copie la paire combinée ou chaque lettre séparément.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="θΔ" aria-label="Copier Theta-Delta (Marque Therian)">θΔ</button>
+      <span class="flag-label">Theta-Delta (Marque Therian)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ΘΔ" aria-label="Copier Theta-Delta Majuscule">ΘΔ</button>
+      <span class="flag-label">Theta-Delta Majuscule</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="θ" aria-label="Copier Lettre Grecque Thêta Minuscule">θ</button>
+      <span class="flag-label">Lettre Grecque Thêta Minuscule</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="Θ" aria-label="Copier Lettre Grecque Thêta Majuscule">Θ</button>
+      <span class="flag-label">Lettre Grecque Thêta Majuscule</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="Δ" aria-label="Copier Lettre Grecque Delta Majuscule">Δ</button>
+      <span class="flag-label">Lettre Grecque Delta Majuscule</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="δ" aria-label="Copier Lettre Grecque Delta Minuscule">δ</button>
+      <span class="flag-label">Lettre Grecque Delta Minuscule</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ϴ" aria-label="Copier Symbole Thêta Majuscule Grec">ϴ</button>
+      <span class="flag-label">Symbole Thêta Majuscule Grec</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ϑ" aria-label="Copier Symbole Thêta Grec">ϑ</button>
+      <span class="flag-label">Symbole Thêta Grec</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="paw-prints">
+  <span class="article-section-label">Pattes &amp; Canidés</span>
+  <h2>Empreintes de Pattes &amp; Symboles Canins</h2>
+  <p class="u-secondary-tight">Empreintes de pattes et emojis loup, renard et chien qui reviennent le plus dans les bios therian.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐾" aria-label="Copier Empreintes de Pattes">🐾</button>
+      <span class="flag-label">Empreintes de Pattes</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐺" aria-label="Copier Loup">🐺</button>
+      <span class="flag-label">Loup</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦊" aria-label="Copier Renard">🦊</button>
+      <span class="flag-label">Renard</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐕" aria-label="Copier Chien">🐕</button>
+      <span class="flag-label">Chien</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐈‍⬛" aria-label="Copier Chat Noir">🐈‍⬛</button>
+      <span class="flag-label">Chat Noir</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦝" aria-label="Copier Raton Laveur">🦝</button>
+      <span class="flag-label">Raton Laveur</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐅" aria-label="Copier Tigre">🐅</button>
+      <span class="flag-label">Tigre</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦴" aria-label="Copier Os">🦴</button>
+      <span class="flag-label">Os</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="wild-animals">
+  <span class="article-section-label">Animaux Sauvages</span>
+  <h2>Symboles d'Animaux Sauvages &amp; Thériotypes</h2>
+  <p class="u-secondary-tight">Emojis pour les thériotypes courants — du cerf aux grands félins, en passant par les rapaces.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦌" aria-label="Copier Cerf">🦌</button>
+      <span class="flag-label">Cerf</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐆" aria-label="Copier Léopard">🐆</button>
+      <span class="flag-label">Léopard</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦅" aria-label="Copier Aigle">🦅</button>
+      <span class="flag-label">Aigle</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦉" aria-label="Copier Hibou">🦉</button>
+      <span class="flag-label">Hibou</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐦‍⬛" aria-label="Copier Oiseau Noir">🐦‍⬛</button>
+      <span class="flag-label">Oiseau Noir</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐍" aria-label="Copier Serpent">🐍</button>
+      <span class="flag-label">Serpent</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦈" aria-label="Copier Requin">🦈</button>
+      <span class="flag-label">Requin</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐉" aria-label="Copier Dragon">🐉</button>
+      <span class="flag-label">Dragon</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="moon-night">
+  <span class="article-section-label">Lune &amp; Nuit</span>
+  <h2>Symboles de Lune &amp; de Nuit</h2>
+  <p class="u-secondary-tight">Phases de lune et croissants — un motif de longue date dans les espaces therian et alterhumains.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌙" aria-label="Copier Croissant de Lune">🌙</button>
+      <span class="flag-label">Croissant de Lune</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☾" aria-label="Copier Dernier Quartier de Lune (Texte)">☾</button>
+      <span class="flag-label">Dernier Quartier de Lune (Texte)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☽" aria-label="Copier Premier Quartier de Lune (Texte)">☽</button>
+      <span class="flag-label">Premier Quartier de Lune (Texte)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌕" aria-label="Copier Pleine Lune">🌕</button>
+      <span class="flag-label">Pleine Lune</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌑" aria-label="Copier Nouvelle Lune">🌑</button>
+      <span class="flag-label">Nouvelle Lune</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌒" aria-label="Copier Premier Croissant de Lune">🌒</button>
+      <span class="flag-label">Premier Croissant de Lune</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="forest-nature">
+  <span class="article-section-label">Forêt &amp; Nature</span>
+  <h2>Symboles de Forêt &amp; de Nature</h2>
+  <p class="u-secondary-tight">Caractères de bois et de nature sauvage pour compléter la légende d'une vidéo de quadrobie ou un profil.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌲" aria-label="Copier Conifère">🌲</button>
+      <span class="flag-label">Conifère</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌿" aria-label="Copier Herbe">🌿</button>
+      <span class="flag-label">Herbe</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🍂" aria-label="Copier Feuille Morte">🍂</button>
+      <span class="flag-label">Feuille Morte</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛰" aria-label="Copier Montagne">⛰</button>
+      <span class="flag-label">Montagne</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🪶" aria-label="Copier Plume">🪶</button>
+      <span class="flag-label">Plume</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌾" aria-label="Copier Gerbe de Riz">🌾</button>
+      <span class="flag-label">Gerbe de Riz</span>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Transforme ton texte avec les polices Unicode</h3>
+  <p>Utilise UltraTextGen pour convertir du texte simple en gras, italique, cursive et plus de 100 autres styles de police Unicode — gratuit et instantané.</p>
+  <a href="/fr/" class="cta-btn">Ouvrir UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Pages liées</span>
+  <div class="compare-grid">
+    <a href="/fr/library/symboles-fairycore/" class="compare-card variant-muted u-no-underline">
+      <h4>Symboles Fairycore</h4>
+      <p>Champignons, papillons et caractères de forêt féerique pour bios.</p>
+    </a>
+    <a href="/fr/library/symboles-goth-grunge/" class="compare-card variant-muted u-no-underline">
+      <h4>Symboles Goth &amp; Grunge</h4>
+      <p>Croix, chauves-souris et symboles sombres pour pseudos edgy.</p>
+    </a>
+    <a href="/fr/library/symboles-dreamcore-weirdcore/" class="compare-card variant-muted u-no-underline">
+      <h4>Symboles Dreamcore &amp; Weirdcore</h4>
+      <p>Symboles oniriques et étranges pour une esthétique surréaliste.</p>
+    </a>
+    <a href="/fr/library/symboles-y2k/" class="compare-card variant-muted u-no-underline">
+      <h4>Symboles Y2K</h4>
+      <p>Étoiles, croix et papillons cyber du début des années 2000.</p>
+    </a>
+    <a href="/fr/library/symboles/" class="compare-card variant-muted u-no-underline">
+      <h4>Symboles à Copier-Coller</h4>
+      <p>Cœurs, étoiles, croix et caractères spéciaux pour bio et pseudo.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/fr/library/symboles-witchy-occult/index.html
+++ b/fr/library/symboles-witchy-occult/index.html
@@ -1,0 +1,769 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Symboles Witchy &amp; Occult ⛧ Pentagrammes, Lune &amp; Alchimie à Copier-Coller | UltraTextGen</title>
+<meta name="description" content="Parcours et copie des symboles witchy et occultes — pentagrammes, phases de lune, signes planétaires, symboles alchimiques et autres caractères ésotériques. Touche pour copier.">
+
+<link rel="canonical" href="https://ultratextgen.com/fr/library/symboles-witchy-occult/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/witchy-occult-symbols/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles-witchy-occult/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/witchy-occult-symbols/">
+
+<meta property="og:image" content="https://ultratextgen.com/assets/og/fr-library-symboles-witchy-occult.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Symboles Witchy &amp; Occult ⛧ Pentagrammes, Lune &amp; Alchimie à Copier-Coller">
+<meta name="twitter:description" content="Parcours et copie des symboles witchy et occultes — pentagrammes, phases de lune, signes planétaires, symboles alchimiques et autres caractères ésotériques. Touche pour copier.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/fr-library-symboles-witchy-occult.png">
+<meta property="og:title" content="Symboles Witchy &amp; Occult ⛧ Pentagrammes, Lune &amp; Alchimie à Copier-Coller">
+<meta property="og:description" content="Parcours et copie des symboles witchy et occultes — pentagrammes, phases de lune, signes planétaires, symboles alchimiques et autres caractères ésotériques. Touche pour copier.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/fr/library/symboles-witchy-occult/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Symboles Witchy &amp; Occult ⛧ Pentagrammes, Lune &amp; Alchimie à Copier-Coller",
+  "inLanguage": "fr",
+  "alternateName": ["Symboles Occultes Copier Coller", "Symboles Witchy Copier Coller", "Symboles de Sorcière Unicode", "Symboles Magiques Copier Coller", "Symboles Ésotériques Copier Coller", "Symbole Pentagramme Copier Coller", "Emojis Witchy Copier Coller"],
+  "description": "Parcours et copie des symboles witchy et occultes — pentagrammes, phases de lune, signes planétaires, symboles alchimiques et autres caractères ésotériques. Touche pour copier.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/fr-library-symboles-witchy-occult.png",
+  "mainEntityOfPage": "https://ultratextgen.com/fr/library/symboles-witchy-occult/",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Accueil",
+      "item": "https://ultratextgen.com/fr/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Symboles Witchy &amp; Occult",
+      "item": "https://ultratextgen.com/fr/library/symboles-witchy-occult/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Fil d'Ariane">
+  <a href="/fr/">Accueil</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Symboles Witchy &amp; Occult</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Symboles Witchy &amp; Occult</h1>
+    <p class="hero-tagline">Une collection soignée de pentagrammes, phases de lune, symboles planétaires, signes alchimiques et autres caractères Unicode ésotériques. Touche un symbole pour le copier aussitôt.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/fr-library-symboles-witchy-occult.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Cette bibliothèque rassemble les symboles Unicode liés à la sorcellerie, à l'occultisme, à l'alchimie et aux traditions ésotériques. Ce sont tous des caractères Unicode standard — utilisables dans les textes, les bios et l'écriture créative. La section des symboles alchimiques couvre le bloc Unicode dédié Alchemical Symbols (U+1F700–U+1F73F).</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="pentagrams-stars">
+  <span class="article-section-label">Pentagrammes &amp; Étoiles</span>
+  <h2>Pentagrammes &amp; Étoiles à Cinq Branches</h2>
+  <p>Étoiles et pentagrammes associés aux traditions ésotériques et occultes.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="★" aria-label="Copier Étoile Noire">★</button>
+      <span class="flag-label">Étoile Noire</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☆" aria-label="Copier Étoile Blanche">☆</button>
+      <span class="flag-label">Étoile Blanche</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚹" aria-label="Copier Sextile">⚹</button>
+      <span class="flag-label">Sextile</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✡" aria-label="Copier Étoile de David">✡</button>
+      <span class="flag-label">Étoile de David</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚜" aria-label="Copier Fleur de Lys">⚜</button>
+      <span class="flag-label">Fleur de Lys</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛤" aria-label="Copier Pentagramme">⛤</button>
+      <span class="flag-label">Pentagramme</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛥" aria-label="Copier Pentagramme Pointant à Droite">⛥</button>
+      <span class="flag-label">Pentagramme Pointant à Droite</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛦" aria-label="Copier Pentagramme Pointant à Gauche">⛦</button>
+      <span class="flag-label">Pentagramme Pointant à Gauche</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛧" aria-label="Copier Pentagramme Inversé">⛧</button>
+      <span class="flag-label">Pentagramme Inversé</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✴" aria-label="Copier Étoile à Huit Branches">✴</button>
+      <span class="flag-label">Étoile à Huit Branches</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✪" aria-label="Copier Étoile Blanche Cerclée">✪</button>
+      <span class="flag-label">Étoile Blanche Cerclée</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✶" aria-label="Copier Étoile à Six Branches">✶</button>
+      <span class="flag-label">Étoile à Six Branches</span>
+    </div>
+      <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✦" aria-label="Copier ✦">✦</button>
+      <span class="flag-label">Étoile Scintillante</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="◯" aria-label="Copier ◯">◯</button>
+      <span class="flag-label">Grand Cercle</span>
+    </div>
+</div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- Anchor preserved for inbound links/bookmarks; canonical content lives on /library/moon-celestial-symbols/#celestial-collections -->
+<section class="mood-explainers" id="moon-phases">
+  <span class="article-section-label">Phases de Lune</span>
+  <h2>Symboles des Phases de Lune</h2>
+  <p>Tu cherches le cycle lunaire complet ? Les symboles célestes et de lune sont regroupés dans la collection générale de symboles.</p>
+  <div class="compare-grid" style="margin-top:1rem;">
+    <a href="/fr/library/symboles/" class="compare-card variant-muted u-no-underline">
+      <h4>Voir : Lune &amp; symboles célestes →</h4>
+      <p>Les huit phases de lune Unicode (🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘) ainsi que les croissants et variantes de lune sombre/claire, prêts à copier en séquence.</p>
+    </a>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- CLASSICAL 7 PLANETS (featured sub-group) -->
+<section class="mood-explainers" id="classical-7-planets">
+  <span class="article-section-label">Les 7 Planètes Classiques</span>
+  <h2>Les Sept Planètes Classiques (Soleil → Saturne)</h2>
+  <p class="u-secondary-tight">Les sept planètes de l'astrologie traditionnelle dans l'ordre chaldéen — les astres visibles du ciel connus des astronomes anciens.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☉" aria-label="Copier Soleil">☉</button>
+      <span class="flag-label">Soleil</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☽" aria-label="Copier Lune">☽</button>
+      <span class="flag-label">Lune</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☿" aria-label="Copier Mercure">☿</button>
+      <span class="flag-label">Mercure</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♀" aria-label="Copier Vénus">♀</button>
+      <span class="flag-label">Vénus</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♂" aria-label="Copier Mars">♂</button>
+      <span class="flag-label">Mars</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♃" aria-label="Copier Jupiter">♃</button>
+      <span class="flag-label">Jupiter</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♄" aria-label="Copier Saturne">♄</button>
+      <span class="flag-label">Saturne</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="planetary-zodiac">
+  <span class="article-section-label">Planétaire &amp; Astrologique</span>
+  <h2>Symboles Planétaires &amp; Astrologiques</h2>
+  <p>Symboles planétaires classiques et glyphes astrologiques aux associations occultes.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☉" aria-label="Copier Soleil">☉</button>
+      <span class="flag-label">Soleil</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☽" aria-label="Copier Lune">☽</button>
+      <span class="flag-label">Lune</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☿" aria-label="Copier Mercure">☿</button>
+      <span class="flag-label">Mercure</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♀" aria-label="Copier Vénus">♀</button>
+      <span class="flag-label">Vénus</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♁" aria-label="Copier Terre">♁</button>
+      <span class="flag-label">Terre</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♂" aria-label="Copier Mars">♂</button>
+      <span class="flag-label">Mars</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♃" aria-label="Copier Jupiter">♃</button>
+      <span class="flag-label">Jupiter</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♄" aria-label="Copier Saturne">♄</button>
+      <span class="flag-label">Saturne</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♅" aria-label="Copier Uranus">♅</button>
+      <span class="flag-label">Uranus</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♆" aria-label="Copier Neptune">♆</button>
+      <span class="flag-label">Neptune</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♇" aria-label="Copier Pluton">♇</button>
+      <span class="flag-label">Pluton</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚸" aria-label="Copier Lune Noire Lilith">⚸</button>
+      <span class="flag-label">Lune Noire Lilith</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚳" aria-label="Copier Cérès">⚳</button>
+      <span class="flag-label">Cérès</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚴" aria-label="Copier Pallas">⚴</button>
+      <span class="flag-label">Pallas</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚵" aria-label="Copier Junon">⚵</button>
+      <span class="flag-label">Junon</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚶" aria-label="Copier Vesta">⚶</button>
+      <span class="flag-label">Vesta</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="alchemical">
+  <span class="article-section-label">Alchimique</span>
+  <h2>Symboles Alchimiques (U+1F700–U+1F73F)</h2>
+  <p>Le bloc Unicode Alchemical Symbols, contenant les signes des éléments, des procédés et des substances utilisés dans l'alchimie historique.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜀" aria-label="Copier Quintessence">🜀</button>
+      <span class="flag-label">Quintessence</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜁" aria-label="Copier Air">🜁</button>
+      <span class="flag-label">Air</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜂" aria-label="Copier Feu">🜂</button>
+      <span class="flag-label">Feu</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜃" aria-label="Copier Terre">🜃</button>
+      <span class="flag-label">Terre</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜄" aria-label="Copier Eau">🜄</button>
+      <span class="flag-label">Eau</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜅" aria-label="Copier Eau-Forte">🜅</button>
+      <span class="flag-label">Eau-Forte</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜆" aria-label="Copier Eau Régale">🜆</button>
+      <span class="flag-label">Eau Régale</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜇" aria-label="Copier Eau Régale II">🜇</button>
+      <span class="flag-label">Eau Régale II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜈" aria-label="Copier Eau-de-Vie">🜈</button>
+      <span class="flag-label">Eau-de-Vie</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜉" aria-label="Copier Eau-de-Vie II">🜉</button>
+      <span class="flag-label">Eau-de-Vie II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜊" aria-label="Copier Vinaigre">🜊</button>
+      <span class="flag-label">Vinaigre</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜋" aria-label="Copier Vinaigre II">🜋</button>
+      <span class="flag-label">Vinaigre II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜌" aria-label="Copier Vinaigre III">🜌</button>
+      <span class="flag-label">Vinaigre III</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜍" aria-label="Copier Soufre">🜍</button>
+      <span class="flag-label">Soufre</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜎" aria-label="Copier Soufre II">🜎</button>
+      <span class="flag-label">Soufre II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜏" aria-label="Copier Soufre III">🜏</button>
+      <span class="flag-label">Soufre III</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜐" aria-label="Copier Sel">🜐</button>
+      <span class="flag-label">Sel</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜑" aria-label="Copier Sel II">🜑</button>
+      <span class="flag-label">Sel II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜒" aria-label="Copier Sel III">🜒</button>
+      <span class="flag-label">Sel III</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜓" aria-label="Copier Sublimé de Mercure">🜓</button>
+      <span class="flag-label">Sublimé de Mercure</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜔" aria-label="Copier Sublimé de Mercure II">🜔</button>
+      <span class="flag-label">Sublimé de Mercure II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜕" aria-label="Copier Sublimé de Mercure III">🜕</button>
+      <span class="flag-label">Sublimé de Mercure III</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜖" aria-label="Copier Cinabre">🜖</button>
+      <span class="flag-label">Cinabre</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜗" aria-label="Copier Sel Ammoniac">🜗</button>
+      <span class="flag-label">Sel Ammoniac</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜘" aria-label="Copier Vitriol">🜘</button>
+      <span class="flag-label">Vitriol</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜙" aria-label="Copier Vitriol II">🜙</button>
+      <span class="flag-label">Vitriol II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜚" aria-label="Copier Or">🜚</button>
+      <span class="flag-label">Or</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜛" aria-label="Copier Argent">🜛</button>
+      <span class="flag-label">Argent</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜜" aria-label="Copier Minerai de Fer">🜜</button>
+      <span class="flag-label">Minerai de Fer</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜝" aria-label="Copier Minerai de Fer II">🜝</button>
+      <span class="flag-label">Minerai de Fer II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜞" aria-label="Copier Crocus de Fer">🜞</button>
+      <span class="flag-label">Crocus de Fer</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜟" aria-label="Copier Régule de Fer">🜟</button>
+      <span class="flag-label">Régule de Fer</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜠" aria-label="Copier Minerai de Cuivre">🜠</button>
+      <span class="flag-label">Minerai de Cuivre</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜡" aria-label="Copier Minerai de Fer-Cuivre">🜡</button>
+      <span class="flag-label">Minerai de Fer-Cuivre</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜢" aria-label="Copier Sublimé de Cuivre">🜢</button>
+      <span class="flag-label">Sublimé de Cuivre</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜣" aria-label="Copier Crocus de Cuivre">🜣</button>
+      <span class="flag-label">Crocus de Cuivre</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜤" aria-label="Copier Antimoniate de Cuivre">🜤</button>
+      <span class="flag-label">Antimoniate de Cuivre</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜥" aria-label="Copier Sel d'Antimoniate de Cuivre">🜥</button>
+      <span class="flag-label">Sel d'Antimoniate de Cuivre</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜦" aria-label="Copier Sublimé de Sel de Cuivre">🜦</button>
+      <span class="flag-label">Sublimé de Sel de Cuivre</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜧" aria-label="Copier Vert-de-Gris">🜧</button>
+      <span class="flag-label">Vert-de-Gris</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜨" aria-label="Copier Minerai d'Étain">🜨</button>
+      <span class="flag-label">Minerai d'Étain</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜩" aria-label="Copier Minerai de Plomb">🜩</button>
+      <span class="flag-label">Minerai de Plomb</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜪" aria-label="Copier Terre de Minerai de Plomb">🜪</button>
+      <span class="flag-label">Terre de Minerai de Plomb</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜫" aria-label="Copier Antimoine">🜫</button>
+      <span class="flag-label">Antimoine</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜬" aria-label="Copier Antimoine II">🜬</button>
+      <span class="flag-label">Antimoine II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜭" aria-label="Copier Sublimé d'Antimoine">🜭</button>
+      <span class="flag-label">Sublimé d'Antimoine</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜮" aria-label="Copier Sel d'Antimoine">🜮</button>
+      <span class="flag-label">Sel d'Antimoine</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜯" aria-label="Copier Sublimé de Sel d'Antimoine">🜯</button>
+      <span class="flag-label">Sublimé de Sel d'Antimoine</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜰" aria-label="Copier Vinaigre d'Antimoine">🜰</button>
+      <span class="flag-label">Vinaigre d'Antimoine</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜱" aria-label="Copier Régule d'Antimoine">🜱</button>
+      <span class="flag-label">Régule d'Antimoine</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜲" aria-label="Copier Régule d'Antimoine II">🜲</button>
+      <span class="flag-label">Régule d'Antimoine II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜳" aria-label="Copier Régule">🜳</button>
+      <span class="flag-label">Régule</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜴" aria-label="Copier Régule II">🜴</button>
+      <span class="flag-label">Régule II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜵" aria-label="Copier Régule III">🜵</button>
+      <span class="flag-label">Régule III</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜶" aria-label="Copier Régule IV">🜶</button>
+      <span class="flag-label">Régule IV</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜷" aria-label="Copier Alcali">🜷</button>
+      <span class="flag-label">Alcali</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜸" aria-label="Copier Alcali II">🜸</button>
+      <span class="flag-label">Alcali II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜹" aria-label="Copier Marcassite">🜹</button>
+      <span class="flag-label">Marcassite</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜺" aria-label="Copier Sel Ammoniac">🜺</button>
+      <span class="flag-label">Sel Ammoniac</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜻" aria-label="Copier Arsenic">🜻</button>
+      <span class="flag-label">Arsenic</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜼" aria-label="Copier Réalgar">🜼</button>
+      <span class="flag-label">Réalgar</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜽" aria-label="Copier Réalgar II">🜽</button>
+      <span class="flag-label">Réalgar II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜾" aria-label="Copier Orpiment">🜾</button>
+      <span class="flag-label">Orpiment</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜿" aria-label="Copier Minerai de Bismuth">🜿</button>
+      <span class="flag-label">Minerai de Bismuth</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="esoteric">
+  <span class="article-section-label">Autres Symboles Ésotériques</span>
+  <h2>Autres Symboles Ésotériques</h2>
+  <p>Symboles supplémentaires associés aux traditions magiques et ésotériques.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☥" aria-label="Copier Ânkh">☥</button>
+      <span class="flag-label">Ânkh</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☯" aria-label="Copier Yin Yang">☯</button>
+      <span class="flag-label">Yin Yang</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☘" aria-label="Copier Trèfle">☘</button>
+      <span class="flag-label">Trèfle</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚷" aria-label="Copier Chiron">⚷</button>
+      <span class="flag-label">Chiron</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚰" aria-label="Copier Cercueil">⚰</button>
+      <span class="flag-label">Cercueil</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚱" aria-label="Copier Urne Funéraire">⚱</button>
+      <span class="flag-label">Urne Funéraire</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚗" aria-label="Copier Alambic">⚗</button>
+      <span class="flag-label">Alambic</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❤" aria-label="Copier Cœur">❤</button>
+      <span class="flag-label">Cœur</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚛" aria-label="Copier Symbole de l'Atome">⚛</button>
+      <span class="flag-label">Symbole de l'Atome</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚡" aria-label="Copier Éclair">⚡</button>
+      <span class="flag-label">Éclair</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♲" aria-label="Copier Recyclage">♲</button>
+      <span class="flag-label">Recyclage</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☼" aria-label="Copier Soleil Blanc à Rayons">☼</button>
+      <span class="flag-label">Soleil Blanc à Rayons</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☦" aria-label="Copier Croix Orthodoxe">☦</button>
+      <span class="flag-label">Croix Orthodoxe</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☢" aria-label="Copier Radioactif">☢</button>
+      <span class="flag-label">Radioactif</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☣" aria-label="Copier Danger Biologique">☣</button>
+      <span class="flag-label">Danger Biologique</span>
+    </div>
+      <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🔮" aria-label="Copier 🔮">🔮</button>
+      <span class="flag-label">Boule de Cristal</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧿" aria-label="Copier 🧿">🧿</button>
+      <span class="flag-label">Amulette Nazar</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🃏" aria-label="Copier 🃏">🃏</button>
+      <span class="flag-label">Carte de Tarot</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕯️" aria-label="Copier 🕯️">🕯️</button>
+      <span class="flag-label">Bougie</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐍" aria-label="Copier 🐍">🐍</button>
+      <span class="flag-label">Serpent</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="∞" aria-label="Copier ∞">∞</button>
+      <span class="flag-label">Infini</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⟳" aria-label="Copier ⟳">⟳</button>
+      <span class="flag-label">Flèche Cyclique</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="↻" aria-label="Copier ↻">↻</button>
+      <span class="flag-label">Flèche Circulaire Ouverte</span>
+    </div>
+</div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- COLLECTIONS -->
+<section class="mood-explainers" id="witchy-collections">
+  <span class="article-section-label">Collections Witchy</span>
+  <h2>Sets Bio &amp; Bordure Witchy</h2>
+  <p class="u-secondary-block">Des chaînes witchy prêtes à coller directement dans une bio, une légende ou un pseudo — copie le combo entier en un clic.</p>
+  <div id="witchyCollectionsContainer"></div>
+</section>
+
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Transforme ton texte avec les polices Unicode</h3>
+  <p>Utilise UltraTextGen pour convertir du texte simple en gras, italique, cursive et plus de 100 autres styles de police Unicode — gratuit et instantané.</p>
+  <a href="/fr/" class="cta-btn">Ouvrir UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Pages liées</span>
+  <div class="compare-grid">
+    <a href="/fr/library/symboles-goth-grunge/" class="compare-card variant-muted u-no-underline">
+      <h4>Symboles Goth &amp; Grunge</h4>
+      <p>Croix sombres, crânes et décorations d'esthétique goth.</p>
+    </a>
+    <a href="/fr/library/symboles-cottagecore/" class="compare-card variant-muted u-no-underline">
+      <h4>Symboles Cottagecore</h4>
+      <p>Champignons, fleurs sauvages et motifs de vie champêtre.</p>
+    </a>
+    <a href="/fr/library/symboles-fairycore/" class="compare-card variant-muted u-no-underline">
+      <h4>Symboles Fairycore</h4>
+      <p>Papillons, fleurs et symboles féeriques pour bios.</p>
+    </a>
+    <a href="/fr/library/symboles-y2k/" class="compare-card variant-muted u-no-underline">
+      <h4>Symboles Y2K</h4>
+      <p>Étoiles, croix et papillons de l'esthétique cyber des années 2000.</p>
+    </a>
+    <a href="/fr/library/symboles/" class="compare-card variant-muted u-no-underline">
+      <h4>Symboles à Copier-Coller</h4>
+      <p>Cœurs, étoiles, croix et caractères spéciaux pour bio et pseudo.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Sélecteur de langue">
+      <a class="lang-option" href="/library/witchy-occult-symbols/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/fr/library/symboles-witchy-occult/" hreflang="fr">FR</a>
+    </div>
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    { name: "Bordure Bio Pentagramme", flags: ["⛧","˖","⛤","˖","⛧"], defaultFormat: "inline" },
+    { name: "Combo Lune & Soleil", flags: ["☽","˚","✴","˚","☉"], defaultFormat: "inline" },
+    { name: "Traînée d'Étoiles Witchy", flags: ["✶","·","✴","·","✶"], defaultFormat: "inline" },
+    { name: "Bordure Croissant de Lune", flags: ["☽⋆ﾟ｡⋆"], defaultFormat: "inline" },
+    { name: "Combo Bio Planétaire", flags: ["☽","☿","♀","♂","♃","♄"], defaultFormat: "inline" },
+    { name: "Séparateur Sort Ânkh", flags: ["☥","˖","⛤","˖","☥"], defaultFormat: "inline" }
+  ];
+
+  ns.buildGrids("witchyCollectionsContainer", GROUPS);
+  ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/id/library/simbol-dreamcore-weirdcore/index.html
+++ b/id/library/simbol-dreamcore-weirdcore/index.html
@@ -1,0 +1,420 @@
+<!DOCTYPE html>
+<html lang="id">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Simbol Dreamcore &amp; Weirdcore: Salin &amp; Tempel 👁 🌈 ⋆ Nuansa Surreal</title>
+<meta name="description" content="Simbol dreamcore dan weirdcore — mata surreal 👁, pelangi 🌈, blok glitch, pintu, dan kombo sleepcore untuk postingan liminal. Klik simbol mana pun untuk langsung menyalin.">
+
+<link rel="canonical" href="https://ultratextgen.com/id/library/simbol-dreamcore-weirdcore/">
+  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-dreamcore-weirdcore/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/id/library/simbol-dreamcore-weirdcore/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/id-library-simbol-dreamcore-weirdcore.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Simbol Dreamcore &amp; Weirdcore: Salin &amp; Tempel 👁 🌈 ⋆ Nuansa Surreal">
+<meta name="twitter:description" content="Simbol dreamcore dan weirdcore — mata surreal 👁, pelangi 🌈, blok glitch, pintu, dan kombo sleepcore untuk postingan liminal. Klik simbol mana pun untuk langsung menyalin.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/id-library-simbol-dreamcore-weirdcore.png">
+<meta property="og:title" content="Simbol Dreamcore &amp; Weirdcore: Salin &amp; Tempel 👁 🌈 ⋆ Nuansa Surreal">
+<meta property="og:description" content="Simbol dreamcore dan weirdcore — mata surreal 👁, pelangi 🌈, blok glitch, pintu, dan kombo sleepcore untuk postingan liminal. Klik simbol mana pun untuk langsung menyalin.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/id/library/simbol-dreamcore-weirdcore/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Simbol Dreamcore & Weirdcore: Salin & Tempel 👁 🌈 ⋆ Nuansa Surreal",
+  "alternateName": ["Simbol Dreamcore Salin Tempel", "Simbol Weirdcore Salin Tempel", "Simbol Aesthetic Dreamcore", "Simbol Aesthetic Weirdcore", "Simbol Nuansa Surreal", "Simbol Liminal Space", "Simbol Teks Dreamcore", "Emoji Dreamcore Weirdcore"],
+  "description": "Simbol dreamcore dan weirdcore — mata surreal 👁, pelangi 🌈, blok glitch, pintu, dan kombo sleepcore untuk postingan liminal. Klik simbol mana pun untuk langsung menyalin.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/id-library-simbol-dreamcore-weirdcore.png",
+  "mainEntityOfPage": "https://ultratextgen.com/id/library/simbol-dreamcore-weirdcore/",
+  "inLanguage": "id",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Beranda",
+      "item": "https://ultratextgen.com/id/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Simbol Dreamcore & Weirdcore",
+      "item": "https://ultratextgen.com/id/library/simbol-dreamcore-weirdcore/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/id/">Beranda</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Simbol Dreamcore &amp; Weirdcore</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Simbol Dreamcore &amp; Weirdcore</h1>
+    <p class="hero-tagline">Mata surreal, pintu tanpa ujung, blok glitch statis, dan langit mengantuk untuk nuansa liminal-space. Klik simbol atau kombo mana pun untuk langsung menyalinnya.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/id-library-simbol-dreamcore-weirdcore.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Dreamcore dan weirdcore adalah dua nuansa internet bersaudara yang dibangun di atas logika surreal mimpi — langit nostalgik, mata yang mengawasi, pintu menuju entah ke mana, dan benda familier yang terasa sedikit janggal. Simbol dreamcore dan weirdcore ini menerjemahkan suasana itu ke teks yang bisa disalin: 👁 mata, 🌈 pelangi, 📺 televisi tua, blok bayangan untuk statis, dan set sleepcore untuk editan yang lebih lembut dan mengantuk. Pakai di status Discord, header Tumblr, caption TikTok, dan deskripsi YouTube, atau ambil satu kombo surreal utuh di bawah ini.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="eyes-surreal">
+  <span class="article-section-label">Mata yang Mengawasi</span>
+  <h2>Simbol Mata yang Mengawasi</h2>
+  <p class="u-secondary-tight">Mata tak berkedip yang jadi inti citra weirdcore, dari emoji hingga hieroglif Mesir.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="👁" aria-label="Salin Mata">👁</button>
+      <span class="flag-label">Mata</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="👁️" aria-label="Salin Mata (Gaya Emoji)">👁️</button>
+      <span class="flag-label">Mata (Gaya Emoji)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="👀" aria-label="Salin Sepasang Mata">👀</button>
+      <span class="flag-label">Sepasang Mata</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓂀" aria-label="Salin Mata Horus (Hieroglif Mesir)">𓂀</button>
+      <span class="flag-label">Mata Horus (Hieroglif Mesir)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓁹" aria-label="Salin Mata Hieroglif Mesir">𓁹</button>
+      <span class="flag-label">Mata Hieroglif Mesir</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="◉" aria-label="Salin Mata Ikan">◉</button>
+      <span class="flag-label">Mata Ikan (Fisheye)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊙" aria-label="Salin Operator Titik Berlingkaran">⊙</button>
+      <span class="flag-label">Operator Titik Berlingkaran</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="👁️‍🗨️" aria-label="Salin Mata dalam Gelembung Ucapan">👁️‍🗨️</button>
+      <span class="flag-label">Mata dalam Gelembung Ucapan</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="dream-sky">
+  <span class="article-section-label">Langit Mimpi</span>
+  <h2>Simbol Langit Dreamcore</h2>
+  <p class="u-secondary-tight">Pelangi, awan, dan langit berpusar — sisi cerah dan nostalgik dari nuansa ini.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌈" aria-label="Salin Pelangi">🌈</button>
+      <span class="flag-label">Pelangi</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☁️" aria-label="Salin Awan">☁️</button>
+      <span class="flag-label">Awan</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌙" aria-label="Salin Bulan Sabit">🌙</button>
+      <span class="flag-label">Bulan Sabit</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⭐" aria-label="Salin Bintang">⭐</button>
+      <span class="flag-label">Bintang</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌀" aria-label="Salin Siklon">🌀</button>
+      <span class="flag-label">Siklon</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🫧" aria-label="Salin Gelembung">🫧</button>
+      <span class="flag-label">Gelembung</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌌" aria-label="Salin Bima Sakti">🌌</button>
+      <span class="flag-label">Bima Sakti</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💫" aria-label="Salin Bintang Berputar">💫</button>
+      <span class="flag-label">Bintang Berputar</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="weirdcore-objects">
+  <span class="article-section-label">Objek Weirdcore</span>
+  <h2>Simbol Objek Weirdcore</h2>
+  <p class="u-secondary-tight">Pintu, lubang, cermin, dan TV tua — benda familier yang diletakkan di tempat yang seharusnya tidak.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="📺" aria-label="Salin Televisi">📺</button>
+      <span class="flag-label">Televisi</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🚪" aria-label="Salin Pintu">🚪</button>
+      <span class="flag-label">Pintu</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕳" aria-label="Salin Lubang">🕳</button>
+      <span class="flag-label">Lubang</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🪞" aria-label="Salin Cermin">🪞</button>
+      <span class="flag-label">Cermin</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🛗" aria-label="Salin Lift">🛗</button>
+      <span class="flag-label">Lift</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🎈" aria-label="Salin Balon">🎈</button>
+      <span class="flag-label">Balon</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🩹" aria-label="Salin Plester Luka">🩹</button>
+      <span class="flag-label">Plester Luka</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧸" aria-label="Salin Boneka Beruang">🧸</button>
+      <span class="flag-label">Boneka Beruang</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="sleepcore">
+  <span class="article-section-label">Sleepcore</span>
+  <h2>Simbol Sleepcore</h2>
+  <p class="u-secondary-tight">Sub-nuansa yang mengantuk — ranjang, langit malam, dan tarikan lembut kantuk.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💤" aria-label="Salin Zzz">💤</button>
+      <span class="flag-label">Zzz</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🛏" aria-label="Salin Ranjang">🛏</button>
+      <span class="flag-label">Ranjang</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="😴" aria-label="Salin Wajah Tidur">😴</button>
+      <span class="flag-label">Wajah Tidur</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌃" aria-label="Salin Malam Berbintang">🌃</button>
+      <span class="flag-label">Malam Berbintang</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕰" aria-label="Salin Jam Perapian">🕰</button>
+      <span class="flag-label">Jam Perapian</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🥱" aria-label="Salin Wajah Menguap">🥱</button>
+      <span class="flag-label">Wajah Menguap</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="glitch-static">
+  <span class="article-section-label">Glitch &amp; Statis</span>
+  <h2>Karakter Blok Glitch &amp; Statis</h2>
+  <p class="u-secondary-tight">Karakter blok dan bayangan Unicode yang terbaca seperti statis TV dan piksel rusak.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="░" aria-label="Salin Bayangan Terang">░</button>
+      <span class="flag-label">Bayangan Terang</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="▒" aria-label="Salin Bayangan Sedang">▒</button>
+      <span class="flag-label">Bayangan Sedang</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="▓" aria-label="Salin Bayangan Gelap">▓</button>
+      <span class="flag-label">Bayangan Gelap</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="█" aria-label="Salin Blok Penuh">█</button>
+      <span class="flag-label">Blok Penuh</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="▚" aria-label="Salin Kuadran Kiri Atas dan Kanan Bawah">▚</button>
+      <span class="flag-label">Kuadran Kiri Atas dan Kanan Bawah</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⋆" aria-label="Salin Operator Bintang">⋆</button>
+      <span class="flag-label">Operator Bintang</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="combo-sets">
+  <span class="article-section-label">Set Kombo</span>
+  <h2>Set Kombo Dreamcore &amp; Weirdcore</h2>
+  <p class="u-secondary-block">Salin satu kombo surreal utuh dengan satu klik — mata, langit, statis, dan tidur, siap tempel di mana saja.</p>
+  <div id="dreamcoreSetsContainer"></div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Ubah teks dengan font Unicode</h3>
+  <p>Pakai UltraTextGen untuk mengubah teks biasa menjadi font Unicode tebal, miring, cursive, dan 100+ gaya lain — gratis dan langsung jadi.</p>
+  <a href="/id/" class="cta-btn">Buka UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Halaman Terkait</span>
+  <div class="compare-grid">
+    <a href="/id/library/simbol-fairycore/" class="compare-card variant-muted u-no-underline">
+      <h4>Simbol Fairycore</h4>
+      <p>Peri, jamur, dan kilau debu peri untuk bio bernuansa dongeng.</p>
+    </a>
+    <a href="/id/library/simbol-y2k/" class="compare-card variant-muted u-no-underline">
+      <h4>Simbol Y2K</h4>
+      <p>Karakter retro-futuristik 2000-an dan tanda nuansa cyber.</p>
+    </a>
+    <a href="/id/library/simbol-aesthetic/" class="compare-card variant-muted u-no-underline">
+      <h4>Simbol Aesthetic</h4>
+      <p>Koleksi utama simbol teks aesthetic dan pembatas.</p>
+    </a>
+    <a href="/id/library/simbol-bintang/" class="compare-card variant-muted u-no-underline">
+      <h4>Simbol Bintang</h4>
+      <p>Bintang dan kilau dalam berbagai gaya untuk dekorasi teks.</p>
+    </a>
+    <a href="/id/library/kaomoji/" class="compare-card variant-muted u-no-underline">
+      <h4>Kaomoji</h4>
+      <p>Emotikon Jepang untuk mengekspresikan suasana hati dengan teks.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    {
+      name: "Langit Dreamcore",
+      flags: ["🌈", "☁️", "👁", "⭐", "🌀"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Lorong Weirdcore",
+      flags: ["🚪", "📺", "🕳", "🪞", "👁"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Hanyut Sleepcore",
+      flags: ["💤", "🛏", "🌙", "☁️", "😴"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Mata Maha Melihat",
+      flags: ["👁", "𓂀", "◉", "👀", "⊙"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Bilah Glitch Statis",
+      flags: ["░▒▓█▓▒░", "▓▒░⋆░▒▓", "█▓▒░"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Mimpi Pastel",
+      flags: ["🫧", "🌈", "🪞", "💫", "☁️"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Malam Liminal",
+      flags: ["🌃", "🛗", "🕰", "🌌", "🚪"],
+      defaultFormat: "inline"
+    }
+  ];
+
+  ns.buildGrids("dreamcoreSetsContainer", GROUPS);
+  if (ns.parseTwemoji) ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/id/library/simbol-fairycore/index.html
+++ b/id/library/simbol-fairycore/index.html
@@ -1,0 +1,387 @@
+<!DOCTYPE html>
+<html lang="id">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Simbol Fairycore: Salin &amp; Tempel 🧚 🍄 ✨ Aesthetic Peri</title>
+<meta name="description" content="Simbol dan kombo emoji fairycore — peri 🧚, jamur 🍄, kilau ✨, dan karakter bunga mungil untuk bio bernuansa magis. Klik simbol mana pun untuk langsung menyalinnya.">
+
+<link rel="canonical" href="https://ultratextgen.com/id/library/simbol-fairycore/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/fairycore-symbols/">
+  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-fairycore/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/fairycore-symbols/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/id-library-simbol-fairycore.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Simbol Fairycore: Salin &amp; Tempel 🧚 🍄 ✨ Aesthetic Peri">
+<meta name="twitter:description" content="Simbol dan kombo emoji fairycore — peri 🧚, jamur 🍄, kilau ✨, dan karakter bunga mungil untuk bio bernuansa magis. Klik simbol mana pun untuk langsung menyalinnya.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/id-library-simbol-fairycore.png">
+<meta property="og:title" content="Simbol Fairycore: Salin &amp; Tempel 🧚 🍄 ✨ Aesthetic Peri">
+<meta property="og:description" content="Simbol dan kombo emoji fairycore — peri 🧚, jamur 🍄, kilau ✨, dan karakter bunga mungil untuk bio bernuansa magis. Klik simbol mana pun untuk langsung menyalinnya.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/id/library/simbol-fairycore/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Simbol Fairycore: Salin & Tempel 🧚 🍄 ✨ Aesthetic Peri",
+  "alternateName": ["Simbol Fairycore Salin Tempel", "Simbol Aesthetic Peri", "Emoji Fairycore", "Simbol Peri Copy Paste", "Simbol Peri Cottagecore", "Simbol Magis Salin Tempel"],
+  "description": "Simbol dan kombo emoji fairycore — peri 🧚, jamur 🍄, kilau ✨, dan karakter bunga mungil untuk bio bernuansa magis. Klik simbol mana pun untuk langsung menyalinnya.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/id-library-simbol-fairycore.png",
+  "mainEntityOfPage": "https://ultratextgen.com/id/library/simbol-fairycore/",
+  "inLanguage": "id",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Beranda",
+      "item": "https://ultratextgen.com/id/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Simbol Fairycore",
+      "item": "https://ultratextgen.com/id/library/simbol-fairycore/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/id/">Beranda</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Simbol Fairycore</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Simbol Fairycore</h1>
+    <p class="hero-tagline">Peri, jamur payung, kilau debu peri, dan bunga hutan untuk aesthetic yang penuh sihir. Klik simbol atau kombo mana pun untuk langsung menyalinnya.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/id-library-simbol-fairycore.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Fairycore adalah aesthetic magis yang dibangun dari peri, hutan bercahaya, lingkaran jamur payung, dan kilau emas yang lembut — bayangkan taman ajaib dan debu peri. Simbol dan kombo emoji fairycore ini menangkap keajaiban itu dengan 🧚 peri, 🍄 jamur, ✨ kilau, dan karakter florette mungil seperti ✿ dan ❀. Pakai di bio Instagram, nama papan Pinterest, caption TikTok, dan bagian about-me Discord, atau salin satu set kombo siap pakai di bawah.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="fairies-magic">
+  <span class="article-section-label">Peri &amp; Sihir</span>
+  <h2>Emoji Peri &amp; Sihir</h2>
+  <p class="u-secondary-tight">Keluarga emoji peri plus tongkat sihir dan kilau magis.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧚" aria-label="Salin Peri">🧚</button>
+      <span class="flag-label">Peri</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧚‍♀️" aria-label="Salin Peri Perempuan">🧚‍♀️</button>
+      <span class="flag-label">Peri Perempuan</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧚‍♂️" aria-label="Salin Peri Laki-laki">🧚‍♂️</button>
+      <span class="flag-label">Peri Laki-laki</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🪄" aria-label="Salin Tongkat Sihir">🪄</button>
+      <span class="flag-label">Tongkat Sihir</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✨" aria-label="Salin Kilau">✨</button>
+      <span class="flag-label">Kilau</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💫" aria-label="Salin Bintang Berputar">💫</button>
+      <span class="flag-label">Bintang Berputar</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🔮" aria-label="Salin Bola Kristal">🔮</button>
+      <span class="flag-label">Bola Kristal</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="mushrooms-flora">
+  <span class="article-section-label">Jamur &amp; Flora</span>
+  <h2>Jamur &amp; Flora Hutan</h2>
+  <p class="u-secondary-tight">Jamur payung, bunga mekar, dan florette Unicode yang jadi pondasi setiap tata letak fairycore.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🍄" aria-label="Salin Jamur">🍄</button>
+      <span class="flag-label">Jamur</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌷" aria-label="Salin Tulip">🌷</button>
+      <span class="flag-label">Tulip</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌸" aria-label="Salin Bunga Sakura">🌸</button>
+      <span class="flag-label">Bunga Sakura</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌼" aria-label="Salin Bunga Mekar">🌼</button>
+      <span class="flag-label">Bunga Mekar</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✿" aria-label="Salin Florette Hitam">✿</button>
+      <span class="flag-label">Florette Hitam</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❀" aria-label="Salin Florette Putih">❀</button>
+      <span class="flag-label">Florette Putih</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌿" aria-label="Salin Tanaman Herbal">🌿</button>
+      <span class="flag-label">Tanaman Herbal</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🍃" aria-label="Salin Daun Tertiup Angin">🍃</button>
+      <span class="flag-label">Daun Tertiup Angin</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🪷" aria-label="Salin Teratai">🪷</button>
+      <span class="flag-label">Teratai</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="pixie-sparkles">
+  <span class="article-section-label">Debu Peri</span>
+  <h2>Debu Peri &amp; Kilau Bintang</h2>
+  <p class="u-secondary-tight">Karakter bintang dan kilau mungil untuk membuat pembatas teks manis dan aksen nama pengguna.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⋆" aria-label="Salin Operator Bintang">⋆</button>
+      <span class="flag-label">Operator Bintang</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✦" aria-label="Salin Bintang Empat Sudut Hitam">✦</button>
+      <span class="flag-label">Bintang Empat Sudut Hitam</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✧" aria-label="Salin Bintang Empat Sudut Putih">✧</button>
+      <span class="flag-label">Bintang Empat Sudut Putih</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✩" aria-label="Salin Bintang Putih Bergaris Tegas">✩</button>
+      <span class="flag-label">Bintang Putih Bergaris Tegas</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="˚" aria-label="Salin Cincin di Atas">˚</button>
+      <span class="flag-label">Cincin di Atas</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="୨୧" aria-label="Salin Tanda Pita Aesthetic (Angka Odia)">୨୧</button>
+      <span class="flag-label">Tanda Pita Aesthetic (Angka Odia)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌟" aria-label="Salin Bintang Bercahaya">🌟</button>
+      <span class="flag-label">Bintang Bercahaya</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="garden-creatures">
+  <span class="article-section-label">Makhluk Taman</span>
+  <h2>Makhluk Taman Ajaib</h2>
+  <p class="u-secondary-tight">Kupu-kupu, siput, dan pengunjung taman yang lembut untuk melengkapi suasana taman peri.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦋" aria-label="Salin Kupu-kupu">🦋</button>
+      <span class="flag-label">Kupu-kupu</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐌" aria-label="Salin Siput">🐌</button>
+      <span class="flag-label">Siput</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐞" aria-label="Salin Kepik">🐞</button>
+      <span class="flag-label">Kepik</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐝" aria-label="Salin Lebah Madu">🐝</button>
+      <span class="flag-label">Lebah Madu</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐇" aria-label="Salin Kelinci">🐇</button>
+      <span class="flag-label">Kelinci</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦢" aria-label="Salin Angsa">🦢</button>
+      <span class="flag-label">Angsa</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕊" aria-label="Salin Merpati">🕊</button>
+      <span class="flag-label">Merpati</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="combo-sets">
+  <span class="article-section-label">Set Kombo</span>
+  <h2>Set Kombo Fairycore</h2>
+  <p class="u-secondary-block">Salin kombo emoji fairycore lengkap dalam satu klik — siap untuk bio, caption, dan nama papan.</p>
+  <div id="fairycoreSetsContainer"></div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Ubah teks dengan font Unicode</h3>
+  <p>Pakai UltraTextGen untuk mengubah teks biasa menjadi font Unicode tebal, miring, cursive, dan 100+ gaya lain — gratis dan langsung jadi.</p>
+  <a href="/id/" class="cta-btn">Buka UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Halaman Terkait</span>
+  <div class="compare-grid">
+    <a href="/id/library/simbol-cottagecore/" class="compare-card variant-muted u-no-underline">
+      <h4>Simbol Cottagecore</h4>
+      <p>Jamur, lebah madu, dan karakter kehidupan pedesaan yang rustic.</p>
+    </a>
+    <a href="/id/library/simbol-coquette/" class="compare-card variant-muted u-no-underline">
+      <h4>Simbol Coquette</h4>
+      <p>Pita, renda, dan karakter aesthetic feminin yang lembut.</p>
+    </a>
+    <a href="/id/library/simbol-aesthetic/" class="compare-card variant-muted u-no-underline">
+      <h4>Simbol Aesthetic</h4>
+      <p>Kumpulan simbol Unicode aesthetic siap salin-tempel untuk bio.</p>
+    </a>
+    <a href="/id/library/simbol-bintang/" class="compare-card variant-muted u-no-underline">
+      <h4>Simbol Bintang</h4>
+      <p>Bintang dan kilau dalam berbagai gaya untuk dekorasi teks.</p>
+    </a>
+    <a href="/id/library/simbol-y2k/" class="compare-card variant-muted u-no-underline">
+      <h4>Simbol Y2K</h4>
+      <p>Bintang kilau, salib gotik, dan simbol cyber era 2000-an.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    {
+      name: "Taman Peri",
+      flags: ["🧚", "🍄", "🌷", "✨", "🌿", "🦋"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Jejak Debu Peri",
+      flags: ["✨", "⋆", "˚", "✧", "🪄", "💫"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Lingkaran Jamur",
+      flags: ["🍄", "🌿", "🍄", "✨", "🍄", "🍃"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Padang Kupu-kupu",
+      flags: ["🦋", "🌼", "🌸", "🐝", "🍃"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Peri Cahaya Bulan",
+      flags: ["🌙", "✨", "🧚", "⋆", "☁️"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Pembatas Bio Mungil",
+      flags: ["⋆˚✿˖°", "୨୧", "⋆˚❀˖°"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Peri Pondok",
+      flags: ["🍄", "🐌", "🌷", "🧺", "🐇"],
+      defaultFormat: "inline"
+    }
+  ];
+
+  ns.buildGrids("fairycoreSetsContainer", GROUPS);
+  if (ns.parseTwemoji) ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/id/library/simbol-goth-grunge/index.html
+++ b/id/library/simbol-goth-grunge/index.html
@@ -1,0 +1,369 @@
+<!DOCTYPE html>
+<html lang="id">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Simbol Goth &amp; Grunge — Dekorasi Bio Aesthetic Gelap Salin &amp; Tempel</title>
+<meta name="description" content="Simbol aesthetic gelap untuk bio goth dan grunge — salib, tengkorak, laba-laba, belati, dan dekorasi fashion alt untuk nama pengguna dan profil. Klik untuk menyalin.">
+
+<link rel="canonical" href="https://ultratextgen.com/id/library/simbol-goth-grunge/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/goth-grunge-symbols/">
+  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-goth-grunge/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/id/library/simbol-goth-grunge/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/id-library-simbol-goth-grunge.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Simbol Goth &amp; Grunge — Dekorasi Bio Aesthetic Gelap Salin &amp; Tempel">
+<meta name="twitter:description" content="Simbol aesthetic gelap untuk bio goth dan grunge — salib, tengkorak, laba-laba, belati, dan dekorasi fashion alt untuk nama pengguna dan profil.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/id-library-simbol-goth-grunge.png">
+<meta property="og:title" content="Simbol Goth &amp; Grunge — Dekorasi Bio Aesthetic Gelap Salin &amp; Tempel">
+<meta property="og:description" content="Simbol aesthetic gelap untuk bio goth dan grunge — salib, tengkorak, laba-laba, belati, dan dekorasi fashion alt untuk nama pengguna dan profil.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/id/library/simbol-goth-grunge/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Simbol Goth & Grunge — Dekorasi Bio Aesthetic Gelap Salin & Tempel",
+  "alternateName": ["Simbol Goth", "Simbol Goth Copy Paste", "Simbol Aesthetic Gelap", "Simbol Grunge", "Simbol Bio Gelap", "Simbol Gotik", "Simbol Emo Copy Paste", "Emoji Goth Copy Paste"],
+  "description": "Simbol aesthetic gelap untuk bio goth dan grunge — salib, tengkorak, laba-laba, belati, dan dekorasi fashion alt untuk nama pengguna dan profil.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/id-library-simbol-goth-grunge.png",
+  "mainEntityOfPage": "https://ultratextgen.com/id/library/simbol-goth-grunge/",
+  "inLanguage": "id",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Beranda",
+      "item": "https://ultratextgen.com/id/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Simbol Goth & Grunge",
+      "item": "https://ultratextgen.com/id/library/simbol-goth-grunge/"
+    }
+  ]
+}
+</script>
+
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/id/">Beranda</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Simbol Goth &amp; Grunge</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Simbol Goth &amp; Grunge</h1>
+    <p class="hero-tagline">Simbol aesthetic gelap untuk bio goth dan grunge — salib, tengkorak, laba-laba, belati, dan dekorasi fashion alt. Klik simbol mana pun untuk langsung menyalinnya.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/id-library-simbol-goth-grunge.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Nuansa goth dan grunge merangkul kegelapan, sisi edgy, dan pemberontakan — mawar hitam, salib gotik, laba-laba, rantai, dan tengkorak. Karakter Unicode dan emoji ini menerjemahkan energi itu menjadi dekorasi bio dan caption. Berfungsi di Instagram, TikTok, Discord, Tumblr, dan mana pun yang mendukung Unicode.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 1 -->
+<section class="mood-explainers" id="crosses-daggers">
+  <span class="article-section-label">Salib &amp; Belati</span>
+  <h2>Salib &amp; Belati</h2>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♱" aria-label="Salin ♱">♱</button>
+      <span class="flag-label">Salib Suryani Timur</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="†" aria-label="Salin †">†</button>
+      <span class="flag-label">Belati</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‡" aria-label="Salin ‡">‡</button>
+      <span class="flag-label">Belati Ganda</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✟" aria-label="Salin ✟">✟</button>
+      <span class="flag-label">Salib Latin Bergaris</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🗡" aria-label="Salin 🗡">🗡</button>
+      <span class="flag-label">Emoji Belati</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚔" aria-label="Salin ⚔">⚔</button>
+      <span class="flag-label">Pedang Bersilang</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🔪" aria-label="Salin 🔪">🔪</button>
+      <span class="flag-label">Pisau Dapur</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛧" aria-label="Salin ⛧">⛧</button>
+      <span class="flag-label">Pentagram Terbalik</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𖤐" aria-label="Salin 𖤐">𖤐</button>
+      <span class="flag-label">Matahari Hitam</span>
+    </div>
+      <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✝" aria-label="Salin ✝">✝</button>
+      <span class="flag-label">Salib Latin</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☥" aria-label="Salin ☥">☥</button>
+      <span class="flag-label">Ankh</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✠" aria-label="Salin ✠">✠</button>
+      <span class="flag-label">Salib Malta</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☦" aria-label="Salin ☦">☦</button>
+      <span class="flag-label">Salib Ortodoks</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☽" aria-label="Salin ☽">☽</button>
+      <span class="flag-label">Bulan Sabit</span>
+    </div>
+</div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 2 -->
+<section class="mood-explainers" id="skulls-death">
+  <span class="article-section-label">Tengkorak &amp; Motif Kematian</span>
+  <h2>Tengkorak &amp; Motif Kematian</h2>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☠" aria-label="Salin ☠">☠</button>
+      <span class="flag-label">Tengkorak dan Tulang Bersilang</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💀" aria-label="Salin 💀">💀</button>
+      <span class="flag-label">Emoji Tengkorak</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🩸" aria-label="Salin 🩸">🩸</button>
+      <span class="flag-label">Emoji Tetes Darah</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚰" aria-label="Salin ⚰">⚰</button>
+      <span class="flag-label">Peti Mati</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🪦" aria-label="Salin 🪦">🪦</button>
+      <span class="flag-label">Emoji Nisan</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚱" aria-label="Salin ⚱">⚱</button>
+      <span class="flag-label">Guci Abu Jenazah</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 3 -->
+<section class="mood-explainers" id="spiders-bats">
+  <span class="article-section-label">Laba-laba, Kelelawar &amp; Makhluk</span>
+  <h2>Laba-laba, Kelelawar &amp; Makhluk</h2>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕷" aria-label="Salin 🕷">🕷</button>
+      <span class="flag-label">Emoji Laba-laba</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕸" aria-label="Salin 🕸">🕸</button>
+      <span class="flag-label">Emoji Jaring Laba-laba</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦇" aria-label="Salin 🦇">🦇</button>
+      <span class="flag-label">Emoji Kelelawar</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐍" aria-label="Salin 🐍">🐍</button>
+      <span class="flag-label">Emoji Ular</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦂" aria-label="Salin 🦂">🦂</button>
+      <span class="flag-label">Emoji Kalajengking</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 4 -->
+<section class="mood-explainers" id="dark-florals">
+  <span class="article-section-label">Bunga Gelap</span>
+  <h2>Bunga Gelap</h2>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🥀" aria-label="Salin 🥀">🥀</button>
+      <span class="flag-label">Emoji Bunga Layu</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚘" aria-label="Salin ⚘">⚘</button>
+      <span class="flag-label">Bunga</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🖤" aria-label="Salin 🖤">🖤</button>
+      <span class="flag-label">Emoji Hati Hitam</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❦" aria-label="Salin ❦">❦</button>
+      <span class="flag-label">Hati Bunga</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❧" aria-label="Salin ❧">❧</button>
+      <span class="flag-label">Hati Bunga Terbalik</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓆩♱𓆪" aria-label="Salin 𓆩♱𓆪">𓆩♱𓆪</button>
+      <span class="flag-label">Bingkai Salib Mesir</span>
+    </div>
+  </div>
+  <p>Banyak simbol goth juga muncul di nuansa Y2K yang gelap — lihat pustaka <a href="/id/library/simbol-y2k/">Simbol Y2K</a> untuk salib, pentagram, dan matahari hitam.</p>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- COLLECTIONS -->
+<section class="mood-explainers" id="goth-grunge-collections">
+  <span class="article-section-label">Set Goth &amp; Grunge</span>
+  <h2>Set Bio Nuansa Gelap</h2>
+  <p class="u-secondary-block">Rangkaian nuansa gelap siap pakai yang bisa langsung Anda tempel ke bio, caption, atau nama pengguna — salin satu kombo utuh dengan satu klik.</p>
+  <div id="gothGrungeCollectionsContainer"></div>
+</section>
+
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Ubah teks dengan font Unicode</h3>
+  <p>Pakai UltraTextGen untuk mengubah teks biasa menjadi font Unicode tebal, miring, cursive, dan 100+ gaya lain — gratis dan langsung jadi.</p>
+  <a href="/id/" class="cta-btn">Buka UltraTextGen →</a>
+</div>
+
+
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Halaman Terkait</span>
+  <div class="compare-grid">
+    <a href="/id/library/simbol-aesthetic/" class="compare-card variant-muted u-no-underline">
+      <h4>Simbol Aesthetic</h4>
+      <p>Kumpulan simbol Unicode aesthetic siap salin-tempel untuk bio.</p>
+    </a>
+    <a href="/id/library/simbol-y2k/" class="compare-card variant-muted u-no-underline">
+      <h4>Simbol Y2K</h4>
+      <p>Dekorasi cyber dan aesthetic gelap gaya awal 2000-an.</p>
+    </a>
+    <a href="/id/library/simbol-bintang/" class="compare-card variant-muted u-no-underline">
+      <h4>Simbol Bintang</h4>
+      <p>Bintang gelap dan varian bintang dekoratif untuk teks.</p>
+    </a>
+    <a href="/id/library/simbol-love/" class="compare-card variant-muted u-no-underline">
+      <h4>Simbol Love</h4>
+      <p>Karakter hati, termasuk hati hitam untuk nuansa gelap.</p>
+    </a>
+    <a href="/id/tulisan-gotik/" class="compare-card variant-muted u-no-underline">
+      <h4>Tulisan Gotik</h4>
+      <p>Ubah nama dan teks menjadi font gotik blackletter yang edgy.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    { name: "Pembatas Salib Goth", flags: ["†","˖","♱","˖","†"], defaultFormat: "inline" },
+    { name: "Bingkai Salib Mesir", flags: ["𓆩♱𓆪"], defaultFormat: "inline" },
+    { name: "Bingkai Belati", flags: ["✟","·","†","‡","†","·","✟"], defaultFormat: "inline" },
+    { name: "Kombo Mawar Layu", flags: ["🥀","🖤","🥀"], defaultFormat: "inline" },
+    { name: "Jejak Bunga Gelap", flags: ["❦","˖","🖤","˖","❧"], defaultFormat: "inline" },
+    { name: "Kombo Bio Pentagram", flags: ["⛧","˖","𖤐","˖","⛧"], defaultFormat: "inline" }
+  ];
+
+  ns.buildGrids("gothGrungeCollectionsContainer", GROUPS);
+  ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/id/library/simbol-kawaii-cute/index.html
+++ b/id/library/simbol-kawaii-cute/index.html
@@ -1,0 +1,421 @@
+<!DOCTYPE html>
+<html lang="id">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Simbol Kawaii &amp; Lucu Salin &amp; Tempel — Dekorasi Aesthetic Lembut</title>
+<meta name="description" content="Simbol kawaii dan lucu untuk bio, nama pengguna, dan pesan. Hati lembut, wajah mungil, kilau, dan dekorasi pastel dari nuansa kawaii.">
+
+<link rel="canonical" href="https://ultratextgen.com/id/library/simbol-kawaii-cute/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/kawaii-cute-symbols/">
+  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-kawaii-cute/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/kawaii-cute-symbols/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/id-library-simbol-kawaii-cute.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Simbol Kawaii &amp; Lucu Salin &amp; Tempel — Dekorasi Aesthetic Lembut">
+<meta name="twitter:description" content="Simbol kawaii dan lucu untuk bio, nama pengguna, dan pesan. Hati lembut, wajah mungil, kilau, dan dekorasi pastel dari nuansa kawaii.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/id-library-simbol-kawaii-cute.png">
+<meta property="og:title" content="Simbol Kawaii &amp; Lucu Salin &amp; Tempel — Dekorasi Aesthetic Lembut">
+<meta property="og:description" content="Simbol kawaii dan lucu untuk bio, nama pengguna, dan pesan. Hati lembut, wajah mungil, kilau, dan dekorasi pastel dari nuansa kawaii.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/id/library/simbol-kawaii-cute/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Simbol Kawaii & Lucu Salin & Tempel — Dekorasi Aesthetic Lembut",
+  "alternateName": ["Simbol Kawaii Salin Tempel", "Simbol Lucu Copy Paste", "Simbol Teks Kawaii", "Simbol Aesthetic Lucu", "Simbol Aesthetic Lembut", "Dekorasi Kawaii", "Simbol Jepang Lucu"],
+  "description": "Simbol kawaii dan lucu untuk bio, nama pengguna, dan pesan. Hati lembut, wajah mungil, kilau, dan dekorasi pastel dari nuansa kawaii.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/id-library-simbol-kawaii-cute.png",
+  "mainEntityOfPage": "https://ultratextgen.com/id/library/simbol-kawaii-cute/",
+  "inLanguage": "id",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Beranda",
+      "item": "https://ultratextgen.com/id/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Simbol Kawaii &amp; Lucu",
+      "item": "https://ultratextgen.com/id/library/simbol-kawaii-cute/"
+    }
+  ]
+}
+</script>
+
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/id/">Beranda</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Simbol Kawaii &amp; Lucu</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Simbol Kawaii &amp; Lucu</h1>
+    <p class="hero-tagline">Hati lembut, wajah mungil, kilau, dan dekorasi kawaii pastel. Klik simbol mana pun untuk langsung menyalinnya ke bio, nama pengguna, dan pesan.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/id-library-simbol-kawaii-cute.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Kawaii (かわいい) berarti lucu dalam bahasa Jepang, dan nuansa kawaii merayakan segala yang lembut, pastel, dan menggemaskan. Karakter Unicode dan emoji ini menangkap perasaan itu: wajah mungil, simbol hati, tanda kilau, dan kurung pembungkus yang lucu. Pakai di bio, pesan, nama pengguna, dan caption di Instagram, TikTok, Discord, serta platform mana pun yang mendukung teks Unicode.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 1 -->
+<section class="mood-explainers" id="cute-hearts">
+  <span class="article-section-label">Hati Lucu</span>
+  <h2>Hati Lucu</h2>
+  <p>Karakter hati lembut untuk bio kawaii dan pesan manis.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♡" aria-label="Salin ♡">♡</button>
+      <span class="flag-label">Hati Putih</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ෆ" aria-label="Salin ෆ">ෆ</button>
+      <span class="flag-label">Huruf Sinhala Alpapraana Ayanna</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❤" aria-label="Salin ❤">❤</button>
+      <span class="flag-label">Hati Merah</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❥" aria-label="Salin ❥">❥</button>
+      <span class="flag-label">Bulet Hati Tebal Berputar</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ʚɞ" aria-label="Salin ʚɞ">ʚɞ</button>
+      <span class="flag-label">Hati Bersayap (kombo)</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 2 -->
+<section class="mood-explainers" id="tiny-cute-faces">
+  <span class="article-section-label">Wajah Mungil Lucu</span>
+  <h2>Wajah Mungil Lucu</h2>
+  <p>Kaomoji dan wajah Unicode untuk menambahkan ekspresi kawaii ke pesan dan bio.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(˶˃ ᵕ ˂˶)" aria-label="Salin (˶˃ ᵕ ˂˶)">(˶˃ ᵕ ˂˶)</button>
+      <span class="flag-label">Wajah Merona (kombo)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ʕ•ᴥ•ʔ" aria-label="Salin ʕ•ᴥ•ʔ">ʕ•ᴥ•ʔ</button>
+      <span class="flag-label">Wajah Beruang (kombo)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(づ ◕‿◕)づ" aria-label="Salin (づ ◕‿◕)づ">(づ ◕‿◕)づ</button>
+      <span class="flag-label">Wajah Memeluk (kombo)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(✿◠‿◠)" aria-label="Salin (✿◠‿◠)">(✿◠‿◠)</button>
+      <span class="flag-label">Wajah Bunga (kombo)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="◕" aria-label="Salin ◕">◕</button>
+      <span class="flag-label">Mata Lingkaran Besar</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="◡" aria-label="Salin ◡">◡</button>
+      <span class="flag-label">Huruf Melengkung</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 3 -->
+<section class="mood-explainers" id="cute-wrappers">
+  <span class="article-section-label">Kurung &amp; Pembungkus Lucu</span>
+  <h2>Kurung &amp; Pembungkus Lucu</h2>
+  <p>Kurung dekoratif dan karakter pembungkus untuk nama pengguna kawaii dan penataan bio.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="꒰" aria-label="Salin ꒰">꒰</button>
+      <span class="flag-label">Kurung Buka Berhias</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="꒱" aria-label="Salin ꒱">꒱</button>
+      <span class="flag-label">Kurung Tutup Berhias</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="◌" aria-label="Salin ◌">◌</button>
+      <span class="flag-label">Cincin Kombinasi</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊂" aria-label="Salin ⊂">⊂</button>
+      <span class="flag-label">Himpunan Bagian</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊃" aria-label="Salin ⊃">⊃</button>
+      <span class="flag-label">Himpunan Super</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="୨୧" aria-label="Salin ୨୧">୨୧</button>
+      <span class="flag-label">Gelombang Coquette (kombo)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✿" aria-label="Salin ✿">✿</button>
+      <span class="flag-label">Florette Hitam</span>
+    </div>
+      <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ʚ" aria-label="Salin ʚ">ʚ</button>
+      <span class="flag-label">Sayap Hati Kiri</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ɞ" aria-label="Salin ɞ">ɞ</button>
+      <span class="flag-label">Sayap Hati Kanan</span>
+    </div>
+</div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 4 -->
+<section class="mood-explainers" id="decorative-marks-kawaii">
+  <span class="article-section-label">Tanda Dekoratif</span>
+  <h2>Tanda Dekoratif</h2>
+  <p>Kilau, titik, dan tanda aksen kecil untuk menambahkan sentuhan kawaii ke teks apa pun.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⋆" aria-label="Salin ⋆">⋆</button>
+      <span class="flag-label">Operator Bintang Enam Sudut</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊹" aria-label="Salin ⊹">⊹</button>
+      <span class="flag-label">Silang Ortogonal</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✧" aria-label="Salin ✧">✧</button>
+      <span class="flag-label">Bintang Empat Sudut Putih</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⩩" aria-label="Salin ⩩">⩩</button>
+      <span class="flag-label">Serupa atau Sama</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="๑" aria-label="Salin ๑">๑</button>
+      <span class="flag-label">Karakter Thai Ko Kai</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⌒" aria-label="Salin ⌒">⌒</button>
+      <span class="flag-label">Busur</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❀" aria-label="Salin ❀">❀</button>
+      <span class="flag-label">Florette Putih</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 5 -->
+<section class="mood-explainers" id="pastel-motifs">
+  <span class="article-section-label">Motif Pastel</span>
+  <h2>Motif Pastel</h2>
+  <p>Simbol bunga dan langit yang lembut untuk membangun nuansa kawaii yang dreamy.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✿" aria-label="Salin ✿">✿</button>
+      <span class="flag-label">Florette Hitam</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❀" aria-label="Salin ❀">❀</button>
+      <span class="flag-label">Florette Putih</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❁" aria-label="Salin ❁">❁</button>
+      <span class="flag-label">Florette Delapan Kelopak</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☁" aria-label="Salin ☁">☁</button>
+      <span class="flag-label">Awan</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☾" aria-label="Salin ☾">☾</button>
+      <span class="flag-label">Bulan Sabit</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛅" aria-label="Salin ⛅">⛅</button>
+      <span class="flag-label">Matahari di Balik Awan</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✦" aria-label="Salin ✦">✦</button>
+      <span class="flag-label">Bintang Empat Sudut Hitam</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⋆" aria-label="Salin ⋆">⋆</button>
+      <span class="flag-label">Operator Bintang Enam Sudut</span>
+    </div>
+      <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧸" aria-label="Salin 🧸">🧸</button>
+      <span class="flag-label">Boneka Beruang</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐻" aria-label="Salin 🐻">🐻</button>
+      <span class="flag-label">Wajah Beruang</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐰" aria-label="Salin 🐰">🐰</button>
+      <span class="flag-label">Wajah Kelinci</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🎀" aria-label="Salin 🎀">🎀</button>
+      <span class="flag-label">Pita</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌸" aria-label="Salin 🌸">🌸</button>
+      <span class="flag-label">Bunga Sakura</span>
+    </div>
+</div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- COLLECTIONS -->
+<section class="mood-explainers" id="kawaii-collections">
+  <span class="article-section-label">Set Kawaii</span>
+  <h2>Set Bio &amp; Nama Pengguna Kawaii</h2>
+  <p class="u-secondary-block">Kombo kawaii siap pakai — hati lembut, wajah mungil, dan kilau pastel yang bisa langsung kamu tempel ke bio, nama pengguna, atau pesan dalam satu klik.</p>
+  <div id="kawaiiCollectionsContainer"></div>
+</section>
+
+<div class="section-divider"></div>
+
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Ubah teks dengan font Unicode</h3>
+  <p>Pakai UltraTextGen untuk mengubah teks biasa menjadi font Unicode tebal, miring, cursive, dan 100+ gaya lain — gratis dan langsung jadi.</p>
+  <a href="/id/" class="cta-btn">Buka UltraTextGen →</a>
+</div>
+
+
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Halaman Terkait</span>
+  <div class="compare-grid">
+    <a href="/id/library/simbol-coquette/" class="compare-card variant-muted u-no-underline">
+      <h4>Simbol Coquette</h4>
+      <p>Pita, bow, dan simbol feminin lembut untuk bio coquette.</p>
+    </a>
+    <a href="/id/library/simbol-cottagecore/" class="compare-card variant-muted u-no-underline">
+      <h4>Simbol Cottagecore</h4>
+      <p>Bunga, daun, dan motif alam untuk nuansa cottagecore.</p>
+    </a>
+    <a href="/id/library/kaomoji/" class="compare-card variant-muted u-no-underline">
+      <h4>Kaomoji &amp; Wajah Teks</h4>
+      <p>Wajah ASCII, emotikon, dan kaomoji Jepang.</p>
+    </a>
+    <a href="/id/library/simbol-love/" class="compare-card variant-muted u-no-underline">
+      <h4>Simbol Love</h4>
+      <p>Karakter hati dan cinta untuk bio dan caption.</p>
+    </a>
+    <a href="/id/library/simbol-aesthetic/" class="compare-card variant-muted u-no-underline">
+      <h4>Simbol Aesthetic</h4>
+      <p>Kumpulan simbol Unicode aesthetic siap salin-tempel untuk bio.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    { name: "Kombo Bio Hati Lembut", flags: ["꒰","♡","꒱","⋆","ෆ"], defaultFormat: "inline" },
+    { name: "Pembatas Kilau Kawaii", flags: ["⊹","⋆","✧","⋆","⊹"], defaultFormat: "inline" },
+    { name: "Nama Pengguna Sayap Bunga", flags: ["ʚ ✿ ɞ"], defaultFormat: "inline" },
+    { name: "Bingkai Debu Pastel", flags: ["✦","⋆","❀","⋆","✦"], defaultFormat: "inline" },
+    { name: "Bungkus Bio Wajah Mungil", flags: ["(˶˃ ᵕ ˂˶)","♡"], defaultFormat: "inline" },
+    { name: "Kombo Kurung Lucu", flags: ["꒰ ♡ ꒱"], defaultFormat: "inline" }
+  ];
+
+  ns.buildGrids("kawaiiCollectionsContainer", GROUPS);
+  ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/id/library/simbol-therian/index.html
+++ b/id/library/simbol-therian/index.html
@@ -1,0 +1,360 @@
+<!DOCTYPE html>
+<html lang="id">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Simbol Therian: Salin &amp; Tempel Δ Theta-Delta &amp; Tanda Alterhuman</title>
+<meta name="description" content="Jelajahi tanda theta-delta (θΔ), jejak kaki, fase bulan, dan simbol hewan yang dipakai komunitas therian dan alterhuman. Klik simbol mana pun untuk langsung menyalinnya.">
+
+<link rel="canonical" href="https://ultratextgen.com/id/library/simbol-therian/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/therian-symbols/">
+  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-therian/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/therian-symbols/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/id-library-simbol-therian.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Simbol Therian: Salin &amp; Tempel Δ Theta-Delta &amp; Tanda Alterhuman">
+<meta name="twitter:description" content="Jelajahi tanda theta-delta (θΔ), jejak kaki, fase bulan, dan simbol hewan yang dipakai komunitas therian dan alterhuman. Klik simbol mana pun untuk langsung menyalinnya.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/id-library-simbol-therian.png">
+<meta property="og:title" content="Simbol Therian: Salin &amp; Tempel Δ Theta-Delta &amp; Tanda Alterhuman">
+<meta property="og:description" content="Jelajahi tanda theta-delta (θΔ), jejak kaki, fase bulan, dan simbol hewan yang dipakai komunitas therian dan alterhuman. Klik simbol mana pun untuk langsung menyalinnya.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/id/library/simbol-therian/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Simbol Therian: Salin & Tempel Δ Theta-Delta & Tanda Alterhuman",
+  "alternateName": ["Simbol Therian Copy Paste", "Simbol Theta Delta Copy Paste", "Simbol Alterhuman", "Simbol Komunitas Therian", "Tanda Therian", "Simbol Jejak Kaki Copy Paste", "Emoji Therian Copy Paste"],
+  "description": "Jelajahi tanda theta-delta (θΔ), jejak kaki, fase bulan, dan simbol hewan yang dipakai komunitas therian dan alterhuman. Klik simbol mana pun untuk langsung menyalinnya.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/id-library-simbol-therian.png",
+  "mainEntityOfPage": "https://ultratextgen.com/id/library/simbol-therian/",
+  "inLanguage": "id",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Beranda",
+      "item": "https://ultratextgen.com/id/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Simbol Therian",
+      "item": "https://ultratextgen.com/id/library/simbol-therian/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/id/">Beranda</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Simbol Therian</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Simbol Therian</h1>
+    <p class="hero-tagline">Tanda komunitas theta-delta (θΔ) plus simbol jejak kaki, bulan, dan hewan dari identitas therian dan alterhuman. Klik simbol mana pun untuk langsung menyalinnya.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/id-library-simbol-therian.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Simbol therian yang paling banyak dicari orang adalah theta-delta — gabungan huruf Yunani theta (θ) dan delta (Δ) — yang diadopsi komunitas therianthropy pada 2003 sebagai tanda identitas bersama yang penuh hormat. Therian adalah orang yang merasakan identifikasi non-fisik yang dalam dengan seekor hewan, dan komunitas alterhuman yang lebih luas memakai tanda-tanda terkait berdampingan dengan jejak kaki, fase bulan, dan emoji hewan. Halaman ini mengumpulkan theta-delta dalam bentuk Unicode umumnya bersama simbol alam dan hewan yang dipakai di bio TikTok, blog Tumblr, dan profil Discord.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="theta-delta">
+  <span class="article-section-label">Theta-Delta</span>
+  <h2>Tanda Komunitas Theta-Delta</h2>
+  <p class="u-secondary-tight">Tanda theta-delta yang dibangun dari huruf Yunani asli — salin pasangan gabungannya atau tiap huruf secara terpisah.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="θΔ" aria-label="Salin Theta-Delta (Tanda Therian)">θΔ</button>
+      <span class="flag-label">Theta-Delta (Tanda Therian)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ΘΔ" aria-label="Salin Theta-Delta Kapital">ΘΔ</button>
+      <span class="flag-label">Theta-Delta Kapital</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="θ" aria-label="Salin Huruf Kecil Yunani Theta">θ</button>
+      <span class="flag-label">Huruf Kecil Yunani Theta</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="Θ" aria-label="Salin Huruf Kapital Yunani Theta">Θ</button>
+      <span class="flag-label">Huruf Kapital Yunani Theta</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="Δ" aria-label="Salin Huruf Kapital Yunani Delta">Δ</button>
+      <span class="flag-label">Huruf Kapital Yunani Delta</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="δ" aria-label="Salin Huruf Kecil Yunani Delta">δ</button>
+      <span class="flag-label">Huruf Kecil Yunani Delta</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ϴ" aria-label="Salin Simbol Theta Kapital Yunani">ϴ</button>
+      <span class="flag-label">Simbol Theta Kapital Yunani</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ϑ" aria-label="Salin Simbol Theta Yunani">ϑ</button>
+      <span class="flag-label">Simbol Theta Yunani</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="paw-prints">
+  <span class="article-section-label">Jejak Kaki &amp; Kanina</span>
+  <h2>Jejak Kaki &amp; Simbol Kanina</h2>
+  <p class="u-secondary-tight">Jejak kaki serta emoji serigala, rubah, dan anjing yang paling sering muncul di bio therian.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐾" aria-label="Salin Jejak Kaki">🐾</button>
+      <span class="flag-label">Jejak Kaki</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐺" aria-label="Salin Serigala">🐺</button>
+      <span class="flag-label">Serigala</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦊" aria-label="Salin Rubah">🦊</button>
+      <span class="flag-label">Rubah</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐕" aria-label="Salin Anjing">🐕</button>
+      <span class="flag-label">Anjing</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐈‍⬛" aria-label="Salin Kucing Hitam">🐈‍⬛</button>
+      <span class="flag-label">Kucing Hitam</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦝" aria-label="Salin Rakun">🦝</button>
+      <span class="flag-label">Rakun</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐅" aria-label="Salin Harimau">🐅</button>
+      <span class="flag-label">Harimau</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦴" aria-label="Salin Tulang">🦴</button>
+      <span class="flag-label">Tulang</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="wild-animals">
+  <span class="article-section-label">Hewan Liar</span>
+  <h2>Simbol Hewan Liar &amp; Theriotype</h2>
+  <p class="u-secondary-tight">Emoji untuk theriotype umum — dari rusa dan kucing besar hingga burung pemangsa.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦌" aria-label="Salin Rusa">🦌</button>
+      <span class="flag-label">Rusa</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐆" aria-label="Salin Macan Tutul">🐆</button>
+      <span class="flag-label">Macan Tutul</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦅" aria-label="Salin Elang">🦅</button>
+      <span class="flag-label">Elang</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦉" aria-label="Salin Burung Hantu">🦉</button>
+      <span class="flag-label">Burung Hantu</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐦‍⬛" aria-label="Salin Burung Hitam">🐦‍⬛</button>
+      <span class="flag-label">Burung Hitam</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐍" aria-label="Salin Ular">🐍</button>
+      <span class="flag-label">Ular</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦈" aria-label="Salin Hiu">🦈</button>
+      <span class="flag-label">Hiu</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐉" aria-label="Salin Naga">🐉</button>
+      <span class="flag-label">Naga</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="moon-night">
+  <span class="article-section-label">Bulan &amp; Malam</span>
+  <h2>Simbol Bulan &amp; Malam</h2>
+  <p class="u-secondary-tight">Fase bulan dan karakter sabit — motif lama yang melekat di ruang therian dan alterhuman.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌙" aria-label="Salin Bulan Sabit">🌙</button>
+      <span class="flag-label">Bulan Sabit</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☾" aria-label="Salin Bulan Perempat Akhir (Teks)">☾</button>
+      <span class="flag-label">Bulan Perempat Akhir (Teks)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☽" aria-label="Salin Bulan Perempat Awal (Teks)">☽</button>
+      <span class="flag-label">Bulan Perempat Awal (Teks)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌕" aria-label="Salin Bulan Purnama">🌕</button>
+      <span class="flag-label">Bulan Purnama</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌑" aria-label="Salin Bulan Baru">🌑</button>
+      <span class="flag-label">Bulan Baru</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌒" aria-label="Salin Bulan Sabit Muda">🌒</button>
+      <span class="flag-label">Bulan Sabit Muda</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="forest-nature">
+  <span class="article-section-label">Hutan &amp; Alam</span>
+  <h2>Simbol Hutan &amp; Alam</h2>
+  <p class="u-secondary-tight">Karakter rimba dan alam liar untuk melengkapi caption video quadrobics atau profil.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌲" aria-label="Salin Pohon Cemara">🌲</button>
+      <span class="flag-label">Pohon Cemara</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌿" aria-label="Salin Tumbuhan Herbal">🌿</button>
+      <span class="flag-label">Tumbuhan Herbal</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🍂" aria-label="Salin Daun Gugur">🍂</button>
+      <span class="flag-label">Daun Gugur</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛰" aria-label="Salin Gunung">⛰</button>
+      <span class="flag-label">Gunung</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🪶" aria-label="Salin Bulu">🪶</button>
+      <span class="flag-label">Bulu</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌾" aria-label="Salin Seikat Padi">🌾</button>
+      <span class="flag-label">Seikat Padi</span>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Ubah teks dengan font Unicode</h3>
+  <p>Pakai UltraTextGen untuk mengubah teks biasa menjadi font Unicode tebal, miring, cursive, dan 100+ gaya lain — gratis dan langsung jadi.</p>
+  <a href="/id/" class="cta-btn">Buka UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Halaman Terkait</span>
+  <div class="compare-grid">
+    <a href="/id/library/simbol-bintang/" class="compare-card variant-muted u-no-underline">
+      <h4>Simbol Bintang</h4>
+      <p>Bulan, bintang, dan karakter langit untuk disalin dan ditempel.</p>
+    </a>
+    <a href="/id/library/simbol-goth-grunge/" class="compare-card variant-muted u-no-underline">
+      <h4>Simbol Goth &amp; Grunge</h4>
+      <p>Simbol gelap dan edgy — salib, duri, dan tanda gotik untuk bio.</p>
+    </a>
+    <a href="/id/library/simbol-fairycore/" class="compare-card variant-muted u-no-underline">
+      <h4>Simbol Fairycore</h4>
+      <p>Simbol hutan, bunga, dan alam untuk pencinta suasana rimba.</p>
+    </a>
+    <a href="/id/library/simbol-aesthetic/" class="compare-card variant-muted u-no-underline">
+      <h4>Simbol Aesthetic</h4>
+      <p>Kumpulan simbol Unicode aesthetic siap salin-tempel untuk bio.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/id/library/simbol-witchy-occult/index.html
+++ b/id/library/simbol-witchy-occult/index.html
@@ -1,0 +1,763 @@
+<!DOCTYPE html>
+<html lang="id">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Simbol Witchy &amp; Occult: Salin &amp; Tempel Semua Karakter Okultisme</title>
+<meta name="description" content="Jelajahi dan salin simbol witchy dan okultisme — pentagram, fase bulan, tanda planet, simbol alkimia, dan karakter esoterik lainnya. Klik untuk menyalin.">
+
+<link rel="canonical" href="https://ultratextgen.com/id/library/simbol-witchy-occult/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/witchy-occult-symbols/">
+  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-witchy-occult/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/witchy-occult-symbols/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/id-library-simbol-witchy-occult.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Simbol Witchy &amp; Occult: Salin &amp; Tempel Semua Karakter Okultisme">
+<meta name="twitter:description" content="Jelajahi dan salin simbol witchy dan okultisme — pentagram, fase bulan, tanda planet, simbol alkimia, dan karakter esoterik lainnya. Klik untuk menyalin.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/id-library-simbol-witchy-occult.png">
+<meta property="og:title" content="Simbol Witchy &amp; Occult: Salin &amp; Tempel Semua Karakter Okultisme">
+<meta property="og:description" content="Jelajahi dan salin simbol witchy dan okultisme — pentagram, fase bulan, tanda planet, simbol alkimia, dan karakter esoterik lainnya. Klik untuk menyalin.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/id/library/simbol-witchy-occult/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Simbol Witchy & Occult: Salin & Tempel Semua Karakter Okultisme",
+  "alternateName": ["Simbol Okultisme Salin Tempel", "Simbol Witchy Salin Tempel", "Simbol Penyihir Unicode", "Simbol Sihir Salin Tempel", "Simbol Esoterik Salin Tempel", "Simbol Pentagram Salin Tempel", "Emoji Witchy Salin Tempel"],
+  "description": "Jelajahi dan salin simbol witchy dan okultisme — pentagram, fase bulan, tanda planet, simbol alkimia, dan karakter esoterik lainnya. Klik untuk menyalin.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/id-library-simbol-witchy-occult.png",
+  "mainEntityOfPage": "https://ultratextgen.com/id/library/simbol-witchy-occult/",
+  "inLanguage": "id",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Beranda",
+      "item": "https://ultratextgen.com/id/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Simbol Witchy & Occult",
+      "item": "https://ultratextgen.com/id/library/simbol-witchy-occult/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/id/">Beranda</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Simbol Witchy &amp; Occult</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Simbol Witchy &amp; Occult</h1>
+    <p class="hero-tagline">Koleksi terpilih berisi pentagram, fase bulan, simbol planet, tanda alkimia, dan karakter Unicode esoterik lainnya. Klik simbol mana pun untuk langsung menyalinnya.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/id-library-simbol-witchy-occult.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Pustaka ini mengumpulkan simbol Unicode yang berkaitan dengan sihir, okultisme, alkimia, dan tradisi esoterik. Semuanya karakter Unicode standar — bisa dipakai di teks, bio, dan tulisan kreatif. Bagian simbol alkimia mencakup blok Unicode Alchemical Symbols khusus (U+1F700–U+1F73F).</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="pentagrams-stars">
+  <span class="article-section-label">Pentagram &amp; Bintang</span>
+  <h2>Pentagram &amp; Bintang Lima Sudut</h2>
+  <p>Bentuk bintang dan pentagram yang berkaitan dengan tradisi esoterik dan okultisme.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="★" aria-label="Salin Bintang Hitam">★</button>
+      <span class="flag-label">Bintang Hitam</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☆" aria-label="Salin Bintang Putih">☆</button>
+      <span class="flag-label">Bintang Putih</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚹" aria-label="Salin Sextile">⚹</button>
+      <span class="flag-label">Sextile</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✡" aria-label="Salin Bintang Daud">✡</button>
+      <span class="flag-label">Bintang Daud</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚜" aria-label="Salin Fleur-de-Lis">⚜</button>
+      <span class="flag-label">Fleur-de-Lis</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛤" aria-label="Salin Pentagram">⛤</button>
+      <span class="flag-label">Pentagram</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛥" aria-label="Salin Pentagram Menghadap Kanan">⛥</button>
+      <span class="flag-label">Pentagram Menghadap Kanan</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛦" aria-label="Salin Pentagram Menghadap Kiri">⛦</button>
+      <span class="flag-label">Pentagram Menghadap Kiri</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛧" aria-label="Salin Pentagram Terbalik">⛧</button>
+      <span class="flag-label">Pentagram Terbalik</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✴" aria-label="Salin Bintang Delapan Sudut">✴</button>
+      <span class="flag-label">Bintang Delapan Sudut</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✪" aria-label="Salin Bintang Putih Berlingkaran">✪</button>
+      <span class="flag-label">Bintang Putih Berlingkaran</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✶" aria-label="Salin Bintang Enam Sudut">✶</button>
+      <span class="flag-label">Bintang Enam Sudut</span>
+    </div>
+      <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✦" aria-label="Salin ✦">✦</button>
+      <span class="flag-label">Bintang Kilau</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="◯" aria-label="Salin ◯">◯</button>
+      <span class="flag-label">Lingkaran Besar</span>
+    </div>
+</div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- Anchor preserved for inbound links/bookmarks; canonical content lives on /library/moon-celestial-symbols/#celestial-collections -->
+<section class="mood-explainers" id="moon-phases">
+  <span class="article-section-label">Fase Bulan</span>
+  <h2>Simbol Fase Bulan</h2>
+  <p>Mencari siklus bulan lengkap? Simbol fase bulan kini tersedia bersama koleksi bintang dan langit malam.</p>
+  <div class="compare-grid" style="margin-top:1rem;">
+    <a href="/id/library/simbol-bintang/" class="compare-card variant-muted u-no-underline">
+      <h4>Lihat: Fase Bulan di Simbol Bintang →</h4>
+      <p>Delapan fase bulan Unicode (🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘) beserta varian sabit dan bulan gelap/terang, siap disalin sebagai satu rangkaian.</p>
+    </a>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- CLASSICAL 7 PLANETS (featured sub-group) -->
+<section class="mood-explainers" id="classical-7-planets">
+  <span class="article-section-label">7 Planet Klasik</span>
+  <h2>Tujuh Planet Klasik (Matahari → Saturnus)</h2>
+  <p class="u-secondary-tight">Tujuh planet astrologi tradisional dalam urutan Kaldea — benda-benda langit kasatmata yang dikenal para astronom kuno.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☉" aria-label="Salin Matahari">☉</button>
+      <span class="flag-label">Matahari</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☽" aria-label="Salin Bulan">☽</button>
+      <span class="flag-label">Bulan</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☿" aria-label="Salin Merkurius">☿</button>
+      <span class="flag-label">Merkurius</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♀" aria-label="Salin Venus">♀</button>
+      <span class="flag-label">Venus</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♂" aria-label="Salin Mars">♂</button>
+      <span class="flag-label">Mars</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♃" aria-label="Salin Jupiter">♃</button>
+      <span class="flag-label">Jupiter</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♄" aria-label="Salin Saturnus">♄</button>
+      <span class="flag-label">Saturnus</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="planetary-zodiac">
+  <span class="article-section-label">Planet &amp; Sekitar Zodiak</span>
+  <h2>Simbol Planet &amp; Astrologi</h2>
+  <p>Simbol planet klasik dan glif astrologi dengan asosiasi okultisme.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☉" aria-label="Salin Matahari">☉</button>
+      <span class="flag-label">Matahari</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☽" aria-label="Salin Bulan">☽</button>
+      <span class="flag-label">Bulan</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☿" aria-label="Salin Merkurius">☿</button>
+      <span class="flag-label">Merkurius</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♀" aria-label="Salin Venus">♀</button>
+      <span class="flag-label">Venus</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♁" aria-label="Salin Bumi">♁</button>
+      <span class="flag-label">Bumi</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♂" aria-label="Salin Mars">♂</button>
+      <span class="flag-label">Mars</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♃" aria-label="Salin Jupiter">♃</button>
+      <span class="flag-label">Jupiter</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♄" aria-label="Salin Saturnus">♄</button>
+      <span class="flag-label">Saturnus</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♅" aria-label="Salin Uranus">♅</button>
+      <span class="flag-label">Uranus</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♆" aria-label="Salin Neptunus">♆</button>
+      <span class="flag-label">Neptunus</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♇" aria-label="Salin Pluto">♇</button>
+      <span class="flag-label">Pluto</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚸" aria-label="Salin Lilith Bulan Hitam">⚸</button>
+      <span class="flag-label">Lilith Bulan Hitam</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚳" aria-label="Salin Ceres">⚳</button>
+      <span class="flag-label">Ceres</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚴" aria-label="Salin Pallas">⚴</button>
+      <span class="flag-label">Pallas</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚵" aria-label="Salin Juno">⚵</button>
+      <span class="flag-label">Juno</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚶" aria-label="Salin Vesta">⚶</button>
+      <span class="flag-label">Vesta</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="alchemical">
+  <span class="article-section-label">Alkimia</span>
+  <h2>Simbol Alkimia (U+1F700–U+1F73F)</h2>
+  <p>Blok Unicode Alchemical Symbols, berisi tanda untuk unsur, proses, dan zat yang dipakai dalam alkimia historis.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜀" aria-label="Salin Kuintesensi">🜀</button>
+      <span class="flag-label">Kuintesensi</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜁" aria-label="Salin Udara">🜁</button>
+      <span class="flag-label">Udara</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜂" aria-label="Salin Api">🜂</button>
+      <span class="flag-label">Api</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜃" aria-label="Salin Tanah">🜃</button>
+      <span class="flag-label">Tanah</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜄" aria-label="Salin Air">🜄</button>
+      <span class="flag-label">Air</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜅" aria-label="Salin Aquafortis">🜅</button>
+      <span class="flag-label">Aquafortis</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜆" aria-label="Salin Aqua Regia">🜆</button>
+      <span class="flag-label">Aqua Regia</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜇" aria-label="Salin Aqua Regia II">🜇</button>
+      <span class="flag-label">Aqua Regia II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜈" aria-label="Salin Aqua Vitae">🜈</button>
+      <span class="flag-label">Aqua Vitae</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜉" aria-label="Salin Aqua Vitae II">🜉</button>
+      <span class="flag-label">Aqua Vitae II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜊" aria-label="Salin Cuka">🜊</button>
+      <span class="flag-label">Cuka</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜋" aria-label="Salin Cuka II">🜋</button>
+      <span class="flag-label">Cuka II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜌" aria-label="Salin Cuka III">🜌</button>
+      <span class="flag-label">Cuka III</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜍" aria-label="Salin Belerang">🜍</button>
+      <span class="flag-label">Belerang</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜎" aria-label="Salin Belerang II">🜎</button>
+      <span class="flag-label">Belerang II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜏" aria-label="Salin Belerang III">🜏</button>
+      <span class="flag-label">Belerang III</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜐" aria-label="Salin Garam">🜐</button>
+      <span class="flag-label">Garam</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜑" aria-label="Salin Garam II">🜑</button>
+      <span class="flag-label">Garam II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜒" aria-label="Salin Garam III">🜒</button>
+      <span class="flag-label">Garam III</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜓" aria-label="Salin Sublimat Merkuri">🜓</button>
+      <span class="flag-label">Sublimat Merkuri</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜔" aria-label="Salin Sublimat Merkuri II">🜔</button>
+      <span class="flag-label">Sublimat Merkuri II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜕" aria-label="Salin Sublimat Merkuri III">🜕</button>
+      <span class="flag-label">Sublimat Merkuri III</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜖" aria-label="Salin Sinabar">🜖</button>
+      <span class="flag-label">Sinabar</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜗" aria-label="Salin Garam Amoniak">🜗</button>
+      <span class="flag-label">Garam Amoniak</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜘" aria-label="Salin Vitriol">🜘</button>
+      <span class="flag-label">Vitriol</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜙" aria-label="Salin Vitriol II">🜙</button>
+      <span class="flag-label">Vitriol II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜚" aria-label="Salin Emas">🜚</button>
+      <span class="flag-label">Emas</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜛" aria-label="Salin Perak">🜛</button>
+      <span class="flag-label">Perak</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜜" aria-label="Salin Bijih Besi">🜜</button>
+      <span class="flag-label">Bijih Besi</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜝" aria-label="Salin Bijih Besi II">🜝</button>
+      <span class="flag-label">Bijih Besi II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜞" aria-label="Salin Crocus Besi">🜞</button>
+      <span class="flag-label">Crocus Besi</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜟" aria-label="Salin Regulus Besi">🜟</button>
+      <span class="flag-label">Regulus Besi</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜠" aria-label="Salin Bijih Tembaga">🜠</button>
+      <span class="flag-label">Bijih Tembaga</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜡" aria-label="Salin Bijih Besi-Tembaga">🜡</button>
+      <span class="flag-label">Bijih Besi-Tembaga</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜢" aria-label="Salin Sublimat Tembaga">🜢</button>
+      <span class="flag-label">Sublimat Tembaga</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜣" aria-label="Salin Crocus Tembaga">🜣</button>
+      <span class="flag-label">Crocus Tembaga</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜤" aria-label="Salin Antimoniat Tembaga">🜤</button>
+      <span class="flag-label">Antimoniat Tembaga</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜥" aria-label="Salin Garam Antimoniat Tembaga">🜥</button>
+      <span class="flag-label">Garam Antimoniat Tembaga</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜦" aria-label="Salin Sublimat Garam Tembaga">🜦</button>
+      <span class="flag-label">Sublimat Garam Tembaga</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜧" aria-label="Salin Verdigris">🜧</button>
+      <span class="flag-label">Verdigris</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜨" aria-label="Salin Bijih Timah">🜨</button>
+      <span class="flag-label">Bijih Timah</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜩" aria-label="Salin Bijih Timbal">🜩</button>
+      <span class="flag-label">Bijih Timbal</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜪" aria-label="Salin Tanah Bijih Timbal">🜪</button>
+      <span class="flag-label">Tanah Bijih Timbal</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜫" aria-label="Salin Antimon">🜫</button>
+      <span class="flag-label">Antimon</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜬" aria-label="Salin Antimon II">🜬</button>
+      <span class="flag-label">Antimon II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜭" aria-label="Salin Sublimat Antimon">🜭</button>
+      <span class="flag-label">Sublimat Antimon</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜮" aria-label="Salin Garam Antimon">🜮</button>
+      <span class="flag-label">Garam Antimon</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜯" aria-label="Salin Sublimat Garam Antimon">🜯</button>
+      <span class="flag-label">Sublimat Garam Antimon</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜰" aria-label="Salin Cuka Antimon">🜰</button>
+      <span class="flag-label">Cuka Antimon</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜱" aria-label="Salin Regulus Antimon">🜱</button>
+      <span class="flag-label">Regulus Antimon</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜲" aria-label="Salin Regulus Antimon II">🜲</button>
+      <span class="flag-label">Regulus Antimon II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜳" aria-label="Salin Regulus">🜳</button>
+      <span class="flag-label">Regulus</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜴" aria-label="Salin Regulus II">🜴</button>
+      <span class="flag-label">Regulus II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜵" aria-label="Salin Regulus III">🜵</button>
+      <span class="flag-label">Regulus III</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜶" aria-label="Salin Regulus IV">🜶</button>
+      <span class="flag-label">Regulus IV</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜷" aria-label="Salin Alkali">🜷</button>
+      <span class="flag-label">Alkali</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜸" aria-label="Salin Alkali II">🜸</button>
+      <span class="flag-label">Alkali II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜹" aria-label="Salin Markasit">🜹</button>
+      <span class="flag-label">Markasit</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜺" aria-label="Salin Sal Ammoniac">🜺</button>
+      <span class="flag-label">Sal Ammoniac</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜻" aria-label="Salin Arsenik">🜻</button>
+      <span class="flag-label">Arsenik</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜼" aria-label="Salin Realgar">🜼</button>
+      <span class="flag-label">Realgar</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜽" aria-label="Salin Realgar II">🜽</button>
+      <span class="flag-label">Realgar II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜾" aria-label="Salin Auripigmen">🜾</button>
+      <span class="flag-label">Auripigmen</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜿" aria-label="Salin Bijih Bismut">🜿</button>
+      <span class="flag-label">Bijih Bismut</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="esoteric">
+  <span class="article-section-label">Esoterik Lainnya</span>
+  <h2>Simbol Esoterik Lainnya</h2>
+  <p>Simbol tambahan yang berkaitan dengan tradisi magis dan esoterik.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☥" aria-label="Salin Ankh">☥</button>
+      <span class="flag-label">Ankh</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☯" aria-label="Salin Yin Yang">☯</button>
+      <span class="flag-label">Yin Yang</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☘" aria-label="Salin Semanggi">☘</button>
+      <span class="flag-label">Semanggi</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚷" aria-label="Salin Chiron">⚷</button>
+      <span class="flag-label">Chiron</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚰" aria-label="Salin Peti Mati">⚰</button>
+      <span class="flag-label">Peti Mati</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚱" aria-label="Salin Guci Abu Jenazah">⚱</button>
+      <span class="flag-label">Guci Abu Jenazah</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚗" aria-label="Salin Alembik">⚗</button>
+      <span class="flag-label">Alembik</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❤" aria-label="Salin Hati">❤</button>
+      <span class="flag-label">Hati</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚛" aria-label="Salin Simbol Atom">⚛</button>
+      <span class="flag-label">Simbol Atom</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚡" aria-label="Salin Petir">⚡</button>
+      <span class="flag-label">Petir</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♲" aria-label="Salin Daur Ulang">♲</button>
+      <span class="flag-label">Daur Ulang</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☼" aria-label="Salin Matahari Putih Bersinar">☼</button>
+      <span class="flag-label">Matahari Putih Bersinar</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☦" aria-label="Salin Salib Ortodoks">☦</button>
+      <span class="flag-label">Salib Ortodoks</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☢" aria-label="Salin Radioaktif">☢</button>
+      <span class="flag-label">Radioaktif</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☣" aria-label="Salin Biohazard">☣</button>
+      <span class="flag-label">Biohazard</span>
+    </div>
+      <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🔮" aria-label="Salin 🔮">🔮</button>
+      <span class="flag-label">Bola Kristal</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧿" aria-label="Salin 🧿">🧿</button>
+      <span class="flag-label">Jimat Nazar</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🃏" aria-label="Salin 🃏">🃏</button>
+      <span class="flag-label">Kartu Tarot</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕯️" aria-label="Salin 🕯️">🕯️</button>
+      <span class="flag-label">Lilin</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐍" aria-label="Salin 🐍">🐍</button>
+      <span class="flag-label">Ular</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="∞" aria-label="Salin ∞">∞</button>
+      <span class="flag-label">Tak Terhingga</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⟳" aria-label="Salin ⟳">⟳</button>
+      <span class="flag-label">Panah Siklus</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="↻" aria-label="Salin ↻">↻</button>
+      <span class="flag-label">Panah Lingkaran Terbuka</span>
+    </div>
+</div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- COLLECTIONS -->
+<section class="mood-explainers" id="witchy-collections">
+  <span class="article-section-label">Koleksi Witchy</span>
+  <h2>Set Bio &amp; Bingkai Witchy</h2>
+  <p class="u-secondary-block">Rangkaian witchy siap tempel langsung ke bio, caption, atau nama pengguna — salin satu kombo utuh dengan satu klik.</p>
+  <div id="witchyCollectionsContainer"></div>
+</section>
+
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Ubah teks dengan font Unicode</h3>
+  <p>Pakai UltraTextGen untuk mengubah teks biasa menjadi font Unicode tebal, miring, cursive, dan 100+ gaya lain — gratis dan langsung jadi.</p>
+  <a href="/id/" class="cta-btn">Buka UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Halaman Terkait</span>
+  <div class="compare-grid">
+    <a href="/id/library/simbol-goth-grunge/" class="compare-card variant-muted u-no-underline">
+      <h4>Simbol Goth &amp; Grunge</h4>
+      <p>Salib gelap, tengkorak, dan dekorasi aesthetic goth.</p>
+    </a>
+    <a href="/id/library/simbol-cottagecore/" class="compare-card variant-muted u-no-underline">
+      <h4>Simbol Cottagecore</h4>
+      <p>Jamur, bunga liar, dan motif kehidupan pedesaan yang earthy.</p>
+    </a>
+    <a href="/id/library/simbol-aesthetic/" class="compare-card variant-muted u-no-underline">
+      <h4>Simbol Aesthetic</h4>
+      <p>Semua koleksi simbol beraliran aesthetic dalam satu tempat.</p>
+    </a>
+    <a href="/id/library/simbol-bintang/" class="compare-card variant-muted u-no-underline">
+      <h4>Simbol Bintang</h4>
+      <p>Bintang dan kilau dalam berbagai gaya untuk dekorasi teks.</p>
+    </a>
+    <a href="/id/tulisan-gotik/" class="compare-card variant-muted u-no-underline">
+      <h4>Generator Tulisan Gotik</h4>
+      <p>Ubah teks biasa menjadi font gotik Unicode untuk nuansa gelap.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    { name: "Bingkai Bio Pentagram", flags: ["⛧","˖","⛤","˖","⛧"], defaultFormat: "inline" },
+    { name: "Kombo Bulan & Matahari", flags: ["☽","˚","✴","˚","☉"], defaultFormat: "inline" },
+    { name: "Jejak Bintang Witchy", flags: ["✶","·","✴","·","✶"], defaultFormat: "inline" },
+    { name: "Bingkai Bulan Sabit", flags: ["☽⋆ﾟ｡⋆"], defaultFormat: "inline" },
+    { name: "Kombo Bio Planet", flags: ["☽","☿","♀","♂","♃","♄"], defaultFormat: "inline" },
+    { name: "Pembatas Mantra Ankh", flags: ["☥","˖","⛤","˖","☥"], defaultFormat: "inline" }
+  ];
+
+  ns.buildGrids("witchyCollectionsContainer", GROUPS);
+  ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/it/library/simboli-dreamcore-weirdcore/index.html
+++ b/it/library/simboli-dreamcore-weirdcore/index.html
@@ -1,0 +1,419 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Simboli Dreamcore e Weirdcore da Copiare 👁 🌈 ⋆ Estetica Surreale | UltraTextGen</title>
+<meta name="description" content="Simboli dreamcore e weirdcore da copiare e incollare — occhi surreali 👁, arcobaleni 🌈, blocchi glitch, porte e combo sleepcore per post liminali. Tocca un simbolo, è copiato.">
+
+<link rel="canonical" href="https://ultratextgen.com/it/library/simboli-dreamcore-weirdcore/">
+  <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-dreamcore-weirdcore/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/it/library/simboli-dreamcore-weirdcore/">
+
+<meta name="robots" content="index, follow">
+<meta property="og:site_name" content="UltraTextGen">
+<meta property="og:title" content="Simboli Dreamcore e Weirdcore da Copiare 👁 🌈 ⋆ Estetica Surreale">
+<meta property="og:description" content="Occhi surreali 👁, arcobaleni 🌈, blocchi glitch, porte e combo sleepcore per post liminali — tocca un simbolo, è copiato.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/it/library/simboli-dreamcore-weirdcore/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/it-library-simboli-dreamcore-weirdcore.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Simboli Dreamcore e Weirdcore da Copiare 👁 🌈 ⋆ Estetica Surreale">
+<meta name="twitter:description" content="Occhi surreali 👁, arcobaleni 🌈, blocchi glitch, porte e combo sleepcore per post liminali — tocca un simbolo, è copiato.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/it-library-simboli-dreamcore-weirdcore.png">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Simboli Dreamcore e Weirdcore da Copiare 👁 🌈 ⋆ Estetica Surreale",
+  "alternateName": ["Simboli Dreamcore Copia e Incolla", "Simboli Weirdcore Copia e Incolla", "Simboli Estetici Dreamcore", "Simboli Estetici Weirdcore", "Simboli Estetica Surreale", "Simboli Spazi Liminali", "Simboli Testo Dreamcore", "Emoji Dreamcore Weirdcore"],
+  "description": "Simboli dreamcore e weirdcore da copiare e incollare — occhi surreali 👁, arcobaleni 🌈, blocchi glitch, porte e combo sleepcore per post liminali. Tocca un simbolo, è copiato.",
+  "inLanguage": "it",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/it-library-simboli-dreamcore-weirdcore.png",
+  "mainEntityOfPage": "https://ultratextgen.com/it/library/simboli-dreamcore-weirdcore/",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "inLanguage": "it",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ultratextgen.com/it/" },
+    { "@type": "ListItem", "position": 2, "name": "Simboli Dreamcore e Weirdcore", "item": "https://ultratextgen.com/it/library/simboli-dreamcore-weirdcore/" }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js"></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/it/">Home</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Simboli Dreamcore e Weirdcore</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Simboli Dreamcore e Weirdcore</h1>
+    <p class="hero-tagline">Occhi surreali, porte infinite, blocchi di statica glitch e cieli assonnati per l'estetica degli spazi liminali. Tocca un simbolo o una combo per copiarlo all'istante.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/it-library-simboli-dreamcore-weirdcore.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Dreamcore e weirdcore sono estetiche gemelle di internet costruite sulla logica surreale dei sogni — cieli nostalgici, occhi che osservano, porte verso il nulla e oggetti familiari leggermente sbagliati. Questi simboli dreamcore e weirdcore traducono quell'atmosfera in testo copiabile: 👁 occhi, 🌈 arcobaleni, 📺 vecchi televisori, blocchi ombreggiati per la statica e un set sleepcore per edit più morbidi e assonnati. Usali negli stati di Discord, nelle intestazioni di Tumblr, nelle didascalie TikTok e nelle descrizioni YouTube, oppure prendi un'intera combo surreale qui sotto.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="eyes-surreal">
+  <span class="article-section-label">Occhi che osservano</span>
+  <h2>Simboli di occhi che osservano</h2>
+  <p class="u-secondary-tight">Gli occhi che non sbattono mai, cuore dell'immaginario weirdcore, dagli emoji ai geroglifici egizi.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="👁" aria-label="Copia Occhio">👁</button>
+      <span class="flag-label">Occhio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="👁️" aria-label="Copia Occhio (stile emoji)">👁️</button>
+      <span class="flag-label">Occhio (stile emoji)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="👀" aria-label="Copia Occhi">👀</button>
+      <span class="flag-label">Occhi</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓂀" aria-label="Copia Occhio di Horus (geroglifico egizio)">𓂀</button>
+      <span class="flag-label">Occhio di Horus (geroglifico egizio)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓁹" aria-label="Copia Occhio geroglifico egizio">𓁹</button>
+      <span class="flag-label">Occhio geroglifico egizio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="◉" aria-label="Copia Occhio di Pesce">◉</button>
+      <span class="flag-label">Occhio di Pesce</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊙" aria-label="Copia Operatore Punto nel Cerchio">⊙</button>
+      <span class="flag-label">Operatore Punto nel Cerchio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="👁️‍🗨️" aria-label="Copia Occhio nel Fumetto">👁️‍🗨️</button>
+      <span class="flag-label">Occhio nel Fumetto</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="dream-sky">
+  <span class="article-section-label">Cielo da sogno</span>
+  <h2>Simboli del cielo dreamcore</h2>
+  <p class="u-secondary-tight">Arcobaleni, nuvole e cieli vorticosi — la metà luminosa e nostalgica dell'estetica.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌈" aria-label="Copia Arcobaleno">🌈</button>
+      <span class="flag-label">Arcobaleno</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☁️" aria-label="Copia Nuvola">☁️</button>
+      <span class="flag-label">Nuvola</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌙" aria-label="Copia Luna Crescente">🌙</button>
+      <span class="flag-label">Luna Crescente</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⭐" aria-label="Copia Stella">⭐</button>
+      <span class="flag-label">Stella</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌀" aria-label="Copia Ciclone">🌀</button>
+      <span class="flag-label">Ciclone</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🫧" aria-label="Copia Bolle">🫧</button>
+      <span class="flag-label">Bolle</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌌" aria-label="Copia Via Lattea">🌌</button>
+      <span class="flag-label">Via Lattea</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💫" aria-label="Copia Stella con Scia">💫</button>
+      <span class="flag-label">Stella con Scia</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="weirdcore-objects">
+  <span class="article-section-label">Oggetti weirdcore</span>
+  <h2>Simboli di oggetti weirdcore</h2>
+  <p class="u-secondary-tight">Porte, buchi, specchi e vecchie TV — oggetti familiari messi dove non dovrebbero stare.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="📺" aria-label="Copia Televisore">📺</button>
+      <span class="flag-label">Televisore</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🚪" aria-label="Copia Porta">🚪</button>
+      <span class="flag-label">Porta</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕳" aria-label="Copia Buco">🕳</button>
+      <span class="flag-label">Buco</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🪞" aria-label="Copia Specchio">🪞</button>
+      <span class="flag-label">Specchio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🛗" aria-label="Copia Ascensore">🛗</button>
+      <span class="flag-label">Ascensore</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🎈" aria-label="Copia Palloncino">🎈</button>
+      <span class="flag-label">Palloncino</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🩹" aria-label="Copia Cerotto">🩹</button>
+      <span class="flag-label">Cerotto</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧸" aria-label="Copia Orsacchiotto">🧸</button>
+      <span class="flag-label">Orsacchiotto</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="sleepcore">
+  <span class="article-section-label">Sleepcore</span>
+  <h2>Simboli sleepcore</h2>
+  <p class="u-secondary-tight">La sotto-estetica assonnata — letti, cieli notturni e il richiamo dolce del sonno.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💤" aria-label="Copia Zzz">💤</button>
+      <span class="flag-label">Zzz</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🛏" aria-label="Copia Letto">🛏</button>
+      <span class="flag-label">Letto</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="😴" aria-label="Copia Faccina che Dorme">😴</button>
+      <span class="flag-label">Faccina che Dorme</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌃" aria-label="Copia Notte Stellata">🌃</button>
+      <span class="flag-label">Notte Stellata</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕰" aria-label="Copia Orologio da Camino">🕰</button>
+      <span class="flag-label">Orologio da Camino</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🥱" aria-label="Copia Faccina che Sbadiglia">🥱</button>
+      <span class="flag-label">Faccina che Sbadiglia</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="glitch-static">
+  <span class="article-section-label">Glitch e statica</span>
+  <h2>Caratteri a blocco per glitch e statica</h2>
+  <p class="u-secondary-tight">Caratteri Unicode di ombreggiatura e blocco che sembrano statica TV e pixel corrotti.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="░" aria-label="Copia Ombreggiatura Chiara">░</button>
+      <span class="flag-label">Ombreggiatura Chiara</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="▒" aria-label="Copia Ombreggiatura Media">▒</button>
+      <span class="flag-label">Ombreggiatura Media</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="▓" aria-label="Copia Ombreggiatura Scura">▓</button>
+      <span class="flag-label">Ombreggiatura Scura</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="█" aria-label="Copia Blocco Pieno">█</button>
+      <span class="flag-label">Blocco Pieno</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="▚" aria-label="Copia Quadrante Alto-Sinistra e Basso-Destra">▚</button>
+      <span class="flag-label">Quadrante Alto-Sinistra e Basso-Destra</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⋆" aria-label="Copia Operatore Stella">⋆</button>
+      <span class="flag-label">Operatore Stella</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="combo-sets">
+  <span class="article-section-label">Set di combo</span>
+  <h2>Set di combo dreamcore e weirdcore</h2>
+  <p class="u-secondary-block">Copia un'intera combo surreale con un clic — occhi, cieli, statica e sonno, pronti da incollare ovunque.</p>
+  <div id="dreamcoreSetsContainer"></div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Trasforma il testo con i font Unicode</h3>
+  <p>Usa UltraTextGen per convertire il testo normale in grassetto, corsivo, calligrafico e oltre 100 altri stili di font Unicode — gratis e immediato.</p>
+  <a href="/it/" class="cta-btn">Apri UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Pagine collegate</span>
+  <div class="compare-grid">
+    <a href="/it/library/simboli-fairycore/" class="compare-card variant-muted u-no-underline">
+      <h4>Simboli Fairycore</h4>
+      <p>Fate, funghi e scintille di polvere magica per bio incantate.</p>
+    </a>
+    <a href="/it/library/simboli-y2k/" class="compare-card variant-muted u-no-underline">
+      <h4>Simboli Y2K</h4>
+      <p>Caratteri retro-futuristici anni 2000 e simboli dell'estetica cyber.</p>
+    </a>
+    <a href="/it/library/simboli/" class="compare-card variant-muted u-no-underline">
+      <h4>Simboli Aesthetic</h4>
+      <p>La raccolta principale di simboli e divisori aesthetic da copiare.</p>
+    </a>
+    <a href="/it/library/simboli-stella/" class="compare-card variant-muted u-no-underline">
+      <h4>Simboli Stella</h4>
+      <p>Stelle e scintille in tutti gli stili per nickname e bio.</p>
+    </a>
+    <a href="/it/library/simboli-cuore/" class="compare-card variant-muted u-no-underline">
+      <h4>Simboli Cuore</h4>
+      <p>Cuori vuoti, pieni ed emoji per didascalie e profili.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Selettore di lingua">
+      <a class="lang-option" href="/library/dreamcore-weirdcore-symbols/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/it/library/simboli-dreamcore-weirdcore/" hreflang="it">IT</a>
+    </div>
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    {
+      name: "Cielo Dreamcore",
+      flags: ["🌈", "☁️", "👁", "⭐", "🌀"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Corridoio Weirdcore",
+      flags: ["🚪", "📺", "🕳", "🪞", "👁"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Deriva Sleepcore",
+      flags: ["💤", "🛏", "🌙", "☁️", "😴"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Occhi Onniveggenti",
+      flags: ["👁", "𓂀", "◉", "👀", "⊙"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Barre di Glitch Statico",
+      flags: ["░▒▓█▓▒░", "▓▒░⋆░▒▓", "█▓▒░"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Sogno Pastello",
+      flags: ["🫧", "🌈", "🪞", "💫", "☁️"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Notte Liminale",
+      flags: ["🌃", "🛗", "🕰", "🌌", "🚪"],
+      defaultFormat: "inline"
+    }
+  ];
+
+  ns.buildGrids("dreamcoreSetsContainer", GROUPS);
+  if (ns.parseTwemoji) ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/it/library/simboli-fairycore/index.html
+++ b/it/library/simboli-fairycore/index.html
@@ -1,0 +1,380 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Simboli Fairycore: Copia e Incolla 🧚 🍄 ✨ Estetica Fatata</title>
+<meta name="description" content="Simboli e combo emoji fairycore — fatine 🧚, funghi 🍄, scintille ✨ e delicati caratteri floreali per bio incantate. Tocca un simbolo per copiarlo all'istante.">
+
+<link rel="canonical" href="https://ultratextgen.com/it/library/simboli-fairycore/">
+  <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-fairycore/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/it/library/simboli-fairycore/">
+
+<meta name="robots" content="index, follow">
+<meta property="og:site_name" content="UltraTextGen">
+<meta property="og:title" content="Simboli Fairycore: Copia e Incolla 🧚 🍄 ✨ Estetica Fatata">
+<meta property="og:description" content="Simboli e combo emoji fairycore — fatine 🧚, funghi 🍄, scintille ✨ e delicati caratteri floreali per bio incantate. Tocca un simbolo per copiarlo all'istante.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/it/library/simboli-fairycore/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/it-library-simboli-fairycore.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Simboli Fairycore: Copia e Incolla 🧚 🍄 ✨ Estetica Fatata">
+<meta name="twitter:description" content="Simboli e combo emoji fairycore — fatine 🧚, funghi 🍄, scintille ✨ e delicati caratteri floreali per bio incantate. Tocca un simbolo per copiarlo all'istante.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/it-library-simboli-fairycore.png">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Simboli Fairycore: Copia e Incolla 🧚 🍄 ✨ Estetica Fatata",
+  "alternateName": ["Simboli Fairycore Copia e Incolla", "Simboli Estetica Fatata", "Emoji Fairycore", "Simboli Fatine Copia Incolla", "Simboli Fairycore Cottagecore", "Simboli Fiabeschi Copia e Incolla"],
+  "description": "Simboli e combo emoji fairycore — fatine 🧚, funghi 🍄, scintille ✨ e delicati caratteri floreali per bio incantate. Tocca un simbolo per copiarlo all'istante.",
+  "inLanguage": "it",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/it-library-simboli-fairycore.png",
+  "mainEntityOfPage": "https://ultratextgen.com/it/library/simboli-fairycore/",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "inLanguage": "it",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ultratextgen.com/it/" },
+    { "@type": "ListItem", "position": 2, "name": "Simboli Fairycore", "item": "https://ultratextgen.com/it/library/simboli-fairycore/" }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/it/">Home</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Simboli Fairycore</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Simboli Fairycore</h1>
+    <p class="hero-tagline">Fatine, funghetti, scintille di polvere di fata e fiori di bosco per un'estetica incantata. Tocca un simbolo o una combo per copiarlo all'istante.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/it-library-simboli-fairycore.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Il fairycore è un'estetica fiabesca costruita attorno a fatine, boschi luminosi, cerchi di funghi e una soffice scintilla dorata — pensa a giardini incantati e polvere di fata. Questi simboli e combo emoji fairycore catturano quella magia con fatine 🧚, funghi 🍄, scintille ✨ e delicati caratteri floreali come ✿ e ❀. Usali nelle bio di Instagram, nei nomi delle bacheche Pinterest, nelle didascalie TikTok e nelle sezioni "chi sono" di Discord, oppure copia una combo già pronta qui sotto.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="fairies-magic">
+  <span class="article-section-label">Fatine e magia</span>
+  <h2>Emoji fatine e magia</h2>
+  <p class="u-secondary-tight">La famiglia delle emoji fatina più bacchette e magia scintillante.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧚" aria-label="Copia Fatina">🧚</button>
+      <span class="flag-label">Fatina</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧚‍♀️" aria-label="Copia Fata Donna">🧚‍♀️</button>
+      <span class="flag-label">Fata Donna</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧚‍♂️" aria-label="Copia Fata Uomo">🧚‍♂️</button>
+      <span class="flag-label">Fata Uomo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🪄" aria-label="Copia Bacchetta Magica">🪄</button>
+      <span class="flag-label">Bacchetta Magica</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✨" aria-label="Copia Scintille">✨</button>
+      <span class="flag-label">Scintille</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💫" aria-label="Copia Stella con Scia">💫</button>
+      <span class="flag-label">Stella con Scia</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🔮" aria-label="Copia Sfera di Cristallo">🔮</button>
+      <span class="flag-label">Sfera di Cristallo</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="mushrooms-flora">
+  <span class="article-section-label">Funghi e flora</span>
+  <h2>Funghi e flora di bosco</h2>
+  <p class="u-secondary-tight">Funghetti, fioriture e i caratteri floreali Unicode che fanno da base a ogni layout fairycore.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🍄" aria-label="Copia Fungo">🍄</button>
+      <span class="flag-label">Fungo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌷" aria-label="Copia Tulipano">🌷</button>
+      <span class="flag-label">Tulipano</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌸" aria-label="Copia Fiore di Ciliegio">🌸</button>
+      <span class="flag-label">Fiore di Ciliegio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌼" aria-label="Copia Fiore Sbocciato">🌼</button>
+      <span class="flag-label">Fiore Sbocciato</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✿" aria-label="Copia Fiorellino Nero">✿</button>
+      <span class="flag-label">Fiorellino Nero</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❀" aria-label="Copia Fiorellino Bianco">❀</button>
+      <span class="flag-label">Fiorellino Bianco</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌿" aria-label="Copia Erbetta">🌿</button>
+      <span class="flag-label">Erbetta</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🍃" aria-label="Copia Foglia al Vento">🍃</button>
+      <span class="flag-label">Foglia al Vento</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🪷" aria-label="Copia Fiore di Loto">🪷</button>
+      <span class="flag-label">Fiore di Loto</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="pixie-sparkles">
+  <span class="article-section-label">Polvere di fata</span>
+  <h2>Polvere di fata e stelline scintillanti</h2>
+  <p class="u-secondary-tight">Piccoli caratteri di stelle e scintille per creare delicati divisori di testo e accenti nei nickname.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⋆" aria-label="Copia Operatore Stella">⋆</button>
+      <span class="flag-label">Operatore Stella</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✦" aria-label="Copia Stella a Quattro Punte Piena">✦</button>
+      <span class="flag-label">Stella a Quattro Punte Piena</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✧" aria-label="Copia Stella a Quattro Punte Vuota">✧</button>
+      <span class="flag-label">Stella a Quattro Punte Vuota</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✩" aria-label="Copia Stella Contornata Sottile">✩</button>
+      <span class="flag-label">Stella Contornata Sottile</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="˚" aria-label="Copia Anello Alto">˚</button>
+      <span class="flag-label">Anello Alto</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="୨୧" aria-label="Copia Fiocco Aesthetic (cifre Odia)">୨୧</button>
+      <span class="flag-label">Fiocco Aesthetic (cifre Odia)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌟" aria-label="Copia Stella Splendente">🌟</button>
+      <span class="flag-label">Stella Splendente</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="garden-creatures">
+  <span class="article-section-label">Creature del giardino</span>
+  <h2>Creature del giardino incantato</h2>
+  <p class="u-secondary-tight">Farfalle, lumache e gentili visitatori del giardino che completano la scena del giardino fatato.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦋" aria-label="Copia Farfalla">🦋</button>
+      <span class="flag-label">Farfalla</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐌" aria-label="Copia Lumaca">🐌</button>
+      <span class="flag-label">Lumaca</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐞" aria-label="Copia Coccinella">🐞</button>
+      <span class="flag-label">Coccinella</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐝" aria-label="Copia Ape">🐝</button>
+      <span class="flag-label">Ape</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐇" aria-label="Copia Coniglio">🐇</button>
+      <span class="flag-label">Coniglio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦢" aria-label="Copia Cigno">🦢</button>
+      <span class="flag-label">Cigno</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕊" aria-label="Copia Colomba">🕊</button>
+      <span class="flag-label">Colomba</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="combo-sets">
+  <span class="article-section-label">Set di combo</span>
+  <h2>Set di combo fairycore</h2>
+  <p class="u-secondary-block">Copia un'intera combo emoji fairycore con un clic — pronta per bio, didascalie e nomi delle bacheche.</p>
+  <div id="fairycoreSetsContainer"></div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Trasforma il testo con i font Unicode</h3>
+  <p>Usa UltraTextGen per convertire il testo normale in grassetto, corsivo, calligrafico e oltre 100 altri stili di font Unicode — gratis e immediato.</p>
+  <a href="/it/" class="cta-btn">Apri UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Pagine collegate</span>
+  <div class="compare-grid">
+    <a href="/it/library/simboli-cottagecore/" class="compare-card variant-muted u-no-underline">
+      <h4>Simboli Cottagecore</h4>
+      <p>Funghi, api e caratteri rustici della vita di campagna.</p>
+    </a>
+    <a href="/it/library/simboli-coquette/" class="compare-card variant-muted u-no-underline">
+      <h4>Simboli Coquette</h4>
+      <p>Fiocchi, nastri e caratteri dall'estetica soft e femminile.</p>
+    </a>
+    <a href="/it/library/simboli-y2k/" class="compare-card variant-muted u-no-underline">
+      <h4>Simboli Y2K</h4>
+      <p>Stelle, croci e simboli cyber dell'estetica anni 2000.</p>
+    </a>
+    <a href="/it/library/simboli-stella/" class="compare-card variant-muted u-no-underline">
+      <h4>Simboli Stella</h4>
+      <p>Stelle e scintille in tutti gli stili per il testo aesthetic.</p>
+    </a>
+    <a href="/it/library/kaomoji/" class="compare-card variant-muted u-no-underline">
+      <h4>Kaomoji</h4>
+      <p>Faccine giapponesi ed emoticon carini da copiare.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    {
+      name: "Giardino delle Fate",
+      flags: ["🧚", "🍄", "🌷", "✨", "🌿", "🦋"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Scia di Polvere di Fata",
+      flags: ["✨", "⋆", "˚", "✧", "🪄", "💫"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Cerchio di Funghi",
+      flags: ["🍄", "🌿", "🍄", "✨", "🍄", "🍃"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Prato delle Farfalle",
+      flags: ["🦋", "🌼", "🌸", "🐝", "🍃"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Fata al Chiaro di Luna",
+      flags: ["🌙", "✨", "🧚", "⋆", "☁️"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Divisore Bio Delicato",
+      flags: ["⋆˚✿˖°", "୨୧", "⋆˚❀˖°"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Fata del Casolare",
+      flags: ["🍄", "🐌", "🌷", "🧺", "🐇"],
+      defaultFormat: "inline"
+    }
+  ];
+
+  ns.buildGrids("fairycoreSetsContainer", GROUPS);
+  if (ns.parseTwemoji) ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/it/library/simboli-goth-grunge/index.html
+++ b/it/library/simboli-goth-grunge/index.html
@@ -1,0 +1,366 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Simboli Goth &amp; Grunge ✟ Croci, Teschi e Dark Aesthetic da Copiare | UltraTextGen</title>
+<meta name="description" content="Simboli goth e grunge da copiare e incollare — croci ♱, teschi 💀, ragni 🕷 e pugnali † per bio, nickname e profili dark aesthetic. Un tocco, è copiato.">
+
+<link rel="canonical" href="https://ultratextgen.com/it/library/simboli-goth-grunge/">
+  <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-goth-grunge/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/it/library/simboli-goth-grunge/">
+
+<meta name="robots" content="index, follow">
+<meta property="og:site_name" content="UltraTextGen">
+<meta property="og:title" content="Simboli Goth &amp; Grunge ✟ Croci, Teschi e Dark Aesthetic da Copiare">
+<meta property="og:description" content="Croci ♱, teschi 💀, ragni 🕷 e pugnali † per bio, nickname e profili dark aesthetic — tocca un simbolo, è copiato.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/it/library/simboli-goth-grunge/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/it-library-simboli-goth-grunge.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Simboli Goth &amp; Grunge ✟ Croci, Teschi e Dark Aesthetic da Copiare">
+<meta name="twitter:description" content="Croci ♱, teschi 💀, ragni 🕷 e pugnali † per bio, nickname e profili dark aesthetic — tocca un simbolo, è copiato.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/it-library-simboli-goth-grunge.png">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Simboli Goth & Grunge da Copiare — Decorazioni Dark Aesthetic per Bio",
+  "alternateName": ["Simboli Goth Copia e Incolla", "Simboli Dark Aesthetic", "Simboli Grunge Copia e Incolla", "Simboli Dark per Bio", "Simboli Gotici", "Simboli Emo Copia e Incolla", "Simboli Testo Dark Aesthetic", "Emoji Goth Copia e Incolla"],
+  "inLanguage": "it",
+  "description": "Simboli dark aesthetic per bio goth e grunge. Croci, teschi, ragni, pugnali e decorazioni alt fashion per nickname e profili.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/it-library-simboli-goth-grunge.png",
+  "mainEntityOfPage": "https://ultratextgen.com/it/library/simboli-goth-grunge/",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "inLanguage": "it",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ultratextgen.com/it/" },
+    { "@type": "ListItem", "position": 2, "name": "Simboli Goth & Grunge", "item": "https://ultratextgen.com/it/library/simboli-goth-grunge/" }
+  ]
+}
+</script>
+
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js"></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/it/">Home</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Simboli Goth &amp; Grunge</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Simboli Goth &amp; Grunge</h1>
+    <p class="hero-tagline">Simboli dark aesthetic per bio goth e grunge — croci, teschi, ragni, pugnali e decorazioni alt fashion. Tocca un simbolo per copiarlo all'istante.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/it-library-simboli-goth-grunge.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Le estetiche goth e grunge abbracciano oscurità, edge e sovversione — rose nere, croci gotiche, ragni, catene e teschi. Questi caratteri Unicode e queste emoji traducono quell'energia in decorazioni per bio e didascalie. Funziona su Instagram, TikTok, Discord, Tumblr e ovunque sia supportato Unicode.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 1 -->
+<section class="mood-explainers" id="crosses-daggers">
+  <span class="article-section-label">Croci e pugnali</span>
+  <h2>Croci e pugnali</h2>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♱" aria-label="Copia ♱">♱</button>
+      <span class="flag-label">Croce Siriaca Orientale</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="†" aria-label="Copia †">†</button>
+      <span class="flag-label">Pugnale</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‡" aria-label="Copia ‡">‡</button>
+      <span class="flag-label">Doppio Pugnale</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✟" aria-label="Copia ✟">✟</button>
+      <span class="flag-label">Croce Latina Contornata</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🗡" aria-label="Copia 🗡">🗡</button>
+      <span class="flag-label">Emoji Pugnale</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚔" aria-label="Copia ⚔">⚔</button>
+      <span class="flag-label">Spade Incrociate</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🔪" aria-label="Copia 🔪">🔪</button>
+      <span class="flag-label">Coltello da Cucina</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛧" aria-label="Copia ⛧">⛧</button>
+      <span class="flag-label">Pentagramma Rovesciato</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𖤐" aria-label="Copia 𖤐">𖤐</button>
+      <span class="flag-label">Sole Nero</span>
+    </div>
+      <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✝" aria-label="Copia ✝">✝</button>
+      <span class="flag-label">Croce Latina</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☥" aria-label="Copia ☥">☥</button>
+      <span class="flag-label">Ankh</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✠" aria-label="Copia ✠">✠</button>
+      <span class="flag-label">Croce di Malta</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☦" aria-label="Copia ☦">☦</button>
+      <span class="flag-label">Croce Ortodossa</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☽" aria-label="Copia ☽">☽</button>
+      <span class="flag-label">Luna Crescente</span>
+    </div>
+</div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 2 -->
+<section class="mood-explainers" id="skulls-death">
+  <span class="article-section-label">Teschi e motivi di morte</span>
+  <h2>Teschi e motivi di morte</h2>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☠" aria-label="Copia ☠">☠</button>
+      <span class="flag-label">Teschio con Tibie Incrociate</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💀" aria-label="Copia 💀">💀</button>
+      <span class="flag-label">Emoji Teschio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🩸" aria-label="Copia 🩸">🩸</button>
+      <span class="flag-label">Emoji Goccia di Sangue</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚰" aria-label="Copia ⚰">⚰</button>
+      <span class="flag-label">Bara</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🪦" aria-label="Copia 🪦">🪦</button>
+      <span class="flag-label">Emoji Lapide</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚱" aria-label="Copia ⚱">⚱</button>
+      <span class="flag-label">Urna Funeraria</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 3 -->
+<section class="mood-explainers" id="spiders-bats">
+  <span class="article-section-label">Ragni, pipistrelli e creature</span>
+  <h2>Ragni, pipistrelli e creature</h2>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕷" aria-label="Copia 🕷">🕷</button>
+      <span class="flag-label">Emoji Ragno</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕸" aria-label="Copia 🕸">🕸</button>
+      <span class="flag-label">Emoji Ragnatela</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦇" aria-label="Copia 🦇">🦇</button>
+      <span class="flag-label">Emoji Pipistrello</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐍" aria-label="Copia 🐍">🐍</button>
+      <span class="flag-label">Emoji Serpente</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦂" aria-label="Copia 🦂">🦂</button>
+      <span class="flag-label">Emoji Scorpione</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 4 -->
+<section class="mood-explainers" id="dark-florals">
+  <span class="article-section-label">Fiori dark</span>
+  <h2>Fiori dark</h2>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🥀" aria-label="Copia 🥀">🥀</button>
+      <span class="flag-label">Emoji Fiore Appassito</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚘" aria-label="Copia ⚘">⚘</button>
+      <span class="flag-label">Fiore</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🖤" aria-label="Copia 🖤">🖤</button>
+      <span class="flag-label">Emoji Cuore Nero</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❦" aria-label="Copia ❦">❦</button>
+      <span class="flag-label">Cuore Floreale</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❧" aria-label="Copia ❧">❧</button>
+      <span class="flag-label">Cuore Floreale Ruotato</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓆩♱𓆪" aria-label="Copia 𓆩♱𓆪">𓆩♱𓆪</button>
+      <span class="flag-label">Cornice Croce Egizia</span>
+    </div>
+  </div>
+  <p>Molti simboli goth si sovrappongono all'estetica witchy e occulta — pentagrammi, fasi lunari e segni planetari si abbinano perfettamente alle decorazioni dark per bio e nickname.</p>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- COLLECTIONS -->
+<section class="mood-explainers" id="goth-grunge-collections">
+  <span class="article-section-label">Collezioni Goth &amp; Grunge</span>
+  <h2>Set Dark Aesthetic per Bio</h2>
+  <p class="u-secondary-block">Stringhe dark aesthetic già pronte da incollare direttamente in una bio, una didascalia o un nickname — copia l'intera combo con un clic.</p>
+  <div id="gothGrungeCollectionsContainer"></div>
+</section>
+
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Trasforma il testo con i font Unicode</h3>
+  <p>Usa UltraTextGen per convertire il testo normale in grassetto, corsivo, calligrafico e oltre 100 altri stili di font Unicode — gratis e immediato.</p>
+  <a href="/it/" class="cta-btn">Apri UltraTextGen →</a>
+</div>
+
+
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Pagine collegate</span>
+  <div class="compare-grid">
+    <a href="/it/library/simboli-y2k/" class="compare-card variant-muted u-no-underline">
+      <h4>Simboli Y2K</h4>
+      <p>Cyber, croci e dark aesthetic dei primi anni 2000.</p>
+    </a>
+    <a href="/it/library/simboli/" class="compare-card variant-muted u-no-underline">
+      <h4>Simboli Aesthetic</h4>
+      <p>Cuori, stelle, frecce e simboli aesthetic da copiare per la bio.</p>
+    </a>
+    <a href="/it/library/simboli-cuore/" class="compare-card variant-muted u-no-underline">
+      <h4>Simboli Cuore</h4>
+      <p>Cuori neri e cuori aesthetic in ogni stile.</p>
+    </a>
+    <a href="/it/library/simboli-stella/" class="compare-card variant-muted u-no-underline">
+      <h4>Simboli Stella</h4>
+      <p>Stelle dark e varianti decorative di stelle.</p>
+    </a>
+    <a href="/it/library/kaomoji/" class="compare-card variant-muted u-no-underline">
+      <h4>Kaomoji</h4>
+      <p>Faccine giapponesi da copiare per chat e bio.</p>
+    </a>
+  </div>
+</section>
+
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Selettore di lingua">
+      <a class="lang-option" href="/library/goth-grunge-symbols/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/it/library/simboli-goth-grunge/" hreflang="it">IT</a>
+    </div>
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js"></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    { name: "Divisore Croce Goth", flags: ["†","˖","♱","˖","†"], defaultFormat: "inline" },
+    { name: "Cornice Croce Egizia", flags: ["𓆩♱𓆪"], defaultFormat: "inline" },
+    { name: "Bordo Pugnale", flags: ["✟","·","†","‡","†","·","✟"], defaultFormat: "inline" },
+    { name: "Combo Rosa Appassita", flags: ["🥀","🖤","🥀"], defaultFormat: "inline" },
+    { name: "Scia Floreale Dark", flags: ["❦","˖","🖤","˖","❧"], defaultFormat: "inline" },
+    { name: "Combo Bio Pentagramma", flags: ["⛧","˖","𖤐","˖","⛧"], defaultFormat: "inline" }
+  ];
+
+  ns.buildGrids("gothGrungeCollectionsContainer", GROUPS);
+  ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js"></script>
+</body>
+</html>

--- a/it/library/simboli-kawaii-cute/index.html
+++ b/it/library/simboli-kawaii-cute/index.html
@@ -1,0 +1,412 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Simboli Kawaii Cute da Copiare — Decorazioni Soft Aesthetic | UltraTextGen</title>
+<meta name="description" content="Simboli kawaii e cute da copiare e incollare per bio, nickname e messaggi. Cuori soft, faccine, scintille e decorazioni pastello dell'estetica kawaii.">
+
+<link rel="canonical" href="https://ultratextgen.com/it/library/simboli-kawaii-cute/">
+  <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-kawaii-cute/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/it/library/simboli-kawaii-cute/">
+
+<meta property="og:image" content="https://ultratextgen.com/assets/og/it-library-simboli-kawaii-cute.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Simboli Kawaii Cute da Copiare — Decorazioni Soft Aesthetic">
+<meta name="twitter:description" content="Simboli kawaii e cute da copiare e incollare per bio, nickname e messaggi. Cuori soft, faccine, scintille e decorazioni pastello dell'estetica kawaii.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/it-library-simboli-kawaii-cute.png">
+<meta property="og:title" content="Simboli Kawaii Cute da Copiare — Decorazioni Soft Aesthetic">
+<meta property="og:description" content="Simboli kawaii e cute da copiare e incollare per bio, nickname e messaggi. Cuori soft, faccine, scintille e decorazioni pastello dell'estetica kawaii.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/it/library/simboli-kawaii-cute/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "inLanguage": "it",
+  "headline": "Simboli Kawaii Cute da Copiare — Decorazioni Soft Aesthetic",
+  "alternateName": ["Simboli Kawaii da Copiare e Incollare", "Simboli Cute Copia e Incolla", "Simboli Testuali Kawaii", "Simboli Cute Aesthetic", "Simboli Soft Aesthetic", "Decorazioni Kawaii", "Simboli Giapponesi Carini"],
+  "description": "Simboli kawaii e cute da copiare e incollare per bio, nickname e messaggi. Cuori soft, faccine, scintille e decorazioni pastello dell'estetica kawaii.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/it-library-simboli-kawaii-cute.png",
+  "mainEntityOfPage": "https://ultratextgen.com/it/library/simboli-kawaii-cute/",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "inLanguage": "it",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ultratextgen.com/it/" },
+    { "@type": "ListItem", "position": 2, "name": "Simboli Kawaii Cute", "item": "https://ultratextgen.com/it/library/simboli-kawaii-cute/" }
+  ]
+}
+</script>
+
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/it/">Home</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Simboli Kawaii Cute</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Simboli Kawaii &amp; Cute</h1>
+    <p class="hero-tagline">Cuori soft, faccine, scintille e decorazioni kawaii pastello. Tocca un simbolo per copiarlo all'istante per bio, nickname e messaggi.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/it-library-simboli-kawaii-cute.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Kawaii (かわいい) significa "carino" in giapponese, e l'estetica kawaii celebra tutto ciò che è soft, pastello e adorabile. Questi caratteri Unicode ed emoji catturano quella sensazione: piccole faccine, simboli a cuore, segni di scintilla e parentesi decorative. Usali nelle bio, nei messaggi, nei nickname e nelle didascalie su Instagram, TikTok, Discord e ovunque sia supportato il testo Unicode.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 1 -->
+<section class="mood-explainers" id="cute-hearts">
+  <span class="article-section-label">Cuori Cute</span>
+  <h2>Cuori Cute</h2>
+  <p>Caratteri a cuore soft per bio kawaii e messaggi dolci.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♡" aria-label="Copia ♡">♡</button>
+      <span class="flag-label">Cuore Bianco</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ෆ" aria-label="Copia ෆ">ෆ</button>
+      <span class="flag-label">Lettera Singalese Alpapraana Ayanna</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❤" aria-label="Copia ❤">❤</button>
+      <span class="flag-label">Cuore Rosso</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❥" aria-label="Copia ❥">❥</button>
+      <span class="flag-label">Cuore Ruotato con Punto</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ʚɞ" aria-label="Copia ʚɞ">ʚɞ</button>
+      <span class="flag-label">Cuore con Ali (combo)</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 2 -->
+<section class="mood-explainers" id="tiny-cute-faces">
+  <span class="article-section-label">Faccine Kawaii</span>
+  <h2>Faccine Kawaii</h2>
+  <p>Kaomoji e faccine Unicode per aggiungere espressioni kawaii a messaggi e bio.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(˶˃ ᵕ ˂˶)" aria-label="Copia (˶˃ ᵕ ˂˶)">(˶˃ ᵕ ˂˶)</button>
+      <span class="flag-label">Faccina che Arrossisce (combo)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ʕ•ᴥ•ʔ" aria-label="Copia ʕ•ᴥ•ʔ">ʕ•ᴥ•ʔ</button>
+      <span class="flag-label">Musetto di Orso (combo)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(づ ◕‿◕)づ" aria-label="Copia (づ ◕‿◕)づ">(づ ◕‿◕)づ</button>
+      <span class="flag-label">Faccina che Abbraccia (combo)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(✿◠‿◠)" aria-label="Copia (✿◠‿◠)">(✿◠‿◠)</button>
+      <span class="flag-label">Faccina Fiore (combo)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="◕" aria-label="Copia ◕">◕</button>
+      <span class="flag-label">Occhio a Cerchio Grande</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="◡" aria-label="Copia ◡">◡</button>
+      <span class="flag-label">Lettera Curva</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 3 -->
+<section class="mood-explainers" id="cute-wrappers">
+  <span class="article-section-label">Parentesi &amp; Cornici Cute</span>
+  <h2>Parentesi &amp; Cornici Cute</h2>
+  <p>Parentesi decorative e caratteri per incorniciare nickname kawaii e formattare la bio.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="꒰" aria-label="Copia ꒰">꒰</button>
+      <span class="flag-label">Parentesi Ornamentale Sinistra</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="꒱" aria-label="Copia ꒱">꒱</button>
+      <span class="flag-label">Parentesi Ornamentale Destra</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="◌" aria-label="Copia ◌">◌</button>
+      <span class="flag-label">Anello Combinante</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊂" aria-label="Copia ⊂">⊂</button>
+      <span class="flag-label">Sottoinsieme di</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊃" aria-label="Copia ⊃">⊃</button>
+      <span class="flag-label">Sovrainsieme di</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="୨୧" aria-label="Copia ୨୧">୨୧</button>
+      <span class="flag-label">Onda Coquette (combo)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✿" aria-label="Copia ✿">✿</button>
+      <span class="flag-label">Fiorellino Nero</span>
+    </div>
+      <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ʚ" aria-label="Copia ʚ">ʚ</button>
+      <span class="flag-label">Ala di Cuore Sinistra</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ɞ" aria-label="Copia ɞ">ɞ</button>
+      <span class="flag-label">Ala di Cuore Destra</span>
+    </div>
+</div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 4 -->
+<section class="mood-explainers" id="decorative-marks-kawaii">
+  <span class="article-section-label">Segni Decorativi</span>
+  <h2>Segni Decorativi</h2>
+  <p>Scintille, puntini e piccoli accenti per aggiungere un tocco kawaii a qualsiasi testo.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⋆" aria-label="Copia ⋆">⋆</button>
+      <span class="flag-label">Operatore Stella a Sei Punte</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊹" aria-label="Copia ⊹">⊹</button>
+      <span class="flag-label">Croce Ortogonale</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✧" aria-label="Copia ✧">✧</button>
+      <span class="flag-label">Stella a Quattro Punte Vuota</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⩩" aria-label="Copia ⩩">⩩</button>
+      <span class="flag-label">Simile o Uguale</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="๑" aria-label="Copia ๑">๑</button>
+      <span class="flag-label">Carattere Thailandese Ko Kai</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⌒" aria-label="Copia ⌒">⌒</button>
+      <span class="flag-label">Arco</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❀" aria-label="Copia ❀">❀</button>
+      <span class="flag-label">Fiorellino Bianco</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 5 -->
+<section class="mood-explainers" id="pastel-motifs">
+  <span class="article-section-label">Motivi Pastello</span>
+  <h2>Motivi Pastello</h2>
+  <p>Simboli floreali e celesti soft per costruire un'estetica kawaii da sogno.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✿" aria-label="Copia ✿">✿</button>
+      <span class="flag-label">Fiorellino Nero</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❀" aria-label="Copia ❀">❀</button>
+      <span class="flag-label">Fiorellino Bianco</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❁" aria-label="Copia ❁">❁</button>
+      <span class="flag-label">Fiorellino a Otto Petali</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☁" aria-label="Copia ☁">☁</button>
+      <span class="flag-label">Nuvola</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☾" aria-label="Copia ☾">☾</button>
+      <span class="flag-label">Luna Crescente</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛅" aria-label="Copia ⛅">⛅</button>
+      <span class="flag-label">Sole Dietro le Nuvole</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✦" aria-label="Copia ✦">✦</button>
+      <span class="flag-label">Stella a Quattro Punte Piena</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⋆" aria-label="Copia ⋆">⋆</button>
+      <span class="flag-label">Operatore Stella a Sei Punte</span>
+    </div>
+      <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧸" aria-label="Copia 🧸">🧸</button>
+      <span class="flag-label">Orsetto di Peluche</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐻" aria-label="Copia 🐻">🐻</button>
+      <span class="flag-label">Musetto di Orso</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐰" aria-label="Copia 🐰">🐰</button>
+      <span class="flag-label">Musetto di Coniglio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🎀" aria-label="Copia 🎀">🎀</button>
+      <span class="flag-label">Fiocco di Nastro</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌸" aria-label="Copia 🌸">🌸</button>
+      <span class="flag-label">Fiore di Ciliegio</span>
+    </div>
+</div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- COLLECTIONS -->
+<section class="mood-explainers" id="kawaii-collections">
+  <span class="article-section-label">Collezioni Kawaii</span>
+  <h2>Set Kawaii per Bio &amp; Nickname</h2>
+  <p class="u-secondary-block">Combo kawaii già pronte — cuori soft, faccine e scintille pastello da incollare direttamente in una bio, un nickname o un messaggio con un clic.</p>
+  <div id="kawaiiCollectionsContainer"></div>
+</section>
+
+<div class="section-divider"></div>
+
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Trasforma il testo con i font Unicode</h3>
+  <p>Usa UltraTextGen per convertire il testo normale in grassetto, corsivo, calligrafico e oltre 100 altri stili di font Unicode — gratis e immediato.</p>
+  <a href="/it/" class="cta-btn">Apri UltraTextGen →</a>
+</div>
+
+
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Pagine collegate</span>
+  <div class="compare-grid">
+    <a href="/it/library/simboli/" class="compare-card variant-muted u-no-underline">
+      <h4>Simboli Aesthetic</h4>
+      <p>Caratteri Unicode aesthetic selezionati per la bio.</p>
+    </a>
+    <a href="/it/library/kaomoji/" class="compare-card variant-muted u-no-underline">
+      <h4>Kaomoji</h4>
+      <p>Faccine ASCII, emoticon e kaomoji giapponesi.</p>
+    </a>
+    <a href="/it/library/simboli-cuore/" class="compare-card variant-muted u-no-underline">
+      <h4>Simboli Cuore</h4>
+      <p>Ogni emoji cuore e carattere Unicode a cuore.</p>
+    </a>
+    <a href="/it/library/simboli-coquette/" class="compare-card variant-muted u-no-underline">
+      <h4>Simboli Coquette</h4>
+      <p>Fiocchi, nastri e simboli soft e femminili per bio coquette.</p>
+    </a>
+    <a href="/it/library/simboli-cottagecore/" class="compare-card variant-muted u-no-underline">
+      <h4>Simboli Cottagecore</h4>
+      <p>Fiori, foglie e simboli di natura per un'estetica cottagecore.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    { name: "Combo Bio Cuore Soft", flags: ["꒰","♡","꒱","⋆","ෆ"], defaultFormat: "inline" },
+    { name: "Divisore Scintille Kawaii", flags: ["⊹","⋆","✧","⋆","⊹"], defaultFormat: "inline" },
+    { name: "Nickname Ali di Fiore", flags: ["ʚ ✿ ɞ"], defaultFormat: "inline" },
+    { name: "Bordo di Polvere Pastello", flags: ["✦","⋆","❀","⋆","✦"], defaultFormat: "inline" },
+    { name: "Cornice Bio con Faccina", flags: ["(˶˃ ᵕ ˂˶)","♡"], defaultFormat: "inline" },
+    { name: "Combo Parentesi Cute", flags: ["꒰ ♡ ꒱"], defaultFormat: "inline" }
+  ];
+
+  ns.buildGrids("kawaiiCollectionsContainer", GROUPS);
+  ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/it/library/simboli-therian/index.html
+++ b/it/library/simboli-therian/index.html
@@ -1,0 +1,363 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Simboli Therian: Copia e Incolla Δ Theta-Delta e Simboli Alterhuman | UltraTextGen</title>
+<meta name="description" content="Sfoglia i simboli theta-delta (θΔ), impronte, fasi lunari e simboli di animali usati dalla comunità therian e alterhuman. Tocca un simbolo per copiarlo all'istante.">
+
+<link rel="canonical" href="https://ultratextgen.com/it/library/simboli-therian/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/therian-symbols/">
+  <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-therian/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/therian-symbols/">
+
+<meta name="robots" content="index, follow">
+<meta property="og:site_name" content="UltraTextGen">
+<meta property="og:title" content="Simboli Therian: Copia e Incolla Δ Theta-Delta e Simboli Alterhuman">
+<meta property="og:description" content="Sfoglia i simboli theta-delta (θΔ), impronte, fasi lunari e simboli di animali usati dalla comunità therian e alterhuman. Tocca un simbolo per copiarlo all'istante.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/it/library/simboli-therian/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/it-library-simboli-therian.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Simboli Therian: Copia e Incolla Δ Theta-Delta e Simboli Alterhuman">
+<meta name="twitter:description" content="Sfoglia i simboli theta-delta (θΔ), impronte, fasi lunari e simboli di animali usati dalla comunità therian e alterhuman. Tocca un simbolo per copiarlo all'istante.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/it-library-simboli-therian.png">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Simboli Therian: Copia e Incolla Δ Theta-Delta e Simboli Alterhuman",
+  "alternateName": ["Simboli Therian Copia e Incolla", "Simbolo Theta Delta Copia e Incolla", "Simboli Alterhuman", "Simboli della Comunità Therian", "Segni Therian", "Simboli Impronta Copia e Incolla", "Emoji Therian Copia e Incolla"],
+  "description": "Sfoglia i simboli theta-delta (θΔ), impronte, fasi lunari e simboli di animali usati dalla comunità therian e alterhuman. Tocca un simbolo per copiarlo all'istante.",
+  "inLanguage": "it",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/it-library-simboli-therian.png",
+  "mainEntityOfPage": "https://ultratextgen.com/it/library/simboli-therian/",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "inLanguage": "it",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ultratextgen.com/it/" },
+    { "@type": "ListItem", "position": 2, "name": "Simboli Therian", "item": "https://ultratextgen.com/it/library/simboli-therian/" }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/it/">Home</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Simboli Therian</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Simboli Therian</h1>
+    <p class="hero-tagline">Il simbolo theta-delta (θΔ) della comunità, insieme alle impronte, alle lune e ai simboli di animali dell'identità therian e alterhuman. Tocca un simbolo per copiarlo all'istante.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/it-library-simboli-therian.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Il simbolo therian più cercato è il theta-delta — le lettere greche theta (θ) e delta (Δ) combinate — adottato dalla comunità della teriantropia nel 2003 come segno identitario condiviso e rispettoso. I therian sono persone che vivono una profonda identificazione non fisica con un animale, e la più ampia comunità alterhuman usa simboli affini insieme a impronte, fasi lunari ed emoji di animali. Questa pagina raccoglie il theta-delta nelle sue forme Unicode più comuni insieme ai simboli di natura e animali usati nelle bio di TikTok, nei blog Tumblr e nei profili Discord.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="theta-delta">
+  <span class="article-section-label">Theta-Delta</span>
+  <h2>Simboli Theta-Delta della Comunità</h2>
+  <p class="u-secondary-tight">Il simbolo theta-delta costruito con vere lettere greche — copia la coppia combinata o ogni lettera singolarmente.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="θΔ" aria-label="Copia Theta-Delta (Simbolo Therian)">θΔ</button>
+      <span class="flag-label">Theta-Delta (Simbolo Therian)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ΘΔ" aria-label="Copia Theta-Delta Maiuscolo">ΘΔ</button>
+      <span class="flag-label">Theta-Delta Maiuscolo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="θ" aria-label="Copia Lettera Greca Theta Minuscola">θ</button>
+      <span class="flag-label">Lettera Greca Theta Minuscola</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="Θ" aria-label="Copia Lettera Greca Theta Maiuscola">Θ</button>
+      <span class="flag-label">Lettera Greca Theta Maiuscola</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="Δ" aria-label="Copia Lettera Greca Delta Maiuscola">Δ</button>
+      <span class="flag-label">Lettera Greca Delta Maiuscola</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="δ" aria-label="Copia Lettera Greca Delta Minuscola">δ</button>
+      <span class="flag-label">Lettera Greca Delta Minuscola</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ϴ" aria-label="Copia Simbolo Greco Theta Maiuscolo">ϴ</button>
+      <span class="flag-label">Simbolo Greco Theta Maiuscolo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ϑ" aria-label="Copia Simbolo Greco Theta">ϑ</button>
+      <span class="flag-label">Simbolo Greco Theta</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="paw-prints">
+  <span class="article-section-label">Zampe e Canidi</span>
+  <h2>Impronte e Simboli Canini</h2>
+  <p class="u-secondary-tight">Impronte e le emoji di lupo, volpe e cane che compaiono più spesso nelle bio therian.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐾" aria-label="Copia Impronte">🐾</button>
+      <span class="flag-label">Impronte</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐺" aria-label="Copia Lupo">🐺</button>
+      <span class="flag-label">Lupo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦊" aria-label="Copia Volpe">🦊</button>
+      <span class="flag-label">Volpe</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐕" aria-label="Copia Cane">🐕</button>
+      <span class="flag-label">Cane</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐈‍⬛" aria-label="Copia Gatto Nero">🐈‍⬛</button>
+      <span class="flag-label">Gatto Nero</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦝" aria-label="Copia Procione">🦝</button>
+      <span class="flag-label">Procione</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐅" aria-label="Copia Tigre">🐅</button>
+      <span class="flag-label">Tigre</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦴" aria-label="Copia Osso">🦴</button>
+      <span class="flag-label">Osso</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="wild-animals">
+  <span class="article-section-label">Animali Selvatici</span>
+  <h2>Simboli di Animali Selvatici e Teriotipi</h2>
+  <p class="u-secondary-tight">Emoji per i teriotipi più comuni — dai cervi ai grandi felini fino ai rapaci.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦌" aria-label="Copia Cervo">🦌</button>
+      <span class="flag-label">Cervo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐆" aria-label="Copia Leopardo">🐆</button>
+      <span class="flag-label">Leopardo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦅" aria-label="Copia Aquila">🦅</button>
+      <span class="flag-label">Aquila</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦉" aria-label="Copia Gufo">🦉</button>
+      <span class="flag-label">Gufo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐦‍⬛" aria-label="Copia Uccello Nero">🐦‍⬛</button>
+      <span class="flag-label">Uccello Nero</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐍" aria-label="Copia Serpente">🐍</button>
+      <span class="flag-label">Serpente</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦈" aria-label="Copia Squalo">🦈</button>
+      <span class="flag-label">Squalo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐉" aria-label="Copia Drago">🐉</button>
+      <span class="flag-label">Drago</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="moon-night">
+  <span class="article-section-label">Luna e Notte</span>
+  <h2>Simboli di Luna e Notte</h2>
+  <p class="u-secondary-tight">Fasi lunari e falci di luna — un motivo di lunga data negli spazi therian e alterhuman.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌙" aria-label="Copia Luna Crescente">🌙</button>
+      <span class="flag-label">Luna Crescente</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☾" aria-label="Copia Ultimo Quarto di Luna (Testo)">☾</button>
+      <span class="flag-label">Ultimo Quarto di Luna (Testo)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☽" aria-label="Copia Primo Quarto di Luna (Testo)">☽</button>
+      <span class="flag-label">Primo Quarto di Luna (Testo)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌕" aria-label="Copia Luna Piena">🌕</button>
+      <span class="flag-label">Luna Piena</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌑" aria-label="Copia Luna Nuova">🌑</button>
+      <span class="flag-label">Luna Nuova</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌒" aria-label="Copia Luna Crescente Iniziale">🌒</button>
+      <span class="flag-label">Luna Crescente Iniziale</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="forest-nature">
+  <span class="article-section-label">Bosco e Natura</span>
+  <h2>Simboli di Bosco e Natura</h2>
+  <p class="u-secondary-tight">Caratteri di bosco e natura selvaggia per completare la didascalia di un video di quadrobica o un profilo.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌲" aria-label="Copia Albero Sempreverde">🌲</button>
+      <span class="flag-label">Albero Sempreverde</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌿" aria-label="Copia Erba">🌿</button>
+      <span class="flag-label">Erba</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🍂" aria-label="Copia Foglia Caduta">🍂</button>
+      <span class="flag-label">Foglia Caduta</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛰" aria-label="Copia Montagna">⛰</button>
+      <span class="flag-label">Montagna</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🪶" aria-label="Copia Piuma">🪶</button>
+      <span class="flag-label">Piuma</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌾" aria-label="Copia Covone di Riso">🌾</button>
+      <span class="flag-label">Covone di Riso</span>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Trasforma il testo con i font Unicode</h3>
+  <p>Usa UltraTextGen per convertire il testo normale in grassetto, corsivo, calligrafico e oltre 100 altri stili di font Unicode — gratis e immediato.</p>
+  <a href="/it/" class="cta-btn">Apri UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Pagine collegate</span>
+  <div class="compare-grid">
+    <a href="/it/library/simboli-stella/" class="compare-card variant-muted u-no-underline">
+      <h4>Simboli Stella</h4>
+      <p>Stelle, scintille e simboli celesti in ogni stile da copiare.</p>
+    </a>
+    <a href="/it/library/simboli-fairycore/" class="compare-card variant-muted u-no-underline">
+      <h4>Simboli Fairycore</h4>
+      <p>Simboli di bosco, fate e natura per una bio soft e sognante.</p>
+    </a>
+    <a href="/it/library/simboli-goth-grunge/" class="compare-card variant-muted u-no-underline">
+      <h4>Simboli Goth Grunge</h4>
+      <p>Croci, pipistrelli e simboli dark per profili grunge.</p>
+    </a>
+    <a href="/it/library/simboli/" class="compare-card variant-muted u-no-underline">
+      <h4>Simboli Aesthetic</h4>
+      <p>Cuori, stelle, frecce e simboli aesthetic da copiare per la bio.</p>
+    </a>
+    <a href="/it/library/simboli-y2k/" class="compare-card variant-muted u-no-underline">
+      <h4>Simboli Y2K</h4>
+      <p>Stelline, croci e simboli cyber dell'era anni 2000.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Selettore di lingua">
+      <a class="lang-option" href="/library/therian-symbols/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/it/library/simboli-therian/" hreflang="it">IT</a>
+    </div>
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/it/library/simboli-witchy-occult/index.html
+++ b/it/library/simboli-witchy-occult/index.html
@@ -1,0 +1,762 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Simboli Witchy e Occulti: Copia e Incolla i Caratteri Occulti | UltraTextGen</title>
+<meta name="description" content="Sfoglia e copia simboli witchy e occulti — pentagrammi, fasi lunari, segni planetari, simboli alchemici e altri caratteri esoterici. Tocca un simbolo per copiarlo.">
+
+<link rel="canonical" href="https://ultratextgen.com/it/library/simboli-witchy-occult/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/witchy-occult-symbols/">
+  <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-witchy-occult/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/witchy-occult-symbols/">
+
+<meta name="robots" content="index, follow">
+<meta property="og:site_name" content="UltraTextGen">
+<meta property="og:title" content="Simboli Witchy e Occulti: Copia e Incolla i Caratteri Occulti">
+<meta property="og:description" content="Pentagrammi, fasi lunari, segni planetari, simboli alchemici e altri caratteri esoterici da copiare — tocca un simbolo, è copiato.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/it/library/simboli-witchy-occult/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/it-library-simboli-witchy-occult.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Simboli Witchy e Occulti: Copia e Incolla i Caratteri Occulti">
+<meta name="twitter:description" content="Pentagrammi, fasi lunari, segni planetari, simboli alchemici e altri caratteri esoterici da copiare — tocca un simbolo, è copiato.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/it-library-simboli-witchy-occult.png">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Simboli Witchy e Occulti: Copia e Incolla i Caratteri Occulti",
+  "alternateName": ["Simboli Occulti Copia e Incolla", "Simboli Witchy Copia Incolla", "Simboli della Strega Unicode", "Simboli Magici Copia Incolla", "Simboli Esoterici Copia Incolla", "Simbolo Pentagramma Copia Incolla", "Emoji Witchy Copia Incolla"],
+  "description": "Sfoglia e copia simboli witchy e occulti — pentagrammi, fasi lunari, segni planetari, simboli alchemici e altri caratteri esoterici. Tocca un simbolo per copiarlo.",
+  "inLanguage": "it",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/it-library-simboli-witchy-occult.png",
+  "mainEntityOfPage": "https://ultratextgen.com/it/library/simboli-witchy-occult/",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "inLanguage": "it",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ultratextgen.com/it/" },
+    { "@type": "ListItem", "position": 2, "name": "Simboli Witchy e Occulti", "item": "https://ultratextgen.com/it/library/simboli-witchy-occult/" }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js"></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/it/">Home</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Simboli Witchy e Occulti</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Simboli Witchy e Occulti</h1>
+    <p class="hero-tagline">Una raccolta curata di pentagrammi, fasi lunari, simboli planetari, segni alchemici e altri caratteri Unicode esoterici. Tocca un simbolo qui sotto per copiarlo all'istante.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/it-library-simboli-witchy-occult.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Questa libreria raccoglie i simboli Unicode associati alla stregoneria, all'occultismo, all'alchimia e alle tradizioni esoteriche. Sono tutti caratteri Unicode standard — utilizzabili in testi, bio e scrittura creativa. La sezione dei simboli alchemici copre l'intero blocco Unicode dei Simboli Alchemici (U+1F700–U+1F73F).</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="pentagrams-stars">
+  <span class="article-section-label">Pentagrammi e Stelle</span>
+  <h2>Pentagrammi e Stelle a Cinque Punte</h2>
+  <p>Forme di stelle e pentagrammi associate alle tradizioni esoteriche e occulte.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="★" aria-label="Copia Stella Nera">★</button>
+      <span class="flag-label">Stella Nera</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☆" aria-label="Copia Stella Bianca">☆</button>
+      <span class="flag-label">Stella Bianca</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚹" aria-label="Copia Sestile">⚹</button>
+      <span class="flag-label">Sestile</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✡" aria-label="Copia Stella di David">✡</button>
+      <span class="flag-label">Stella di David</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚜" aria-label="Copia Giglio Araldico">⚜</button>
+      <span class="flag-label">Giglio Araldico</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛤" aria-label="Copia Pentagramma">⛤</button>
+      <span class="flag-label">Pentagramma</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛥" aria-label="Copia Pentagramma Rivolto a Destra">⛥</button>
+      <span class="flag-label">Pentagramma Rivolto a Destra</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛦" aria-label="Copia Pentagramma Rivolto a Sinistra">⛦</button>
+      <span class="flag-label">Pentagramma Rivolto a Sinistra</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛧" aria-label="Copia Pentagramma Rovesciato">⛧</button>
+      <span class="flag-label">Pentagramma Rovesciato</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✴" aria-label="Copia Stella a Otto Punte">✴</button>
+      <span class="flag-label">Stella a Otto Punte</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✪" aria-label="Copia Stella Bianca nel Cerchio">✪</button>
+      <span class="flag-label">Stella Bianca nel Cerchio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✶" aria-label="Copia Stella a Sei Punte">✶</button>
+      <span class="flag-label">Stella a Sei Punte</span>
+    </div>
+      <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✦" aria-label="Copia ✦">✦</button>
+      <span class="flag-label">Stella Scintilla</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="◯" aria-label="Copia ◯">◯</button>
+      <span class="flag-label">Cerchio Grande</span>
+    </div>
+</div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- Anchor preserved for inbound links/bookmarks; canonical content lives on /it/library/simboli-stella/ -->
+<section class="mood-explainers" id="moon-phases">
+  <span class="article-section-label">Fasi Lunari</span>
+  <h2>Simboli delle Fasi Lunari</h2>
+  <p>Cerchi il ciclo lunare completo? I simboli delle fasi lunari e celesti sono raccolti nella pagina dedicata in ordine astronomico canonico.</p>
+  <div class="compare-grid" style="margin-top:1rem;">
+    <a href="/it/library/simboli-stella/" class="compare-card variant-muted u-no-underline">
+      <h4>Vedi: Simboli Stella e Celesti →</h4>
+      <p>Le otto fasi lunari Unicode (🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘) più le varianti di luna crescente e luna scura/chiara, pronte da copiare in sequenza.</p>
+    </a>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- CLASSICAL 7 PLANETS (featured sub-group) -->
+<section class="mood-explainers" id="classical-7-planets">
+  <span class="article-section-label">I 7 Pianeti Classici</span>
+  <h2>I Sette Pianeti Classici (Sole → Saturno)</h2>
+  <p class="u-secondary-tight">I sette pianeti dell'astrologia tradizionale in ordine caldeo — i corpi celesti visibili conosciuti dagli antichi astronomi.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☉" aria-label="Copia Sole">☉</button>
+      <span class="flag-label">Sole</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☽" aria-label="Copia Luna">☽</button>
+      <span class="flag-label">Luna</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☿" aria-label="Copia Mercurio">☿</button>
+      <span class="flag-label">Mercurio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♀" aria-label="Copia Venere">♀</button>
+      <span class="flag-label">Venere</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♂" aria-label="Copia Marte">♂</button>
+      <span class="flag-label">Marte</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♃" aria-label="Copia Giove">♃</button>
+      <span class="flag-label">Giove</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♄" aria-label="Copia Saturno">♄</button>
+      <span class="flag-label">Saturno</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="planetary-zodiac">
+  <span class="article-section-label">Pianeti e Zodiaco</span>
+  <h2>Simboli Planetari e Astrologici</h2>
+  <p>Simboli planetari classici e glifi astrologici con associazioni occulte.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☉" aria-label="Copia Sole">☉</button>
+      <span class="flag-label">Sole</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☽" aria-label="Copia Luna">☽</button>
+      <span class="flag-label">Luna</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☿" aria-label="Copia Mercurio">☿</button>
+      <span class="flag-label">Mercurio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♀" aria-label="Copia Venere">♀</button>
+      <span class="flag-label">Venere</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♁" aria-label="Copia Terra">♁</button>
+      <span class="flag-label">Terra</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♂" aria-label="Copia Marte">♂</button>
+      <span class="flag-label">Marte</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♃" aria-label="Copia Giove">♃</button>
+      <span class="flag-label">Giove</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♄" aria-label="Copia Saturno">♄</button>
+      <span class="flag-label">Saturno</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♅" aria-label="Copia Urano">♅</button>
+      <span class="flag-label">Urano</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♆" aria-label="Copia Nettuno">♆</button>
+      <span class="flag-label">Nettuno</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♇" aria-label="Copia Plutone">♇</button>
+      <span class="flag-label">Plutone</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚸" aria-label="Copia Luna Nera Lilith">⚸</button>
+      <span class="flag-label">Luna Nera Lilith</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚳" aria-label="Copia Cerere">⚳</button>
+      <span class="flag-label">Cerere</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚴" aria-label="Copia Pallade">⚴</button>
+      <span class="flag-label">Pallade</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚵" aria-label="Copia Giunone">⚵</button>
+      <span class="flag-label">Giunone</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚶" aria-label="Copia Vesta">⚶</button>
+      <span class="flag-label">Vesta</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="alchemical">
+  <span class="article-section-label">Alchemici</span>
+  <h2>Simboli Alchemici (U+1F700–U+1F73F)</h2>
+  <p>Il blocco Unicode dei Simboli Alchemici, contenente i segni per elementi, processi e sostanze usati nell'alchimia storica.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜀" aria-label="Copia Quintessenza">🜀</button>
+      <span class="flag-label">Quintessenza</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜁" aria-label="Copia Aria">🜁</button>
+      <span class="flag-label">Aria</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜂" aria-label="Copia Fuoco">🜂</button>
+      <span class="flag-label">Fuoco</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜃" aria-label="Copia Terra">🜃</button>
+      <span class="flag-label">Terra</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜄" aria-label="Copia Acqua">🜄</button>
+      <span class="flag-label">Acqua</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜅" aria-label="Copia Acquaforte">🜅</button>
+      <span class="flag-label">Acquaforte</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜆" aria-label="Copia Acqua Regia">🜆</button>
+      <span class="flag-label">Acqua Regia</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜇" aria-label="Copia Acqua Regia II">🜇</button>
+      <span class="flag-label">Acqua Regia II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜈" aria-label="Copia Acqua Vitae">🜈</button>
+      <span class="flag-label">Acqua Vitae</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜉" aria-label="Copia Acqua Vitae II">🜉</button>
+      <span class="flag-label">Acqua Vitae II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜊" aria-label="Copia Aceto">🜊</button>
+      <span class="flag-label">Aceto</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜋" aria-label="Copia Aceto II">🜋</button>
+      <span class="flag-label">Aceto II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜌" aria-label="Copia Aceto III">🜌</button>
+      <span class="flag-label">Aceto III</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜍" aria-label="Copia Zolfo">🜍</button>
+      <span class="flag-label">Zolfo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜎" aria-label="Copia Zolfo II">🜎</button>
+      <span class="flag-label">Zolfo II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜏" aria-label="Copia Zolfo III">🜏</button>
+      <span class="flag-label">Zolfo III</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜐" aria-label="Copia Sale">🜐</button>
+      <span class="flag-label">Sale</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜑" aria-label="Copia Sale II">🜑</button>
+      <span class="flag-label">Sale II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜒" aria-label="Copia Sale III">🜒</button>
+      <span class="flag-label">Sale III</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜓" aria-label="Copia Mercurio Sublimato">🜓</button>
+      <span class="flag-label">Mercurio Sublimato</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜔" aria-label="Copia Mercurio Sublimato II">🜔</button>
+      <span class="flag-label">Mercurio Sublimato II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜕" aria-label="Copia Mercurio Sublimato III">🜕</button>
+      <span class="flag-label">Mercurio Sublimato III</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜖" aria-label="Copia Cinabro">🜖</button>
+      <span class="flag-label">Cinabro</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜗" aria-label="Copia Sale Ammoniaco">🜗</button>
+      <span class="flag-label">Sale Ammoniaco</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜘" aria-label="Copia Vetriolo">🜘</button>
+      <span class="flag-label">Vetriolo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜙" aria-label="Copia Vetriolo II">🜙</button>
+      <span class="flag-label">Vetriolo II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜚" aria-label="Copia Oro">🜚</button>
+      <span class="flag-label">Oro</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜛" aria-label="Copia Argento">🜛</button>
+      <span class="flag-label">Argento</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜜" aria-label="Copia Minerale di Ferro">🜜</button>
+      <span class="flag-label">Minerale di Ferro</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜝" aria-label="Copia Minerale di Ferro II">🜝</button>
+      <span class="flag-label">Minerale di Ferro II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜞" aria-label="Copia Croco di Ferro">🜞</button>
+      <span class="flag-label">Croco di Ferro</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜟" aria-label="Copia Regolo di Ferro">🜟</button>
+      <span class="flag-label">Regolo di Ferro</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜠" aria-label="Copia Minerale di Rame">🜠</button>
+      <span class="flag-label">Minerale di Rame</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜡" aria-label="Copia Minerale di Ferro-Rame">🜡</button>
+      <span class="flag-label">Minerale di Ferro-Rame</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜢" aria-label="Copia Sublimato di Rame">🜢</button>
+      <span class="flag-label">Sublimato di Rame</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜣" aria-label="Copia Croco di Rame">🜣</button>
+      <span class="flag-label">Croco di Rame</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜤" aria-label="Copia Antimoniato di Rame">🜤</button>
+      <span class="flag-label">Antimoniato di Rame</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜥" aria-label="Copia Sale di Antimoniato di Rame">🜥</button>
+      <span class="flag-label">Sale di Antimoniato di Rame</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜦" aria-label="Copia Sublimato di Sale di Rame">🜦</button>
+      <span class="flag-label">Sublimato di Sale di Rame</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜧" aria-label="Copia Verderame">🜧</button>
+      <span class="flag-label">Verderame</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜨" aria-label="Copia Minerale di Stagno">🜨</button>
+      <span class="flag-label">Minerale di Stagno</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜩" aria-label="Copia Minerale di Piombo">🜩</button>
+      <span class="flag-label">Minerale di Piombo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜪" aria-label="Copia Terra di Minerale di Piombo">🜪</button>
+      <span class="flag-label">Terra di Minerale di Piombo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜫" aria-label="Copia Antimonio">🜫</button>
+      <span class="flag-label">Antimonio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜬" aria-label="Copia Antimonio II">🜬</button>
+      <span class="flag-label">Antimonio II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜭" aria-label="Copia Sublimato di Antimonio">🜭</button>
+      <span class="flag-label">Sublimato di Antimonio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜮" aria-label="Copia Sale di Antimonio">🜮</button>
+      <span class="flag-label">Sale di Antimonio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜯" aria-label="Copia Sublimato di Sale di Antimonio">🜯</button>
+      <span class="flag-label">Sublimato di Sale di Antimonio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜰" aria-label="Copia Aceto di Antimonio">🜰</button>
+      <span class="flag-label">Aceto di Antimonio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜱" aria-label="Copia Regolo di Antimonio">🜱</button>
+      <span class="flag-label">Regolo di Antimonio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜲" aria-label="Copia Regolo di Antimonio II">🜲</button>
+      <span class="flag-label">Regolo di Antimonio II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜳" aria-label="Copia Regolo">🜳</button>
+      <span class="flag-label">Regolo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜴" aria-label="Copia Regolo II">🜴</button>
+      <span class="flag-label">Regolo II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜵" aria-label="Copia Regolo III">🜵</button>
+      <span class="flag-label">Regolo III</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜶" aria-label="Copia Regolo IV">🜶</button>
+      <span class="flag-label">Regolo IV</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜷" aria-label="Copia Alcali">🜷</button>
+      <span class="flag-label">Alcali</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜸" aria-label="Copia Alcali II">🜸</button>
+      <span class="flag-label">Alcali II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜹" aria-label="Copia Marcassite">🜹</button>
+      <span class="flag-label">Marcassite</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜺" aria-label="Copia Sale Ammoniaco">🜺</button>
+      <span class="flag-label">Sale Ammoniaco</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜻" aria-label="Copia Arsenico">🜻</button>
+      <span class="flag-label">Arsenico</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜼" aria-label="Copia Realgar">🜼</button>
+      <span class="flag-label">Realgar</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜽" aria-label="Copia Realgar II">🜽</button>
+      <span class="flag-label">Realgar II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜾" aria-label="Copia Orpimento">🜾</button>
+      <span class="flag-label">Orpimento</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜿" aria-label="Copia Minerale di Bismuto">🜿</button>
+      <span class="flag-label">Minerale di Bismuto</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="esoteric">
+  <span class="article-section-label">Altri Esoterici</span>
+  <h2>Altri Simboli Esoterici</h2>
+  <p>Ulteriori simboli associati alle tradizioni magiche ed esoteriche.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☥" aria-label="Copia Ankh">☥</button>
+      <span class="flag-label">Ankh</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☯" aria-label="Copia Yin Yang">☯</button>
+      <span class="flag-label">Yin Yang</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☘" aria-label="Copia Trifoglio">☘</button>
+      <span class="flag-label">Trifoglio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚷" aria-label="Copia Chirone">⚷</button>
+      <span class="flag-label">Chirone</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚰" aria-label="Copia Bara">⚰</button>
+      <span class="flag-label">Bara</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚱" aria-label="Copia Urna Funeraria">⚱</button>
+      <span class="flag-label">Urna Funeraria</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚗" aria-label="Copia Alambicco">⚗</button>
+      <span class="flag-label">Alambicco</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❤" aria-label="Copia Cuore">❤</button>
+      <span class="flag-label">Cuore</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚛" aria-label="Copia Simbolo dell'Atomo">⚛</button>
+      <span class="flag-label">Simbolo dell'Atomo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚡" aria-label="Copia Fulmine">⚡</button>
+      <span class="flag-label">Fulmine</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♲" aria-label="Copia Riciclaggio">♲</button>
+      <span class="flag-label">Riciclaggio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☼" aria-label="Copia Sole Bianco con Raggi">☼</button>
+      <span class="flag-label">Sole Bianco con Raggi</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☦" aria-label="Copia Croce Ortodossa">☦</button>
+      <span class="flag-label">Croce Ortodossa</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☢" aria-label="Copia Radioattivo">☢</button>
+      <span class="flag-label">Radioattivo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☣" aria-label="Copia Rischio Biologico">☣</button>
+      <span class="flag-label">Rischio Biologico</span>
+    </div>
+      <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🔮" aria-label="Copia 🔮">🔮</button>
+      <span class="flag-label">Sfera di Cristallo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧿" aria-label="Copia 🧿">🧿</button>
+      <span class="flag-label">Amuleto Nazar</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🃏" aria-label="Copia 🃏">🃏</button>
+      <span class="flag-label">Carta dei Tarocchi</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕯️" aria-label="Copia 🕯️">🕯️</button>
+      <span class="flag-label">Candela</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐍" aria-label="Copia 🐍">🐍</button>
+      <span class="flag-label">Serpente</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="∞" aria-label="Copia ∞">∞</button>
+      <span class="flag-label">Infinito</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⟳" aria-label="Copia ⟳">⟳</button>
+      <span class="flag-label">Freccia Ciclica</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="↻" aria-label="Copia ↻">↻</button>
+      <span class="flag-label">Freccia Circolare Aperta</span>
+    </div>
+</div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- COLLECTIONS -->
+<section class="mood-explainers" id="witchy-collections">
+  <span class="article-section-label">Collezioni Witchy</span>
+  <h2>Set Witchy per Bio e Cornici</h2>
+  <p class="u-secondary-block">Stringhe witchy già pronte da incollare direttamente in una bio, una didascalia o un nickname — copia l'intera combo con un clic.</p>
+  <div id="witchyCollectionsContainer"></div>
+</section>
+
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Trasforma il testo con i font Unicode</h3>
+  <p>Usa UltraTextGen per convertire il testo normale in grassetto, corsivo, calligrafico e oltre 100 altri stili di font Unicode — gratis e immediato.</p>
+  <a href="/it/" class="cta-btn">Apri UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Pagine collegate</span>
+  <div class="compare-grid">
+    <a href="/it/library/simboli-goth-grunge/" class="compare-card variant-muted u-no-underline">
+      <h4>Simboli Goth e Grunge</h4>
+      <p>Croci scure, teschi e decorazioni dell'estetica goth.</p>
+    </a>
+    <a href="/it/library/simboli/" class="compare-card variant-muted u-no-underline">
+      <h4>Simboli Aesthetic</h4>
+      <p>Cuori, stelle, frecce e simboli aesthetic da copiare per la bio.</p>
+    </a>
+    <a href="/it/gotico/" class="compare-card variant-muted u-no-underline">
+      <h4>Testo Gotico</h4>
+      <p>Trasforma il testo in font gotico e blackletter da copiare.</p>
+    </a>
+    <a href="/it/library/simboli-stella/" class="compare-card variant-muted u-no-underline">
+      <h4>Simboli Stella</h4>
+      <p>Stelle e scintille in tutti gli stili da copiare.</p>
+    </a>
+    <a href="/it/library/simboli-cuore/" class="compare-card variant-muted u-no-underline">
+      <h4>Simboli Cuore</h4>
+      <p>Cuori di ogni tipo e stile da copiare e incollare.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Selettore di lingua">
+      <a class="lang-option" href="/library/witchy-occult-symbols/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/it/library/simboli-witchy-occult/" hreflang="it">IT</a>
+    </div>
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js"></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  const ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  const GROUPS = [
+    { name: "Cornice Bio Pentagramma", flags: ["⛧","˖","⛤","˖","⛧"], defaultFormat: "inline" },
+    { name: "Combo Luna e Sole", flags: ["☽","˚","✴","˚","☉"], defaultFormat: "inline" },
+    { name: "Scia di Stelle Witchy", flags: ["✶","·","✴","·","✶"], defaultFormat: "inline" },
+    { name: "Cornice Luna Crescente", flags: ["☽⋆ﾟ｡⋆"], defaultFormat: "inline" },
+    { name: "Combo Bio Planetaria", flags: ["☽","☿","♀","♂","♃","♄"], defaultFormat: "inline" },
+    { name: "Divisore Ankh Incantesimo", flags: ["☥","˖","⛤","˖","☥"], defaultFormat: "inline" }
+  ];
+
+  ns.buildGrids("witchyCollectionsContainer", GROUPS);
+  ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js"></script>
+</body>
+</html>

--- a/pl/library/symbole-dreamcore-weirdcore/index.html
+++ b/pl/library/symbole-dreamcore-weirdcore/index.html
@@ -1,0 +1,421 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Symbole dreamcore i weirdcore: kopiuj i wklej 👁 🌈 ⋆ surrealistyczna estetyka</title>
+<meta name="description" content="Symbole dreamcore i weirdcore — surrealistyczne oczy 👁, tęcze 🌈, bloki glitchu, drzwi i kombinacje sleepcore do liminalnych postów. Dotknij dowolnego symbolu, aby go od razu skopiować.">
+
+<link rel="canonical" href="https://ultratextgen.com/pl/library/symbole-dreamcore-weirdcore/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/dreamcore-weirdcore-symbols/">
+  <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-dreamcore-weirdcore/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/dreamcore-weirdcore-symbols/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/pl-library-symbole-dreamcore-weirdcore.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Symbole dreamcore i weirdcore: kopiuj i wklej 👁 🌈 ⋆ surrealistyczna estetyka">
+<meta name="twitter:description" content="Symbole dreamcore i weirdcore — surrealistyczne oczy 👁, tęcze 🌈, bloki glitchu, drzwi i kombinacje sleepcore do liminalnych postów. Dotknij dowolnego symbolu, aby go od razu skopiować.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/pl-library-symbole-dreamcore-weirdcore.png">
+<meta property="og:title" content="Symbole dreamcore i weirdcore: kopiuj i wklej 👁 🌈 ⋆ surrealistyczna estetyka">
+<meta property="og:description" content="Symbole dreamcore i weirdcore — surrealistyczne oczy 👁, tęcze 🌈, bloki glitchu, drzwi i kombinacje sleepcore do liminalnych postów. Dotknij dowolnego symbolu, aby go od razu skopiować.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/pl/library/symbole-dreamcore-weirdcore/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Symbole dreamcore i weirdcore: kopiuj i wklej 👁 🌈 ⋆ surrealistyczna estetyka",
+  "alternateName": ["symbole dreamcore kopiuj wklej", "symbole weirdcore kopiuj wklej", "estetyczne symbole dreamcore", "estetyczne symbole weirdcore", "surrealistyczne symbole estetyczne", "symbole liminalnej przestrzeni", "symbole tekstowe dreamcore", "emoji dreamcore weirdcore"],
+  "description": "Symbole dreamcore i weirdcore — surrealistyczne oczy 👁, tęcze 🌈, bloki glitchu, drzwi i kombinacje sleepcore do liminalnych postów. Dotknij dowolnego symbolu, aby go od razu skopiować.",
+  "inLanguage": "pl",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/pl-library-symbole-dreamcore-weirdcore.png",
+  "mainEntityOfPage": "https://ultratextgen.com/pl/library/symbole-dreamcore-weirdcore/",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Strona główna",
+      "item": "https://ultratextgen.com/pl/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Symbole dreamcore i weirdcore",
+      "item": "https://ultratextgen.com/pl/library/symbole-dreamcore-weirdcore/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/pl/">Strona główna</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Symbole dreamcore i weirdcore</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Symbole dreamcore i weirdcore</h1>
+    <p class="hero-tagline">Surrealistyczne oczy, nieskończone drzwi, bloki statycznego szumu i senne niebo dla estetyki liminalnej przestrzeni. Dotknij dowolnego symbolu lub kombinacji, aby go od razu skopiować.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pl-library-symbole-dreamcore-weirdcore.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Dreamcore i weirdcore to siostrzane internetowe estetyki oparte na surrealistycznej logice snów — nostalgiczne niebo, patrzące oczy, drzwi donikąd i nieco przekształcone znajome przedmioty. Te symbole dreamcore i weirdcore przekładają ten nastrój na tekst do kopiowania: 👁 oczy, 🌈 tęcze, 📺 stare telewizory, bloki cienia jako szum oraz zestaw sleepcore do łagodniejszych, sennych edycji. Używaj ich w statusach na Discordzie, nagłówkach na Tumblrze, opisach na TikToku i YouTube albo pobierz całą surrealistyczną kombinację poniżej.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="eyes-surreal">
+  <span class="article-section-label">Patrzące oczy</span>
+  <h2>Symbole patrzących oczu</h2>
+  <p class="u-secondary-tight">Niemrugające oczy w sercu obrazowania weirdcore — od emoji po egipskie hieroglify.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="👁" aria-label="Skopiuj 👁">👁</button>
+      <span class="flag-label">Oko</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="👁️" aria-label="Skopiuj 👁️">👁️</button>
+      <span class="flag-label">Oko (styl emoji)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="👀" aria-label="Skopiuj 👀">👀</button>
+      <span class="flag-label">Oczy</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓂀" aria-label="Skopiuj 𓂀">𓂀</button>
+      <span class="flag-label">Oko Horusa (hieroglif egipski)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓁹" aria-label="Skopiuj 𓁹">𓁹</button>
+      <span class="flag-label">Egipskie hieroglificzne oko</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="◉" aria-label="Skopiuj ◉">◉</button>
+      <span class="flag-label">Rybie oko</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊙" aria-label="Skopiuj ⊙">⊙</button>
+      <span class="flag-label">Operator kropki w kółku</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="👁️‍🗨️" aria-label="Skopiuj 👁️‍🗨️">👁️‍🗨️</button>
+      <span class="flag-label">Oko w dymku</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="dream-sky">
+  <span class="article-section-label">Senne niebo</span>
+  <h2>Symbole nieba dreamcore</h2>
+  <p class="u-secondary-tight">Tęcze, chmury i wirujące niebo — jasna, nostalgiczna strona tej estetyki.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌈" aria-label="Skopiuj 🌈">🌈</button>
+      <span class="flag-label">Tęcza</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☁️" aria-label="Skopiuj ☁️">☁️</button>
+      <span class="flag-label">Chmura</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌙" aria-label="Skopiuj 🌙">🌙</button>
+      <span class="flag-label">Sierp księżyca</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⭐" aria-label="Skopiuj ⭐">⭐</button>
+      <span class="flag-label">Gwiazda</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌀" aria-label="Skopiuj 🌀">🌀</button>
+      <span class="flag-label">Cyklon</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🫧" aria-label="Skopiuj 🫧">🫧</button>
+      <span class="flag-label">Bąbelki</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌌" aria-label="Skopiuj 🌌">🌌</button>
+      <span class="flag-label">Droga Mleczna</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💫" aria-label="Skopiuj 💫">💫</button>
+      <span class="flag-label">Wirująca gwiazda</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="weirdcore-objects">
+  <span class="article-section-label">Obiekty weirdcore</span>
+  <h2>Symbole obiektów weirdcore</h2>
+  <p class="u-secondary-tight">Drzwi, dziury, lustra i stare telewizory — znajome przedmioty umieszczone tam, gdzie nie powinny być.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="📺" aria-label="Skopiuj 📺">📺</button>
+      <span class="flag-label">Telewizor</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🚪" aria-label="Skopiuj 🚪">🚪</button>
+      <span class="flag-label">Drzwi</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕳" aria-label="Skopiuj 🕳">🕳</button>
+      <span class="flag-label">Dziura</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🪞" aria-label="Skopiuj 🪞">🪞</button>
+      <span class="flag-label">Lustro</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🛗" aria-label="Skopiuj 🛗">🛗</button>
+      <span class="flag-label">Winda</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🎈" aria-label="Skopiuj 🎈">🎈</button>
+      <span class="flag-label">Balon</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🩹" aria-label="Skopiuj 🩹">🩹</button>
+      <span class="flag-label">Plaster</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧸" aria-label="Skopiuj 🧸">🧸</button>
+      <span class="flag-label">Pluszowy miś</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="sleepcore">
+  <span class="article-section-label">Sleepcore</span>
+  <h2>Symbole sleepcore</h2>
+  <p class="u-secondary-tight">Senna pod-estetyka — łóżka, nocne niebo i miękkie przyciąganie snu.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💤" aria-label="Skopiuj 💤">💤</button>
+      <span class="flag-label">Zzz</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🛏" aria-label="Skopiuj 🛏">🛏</button>
+      <span class="flag-label">Łóżko</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="😴" aria-label="Skopiuj 😴">😴</button>
+      <span class="flag-label">Śpiąca twarz</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌃" aria-label="Skopiuj 🌃">🌃</button>
+      <span class="flag-label">Noc z gwiazdami</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕰" aria-label="Skopiuj 🕰">🕰</button>
+      <span class="flag-label">Zegar kominkowy</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🥱" aria-label="Skopiuj 🥱">🥱</button>
+      <span class="flag-label">Ziewająca twarz</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="glitch-static">
+  <span class="article-section-label">Glitch i szum</span>
+  <h2>Znaki bloków glitchu i szumu</h2>
+  <p class="u-secondary-tight">Znaki cienia i bloków Unicode, które wyglądają jak szum telewizora i uszkodzone piksele.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="░" aria-label="Skopiuj ░">░</button>
+      <span class="flag-label">Jasny cień</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="▒" aria-label="Skopiuj ▒">▒</button>
+      <span class="flag-label">Średni cień</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="▓" aria-label="Skopiuj ▓">▓</button>
+      <span class="flag-label">Ciemny cień</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="█" aria-label="Skopiuj █">█</button>
+      <span class="flag-label">Pełny blok</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="▚" aria-label="Skopiuj ▚">▚</button>
+      <span class="flag-label">Kwadrant lewy górny i prawy dolny</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⋆" aria-label="Skopiuj ⋆">⋆</button>
+      <span class="flag-label">Operator gwiazdki</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="combo-sets">
+  <span class="article-section-label">Zestawy kombinacji</span>
+  <h2>Zestawy kombinacji dreamcore i weirdcore</h2>
+  <p class="u-secondary-block">Skopiuj całą surrealistyczną kombinację jednym kliknięciem — oczy, niebo, szum i sen, gotowe do wklejenia gdziekolwiek.</p>
+  <div id="dreamcoreSetsContainer"></div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Zmień tekst za pomocą czcionek Unicode</h3>
+  <p>Użyj UltraTextGen, aby zamienić zwykły tekst na pogrubienie, kursywę, kaligrafię i ponad 100 innych stylów czcionek Unicode — za darmo i od razu.</p>
+  <a href="/pl/" class="cta-btn">Otwórz UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Powiązane strony</span>
+  <div class="compare-grid">
+    <a href="/pl/library/symbole-fairycore/" class="compare-card variant-muted u-no-underline">
+      <h4>Symbole fairycore</h4>
+      <p>Wróżki, grzyby i magiczny pył do zaczarowanych bio.</p>
+    </a>
+    <a href="/pl/library/symbole-y2k/" class="compare-card variant-muted u-no-underline">
+      <h4>Symbole Y2K</h4>
+      <p>Retro-futurystyczne znaki lat 2000 i estetyka cyber.</p>
+    </a>
+    <a href="/pl/library/symbole-coquette/" class="compare-card variant-muted u-no-underline">
+      <h4>Symbole coquette</h4>
+      <p>Kokardki, wstążki i miękkie, dziewczęce znaki do bio.</p>
+    </a>
+    <a href="/pl/library/symbole-serca/" class="compare-card variant-muted u-no-underline">
+      <h4>Symbole serca</h4>
+      <p>Serca w każdym stylu do bio i nicków.</p>
+    </a>
+    <a href="/pl/library/symbole-gwiazdek/" class="compare-card variant-muted u-no-underline">
+      <h4>Kolekcja symboli gwiazd</h4>
+      <p>Gwiazdki i znaki brokatu w różnych stylach.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    {
+      name: "Niebo dreamcore",
+      flags: ["🌈", "☁️", "👁", "⭐", "🌀"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Korytarz weirdcore",
+      flags: ["🚪", "📺", "🕳", "🪞", "👁"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Dryf sleepcore",
+      flags: ["💤", "🛏", "🌙", "☁️", "😴"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Wszechwidzące oczy",
+      flags: ["👁", "𓂀", "◉", "👀", "⊙"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Paski statycznego glitchu",
+      flags: ["░▒▓█▓▒░", "▓▒░⋆░▒▓", "█▓▒░"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Pastelowy sen",
+      flags: ["🫧", "🌈", "🪞", "💫", "☁️"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Liminalna noc",
+      flags: ["🌃", "🛗", "🕰", "🌌", "🚪"],
+      defaultFormat: "inline"
+    }
+  ];
+
+  ns.buildGrids("dreamcoreSetsContainer", GROUPS);
+  if (ns.parseTwemoji) ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/pl/library/symbole-fairycore/index.html
+++ b/pl/library/symbole-fairycore/index.html
@@ -1,0 +1,386 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Symbole fairycore: kopiuj i wklej 🧚 🍄 ✨ baśniowa estetyka</title>
+<meta name="description" content="Symbole i kombinacje emoji fairycore — wróżki 🧚, grzybki 🍄, brokat ✨ i delikatne znaki kwiatów do baśniowych bio. Kliknij dowolny symbol, aby od razu go skopiować.">
+
+<link rel="canonical" href="https://ultratextgen.com/pl/library/symbole-fairycore/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/fairycore-symbols/">
+  <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-fairycore/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/fairycore-symbols/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/pl-library-symbole-fairycore.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Symbole fairycore: kopiuj i wklej 🧚 🍄 ✨ baśniowa estetyka">
+<meta name="twitter:description" content="Symbole i kombinacje emoji fairycore — wróżki 🧚, grzybki 🍄, brokat ✨ i delikatne znaki kwiatów do baśniowych bio. Kliknij dowolny symbol, aby od razu go skopiować.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/pl-library-symbole-fairycore.png">
+<meta property="og:title" content="Symbole fairycore: kopiuj i wklej 🧚 🍄 ✨ baśniowa estetyka">
+<meta property="og:description" content="Symbole i kombinacje emoji fairycore — wróżki 🧚, grzybki 🍄, brokat ✨ i delikatne znaki kwiatów do baśniowych bio. Kliknij dowolny symbol, aby od razu go skopiować.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/pl/library/symbole-fairycore/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Symbole fairycore: kopiuj i wklej 🧚 🍄 ✨ baśniowa estetyka",
+  "alternateName": ["Symbole fairycore kopiuj wklej", "Symbole baśniowej estetyki", "Emoji fairycore", "Symbole wróżek kopiuj wklej", "Symbole cottagecore z wróżkami", "Baśniowe symbole kopiuj wklej"],
+  "description": "Symbole i kombinacje emoji fairycore — wróżki 🧚, grzybki 🍄, brokat ✨ i delikatne znaki kwiatów do baśniowych bio. Kliknij dowolny symbol, aby od razu go skopiować.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/pl-library-symbole-fairycore.png",
+  "mainEntityOfPage": "https://ultratextgen.com/pl/library/symbole-fairycore/",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Strona główna",
+      "item": "https://ultratextgen.com/pl/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Symbole fairycore",
+      "item": "https://ultratextgen.com/pl/library/symbole-fairycore/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/pl/">Strona główna</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Symbole fairycore</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Symbole fairycore</h1>
+    <p class="hero-tagline">Wróżki, muchomory, brokat pyłku wróżek i leśne kwiaty dla zaczarowanej estetyki. Dotknij dowolnego symbolu lub kombinacji, aby go od razu skopiować.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pl-library-symbole-fairycore.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Fairycore to baśniowa estetyka zbudowana wokół wróżek, rozświetlonych lasów, kręgów muchomorów i miękkiego, złotego brokatu — pomyśl o zaczarowanych ogrodach i pyłku wróżek. Te symbole i kombinacje emoji fairycore oddają tę magię za pomocą 🧚 wróżek, 🍄 grzybów, ✨ brokatu i delikatnych znaków kwiatków, takich jak ✿ i ❀. Używaj ich w bio na Instagramie, nazwach tablic na Pintereście, opisach na TikToku i sekcjach „o mnie” na Discordzie albo skopiuj gotowy zestaw kombinacji poniżej.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="fairies-magic">
+  <span class="article-section-label">Wróżki i magia</span>
+  <h2>Emoji wróżek i magii</h2>
+  <p class="u-secondary-tight">Rodzina emoji wróżek oraz różdżki i magiczny brokat.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧚" aria-label="Skopiuj Wróżka">🧚</button>
+      <span class="flag-label">Wróżka</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧚‍♀️" aria-label="Skopiuj Wróżka (kobieta)">🧚‍♀️</button>
+      <span class="flag-label">Wróżka (kobieta)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧚‍♂️" aria-label="Skopiuj Wróżka (mężczyzna)">🧚‍♂️</button>
+      <span class="flag-label">Wróżka (mężczyzna)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🪄" aria-label="Skopiuj Magiczna różdżka">🪄</button>
+      <span class="flag-label">Magiczna różdżka</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✨" aria-label="Skopiuj Brokat">✨</button>
+      <span class="flag-label">Brokat</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💫" aria-label="Skopiuj Wirująca gwiazdka">💫</button>
+      <span class="flag-label">Wirująca gwiazdka</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🔮" aria-label="Skopiuj Kryształowa kula">🔮</button>
+      <span class="flag-label">Kryształowa kula</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="mushrooms-flora">
+  <span class="article-section-label">Grzyby i flora</span>
+  <h2>Grzyby i leśna flora</h2>
+  <p class="u-secondary-tight">Muchomory, kwiaty i uniksowe kwiatki, które są rdzeniem każdego układu fairycore.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🍄" aria-label="Skopiuj Grzyb">🍄</button>
+      <span class="flag-label">Grzyb</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌷" aria-label="Skopiuj Tulipan">🌷</button>
+      <span class="flag-label">Tulipan</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌸" aria-label="Skopiuj Kwiat wiśni">🌸</button>
+      <span class="flag-label">Kwiat wiśni</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌼" aria-label="Skopiuj Kwiat">🌼</button>
+      <span class="flag-label">Kwiat</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✿" aria-label="Skopiuj Czarny kwiatek">✿</button>
+      <span class="flag-label">Czarny kwiatek</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❀" aria-label="Skopiuj Biały kwiatek">❀</button>
+      <span class="flag-label">Biały kwiatek</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌿" aria-label="Skopiuj Zioło">🌿</button>
+      <span class="flag-label">Zioło</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🍃" aria-label="Skopiuj Liść na wietrze">🍃</button>
+      <span class="flag-label">Liść na wietrze</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🪷" aria-label="Skopiuj Lotos">🪷</button>
+      <span class="flag-label">Lotos</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="pixie-sparkles">
+  <span class="article-section-label">Pyłek wróżek</span>
+  <h2>Pyłek wróżek i gwiezdny brokat</h2>
+  <p class="u-secondary-tight">Drobne gwiazdki i znaczniki brokatu do budowania delikatnych separatorów tekstu i akcentów w nickach.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⋆" aria-label="Skopiuj Operator gwiazdki">⋆</button>
+      <span class="flag-label">Operator gwiazdki</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✦" aria-label="Skopiuj Czarna gwiazda czteroramienna">✦</button>
+      <span class="flag-label">Czarna gwiazda czteroramienna</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✧" aria-label="Skopiuj Biała gwiazda czteroramienna">✧</button>
+      <span class="flag-label">Biała gwiazda czteroramienna</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✩" aria-label="Skopiuj Gruba obrysowana biała gwiazda">✩</button>
+      <span class="flag-label">Gruba obrysowana biała gwiazda</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="˚" aria-label="Skopiuj Kółko górne">˚</button>
+      <span class="flag-label">Kółko górne</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="୨୧" aria-label="Skopiuj Estetyczna kokardka (cyfry orija)">୨୧</button>
+      <span class="flag-label">Estetyczna kokardka (cyfry orija)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌟" aria-label="Skopiuj Świecąca gwiazda">🌟</button>
+      <span class="flag-label">Świecąca gwiazda</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="garden-creatures">
+  <span class="article-section-label">Ogrodowe stworzenia</span>
+  <h2>Stworzenia z zaczarowanego ogrodu</h2>
+  <p class="u-secondary-tight">Motyle, ślimaki i łagodni goście ogrodu, którzy dopełniają scenę baśniowego ogrodu.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦋" aria-label="Skopiuj Motyl">🦋</button>
+      <span class="flag-label">Motyl</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐌" aria-label="Skopiuj Ślimak">🐌</button>
+      <span class="flag-label">Ślimak</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐞" aria-label="Skopiuj Biedronka">🐞</button>
+      <span class="flag-label">Biedronka</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐝" aria-label="Skopiuj Pszczoła">🐝</button>
+      <span class="flag-label">Pszczoła</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐇" aria-label="Skopiuj Królik">🐇</button>
+      <span class="flag-label">Królik</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦢" aria-label="Skopiuj Łabędź">🦢</button>
+      <span class="flag-label">Łabędź</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕊" aria-label="Skopiuj Gołąb">🕊</button>
+      <span class="flag-label">Gołąb</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="combo-sets">
+  <span class="article-section-label">Kombinacje</span>
+  <h2>Gotowe kombinacje fairycore</h2>
+  <p class="u-secondary-block">Skopiuj kompletną kombinację emoji fairycore jednym kliknięciem — gotową do bio, opisów i nazw tablic.</p>
+  <div id="fairycoreSetsContainer"></div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Zmień tekst za pomocą czcionek Unicode</h3>
+  <p>Użyj UltraTextGen, aby zamienić zwykły tekst na pogrubienie, kursywę, kaligrafię i ponad 100 innych stylów czcionek Unicode — za darmo i od razu.</p>
+  <a href="/pl/" class="cta-btn">Otwórz UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Powiązane strony</span>
+  <div class="compare-grid">
+    <a href="/pl/library/symbole-cottagecore/" class="compare-card variant-muted u-no-underline">
+      <h4>Symbole cottagecore</h4>
+      <p>Grzyby, pszczoły i wiejskie znaki w rustykalnym stylu.</p>
+    </a>
+    <a href="/pl/library/symbole-coquette/" class="compare-card variant-muted u-no-underline">
+      <h4>Symbole coquette</h4>
+      <p>Kokardki, wstążki i miękkie, dziewczęce znaki do bio.</p>
+    </a>
+    <a href="/pl/library/symbole-gwiazdek/" class="compare-card variant-muted u-no-underline">
+      <h4>Symbole gwiazdek</h4>
+      <p>Gwiazdki i znaki brokatu w różnych stylach.</p>
+    </a>
+    <a href="/pl/library/symbole-serca/" class="compare-card variant-muted u-no-underline">
+      <h4>Symbole serca</h4>
+      <p>Serca i znaki miłości do bio i nicków.</p>
+    </a>
+    <a href="/pl/library/kaomoji/" class="compare-card variant-muted u-no-underline">
+      <h4>Kaomoji</h4>
+      <p>Japońskie emotikony do wyrażania emocji tekstem.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    {
+      name: "Baśniowy ogród",
+      flags: ["🧚", "🍄", "🌷", "✨", "🌿", "🦋"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Ślad pyłku wróżek",
+      flags: ["✨", "⋆", "˚", "✧", "🪄", "💫"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Krąg grzybów",
+      flags: ["🍄", "🌿", "🍄", "✨", "🍄", "🍃"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Motyla łąka",
+      flags: ["🦋", "🌼", "🌸", "🐝", "🍃"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Wróżka w świetle księżyca",
+      flags: ["🌙", "✨", "🧚", "⋆", "☁️"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Delikatny separator do bio",
+      flags: ["⋆˚✿˖°", "୨୧", "⋆˚❀˖°"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Chatkowa wróżka",
+      flags: ["🍄", "🐌", "🌷", "🧺", "🐇"],
+      defaultFormat: "inline"
+    }
+  ];
+
+  ns.buildGrids("fairycoreSetsContainer", GROUPS);
+  if (ns.parseTwemoji) ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/pl/library/symbole-goth-grunge/index.html
+++ b/pl/library/symbole-goth-grunge/index.html
@@ -1,0 +1,369 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Symbole goth i grunge do kopiowania i wklejania — mroczne ozdobniki do bio</title>
+<meta name="description" content="Mroczne estetyczne symbole do bio w stylu goth i grunge — krzyże, czaszki, pająki, sztylety i alternatywne ozdobniki do nicków i profili. Kopiuj jednym dotknięciem.">
+
+<link rel="canonical" href="https://ultratextgen.com/pl/library/symbole-goth-grunge/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/goth-grunge-symbols/">
+  <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-goth-grunge/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/goth-grunge-symbols/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/pl-library-symbole-goth-grunge.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Symbole goth i grunge do kopiowania i wklejania — mroczne ozdobniki do bio">
+<meta name="twitter:description" content="Mroczne estetyczne symbole do bio w stylu goth i grunge — krzyże, czaszki, pająki, sztylety i alternatywne ozdobniki do nicków i profili. Kopiuj jednym dotknięciem.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/pl-library-symbole-goth-grunge.png">
+<meta property="og:title" content="Symbole goth i grunge do kopiowania i wklejania — mroczne ozdobniki do bio">
+<meta property="og:description" content="Mroczne estetyczne symbole do bio w stylu goth i grunge — krzyże, czaszki, pająki, sztylety i alternatywne ozdobniki do nicków i profili. Kopiuj jednym dotknięciem.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/pl/library/symbole-goth-grunge/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Symbole goth i grunge do kopiowania i wklejania — mroczne ozdobniki do bio",
+  "alternateName": ["symbole goth kopiuj wklej", "mroczne estetyczne symbole", "symbole grunge kopiuj wklej", "mroczne symbole do bio", "gotyckie symbole", "symbole emo kopiuj wklej", "mroczne symbole tekstowe", "emotki goth kopiuj wklej"],
+  "description": "Mroczne estetyczne symbole do bio w stylu goth i grunge — krzyże, czaszki, pająki, sztylety i alternatywne ozdobniki do nicków i profili.",
+  "inLanguage": "pl",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/pl-library-symbole-goth-grunge.png",
+  "mainEntityOfPage": "https://ultratextgen.com/pl/library/symbole-goth-grunge/",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Strona główna",
+      "item": "https://ultratextgen.com/pl/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Symbole goth i grunge",
+      "item": "https://ultratextgen.com/pl/library/symbole-goth-grunge/"
+    }
+  ]
+}
+</script>
+
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/pl/">Strona główna</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Symbole goth i grunge</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Symbole goth i grunge</h1>
+    <p class="hero-tagline">Mroczne estetyczne symbole do bio w stylu goth i grunge — krzyże, czaszki, pająki, sztylety i alternatywne ozdobniki. Dotknij dowolnego, aby od razu skopiować.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pl-library-symbole-goth-grunge.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Estetyka goth i grunge to mrok, pazur i przekora — czarne róże, gotyckie krzyże, pająki, łańcuchy i czaszki. Te znaki Unicode i emoji przenoszą tę energię do ozdobników w bio i opisach. Działają na Instagramie, TikToku, Discordzie, Tumblrze i wszędzie tam, gdzie obsługiwany jest Unicode.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 1 -->
+<section class="mood-explainers" id="crosses-daggers">
+  <span class="article-section-label">Krzyże i sztylety</span>
+  <h2>Krzyże i sztylety</h2>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♱" aria-label="Skopiuj ♱">♱</button>
+      <span class="flag-label">Krzyż wschodniosyryjski</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="†" aria-label="Skopiuj †">†</button>
+      <span class="flag-label">Sztylet</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‡" aria-label="Skopiuj ‡">‡</button>
+      <span class="flag-label">Podwójny sztylet</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✟" aria-label="Skopiuj ✟">✟</button>
+      <span class="flag-label">Obrysowany krzyż łaciński</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🗡" aria-label="Skopiuj 🗡">🗡</button>
+      <span class="flag-label">Emotka sztyletu</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚔" aria-label="Skopiuj ⚔">⚔</button>
+      <span class="flag-label">Skrzyżowane miecze</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🔪" aria-label="Skopiuj 🔪">🔪</button>
+      <span class="flag-label">Nóż kuchenny</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛧" aria-label="Skopiuj ⛧">⛧</button>
+      <span class="flag-label">Odwrócony pentagram</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𖤐" aria-label="Skopiuj 𖤐">𖤐</button>
+      <span class="flag-label">Czarne słońce</span>
+    </div>
+      <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✝" aria-label="Skopiuj ✝">✝</button>
+      <span class="flag-label">Krzyż łaciński</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☥" aria-label="Skopiuj ☥">☥</button>
+      <span class="flag-label">Ankh</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✠" aria-label="Skopiuj ✠">✠</button>
+      <span class="flag-label">Krzyż maltański</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☦" aria-label="Skopiuj ☦">☦</button>
+      <span class="flag-label">Krzyż prawosławny</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☽" aria-label="Skopiuj ☽">☽</button>
+      <span class="flag-label">Sierp księżyca</span>
+    </div>
+</div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 2 -->
+<section class="mood-explainers" id="skulls-death">
+  <span class="article-section-label">Czaszki i motywy śmierci</span>
+  <h2>Czaszki i motywy śmierci</h2>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☠" aria-label="Skopiuj ☠">☠</button>
+      <span class="flag-label">Trupia czaszka</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💀" aria-label="Skopiuj 💀">💀</button>
+      <span class="flag-label">Emotka czaszki</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🩸" aria-label="Skopiuj 🩸">🩸</button>
+      <span class="flag-label">Emotka kropli krwi</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚰" aria-label="Skopiuj ⚰">⚰</button>
+      <span class="flag-label">Trumna</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🪦" aria-label="Skopiuj 🪦">🪦</button>
+      <span class="flag-label">Emotka nagrobka</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚱" aria-label="Skopiuj ⚱">⚱</button>
+      <span class="flag-label">Urna pogrzebowa</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 3 -->
+<section class="mood-explainers" id="spiders-bats">
+  <span class="article-section-label">Pająki, nietoperze i stworzenia</span>
+  <h2>Pająki, nietoperze i stworzenia</h2>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕷" aria-label="Skopiuj 🕷">🕷</button>
+      <span class="flag-label">Emotka pająka</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕸" aria-label="Skopiuj 🕸">🕸</button>
+      <span class="flag-label">Emotka pajęczyny</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦇" aria-label="Skopiuj 🦇">🦇</button>
+      <span class="flag-label">Emotka nietoperza</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐍" aria-label="Skopiuj 🐍">🐍</button>
+      <span class="flag-label">Emotka węża</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦂" aria-label="Skopiuj 🦂">🦂</button>
+      <span class="flag-label">Emotka skorpiona</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 4 -->
+<section class="mood-explainers" id="dark-florals">
+  <span class="article-section-label">Mroczne kwiaty</span>
+  <h2>Mroczne kwiaty</h2>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🥀" aria-label="Skopiuj 🥀">🥀</button>
+      <span class="flag-label">Emotka zwiędłego kwiatu</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚘" aria-label="Skopiuj ⚘">⚘</button>
+      <span class="flag-label">Kwiat</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🖤" aria-label="Skopiuj 🖤">🖤</button>
+      <span class="flag-label">Emotka czarnego serca</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❦" aria-label="Skopiuj ❦">❦</button>
+      <span class="flag-label">Serce kwiatowe</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❧" aria-label="Skopiuj ❧">❧</button>
+      <span class="flag-label">Obrócone serce kwiatowe</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓆩♱𓆪" aria-label="Skopiuj 𓆩♱𓆪">𓆩♱𓆪</button>
+      <span class="flag-label">Egipska ramka z krzyżem</span>
+    </div>
+  </div>
+  <p>Wiele symboli goth pokrywa się z estetyką Y2K i mroczną stroną cyber — zajrzyj do biblioteki <a href="/pl/library/symbole-y2k/">Symbole Y2K</a> po krzyże, pentagramy i znaki cyber.</p>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- COLLECTIONS -->
+<section class="mood-explainers" id="goth-grunge-collections">
+  <span class="article-section-label">Zestawy goth i grunge</span>
+  <h2>Mroczne zestawy do bio</h2>
+  <p class="u-secondary-block">Gotowe mroczne ciągi, które wkleisz prosto do bio, opisu lub nicku — skopiuj cały zestaw jednym kliknięciem.</p>
+  <div id="gothGrungeCollectionsContainer"></div>
+</section>
+
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Zmień tekst za pomocą czcionek Unicode</h3>
+  <p>Użyj UltraTextGen, aby zamienić zwykły tekst na pogrubienie, kursywę, kaligrafię i ponad 100 innych stylów czcionek Unicode — za darmo i od razu.</p>
+  <a href="/pl/" class="cta-btn">Otwórz UltraTextGen →</a>
+</div>
+
+
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Powiązane strony</span>
+  <div class="compare-grid">
+    <a href="/pl/library/symbole-y2k/" class="compare-card variant-muted u-no-underline">
+      <h4>Symbole Y2K</h4>
+      <p>Cyber i mroczne ozdobniki w stylu Y2K.</p>
+    </a>
+    <a href="/pl/library/symbole-serca/" class="compare-card variant-muted u-no-underline">
+      <h4>Symbole serc</h4>
+      <p>Czarne serca i ozdobniki w kształcie serca.</p>
+    </a>
+    <a href="/pl/library/symbole-gwiazdek/" class="compare-card variant-muted u-no-underline">
+      <h4>Symbole gwiazdek</h4>
+      <p>Mroczne gwiazdy i ozdobne warianty gwiazdek.</p>
+    </a>
+    <a href="/pl/library/symbole-coquette/" class="compare-card variant-muted u-no-underline">
+      <h4>Symbole coquette</h4>
+      <p>Kokardki, wstążki i miękkie, dziewczęce znaki do bio.</p>
+    </a>
+    <a href="/pl/library/symbole-cottagecore/" class="compare-card variant-muted u-no-underline">
+      <h4>Symbole cottagecore</h4>
+      <p>Rośliny, kwiaty i przytulne znaki natury.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    { name: "Separator z krzyżem goth", flags: ["†","˖","♱","˖","†"], defaultFormat: "inline" },
+    { name: "Egipska ramka z krzyżem", flags: ["𓆩♱𓆪"], defaultFormat: "inline" },
+    { name: "Obramowanie ze sztyletów", flags: ["✟","·","†","‡","†","·","✟"], defaultFormat: "inline" },
+    { name: "Kombinacja z uschłą różą", flags: ["🥀","🖤","🥀"], defaultFormat: "inline" },
+    { name: "Mroczny kwiatowy ślad", flags: ["❦","˖","🖤","˖","❧"], defaultFormat: "inline" },
+    { name: "Kombinacja z pentagramem do bio", flags: ["⛧","˖","𖤐","˖","⛧"], defaultFormat: "inline" }
+  ];
+
+  ns.buildGrids("gothGrungeCollectionsContainer", GROUPS);
+  ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/pl/library/symbole-kawaii-cute/index.html
+++ b/pl/library/symbole-kawaii-cute/index.html
@@ -1,0 +1,420 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Symbole kawaii i cute — miękkie estetyczne ozdobniki do kopiowania</title>
+<meta name="description" content="Symbole kawaii i cute do bio, nicków i wiadomości. Miękkie serca, małe buźki, brokat i pastelowe ozdobniki z estetyki kawaii. Kopiuj jednym dotknięciem.">
+
+<link rel="canonical" href="https://ultratextgen.com/pl/library/symbole-kawaii-cute/">
+  <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-kawaii-cute/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/pl/library/symbole-kawaii-cute/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/pl-library-symbole-kawaii-cute.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Symbole kawaii i cute — miękkie estetyczne ozdobniki do kopiowania">
+<meta name="twitter:description" content="Symbole kawaii i cute do bio, nicków i wiadomości. Miękkie serca, małe buźki, brokat i pastelowe ozdobniki z estetyki kawaii. Kopiuj jednym dotknięciem.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/pl-library-symbole-kawaii-cute.png">
+<meta property="og:title" content="Symbole kawaii i cute — miękkie estetyczne ozdobniki do kopiowania">
+<meta property="og:description" content="Symbole kawaii i cute do bio, nicków i wiadomości. Miękkie serca, małe buźki, brokat i pastelowe ozdobniki z estetyki kawaii. Kopiuj jednym dotknięciem.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/pl/library/symbole-kawaii-cute/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Symbole kawaii i cute — miękkie estetyczne ozdobniki do kopiowania",
+  "alternateName": ["symbole kawaii kopiuj wklej", "symbole cute kopiuj wklej", "tekstowe symbole kawaii", "słodkie estetyczne symbole", "miękkie estetyczne symbole", "ozdobniki kawaii", "słodkie japońskie symbole"],
+  "description": "Symbole kawaii i cute do bio, nicków i wiadomości. Miękkie serca, małe buźki, brokat i pastelowe ozdobniki z estetyki kawaii.",
+  "inLanguage": "pl",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/pl-library-symbole-kawaii-cute.png",
+  "mainEntityOfPage": "https://ultratextgen.com/pl/library/symbole-kawaii-cute/",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Strona główna",
+      "item": "https://ultratextgen.com/pl/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Symbole kawaii i cute",
+      "item": "https://ultratextgen.com/pl/library/symbole-kawaii-cute/"
+    }
+  ]
+}
+</script>
+
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/pl/">Strona główna</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Symbole kawaii i cute</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Symbole kawaii i cute</h1>
+    <p class="hero-tagline">Miękkie serca, małe buźki, brokat i pastelowe ozdobniki kawaii. Dotknij dowolnego symbolu, aby od razu skopiować go do bio, nicku czy wiadomości.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pl-library-symbole-kawaii-cute.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Kawaii (かわいい) po japońsku znaczy „słodki", a estetyka kawaii celebruje wszystko, co miękkie, pastelowe i urocze. Te znaki Unicode i emotki oddają tę energię: małe buźki, symbole serc, znaczniki brokatu i słodkie nawiasy-ramki. Używaj ich w bio, wiadomościach, nickach i opisach na Instagramie, TikToku, Discordzie i wszędzie tam, gdzie działa tekst Unicode.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 1 -->
+<section class="mood-explainers" id="cute-hearts">
+  <span class="article-section-label">Słodkie serca</span>
+  <h2>Słodkie serca</h2>
+  <p>Miękkie znaki serc do słodkich bio kawaii i czułych wiadomości.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♡" aria-label="Skopiuj ♡">♡</button>
+      <span class="flag-label">Białe serce</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ෆ" aria-label="Skopiuj ෆ">ෆ</button>
+      <span class="flag-label">Serduszko syngaleskie</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❤" aria-label="Skopiuj ❤">❤</button>
+      <span class="flag-label">Czerwone serce</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❥" aria-label="Skopiuj ❥">❥</button>
+      <span class="flag-label">Obrócone serce (punktor)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ʚɞ" aria-label="Skopiuj ʚɞ">ʚɞ</button>
+      <span class="flag-label">Uskrzydlone serce (kombinacja)</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 2 -->
+<section class="mood-explainers" id="tiny-cute-faces">
+  <span class="article-section-label">Małe słodkie buźki</span>
+  <h2>Małe słodkie buźki</h2>
+  <p>Kaomoji i buźki Unicode, które dodają wiadomościom i bio uroczych, kawaii wyrazów.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(˶˃ ᵕ ˂˶)" aria-label="Skopiuj (˶˃ ᵕ ˂˶)">(˶˃ ᵕ ˂˶)</button>
+      <span class="flag-label">Zawstydzona buźka (kombinacja)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ʕ•ᴥ•ʔ" aria-label="Skopiuj ʕ•ᴥ•ʔ">ʕ•ᴥ•ʔ</button>
+      <span class="flag-label">Buźka misia (kombinacja)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(づ ◕‿◕)づ" aria-label="Skopiuj (づ ◕‿◕)づ">(づ ◕‿◕)づ</button>
+      <span class="flag-label">Przytulająca buźka (kombinacja)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(✿◠‿◠)" aria-label="Skopiuj (✿◠‿◠)">(✿◠‿◠)</button>
+      <span class="flag-label">Kwiatowa buźka (kombinacja)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="◕" aria-label="Skopiuj ◕">◕</button>
+      <span class="flag-label">Duże okrągłe oko</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="◡" aria-label="Skopiuj ◡">◡</button>
+      <span class="flag-label">Uśmiech (łuk)</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 3 -->
+<section class="mood-explainers" id="cute-wrappers">
+  <span class="article-section-label">Słodkie nawiasy i ramki</span>
+  <h2>Słodkie nawiasy i ramki</h2>
+  <p>Ozdobne nawiasy i znaki-ramki do słodkich nicków kawaii i formatowania bio.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="꒰" aria-label="Skopiuj ꒰">꒰</button>
+      <span class="flag-label">Ozdobny nawias lewy</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="꒱" aria-label="Skopiuj ꒱">꒱</button>
+      <span class="flag-label">Ozdobny nawias prawy</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="◌" aria-label="Skopiuj ◌">◌</button>
+      <span class="flag-label">Kółko łączące</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊂" aria-label="Skopiuj ⊂">⊂</button>
+      <span class="flag-label">Nawias „zawiera się w"</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊃" aria-label="Skopiuj ⊃">⊃</button>
+      <span class="flag-label">Nawias „zawiera"</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="୨୧" aria-label="Skopiuj ୨୧">୨୧</button>
+      <span class="flag-label">Fala coquette (kombinacja)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✿" aria-label="Skopiuj ✿">✿</button>
+      <span class="flag-label">Czarny kwiatek</span>
+    </div>
+      <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ʚ" aria-label="Skopiuj ʚ">ʚ</button>
+      <span class="flag-label">Lewe skrzydło serca</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ɞ" aria-label="Skopiuj ɞ">ɞ</button>
+      <span class="flag-label">Prawe skrzydło serca</span>
+    </div>
+</div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 4 -->
+<section class="mood-explainers" id="decorative-marks-kawaii">
+  <span class="article-section-label">Ozdobne znaczniki</span>
+  <h2>Ozdobne znaczniki</h2>
+  <p>Brokat, kropki i drobne akcenty, które dodają każdemu tekstowi kawaii pazura.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⋆" aria-label="Skopiuj ⋆">⋆</button>
+      <span class="flag-label">Operator gwiazdki sześcioramiennej</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊹" aria-label="Skopiuj ⊹">⊹</button>
+      <span class="flag-label">Krzyż ortogonalny</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✧" aria-label="Skopiuj ✧">✧</button>
+      <span class="flag-label">Biała gwiazda czteroramienna</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⩩" aria-label="Skopiuj ⩩">⩩</button>
+      <span class="flag-label">Podobne lub równe</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="๑" aria-label="Skopiuj ๑">๑</button>
+      <span class="flag-label">Tajski znak (kropka ๑)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⌒" aria-label="Skopiuj ⌒">⌒</button>
+      <span class="flag-label">Łuk</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❀" aria-label="Skopiuj ❀">❀</button>
+      <span class="flag-label">Biały kwiatek</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 5 -->
+<section class="mood-explainers" id="pastel-motifs">
+  <span class="article-section-label">Pastelowe motywy</span>
+  <h2>Pastelowe motywy</h2>
+  <p>Miękkie symbole kwiatów i nieba do budowania sennej estetyki kawaii.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✿" aria-label="Skopiuj ✿">✿</button>
+      <span class="flag-label">Czarny kwiatek</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❀" aria-label="Skopiuj ❀">❀</button>
+      <span class="flag-label">Biały kwiatek</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❁" aria-label="Skopiuj ❁">❁</button>
+      <span class="flag-label">Kwiatek ośmiopłatkowy</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☁" aria-label="Skopiuj ☁">☁</button>
+      <span class="flag-label">Chmurka</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☾" aria-label="Skopiuj ☾">☾</button>
+      <span class="flag-label">Księżyc</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛅" aria-label="Skopiuj ⛅">⛅</button>
+      <span class="flag-label">Słońce za chmurą</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✦" aria-label="Skopiuj ✦">✦</button>
+      <span class="flag-label">Czarna gwiazda czteroramienna</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⋆" aria-label="Skopiuj ⋆">⋆</button>
+      <span class="flag-label">Operator gwiazdki</span>
+    </div>
+      <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧸" aria-label="Skopiuj 🧸">🧸</button>
+      <span class="flag-label">Emotka misia</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐻" aria-label="Skopiuj 🐻">🐻</button>
+      <span class="flag-label">Emotka pyszczka misia</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐰" aria-label="Skopiuj 🐰">🐰</button>
+      <span class="flag-label">Emotka pyszczka królika</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🎀" aria-label="Skopiuj 🎀">🎀</button>
+      <span class="flag-label">Emotka kokardki</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌸" aria-label="Skopiuj 🌸">🌸</button>
+      <span class="flag-label">Kwiat wiśni</span>
+    </div>
+</div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- COLLECTIONS -->
+<section class="mood-explainers" id="kawaii-collections">
+  <span class="article-section-label">Kolekcje kawaii</span>
+  <h2>Zestawy kawaii do bio i nicku</h2>
+  <p class="u-secondary-block">Gotowe kombinacje kawaii — miękkie serca, małe buźki i pastelowy brokat, które jednym kliknięciem wkleisz prosto do bio, nicku lub wiadomości.</p>
+  <div id="kawaiiCollectionsContainer"></div>
+</section>
+
+<div class="section-divider"></div>
+
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Zmień tekst za pomocą czcionek Unicode</h3>
+  <p>Użyj UltraTextGen, aby zamienić zwykły tekst na pogrubienie, kursywę, kaligrafię i ponad 100 innych stylów czcionek Unicode — za darmo i od razu.</p>
+  <a href="/pl/" class="cta-btn">Otwórz UltraTextGen →</a>
+</div>
+
+
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Powiązane strony</span>
+  <div class="compare-grid">
+    <a href="/pl/library/symbole-coquette/" class="compare-card variant-muted u-no-underline">
+      <h4>Symbole coquette</h4>
+      <p>Kokardki, wstążki i miękkie, dziewczęce znaki do bio coquette.</p>
+    </a>
+    <a href="/pl/library/symbole-cottagecore/" class="compare-card variant-muted u-no-underline">
+      <h4>Symbole cottagecore</h4>
+      <p>Kwiaty, listki i sielskie znaki w klimacie cottagecore.</p>
+    </a>
+    <a href="/pl/library/kaomoji/" class="compare-card variant-muted u-no-underline">
+      <h4>Kaomoji</h4>
+      <p>Japońskie emotikony i buźki tekstowe do wiadomości.</p>
+    </a>
+    <a href="/pl/library/symbole-serca/" class="compare-card variant-muted u-no-underline">
+      <h4>Symbole serca</h4>
+      <p>Każda emotka serca i znak serca w Unicode.</p>
+    </a>
+    <a href="/pl/library/symbole-gwiazdek/" class="compare-card variant-muted u-no-underline">
+      <h4>Symbole gwiazdek</h4>
+      <p>Gwiazdki i znaki brokatu w różnych stylach.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    { name: "Miękka kombinacja z sercem do bio", flags: ["꒰","♡","꒱","⋆","ෆ"], defaultFormat: "inline" },
+    { name: "Kawaii separator z brokatu", flags: ["⊹","⋆","✧","⋆","⊹"], defaultFormat: "inline" },
+    { name: "Nick z uskrzydlonym kwiatkiem", flags: ["ʚ ✿ ɞ"], defaultFormat: "inline" },
+    { name: "Pastelowa ramka z pyłku", flags: ["✦","⋆","❀","⋆","✦"], defaultFormat: "inline" },
+    { name: "Bio z małą buźką", flags: ["(˶˃ ᵕ ˂˶)","♡"], defaultFormat: "inline" },
+    { name: "Kombinacja słodkich nawiasów", flags: ["꒰ ♡ ꒱"], defaultFormat: "inline" }
+  ];
+
+  ns.buildGrids("kawaiiCollectionsContainer", GROUPS);
+  ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/pl/library/symbole-therian/index.html
+++ b/pl/library/symbole-therian/index.html
@@ -1,0 +1,360 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Symbole therian: kopiuj i wklej Δ theta-delta i znaki alterhuman</title>
+<meta name="description" content="Przeglądaj znaki theta-delta (θΔ), ślady łap, fazy księżyca i symbole zwierząt używane przez społeczność therian i alterhuman. Kliknij dowolny symbol, aby go od razu skopiować.">
+
+<link rel="canonical" href="https://ultratextgen.com/pl/library/symbole-therian/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/therian-symbols/">
+  <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-therian/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/therian-symbols/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/pl-library-symbole-therian.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Symbole therian: kopiuj i wklej Δ theta-delta i znaki alterhuman">
+<meta name="twitter:description" content="Przeglądaj znaki theta-delta (θΔ), ślady łap, fazy księżyca i symbole zwierząt używane przez społeczność therian i alterhuman. Kliknij dowolny symbol, aby go od razu skopiować.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/pl-library-symbole-therian.png">
+<meta property="og:title" content="Symbole therian: kopiuj i wklej Δ theta-delta i znaki alterhuman">
+<meta property="og:description" content="Przeglądaj znaki theta-delta (θΔ), ślady łap, fazy księżyca i symbole zwierząt używane przez społeczność therian i alterhuman. Kliknij dowolny symbol, aby go od razu skopiować.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/pl/library/symbole-therian/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Symbole therian: kopiuj i wklej Δ theta-delta i znaki alterhuman",
+  "alternateName": ["Therian kopiuj wklej", "Symbol theta delta kopiuj wklej", "Symbole alterhuman", "Symbole społeczności therian", "Znaki therian", "Symbole śladów łap kopiuj wklej", "Emotki therian kopiuj wklej"],
+  "description": "Przeglądaj znaki theta-delta (θΔ), ślady łap, fazy księżyca i symbole zwierząt używane przez społeczność therian i alterhuman. Kliknij dowolny symbol, aby go od razu skopiować.",
+  "inLanguage": "pl",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/pl-library-symbole-therian.png",
+  "mainEntityOfPage": "https://ultratextgen.com/pl/library/symbole-therian/",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Strona główna",
+      "item": "https://ultratextgen.com/pl/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Symbole therian",
+      "item": "https://ultratextgen.com/pl/library/symbole-therian/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/pl/">Strona główna</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Symbole therian</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Symbole therian</h1>
+    <p class="hero-tagline">Wspólnotowy znak theta-delta (θΔ) oraz symbole łap, księżyca i zwierząt tożsamości therian i alterhuman. Dotknij dowolnego symbolu, aby go od razu skopiować.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pl-library-symbole-therian.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Symbol therian, którego szuka najwięcej osób, to theta-delta — greckie litery theta (θ) i delta (Δ) połączone razem — przyjęty przez społeczność therianthropii w 2003 roku jako wspólny, pełen szacunku znak tożsamości. Therianie to osoby, które doświadczają głębokiej, niefizycznej identyfikacji ze zwierzęciem, a szersza społeczność alterhuman używa pokrewnych znaków obok śladów łap, faz księżyca i emotek zwierząt. Ta strona zbiera theta-delta w jej najczęstszych formach Unicode wraz z symbolami natury i zwierząt używanymi w bio na TikToku, na blogach Tumblr i w profilach na Discordzie.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="theta-delta">
+  <span class="article-section-label">Theta-delta</span>
+  <h2>Wspólnotowe znaki theta-delta</h2>
+  <p class="u-secondary-tight">Znak theta-delta zbudowany z prawdziwych greckich liter — skopiuj połączoną parę albo każdą literę osobno.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="θΔ" aria-label="Skopiuj theta-delta (znak therian)">θΔ</button>
+      <span class="flag-label">Theta-delta (znak therian)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ΘΔ" aria-label="Skopiuj wielka theta-delta">ΘΔ</button>
+      <span class="flag-label">Wielka theta-delta</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="θ" aria-label="Skopiuj mała grecka litera theta">θ</button>
+      <span class="flag-label">Mała grecka litera theta</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="Θ" aria-label="Skopiuj wielka grecka litera theta">Θ</button>
+      <span class="flag-label">Wielka grecka litera theta</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="Δ" aria-label="Skopiuj wielka grecka litera delta">Δ</button>
+      <span class="flag-label">Wielka grecka litera delta</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="δ" aria-label="Skopiuj mała grecka litera delta">δ</button>
+      <span class="flag-label">Mała grecka litera delta</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ϴ" aria-label="Skopiuj symbol wielkiej greckiej theta">ϴ</button>
+      <span class="flag-label">Symbol wielkiej greckiej theta</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ϑ" aria-label="Skopiuj symbol greckiej theta">ϑ</button>
+      <span class="flag-label">Symbol greckiej theta</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="paw-prints">
+  <span class="article-section-label">Łapy i psowate</span>
+  <h2>Ślady łap i symbole psowatych</h2>
+  <p class="u-secondary-tight">Ślady łap oraz emotki wilka, lisa i psa, które najczęściej pojawiają się w bio therian.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐾" aria-label="Skopiuj ślady łap">🐾</button>
+      <span class="flag-label">Ślady łap</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐺" aria-label="Skopiuj wilk">🐺</button>
+      <span class="flag-label">Wilk</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦊" aria-label="Skopiuj lis">🦊</button>
+      <span class="flag-label">Lis</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐕" aria-label="Skopiuj pies">🐕</button>
+      <span class="flag-label">Pies</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐈‍⬛" aria-label="Skopiuj czarny kot">🐈‍⬛</button>
+      <span class="flag-label">Czarny kot</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦝" aria-label="Skopiuj szop">🦝</button>
+      <span class="flag-label">Szop</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐅" aria-label="Skopiuj tygrys">🐅</button>
+      <span class="flag-label">Tygrys</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦴" aria-label="Skopiuj kość">🦴</button>
+      <span class="flag-label">Kość</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="wild-animals">
+  <span class="article-section-label">Dzikie zwierzęta</span>
+  <h2>Symbole dzikich zwierząt i teriotypów</h2>
+  <p class="u-secondary-tight">Emotki popularnych teriotypów — od jeleni i wielkich kotów po ptaki drapieżne.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦌" aria-label="Skopiuj jeleń">🦌</button>
+      <span class="flag-label">Jeleń</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐆" aria-label="Skopiuj lampart">🐆</button>
+      <span class="flag-label">Lampart</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦅" aria-label="Skopiuj orzeł">🦅</button>
+      <span class="flag-label">Orzeł</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦉" aria-label="Skopiuj sowa">🦉</button>
+      <span class="flag-label">Sowa</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐦‍⬛" aria-label="Skopiuj czarny ptak">🐦‍⬛</button>
+      <span class="flag-label">Czarny ptak</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐍" aria-label="Skopiuj wąż">🐍</button>
+      <span class="flag-label">Wąż</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦈" aria-label="Skopiuj rekin">🦈</button>
+      <span class="flag-label">Rekin</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐉" aria-label="Skopiuj smok">🐉</button>
+      <span class="flag-label">Smok</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="moon-night">
+  <span class="article-section-label">Księżyc i noc</span>
+  <h2>Symbole księżyca i nocy</h2>
+  <p class="u-secondary-tight">Fazy księżyca i znaki półksiężyca — od dawna obecny motyw w przestrzeniach therian i alterhuman.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌙" aria-label="Skopiuj półksiężyc">🌙</button>
+      <span class="flag-label">Półksiężyc</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☾" aria-label="Skopiuj ostatnia kwadra (tekst)">☾</button>
+      <span class="flag-label">Ostatnia kwadra (tekst)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☽" aria-label="Skopiuj pierwsza kwadra (tekst)">☽</button>
+      <span class="flag-label">Pierwsza kwadra (tekst)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌕" aria-label="Skopiuj pełnia">🌕</button>
+      <span class="flag-label">Pełnia</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌑" aria-label="Skopiuj nów">🌑</button>
+      <span class="flag-label">Nów</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌒" aria-label="Skopiuj przybywający półksiężyc">🌒</button>
+      <span class="flag-label">Przybywający półksiężyc</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="forest-nature">
+  <span class="article-section-label">Las i natura</span>
+  <h2>Symbole lasu i natury</h2>
+  <p class="u-secondary-tight">Znaki leśne i dzikiej przyrody, które dopełnią opis filmu z quadrobiki albo profil.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌲" aria-label="Skopiuj drzewo iglaste">🌲</button>
+      <span class="flag-label">Drzewo iglaste</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌿" aria-label="Skopiuj zioło">🌿</button>
+      <span class="flag-label">Zioło</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🍂" aria-label="Skopiuj opadły liść">🍂</button>
+      <span class="flag-label">Opadły liść</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛰" aria-label="Skopiuj góra">⛰</button>
+      <span class="flag-label">Góra</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🪶" aria-label="Skopiuj pióro">🪶</button>
+      <span class="flag-label">Pióro</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌾" aria-label="Skopiuj snop ryżu">🌾</button>
+      <span class="flag-label">Snop ryżu</span>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Zmień tekst za pomocą czcionek Unicode</h3>
+  <p>Użyj UltraTextGen, aby zamienić zwykły tekst na pogrubienie, kursywę, kaligrafię i ponad 100 innych stylów czcionek Unicode — za darmo i od razu.</p>
+  <a href="/pl/" class="cta-btn">Otwórz UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Powiązane strony</span>
+  <div class="compare-grid">
+    <a href="/pl/library/symbole-gwiazdek/" class="compare-card variant-muted u-no-underline">
+      <h4>Symbole gwiazdek</h4>
+      <p>Gwiazdki i znaki niebiańskie do kopiowania i wklejania.</p>
+    </a>
+    <a href="/pl/library/symbole-goth-grunge/" class="compare-card variant-muted u-no-underline">
+      <h4>Symbole goth i grunge</h4>
+      <p>Mroczne, gotyckie znaki do bio, nicków i opisów.</p>
+    </a>
+    <a href="/pl/library/symbole-fairycore/" class="compare-card variant-muted u-no-underline">
+      <h4>Symbole fairycore</h4>
+      <p>Leśne, baśniowe znaki natury do estetycznego bio.</p>
+    </a>
+    <a href="/pl/library/symbole-y2k/" class="compare-card variant-muted u-no-underline">
+      <h4>Symbole Y2K</h4>
+      <p>Estetyczne znaki cyber w stylu początku lat 2000.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/pl/library/symbole-witchy-occult/index.html
+++ b/pl/library/symbole-witchy-occult/index.html
@@ -1,0 +1,762 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Symbole witchy i okultystyczne: kopiuj i wklej znaki okultystyczne</title>
+<meta name="description" content="Przeglądaj i kopiuj symbole witchy i okultystyczne — pentagramy, fazy księżyca, znaki planet, symbole alchemiczne i inne znaki ezoteryczne. Kliknij dowolny, aby skopiować.">
+
+<link rel="canonical" href="https://ultratextgen.com/pl/library/symbole-witchy-occult/">
+  <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-witchy-occult/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/pl/library/symbole-witchy-occult/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/pl-library-symbole-witchy-occult.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Symbole witchy i okultystyczne: kopiuj i wklej znaki okultystyczne">
+<meta name="twitter:description" content="Przeglądaj i kopiuj symbole witchy i okultystyczne — pentagramy, fazy księżyca, znaki planet, symbole alchemiczne i inne znaki ezoteryczne. Kliknij dowolny, aby skopiować.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/pl-library-symbole-witchy-occult.png">
+<meta property="og:title" content="Symbole witchy i okultystyczne: kopiuj i wklej znaki okultystyczne">
+<meta property="og:description" content="Przeglądaj i kopiuj symbole witchy i okultystyczne — pentagramy, fazy księżyca, znaki planet, symbole alchemiczne i inne znaki ezoteryczne. Kliknij dowolny, aby skopiować.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/pl/library/symbole-witchy-occult/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Symbole witchy i okultystyczne: kopiuj i wklej znaki okultystyczne",
+  "alternateName": ["Symbole okultystyczne kopiuj wklej", "Symbole witchy kopiuj wklej", "Znaki wiedźmy Unicode", "Symbole magiczne kopiuj wklej", "Symbole ezoteryczne kopiuj wklej", "Symbol pentagramu kopiuj wklej", "Emotki witchy kopiuj wklej"],
+  "description": "Przeglądaj i kopiuj symbole witchy i okultystyczne — pentagramy, fazy księżyca, znaki planet, symbole alchemiczne i inne znaki ezoteryczne. Kliknij dowolny, aby skopiować.",
+  "inLanguage": "pl",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/pl-library-symbole-witchy-occult.png",
+  "mainEntityOfPage": "https://ultratextgen.com/pl/library/symbole-witchy-occult/",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Strona główna",
+      "item": "https://ultratextgen.com/pl/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Symbole witchy i okultystyczne",
+      "item": "https://ultratextgen.com/pl/library/symbole-witchy-occult/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/pl/">Strona główna</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Symbole witchy i okultystyczne</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Symbole witchy i okultystyczne</h1>
+    <p class="hero-tagline">Wyselekcjonowana kolekcja pentagramów, faz księżyca, znaków planet, symboli alchemicznych i innych ezoterycznych znaków Unicode. Kliknij dowolny symbol, aby od razu go skopiować.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pl-library-symbole-witchy-occult.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Ta biblioteka zbiera znaki Unicode kojarzone z czarami, okultyzmem, alchemią i tradycjami ezoterycznymi. Wszystkie to standardowe znaki Unicode — możesz ich używać w tekstach, bio i twórczości. Sekcja symboli alchemicznych obejmuje dedykowany blok Unicode Alchemical Symbols (U+1F700–U+1F73F).</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="pentagrams-stars">
+  <span class="article-section-label">Pentagramy i gwiazdy</span>
+  <h2>Pentagramy i gwiazdy pięcioramienne</h2>
+  <p>Kształty gwiazd i pentagramów kojarzone z tradycjami ezoterycznymi i okultystycznymi.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="★" aria-label="Skopiuj Czarna gwiazda">★</button>
+      <span class="flag-label">Czarna gwiazda</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☆" aria-label="Skopiuj Biała gwiazda">☆</button>
+      <span class="flag-label">Biała gwiazda</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚹" aria-label="Skopiuj Sekstyl">⚹</button>
+      <span class="flag-label">Sekstyl</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✡" aria-label="Skopiuj Gwiazda Dawida">✡</button>
+      <span class="flag-label">Gwiazda Dawida</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚜" aria-label="Skopiuj Lilijka heraldyczna">⚜</button>
+      <span class="flag-label">Lilijka heraldyczna (fleur-de-lis)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛤" aria-label="Skopiuj Pentagram">⛤</button>
+      <span class="flag-label">Pentagram</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛥" aria-label="Skopiuj Pentagram skierowany w prawo">⛥</button>
+      <span class="flag-label">Pentagram skierowany w prawo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛦" aria-label="Skopiuj Pentagram skierowany w lewo">⛦</button>
+      <span class="flag-label">Pentagram skierowany w lewo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛧" aria-label="Skopiuj Odwrócony pentagram">⛧</button>
+      <span class="flag-label">Odwrócony pentagram</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✴" aria-label="Skopiuj Gwiazda ośmioramienna">✴</button>
+      <span class="flag-label">Gwiazda ośmioramienna</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✪" aria-label="Skopiuj Biała gwiazda w kółku">✪</button>
+      <span class="flag-label">Biała gwiazda w kółku</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✶" aria-label="Skopiuj Gwiazda sześcioramienna">✶</button>
+      <span class="flag-label">Gwiazda sześcioramienna</span>
+    </div>
+      <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✦" aria-label="Skopiuj ✦">✦</button>
+      <span class="flag-label">Gwiazda-brokat</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="◯" aria-label="Skopiuj ◯">◯</button>
+      <span class="flag-label">Duże kółko</span>
+    </div>
+</div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- Anchor preserved for inbound links/bookmarks; canonical content lives on /library/moon-celestial-symbols/#celestial-collections -->
+<section class="mood-explainers" id="moon-phases">
+  <span class="article-section-label">Fazy księżyca</span>
+  <h2>Symbole faz księżyca</h2>
+  <p>Szukasz pełnego cyklu księżycowego? Fazy księżyca i znaki niebieskie znajdziesz w wyselekcjonowanej kolekcji symboli gwiazd i motywów astralnych.</p>
+  <div class="compare-grid" style="margin-top:1rem;">
+    <a href="/pl/library/symbole-gwiazdek/" class="compare-card variant-muted u-no-underline">
+      <h4>Zobacz: symbole gwiazd i znaki astralne →</h4>
+      <p>Osiem faz księżyca w Unicode (🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘) oraz warianty sierpa i ciemnego/jasnego księżyca, gotowe do skopiowania jako sekwencja.</p>
+    </a>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- CLASSICAL 7 PLANETS (featured sub-group) -->
+<section class="mood-explainers" id="classical-7-planets">
+  <span class="article-section-label">Klasyczne 7 planet</span>
+  <h2>Klasyczne siedem planet (Słońce → Saturn)</h2>
+  <p class="u-secondary-tight">Siedem planet tradycyjnej astrologii w porządku chaldejskim — widoczne na niebie ciała znane starożytnym astronomom.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☉" aria-label="Skopiuj Słońce">☉</button>
+      <span class="flag-label">Słońce</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☽" aria-label="Skopiuj Księżyc">☽</button>
+      <span class="flag-label">Księżyc</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☿" aria-label="Skopiuj Merkury">☿</button>
+      <span class="flag-label">Merkury</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♀" aria-label="Skopiuj Wenus">♀</button>
+      <span class="flag-label">Wenus</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♂" aria-label="Skopiuj Mars">♂</button>
+      <span class="flag-label">Mars</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♃" aria-label="Skopiuj Jowisz">♃</button>
+      <span class="flag-label">Jowisz</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♄" aria-label="Skopiuj Saturn">♄</button>
+      <span class="flag-label">Saturn</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="planetary-zodiac">
+  <span class="article-section-label">Planetarne i zodiakalne</span>
+  <h2>Symbole planet i astrologiczne</h2>
+  <p>Klasyczne symbole planet i glify astrologiczne o skojarzeniach okultystycznych.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☉" aria-label="Skopiuj Słońce">☉</button>
+      <span class="flag-label">Słońce</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☽" aria-label="Skopiuj Księżyc">☽</button>
+      <span class="flag-label">Księżyc</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☿" aria-label="Skopiuj Merkury">☿</button>
+      <span class="flag-label">Merkury</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♀" aria-label="Skopiuj Wenus">♀</button>
+      <span class="flag-label">Wenus</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♁" aria-label="Skopiuj Ziemia">♁</button>
+      <span class="flag-label">Ziemia</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♂" aria-label="Skopiuj Mars">♂</button>
+      <span class="flag-label">Mars</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♃" aria-label="Skopiuj Jowisz">♃</button>
+      <span class="flag-label">Jowisz</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♄" aria-label="Skopiuj Saturn">♄</button>
+      <span class="flag-label">Saturn</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♅" aria-label="Skopiuj Uran">♅</button>
+      <span class="flag-label">Uran</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♆" aria-label="Skopiuj Neptun">♆</button>
+      <span class="flag-label">Neptun</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♇" aria-label="Skopiuj Pluton">♇</button>
+      <span class="flag-label">Pluton</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚸" aria-label="Skopiuj Czarny Księżyc Lilith">⚸</button>
+      <span class="flag-label">Czarny Księżyc Lilith</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚳" aria-label="Skopiuj Ceres">⚳</button>
+      <span class="flag-label">Ceres</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚴" aria-label="Skopiuj Pallas">⚴</button>
+      <span class="flag-label">Pallas</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚵" aria-label="Skopiuj Juno">⚵</button>
+      <span class="flag-label">Juno</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚶" aria-label="Skopiuj Westa">⚶</button>
+      <span class="flag-label">Westa</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="alchemical">
+  <span class="article-section-label">Alchemiczne</span>
+  <h2>Symbole alchemiczne (U+1F700–U+1F73F)</h2>
+  <p>Blok Unicode Alchemical Symbols zawierający znaki żywiołów, procesów i substancji używanych w historycznej alchemii.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜀" aria-label="Skopiuj Kwintesencja">🜀</button>
+      <span class="flag-label">Kwintesencja</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜁" aria-label="Skopiuj Powietrze">🜁</button>
+      <span class="flag-label">Powietrze</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜂" aria-label="Skopiuj Ogień">🜂</button>
+      <span class="flag-label">Ogień</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜃" aria-label="Skopiuj Ziemia">🜃</button>
+      <span class="flag-label">Ziemia</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜄" aria-label="Skopiuj Woda">🜄</button>
+      <span class="flag-label">Woda</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜅" aria-label="Skopiuj Aquafortis">🜅</button>
+      <span class="flag-label">Aquafortis (kwas azotowy)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜆" aria-label="Skopiuj Woda królewska">🜆</button>
+      <span class="flag-label">Woda królewska</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜇" aria-label="Skopiuj Woda królewska II">🜇</button>
+      <span class="flag-label">Woda królewska II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜈" aria-label="Skopiuj Woda życia">🜈</button>
+      <span class="flag-label">Woda życia (aqua vitae)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜉" aria-label="Skopiuj Woda życia II">🜉</button>
+      <span class="flag-label">Woda życia II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜊" aria-label="Skopiuj Ocet">🜊</button>
+      <span class="flag-label">Ocet</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜋" aria-label="Skopiuj Ocet II">🜋</button>
+      <span class="flag-label">Ocet II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜌" aria-label="Skopiuj Ocet III">🜌</button>
+      <span class="flag-label">Ocet III</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜍" aria-label="Skopiuj Siarka">🜍</button>
+      <span class="flag-label">Siarka</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜎" aria-label="Skopiuj Siarka II">🜎</button>
+      <span class="flag-label">Siarka II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜏" aria-label="Skopiuj Siarka III">🜏</button>
+      <span class="flag-label">Siarka III</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜐" aria-label="Skopiuj Sól">🜐</button>
+      <span class="flag-label">Sól</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜑" aria-label="Skopiuj Sól II">🜑</button>
+      <span class="flag-label">Sól II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜒" aria-label="Skopiuj Sól III">🜒</button>
+      <span class="flag-label">Sól III</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜓" aria-label="Skopiuj Sublimat rtęci">🜓</button>
+      <span class="flag-label">Sublimat rtęci</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜔" aria-label="Skopiuj Sublimat rtęci II">🜔</button>
+      <span class="flag-label">Sublimat rtęci II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜕" aria-label="Skopiuj Sublimat rtęci III">🜕</button>
+      <span class="flag-label">Sublimat rtęci III</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜖" aria-label="Skopiuj Cynober">🜖</button>
+      <span class="flag-label">Cynober</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜗" aria-label="Skopiuj Salmiak">🜗</button>
+      <span class="flag-label">Salmiak</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜘" aria-label="Skopiuj Witriol">🜘</button>
+      <span class="flag-label">Witriol</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜙" aria-label="Skopiuj Witriol II">🜙</button>
+      <span class="flag-label">Witriol II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜚" aria-label="Skopiuj Złoto">🜚</button>
+      <span class="flag-label">Złoto</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜛" aria-label="Skopiuj Srebro">🜛</button>
+      <span class="flag-label">Srebro</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜜" aria-label="Skopiuj Ruda żelaza">🜜</button>
+      <span class="flag-label">Ruda żelaza</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜝" aria-label="Skopiuj Ruda żelaza II">🜝</button>
+      <span class="flag-label">Ruda żelaza II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜞" aria-label="Skopiuj Szafran żelaza">🜞</button>
+      <span class="flag-label">Szafran żelaza</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜟" aria-label="Skopiuj Regulus żelaza">🜟</button>
+      <span class="flag-label">Regulus żelaza</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜠" aria-label="Skopiuj Ruda miedzi">🜠</button>
+      <span class="flag-label">Ruda miedzi</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜡" aria-label="Skopiuj Ruda żelazowo-miedziowa">🜡</button>
+      <span class="flag-label">Ruda żelazowo-miedziowa</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜢" aria-label="Skopiuj Sublimat miedzi">🜢</button>
+      <span class="flag-label">Sublimat miedzi</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜣" aria-label="Skopiuj Szafran miedzi">🜣</button>
+      <span class="flag-label">Szafran miedzi</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜤" aria-label="Skopiuj Antymonian miedzi">🜤</button>
+      <span class="flag-label">Antymonian miedzi</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜥" aria-label="Skopiuj Sól antymonianu miedzi">🜥</button>
+      <span class="flag-label">Sól antymonianu miedzi</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜦" aria-label="Skopiuj Sublimat soli miedzi">🜦</button>
+      <span class="flag-label">Sublimat soli miedzi</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜧" aria-label="Skopiuj Grynszpan">🜧</button>
+      <span class="flag-label">Grynszpan</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜨" aria-label="Skopiuj Ruda cyny">🜨</button>
+      <span class="flag-label">Ruda cyny</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜩" aria-label="Skopiuj Ruda ołowiu">🜩</button>
+      <span class="flag-label">Ruda ołowiu</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜪" aria-label="Skopiuj Ziemia rudy ołowiu">🜪</button>
+      <span class="flag-label">Ziemia rudy ołowiu</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜫" aria-label="Skopiuj Antymon">🜫</button>
+      <span class="flag-label">Antymon</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜬" aria-label="Skopiuj Antymon II">🜬</button>
+      <span class="flag-label">Antymon II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜭" aria-label="Skopiuj Sublimat antymonu">🜭</button>
+      <span class="flag-label">Sublimat antymonu</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜮" aria-label="Skopiuj Sól antymonu">🜮</button>
+      <span class="flag-label">Sól antymonu</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜯" aria-label="Skopiuj Sublimat soli antymonu">🜯</button>
+      <span class="flag-label">Sublimat soli antymonu</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜰" aria-label="Skopiuj Ocet antymonu">🜰</button>
+      <span class="flag-label">Ocet antymonu</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜱" aria-label="Skopiuj Regulus antymonu">🜱</button>
+      <span class="flag-label">Regulus antymonu</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜲" aria-label="Skopiuj Regulus antymonu II">🜲</button>
+      <span class="flag-label">Regulus antymonu II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜳" aria-label="Skopiuj Regulus">🜳</button>
+      <span class="flag-label">Regulus</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜴" aria-label="Skopiuj Regulus II">🜴</button>
+      <span class="flag-label">Regulus II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜵" aria-label="Skopiuj Regulus III">🜵</button>
+      <span class="flag-label">Regulus III</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜶" aria-label="Skopiuj Regulus IV">🜶</button>
+      <span class="flag-label">Regulus IV</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜷" aria-label="Skopiuj Alkalia">🜷</button>
+      <span class="flag-label">Alkalia</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜸" aria-label="Skopiuj Alkalia II">🜸</button>
+      <span class="flag-label">Alkalia II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜹" aria-label="Skopiuj Markasyt">🜹</button>
+      <span class="flag-label">Markasyt</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜺" aria-label="Skopiuj Salmiak (sal ammoniac)">🜺</button>
+      <span class="flag-label">Salmiak (sal ammoniac)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜻" aria-label="Skopiuj Arsen">🜻</button>
+      <span class="flag-label">Arsen</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜼" aria-label="Skopiuj Realgar">🜼</button>
+      <span class="flag-label">Realgar</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜽" aria-label="Skopiuj Realgar II">🜽</button>
+      <span class="flag-label">Realgar II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜾" aria-label="Skopiuj Aurypigment">🜾</button>
+      <span class="flag-label">Aurypigment</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜿" aria-label="Skopiuj Ruda bizmutu">🜿</button>
+      <span class="flag-label">Ruda bizmutu</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="esoteric">
+  <span class="article-section-label">Inne ezoteryczne</span>
+  <h2>Inne symbole ezoteryczne</h2>
+  <p>Dodatkowe symbole kojarzone z tradycjami magicznymi i ezoterycznymi.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☥" aria-label="Skopiuj Ankh">☥</button>
+      <span class="flag-label">Ankh</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☯" aria-label="Skopiuj Yin Yang">☯</button>
+      <span class="flag-label">Yin Yang</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☘" aria-label="Skopiuj Koniczyna">☘</button>
+      <span class="flag-label">Koniczyna</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚷" aria-label="Skopiuj Chiron">⚷</button>
+      <span class="flag-label">Chiron</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚰" aria-label="Skopiuj Trumna">⚰</button>
+      <span class="flag-label">Trumna</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚱" aria-label="Skopiuj Urna pogrzebowa">⚱</button>
+      <span class="flag-label">Urna pogrzebowa</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚗" aria-label="Skopiuj Alembik">⚗</button>
+      <span class="flag-label">Alembik</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❤" aria-label="Skopiuj Serce">❤</button>
+      <span class="flag-label">Serce</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚛" aria-label="Skopiuj Symbol atomu">⚛</button>
+      <span class="flag-label">Symbol atomu</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚡" aria-label="Skopiuj Błyskawica">⚡</button>
+      <span class="flag-label">Błyskawica</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♲" aria-label="Skopiuj Recykling">♲</button>
+      <span class="flag-label">Recykling</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☼" aria-label="Skopiuj Białe słońce z promieniami">☼</button>
+      <span class="flag-label">Białe słońce z promieniami</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☦" aria-label="Skopiuj Krzyż prawosławny">☦</button>
+      <span class="flag-label">Krzyż prawosławny</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☢" aria-label="Skopiuj Znak promieniowania">☢</button>
+      <span class="flag-label">Znak promieniowania</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☣" aria-label="Skopiuj Zagrożenie biologiczne">☣</button>
+      <span class="flag-label">Zagrożenie biologiczne</span>
+    </div>
+      <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🔮" aria-label="Skopiuj 🔮">🔮</button>
+      <span class="flag-label">Kryształowa kula</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧿" aria-label="Skopiuj 🧿">🧿</button>
+      <span class="flag-label">Amulet nazar</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🃏" aria-label="Skopiuj 🃏">🃏</button>
+      <span class="flag-label">Karta tarota</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕯️" aria-label="Skopiuj 🕯️">🕯️</button>
+      <span class="flag-label">Świeca</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐍" aria-label="Skopiuj 🐍">🐍</button>
+      <span class="flag-label">Wąż</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="∞" aria-label="Skopiuj ∞">∞</button>
+      <span class="flag-label">Nieskończoność</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⟳" aria-label="Skopiuj ⟳">⟳</button>
+      <span class="flag-label">Strzałka cykliczna</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="↻" aria-label="Skopiuj ↻">↻</button>
+      <span class="flag-label">Otwarta strzałka kolista</span>
+    </div>
+</div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- COLLECTIONS -->
+<section class="mood-explainers" id="witchy-collections">
+  <span class="article-section-label">Zestawy witchy</span>
+  <h2>Zestawy witchy do bio i ramek</h2>
+  <p class="u-secondary-block">Gotowe ciągi witchy, które wkleisz prosto do bio, opisu lub nicku — skopiuj cały zestaw jednym kliknięciem.</p>
+  <div id="witchyCollectionsContainer"></div>
+</section>
+
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Zmień tekst za pomocą czcionek Unicode</h3>
+  <p>Użyj UltraTextGen, aby zamienić zwykły tekst na pogrubienie, kursywę, kaligrafię i ponad 100 innych stylów czcionek Unicode — za darmo i od razu.</p>
+  <a href="/pl/" class="cta-btn">Otwórz UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Powiązane strony</span>
+  <div class="compare-grid">
+    <a href="/pl/library/symbole-goth-grunge/" class="compare-card variant-muted u-no-underline">
+      <h4>Symbole goth i grunge</h4>
+      <p>Mroczne krzyże, czaszki i ozdobniki w estetyce goth.</p>
+    </a>
+    <a href="/pl/library/symbole-cottagecore/" class="compare-card variant-muted u-no-underline">
+      <h4>Symbole cottagecore</h4>
+      <p>Grzyby, polne kwiaty i przytulne motywy wiejskiego życia.</p>
+    </a>
+    <a href="/pl/library/symbole-gwiazdek/" class="compare-card variant-muted u-no-underline">
+      <h4>Symbole gwiazd</h4>
+      <p>Gwiazdki i znaki brokatu w różnych stylach.</p>
+    </a>
+    <a href="/pl/library/symbole-serca/" class="compare-card variant-muted u-no-underline">
+      <h4>Symbole serca</h4>
+      <p>Serca w każdym stylu — do bio, nicków i opisów.</p>
+    </a>
+    <a href="/pl/czcionki-gotyckie/" class="compare-card variant-muted u-no-underline">
+      <h4>Czcionki gotyckie</h4>
+      <p>Zamień tekst na mroczne, gotyckie style Unicode.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    { name: "Ramka do bio z pentagramem", flags: ["⛧","˖","⛤","˖","⛧"], defaultFormat: "inline" },
+    { name: "Kombinacja księżyca i słońca", flags: ["☽","˚","✴","˚","☉"], defaultFormat: "inline" },
+    { name: "Wiedźmi szlak gwiazd", flags: ["✶","·","✴","·","✶"], defaultFormat: "inline" },
+    { name: "Ramka z sierpem księżyca", flags: ["☽⋆ﾟ｡⋆"], defaultFormat: "inline" },
+    { name: "Planetarna kombinacja do bio", flags: ["☽","☿","♀","♂","♃","♄"], defaultFormat: "inline" },
+    { name: "Separator zaklęcia z ankh", flags: ["☥","˖","⛤","˖","☥"], defaultFormat: "inline" }
+  ];
+
+  ns.buildGrids("witchyCollectionsContainer", GROUPS);
+  ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/pt/library/simbolos-dreamcore-weirdcore/index.html
+++ b/pt/library/simbolos-dreamcore-weirdcore/index.html
@@ -1,0 +1,420 @@
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Símbolos Dreamcore e Weirdcore 👁 Copiar e colar para estética surreal | UltraTextGen</title>
+<meta name="description" content="Símbolos dreamcore e weirdcore — olhos surreais 👁, arco-íris 🌈, blocos de glitch, portas e combos sleepcore para posts liminais. Toque em qualquer símbolo para copiar na hora.">
+
+<link rel="canonical" href="https://ultratextgen.com/pt/library/simbolos-dreamcore-weirdcore/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-dreamcore-weirdcore/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/pt/library/simbolos-dreamcore-weirdcore/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/pt-library-simbolos-dreamcore-weirdcore.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Símbolos Dreamcore e Weirdcore 👁 🌈 ⋆ Estética surreal para copiar e colar">
+<meta name="twitter:description" content="Símbolos dreamcore e weirdcore — olhos surreais 👁, arco-íris 🌈, blocos de glitch, portas e combos sleepcore para posts liminais. Toque em qualquer símbolo para copiar na hora.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/pt-library-simbolos-dreamcore-weirdcore.png">
+<meta property="og:title" content="Símbolos Dreamcore e Weirdcore 👁 🌈 ⋆ Estética surreal para copiar e colar">
+<meta property="og:description" content="Símbolos dreamcore e weirdcore — olhos surreais 👁, arco-íris 🌈, blocos de glitch, portas e combos sleepcore para posts liminais. Toque em qualquer símbolo para copiar na hora.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/pt/library/simbolos-dreamcore-weirdcore/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Símbolos Dreamcore e Weirdcore — estética surreal para copiar e colar",
+  "alternateName": ["Símbolos dreamcore copiar colar", "Símbolos weirdcore copiar colar", "Símbolos aesthetic dreamcore", "Símbolos aesthetic weirdcore", "Símbolos de estética surreal", "Símbolos de espaço liminal", "Símbolos de texto dreamcore", "Emojis dreamcore weirdcore"],
+  "description": "Símbolos dreamcore e weirdcore — olhos surreais 👁, arco-íris 🌈, blocos de glitch, portas e combos sleepcore para posts liminais. Toque em qualquer símbolo para copiar na hora.",
+  "inLanguage": "pt",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/pt-library-simbolos-dreamcore-weirdcore.png",
+  "mainEntityOfPage": "https://ultratextgen.com/pt/library/simbolos-dreamcore-weirdcore/",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Início",
+      "item": "https://ultratextgen.com/pt/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Símbolos Dreamcore e Weirdcore",
+      "item": "https://ultratextgen.com/pt/library/simbolos-dreamcore-weirdcore/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/pt/">Início</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Símbolos Dreamcore e Weirdcore</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Símbolos Dreamcore e Weirdcore</h1>
+    <p class="hero-tagline">Olhos surreais, portas infinitas, blocos de estática e céus sonolentos para a estética de espaços liminais. Toque em qualquer símbolo ou combo para copiar na hora.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pt-library-simbolos-dreamcore-weirdcore.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Dreamcore e weirdcore são estéticas irmãs da internet, construídas sobre a lógica surreal dos sonhos — céus nostálgicos, olhos que observam, portas para lugar nenhum e objetos familiares levemente estranhos. Esses símbolos dreamcore e weirdcore traduzem esse clima em texto copiável: 👁 olhos, 🌈 arco-íris, 📺 televisões antigas, blocos de sombra para a estática e um conjunto sleepcore para edições mais suaves e sonolentas. Use-os em status do Discord, capas do Tumblr, legendas do TikTok e descrições do YouTube, ou pegue um combo surreal inteiro abaixo.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="eyes-surreal">
+  <span class="article-section-label">Olhos que observam</span>
+  <h2>Símbolos de olhos que observam</h2>
+  <p class="u-secondary-tight">Os olhos que não piscam no coração das imagens weirdcore, de emojis a hieróglifos egípcios.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="👁" aria-label="Copiar Olho">👁</button>
+      <span class="flag-label">Olho</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="👁️" aria-label="Copiar Olho (estilo emoji)">👁️</button>
+      <span class="flag-label">Olho (estilo emoji)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="👀" aria-label="Copiar Olhos">👀</button>
+      <span class="flag-label">Olhos</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓂀" aria-label="Copiar Olho de Hórus (hieróglifo egípcio)">𓂀</button>
+      <span class="flag-label">Olho de Hórus (hieróglifo egípcio)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓁹" aria-label="Copiar Olho em hieróglifo egípcio">𓁹</button>
+      <span class="flag-label">Olho em hieróglifo egípcio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="◉" aria-label="Copiar Olho de peixe">◉</button>
+      <span class="flag-label">Olho de peixe</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊙" aria-label="Copiar Operador de ponto circulado">⊙</button>
+      <span class="flag-label">Operador de ponto circulado</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="👁️‍🗨️" aria-label="Copiar Olho em balão de fala">👁️‍🗨️</button>
+      <span class="flag-label">Olho em balão de fala</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="dream-sky">
+  <span class="article-section-label">Céu dos sonhos</span>
+  <h2>Símbolos de céu dreamcore</h2>
+  <p class="u-secondary-tight">Arco-íris, nuvens e céus rodopiantes — a metade luminosa e nostálgica da estética.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌈" aria-label="Copiar Arco-íris">🌈</button>
+      <span class="flag-label">Arco-íris</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☁️" aria-label="Copiar Nuvem">☁️</button>
+      <span class="flag-label">Nuvem</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌙" aria-label="Copiar Lua crescente">🌙</button>
+      <span class="flag-label">Lua crescente</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⭐" aria-label="Copiar Estrela">⭐</button>
+      <span class="flag-label">Estrela</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌀" aria-label="Copiar Ciclone">🌀</button>
+      <span class="flag-label">Ciclone</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🫧" aria-label="Copiar Bolhas">🫧</button>
+      <span class="flag-label">Bolhas</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌌" aria-label="Copiar Via Láctea">🌌</button>
+      <span class="flag-label">Via Láctea</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💫" aria-label="Copiar Tontura">💫</button>
+      <span class="flag-label">Tontura</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="weirdcore-objects">
+  <span class="article-section-label">Objetos weirdcore</span>
+  <h2>Símbolos de objetos weirdcore</h2>
+  <p class="u-secondary-tight">Portas, buracos, espelhos e TVs antigas — objetos familiares colocados onde não deveriam estar.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="📺" aria-label="Copiar Televisão">📺</button>
+      <span class="flag-label">Televisão</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🚪" aria-label="Copiar Porta">🚪</button>
+      <span class="flag-label">Porta</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕳" aria-label="Copiar Buraco">🕳</button>
+      <span class="flag-label">Buraco</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🪞" aria-label="Copiar Espelho">🪞</button>
+      <span class="flag-label">Espelho</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🛗" aria-label="Copiar Elevador">🛗</button>
+      <span class="flag-label">Elevador</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🎈" aria-label="Copiar Balão">🎈</button>
+      <span class="flag-label">Balão</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🩹" aria-label="Copiar Curativo">🩹</button>
+      <span class="flag-label">Curativo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧸" aria-label="Copiar Ursinho de pelúcia">🧸</button>
+      <span class="flag-label">Ursinho de pelúcia</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="sleepcore">
+  <span class="article-section-label">Sleepcore</span>
+  <h2>Símbolos sleepcore</h2>
+  <p class="u-secondary-tight">A subestética sonolenta — camas, céus noturnos e o puxão suave do sono.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💤" aria-label="Copiar Zzz">💤</button>
+      <span class="flag-label">Zzz</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🛏" aria-label="Copiar Cama">🛏</button>
+      <span class="flag-label">Cama</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="😴" aria-label="Copiar Rosto dormindo">😴</button>
+      <span class="flag-label">Rosto dormindo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌃" aria-label="Copiar Noite com estrelas">🌃</button>
+      <span class="flag-label">Noite com estrelas</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕰" aria-label="Copiar Relógio de lareira">🕰</button>
+      <span class="flag-label">Relógio de lareira</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🥱" aria-label="Copiar Rosto bocejando">🥱</button>
+      <span class="flag-label">Rosto bocejando</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="glitch-static">
+  <span class="article-section-label">Glitch e estática</span>
+  <h2>Caracteres de bloco de glitch e estática</h2>
+  <p class="u-secondary-tight">Caracteres Unicode de sombra e bloco que parecem estática de TV e pixels corrompidos.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="░" aria-label="Copiar Sombra clara">░</button>
+      <span class="flag-label">Sombra clara</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="▒" aria-label="Copiar Sombra média">▒</button>
+      <span class="flag-label">Sombra média</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="▓" aria-label="Copiar Sombra escura">▓</button>
+      <span class="flag-label">Sombra escura</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="█" aria-label="Copiar Bloco cheio">█</button>
+      <span class="flag-label">Bloco cheio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="▚" aria-label="Copiar Quadrante superior esquerdo e inferior direito">▚</button>
+      <span class="flag-label">Quadrante superior esquerdo e inferior direito</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⋆" aria-label="Copiar Operador de estrela">⋆</button>
+      <span class="flag-label">Operador de estrela</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="combo-sets">
+  <span class="article-section-label">Conjuntos de combos</span>
+  <h2>Conjuntos de combos dreamcore e weirdcore</h2>
+  <p class="u-secondary-block">Copie um combo surreal inteiro em um clique — olhos, céus, estática e sono, prontos para colar em qualquer lugar.</p>
+  <div id="dreamcoreSetsContainer"></div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Transforme texto com fontes Unicode</h3>
+  <p>Use o UltraTextGen para converter texto simples em negrito, itálico, cursiva e mais de 100 outros estilos de fonte Unicode — grátis e instantâneo.</p>
+  <a href="https://ultratextgen.com/pt/" class="cta-btn">Abrir UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Recursos relacionados</span>
+  <div class="compare-grid">
+    <a href="/pt/library/simbolos-fairycore/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos Fairycore</h4>
+      <p>Fadas, cogumelos e brilhos de pó mágico para bios encantadas.</p>
+    </a>
+    <a href="/pt/library/simbolos-y2k/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos Y2K</h4>
+      <p>Caracteres retrofuturistas dos anos 2000 e marcas da estética cyber.</p>
+    </a>
+    <a href="/pt/library/simbolos-cottagecore/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos Cottagecore</h4>
+      <p>Cogumelos, flores e caracteres aconchegantes de casa de campo.</p>
+    </a>
+    <a href="/pt/library/simbolos-coquette/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos Coquette</h4>
+      <p>Laços, corações e brilhos suaves para a estética coquette.</p>
+    </a>
+    <a href="/pt/library/simbolos/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos para copiar</h4>
+      <p>A coleção principal de símbolos de texto aesthetic e divisores.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    {
+      name: "Céu dreamcore",
+      flags: ["🌈", "☁️", "👁", "⭐", "🌀"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Corredor weirdcore",
+      flags: ["🚪", "📺", "🕳", "🪞", "👁"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Deriva sleepcore",
+      flags: ["💤", "🛏", "🌙", "☁️", "😴"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Olhos que tudo veem",
+      flags: ["👁", "𓂀", "◉", "👀", "⊙"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Barras de glitch estático",
+      flags: ["░▒▓█▓▒░", "▓▒░⋆░▒▓", "█▓▒░"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Sonho pastel",
+      flags: ["🫧", "🌈", "🪞", "💫", "☁️"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Noite liminal",
+      flags: ["🌃", "🛗", "🕰", "🌌", "🚪"],
+      defaultFormat: "inline"
+    }
+  ];
+
+  ns.buildGrids("dreamcoreSetsContainer", GROUPS);
+  if (ns.parseTwemoji) ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/pt/library/simbolos-fairycore/index.html
+++ b/pt/library/simbolos-fairycore/index.html
@@ -1,0 +1,386 @@
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Símbolos Fairycore ✨ Fadas, cogumelos e brilhos aesthetic para copiar e colar | UltraTextGen</title>
+<meta name="description" content="Símbolos e combos de emoji fairycore — fadas 🧚, cogumelos 🍄, brilhos ✨ e caracteres de flores delicadas para bios encantadas. Toque em qualquer símbolo para copiar na hora.">
+
+<link rel="canonical" href="https://ultratextgen.com/pt/library/simbolos-fairycore/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-fairycore/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/pt/library/simbolos-fairycore/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/pt-library-simbolos-fairycore.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Símbolos Fairycore ✨ Fadas, cogumelos e brilhos aesthetic para copiar e colar">
+<meta name="twitter:description" content="Símbolos e combos de emoji fairycore — fadas 🧚, cogumelos 🍄, brilhos ✨ e caracteres de flores delicadas para bios encantadas. Toque em qualquer símbolo para copiar na hora.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/pt-library-simbolos-fairycore.png">
+<meta property="og:title" content="Símbolos Fairycore ✨ Fadas, cogumelos e brilhos aesthetic para copiar e colar">
+<meta property="og:description" content="Símbolos e combos de emoji fairycore — fadas 🧚, cogumelos 🍄, brilhos ✨ e caracteres de flores delicadas para bios encantadas. Toque em qualquer símbolo para copiar na hora.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/pt/library/simbolos-fairycore/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Símbolos Fairycore — fadas, cogumelos e brilhos aesthetic para copiar e colar",
+  "alternateName": ["Símbolos fairycore copiar colar", "Símbolos fairy aesthetic", "Emoji fairycore", "Símbolos de fada copiar colar", "Símbolos de fada cottagecore", "Símbolos lúdicos copiar e colar"],
+  "description": "Símbolos e combos de emoji fairycore — fadas 🧚, cogumelos 🍄, brilhos ✨ e caracteres de flores delicadas para bios encantadas. Toque em qualquer símbolo para copiar na hora.",
+  "inLanguage": "pt",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/pt-library-simbolos-fairycore.png",
+  "mainEntityOfPage": "https://ultratextgen.com/pt/library/simbolos-fairycore/",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Início",
+      "item": "https://ultratextgen.com/pt/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Símbolos Fairycore",
+      "item": "https://ultratextgen.com/pt/library/simbolos-fairycore/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/pt/">Início</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Símbolos Fairycore</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Símbolos Fairycore</h1>
+    <p class="hero-tagline">Fadas, cogumelos, brilhos de poeira de fada e flores da floresta para uma estética encantada. Toque em qualquer símbolo ou combo para copiar na hora.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pt-library-simbolos-fairycore.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>O fairycore é uma estética lúdica construída em torno de fadas, florestas luminosas, anéis de cogumelos e um brilho dourado suave — pense em jardins encantados e poeira de fada. Esses símbolos e combos de emoji fairycore capturam essa magia com fadas 🧚, cogumelos 🍄, brilhos ✨ e caracteres de florete delicados como ✿ e ❀. Use-os em bios do Instagram, nomes de quadros no Pinterest, legendas do TikTok e seções sobre-mim do Discord, ou copie um combo pronto abaixo.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="fairies-magic">
+  <span class="article-section-label">Fadas e magia</span>
+  <h2>Emojis de fada e magia</h2>
+  <p class="u-secondary-tight">A família de emojis de fada mais varinhas e a magia dos brilhos.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧚" aria-label="Copiar 🧚">🧚</button>
+      <span class="flag-label">Fada</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧚‍♀️" aria-label="Copiar 🧚‍♀️">🧚‍♀️</button>
+      <span class="flag-label">Fada mulher</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧚‍♂️" aria-label="Copiar 🧚‍♂️">🧚‍♂️</button>
+      <span class="flag-label">Fada homem</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🪄" aria-label="Copiar 🪄">🪄</button>
+      <span class="flag-label">Varinha mágica</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✨" aria-label="Copiar ✨">✨</button>
+      <span class="flag-label">Brilhos</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💫" aria-label="Copiar 💫">💫</button>
+      <span class="flag-label">Estrela tonta</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🔮" aria-label="Copiar 🔮">🔮</button>
+      <span class="flag-label">Bola de cristal</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="mushrooms-flora">
+  <span class="article-section-label">Cogumelos e flora</span>
+  <h2>Cogumelos e flora da floresta</h2>
+  <p class="u-secondary-tight">Cogumelos, flores e os floretes Unicode que sustentam todo layout fairycore.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🍄" aria-label="Copiar 🍄">🍄</button>
+      <span class="flag-label">Cogumelo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌷" aria-label="Copiar 🌷">🌷</button>
+      <span class="flag-label">Tulipa</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌸" aria-label="Copiar 🌸">🌸</button>
+      <span class="flag-label">Flor de cerejeira</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌼" aria-label="Copiar 🌼">🌼</button>
+      <span class="flag-label">Florzinha</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✿" aria-label="Copiar ✿">✿</button>
+      <span class="flag-label">Florete preta</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❀" aria-label="Copiar ❀">❀</button>
+      <span class="flag-label">Florete branca</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌿" aria-label="Copiar 🌿">🌿</button>
+      <span class="flag-label">Erva</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🍃" aria-label="Copiar 🍃">🍃</button>
+      <span class="flag-label">Folha ao vento</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🪷" aria-label="Copiar 🪷">🪷</button>
+      <span class="flag-label">Lótus</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="pixie-sparkles">
+  <span class="article-section-label">Poeira de fada</span>
+  <h2>Poeira de fada e brilhos de estrela</h2>
+  <p class="u-secondary-tight">Pequenos caracteres de estrela e brilho para montar divisores delicados e enfeitar nomes de usuário.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⋆" aria-label="Copiar ⋆">⋆</button>
+      <span class="flag-label">Operador de estrela</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✦" aria-label="Copiar ✦">✦</button>
+      <span class="flag-label">Estrela preta de quatro pontas</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✧" aria-label="Copiar ✧">✧</button>
+      <span class="flag-label">Estrela branca de quatro pontas</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✩" aria-label="Copiar ✩">✩</button>
+      <span class="flag-label">Estrela de contorno realçado</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="˚" aria-label="Copiar ˚">˚</button>
+      <span class="flag-label">Anel acima</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="୨୧" aria-label="Copiar ୨୧">୨୧</button>
+      <span class="flag-label">Marca de laço aesthetic (dígitos odia)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌟" aria-label="Copiar 🌟">🌟</button>
+      <span class="flag-label">Estrela cintilante</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="garden-creatures">
+  <span class="article-section-label">Criaturas do jardim</span>
+  <h2>Criaturas do jardim encantado</h2>
+  <p class="u-secondary-tight">Borboletas, caracóis e visitantes gentis do jardim que completam a cena do jardim das fadas.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦋" aria-label="Copiar 🦋">🦋</button>
+      <span class="flag-label">Borboleta</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐌" aria-label="Copiar 🐌">🐌</button>
+      <span class="flag-label">Caracol</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐞" aria-label="Copiar 🐞">🐞</button>
+      <span class="flag-label">Joaninha</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐝" aria-label="Copiar 🐝">🐝</button>
+      <span class="flag-label">Abelha</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐇" aria-label="Copiar 🐇">🐇</button>
+      <span class="flag-label">Coelho</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦢" aria-label="Copiar 🦢">🦢</button>
+      <span class="flag-label">Cisne</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕊" aria-label="Copiar 🕊">🕊</button>
+      <span class="flag-label">Pomba</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="combo-sets">
+  <span class="article-section-label">Conjuntos de combo</span>
+  <h2>Conjuntos de combo fairycore</h2>
+  <p class="u-secondary-block">Copie um combo completo de emojis fairycore em um clique — pronto para bios, legendas e nomes de quadros.</p>
+  <div id="fairycoreSetsContainer"></div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Transforme texto com fontes Unicode</h3>
+  <p>Use o UltraTextGen para converter texto simples em negrito, itálico, cursiva e mais de 100 outros estilos de fonte Unicode — grátis e instantâneo.</p>
+  <a href="https://ultratextgen.com/pt/" class="cta-btn">Abrir UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Recursos relacionados</span>
+  <div class="compare-grid">
+    <a href="/pt/library/simbolos-cottagecore/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos cottagecore</h4>
+      <p>Cogumelos, abelhas e caracteres rústicos da vida no campo.</p>
+    </a>
+    <a href="/pt/library/simbolos-coquette/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos coquette</h4>
+      <p>Laços, fitas e caracteres de estética suave e feminina.</p>
+    </a>
+    <a href="/pt/library/simbolos-de-estrela/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos de estrela</h4>
+      <p>Estrelas e caracteres de brilho em vários estilos.</p>
+    </a>
+    <a href="/pt/library/simbolos-y2k/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos Y2K</h4>
+      <p>Estrelas, cruzes e caracteres cyber da estética dos anos 2000.</p>
+    </a>
+    <a href="/pt/library/kaomoji/" class="compare-card variant-muted u-no-underline">
+      <h4>Kaomoji</h4>
+      <p>Emoticons japoneses fofos feitos com caracteres.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    {
+      name: "Jardim das fadas",
+      flags: ["🧚", "🍄", "🌷", "✨", "🌿", "🦋"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Rastro de poeira de fada",
+      flags: ["✨", "⋆", "˚", "✧", "🪄", "💫"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Anel de cogumelos",
+      flags: ["🍄", "🌿", "🍄", "✨", "🍄", "🍃"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Prado de borboletas",
+      flags: ["🦋", "🌼", "🌸", "🐝", "🍃"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Fada ao luar",
+      flags: ["🌙", "✨", "🧚", "⋆", "☁️"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Divisor delicado de bio",
+      flags: ["⋆˚✿˖°", "୨୧", "⋆˚❀˖°"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Fada da casa de campo",
+      flags: ["🍄", "🐌", "🌷", "🧺", "🐇"],
+      defaultFormat: "inline"
+    }
+  ];
+
+  ns.buildGrids("fairycoreSetsContainer", GROUPS);
+  if (ns.parseTwemoji) ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/pt/library/simbolos-goth-grunge/index.html
+++ b/pt/library/simbolos-goth-grunge/index.html
@@ -1,0 +1,368 @@
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Símbolos goth e grunge para copiar e colar — decorações dark aesthetic para bio | UltraTextGen</title>
+<meta name="description" content="Símbolos dark aesthetic para bios goth e grunge. Cruzes, caveiras, aranhas, adagas e decorações de moda alt para nomes de usuário e perfis.">
+
+<link rel="canonical" href="https://ultratextgen.com/pt/library/simbolos-goth-grunge/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-goth-grunge/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/pt/library/simbolos-goth-grunge/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/pt-library-simbolos-goth-grunge.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Símbolos goth e grunge para copiar e colar — decorações dark aesthetic para bio">
+<meta name="twitter:description" content="Símbolos dark aesthetic para bios goth e grunge. Cruzes, caveiras, aranhas, adagas e decorações de moda alt para nomes de usuário e perfis.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/pt-library-simbolos-goth-grunge.png">
+<meta property="og:title" content="Símbolos goth e grunge para copiar e colar — decorações dark aesthetic para bio">
+<meta property="og:description" content="Símbolos dark aesthetic para bios goth e grunge. Cruzes, caveiras, aranhas, adagas e decorações de moda alt para nomes de usuário e perfis.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/pt/library/simbolos-goth-grunge/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Símbolos goth e grunge para copiar e colar — decorações dark aesthetic para bio",
+  "alternateName": ["Símbolos goth copiar colar", "Símbolos dark aesthetic", "Símbolos grunge copiar colar", "Símbolos dark para bio", "Símbolos góticos", "Símbolos emo copiar colar", "Símbolos de texto dark aesthetic", "Emojis goth copiar colar"],
+  "description": "Símbolos dark aesthetic para bios goth e grunge. Cruzes, caveiras, aranhas, adagas e decorações de moda alt para nomes de usuário e perfis.",
+  "inLanguage": "pt",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/pt-library-simbolos-goth-grunge.png",
+  "mainEntityOfPage": "https://ultratextgen.com/pt/library/simbolos-goth-grunge/",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Início",
+      "item": "https://ultratextgen.com/pt/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Símbolos goth e grunge",
+      "item": "https://ultratextgen.com/pt/library/simbolos-goth-grunge/"
+    }
+  ]
+}
+</script>
+
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/pt/">Início</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Símbolos goth e grunge</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Símbolos goth e grunge</h1>
+    <p class="hero-tagline">Símbolos dark aesthetic para bios goth e grunge — cruzes, caveiras, aranhas, adagas e decorações de moda alt. Toque em qualquer um para copiar na hora.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pt-library-simbolos-goth-grunge.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>As estéticas goth e grunge abraçam o escuro, a atitude e a subversão — rosas negras, cruzes góticas, aranhas, correntes e caveiras. Esses caracteres Unicode e emojis traduzem essa energia em decorações de bio e legendas. Funciona no Instagram, TikTok, Discord, Tumblr e em qualquer lugar que aceite Unicode.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 1 -->
+<section class="mood-explainers" id="crosses-daggers">
+  <span class="article-section-label">Cruzes e adagas</span>
+  <h2>Cruzes e adagas</h2>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♱" aria-label="Copiar ♱">♱</button>
+      <span class="flag-label">Cruz siríaca oriental</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="†" aria-label="Copiar †">†</button>
+      <span class="flag-label">Adaga</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‡" aria-label="Copiar ‡">‡</button>
+      <span class="flag-label">Adaga dupla</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✟" aria-label="Copiar ✟">✟</button>
+      <span class="flag-label">Cruz latina contornada</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🗡" aria-label="Copiar 🗡">🗡</button>
+      <span class="flag-label">Emoji de adaga</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚔" aria-label="Copiar ⚔">⚔</button>
+      <span class="flag-label">Espadas cruzadas</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🔪" aria-label="Copiar 🔪">🔪</button>
+      <span class="flag-label">Faca</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛧" aria-label="Copiar ⛧">⛧</button>
+      <span class="flag-label">Pentagrama invertido</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𖤐" aria-label="Copiar 𖤐">𖤐</button>
+      <span class="flag-label">Sol negro</span>
+    </div>
+      <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✝" aria-label="Copiar ✝">✝</button>
+      <span class="flag-label">Cruz latina</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☥" aria-label="Copiar ☥">☥</button>
+      <span class="flag-label">Ankh</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✠" aria-label="Copiar ✠">✠</button>
+      <span class="flag-label">Cruz de Malta</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☦" aria-label="Copiar ☦">☦</button>
+      <span class="flag-label">Cruz ortodoxa</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☽" aria-label="Copiar ☽">☽</button>
+      <span class="flag-label">Lua crescente</span>
+    </div>
+</div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 2 -->
+<section class="mood-explainers" id="skulls-death">
+  <span class="article-section-label">Caveiras e motivos de morte</span>
+  <h2>Caveiras e motivos de morte</h2>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☠" aria-label="Copiar ☠">☠</button>
+      <span class="flag-label">Caveira com ossos cruzados</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💀" aria-label="Copiar 💀">💀</button>
+      <span class="flag-label">Emoji de caveira</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🩸" aria-label="Copiar 🩸">🩸</button>
+      <span class="flag-label">Emoji de gota de sangue</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚰" aria-label="Copiar ⚰">⚰</button>
+      <span class="flag-label">Caixão</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🪦" aria-label="Copiar 🪦">🪦</button>
+      <span class="flag-label">Emoji de lápide</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚱" aria-label="Copiar ⚱">⚱</button>
+      <span class="flag-label">Urna funerária</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 3 -->
+<section class="mood-explainers" id="spiders-bats">
+  <span class="article-section-label">Aranhas, morcegos e criaturas</span>
+  <h2>Aranhas, morcegos e criaturas</h2>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕷" aria-label="Copiar 🕷">🕷</button>
+      <span class="flag-label">Emoji de aranha</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕸" aria-label="Copiar 🕸">🕸</button>
+      <span class="flag-label">Emoji de teia de aranha</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦇" aria-label="Copiar 🦇">🦇</button>
+      <span class="flag-label">Emoji de morcego</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐍" aria-label="Copiar 🐍">🐍</button>
+      <span class="flag-label">Emoji de cobra</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦂" aria-label="Copiar 🦂">🦂</button>
+      <span class="flag-label">Emoji de escorpião</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 4 -->
+<section class="mood-explainers" id="dark-florals">
+  <span class="article-section-label">Flores dark</span>
+  <h2>Flores dark</h2>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🥀" aria-label="Copiar 🥀">🥀</button>
+      <span class="flag-label">Emoji de flor murcha</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚘" aria-label="Copiar ⚘">⚘</button>
+      <span class="flag-label">Flor</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🖤" aria-label="Copiar 🖤">🖤</button>
+      <span class="flag-label">Emoji de coração preto</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❦" aria-label="Copiar ❦">❦</button>
+      <span class="flag-label">Coração floral</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❧" aria-label="Copiar ❧">❧</button>
+      <span class="flag-label">Coração floral girado</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓆩♱𓆪" aria-label="Copiar 𓆩♱𓆪">𓆩♱𓆪</button>
+      <span class="flag-label">Moldura de cruz egípcia</span>
+    </div>
+  </div>
+  <p>Muitos símbolos goth se cruzam com a estética Y2K — veja a biblioteca de <a href="/pt/library/simbolos-y2k/">Símbolos Y2K</a> para cruzes góticas, estrelas escuras e caracteres cyber.</p>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- COLLECTIONS -->
+<section class="mood-explainers" id="goth-grunge-collections">
+  <span class="article-section-label">Coleções goth e grunge</span>
+  <h2>Conjuntos de bio dark aesthetic</h2>
+  <p class="u-secondary-block">Strings dark aesthetic prontas para colar direto em uma bio, legenda ou nome de usuário — copie o combo inteiro em um clique.</p>
+  <div id="gothGrungeCollectionsContainer"></div>
+</section>
+
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Transforme texto com fontes Unicode</h3>
+  <p>Use o UltraTextGen para converter texto simples em negrito, itálico, cursiva e mais de 100 outros estilos de fonte Unicode — grátis e instantâneo.</p>
+  <a href="https://ultratextgen.com/pt/" class="cta-btn">Abrir UltraTextGen →</a>
+</div>
+
+
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Recursos relacionados</span>
+  <div class="compare-grid">
+    <a href="/pt/library/simbolos-y2k/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos Y2K</h4>
+      <p>Decorações cyber e dark da estética Y2K.</p>
+    </a>
+    <a href="/pt/library/simbolos-coquette/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos coquette</h4>
+      <p>Laços, corações e detalhes suaves da estética coquette.</p>
+    </a>
+    <a href="/pt/library/simbolos-cottagecore/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos cottagecore</h4>
+      <p>Flores, folhas e símbolos aconchegantes de campo.</p>
+    </a>
+    <a href="/pt/library/simbolos-de-coracao/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos de coração</h4>
+      <p>Corações Unicode e emojis de coração para bios.</p>
+    </a>
+    <a href="/pt/library/simbolos/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos para copiar</h4>
+      <p>Uma biblioteca de símbolos Unicode, setas, estrelas e caracteres decorativos.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    { name: "Divisor de cruz gótica", flags: ["†","˖","♱","˖","†"], defaultFormat: "inline" },
+    { name: "Moldura de cruz egípcia", flags: ["𓆩♱𓆪"], defaultFormat: "inline" },
+    { name: "Borda de adagas", flags: ["✟","·","†","‡","†","·","✟"], defaultFormat: "inline" },
+    { name: "Combo de rosa murcha", flags: ["🥀","🖤","🥀"], defaultFormat: "inline" },
+    { name: "Trilha floral dark", flags: ["❦","˖","🖤","˖","❧"], defaultFormat: "inline" },
+    { name: "Combo de bio com pentagrama", flags: ["⛧","˖","𖤐","˖","⛧"], defaultFormat: "inline" }
+  ];
+
+  ns.buildGrids("gothGrungeCollectionsContainer", GROUPS);
+  ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/pt/library/simbolos-kawaii-cute/index.html
+++ b/pt/library/simbolos-kawaii-cute/index.html
@@ -1,0 +1,420 @@
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Símbolos Kawaii Fofos para copiar e colar — Decorações aesthetic suaves | UltraTextGen</title>
+<meta name="description" content="Símbolos kawaii e fofos para bio, nome de usuário e mensagens. Corações suaves, carinhas pequenas, brilhos e decorações pastel da estética kawaii. Copie com um toque.">
+
+<link rel="canonical" href="https://ultratextgen.com/pt/library/simbolos-kawaii-cute/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-kawaii-cute/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/pt/library/simbolos-kawaii-cute/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/pt-library-simbolos-kawaii-cute.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Símbolos Kawaii Fofos para copiar e colar — Decorações aesthetic suaves">
+<meta name="twitter:description" content="Símbolos kawaii e fofos para bio, nome de usuário e mensagens. Corações suaves, carinhas pequenas, brilhos e decorações pastel da estética kawaii. Copie com um toque.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/pt-library-simbolos-kawaii-cute.png">
+<meta property="og:title" content="Símbolos Kawaii Fofos para copiar e colar — Decorações aesthetic suaves">
+<meta property="og:description" content="Símbolos kawaii e fofos para bio, nome de usuário e mensagens. Corações suaves, carinhas pequenas, brilhos e decorações pastel da estética kawaii. Copie com um toque.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/pt/library/simbolos-kawaii-cute/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Símbolos Kawaii Fofos para copiar e colar — Decorações aesthetic suaves",
+  "alternateName": ["Símbolos kawaii copiar colar", "Símbolos fofos copiar colar", "Símbolos de texto kawaii", "Símbolos fofos aesthetic", "Símbolos aesthetic suaves", "Decorações kawaii", "Símbolos japoneses fofos"],
+  "description": "Símbolos kawaii e fofos para bio, nome de usuário e mensagens. Corações suaves, carinhas pequenas, brilhos e decorações pastel da estética kawaii.",
+  "inLanguage": "pt",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/pt-library-simbolos-kawaii-cute.png",
+  "mainEntityOfPage": "https://ultratextgen.com/pt/library/simbolos-kawaii-cute/",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Início",
+      "item": "https://ultratextgen.com/pt/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Símbolos Kawaii Fofos",
+      "item": "https://ultratextgen.com/pt/library/simbolos-kawaii-cute/"
+    }
+  ]
+}
+</script>
+
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/pt/">Início</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Símbolos Kawaii Fofos</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Símbolos Kawaii Fofos</h1>
+    <p class="hero-tagline">Corações suaves, carinhas pequenas, brilhos e decorações kawaii em tons pastel. Toque em qualquer símbolo para copiar na hora e usar em bio, nome de usuário e mensagens.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pt-library-simbolos-kawaii-cute.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Kawaii (かわいい) significa "fofo" em japonês, e a estética kawaii celebra tudo o que é suave, pastel e adorável. Estes caracteres Unicode e emojis capturam essa vibe: carinhas pequenas, símbolos de coração, marcas de brilho e colchetes fofos para emoldurar seu texto. Use em bios, mensagens, nomes de usuário e legendas no Instagram, TikTok, Discord e em qualquer plataforma que aceite texto Unicode.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 1 -->
+<section class="mood-explainers" id="cute-hearts">
+  <span class="article-section-label">Corações fofos</span>
+  <h2>Corações fofos</h2>
+  <p>Caracteres de coração suaves para bios kawaii e mensagens carinhosas.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♡" aria-label="Copiar ♡">♡</button>
+      <span class="flag-label">Coração branco</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ෆ" aria-label="Copiar ෆ">ෆ</button>
+      <span class="flag-label">Letra cingalesa alpapraana ayanna</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❤" aria-label="Copiar ❤">❤</button>
+      <span class="flag-label">Coração vermelho</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❥" aria-label="Copiar ❥">❥</button>
+      <span class="flag-label">Coração girado em relevo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ʚɞ" aria-label="Copiar ʚɞ">ʚɞ</button>
+      <span class="flag-label">Coração com asas (combo)</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 2 -->
+<section class="mood-explainers" id="tiny-cute-faces">
+  <span class="article-section-label">Carinhas fofas</span>
+  <h2>Carinhas fofas</h2>
+  <p>Kaomoji e carinhas Unicode para dar expressões kawaii às mensagens e bios.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(˶˃ ᵕ ˂˶)" aria-label="Copiar (˶˃ ᵕ ˂˶)">(˶˃ ᵕ ˂˶)</button>
+      <span class="flag-label">Carinha corada (combo)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ʕ•ᴥ•ʔ" aria-label="Copiar ʕ•ᴥ•ʔ">ʕ•ᴥ•ʔ</button>
+      <span class="flag-label">Carinha de ursinho (combo)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(づ ◕‿◕)づ" aria-label="Copiar (づ ◕‿◕)づ">(づ ◕‿◕)づ</button>
+      <span class="flag-label">Carinha abraçando (combo)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="(✿◠‿◠)" aria-label="Copiar (✿◠‿◠)">(✿◠‿◠)</button>
+      <span class="flag-label">Carinha com flor (combo)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="◕" aria-label="Copiar ◕">◕</button>
+      <span class="flag-label">Olho de círculo grande</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="◡" aria-label="Copiar ◡">◡</button>
+      <span class="flag-label">Traço curvo (sorriso)</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 3 -->
+<section class="mood-explainers" id="cute-wrappers">
+  <span class="article-section-label">Colchetes e molduras fofas</span>
+  <h2>Colchetes e molduras fofas</h2>
+  <p>Colchetes decorativos e caracteres de moldura para nomes de usuário kawaii e formatação de bio.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="꒰" aria-label="Copiar ꒰">꒰</button>
+      <span class="flag-label">Parêntese ornamental esquerdo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="꒱" aria-label="Copiar ꒱">꒱</button>
+      <span class="flag-label">Parêntese ornamental direito</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="◌" aria-label="Copiar ◌">◌</button>
+      <span class="flag-label">Anel combinante</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊂" aria-label="Copiar ⊂">⊂</button>
+      <span class="flag-label">Subconjunto de</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊃" aria-label="Copiar ⊃">⊃</button>
+      <span class="flag-label">Superconjunto de</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="୨୧" aria-label="Copiar ୨୧">୨୧</button>
+      <span class="flag-label">Onda coquette (combo)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✿" aria-label="Copiar ✿">✿</button>
+      <span class="flag-label">Florzinha preta</span>
+    </div>
+      <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ʚ" aria-label="Copiar ʚ">ʚ</button>
+      <span class="flag-label">Asa de coração esquerda</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ɞ" aria-label="Copiar ɞ">ɞ</button>
+      <span class="flag-label">Asa de coração direita</span>
+    </div>
+</div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 4 -->
+<section class="mood-explainers" id="decorative-marks-kawaii">
+  <span class="article-section-label">Marcas decorativas</span>
+  <h2>Marcas decorativas</h2>
+  <p>Brilhos, pontinhos e pequenos acentos para dar um toque kawaii a qualquer texto.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⋆" aria-label="Copiar ⋆">⋆</button>
+      <span class="flag-label">Operador de estrela de seis pontas</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊹" aria-label="Copiar ⊹">⊹</button>
+      <span class="flag-label">Cruz ortogonal</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✧" aria-label="Copiar ✧">✧</button>
+      <span class="flag-label">Estrela branca de quatro pontas</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⩩" aria-label="Copiar ⩩">⩩</button>
+      <span class="flag-label">Semelhante ou igual</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="๑" aria-label="Copiar ๑">๑</button>
+      <span class="flag-label">Caractere tailandês ko kai</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⌒" aria-label="Copiar ⌒">⌒</button>
+      <span class="flag-label">Arco</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❀" aria-label="Copiar ❀">❀</button>
+      <span class="flag-label">Florzinha branca</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 5 -->
+<section class="mood-explainers" id="pastel-motifs">
+  <span class="article-section-label">Motivos pastel</span>
+  <h2>Motivos pastel</h2>
+  <p>Símbolos suaves de flores e céu para montar uma estética kawaii sonhadora.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✿" aria-label="Copiar ✿">✿</button>
+      <span class="flag-label">Florzinha preta</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❀" aria-label="Copiar ❀">❀</button>
+      <span class="flag-label">Florzinha branca</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❁" aria-label="Copiar ❁">❁</button>
+      <span class="flag-label">Florzinha de oito pétalas</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☁" aria-label="Copiar ☁">☁</button>
+      <span class="flag-label">Nuvem</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☾" aria-label="Copiar ☾">☾</button>
+      <span class="flag-label">Lua crescente</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛅" aria-label="Copiar ⛅">⛅</button>
+      <span class="flag-label">Sol atrás de nuvem</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✦" aria-label="Copiar ✦">✦</button>
+      <span class="flag-label">Estrela preta de quatro pontas</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⋆" aria-label="Copiar ⋆">⋆</button>
+      <span class="flag-label">Operador de estrela de seis pontas</span>
+    </div>
+      <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧸" aria-label="Copiar 🧸">🧸</button>
+      <span class="flag-label">Ursinho de pelúcia</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐻" aria-label="Copiar 🐻">🐻</button>
+      <span class="flag-label">Carinha de urso</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐰" aria-label="Copiar 🐰">🐰</button>
+      <span class="flag-label">Carinha de coelho</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🎀" aria-label="Copiar 🎀">🎀</button>
+      <span class="flag-label">Laço de fita</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌸" aria-label="Copiar 🌸">🌸</button>
+      <span class="flag-label">Flor de cerejeira</span>
+    </div>
+</div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- COLLECTIONS -->
+<section class="mood-explainers" id="kawaii-collections">
+  <span class="article-section-label">Coleções kawaii</span>
+  <h2>Conjuntos kawaii para bio e nome de usuário</h2>
+  <p class="u-secondary-block">Combos kawaii prontos — corações suaves, carinhas pequenas e brilhos pastel para colar direto em uma bio, nome de usuário ou mensagem com um clique.</p>
+  <div id="kawaiiCollectionsContainer"></div>
+</section>
+
+<div class="section-divider"></div>
+
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Transforme texto com fontes Unicode</h3>
+  <p>Use o UltraTextGen para converter texto simples em negrito, itálico, cursiva e mais de 100 outros estilos de fonte Unicode — grátis e instantâneo.</p>
+  <a href="https://ultratextgen.com/pt/" class="cta-btn">Abrir UltraTextGen →</a>
+</div>
+
+
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Recursos relacionados</span>
+  <div class="compare-grid">
+    <a href="/pt/library/simbolos-coquette/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos coquette</h4>
+      <p>Laços, fitas e símbolos suaves e femininos para bios coquette.</p>
+    </a>
+    <a href="/pt/library/simbolos-cottagecore/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos cottagecore</h4>
+      <p>Flores, folhas e símbolos aconchegantes do campo para uma vibe cottagecore.</p>
+    </a>
+    <a href="/pt/library/kaomoji/" class="compare-card variant-muted u-no-underline">
+      <h4>Kaomoji</h4>
+      <p>Carinhas em ASCII, emoticons e kaomoji japoneses fofos.</p>
+    </a>
+    <a href="/pt/library/simbolos-de-coracao/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos de coração</h4>
+      <p>Corações Unicode e emojis de coração para bios.</p>
+    </a>
+    <a href="/pt/library/simbolos-y2k/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos Y2K</h4>
+      <p>Estrelas, cruzes e brilhos da estética cyber dos anos 2000.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    { name: "Combo de bio com coração suave", flags: ["꒰","♡","꒱","⋆","ෆ"], defaultFormat: "inline" },
+    { name: "Divisor de brilho kawaii", flags: ["⊹","⋆","✧","⋆","⊹"], defaultFormat: "inline" },
+    { name: "Nome de usuário com asas de flor", flags: ["ʚ ✿ ɞ"], defaultFormat: "inline" },
+    { name: "Borda de poeira pastel", flags: ["✦","⋆","❀","⋆","✦"], defaultFormat: "inline" },
+    { name: "Moldura de bio com carinha fofa", flags: ["(˶˃ ᵕ ˂˶)","♡"], defaultFormat: "inline" },
+    { name: "Combo de colchete fofo", flags: ["꒰ ♡ ꒱"], defaultFormat: "inline" }
+  ];
+
+  ns.buildGrids("kawaiiCollectionsContainer", GROUPS);
+  ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/pt/library/simbolos-therian/index.html
+++ b/pt/library/simbolos-therian/index.html
@@ -1,0 +1,364 @@
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Símbolos Therian θΔ — theta-delta e marcas alterhuman para copiar e colar | UltraTextGen</title>
+<meta name="description" content="Símbolos therian para copiar e colar — a marca theta-delta (θΔ), patas, fases da lua e emojis de animais usados pela comunidade therian e alterhuman. Toque para copiar na hora.">
+
+<link rel="canonical" href="https://ultratextgen.com/pt/library/simbolos-therian/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/therian-symbols/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-therian/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/therian-symbols/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/pt-library-simbolos-therian.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Símbolos Therian θΔ — theta-delta e marcas alterhuman para copiar e colar">
+<meta name="twitter:description" content="Símbolos therian para copiar e colar — a marca theta-delta (θΔ), patas, fases da lua e emojis de animais usados pela comunidade therian e alterhuman. Toque para copiar na hora.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/pt-library-simbolos-therian.png">
+<meta property="og:title" content="Símbolos Therian θΔ — theta-delta e marcas alterhuman para copiar e colar">
+<meta property="og:description" content="Símbolos therian para copiar e colar — a marca theta-delta (θΔ), patas, fases da lua e emojis de animais usados pela comunidade therian e alterhuman. Toque para copiar na hora.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/pt/library/simbolos-therian/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Símbolos Therian — theta-delta e marcas alterhuman para copiar e colar",
+  "alternateName": ["Símbolos therian copiar colar", "Símbolo theta delta copiar colar", "Símbolos alterhuman", "Símbolos da comunidade therian", "Sinais therian", "Símbolos de pata para copiar", "Emojis therian para copiar"],
+  "description": "Símbolos therian para copiar e colar — a marca theta-delta (θΔ), patas, fases da lua e emojis de animais usados pela comunidade therian e alterhuman. Toque para copiar na hora.",
+  "inLanguage": "pt",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/pt-library-simbolos-therian.png",
+  "mainEntityOfPage": "https://ultratextgen.com/pt/library/simbolos-therian/",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Início",
+      "item": "https://ultratextgen.com/pt/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Símbolos Therian",
+      "item": "https://ultratextgen.com/pt/library/simbolos-therian/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/pt/">Início</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Símbolos Therian</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Símbolos Therian</h1>
+    <p class="hero-tagline">A marca da comunidade theta-delta (θΔ) mais os símbolos de pata, lua e animais da identidade therian e alterhuman. Toque em qualquer símbolo para copiar na hora.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pt-library-simbolos-therian.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>O símbolo therian que a maioria das pessoas procura é o theta-delta — as letras gregas teta (θ) e delta (Δ) combinadas —, adotado pela comunidade da terianthropia em 2003 como uma marca de identidade compartilhada e respeitosa. Therians são pessoas que sentem uma identificação profunda e não física com um animal, e a comunidade alterhuman em geral usa marcas relacionadas junto de patas, fases da lua e emojis de animais. Esta página reúne o theta-delta em suas formas Unicode mais comuns junto dos símbolos de natureza e animais usados em bios do TikTok, blogs do Tumblr e perfis do Discord.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="theta-delta">
+  <span class="article-section-label">Theta-Delta</span>
+  <h2>Marcas da comunidade theta-delta</h2>
+  <p class="u-secondary-tight">A marca theta-delta construída com letras gregas reais — copie o par combinado ou cada letra separadamente.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="θΔ" aria-label="Copiar Theta-Delta (marca therian)">θΔ</button>
+      <span class="flag-label">Theta-Delta (marca therian)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ΘΔ" aria-label="Copiar Theta-Delta maiúsculo">ΘΔ</button>
+      <span class="flag-label">Theta-Delta maiúsculo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="θ" aria-label="Copiar letra grega minúscula teta">θ</button>
+      <span class="flag-label">Letra grega minúscula teta</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="Θ" aria-label="Copiar letra grega maiúscula teta">Θ</button>
+      <span class="flag-label">Letra grega maiúscula teta</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="Δ" aria-label="Copiar letra grega maiúscula delta">Δ</button>
+      <span class="flag-label">Letra grega maiúscula delta</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="δ" aria-label="Copiar letra grega minúscula delta">δ</button>
+      <span class="flag-label">Letra grega minúscula delta</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ϴ" aria-label="Copiar símbolo grego teta maiúsculo">ϴ</button>
+      <span class="flag-label">Símbolo grego teta maiúsculo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ϑ" aria-label="Copiar símbolo grego teta">ϑ</button>
+      <span class="flag-label">Símbolo grego teta</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="paw-prints">
+  <span class="article-section-label">Patas e caninos</span>
+  <h2>Patas e símbolos caninos</h2>
+  <p class="u-secondary-tight">Patas e os emojis de lobo, raposa e cachorro que mais aparecem em bios therian.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐾" aria-label="Copiar patas">🐾</button>
+      <span class="flag-label">Patas</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐺" aria-label="Copiar lobo">🐺</button>
+      <span class="flag-label">Lobo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦊" aria-label="Copiar raposa">🦊</button>
+      <span class="flag-label">Raposa</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐕" aria-label="Copiar cachorro">🐕</button>
+      <span class="flag-label">Cachorro</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐈‍⬛" aria-label="Copiar gato preto">🐈‍⬛</button>
+      <span class="flag-label">Gato preto</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦝" aria-label="Copiar guaxinim">🦝</button>
+      <span class="flag-label">Guaxinim</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐅" aria-label="Copiar tigre">🐅</button>
+      <span class="flag-label">Tigre</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦴" aria-label="Copiar osso">🦴</button>
+      <span class="flag-label">Osso</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="wild-animals">
+  <span class="article-section-label">Animais selvagens</span>
+  <h2>Símbolos de animais selvagens e teriótipos</h2>
+  <p class="u-secondary-tight">Emojis para teriótipos comuns — de cervos e grandes felinos a aves de rapina.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦌" aria-label="Copiar cervo">🦌</button>
+      <span class="flag-label">Cervo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐆" aria-label="Copiar leopardo">🐆</button>
+      <span class="flag-label">Leopardo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦅" aria-label="Copiar águia">🦅</button>
+      <span class="flag-label">Águia</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦉" aria-label="Copiar coruja">🦉</button>
+      <span class="flag-label">Coruja</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐦‍⬛" aria-label="Copiar pássaro preto">🐦‍⬛</button>
+      <span class="flag-label">Pássaro preto</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐍" aria-label="Copiar cobra">🐍</button>
+      <span class="flag-label">Cobra</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦈" aria-label="Copiar tubarão">🦈</button>
+      <span class="flag-label">Tubarão</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐉" aria-label="Copiar dragão">🐉</button>
+      <span class="flag-label">Dragão</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="moon-night">
+  <span class="article-section-label">Lua e noite</span>
+  <h2>Símbolos de lua e noite</h2>
+  <p class="u-secondary-tight">Fases da lua e caracteres de lua crescente — um motivo antigo em espaços therian e alterhuman.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌙" aria-label="Copiar lua crescente">🌙</button>
+      <span class="flag-label">Lua crescente</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☾" aria-label="Copiar lua em quarto minguante (texto)">☾</button>
+      <span class="flag-label">Lua em quarto minguante (texto)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☽" aria-label="Copiar lua em quarto crescente (texto)">☽</button>
+      <span class="flag-label">Lua em quarto crescente (texto)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌕" aria-label="Copiar lua cheia">🌕</button>
+      <span class="flag-label">Lua cheia</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌑" aria-label="Copiar lua nova">🌑</button>
+      <span class="flag-label">Lua nova</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌒" aria-label="Copiar lua crescente côncava">🌒</button>
+      <span class="flag-label">Lua crescente côncava</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="forest-nature">
+  <span class="article-section-label">Floresta e natureza</span>
+  <h2>Símbolos de floresta e natureza</h2>
+  <p class="u-secondary-tight">Caracteres de bosque e natureza para completar a legenda de um vídeo de quadrobismo ou um perfil.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌲" aria-label="Copiar árvore perene">🌲</button>
+      <span class="flag-label">Árvore perene</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌿" aria-label="Copiar erva">🌿</button>
+      <span class="flag-label">Erva</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🍂" aria-label="Copiar folha caída">🍂</button>
+      <span class="flag-label">Folha caída</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛰" aria-label="Copiar montanha">⛰</button>
+      <span class="flag-label">Montanha</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🪶" aria-label="Copiar pena">🪶</button>
+      <span class="flag-label">Pena</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌾" aria-label="Copiar feixe de arroz">🌾</button>
+      <span class="flag-label">Feixe de arroz</span>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Transforme texto com fontes Unicode</h3>
+  <p>Use o UltraTextGen para converter texto simples em negrito, itálico, cursiva e mais de 100 outros estilos de fonte Unicode — grátis e instantâneo.</p>
+  <a href="https://ultratextgen.com/pt/" class="cta-btn">Abrir UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Recursos relacionados</span>
+  <div class="compare-grid">
+    <a href="/pt/library/simbolos-fairycore/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos fairycore</h4>
+      <p>Cogumelos, fadas e caracteres de bosque para copiar e colar.</p>
+    </a>
+    <a href="/pt/library/simbolos-de-estrela/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos de estrela</h4>
+      <p>Estrelas, luas e caracteres celestes em vários estilos.</p>
+    </a>
+    <a href="/pt/library/simbolos-goth-grunge/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos goth e grunge</h4>
+      <p>Cruzes, morcegos e caracteres sombrios para bios alternativas.</p>
+    </a>
+    <a href="/pt/library/simbolos/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos para copiar</h4>
+      <p>Uma biblioteca de símbolos Unicode, setas, estrelas e caracteres decorativos.</p>
+    </a>
+    <a href="/pt/library/kaomoji/" class="compare-card variant-muted u-no-underline">
+      <h4>Kaomoji</h4>
+      <p>Carinhas japonesas expressivas feitas com texto para copiar e colar.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/pt/library/simbolos-witchy-occult/index.html
+++ b/pt/library/simbolos-witchy-occult/index.html
@@ -1,0 +1,762 @@
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Símbolos Witchy e Ocultos ⛧ Pentagramas, luas e alquimia para copiar e colar | UltraTextGen</title>
+<meta name="description" content="Símbolos witchy e ocultos para copiar e colar — pentagramas, fases da lua, signos planetários, símbolos alquímicos e outros caracteres esotéricos. Toque em qualquer um para copiar.">
+
+<link rel="canonical" href="https://ultratextgen.com/pt/library/simbolos-witchy-occult/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-witchy-occult/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/pt/library/simbolos-witchy-occult/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/pt-library-simbolos-witchy-occult.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Símbolos Witchy e Ocultos ⛧ Pentagramas, luas e alquimia para copiar e colar">
+<meta name="twitter:description" content="Símbolos witchy e ocultos para copiar e colar — pentagramas, fases da lua, signos planetários, símbolos alquímicos e outros caracteres esotéricos. Toque em qualquer um para copiar.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/pt-library-simbolos-witchy-occult.png">
+<meta property="og:title" content="Símbolos Witchy e Ocultos ⛧ Pentagramas, luas e alquimia para copiar e colar">
+<meta property="og:description" content="Símbolos witchy e ocultos para copiar e colar — pentagramas, fases da lua, signos planetários, símbolos alquímicos e outros caracteres esotéricos. Toque em qualquer um para copiar.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/pt/library/simbolos-witchy-occult/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Símbolos Witchy e Ocultos — pentagramas, luas e alquimia para copiar e colar",
+  "alternateName": ["Símbolos ocultos copiar colar", "Símbolos witchy copiar colar", "Símbolos de bruxa Unicode", "Símbolos mágicos copiar colar", "Símbolos esotéricos copiar colar", "Símbolo de pentagrama copiar colar", "Emojis witchy copiar colar"],
+  "description": "Símbolos witchy e ocultos para copiar e colar — pentagramas, fases da lua, signos planetários, símbolos alquímicos e outros caracteres esotéricos. Toque em qualquer um para copiar.",
+  "inLanguage": "pt",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/pt-library-simbolos-witchy-occult.png",
+  "mainEntityOfPage": "https://ultratextgen.com/pt/library/simbolos-witchy-occult/",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Início",
+      "item": "https://ultratextgen.com/pt/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Símbolos Witchy e Ocultos",
+      "item": "https://ultratextgen.com/pt/library/simbolos-witchy-occult/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/pt/">Início</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Símbolos Witchy e Ocultos</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Símbolos Witchy e Ocultos</h1>
+    <p class="hero-tagline">Uma coleção selecionada de pentagramas, fases da lua, símbolos planetários, signos alquímicos e outros caracteres Unicode esotéricos. Toque em qualquer símbolo para copiar na hora.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pt-library-simbolos-witchy-occult.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Esta biblioteca reúne símbolos Unicode ligados à bruxaria, ao ocultismo, à alquimia e às tradições esotéricas. Todos são caracteres Unicode padrão — dá para usar em textos, bios e escrita criativa. A seção de símbolos alquímicos cobre o bloco Unicode dedicado aos Símbolos Alquímicos (U+1F700–U+1F73F).</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="pentagrams-stars">
+  <span class="article-section-label">Pentagramas e estrelas</span>
+  <h2>Pentagramas e estrelas de cinco pontas</h2>
+  <p>Formas de estrela e pentagrama associadas às tradições esotéricas e ocultas.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="★" aria-label="Copiar Estrela preta">★</button>
+      <span class="flag-label">Estrela preta</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☆" aria-label="Copiar Estrela branca">☆</button>
+      <span class="flag-label">Estrela branca</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚹" aria-label="Copiar Sextil">⚹</button>
+      <span class="flag-label">Sextil</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✡" aria-label="Copiar Estrela de Davi">✡</button>
+      <span class="flag-label">Estrela de Davi</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚜" aria-label="Copiar Flor de lis">⚜</button>
+      <span class="flag-label">Flor de lis</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛤" aria-label="Copiar Pentagrama">⛤</button>
+      <span class="flag-label">Pentagrama</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛥" aria-label="Copiar Pentagrama voltado à direita">⛥</button>
+      <span class="flag-label">Pentagrama voltado à direita</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛦" aria-label="Copiar Pentagrama voltado à esquerda">⛦</button>
+      <span class="flag-label">Pentagrama voltado à esquerda</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛧" aria-label="Copiar Pentagrama invertido">⛧</button>
+      <span class="flag-label">Pentagrama invertido</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✴" aria-label="Copiar Estrela de oito pontas">✴</button>
+      <span class="flag-label">Estrela de oito pontas</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✪" aria-label="Copiar Estrela branca circulada">✪</button>
+      <span class="flag-label">Estrela branca circulada</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✶" aria-label="Copiar Estrela de seis pontas">✶</button>
+      <span class="flag-label">Estrela de seis pontas</span>
+    </div>
+      <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✦" aria-label="Copiar ✦">✦</button>
+      <span class="flag-label">Estrela de brilho</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="◯" aria-label="Copiar ◯">◯</button>
+      <span class="flag-label">Círculo grande</span>
+    </div>
+</div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- Anchor preserved for inbound links/bookmarks; canonical content lives on /library/moon-celestial-symbols/#celestial-collections -->
+<section class="mood-explainers" id="moon-phases">
+  <span class="article-section-label">Fases da lua</span>
+  <h2>Símbolos de fases da lua</h2>
+  <p>Procurando o ciclo lunar completo? Os símbolos de fases da lua combinam perfeitamente com os caracteres celestes de estrelas para montar suas sequências.</p>
+  <div class="compare-grid" style="margin-top:1rem;">
+    <a href="/pt/library/simbolos-de-estrela/" class="compare-card variant-muted u-no-underline">
+      <h4>Veja: fases da lua em Símbolos de estrela →</h4>
+      <p>As oito fases da lua em Unicode (🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘), além de variantes de lua crescente e de lua escura/clara, prontas para copiar em sequência com outros símbolos celestes.</p>
+    </a>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- CLASSICAL 7 PLANETS (featured sub-group) -->
+<section class="mood-explainers" id="classical-7-planets">
+  <span class="article-section-label">Os sete planetas clássicos</span>
+  <h2>Os sete planetas clássicos (Sol → Saturno)</h2>
+  <p class="u-secondary-tight">Os sete planetas da astrologia tradicional em ordem caldaica — os corpos visíveis no céu conhecidos pelos astrônomos antigos.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☉" aria-label="Copiar Sol">☉</button>
+      <span class="flag-label">Sol</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☽" aria-label="Copiar Lua">☽</button>
+      <span class="flag-label">Lua</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☿" aria-label="Copiar Mercúrio">☿</button>
+      <span class="flag-label">Mercúrio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♀" aria-label="Copiar Vênus">♀</button>
+      <span class="flag-label">Vênus</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♂" aria-label="Copiar Marte">♂</button>
+      <span class="flag-label">Marte</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♃" aria-label="Copiar Júpiter">♃</button>
+      <span class="flag-label">Júpiter</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♄" aria-label="Copiar Saturno">♄</button>
+      <span class="flag-label">Saturno</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="planetary-zodiac">
+  <span class="article-section-label">Planetários e astrológicos</span>
+  <h2>Símbolos planetários e astrológicos</h2>
+  <p>Símbolos planetários clássicos e glifos astrológicos com associações ocultas.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☉" aria-label="Copiar Sol">☉</button>
+      <span class="flag-label">Sol</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☽" aria-label="Copiar Lua">☽</button>
+      <span class="flag-label">Lua</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☿" aria-label="Copiar Mercúrio">☿</button>
+      <span class="flag-label">Mercúrio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♀" aria-label="Copiar Vênus">♀</button>
+      <span class="flag-label">Vênus</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♁" aria-label="Copiar Terra">♁</button>
+      <span class="flag-label">Terra</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♂" aria-label="Copiar Marte">♂</button>
+      <span class="flag-label">Marte</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♃" aria-label="Copiar Júpiter">♃</button>
+      <span class="flag-label">Júpiter</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♄" aria-label="Copiar Saturno">♄</button>
+      <span class="flag-label">Saturno</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♅" aria-label="Copiar Urano">♅</button>
+      <span class="flag-label">Urano</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♆" aria-label="Copiar Netuno">♆</button>
+      <span class="flag-label">Netuno</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♇" aria-label="Copiar Plutão">♇</button>
+      <span class="flag-label">Plutão</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚸" aria-label="Copiar Lua Negra Lilith">⚸</button>
+      <span class="flag-label">Lua Negra Lilith</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚳" aria-label="Copiar Ceres">⚳</button>
+      <span class="flag-label">Ceres</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚴" aria-label="Copiar Palas">⚴</button>
+      <span class="flag-label">Palas</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚵" aria-label="Copiar Juno">⚵</button>
+      <span class="flag-label">Juno</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚶" aria-label="Copiar Vesta">⚶</button>
+      <span class="flag-label">Vesta</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="alchemical">
+  <span class="article-section-label">Alquímicos</span>
+  <h2>Símbolos alquímicos (U+1F700–U+1F73F)</h2>
+  <p>O bloco Unicode de Símbolos Alquímicos, com signos para os elementos, processos e substâncias usados na alquimia histórica.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜀" aria-label="Copiar Quintessência">🜀</button>
+      <span class="flag-label">Quintessência</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜁" aria-label="Copiar Ar">🜁</button>
+      <span class="flag-label">Ar</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜂" aria-label="Copiar Fogo">🜂</button>
+      <span class="flag-label">Fogo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜃" aria-label="Copiar Terra">🜃</button>
+      <span class="flag-label">Terra</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜄" aria-label="Copiar Água">🜄</button>
+      <span class="flag-label">Água</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜅" aria-label="Copiar Água-forte">🜅</button>
+      <span class="flag-label">Água-forte</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜆" aria-label="Copiar Água-régia">🜆</button>
+      <span class="flag-label">Água-régia</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜇" aria-label="Copiar Água-régia II">🜇</button>
+      <span class="flag-label">Água-régia II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜈" aria-label="Copiar Aqua vitae">🜈</button>
+      <span class="flag-label">Aqua vitae</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜉" aria-label="Copiar Aqua vitae II">🜉</button>
+      <span class="flag-label">Aqua vitae II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜊" aria-label="Copiar Vinagre">🜊</button>
+      <span class="flag-label">Vinagre</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜋" aria-label="Copiar Vinagre II">🜋</button>
+      <span class="flag-label">Vinagre II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜌" aria-label="Copiar Vinagre III">🜌</button>
+      <span class="flag-label">Vinagre III</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜍" aria-label="Copiar Enxofre">🜍</button>
+      <span class="flag-label">Enxofre</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜎" aria-label="Copiar Enxofre II">🜎</button>
+      <span class="flag-label">Enxofre II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜏" aria-label="Copiar Enxofre III">🜏</button>
+      <span class="flag-label">Enxofre III</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜐" aria-label="Copiar Sal">🜐</button>
+      <span class="flag-label">Sal</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜑" aria-label="Copiar Sal II">🜑</button>
+      <span class="flag-label">Sal II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜒" aria-label="Copiar Sal III">🜒</button>
+      <span class="flag-label">Sal III</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜓" aria-label="Copiar Sublimado de mercúrio">🜓</button>
+      <span class="flag-label">Sublimado de mercúrio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜔" aria-label="Copiar Sublimado de mercúrio II">🜔</button>
+      <span class="flag-label">Sublimado de mercúrio II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜕" aria-label="Copiar Sublimado de mercúrio III">🜕</button>
+      <span class="flag-label">Sublimado de mercúrio III</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜖" aria-label="Copiar Cinábrio">🜖</button>
+      <span class="flag-label">Cinábrio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜗" aria-label="Copiar Sal amoníaco">🜗</button>
+      <span class="flag-label">Sal amoníaco</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜘" aria-label="Copiar Vitríolo">🜘</button>
+      <span class="flag-label">Vitríolo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜙" aria-label="Copiar Vitríolo II">🜙</button>
+      <span class="flag-label">Vitríolo II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜚" aria-label="Copiar Ouro">🜚</button>
+      <span class="flag-label">Ouro</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜛" aria-label="Copiar Prata">🜛</button>
+      <span class="flag-label">Prata</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜜" aria-label="Copiar Minério de ferro">🜜</button>
+      <span class="flag-label">Minério de ferro</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜝" aria-label="Copiar Minério de ferro II">🜝</button>
+      <span class="flag-label">Minério de ferro II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜞" aria-label="Copiar Croco de ferro">🜞</button>
+      <span class="flag-label">Croco de ferro</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜟" aria-label="Copiar Régulo de ferro">🜟</button>
+      <span class="flag-label">Régulo de ferro</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜠" aria-label="Copiar Minério de cobre">🜠</button>
+      <span class="flag-label">Minério de cobre</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜡" aria-label="Copiar Minério de ferro-cobre">🜡</button>
+      <span class="flag-label">Minério de ferro-cobre</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜢" aria-label="Copiar Sublimado de cobre">🜢</button>
+      <span class="flag-label">Sublimado de cobre</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜣" aria-label="Copiar Croco de cobre">🜣</button>
+      <span class="flag-label">Croco de cobre</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜤" aria-label="Copiar Antimoniato de cobre">🜤</button>
+      <span class="flag-label">Antimoniato de cobre</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜥" aria-label="Copiar Sal de antimoniato de cobre">🜥</button>
+      <span class="flag-label">Sal de antimoniato de cobre</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜦" aria-label="Copiar Sublimado de sal de cobre">🜦</button>
+      <span class="flag-label">Sublimado de sal de cobre</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜧" aria-label="Copiar Verdete">🜧</button>
+      <span class="flag-label">Verdete</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜨" aria-label="Copiar Minério de estanho">🜨</button>
+      <span class="flag-label">Minério de estanho</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜩" aria-label="Copiar Minério de chumbo">🜩</button>
+      <span class="flag-label">Minério de chumbo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜪" aria-label="Copiar Terra de minério de chumbo">🜪</button>
+      <span class="flag-label">Terra de minério de chumbo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜫" aria-label="Copiar Antimônio">🜫</button>
+      <span class="flag-label">Antimônio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜬" aria-label="Copiar Antimônio II">🜬</button>
+      <span class="flag-label">Antimônio II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜭" aria-label="Copiar Sublimado de antimônio">🜭</button>
+      <span class="flag-label">Sublimado de antimônio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜮" aria-label="Copiar Sal de antimônio">🜮</button>
+      <span class="flag-label">Sal de antimônio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜯" aria-label="Copiar Sublimado de sal de antimônio">🜯</button>
+      <span class="flag-label">Sublimado de sal de antimônio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜰" aria-label="Copiar Vinagre de antimônio">🜰</button>
+      <span class="flag-label">Vinagre de antimônio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜱" aria-label="Copiar Régulo de antimônio">🜱</button>
+      <span class="flag-label">Régulo de antimônio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜲" aria-label="Copiar Régulo de antimônio II">🜲</button>
+      <span class="flag-label">Régulo de antimônio II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜳" aria-label="Copiar Régulo">🜳</button>
+      <span class="flag-label">Régulo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜴" aria-label="Copiar Régulo II">🜴</button>
+      <span class="flag-label">Régulo II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜵" aria-label="Copiar Régulo III">🜵</button>
+      <span class="flag-label">Régulo III</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜶" aria-label="Copiar Régulo IV">🜶</button>
+      <span class="flag-label">Régulo IV</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜷" aria-label="Copiar Álcali">🜷</button>
+      <span class="flag-label">Álcali</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜸" aria-label="Copiar Álcali II">🜸</button>
+      <span class="flag-label">Álcali II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜹" aria-label="Copiar Marcassita">🜹</button>
+      <span class="flag-label">Marcassita</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜺" aria-label="Copiar Sal amoníaco">🜺</button>
+      <span class="flag-label">Sal amoníaco</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜻" aria-label="Copiar Arsênio">🜻</button>
+      <span class="flag-label">Arsênio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜼" aria-label="Copiar Realgar">🜼</button>
+      <span class="flag-label">Realgar</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜽" aria-label="Copiar Realgar II">🜽</button>
+      <span class="flag-label">Realgar II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜾" aria-label="Copiar Auripigmento">🜾</button>
+      <span class="flag-label">Auripigmento</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜿" aria-label="Copiar Minério de bismuto">🜿</button>
+      <span class="flag-label">Minério de bismuto</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="esoteric">
+  <span class="article-section-label">Outros esotéricos</span>
+  <h2>Outros símbolos esotéricos</h2>
+  <p>Símbolos adicionais associados às tradições mágicas e esotéricas.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☥" aria-label="Copiar Ankh">☥</button>
+      <span class="flag-label">Ankh</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☯" aria-label="Copiar Yin yang">☯</button>
+      <span class="flag-label">Yin yang</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☘" aria-label="Copiar Trevo">☘</button>
+      <span class="flag-label">Trevo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚷" aria-label="Copiar Quíron">⚷</button>
+      <span class="flag-label">Quíron</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚰" aria-label="Copiar Caixão">⚰</button>
+      <span class="flag-label">Caixão</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚱" aria-label="Copiar Urna funerária">⚱</button>
+      <span class="flag-label">Urna funerária</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚗" aria-label="Copiar Alambique">⚗</button>
+      <span class="flag-label">Alambique</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❤" aria-label="Copiar Coração">❤</button>
+      <span class="flag-label">Coração</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚛" aria-label="Copiar Símbolo do átomo">⚛</button>
+      <span class="flag-label">Símbolo do átomo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚡" aria-label="Copiar Raio">⚡</button>
+      <span class="flag-label">Raio</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♲" aria-label="Copiar Reciclagem">♲</button>
+      <span class="flag-label">Reciclagem</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☼" aria-label="Copiar Sol branco com raios">☼</button>
+      <span class="flag-label">Sol branco com raios</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☦" aria-label="Copiar Cruz ortodoxa">☦</button>
+      <span class="flag-label">Cruz ortodoxa</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☢" aria-label="Copiar Radioativo">☢</button>
+      <span class="flag-label">Radioativo</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☣" aria-label="Copiar Risco biológico">☣</button>
+      <span class="flag-label">Risco biológico</span>
+    </div>
+      <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🔮" aria-label="Copiar 🔮">🔮</button>
+      <span class="flag-label">Bola de cristal</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧿" aria-label="Copiar 🧿">🧿</button>
+      <span class="flag-label">Amuleto nazar</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🃏" aria-label="Copiar 🃏">🃏</button>
+      <span class="flag-label">Carta de tarô</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕯️" aria-label="Copiar 🕯️">🕯️</button>
+      <span class="flag-label">Vela</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐍" aria-label="Copiar 🐍">🐍</button>
+      <span class="flag-label">Cobra</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="∞" aria-label="Copiar ∞">∞</button>
+      <span class="flag-label">Infinito</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⟳" aria-label="Copiar ⟳">⟳</button>
+      <span class="flag-label">Seta cíclica</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="↻" aria-label="Copiar ↻">↻</button>
+      <span class="flag-label">Seta de círculo aberto</span>
+    </div>
+</div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- COLLECTIONS -->
+<section class="mood-explainers" id="witchy-collections">
+  <span class="article-section-label">Coleções bruxas</span>
+  <h2>Conjuntos de bio e moldura bruxos</h2>
+  <p class="u-secondary-block">Strings bruxas prontas para colar direto em uma bio, legenda ou nome de usuário — copie o combo inteiro em um clique.</p>
+  <div id="witchyCollectionsContainer"></div>
+</section>
+
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Transforme texto com fontes Unicode</h3>
+  <p>Use o UltraTextGen para converter texto simples em negrito, itálico, cursiva e mais de 100 outros estilos de fonte Unicode — grátis e instantâneo.</p>
+  <a href="https://ultratextgen.com/pt/" class="cta-btn">Abrir UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Recursos relacionados</span>
+  <div class="compare-grid">
+    <a href="/pt/library/simbolos/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos para copiar</h4>
+      <p>Uma biblioteca de símbolos Unicode, setas, estrelas e caracteres decorativos.</p>
+    </a>
+    <a href="/pt/library/simbolos-goth-grunge/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos goth e grunge</h4>
+      <p>Cruzes escuras, caveiras e decorações da estética goth.</p>
+    </a>
+    <a href="/pt/library/simbolos-cottagecore/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos cottagecore</h4>
+      <p>Cogumelos, flores silvestres e motivos terrosos da vida no campo.</p>
+    </a>
+    <a href="/pt/library/simbolos-de-estrela/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos de estrela</h4>
+      <p>Estrelas e caracteres de brilho em vários estilos, além de motivos celestes.</p>
+    </a>
+    <a href="/pt/library/simbolos-de-coracao/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos de coração</h4>
+      <p>Corações Unicode e emojis de coração para bios.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    { name: "Moldura de bio com pentagrama", flags: ["⛧","˖","⛤","˖","⛧"], defaultFormat: "inline" },
+    { name: "Combo de lua e sol", flags: ["☽","˚","✴","˚","☉"], defaultFormat: "inline" },
+    { name: "Rastro de estrelas bruxo", flags: ["✶","·","✴","·","✶"], defaultFormat: "inline" },
+    { name: "Moldura de lua crescente", flags: ["☽⋆ﾟ｡⋆"], defaultFormat: "inline" },
+    { name: "Combo planetário para bio", flags: ["☽","☿","♀","♂","♃","♄"], defaultFormat: "inline" },
+    { name: "Divisor de feitiço com ankh", flags: ["☥","˖","⛤","˖","☥"], defaultFormat: "inline" }
+  ];
+
+  ns.buildGrids("witchyCollectionsContainer", GROUPS);
+  ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/tr/library/dreamcore-weirdcore-sembolleri/index.html
+++ b/tr/library/dreamcore-weirdcore-sembolleri/index.html
@@ -1,0 +1,414 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Dreamcore &amp; Weirdcore Sembolleri: Kopyala Yapıştır 👁 🌈 ⋆ Sürreal Estetik</title>
+<meta name="description" content="Dreamcore ve weirdcore sembolleri — sürreal gözler 👁, gökkuşakları 🌈, glitch blokları, kapılar ve sleepcore kombinleri liminal paylaşımlar için. Kopyalamak için herhangi bir sembole dokun.">
+
+<link rel="canonical" href="https://ultratextgen.com/tr/library/dreamcore-weirdcore-sembolleri/">
+<link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/dreamcore-weirdcore-sembolleri/">
+<link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/tr/library/dreamcore-weirdcore-sembolleri/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/tr-library-dreamcore-weirdcore-sembolleri.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Dreamcore &amp; Weirdcore Sembolleri: Kopyala Yapıştır 👁 🌈 ⋆ Sürreal Estetik">
+<meta name="twitter:description" content="Dreamcore ve weirdcore sembolleri — sürreal gözler 👁, gökkuşakları 🌈, glitch blokları, kapılar ve sleepcore kombinleri liminal paylaşımlar için. Kopyalamak için herhangi bir sembole dokun.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/tr-library-dreamcore-weirdcore-sembolleri.png">
+<meta property="og:title" content="Dreamcore &amp; Weirdcore Sembolleri: Kopyala Yapıştır 👁 🌈 ⋆ Sürreal Estetik">
+<meta property="og:description" content="Dreamcore ve weirdcore sembolleri — sürreal gözler 👁, gökkuşakları 🌈, glitch blokları, kapılar ve sleepcore kombinleri liminal paylaşımlar için. Kopyalamak için herhangi bir sembole dokun.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/tr/library/dreamcore-weirdcore-sembolleri/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Dreamcore & Weirdcore Sembolleri: Kopyala Yapıştır 👁 🌈 ⋆ Sürreal Estetik",
+  "alternateName": ["Dreamcore Sembolleri Kopyala Yapıştır", "Weirdcore Sembolleri Kopyala Yapıştır", "Dreamcore Aesthetic Semboller", "Weirdcore Aesthetic Semboller", "Sürreal Aesthetic Semboller", "Liminal Alan Sembolleri", "Dreamcore Metin Sembolleri", "Dreamcore Weirdcore Emojileri"],
+  "description": "Dreamcore ve weirdcore sembolleri — sürreal gözler 👁, gökkuşakları 🌈, glitch blokları, kapılar ve sleepcore kombinleri liminal paylaşımlar için. Kopyalamak için herhangi bir sembole dokun.",
+  "inLanguage": "tr",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/tr-library-dreamcore-weirdcore-sembolleri.png",
+  "mainEntityOfPage": "https://ultratextgen.com/tr/library/dreamcore-weirdcore-sembolleri/",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Ana Sayfa", "item": "https://ultratextgen.com/tr/" },
+    { "@type": "ListItem", "position": 2, "name": "Dreamcore & Weirdcore Sembolleri", "item": "https://ultratextgen.com/tr/library/dreamcore-weirdcore-sembolleri/" }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/tr/">Ana Sayfa</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Dreamcore &amp; Weirdcore Sembolleri</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Dreamcore &amp; Weirdcore Sembolleri</h1>
+    <p class="hero-tagline">Liminal alan estetiği için sürreal gözler, sonsuz kapılar, statik glitch blokları ve uykulu gökyüzü. Anında kopyalamak için herhangi bir sembole ya da kombine dokun.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/tr-library-dreamcore-weirdcore-sembolleri.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Dreamcore ve weirdcore, rüyaların sürreal mantığı üzerine kurulu kardeş internet estetikleridir — nostaljik gökyüzü, izleyen gözler, hiçliğe açılan kapılar ve azıcık tuhaflaşmış tanıdık nesneler. Bu dreamcore ve weirdcore sembolleri o ruh halini kopyalanabilir metne çevirir: 👁 gözler, 🌈 gökkuşakları, 📺 eski televizyonlar, statik için gölge blokları ve daha yumuşak, uykulu düzenlemeler için bir sleepcore seti. Bunları Discord durumlarında, Tumblr başlıklarında, TikTok caption'larında ve YouTube açıklamalarında kullan ya da aşağıdan bütün bir sürreal kombin kap.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="eyes-surreal">
+  <span class="article-section-label">İzleyen Gözler</span>
+  <h2>İzleyen Göz Sembolleri</h2>
+  <p class="u-secondary-tight">Emojiden Mısır hiyerogliflerine, weirdcore imgeleminin kalbindeki gözünü kırpmayan gözler.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="👁" aria-label="👁 kopyala">👁</button>
+      <span class="flag-label">Göz</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="👁️" aria-label="👁️ kopyala">👁️</button>
+      <span class="flag-label">Göz (Emoji Stili)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="👀" aria-label="👀 kopyala">👀</button>
+      <span class="flag-label">Gözler</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓂀" aria-label="𓂀 kopyala">𓂀</button>
+      <span class="flag-label">Horus'un Gözü (Mısır Hiyeroglifi)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓁹" aria-label="𓁹 kopyala">𓁹</button>
+      <span class="flag-label">Mısır Hiyeroglif Gözü</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="◉" aria-label="◉ kopyala">◉</button>
+      <span class="flag-label">Balık Gözü</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊙" aria-label="⊙ kopyala">⊙</button>
+      <span class="flag-label">Daire İçinde Nokta Operatörü</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="👁️‍🗨️" aria-label="👁️‍🗨️ kopyala">👁️‍🗨️</button>
+      <span class="flag-label">Konuşma Balonunda Göz</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="dream-sky">
+  <span class="article-section-label">Rüya Gökyüzü</span>
+  <h2>Dreamcore Gökyüzü Sembolleri</h2>
+  <p class="u-secondary-tight">Gökkuşakları, bulutlar ve dönen gökyüzü — estetiğin parlak, nostaljik yarısı.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌈" aria-label="🌈 kopyala">🌈</button>
+      <span class="flag-label">Gökkuşağı</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☁️" aria-label="☁️ kopyala">☁️</button>
+      <span class="flag-label">Bulut</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌙" aria-label="🌙 kopyala">🌙</button>
+      <span class="flag-label">Hilal</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⭐" aria-label="⭐ kopyala">⭐</button>
+      <span class="flag-label">Yıldız</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌀" aria-label="🌀 kopyala">🌀</button>
+      <span class="flag-label">Kasırga</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🫧" aria-label="🫧 kopyala">🫧</button>
+      <span class="flag-label">Baloncuklar</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌌" aria-label="🌌 kopyala">🌌</button>
+      <span class="flag-label">Samanyolu</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💫" aria-label="💫 kopyala">💫</button>
+      <span class="flag-label">Dönen Yıldızlar</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="weirdcore-objects">
+  <span class="article-section-label">Weirdcore Nesneleri</span>
+  <h2>Weirdcore Nesne Sembolleri</h2>
+  <p class="u-secondary-tight">Kapılar, delikler, aynalar ve eski TV'ler — olmaması gereken yere yerleştirilmiş tanıdık nesneler.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="📺" aria-label="📺 kopyala">📺</button>
+      <span class="flag-label">Televizyon</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🚪" aria-label="🚪 kopyala">🚪</button>
+      <span class="flag-label">Kapı</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕳" aria-label="🕳 kopyala">🕳</button>
+      <span class="flag-label">Delik</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🪞" aria-label="🪞 kopyala">🪞</button>
+      <span class="flag-label">Ayna</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🛗" aria-label="🛗 kopyala">🛗</button>
+      <span class="flag-label">Asansör</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🎈" aria-label="🎈 kopyala">🎈</button>
+      <span class="flag-label">Balon</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🩹" aria-label="🩹 kopyala">🩹</button>
+      <span class="flag-label">Yara Bandı</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧸" aria-label="🧸 kopyala">🧸</button>
+      <span class="flag-label">Oyuncak Ayı</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="sleepcore">
+  <span class="article-section-label">Sleepcore</span>
+  <h2>Sleepcore Sembolleri</h2>
+  <p class="u-secondary-tight">Uykulu alt-estetik — yataklar, gece gökyüzü ve uykunun yumuşak çağrısı.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💤" aria-label="💤 kopyala">💤</button>
+      <span class="flag-label">Zzz</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🛏" aria-label="🛏 kopyala">🛏</button>
+      <span class="flag-label">Yatak</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="😴" aria-label="😴 kopyala">😴</button>
+      <span class="flag-label">Uyuyan Yüz</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌃" aria-label="🌃 kopyala">🌃</button>
+      <span class="flag-label">Yıldızlı Gece</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕰" aria-label="🕰 kopyala">🕰</button>
+      <span class="flag-label">Şömine Saati</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🥱" aria-label="🥱 kopyala">🥱</button>
+      <span class="flag-label">Esneyen Yüz</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="glitch-static">
+  <span class="article-section-label">Glitch &amp; Statik</span>
+  <h2>Glitch &amp; Statik Blok Karakterleri</h2>
+  <p class="u-secondary-tight">TV statiği ve bozuk piksel gibi görünen Unicode gölge ve blok karakterleri.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="░" aria-label="░ kopyala">░</button>
+      <span class="flag-label">Açık Gölge</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="▒" aria-label="▒ kopyala">▒</button>
+      <span class="flag-label">Orta Gölge</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="▓" aria-label="▓ kopyala">▓</button>
+      <span class="flag-label">Koyu Gölge</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="█" aria-label="█ kopyala">█</button>
+      <span class="flag-label">Tam Blok</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="▚" aria-label="▚ kopyala">▚</button>
+      <span class="flag-label">Sol Üst ve Sağ Alt Çeyrek</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⋆" aria-label="⋆ kopyala">⋆</button>
+      <span class="flag-label">Yıldız Operatörü</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="combo-sets">
+  <span class="article-section-label">Kombin Setleri</span>
+  <h2>Dreamcore &amp; Weirdcore Kombin Setleri</h2>
+  <p class="u-secondary-block">Tek tıkla bütün bir sürreal kombini kopyala — gözler, gökyüzü, statik ve uyku, her yere yapıştırmaya hazır.</p>
+  <div id="dreamcoreSetsContainer"></div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Metni Unicode fontlarla dönüştür</h3>
+  <p>Düz metni kalın, italik, el yazısı ve 100+ başka Unicode font stiline dönüştürmek için UltraTextGen'i kullan — ücretsiz ve anında.</p>
+  <a href="https://ultratextgen.com/tr/" class="cta-btn">UltraTextGen'i Aç →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">İlgili Kaynaklar</span>
+  <div class="compare-grid">
+    <a href="/tr/library/fairycore-sembolleri/" class="compare-card variant-muted u-no-underline">
+      <h4>Fairycore Sembolleri</h4>
+      <p>Büyülü biolar için periler, mantarlar ve peri tozu parıltıları.</p>
+    </a>
+    <a href="/tr/library/y2k-sembolleri/" class="compare-card variant-muted u-no-underline">
+      <h4>Y2K Sembolleri</h4>
+      <p>Retro-fütüristik 2000'ler karakterleri ve cyber estetik işaretleri.</p>
+    </a>
+    <a href="/tr/library/yildiz-sembolleri/" class="compare-card variant-muted u-no-underline">
+      <h4>Yıldız Sembolleri</h4>
+      <p>Gökyüzü ve rüya estetiği için yıldız ve parıltı işaretleri.</p>
+    </a>
+    <a href="/tr/library/kalp-sembolleri/" class="compare-card variant-muted u-no-underline">
+      <h4>Kalp Sembolleri</h4>
+      <p>Yumuşak paylaşımlar için her stilde kalp sembolleri.</p>
+    </a>
+    <a href="/tr/library/estetik-semboller/" class="compare-card variant-muted u-no-underline">
+      <h4>Estetik Semboller</h4>
+      <p>Aesthetic metin sembolleri ve ayraçların ana koleksiyonu.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <div class="lang-switcher" role="navigation" aria-label="Language switcher">
+      <a class="lang-option" href="/library/dreamcore-weirdcore-symbols/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/tr/library/dreamcore-weirdcore-sembolleri/" hreflang="tr">TR</a>
+    </div>
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  const ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  const GROUPS = [
+    {
+      name: "Dreamcore Gökyüzü",
+      flags: ["🌈", "☁️", "👁", "⭐", "🌀"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Weirdcore Koridoru",
+      flags: ["🚪", "📺", "🕳", "🪞", "👁"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Sleepcore Süzülüşü",
+      flags: ["💤", "🛏", "🌙", "☁️", "😴"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Her Şeyi Gören Gözler",
+      flags: ["👁", "𓂀", "◉", "👀", "⊙"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Statik Glitch Çubukları",
+      flags: ["░▒▓█▓▒░", "▓▒░⋆░▒▓", "█▓▒░"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Pastel Rüya",
+      flags: ["🫧", "🌈", "🪞", "💫", "☁️"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Liminal Gece",
+      flags: ["🌃", "🛗", "🕰", "🌌", "🚪"],
+      defaultFormat: "inline"
+    }
+  ];
+
+  ns.buildGrids("dreamcoreSetsContainer", GROUPS);
+  if (ns.parseTwemoji) ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/tr/library/fairycore-sembolleri/index.html
+++ b/tr/library/fairycore-sembolleri/index.html
@@ -1,0 +1,380 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Fairycore Sembolleri: Kopyala Yapıştır 🧚 🍄 ✨ Peri Estetiği</title>
+<meta name="description" content="Fairycore sembolleri ve emoji kombinleri — periler 🧚, mantarlar 🍄, parıltılar ✨ ve zarif çiçek karakterleriyle büyülü bio'lar. Kopyalamak için herhangi bir sembole dokun.">
+
+<link rel="canonical" href="https://ultratextgen.com/tr/library/fairycore-sembolleri/">
+<link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/fairycore-sembolleri/">
+<link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/tr/library/fairycore-sembolleri/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/tr-library-fairycore-sembolleri.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Fairycore Sembolleri: Kopyala Yapıştır 🧚 🍄 ✨ Peri Estetiği">
+<meta name="twitter:description" content="Fairycore sembolleri ve emoji kombinleri — periler 🧚, mantarlar 🍄, parıltılar ✨ ve zarif çiçek karakterleriyle büyülü bio'lar. Kopyalamak için herhangi bir sembole dokun.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/tr-library-fairycore-sembolleri.png">
+<meta property="og:title" content="Fairycore Sembolleri: Kopyala Yapıştır 🧚 🍄 ✨ Peri Estetiği">
+<meta property="og:description" content="Fairycore sembolleri ve emoji kombinleri — periler 🧚, mantarlar 🍄, parıltılar ✨ ve zarif çiçek karakterleriyle büyülü bio'lar. Kopyalamak için herhangi bir sembole dokun.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/tr/library/fairycore-sembolleri/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Fairycore Sembolleri: Kopyala Yapıştır 🧚 🍄 ✨ Peri Estetiği",
+  "alternateName": ["Fairycore Sembolleri Kopyala Yapıştır", "Peri Estetiği Sembolleri", "Fairycore Emoji", "Peri Sembolleri Kopyala Yapıştır", "Cottagecore Peri Sembolleri", "Büyülü Semboller Kopyala Yapıştır"],
+  "description": "Fairycore sembolleri ve emoji kombinleri — periler 🧚, mantarlar 🍄, parıltılar ✨ ve zarif çiçek karakterleriyle büyülü bio'lar. Kopyalamak için herhangi bir sembole dokun.",
+  "inLanguage": "tr",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/tr-library-fairycore-sembolleri.png",
+  "mainEntityOfPage": "https://ultratextgen.com/tr/library/fairycore-sembolleri/",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Ana Sayfa", "item": "https://ultratextgen.com/tr/" },
+    { "@type": "ListItem", "position": 2, "name": "Fairycore Sembolleri", "item": "https://ultratextgen.com/tr/library/fairycore-sembolleri/" }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/tr/">Ana Sayfa</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Fairycore Sembolleri</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Fairycore Sembolleri</h1>
+    <p class="hero-tagline">Büyülü bir estetik için periler, mantarlar, peri tozu parıltıları ve orman çiçekleri. Herhangi bir sembole veya kombine dokun, anında kopyalansın.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/tr-library-fairycore-sembolleri.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Fairycore, periler, ışıldayan ormanlar, mantar halkaları ve yumuşak altın parıltı etrafında kurulmuş büyülü bir estetiktir — büyülü bahçeleri ve peri tozunu düşün. Bu fairycore sembolleri ve emoji kombinleri o büyüyü 🧚 periler, 🍄 mantarlar, ✨ parıltılar ve ✿ ile ❀ gibi zarif çiçek karakterleriyle yakalar. Bunları Instagram bio'larında, Pinterest pano adlarında, TikTok caption'larında ve Discord hakkımda bölümlerinde kullan ya da aşağıdaki hazır bir kombin setini kopyala.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="fairies-magic">
+  <span class="article-section-label">Periler &amp; Büyü</span>
+  <h2>Peri &amp; Büyü Emojileri</h2>
+  <p class="u-secondary-tight">Peri emoji ailesi, sihirli değnekler ve parıltı büyüsü.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧚" aria-label="🧚 kopyala">🧚</button>
+      <span class="flag-label">Peri</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧚‍♀️" aria-label="🧚‍♀️ kopyala">🧚‍♀️</button>
+      <span class="flag-label">Kadın Peri</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧚‍♂️" aria-label="🧚‍♂️ kopyala">🧚‍♂️</button>
+      <span class="flag-label">Erkek Peri</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🪄" aria-label="🪄 kopyala">🪄</button>
+      <span class="flag-label">Sihirli Değnek</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✨" aria-label="✨ kopyala">✨</button>
+      <span class="flag-label">Parıltılar</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💫" aria-label="💫 kopyala">💫</button>
+      <span class="flag-label">Dönen Yıldız</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🔮" aria-label="🔮 kopyala">🔮</button>
+      <span class="flag-label">Kristal Küre</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="mushrooms-flora">
+  <span class="article-section-label">Mantarlar &amp; Flora</span>
+  <h2>Mantarlar &amp; Orman Florası</h2>
+  <p class="u-secondary-tight">Her fairycore düzeninin temelini oluşturan mantarlar, çiçekler ve Unicode florette karakterleri.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🍄" aria-label="🍄 kopyala">🍄</button>
+      <span class="flag-label">Mantar</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌷" aria-label="🌷 kopyala">🌷</button>
+      <span class="flag-label">Lale</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌸" aria-label="🌸 kopyala">🌸</button>
+      <span class="flag-label">Kiraz Çiçeği</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌼" aria-label="🌼 kopyala">🌼</button>
+      <span class="flag-label">Çiçek</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✿" aria-label="✿ kopyala">✿</button>
+      <span class="flag-label">Siyah Çiçek (Florette)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❀" aria-label="❀ kopyala">❀</button>
+      <span class="flag-label">Beyaz Çiçek (Florette)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌿" aria-label="🌿 kopyala">🌿</button>
+      <span class="flag-label">Yeşil Ot</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🍃" aria-label="🍃 kopyala">🍃</button>
+      <span class="flag-label">Rüzgârda Uçuşan Yaprak</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🪷" aria-label="🪷 kopyala">🪷</button>
+      <span class="flag-label">Nilüfer</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="pixie-sparkles">
+  <span class="article-section-label">Peri Tozu</span>
+  <h2>Peri Tozu &amp; Yıldız Parıltıları</h2>
+  <p class="u-secondary-tight">Zarif metin ayraçları ve kullanıcı adı vurguları oluşturmak için minik yıldız ve parıltı karakterleri.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⋆" aria-label="⋆ kopyala">⋆</button>
+      <span class="flag-label">Yıldız Operatörü</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✦" aria-label="✦ kopyala">✦</button>
+      <span class="flag-label">Siyah Dört Köşeli Yıldız</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✧" aria-label="✧ kopyala">✧</button>
+      <span class="flag-label">Beyaz Dört Köşeli Yıldız</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✩" aria-label="✩ kopyala">✩</button>
+      <span class="flag-label">İnce Konturlu Beyaz Yıldız</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="˚" aria-label="˚ kopyala">˚</button>
+      <span class="flag-label">Üst Halka</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="୨୧" aria-label="୨୧ kopyala">୨୧</button>
+      <span class="flag-label">Estetik Fiyonk İşareti (Odia Rakamları)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌟" aria-label="🌟 kopyala">🌟</button>
+      <span class="flag-label">Parlayan Yıldız</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="garden-creatures">
+  <span class="article-section-label">Bahçe Canlıları</span>
+  <h2>Büyülü Bahçe Canlıları</h2>
+  <p class="u-secondary-tight">Peri bahçesi sahnesini tamamlayan kelebekler, salyangozlar ve nazik bahçe ziyaretçileri.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦋" aria-label="🦋 kopyala">🦋</button>
+      <span class="flag-label">Kelebek</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐌" aria-label="🐌 kopyala">🐌</button>
+      <span class="flag-label">Salyangoz</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐞" aria-label="🐞 kopyala">🐞</button>
+      <span class="flag-label">Uğur Böceği</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐝" aria-label="🐝 kopyala">🐝</button>
+      <span class="flag-label">Bal Arısı</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐇" aria-label="🐇 kopyala">🐇</button>
+      <span class="flag-label">Tavşan</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦢" aria-label="🦢 kopyala">🦢</button>
+      <span class="flag-label">Kuğu</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕊" aria-label="🕊 kopyala">🕊</button>
+      <span class="flag-label">Güvercin</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="combo-sets">
+  <span class="article-section-label">Kombin Setleri</span>
+  <h2>Fairycore Kombin Setleri</h2>
+  <p class="u-secondary-block">Tek tıkla tam bir fairycore emoji kombini kopyala — bio, caption ve pano adları için hazır.</p>
+  <div id="fairycoreSetsContainer"></div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Metni Unicode fontlarla dönüştür</h3>
+  <p>Düz metni kalın, italik, el yazısı ve 100+ başka Unicode font stiline dönüştürmek için UltraTextGen'i kullan — ücretsiz ve anında.</p>
+  <a href="https://ultratextgen.com/tr/" class="cta-btn">UltraTextGen'i Aç →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">İlgili Kaynaklar</span>
+  <div class="compare-grid">
+    <a href="/tr/library/cottagecore-sembolleri/" class="compare-card variant-muted u-no-underline">
+      <h4>Cottagecore Sembolleri</h4>
+      <p>Mantarlar, bal arıları ve kır yaşamı karakterleri.</p>
+    </a>
+    <a href="/tr/library/coquette-sembolleri/" class="compare-card variant-muted u-no-underline">
+      <h4>Coquette Sembolleri</h4>
+      <p>Fiyonklar, kurdeleler ve yumuşak feminen estetik karakterleri.</p>
+    </a>
+    <a href="/tr/library/yildiz-sembolleri/" class="compare-card variant-muted u-no-underline">
+      <h4>Yıldız Sembolleri</h4>
+      <p>Estetik metin için parıltı ve yıldız karakterleri.</p>
+    </a>
+    <a href="/tr/library/y2k-sembolleri/" class="compare-card variant-muted u-no-underline">
+      <h4>Y2K Sembolleri</h4>
+      <p>2000'ler cyber estetiği için yıldız, haç ve kelebek sembolleri.</p>
+    </a>
+    <a href="/tr/library/estetik-semboller/" class="compare-card variant-muted u-no-underline">
+      <h4>Estetik Semboller</h4>
+      <p>Bio için seçilmiş aesthetic Unicode karakterleri.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <div class="lang-switcher" role="navigation" aria-label="Language switcher">
+      <a class="lang-option" href="/library/fairycore-symbols/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/tr/library/fairycore-sembolleri/" hreflang="tr">TR</a>
+    </div>
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    {
+      name: "Peri Bahçesi",
+      flags: ["🧚", "🍄", "🌷", "✨", "🌿", "🦋"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Peri Tozu İzi",
+      flags: ["✨", "⋆", "˚", "✧", "🪄", "💫"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Mantar Halkası",
+      flags: ["🍄", "🌿", "🍄", "✨", "🍄", "🍃"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Kelebek Çayırı",
+      flags: ["🦋", "🌼", "🌸", "🐝", "🍃"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Ay Işığında Peri",
+      flags: ["🌙", "✨", "🧚", "⋆", "☁️"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Zarif Bio Ayracı",
+      flags: ["⋆˚✿˖°", "୨୧", "⋆˚❀˖°"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Kır Evi Perisi",
+      flags: ["🍄", "🐌", "🌷", "🧺", "🐇"],
+      defaultFormat: "inline"
+    }
+  ];
+
+  ns.buildGrids("fairycoreSetsContainer", GROUPS);
+  if (ns.parseTwemoji) ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/tr/library/goth-grunge-sembolleri/index.html
+++ b/tr/library/goth-grunge-sembolleri/index.html
@@ -1,0 +1,356 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Goth &amp; Grunge Sembolleri ✝ Kopyala Yapıştır — Karanlık Aesthetic Bio İşaretleri</title>
+  <meta name="description" content="Goth ve grunge bio'ları için karanlık aesthetic semboller: haçlar ♱ ✟ †, kurukafalar 💀, örümcekler 🕷, hançerler 🗡 ve alt moda süsleri. Nick ve bio için dokun, anında kopyalansın.">
+
+  <link rel="canonical" href="https://ultratextgen.com/tr/library/goth-grunge-sembolleri/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/goth-grunge-symbols/">
+  <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/goth-grunge-sembolleri/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/tr/library/goth-grunge-sembolleri/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Goth &amp; Grunge Sembolleri — Kopyala Yapıştır">
+  <meta property="og:description" content="Haçlar, kurukafalar, örümcekler, hançerler ve karanlık çiçekler — goth ve grunge estetiği için semboller. Dokun, kopyalansın.">
+  <meta property="og:url" content="https://ultratextgen.com/tr/library/goth-grunge-sembolleri/">
+  <meta property="og:type" content="article">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/tr-library-goth-grunge-sembolleri.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Goth &amp; Grunge Sembolleri">
+  <meta name="twitter:description" content="Bio, nick ve caption için karanlık aesthetic goth ve grunge semboller kopyala yapıştır.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/tr-library-goth-grunge-sembolleri.png">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+  <link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Goth & Grunge Sembolleri Kopyala Yapıştır",
+  "alternateName": ["Goth Semboller Kopyala Yapıştır", "Karanlık Aesthetic Semboller", "Grunge Sembolleri", "Karanlık Bio Sembolleri", "Gotik Semboller", "Emo Sembolleri", "Karanlık Aesthetic Metin Sembolleri", "Goth Emojiler"],
+  "description": "Goth ve grunge bio'ları için karanlık aesthetic semboller — haçlar, kurukafalar, örümcekler, hançerler ve alt moda süsleri. Nick ve profiller için.",
+  "inLanguage": "tr",
+  "image": "https://ultratextgen.com/assets/og/tr-library-goth-grunge-sembolleri.png",
+  "mainEntityOfPage": "https://ultratextgen.com/tr/library/goth-grunge-sembolleri/",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10",
+  "author": { "@type": "Organization", "name": "UltraTextGen", "url": "https://ultratextgen.com/" },
+  "publisher": { "@type": "Organization", "name": "UltraTextGen", "url": "https://ultratextgen.com/" }
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Ana Sayfa", "item": "https://ultratextgen.com/tr/" },
+    { "@type": "ListItem", "position": 2, "name": "Goth & Grunge Sembolleri", "item": "https://ultratextgen.com/tr/library/goth-grunge-sembolleri/" }
+  ]
+}
+</script>
+
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+  <script src="/header.js" defer></script>
+
+  <nav class="breadcrumbs" aria-label="Breadcrumb">
+    <a href="/tr/">Ana Sayfa</a>
+    <span class="breadcrumb-separator">›</span>
+    <span class="breadcrumb-current">Goth &amp; Grunge Sembolleri</span>
+  </nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Goth &amp; Grunge Sembolleri</h1>
+    <p class="hero-tagline">Goth ve grunge bio'ları için karanlık aesthetic semboller — haçlar, kurukafalar, örümcekler, hançerler ve alt moda süsleri. Kopyalamak için herhangi birine dokun.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/tr-library-goth-grunge-sembolleri.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Goth ve grunge estetiği karanlığı, sertliği ve isyanı benimser — kara güller, gotik haçlar, örümcekler, zincirler ve kurukafalar. Bu Unicode karakterleri ve emojiler o enerjiyi bio süslerine ve caption'lara taşır. Instagram, TikTok, Discord, Tumblr ve Unicode'un desteklendiği her yerde çalışır.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 1 -->
+<section class="mood-explainers" id="crosses-daggers">
+  <span class="article-section-label">Haçlar &amp; Hançerler</span>
+  <h2>Haçlar &amp; Hançerler</h2>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♱" aria-label="♱ kopyala">♱</button>
+      <span class="flag-label">Doğu Süryani Haçı</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="†" aria-label="† kopyala">†</button>
+      <span class="flag-label">Hançer</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‡" aria-label="‡ kopyala">‡</button>
+      <span class="flag-label">Çift Hançer</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✟" aria-label="✟ kopyala">✟</button>
+      <span class="flag-label">Konturlu Latin Haçı</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🗡" aria-label="🗡 kopyala">🗡</button>
+      <span class="flag-label">Hançer Emoji</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚔" aria-label="⚔ kopyala">⚔</button>
+      <span class="flag-label">Çapraz Kılıçlar</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🔪" aria-label="🔪 kopyala">🔪</button>
+      <span class="flag-label">Mutfak Bıçağı</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛧" aria-label="⛧ kopyala">⛧</button>
+      <span class="flag-label">Ters Pentagram</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𖤐" aria-label="𖤐 kopyala">𖤐</button>
+      <span class="flag-label">Kara Güneş</span>
+    </div>
+      <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✝" aria-label="✝ kopyala">✝</button>
+      <span class="flag-label">Latin Haçı</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☥" aria-label="☥ kopyala">☥</button>
+      <span class="flag-label">Ankh</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✠" aria-label="✠ kopyala">✠</button>
+      <span class="flag-label">Malta Haçı</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☦" aria-label="☦ kopyala">☦</button>
+      <span class="flag-label">Ortodoks Haçı</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☽" aria-label="☽ kopyala">☽</button>
+      <span class="flag-label">Hilal</span>
+    </div>
+</div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 2 -->
+<section class="mood-explainers" id="skulls-death">
+  <span class="article-section-label">Kurukafalar &amp; Ölüm Motifleri</span>
+  <h2>Kurukafalar &amp; Ölüm Motifleri</h2>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☠" aria-label="☠ kopyala">☠</button>
+      <span class="flag-label">Kurukafa ve Çapraz Kemikler</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💀" aria-label="💀 kopyala">💀</button>
+      <span class="flag-label">Kurukafa Emoji</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🩸" aria-label="🩸 kopyala">🩸</button>
+      <span class="flag-label">Kan Damlası Emoji</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚰" aria-label="⚰ kopyala">⚰</button>
+      <span class="flag-label">Tabut</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🪦" aria-label="🪦 kopyala">🪦</button>
+      <span class="flag-label">Mezar Taşı Emoji</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚱" aria-label="⚱ kopyala">⚱</button>
+      <span class="flag-label">Cenaze Vazosu</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 3 -->
+<section class="mood-explainers" id="spiders-bats">
+  <span class="article-section-label">Örümcekler, Yarasalar &amp; Yaratıklar</span>
+  <h2>Örümcekler, Yarasalar &amp; Yaratıklar</h2>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕷" aria-label="🕷 kopyala">🕷</button>
+      <span class="flag-label">Örümcek Emoji</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕸" aria-label="🕸 kopyala">🕸</button>
+      <span class="flag-label">Örümcek Ağı Emoji</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦇" aria-label="🦇 kopyala">🦇</button>
+      <span class="flag-label">Yarasa Emoji</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐍" aria-label="🐍 kopyala">🐍</button>
+      <span class="flag-label">Yılan Emoji</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦂" aria-label="🦂 kopyala">🦂</button>
+      <span class="flag-label">Akrep Emoji</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 4 -->
+<section class="mood-explainers" id="dark-florals">
+  <span class="article-section-label">Karanlık Çiçekler</span>
+  <h2>Karanlık Çiçekler</h2>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🥀" aria-label="🥀 kopyala">🥀</button>
+      <span class="flag-label">Solmuş Çiçek Emoji</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚘" aria-label="⚘ kopyala">⚘</button>
+      <span class="flag-label">Çiçek</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🖤" aria-label="🖤 kopyala">🖤</button>
+      <span class="flag-label">Siyah Kalp Emoji</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❦" aria-label="❦ kopyala">❦</button>
+      <span class="flag-label">Çiçekli Kalp</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❧" aria-label="❧ kopyala">❧</button>
+      <span class="flag-label">Döndürülmüş Çiçekli Kalp</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓆩♱𓆪" aria-label="𓆩♱𓆪 kopyala">𓆩♱𓆪</button>
+      <span class="flag-label">Mısır Haç Çerçevesi</span>
+    </div>
+  </div>
+  <p>Birçok goth sembol büyülü ve okült estetikle örtüşür — pentagram, hilal ve gotik haçlar için <a href="/tr/library/y2k-sembolleri/">Y2K Sembolleri</a> kütüphanesine de göz at.</p>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- COLLECTIONS -->
+<section class="mood-explainers" id="goth-grunge-collections">
+  <span class="article-section-label">Goth &amp; Grunge Koleksiyonları</span>
+  <h2>Karanlık Aesthetic Bio Setleri</h2>
+  <p class="u-secondary-block">Doğrudan bir bio, caption veya nick'e yapıştırabileceğin hazır karanlık aesthetic diziler — bütün kombini tek tıkla kopyala.</p>
+  <div id="gothGrungeCollectionsContainer"></div>
+</section>
+
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Metni Unicode fontlarla dönüştür</h3>
+  <p>Düz metni kalın, italik, el yazısı ve 100+ başka Unicode font stiline dönüştürmek için UltraTextGen'i kullan — ücretsiz ve anında.</p>
+  <a href="https://ultratextgen.com/tr/" class="cta-btn">UltraTextGen'i Aç →</a>
+</div>
+
+
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">İlgili Kaynaklar</span>
+  <div class="compare-grid">
+    <a href="/tr/library/estetik-semboller/" class="compare-card variant-muted u-no-underline">
+      <h4>Estetik Semboller</h4>
+      <p>Bio için seçilmiş aesthetic Unicode karakterleri.</p>
+    </a>
+    <a href="/tr/library/y2k-sembolleri/" class="compare-card variant-muted u-no-underline">
+      <h4>Y2K Sembolleri</h4>
+      <p>Cyber ve karanlık Y2K aesthetic süsleri.</p>
+    </a>
+    <a href="/tr/library/coquette-sembolleri/" class="compare-card variant-muted u-no-underline">
+      <h4>Coquette Sembolleri</h4>
+      <p>Fiyonklar, kalpler ve yumuşak coquette süsleri.</p>
+    </a>
+    <a href="/tr/library/cottagecore-sembolleri/" class="compare-card variant-muted u-no-underline">
+      <h4>Cottagecore Sembolleri</h4>
+      <p>Çiçekler, bitkiler ve kırsal cottagecore işaretleri.</p>
+    </a>
+    <a href="/tr/library/yildiz-sembolleri/" class="compare-card variant-muted u-no-underline">
+      <h4>Yıldız Sembolleri</h4>
+      <p>Karanlık yıldızlar ve dekoratif yıldız çeşitleri.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <div class="lang-switcher" role="navigation" aria-label="Language switcher">
+      <a class="lang-option" href="/library/goth-grunge-symbols/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/tr/library/goth-grunge-sembolleri/" hreflang="tr">TR</a>
+    </div>
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  const ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  const GROUPS = [
+    { name: "Goth Haç Ayracı", flags: ["†","˖","♱","˖","†"], defaultFormat: "inline" },
+    { name: "Mısır Haç Çerçevesi", flags: ["𓆩♱𓆪"], defaultFormat: "inline" },
+    { name: "Hançer Kenarlığı", flags: ["✟","·","†","‡","†","·","✟"], defaultFormat: "inline" },
+    { name: "Solmuş Gül Kombini", flags: ["🥀","🖤","🥀"], defaultFormat: "inline" },
+    { name: "Karanlık Çiçek İzi", flags: ["❦","˖","🖤","˖","❧"], defaultFormat: "inline" },
+    { name: "Pentagram Bio Kombini", flags: ["⛧","˖","𖤐","˖","⛧"], defaultFormat: "inline" }
+  ];
+
+  ns.buildGrids("gothGrungeCollectionsContainer", GROUPS);
+  ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/tr/library/kawaii-cute-sembolleri/index.html
+++ b/tr/library/kawaii-cute-sembolleri/index.html
@@ -1,0 +1,402 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Kawaii Sevimli Semboller ♡ Kopyala Yapıştır — Yumuşak Aesthetic Süslemeler</title>
+  <meta name="description" content="Kawaii ve sevimli semboller kopyala yapıştır: yumuşak kalpler ♡, minik yüzler, parıltılar ve pastel süslemeler. Bio, nick ve mesajlar için dokun, anında kopyalansın.">
+
+  <link rel="canonical" href="https://ultratextgen.com/tr/library/kawaii-cute-sembolleri/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/kawaii-cute-symbols/">
+  <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/kawaii-cute-sembolleri/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/kawaii-cute-symbols/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Kawaii Sevimli Semboller — Kopyala Yapıştır">
+  <meta property="og:description" content="Yumuşak kalpler, minik yüzler, parıltılar ve pastel süslemeler — kawaii estetiği için semboller. Dokun, kopyalansın.">
+  <meta property="og:url" content="https://ultratextgen.com/tr/library/kawaii-cute-sembolleri/">
+  <meta property="og:type" content="article">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/tr-library-kawaii-cute-sembolleri.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Kawaii Sevimli Semboller">
+  <meta name="twitter:description" content="Bio, nick ve mesajlar için kawaii sevimli semboller kopyala yapıştır.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/tr-library-kawaii-cute-sembolleri.png">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+  <link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Kawaii Sevimli Semboller Kopyala Yapıştır",
+  "alternateName": ["Kawaii Semboller Kopyala Yapıştır", "Sevimli Semboller", "Kawaii Metin Sembolleri", "Sevimli Aesthetic Semboller", "Yumuşak Aesthetic Semboller", "Kawaii Süslemeler", "Sevimli Japon Sembolleri"],
+  "description": "Kawaii ve sevimli semboller kopyala yapıştır — yumuşak kalpler ♡, minik yüzler, parıltılar ve pastel süslemeler. Bio, nick ve mesajlar için.",
+  "inLanguage": "tr",
+  "image": "https://ultratextgen.com/assets/og/tr-library-kawaii-cute-sembolleri.png",
+  "mainEntityOfPage": "https://ultratextgen.com/tr/library/kawaii-cute-sembolleri/",
+  "author": { "@type": "Organization", "name": "UltraTextGen", "url": "https://ultratextgen.com/" },
+  "publisher": { "@type": "Organization", "name": "UltraTextGen", "url": "https://ultratextgen.com/" },
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Ana Sayfa", "item": "https://ultratextgen.com/tr/" },
+    { "@type": "ListItem", "position": 2, "name": "Kawaii Sevimli Semboller", "item": "https://ultratextgen.com/tr/library/kawaii-cute-sembolleri/" }
+  ]
+}
+</script>
+
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+  <script src="/header.js" defer></script>
+
+  <nav class="breadcrumbs" aria-label="Breadcrumb">
+    <a href="/tr/">Ana Sayfa</a>
+    <span class="breadcrumb-separator">›</span>
+    <span class="breadcrumb-current">Kawaii Sevimli Semboller</span>
+  </nav>
+
+  <!-- HERO -->
+  <section class="hero">
+    <div class="hero-inner">
+      <h1 class="hero-headline">Kawaii &amp; Sevimli Semboller</h1>
+      <p class="hero-tagline">Yumuşak kalpler, minik yüzler, parıltılar ve pastel kawaii süslemeler. Bio, nick ve mesajlar için herhangi bir sembole dokun, anında kopyalansın.</p>
+    </div>
+  </section>
+  <figure class="page-hero-figure" data-uthero aria-hidden="true">
+    <img src="/assets/hero/tr-library-kawaii-cute-sembolleri.svg" width="1200" height="340" loading="lazy" alt="">
+  </figure>
+
+  <!-- INTRO -->
+  <section class="editorial-section">
+    <div class="editorial-block">
+      <p>Kawaii (かわいい) Japoncada sevimli demektir ve kawaii estetiği yumuşak, pastel ve şirin olan her şeyi kutlar. Bu Unicode karakterleri ve emojiler o hissi yakalar: minik yüzler, kalp sembolleri, parıltı işaretleri ve sevimli sarmalayıcı ayraçlar. Bunları Instagram, TikTok, Discord ve Unicode metni destekleyen her platformda bio, mesaj, nick ve caption içinde kullan.</p>
+    </div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <!-- SECTION 1 -->
+  <section class="mood-explainers" id="cute-hearts">
+    <span class="article-section-label">Sevimli Kalpler</span>
+    <h2>Sevimli Kalpler</h2>
+    <p>Kawaii bio'lar ve tatlı mesajlar için yumuşak kalp karakterleri.</p>
+    <div class="flag-rows">
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="♡" aria-label="♡ kopyala">♡</button>
+        <span class="flag-label">Beyaz Kalp</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="ෆ" aria-label="ෆ kopyala">ෆ</button>
+        <span class="flag-label">Sinhala Ayanna Harfi (kalp)</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="❤" aria-label="❤ kopyala">❤</button>
+        <span class="flag-label">Kırmızı Kalp</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="❥" aria-label="❥ kopyala">❥</button>
+        <span class="flag-label">Döndürülmüş Kalp İşareti</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="ʚɞ" aria-label="ʚɞ kopyala">ʚɞ</button>
+        <span class="flag-label">Kanatlı Kalp (kombin)</span>
+      </div>
+    </div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <!-- SECTION 2 -->
+  <section class="mood-explainers" id="tiny-cute-faces">
+    <span class="article-section-label">Minik Sevimli Yüzler</span>
+    <h2>Minik Sevimli Yüzler</h2>
+    <p>Mesaj ve bio'lara kawaii ifadeler katmak için kaomoji ve Unicode yüzler.</p>
+    <div class="flag-rows">
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="(˶˃ ᵕ ˂˶)" aria-label="(˶˃ ᵕ ˂˶) kopyala">(˶˃ ᵕ ˂˶)</button>
+        <span class="flag-label">Kızaran Yüz (kombin)</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="ʕ•ᴥ•ʔ" aria-label="ʕ•ᴥ•ʔ kopyala">ʕ•ᴥ•ʔ</button>
+        <span class="flag-label">Ayı Yüzü (kombin)</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="(づ ◕‿◕)づ" aria-label="(づ ◕‿◕)づ kopyala">(づ ◕‿◕)づ</button>
+        <span class="flag-label">Sarılan Yüz (kombin)</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="(✿◠‿◠)" aria-label="(✿◠‿◠) kopyala">(✿◠‿◠)</button>
+        <span class="flag-label">Çiçek Yüzü (kombin)</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="◕" aria-label="◕ kopyala">◕</button>
+        <span class="flag-label">Büyük Daire Göz</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="◡" aria-label="◡ kopyala">◡</button>
+        <span class="flag-label">Kavisli Harf</span>
+      </div>
+    </div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <!-- SECTION 3 -->
+  <section class="mood-explainers" id="cute-wrappers">
+    <span class="article-section-label">Sevimli Ayraçlar &amp; Sarmalar</span>
+    <h2>Sevimli Ayraçlar &amp; Sarmalar</h2>
+    <p>Kawaii nickler ve bio biçimlendirmesi için dekoratif ayraçlar ve sarmalayıcı karakterler.</p>
+    <div class="flag-rows">
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="꒰" aria-label="꒰ kopyala">꒰</button>
+        <span class="flag-label">Süslü Sol Parantez</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="꒱" aria-label="꒱ kopyala">꒱</button>
+        <span class="flag-label">Süslü Sağ Parantez</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="◌" aria-label="◌ kopyala">◌</button>
+        <span class="flag-label">Birleşen Halka</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="⊂" aria-label="⊂ kopyala">⊂</button>
+        <span class="flag-label">Alt Küme</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="⊃" aria-label="⊃ kopyala">⊃</button>
+        <span class="flag-label">Üst Küme</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="୨୧" aria-label="୨୧ kopyala">୨୧</button>
+        <span class="flag-label">Coquette Dalgası (kombin)</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="✿" aria-label="✿ kopyala">✿</button>
+        <span class="flag-label">Siyah Çiçek</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="ʚ" aria-label="ʚ kopyala">ʚ</button>
+        <span class="flag-label">Sol Kalp Kanadı</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="ɞ" aria-label="ɞ kopyala">ɞ</button>
+        <span class="flag-label">Sağ Kalp Kanadı</span>
+      </div>
+</div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <!-- SECTION 4 -->
+  <section class="mood-explainers" id="decorative-marks-kawaii">
+    <span class="article-section-label">Dekoratif İşaretler</span>
+    <h2>Dekoratif İşaretler</h2>
+    <p>Herhangi bir metne kawaii hava katmak için parıltılar, noktalar ve küçük vurgu işaretleri.</p>
+    <div class="flag-rows">
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="⋆" aria-label="⋆ kopyala">⋆</button>
+        <span class="flag-label">Altı Köşeli Yıldız Operatörü</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="⊹" aria-label="⊹ kopyala">⊹</button>
+        <span class="flag-label">Dik Haç</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="✧" aria-label="✧ kopyala">✧</button>
+        <span class="flag-label">Beyaz Dört Köşeli Yıldız</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="⩩" aria-label="⩩ kopyala">⩩</button>
+        <span class="flag-label">Benzer veya Eşit</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="๑" aria-label="๑ kopyala">๑</button>
+        <span class="flag-label">Tay Harfi Ko Kai</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="⌒" aria-label="⌒ kopyala">⌒</button>
+        <span class="flag-label">Kavis</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="❀" aria-label="❀ kopyala">❀</button>
+        <span class="flag-label">Beyaz Çiçek</span>
+      </div>
+    </div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <!-- SECTION 5 -->
+  <section class="mood-explainers" id="pastel-motifs">
+    <span class="article-section-label">Pastel Motifler</span>
+    <h2>Pastel Motifler</h2>
+    <p>Hayalperest bir kawaii estetiği kurmak için yumuşak çiçek ve gökyüzü sembolleri.</p>
+    <div class="flag-rows">
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="✿" aria-label="✿ kopyala">✿</button>
+        <span class="flag-label">Siyah Çiçek</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="❀" aria-label="❀ kopyala">❀</button>
+        <span class="flag-label">Beyaz Çiçek</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="❁" aria-label="❁ kopyala">❁</button>
+        <span class="flag-label">Sekiz Yapraklı Çiçek</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="☁" aria-label="☁ kopyala">☁</button>
+        <span class="flag-label">Bulut</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="☾" aria-label="☾ kopyala">☾</button>
+        <span class="flag-label">Hilal</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="⛅" aria-label="⛅ kopyala">⛅</button>
+        <span class="flag-label">Bulut Arkasında Güneş</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="✦" aria-label="✦ kopyala">✦</button>
+        <span class="flag-label">Siyah Dört Köşeli Yıldız</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="⋆" aria-label="⋆ kopyala">⋆</button>
+        <span class="flag-label">Altı Köşeli Yıldız Operatörü</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="🧸" aria-label="🧸 kopyala">🧸</button>
+        <span class="flag-label">Oyuncak Ayı</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="🐻" aria-label="🐻 kopyala">🐻</button>
+        <span class="flag-label">Ayı Yüzü</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="🐰" aria-label="🐰 kopyala">🐰</button>
+        <span class="flag-label">Tavşan Yüzü</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="🎀" aria-label="🎀 kopyala">🎀</button>
+        <span class="flag-label">Kurdele</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="🌸" aria-label="🌸 kopyala">🌸</button>
+        <span class="flag-label">Kiraz Çiçeği</span>
+      </div>
+</div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <!-- COLLECTIONS -->
+  <section class="mood-explainers" id="kawaii-collections">
+    <span class="article-section-label">Kawaii Koleksiyonları</span>
+    <h2>Kawaii Bio &amp; Nick Setleri</h2>
+    <p class="u-secondary-block">Hazır kawaii kombinleri — doğrudan bir bio, nick veya mesaja tek tıkla yapıştırabileceğin yumuşak kalpler, minik yüzler ve pastel parıltı.</p>
+    <div id="kawaiiCollectionsContainer"></div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <!-- CTA -->
+  <div class="cta-card">
+    <h3>Metni Unicode fontlarla dönüştür</h3>
+    <p>Düz metni kalın, italik, el yazısı ve 100+ başka Unicode font stiline dönüştürmek için UltraTextGen'i kullan — ücretsiz ve anında.</p>
+    <a href="https://ultratextgen.com/tr/" class="cta-btn">UltraTextGen'i Aç →</a>
+  </div>
+
+  <!-- RELATED -->
+  <section class="editorial-section">
+    <span class="article-section-label">İlgili Kaynaklar</span>
+    <div class="compare-grid">
+      <a href="/tr/library/coquette-sembolleri/" class="compare-card variant-muted u-no-underline">
+        <h4>Coquette Sembolleri</h4>
+        <p>Fiyonklar, kurdeleler ve coquette bio'lar için yumuşak feminen semboller.</p>
+      </a>
+      <a href="/tr/library/cottagecore-sembolleri/" class="compare-card variant-muted u-no-underline">
+        <h4>Cottagecore Sembolleri</h4>
+        <p>Çiçekler, yapraklar ve doğa dokunuşlu pastoral estetik semboller.</p>
+      </a>
+      <a href="/tr/library/kalp-sembolleri/" class="compare-card variant-muted u-no-underline">
+        <h4>Kalp Sembolleri</h4>
+        <p>Her kalp emojisi ve Unicode kalp karakteri.</p>
+      </a>
+      <a href="/tr/library/kaomoji/" class="compare-card variant-muted u-no-underline">
+        <h4>Kaomoji</h4>
+        <p>ASCII yüz sanatı, emoticon ve Japon kaomojileri.</p>
+      </a>
+      <a href="/tr/library/estetik-semboller/" class="compare-card variant-muted u-no-underline">
+        <h4>Estetik Semboller</h4>
+        <p>Bio için seçilmiş aesthetic Unicode karakterleri.</p>
+      </a>
+    </div>
+  </section>
+
+  <!-- FOOTER -->
+  <footer class="footer">
+    <div class="footer-inner">
+      <div class="lang-switcher" role="navigation" aria-label="Language switcher">
+      <a class="lang-option" href="/library/kawaii-cute-symbols/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/tr/library/kawaii-cute-sembolleri/" hreflang="tr">TR</a>
+    </div>
+    </div>
+  </footer>
+
+  <!-- TOAST -->
+  <div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+  <script src="/symbol-explorer.js" defer></script>
+  <script>
+  document.addEventListener("DOMContentLoaded", function () {
+    "use strict";
+    const ns = window.UltraTextGen;
+    if (!ns || !ns.buildGrids) return;
+
+    const GROUPS = [
+      { name: "Yumuşak Kalp Bio Kombini", flags: ["꒰","♡","꒱","⋆","ෆ"], defaultFormat: "inline" },
+      { name: "Kawaii Parıltı Ayracı", flags: ["⊹","⋆","✧","⋆","⊹"], defaultFormat: "inline" },
+      { name: "Çiçek Kanat Nick", flags: ["ʚ ✿ ɞ"], defaultFormat: "inline" },
+      { name: "Pastel Toz Kenarlık", flags: ["✦","⋆","❀","⋆","✦"], defaultFormat: "inline" },
+      { name: "Minik Yüz Bio Sarması", flags: ["(˶˃ ᵕ ˂˶)","♡"], defaultFormat: "inline" },
+      { name: "Sevimli Ayraç Kombini", flags: ["꒰ ♡ ꒱"], defaultFormat: "inline" }
+    ];
+
+    ns.buildGrids("kawaiiCollectionsContainer", GROUPS);
+    ns.parseTwemoji(document.body);
+  });
+  </script>
+  <script src="/footer.js" defer></script>
+</body>
+</html>

--- a/tr/library/therian-sembolleri/index.html
+++ b/tr/library/therian-sembolleri/index.html
@@ -1,0 +1,358 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Therian Sembolleri: Kopyala Yapıştır Δ Theta-Delta ve Alterhuman İşaretleri</title>
+<meta name="description" content="Therian ve alterhuman topluluğunun kullandığı theta-delta (θΔ) işaretleri, pati izleri, ay evreleri ve hayvan sembollerine göz at. Herhangi bir sembole dokun, anında kopyalansın.">
+
+<link rel="canonical" href="https://ultratextgen.com/tr/library/therian-sembolleri/">
+<link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/therian-symbols/">
+<link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/therian-sembolleri/">
+<link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/therian-symbols/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/tr-library-therian-sembolleri.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Therian Sembolleri: Kopyala Yapıştır Δ Theta-Delta ve Alterhuman İşaretleri">
+<meta name="twitter:description" content="Therian ve alterhuman topluluğunun kullandığı theta-delta (θΔ) işaretleri, pati izleri, ay evreleri ve hayvan sembollerine göz at. Herhangi bir sembole dokun, anında kopyalansın.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/tr-library-therian-sembolleri.png">
+<meta property="og:title" content="Therian Sembolleri: Kopyala Yapıştır Δ Theta-Delta ve Alterhuman İşaretleri">
+<meta property="og:description" content="Therian ve alterhuman topluluğunun kullandığı theta-delta (θΔ) işaretleri, pati izleri, ay evreleri ve hayvan sembollerine göz at. Herhangi bir sembole dokun, anında kopyalansın.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/tr/library/therian-sembolleri/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Therian Sembolleri: Kopyala Yapıştır Δ Theta-Delta ve Alterhuman İşaretleri",
+  "alternateName": ["Therian Sembolü Kopyala Yapıştır", "Theta Delta Sembolü Kopyala Yapıştır", "Alterhuman Semboller", "Therian Topluluk Sembolleri", "Therian İşaretleri", "Pati İzi Sembolleri Kopyala Yapıştır", "Therian Emojileri Kopyala Yapıştır"],
+  "description": "Therian ve alterhuman topluluğunun kullandığı theta-delta (θΔ) işaretleri, pati izleri, ay evreleri ve hayvan sembollerine göz at. Herhangi bir sembole dokun, anında kopyalansın.",
+  "inLanguage": "tr",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/tr-library-therian-sembolleri.png",
+  "mainEntityOfPage": "https://ultratextgen.com/tr/library/therian-sembolleri/",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Ana Sayfa", "item": "https://ultratextgen.com/tr/" },
+    { "@type": "ListItem", "position": 2, "name": "Therian Sembolleri", "item": "https://ultratextgen.com/tr/library/therian-sembolleri/" }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+  <nav class="breadcrumbs" aria-label="Breadcrumb">
+    <a href="/tr/">Ana Sayfa</a>
+    <span class="breadcrumb-separator">›</span>
+    <span class="breadcrumb-current">Therian Sembolleri</span>
+  </nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Therian Sembolleri</h1>
+    <p class="hero-tagline">Theta-delta (θΔ) topluluk işareti ile therian ve alterhuman kimliğinin pati, ay ve hayvan sembolleri. Herhangi bir sembole dokun, anında kopyalansın.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/tr-library-therian-sembolleri.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>İnsanların en çok aradığı therian sembolü theta-delta'dır — Yunan harfleri theta (θ) ve delta (Δ) birleşimi — therianthropy topluluğu tarafından 2003'te ortak, saygılı bir kimlik işareti olarak benimsenmiştir. Therianlar, bir hayvanla derin, fiziksel olmayan bir özdeşleşme yaşayan kişilerdir ve daha geniş alterhuman topluluğu bu işaretin yanında pati izleri, ay evreleri ve hayvan emojileri kullanır. Bu sayfa, theta-delta'yı yaygın Unicode biçimlerinde toplayıp TikTok biolarında, Tumblr bloglarında ve Discord profillerinde kullanılan doğa ve hayvan sembolleriyle bir araya getirir.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="theta-delta">
+  <span class="article-section-label">Theta-Delta</span>
+  <h2>Theta-Delta Topluluk İşaretleri</h2>
+  <p class="u-secondary-tight">Gerçek Yunan harflerinden kurulan theta-delta işareti — kombine çifti ya da her harfi tek tek kopyala.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="θΔ" aria-label="Theta-Delta (Therian İşareti) kopyala">θΔ</button>
+      <span class="flag-label">Theta-Delta (Therian İşareti)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ΘΔ" aria-label="Büyük Theta-Delta kopyala">ΘΔ</button>
+      <span class="flag-label">Büyük Theta-Delta</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="θ" aria-label="Yunan Küçük Theta Harfi kopyala">θ</button>
+      <span class="flag-label">Yunan Küçük Theta Harfi</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="Θ" aria-label="Yunan Büyük Theta Harfi kopyala">Θ</button>
+      <span class="flag-label">Yunan Büyük Theta Harfi</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="Δ" aria-label="Yunan Büyük Delta Harfi kopyala">Δ</button>
+      <span class="flag-label">Yunan Büyük Delta Harfi</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="δ" aria-label="Yunan Küçük Delta Harfi kopyala">δ</button>
+      <span class="flag-label">Yunan Küçük Delta Harfi</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ϴ" aria-label="Yunan Büyük Theta Sembolü kopyala">ϴ</button>
+      <span class="flag-label">Yunan Büyük Theta Sembolü</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ϑ" aria-label="Yunan Theta Sembolü kopyala">ϑ</button>
+      <span class="flag-label">Yunan Theta Sembolü</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="paw-prints">
+  <span class="article-section-label">Patiler &amp; Köpekgiller</span>
+  <h2>Pati İzleri &amp; Köpekgil Sembolleri</h2>
+  <p class="u-secondary-tight">Therian biolarında en sık görünen pati izleri ile kurt, tilki ve köpek emojileri.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐾" aria-label="Pati İzleri kopyala">🐾</button>
+      <span class="flag-label">Pati İzleri</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐺" aria-label="Kurt kopyala">🐺</button>
+      <span class="flag-label">Kurt</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦊" aria-label="Tilki kopyala">🦊</button>
+      <span class="flag-label">Tilki</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐕" aria-label="Köpek kopyala">🐕</button>
+      <span class="flag-label">Köpek</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐈‍⬛" aria-label="Kara Kedi kopyala">🐈‍⬛</button>
+      <span class="flag-label">Kara Kedi</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦝" aria-label="Rakun kopyala">🦝</button>
+      <span class="flag-label">Rakun</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐅" aria-label="Kaplan kopyala">🐅</button>
+      <span class="flag-label">Kaplan</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦴" aria-label="Kemik kopyala">🦴</button>
+      <span class="flag-label">Kemik</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="wild-animals">
+  <span class="article-section-label">Vahşi Hayvanlar</span>
+  <h2>Vahşi Hayvan &amp; Theriotype Sembolleri</h2>
+  <p class="u-secondary-tight">Yaygın theriotype'lar için emojiler — geyik ve büyük kedilerden yırtıcı kuşlara.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦌" aria-label="Geyik kopyala">🦌</button>
+      <span class="flag-label">Geyik</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐆" aria-label="Leopar kopyala">🐆</button>
+      <span class="flag-label">Leopar</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦅" aria-label="Kartal kopyala">🦅</button>
+      <span class="flag-label">Kartal</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦉" aria-label="Baykuş kopyala">🦉</button>
+      <span class="flag-label">Baykuş</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐦‍⬛" aria-label="Kara Kuş kopyala">🐦‍⬛</button>
+      <span class="flag-label">Kara Kuş</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐍" aria-label="Yılan kopyala">🐍</button>
+      <span class="flag-label">Yılan</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦈" aria-label="Köpekbalığı kopyala">🦈</button>
+      <span class="flag-label">Köpekbalığı</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐉" aria-label="Ejderha kopyala">🐉</button>
+      <span class="flag-label">Ejderha</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="moon-night">
+  <span class="article-section-label">Ay &amp; Gece</span>
+  <h2>Ay &amp; Gece Sembolleri</h2>
+  <p class="u-secondary-tight">Ay evreleri ve hilal karakterleri — therian ve alterhuman alanlarında köklü bir motif.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌙" aria-label="Hilal kopyala">🌙</button>
+      <span class="flag-label">Hilal</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☾" aria-label="Son Dördün Ay (Metin) kopyala">☾</button>
+      <span class="flag-label">Son Dördün Ay (Metin)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☽" aria-label="İlk Dördün Ay (Metin) kopyala">☽</button>
+      <span class="flag-label">İlk Dördün Ay (Metin)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌕" aria-label="Dolunay kopyala">🌕</button>
+      <span class="flag-label">Dolunay</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌑" aria-label="Yeni Ay kopyala">🌑</button>
+      <span class="flag-label">Yeni Ay</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌒" aria-label="Büyüyen Hilal Ay kopyala">🌒</button>
+      <span class="flag-label">Büyüyen Hilal Ay</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="forest-nature">
+  <span class="article-section-label">Orman &amp; Doğa</span>
+  <h2>Orman &amp; Doğa Sembolleri</h2>
+  <p class="u-secondary-tight">Bir quadrobics video başlığını ya da profili tamamlamak için orman ve doğa karakterleri.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌲" aria-label="Herdem Yeşil Ağaç kopyala">🌲</button>
+      <span class="flag-label">Herdem Yeşil Ağaç</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌿" aria-label="Yeşillik kopyala">🌿</button>
+      <span class="flag-label">Yeşillik</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🍂" aria-label="Düşmüş Yaprak kopyala">🍂</button>
+      <span class="flag-label">Düşmüş Yaprak</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛰" aria-label="Dağ kopyala">⛰</button>
+      <span class="flag-label">Dağ</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🪶" aria-label="Tüy kopyala">🪶</button>
+      <span class="flag-label">Tüy</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌾" aria-label="Buğday Demeti kopyala">🌾</button>
+      <span class="flag-label">Buğday Demeti</span>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Metni Unicode fontlarla dönüştür</h3>
+  <p>Düz metni kalın, italik, el yazısı ve 100+ başka Unicode font stiline dönüştürmek için UltraTextGen'i kullan — ücretsiz ve anında.</p>
+  <a href="https://ultratextgen.com/tr/" class="cta-btn">UltraTextGen'i Aç →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">İlgili Kaynaklar</span>
+  <div class="compare-grid">
+    <a href="/tr/library/yildiz-sembolleri/" class="compare-card variant-muted u-no-underline">
+      <h4>Yıldız Sembolleri</h4>
+      <p>Ay, yıldız ve göksel karakterler kopyala yapıştır.</p>
+    </a>
+    <a href="/tr/library/fairycore-sembolleri/" class="compare-card variant-muted u-no-underline">
+      <h4>Fairycore Sembolleri</h4>
+      <p>Orman, çiçek ve doğa temalı peri estetiği sembolleri.</p>
+    </a>
+    <a href="/tr/library/goth-grunge-sembolleri/" class="compare-card variant-muted u-no-underline">
+      <h4>Goth &amp; Grunge Sembolleri</h4>
+      <p>Karanlık estetik için haç, ay ve gotik işaretler.</p>
+    </a>
+    <a href="/tr/library/estetik-semboller/" class="compare-card variant-muted u-no-underline">
+      <h4>Estetik Semboller</h4>
+      <p>Bio için seçilmiş aesthetic Unicode karakterleri.</p>
+    </a>
+    <a href="/tr/library/kaomoji/" class="compare-card variant-muted u-no-underline">
+      <h4>Kaomoji</h4>
+      <p>Hayvan yüzlü ve sevimli Japon emoji yüzleri.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <div class="lang-switcher" role="navigation" aria-label="Language switcher">
+      <a class="lang-option" href="/library/therian-symbols/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/tr/library/therian-sembolleri/" hreflang="tr">TR</a>
+    </div>
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/tr/library/witchy-occult-sembolleri/index.html
+++ b/tr/library/witchy-occult-sembolleri/index.html
@@ -1,0 +1,756 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Witchy &amp; Okült Sembolleri: Kopyala Yapıştır Tüm Okült Karakterler</title>
+<meta name="description" content="Witchy ve okült sembollere göz at ve kopyala — pentagramlar, ay evreleri, gezegen işaretleri, simya sembolleri ve diğer ezoterik karakterler. Kopyalamak için herhangi birine dokun.">
+
+<link rel="canonical" href="https://ultratextgen.com/tr/library/witchy-occult-sembolleri/">
+<link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/witchy-occult-sembolleri/">
+<link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/tr/library/witchy-occult-sembolleri/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/tr-library-witchy-occult-sembolleri.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Witchy &amp; Okült Sembolleri: Kopyala Yapıştır Tüm Okült Karakterler">
+<meta name="twitter:description" content="Witchy ve okült sembollere göz at ve kopyala — pentagramlar, ay evreleri, gezegen işaretleri, simya sembolleri ve diğer ezoterik karakterler. Kopyalamak için herhangi birine dokun.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/tr-library-witchy-occult-sembolleri.png">
+<meta property="og:title" content="Witchy &amp; Okült Sembolleri: Kopyala Yapıştır Tüm Okült Karakterler">
+<meta property="og:description" content="Witchy ve okült sembollere göz at ve kopyala — pentagramlar, ay evreleri, gezegen işaretleri, simya sembolleri ve diğer ezoterik karakterler. Kopyalamak için herhangi birine dokun.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/tr/library/witchy-occult-sembolleri/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Witchy &amp; Okült Sembolleri Kopyala Yapıştır",
+  "alternateName": ["Okült Semboller Kopyala Yapıştır", "Witchy Semboller Kopyala Yapıştır", "Cadı Sembolleri Unicode", "Büyü Sembolleri Kopyala Yapıştır", "Ezoterik Semboller Kopyala Yapıştır", "Pentagram Sembolü Kopyala Yapıştır", "Witchy Emojileri Kopyala Yapıştır"],
+  "description": "Witchy ve okült sembollere göz at ve kopyala — pentagramlar, ay evreleri, gezegen işaretleri, simya sembolleri ve diğer ezoterik karakterler. Kopyalamak için herhangi birine dokun.",
+  "inLanguage": "tr",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/tr-library-witchy-occult-sembolleri.png",
+  "mainEntityOfPage": "https://ultratextgen.com/tr/library/witchy-occult-sembolleri/",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Ana Sayfa", "item": "https://ultratextgen.com/tr/" },
+    { "@type": "ListItem", "position": 2, "name": "Witchy &amp; Okült Sembolleri", "item": "https://ultratextgen.com/tr/library/witchy-occult-sembolleri/" }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/tr/">Ana Sayfa</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Witchy &amp; Okült Sembolleri</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Witchy &amp; Okült Sembolleri</h1>
+    <p class="hero-tagline">Pentagramlar, ay evreleri, gezegen sembolleri, simya işaretleri ve diğer ezoterik Unicode karakterlerinden özenle seçilmiş bir koleksiyon. Anında kopyalamak için herhangi bir sembole dokun.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/tr-library-witchy-occult-sembolleri.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Bu kütüphane büyücülük, okültizm, simya ve ezoterik geleneklerle ilişkilendirilen Unicode sembollerini bir araya getirir. Hepsi standart Unicode karakterleridir — metinlerde, bio'larda ve yaratıcı yazılarda kullanılabilir. Simya sembolleri bölümü, özel Simya Sembolleri Unicode bloğunu (U+1F700–U+1F73F) kapsar.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="pentagrams-stars">
+  <span class="article-section-label">Pentagramlar &amp; Yıldızlar</span>
+  <h2>Pentagramlar &amp; Beş Köşeli Yıldızlar</h2>
+  <p>Ezoterik ve okült geleneklerle ilişkilendirilen yıldız ve pentagram şekilleri.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="★" aria-label="Siyah Yıldız kopyala">★</button>
+      <span class="flag-label">Siyah Yıldız</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☆" aria-label="Beyaz Yıldız kopyala">☆</button>
+      <span class="flag-label">Beyaz Yıldız</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚹" aria-label="Sekstil kopyala">⚹</button>
+      <span class="flag-label">Sekstil</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✡" aria-label="Davud Yıldızı kopyala">✡</button>
+      <span class="flag-label">Davud Yıldızı</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚜" aria-label="Zambak (Fleur-de-Lis) kopyala">⚜</button>
+      <span class="flag-label">Zambak (Fleur-de-Lis)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛤" aria-label="Pentagram kopyala">⛤</button>
+      <span class="flag-label">Pentagram</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛥" aria-label="Sağa Dönük Pentagram kopyala">⛥</button>
+      <span class="flag-label">Sağa Dönük Pentagram</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛦" aria-label="Sola Dönük Pentagram kopyala">⛦</button>
+      <span class="flag-label">Sola Dönük Pentagram</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛧" aria-label="Ters Pentagram kopyala">⛧</button>
+      <span class="flag-label">Ters Pentagram</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✴" aria-label="Sekiz Köşeli Yıldız kopyala">✴</button>
+      <span class="flag-label">Sekiz Köşeli Yıldız</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✪" aria-label="Daire İçinde Beyaz Yıldız kopyala">✪</button>
+      <span class="flag-label">Daire İçinde Beyaz Yıldız</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✶" aria-label="Altı Köşeli Yıldız kopyala">✶</button>
+      <span class="flag-label">Altı Köşeli Yıldız</span>
+    </div>
+      <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✦" aria-label="✦ kopyala">✦</button>
+      <span class="flag-label">Parıltı Yıldızı</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="◯" aria-label="◯ kopyala">◯</button>
+      <span class="flag-label">Büyük Daire</span>
+    </div>
+</div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- Anchor preserved for inbound links/bookmarks; canonical content lives on /library/moon-celestial-symbols/#celestial-collections -->
+<section class="mood-explainers" id="moon-phases">
+  <span class="article-section-label">Ay Evreleri</span>
+  <h2>Ay Evresi Sembolleri</h2>
+  <p>Tam ay döngüsünü mü arıyorsun? Ay evresi sembollerinin yanı sıra gök cismi işaretlerini yıldız sembolleri sayfasında bir arada bulabilirsin.</p>
+  <div class="compare-grid" style="margin-top:1rem;">
+    <a href="/tr/library/yildiz-sembolleri/" class="compare-card variant-muted u-no-underline">
+      <h4>Bkz: Yıldız &amp; Gök Sembolleri →</h4>
+      <p>Sekiz Unicode ay evresi (🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘) ve hilal ile karanlık/aydınlık ay varyantları — bir dizi olarak kopyalamaya hazır.</p>
+    </a>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- CLASSICAL 7 PLANETS (featured sub-group) -->
+<section class="mood-explainers" id="classical-7-planets">
+  <span class="article-section-label">Klasik 7 Gezegen</span>
+  <h2>Klasik Yedi Gezegen (Güneş → Satürn)</h2>
+  <p class="u-secondary-tight">Geleneksel astrolojinin yedi gezegeni Keldani sırasında — antik astronomların bildiği, gökyüzünde çıplak gözle görülen cisimler.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☉" aria-label="Güneş kopyala">☉</button>
+      <span class="flag-label">Güneş</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☽" aria-label="Ay kopyala">☽</button>
+      <span class="flag-label">Ay</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☿" aria-label="Merkür kopyala">☿</button>
+      <span class="flag-label">Merkür</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♀" aria-label="Venüs kopyala">♀</button>
+      <span class="flag-label">Venüs</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♂" aria-label="Mars kopyala">♂</button>
+      <span class="flag-label">Mars</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♃" aria-label="Jüpiter kopyala">♃</button>
+      <span class="flag-label">Jüpiter</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♄" aria-label="Satürn kopyala">♄</button>
+      <span class="flag-label">Satürn</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="planetary-zodiac">
+  <span class="article-section-label">Gezegensel &amp; Zodyak-Yakını</span>
+  <h2>Gezegensel &amp; Astrolojik Semboller</h2>
+  <p>Okült çağrışımları olan klasik gezegen sembolleri ve astrolojik glyphler.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☉" aria-label="Güneş kopyala">☉</button>
+      <span class="flag-label">Güneş</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☽" aria-label="Ay kopyala">☽</button>
+      <span class="flag-label">Ay</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☿" aria-label="Merkür kopyala">☿</button>
+      <span class="flag-label">Merkür</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♀" aria-label="Venüs kopyala">♀</button>
+      <span class="flag-label">Venüs</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♁" aria-label="Dünya kopyala">♁</button>
+      <span class="flag-label">Dünya</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♂" aria-label="Mars kopyala">♂</button>
+      <span class="flag-label">Mars</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♃" aria-label="Jüpiter kopyala">♃</button>
+      <span class="flag-label">Jüpiter</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♄" aria-label="Satürn kopyala">♄</button>
+      <span class="flag-label">Satürn</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♅" aria-label="Uranüs kopyala">♅</button>
+      <span class="flag-label">Uranüs</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♆" aria-label="Neptün kopyala">♆</button>
+      <span class="flag-label">Neptün</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♇" aria-label="Plüton kopyala">♇</button>
+      <span class="flag-label">Plüton</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚸" aria-label="Kara Ay Lilith kopyala">⚸</button>
+      <span class="flag-label">Kara Ay Lilith</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚳" aria-label="Ceres kopyala">⚳</button>
+      <span class="flag-label">Ceres</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚴" aria-label="Pallas kopyala">⚴</button>
+      <span class="flag-label">Pallas</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚵" aria-label="Juno kopyala">⚵</button>
+      <span class="flag-label">Juno</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚶" aria-label="Vesta kopyala">⚶</button>
+      <span class="flag-label">Vesta</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="alchemical">
+  <span class="article-section-label">Simya</span>
+  <h2>Simya Sembolleri (U+1F700–U+1F73F)</h2>
+  <p>Tarihsel simyada kullanılan elementler, işlemler ve maddeler için işaretler içeren Unicode Simya Sembolleri bloğu.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜀" aria-label="Beşinci Öz kopyala">🜀</button>
+      <span class="flag-label">Beşinci Öz (Quintessence)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜁" aria-label="Hava kopyala">🜁</button>
+      <span class="flag-label">Hava</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜂" aria-label="Ateş kopyala">🜂</button>
+      <span class="flag-label">Ateş</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜃" aria-label="Toprak kopyala">🜃</button>
+      <span class="flag-label">Toprak</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜄" aria-label="Su kopyala">🜄</button>
+      <span class="flag-label">Su</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜅" aria-label="Aquafortis kopyala">🜅</button>
+      <span class="flag-label">Aquafortis</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜆" aria-label="Aqua Regia kopyala">🜆</button>
+      <span class="flag-label">Aqua Regia</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜇" aria-label="Aqua Regia II kopyala">🜇</button>
+      <span class="flag-label">Aqua Regia II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜈" aria-label="Aqua Vitae kopyala">🜈</button>
+      <span class="flag-label">Aqua Vitae</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜉" aria-label="Aqua Vitae II kopyala">🜉</button>
+      <span class="flag-label">Aqua Vitae II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜊" aria-label="Sirke kopyala">🜊</button>
+      <span class="flag-label">Sirke</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜋" aria-label="Sirke II kopyala">🜋</button>
+      <span class="flag-label">Sirke II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜌" aria-label="Sirke III kopyala">🜌</button>
+      <span class="flag-label">Sirke III</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜍" aria-label="Kükürt kopyala">🜍</button>
+      <span class="flag-label">Kükürt</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜎" aria-label="Kükürt II kopyala">🜎</button>
+      <span class="flag-label">Kükürt II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜏" aria-label="Kükürt III kopyala">🜏</button>
+      <span class="flag-label">Kükürt III</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜐" aria-label="Tuz kopyala">🜐</button>
+      <span class="flag-label">Tuz</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜑" aria-label="Tuz II kopyala">🜑</button>
+      <span class="flag-label">Tuz II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜒" aria-label="Tuz III kopyala">🜒</button>
+      <span class="flag-label">Tuz III</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜓" aria-label="Cıva Süblimatı kopyala">🜓</button>
+      <span class="flag-label">Cıva Süblimatı</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜔" aria-label="Cıva Süblimatı II kopyala">🜔</button>
+      <span class="flag-label">Cıva Süblimatı II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜕" aria-label="Cıva Süblimatı III kopyala">🜕</button>
+      <span class="flag-label">Cıva Süblimatı III</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜖" aria-label="Zincifre kopyala">🜖</button>
+      <span class="flag-label">Zincifre</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜗" aria-label="Nişadır kopyala">🜗</button>
+      <span class="flag-label">Nişadır</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜘" aria-label="Vitriol kopyala">🜘</button>
+      <span class="flag-label">Vitriol</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜙" aria-label="Vitriol II kopyala">🜙</button>
+      <span class="flag-label">Vitriol II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜚" aria-label="Altın kopyala">🜚</button>
+      <span class="flag-label">Altın</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜛" aria-label="Gümüş kopyala">🜛</button>
+      <span class="flag-label">Gümüş</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜜" aria-label="Demir Cevheri kopyala">🜜</button>
+      <span class="flag-label">Demir Cevheri</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜝" aria-label="Demir Cevheri II kopyala">🜝</button>
+      <span class="flag-label">Demir Cevheri II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜞" aria-label="Demir Krokusu kopyala">🜞</button>
+      <span class="flag-label">Demir Krokusu</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜟" aria-label="Demir Regulusu kopyala">🜟</button>
+      <span class="flag-label">Demir Regulusu</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜠" aria-label="Bakır Cevheri kopyala">🜠</button>
+      <span class="flag-label">Bakır Cevheri</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜡" aria-label="Demir-Bakır Cevheri kopyala">🜡</button>
+      <span class="flag-label">Demir-Bakır Cevheri</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜢" aria-label="Bakır Süblimatı kopyala">🜢</button>
+      <span class="flag-label">Bakır Süblimatı</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜣" aria-label="Bakır Krokusu kopyala">🜣</button>
+      <span class="flag-label">Bakır Krokusu</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜤" aria-label="Bakır Antimoniatı kopyala">🜤</button>
+      <span class="flag-label">Bakır Antimoniatı</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜥" aria-label="Bakır Antimoniat Tuzu kopyala">🜥</button>
+      <span class="flag-label">Bakır Antimoniat Tuzu</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜦" aria-label="Bakır Tuzu Süblimatı kopyala">🜦</button>
+      <span class="flag-label">Bakır Tuzu Süblimatı</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜧" aria-label="Bakır Pası (Verdigris) kopyala">🜧</button>
+      <span class="flag-label">Bakır Pası (Verdigris)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜨" aria-label="Kalay Cevheri kopyala">🜨</button>
+      <span class="flag-label">Kalay Cevheri</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜩" aria-label="Kurşun Cevheri kopyala">🜩</button>
+      <span class="flag-label">Kurşun Cevheri</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜪" aria-label="Kurşun Cevheri Toprağı kopyala">🜪</button>
+      <span class="flag-label">Kurşun Cevheri Toprağı</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜫" aria-label="Antimon kopyala">🜫</button>
+      <span class="flag-label">Antimon</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜬" aria-label="Antimon II kopyala">🜬</button>
+      <span class="flag-label">Antimon II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜭" aria-label="Antimon Süblimatı kopyala">🜭</button>
+      <span class="flag-label">Antimon Süblimatı</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜮" aria-label="Antimon Tuzu kopyala">🜮</button>
+      <span class="flag-label">Antimon Tuzu</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜯" aria-label="Antimon Tuzu Süblimatı kopyala">🜯</button>
+      <span class="flag-label">Antimon Tuzu Süblimatı</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜰" aria-label="Antimon Sirkesi kopyala">🜰</button>
+      <span class="flag-label">Antimon Sirkesi</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜱" aria-label="Antimon Regulusu kopyala">🜱</button>
+      <span class="flag-label">Antimon Regulusu</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜲" aria-label="Antimon Regulusu II kopyala">🜲</button>
+      <span class="flag-label">Antimon Regulusu II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜳" aria-label="Regulus kopyala">🜳</button>
+      <span class="flag-label">Regulus</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜴" aria-label="Regulus II kopyala">🜴</button>
+      <span class="flag-label">Regulus II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜵" aria-label="Regulus III kopyala">🜵</button>
+      <span class="flag-label">Regulus III</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜶" aria-label="Regulus IV kopyala">🜶</button>
+      <span class="flag-label">Regulus IV</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜷" aria-label="Alkali kopyala">🜷</button>
+      <span class="flag-label">Alkali</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜸" aria-label="Alkali II kopyala">🜸</button>
+      <span class="flag-label">Alkali II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜹" aria-label="Markazit kopyala">🜹</button>
+      <span class="flag-label">Markazit</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜺" aria-label="Nişadır (Sal Ammoniac) kopyala">🜺</button>
+      <span class="flag-label">Nişadır (Sal Ammoniac)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜻" aria-label="Arsenik kopyala">🜻</button>
+      <span class="flag-label">Arsenik</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜼" aria-label="Realgar kopyala">🜼</button>
+      <span class="flag-label">Realgar</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜽" aria-label="Realgar II kopyala">🜽</button>
+      <span class="flag-label">Realgar II</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜾" aria-label="Zırnık (Auripigment) kopyala">🜾</button>
+      <span class="flag-label">Zırnık (Auripigment)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜿" aria-label="Bizmut Cevheri kopyala">🜿</button>
+      <span class="flag-label">Bizmut Cevheri</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="esoteric">
+  <span class="article-section-label">Diğer Ezoterik</span>
+  <h2>Diğer Ezoterik Semboller</h2>
+  <p>Büyüsel ve ezoterik geleneklerle ilişkilendirilen ek semboller.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☥" aria-label="Ankh kopyala">☥</button>
+      <span class="flag-label">Ankh</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☯" aria-label="Yin Yang kopyala">☯</button>
+      <span class="flag-label">Yin Yang</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☘" aria-label="Yonca kopyala">☘</button>
+      <span class="flag-label">Yonca</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚷" aria-label="Chiron kopyala">⚷</button>
+      <span class="flag-label">Chiron</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚰" aria-label="Tabut kopyala">⚰</button>
+      <span class="flag-label">Tabut</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚱" aria-label="Cenaze Vazosu kopyala">⚱</button>
+      <span class="flag-label">Cenaze Vazosu</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚗" aria-label="İmbik kopyala">⚗</button>
+      <span class="flag-label">İmbik</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❤" aria-label="Kalp kopyala">❤</button>
+      <span class="flag-label">Kalp</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚛" aria-label="Atom Sembolü kopyala">⚛</button>
+      <span class="flag-label">Atom Sembolü</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚡" aria-label="Şimşek kopyala">⚡</button>
+      <span class="flag-label">Şimşek</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♲" aria-label="Geri Dönüşüm kopyala">♲</button>
+      <span class="flag-label">Geri Dönüşüm</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☼" aria-label="Işınlı Beyaz Güneş kopyala">☼</button>
+      <span class="flag-label">Işınlı Beyaz Güneş</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☦" aria-label="Ortodoks Haçı kopyala">☦</button>
+      <span class="flag-label">Ortodoks Haçı</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☢" aria-label="Radyoaktif kopyala">☢</button>
+      <span class="flag-label">Radyoaktif</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☣" aria-label="Biyotehlike kopyala">☣</button>
+      <span class="flag-label">Biyotehlike</span>
+    </div>
+      <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🔮" aria-label="🔮 kopyala">🔮</button>
+      <span class="flag-label">Kristal Küre</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧿" aria-label="🧿 kopyala">🧿</button>
+      <span class="flag-label">Nazar Boncuğu</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🃏" aria-label="🃏 kopyala">🃏</button>
+      <span class="flag-label">Tarot Kartı</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕯️" aria-label="🕯️ kopyala">🕯️</button>
+      <span class="flag-label">Mum</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐍" aria-label="🐍 kopyala">🐍</button>
+      <span class="flag-label">Yılan</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="∞" aria-label="∞ kopyala">∞</button>
+      <span class="flag-label">Sonsuzluk</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⟳" aria-label="⟳ kopyala">⟳</button>
+      <span class="flag-label">Döngüsel Ok</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="↻" aria-label="↻ kopyala">↻</button>
+      <span class="flag-label">Açık Daire Ok</span>
+    </div>
+</div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- COLLECTIONS -->
+<section class="mood-explainers" id="witchy-collections">
+  <span class="article-section-label">Witchy Koleksiyonları</span>
+  <h2>Witchy Bio &amp; Çerçeve Setleri</h2>
+  <p class="u-secondary-block">Doğrudan bir bio, caption veya kullanıcı adına yapıştırabileceğin hazır witchy dizileri — bütün kombini tek tıkla kopyala.</p>
+  <div id="witchyCollectionsContainer"></div>
+</section>
+
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Metni Unicode fontlarla dönüştür</h3>
+  <p>Düz metni kalın, italik, el yazısı ve 100+ başka Unicode font stiline dönüştürmek için UltraTextGen'i kullan — ücretsiz ve anında.</p>
+  <a href="https://ultratextgen.com/tr/" class="cta-btn">UltraTextGen'i Aç →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">İlgili Kaynaklar</span>
+  <div class="compare-grid">
+    <a href="/tr/library/estetik-semboller/" class="compare-card variant-muted u-no-underline">
+      <h4>Estetik Semboller</h4>
+      <p>Tüm isimli-estetik sembol koleksiyonları tek yerde.</p>
+    </a>
+    <a href="/tr/library/goth-grunge-sembolleri/" class="compare-card variant-muted u-no-underline">
+      <h4>Goth &amp; Grunge Sembolleri</h4>
+      <p>Karanlık haçlar, kuru kafalar ve goth estetiği süslemeleri.</p>
+    </a>
+    <a href="/tr/library/cottagecore-sembolleri/" class="compare-card variant-muted u-no-underline">
+      <h4>Cottagecore Sembolleri</h4>
+      <p>Mantarlar, kır çiçekleri ve toprak kokan kır yaşamı motifleri.</p>
+    </a>
+    <a href="/tr/library/yildiz-sembolleri/" class="compare-card variant-muted u-no-underline">
+      <h4>Yıldız Sembolleri</h4>
+      <p>Parıltılı yıldızlar, gök cisimleri ve gökyüzü işaretleri.</p>
+    </a>
+    <a href="/tr/library/y2k-sembolleri/" class="compare-card variant-muted u-no-underline">
+      <h4>Y2K Sembolleri</h4>
+      <p>Yıldızlar, gotik haçlar, kelebekler ve CD parlaklığı.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <div class="lang-switcher" role="navigation" aria-label="Language switcher">
+      <a class="lang-option" href="/library/witchy-occult-symbols/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/tr/library/witchy-occult-sembolleri/" hreflang="tr">TR</a>
+    </div>
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    { name: "Pentagram Bio Çerçevesi", flags: ["⛧","˖","⛤","˖","⛧"], defaultFormat: "inline" },
+    { name: "Ay & Güneş Kombini", flags: ["☽","˚","✴","˚","☉"], defaultFormat: "inline" },
+    { name: "Witchy Yıldız İzi", flags: ["✶","·","✴","·","✶"], defaultFormat: "inline" },
+    { name: "Hilal Çerçevesi", flags: ["☽⋆ﾟ｡⋆"], defaultFormat: "inline" },
+    { name: "Gezegen Bio Kombini", flags: ["☽","☿","♀","♂","♃","♄"], defaultFormat: "inline" },
+    { name: "Ankh Büyü Ayracı", flags: ["☥","˖","⛤","˖","☥"], defaultFormat: "inline" }
+  ];
+
+  ns.buildGrids("witchyCollectionsContainer", GROUPS);
+  ns.parseTwemoji(document.body);
+});
+</script>
+<script src="/footer.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Completes the aesthetic-symbol-pack localization genre. Translates the **6 remaining packs** into the 7 established markets (**42 new pages**), following the exact conventions of the coquette/cottagecore/y2k rollout (merged in #449).

| Pack | Markets (es · fr · id · it · pl · tr · pt) |
|---|---|
| fairycore | ✅ all 7 |
| kawaii-cute | ✅ all 7 |
| goth-grunge | ✅ all 7 |
| dreamcore-weirdcore | ✅ all 7 |
| therian | ✅ all 7 |
| witchy-occult (incl. full ~64-symbol alchemical block) | ✅ all 7 |

With this, all **9 aesthetic packs** now exist across the 7 core markets (y2k + coquette + cottagecore + these 6).

## What each page does

Each localized page lives at `/<market>/library/<localized-slug>/` and mirrors its English source:
- English structure, section ids, CSS classes, `data-symbol` values, and JS `flags` arrays kept **byte-identical** — only human-readable copy + combo names are localized.
- Metadata localized: `<title>`, meta description, OG/Twitter tags, Article + BreadcrumbList JSON-LD (`inLanguage`, dates `2026-07-10`).
- **2-item breadcrumbs** (`Home › Pack`) — no localized `/library/` index exists, so the English 3-item breadcrumb is intentionally dropped, matching the y2k reference.
- `hreflang` self + x-default; `og:image`/hero assets follow the `<market>-library-<slug>` naming convention.
- Related-resources and inline cross-links point only to **verified same-market pages**; English-only targets (moon-celestial, animal-emojis, greek-letter, etc.) are repointed to existing local pages.

## Verification

Automated sweep across all 42 pages — **0 issues**:
- correct `html lang` + canonical
- valid JSON-LD (all blocks parse)
- 2-item breadcrumbs everywhere
- correct `og:image` naming (2 agent deviations caught and normalized)
- **zero broken internal links**

No framework/bundler added; pure static HTML consistent with the rest of the site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GN4jbatvtsALB9e6xwsVqG)_