### PR TITLE
Add ASCII art library pages and converter/generator tools

### DIFF
--- a/ascii-art-generator/index.html
+++ b/ascii-art-generator/index.html
@@ -1,0 +1,195 @@
+<!DOCTYPE html><html lang="en"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ASCII Art Generator — Turn Text Into Block-Letter ASCII Art | UltraTextGen</title>
+  <meta name="description" content="Free ASCII art generator. Type a word or name and watch it turn into big multi-line block-letter ASCII art instantly, with several font styles to switch between — copy and paste anywhere.">
+  <link rel="canonical" href="https://ultratextgen.com/ascii-art-generator/">
+  <meta property="og:title" content="ASCII Art Generator — Text to Block-Letter ASCII Art | UltraTextGen">
+  <meta property="og:description" content="Type a word and get big multi-line block-letter ASCII art instantly, with several font styles — free, live as you type, no signup.">
+  <meta property="og:url" content="https://ultratextgen.com/ascii-art-generator/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="ASCII Art Generator — Text to Block-Letter ASCII Art | UltraTextGen">
+  <meta name="twitter:description" content="Type a word and get big multi-line block-letter ASCII art instantly, with several font styles — free, live as you type, no signup.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=Space+Mono&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "ASCII Art Generator",
+  "alternateName": ["ASCII Art Maker", "ASCII Art Creator", "ASCII Text Generator", "ASCII Banner Generator", "ASCII Font Generator", "ASCII Letters Generator", "Text to ASCII Art Converter"],
+  "url": "https://ultratextgen.com/ascii-art-generator/",
+  "applicationCategory": "UtilitiesApplication",
+  "operatingSystem": "Any",
+  "description": "Turn text into large multi-line block-letter ASCII art (FIGlet style) instantly as you type, with several font styles to switch between and copy.",
+  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {"@type":"Question","name":"How do I make ASCII art from text?","acceptedAnswer":{"@type":"Answer","text":"Type a word or short phrase into the input box. Each letter is drawn as large multi-line block characters and the banner updates live as you type — no submit button. Pick a font style, then press Copy to grab the whole multi-line result and paste it anywhere that uses a fixed-width (monospace) font."}},
+    {"@type":"Question","name":"What is ASCII art?","acceptedAnswer":{"@type":"Answer","text":"ASCII art is pictures or big lettering built entirely out of ordinary keyboard characters — letters, digits, and symbols — arranged on a grid. Block-letter or \"banner\" ASCII art, the kind this generator makes, spells a word out in oversized letters made of stacked characters, the same style you see in code comments, terminal splash screens, and README files."}},
+    {"@type":"Question","name":"What font styles are available?","acceptedAnswer":{"@type":"Answer","text":"Five distinct styles: Block (solid full-block capitals), Slant (leaning italic letters), Shadow (3D letters with a drop shadow), Banner (the classic hash-mark look), and Mini (compact half-height letters). Switch between them with one click and the same word instantly re-renders in the new style."}},
+    {"@type":"Question","name":"Can I use ASCII art on Discord?","acceptedAnswer":{"@type":"Answer","text":"Yes. Copy your banner, then on Discord wrap it in a code block by putting three backticks on their own line before and after the pasted art. The code block forces a monospace font so the characters line up into clean letters instead of collapsing."}},
+    {"@type":"Question","name":"Can I use ASCII art on Instagram, WhatsApp, or in a bio?","acceptedAnswer":{"@type":"Answer","text":"You can paste it, but be careful: multi-line ASCII art only lines up in places that use a fixed-width font, and most social feeds and bios use a proportional font that will skew the letters. It works best in code blocks, terminals, plain-text files, and monospace chats. For stylish single-line text that looks right in any Instagram or WhatsApp bio, use the main UltraTextGen Unicode font generator instead."}},
+    {"@type":"Question","name":"Why does my ASCII art look crooked when I paste it?","acceptedAnswer":{"@type":"Answer","text":"Block-letter ASCII art relies on every character being exactly the same width, which only happens in a monospace font. If you paste it somewhere that uses a normal proportional font, the columns drift and the letters look crooked. Paste it into a code block, a code editor, a terminal, or anywhere set to a monospace font and it will align correctly."}},
+    {"@type":"Question","name":"Is this ASCII art generator free, and does it store my text?","acceptedAnswer":{"@type":"Answer","text":"Yes, it's completely free with no signup. Everything runs client-side in your browser with plain JavaScript and hand-built letter shapes — nothing you type is uploaded, logged, or stored anywhere."}}
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ultratextgen.com/" },
+    { "@type": "ListItem", "position": 2, "name": "ASCII Art Generator", "item": "https://ultratextgen.com/ascii-art-generator/" }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/">Home</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">ASCII Art Generator</span>
+</nav>
+
+<section class="hero"><div class="hero-inner"><div class="hero-card">
+  <h1 class="hero-headline">ASCII Art Generator</h1>
+  <p class="hero-sub">Type a word and turn it into big block-letter ASCII art as you type — switch between font styles and copy the whole banner in one click.</p>
+</div></div></section>
+
+<main class="container">
+  <section class="editorial-section">
+    <div class="editorial-block">
+      <p>This tool turns plain text into large, multi-line block-letter ASCII art — the FIGlet-style "banner" lettering you see in terminals, code comments, and README files — entirely in your browser. Type a word or short name and it renders instantly, letter by letter, with no submit button and no page reload. Switch between font styles to change the whole look, then copy the finished banner and paste it wherever a fixed-width (monospace) font is used. For a static reference of every character code behind the art, see the <a href="/library/ascii-table/">ASCII table</a>, and to convert text to raw ASCII code numbers use the <a href="/ascii-converter/">ASCII converter</a>.</p>
+    </div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <div class="ascii-art-tool">
+    <div class="ascii-art-field">
+      <label for="asciiBannerInput">Your text</label>
+      <input id="asciiBannerInput" type="text" maxlength="40" autocomplete="off" spellcheck="false" placeholder="Type a word…" value="HELLO">
+    </div>
+
+    <div>
+      <div class="ascii-font-picker-label">Font style</div>
+      <div class="ascii-font-picker" id="asciiFontPicker" role="group" aria-label="ASCII art font style"></div>
+    </div>
+
+    <div>
+      <div class="ascii-art-output-head">
+        <label for="asciiBannerOutput">ASCII art</label>
+        <button class="copy-btn" type="button" id="asciiBannerCopy">Copy</button>
+      </div>
+      <div class="ascii-art-output-wrap">
+        <pre class="ascii-art-output" id="asciiBannerOutput" aria-live="polite"></pre>
+      </div>
+      <p class="ascii-art-empty" id="asciiBannerEmpty" hidden>Type something above to generate your ASCII art.</p>
+    </div>
+  </div>
+
+  <div class="section-divider"></div>
+
+  <section class="editorial-section" id="faq">
+    <span class="article-section-label">FAQ</span>
+    <h2>ASCII art, answered</h2>
+    <details class="faq-item">
+      <summary class="faq-question">How do I make ASCII art from text?</summary>
+      <p class="faq-answer">Type a word or short phrase into the input box. Each letter is drawn as large multi-line block characters and the banner updates live as you type — no submit button. Pick a font style, then press Copy to grab the whole multi-line result and paste it anywhere that uses a fixed-width (monospace) font.</p>
+    </details>
+    <details class="faq-item">
+      <summary class="faq-question">What is ASCII art?</summary>
+      <p class="faq-answer">ASCII art is pictures or big lettering built entirely out of ordinary keyboard characters — letters, digits, and symbols — arranged on a grid. Block-letter or "banner" ASCII art, the kind this generator makes, spells a word out in oversized letters made of stacked characters, the same style you see in code comments, terminal splash screens, and README files.</p>
+    </details>
+    <details class="faq-item">
+      <summary class="faq-question">What font styles are available?</summary>
+      <p class="faq-answer">Five distinct styles: Block (solid full-block capitals), Slant (leaning italic letters), Shadow (3D letters with a drop shadow), Banner (the classic hash-mark look), and Mini (compact half-height letters). Switch between them with one click and the same word instantly re-renders in the new style.</p>
+    </details>
+    <details class="faq-item">
+      <summary class="faq-question">Can I use ASCII art on Discord?</summary>
+      <p class="faq-answer">Yes. Copy your banner, then on Discord wrap it in a code block by putting three backticks on their own line before and after the pasted art. The code block forces a monospace font so the characters line up into clean letters instead of collapsing.</p>
+    </details>
+    <details class="faq-item">
+      <summary class="faq-question">Can I use ASCII art on Instagram, WhatsApp, or in a bio?</summary>
+      <p class="faq-answer">You can paste it, but be careful: multi-line ASCII art only lines up in places that use a fixed-width font, and most social feeds and bios use a proportional font that will skew the letters. It works best in code blocks, terminals, plain-text files, and monospace chats. For stylish single-line text that looks right in any Instagram or WhatsApp bio, use the main UltraTextGen Unicode font generator instead.</p>
+    </details>
+    <details class="faq-item">
+      <summary class="faq-question">Why does my ASCII art look crooked when I paste it?</summary>
+      <p class="faq-answer">Block-letter ASCII art relies on every character being exactly the same width, which only happens in a monospace font. If you paste it somewhere that uses a normal proportional font, the columns drift and the letters look crooked. Paste it into a code block, a code editor, a terminal, or anywhere set to a monospace font and it will align correctly.</p>
+    </details>
+    <details class="faq-item">
+      <summary class="faq-question">Is this ASCII art generator free, and does it store my text?</summary>
+      <p class="faq-answer">Yes, it's completely free with no signup. Everything runs client-side in your browser with plain JavaScript and hand-built letter shapes — nothing you type is uploaded, logged, or stored anywhere.</p>
+    </details>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <div class="cta-card">
+    <h3>Need stylish single-line text instead?</h3>
+    <p>UltraTextGen turns plain text into bold, italic, cursive, and 100+ other Unicode font styles that work in any bio or chat — free and instant.</p>
+    <a href="https://ultratextgen.com/" class="cta-btn">Open UltraTextGen →</a>
+  </div>
+
+  <section class="editorial-section">
+    <span class="article-section-label">Related Resources</span>
+    <div class="compare-grid">
+      <a href="/library/ascii-table/" class="compare-card variant-muted u-no-underline">
+        <h4>ASCII Table</h4>
+        <p>The full reference chart — every ASCII code with its decimal and hex value.</p>
+      </a>
+      <a href="/ascii-converter/" class="compare-card variant-muted u-no-underline">
+        <h4>ASCII Converter</h4>
+        <p>Convert text to decimal, hex, binary, or octal codes — and decode them back — live.</p>
+      </a>
+      <a href="/library/text-art/" class="compare-card variant-muted u-no-underline">
+        <h4>Text Art</h4>
+        <p>ASCII and Unicode art collections to copy and paste.</p>
+      </a>
+    </div>
+  </section>
+</main>
+
+<footer class="footer"><div class="footer-inner"></div></footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script src="/js/ascii/asciiBannerFonts.js" defer></script>
+<script src="/js/ascii/asciiBannerController.js" defer></script>
+<script src="/footer.js" defer></script>
+</body></html>

--- a/ascii-converter/index.html
+++ b/ascii-converter/index.html
@@ -1,0 +1,245 @@
+<!DOCTYPE html><html lang="en"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ASCII Converter — Text to Hex, Binary &amp; Decimal (and Back) | UltraTextGen</title>
+  <meta name="description" content="Free ASCII converter. Turn text into decimal, hex, binary, and octal codes instantly as you type, or paste hex, binary, or decimal codes to decode them back into text.">
+  <link rel="canonical" href="https://ultratextgen.com/ascii-converter/">
+  <meta property="og:title" content="ASCII Converter — Text to Hex, Binary &amp; Decimal | UltraTextGen">
+  <meta property="og:description" content="Convert text to ASCII decimal, hex, binary, and octal codes instantly, or decode codes back into text — free, instant, no signup.">
+  <meta property="og:url" content="https://ultratextgen.com/ascii-converter/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="ASCII Converter — Text to Hex, Binary &amp; Decimal | UltraTextGen">
+  <meta name="twitter:description" content="Convert text to ASCII decimal, hex, binary, and octal codes instantly, or decode codes back into text — free, instant, no signup.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=Space+Mono&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "ASCII Converter",
+  "alternateName": ["ASCII to Hex Converter", "Hex to ASCII Converter", "ASCII to Binary Converter", "Binary to ASCII Converter", "ASCII Code Translator", "ASCII to Decimal Converter", "Decimal to ASCII Converter"],
+  "url": "https://ultratextgen.com/ascii-converter/",
+  "applicationCategory": "UtilitiesApplication",
+  "operatingSystem": "Any",
+  "description": "Convert text to ASCII decimal, hex, binary, and octal codes instantly, or decode hex, binary, and decimal codes back into text.",
+  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {"@type":"Question","name":"How do I convert hex to ASCII?","acceptedAnswer":{"@type":"Answer","text":"Paste your hex string into the \"Codes → Text\" box — with or without spaces, like \"48 65 6C 6C 6F\" or \"48656C6C6F\" — and it decodes each byte into a character automatically. Pick \"Hexadecimal\" from the Format menu if auto-detect guesses wrong."}},
+    {"@type":"Question","name":"How do I convert ASCII to hex?","acceptedAnswer":{"@type":"Answer","text":"Type or paste your text into the \"Text → ASCII Codes\" box. The Hexadecimal field updates instantly with each character's two-digit hex code, separated by spaces — click Copy to grab it."}},
+    {"@type":"Question","name":"How do I convert between ASCII and decimal?","acceptedAnswer":{"@type":"Answer","text":"Decimal is the plain number form of an ASCII code — \"A\" is 65. Type text into the left panel to see its Decimal codes, or paste decimal numbers separated by spaces or commas into the right panel (Auto-detect or the Decimal option both work) to translate them back into text."}},
+    {"@type":"Question","name":"How does binary to ASCII conversion work?","acceptedAnswer":{"@type":"Answer","text":"Each ASCII character is one byte, so its binary form is 8 digits — \"H\" is 01001000. Paste a binary string into the \"Codes → Text\" box, spaced or unspaced as long as the digit count is a multiple of 8, to decode it back into text."}},
+    {"@type":"Question","name":"What's the difference between ASCII and Unicode?","acceptedAnswer":{"@type":"Answer","text":"ASCII is a 128-character set (codes 0–127) covering English letters, digits, and basic punctuation. Unicode is a far larger standard covering every written language and emoji, and its first 128 code points are identical to ASCII — so plain ASCII text is always valid Unicode."}},
+    {"@type":"Question","name":"What happens with characters outside the ASCII range (0–127)?","acceptedAnswer":{"@type":"Answer","text":"Accented letters, most emoji, and non-Latin scripts fall outside ASCII. This converter still encodes and decodes them correctly using their full Unicode code point — for example \"é\" is 233 — and a note appears whenever your input includes non-ASCII characters."}},
+    {"@type":"Question","name":"Is this ASCII converter free, and does it store my text?","acceptedAnswer":{"@type":"Answer","text":"Yes, it's free with no signup required. Everything runs client-side in your browser with plain JavaScript — nothing you type is uploaded, logged, or stored anywhere."}}
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ultratextgen.com/" },
+    { "@type": "ListItem", "position": 2, "name": "ASCII Converter", "item": "https://ultratextgen.com/ascii-converter/" }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/">Home</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">ASCII Converter</span>
+</nav>
+
+<section class="hero"><div class="hero-inner"><div class="hero-card">
+  <h1 class="hero-headline">ASCII Converter</h1>
+  <p class="hero-sub">Convert text to decimal, hex, binary, and octal ASCII codes as you type — or paste codes to decode them back into text.</p>
+</div></div></section>
+
+<main class="container">
+  <section class="editorial-section">
+    <div class="editorial-block">
+      <p>This tool converts plain text into ASCII character codes and back again, entirely in your browser. Type or paste text on the left to see its decimal, hexadecimal, binary, and octal codes update instantly — no submit button, no page reload. Or flip it around: paste a hex, binary, or decimal code string on the right and get readable text back. Codes can be space- or comma-separated, or pasted as one continuous string (like <code>48656c6c6f</code> for hex) — the format is auto-detected, with a manual override if it guesses wrong. For a static reference of every ASCII code, see the <a href="/library/ascii-table/">ASCII table</a>.</p>
+    </div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <div class="ascii-tool">
+    <section class="ascii-panel" aria-labelledby="asciiEncodeHeading">
+      <h2 id="asciiEncodeHeading" class="ascii-panel-title">Text → ASCII Codes</h2>
+
+      <div class="ascii-field">
+        <label for="asciiTextInput">Your text</label>
+        <textarea id="asciiTextInput" maxlength="1000" placeholder="Type or paste text…">Hello, World!</textarea>
+      </div>
+      <p class="ascii-note" id="asciiNonAsciiNote" hidden></p>
+
+      <div class="ascii-output-row">
+        <div class="ascii-output-head">
+          <label for="asciiDecimalOut">Decimal</label>
+          <button class="copy-btn ascii-copy-btn" type="button" data-copy-target="asciiDecimalOut" data-label="decimal codes">Copy</button>
+        </div>
+        <div class="ascii-output" id="asciiDecimalOut" aria-live="polite"></div>
+      </div>
+
+      <div class="ascii-output-row">
+        <div class="ascii-output-head">
+          <label for="asciiHexOut">Hexadecimal</label>
+          <button class="copy-btn ascii-copy-btn" type="button" data-copy-target="asciiHexOut" data-label="hex codes">Copy</button>
+        </div>
+        <div class="ascii-output" id="asciiHexOut" aria-live="polite"></div>
+      </div>
+
+      <div class="ascii-output-row">
+        <div class="ascii-output-head">
+          <label for="asciiBinaryOut">Binary</label>
+          <button class="copy-btn ascii-copy-btn" type="button" data-copy-target="asciiBinaryOut" data-label="binary codes">Copy</button>
+        </div>
+        <div class="ascii-output" id="asciiBinaryOut" aria-live="polite"></div>
+      </div>
+
+      <div class="ascii-output-row">
+        <div class="ascii-output-head">
+          <label for="asciiOctalOut">Octal</label>
+          <button class="copy-btn ascii-copy-btn" type="button" data-copy-target="asciiOctalOut" data-label="octal codes">Copy</button>
+        </div>
+        <div class="ascii-output" id="asciiOctalOut" aria-live="polite"></div>
+      </div>
+    </section>
+
+    <section class="ascii-panel" aria-labelledby="asciiDecodeHeading">
+      <h2 id="asciiDecodeHeading" class="ascii-panel-title">Codes → Text</h2>
+
+      <div class="ascii-field">
+        <label for="asciiCodeInput">Paste decimal, hex, binary, or octal codes</label>
+        <textarea id="asciiCodeInput" maxlength="4000" placeholder="e.g. 72 101 108 108 111  or  48 65 6C 6C 6F  or  0x48656C6C6F">72 101 108 108 111</textarea>
+      </div>
+
+      <div class="ascii-field">
+        <label for="asciiDecodeMode">Format</label>
+        <select id="asciiDecodeMode">
+          <option value="auto" selected>Auto-detect</option>
+          <option value="decimal">Decimal</option>
+          <option value="hex">Hexadecimal</option>
+          <option value="binary">Binary</option>
+          <option value="octal">Octal</option>
+        </select>
+      </div>
+      <p class="ascii-note" id="asciiDecodeNote" aria-live="polite"></p>
+
+      <div class="ascii-output-row">
+        <div class="ascii-output-head">
+          <label for="asciiDecodedOut">Decoded text</label>
+          <button class="copy-btn ascii-copy-btn" type="button" data-copy-target="asciiDecodedOut" data-label="decoded text">Copy</button>
+        </div>
+        <div class="ascii-output ascii-output-text" id="asciiDecodedOut" aria-live="polite"></div>
+      </div>
+    </section>
+  </div>
+
+  <div class="section-divider"></div>
+
+  <section class="editorial-section" id="faq">
+    <span class="article-section-label">FAQ</span>
+    <h2>ASCII conversion, answered</h2>
+    <details class="faq-item">
+      <summary class="faq-question">How do I convert hex to ASCII?</summary>
+      <p class="faq-answer">Paste your hex string into the "Codes → Text" box — with or without spaces, like "48 65 6C 6C 6F" or "48656C6C6F" — and it decodes each byte into a character automatically. Pick "Hexadecimal" from the Format menu if auto-detect guesses wrong.</p>
+    </details>
+    <details class="faq-item">
+      <summary class="faq-question">How do I convert ASCII to hex?</summary>
+      <p class="faq-answer">Type or paste your text into the "Text → ASCII Codes" box. The Hexadecimal field updates instantly with each character's two-digit hex code, separated by spaces — click Copy to grab it.</p>
+    </details>
+    <details class="faq-item">
+      <summary class="faq-question">How do I convert between ASCII and decimal?</summary>
+      <p class="faq-answer">Decimal is the plain number form of an ASCII code — "A" is 65. Type text into the left panel to see its Decimal codes, or paste decimal numbers separated by spaces or commas into the right panel (Auto-detect or the Decimal option both work) to translate them back into text.</p>
+    </details>
+    <details class="faq-item">
+      <summary class="faq-question">How does binary to ASCII conversion work?</summary>
+      <p class="faq-answer">Each ASCII character is one byte, so its binary form is 8 digits — "H" is 01001000. Paste a binary string into the "Codes → Text" box, spaced or unspaced as long as the digit count is a multiple of 8, to decode it back into text.</p>
+    </details>
+    <details class="faq-item">
+      <summary class="faq-question">What's the difference between ASCII and Unicode?</summary>
+      <p class="faq-answer">ASCII is a 128-character set (codes 0–127) covering English letters, digits, and basic punctuation. Unicode is a far larger standard covering every written language and emoji, and its first 128 code points are identical to ASCII — so plain ASCII text is always valid Unicode.</p>
+    </details>
+    <details class="faq-item">
+      <summary class="faq-question">What happens with characters outside the ASCII range (0–127)?</summary>
+      <p class="faq-answer">Accented letters, most emoji, and non-Latin scripts fall outside ASCII. This converter still encodes and decodes them correctly using their full Unicode code point — for example "é" is 233 — and a note appears whenever your input includes non-ASCII characters.</p>
+    </details>
+    <details class="faq-item">
+      <summary class="faq-question">Is this ASCII converter free, and does it store my text?</summary>
+      <p class="faq-answer">Yes, it's free with no signup required. Everything runs client-side in your browser with plain JavaScript — nothing you type is uploaded, logged, or stored anywhere.</p>
+    </details>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <div class="cta-card">
+    <h3>Need stylized text instead?</h3>
+    <p>UltraTextGen turns plain text into bold, italic, cursive, and 100+ other Unicode font styles — free and instant.</p>
+    <a href="https://ultratextgen.com/" class="cta-btn">Open UltraTextGen →</a>
+  </div>
+
+  <section class="editorial-section">
+    <span class="article-section-label">Related Resources</span>
+    <div class="compare-grid">
+      <a href="/library/ascii-table/" class="compare-card variant-muted u-no-underline">
+        <h4>ASCII Table</h4>
+        <p>The full reference chart — every ASCII code 33–126 with decimal and hex values.</p>
+      </a>
+      <a href="/library/alt-codes/" class="compare-card variant-muted u-no-underline">
+        <h4>Alt Codes</h4>
+        <p>Keyboard Alt key codes for typing special characters.</p>
+      </a>
+      <a href="/library/html-entities/" class="compare-card variant-muted u-no-underline">
+        <h4>HTML Entities</h4>
+        <p>Named HTML entity codes for symbols on the web.</p>
+      </a>
+    </div>
+  </section>
+</main>
+
+<footer class="footer"><div class="footer-inner"></div></footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script src="/js/ascii/asciiConverter.js" defer></script>
+<script src="/js/ascii/asciiConverterController.js" defer></script>
+<script src="/footer.js" defer></script>
+</body></html>

--- a/ascii-converter/index.html
+++ b/ascii-converter/index.html
@@ -217,6 +217,10 @@
   <section class="editorial-section">
     <span class="article-section-label">Related Resources</span>
     <div class="compare-grid">
+      <a href="/ascii-art-generator/" class="compare-card variant-muted u-no-underline">
+        <h4>ASCII Art Generator</h4>
+        <p>Turn a word into big multi-line block-letter ASCII art, live, in several font styles.</p>
+      </a>
       <a href="/library/ascii-table/" class="compare-card variant-muted u-no-underline">
         <h4>ASCII Table</h4>
         <p>The full reference chart — every ASCII code 33–126 with decimal and hex values.</p>

--- a/data/library_page_specs/ascii-table.json
+++ b/data/library_page_specs/ascii-table.json
@@ -1,14 +1,14 @@
 {
   "slug": "ascii-table",
-  "title": "ASCII Table: Copy & Paste ASCII Codes & Characters",
-  "meta_description": "ASCII table with decimal and hex codes for punctuation, digits, letters, and symbols — a quick developer reference chart. Click any character to copy it instantly.",
+  "title": "ASCII Table & Chart: Copy & Paste ASCII Codes & Characters",
+  "meta_description": "ASCII table and chart with decimal and hex codes for punctuation, digits, letters, and symbols — a quick developer reference. Click any character to copy it instantly.",
   "canonical": "https://ultratextgen.com/library/ascii-table/",
   "breadcrumb": "ASCII Table",
   "hero_h1": "ASCII Table",
   "hero_tagline": "Printable ASCII characters 33–126 with their decimal and hexadecimal codes. Click any character to copy it instantly.",
   "intro": "The ASCII table maps the 128 characters of the American Standard Code for Information Interchange to the numbers 0–127 — the foundation of modern text encoding and the first 128 code points of Unicode. This reference covers the printable range (33–126) grouped by type, with each character labeled by its decimal and hex code. Codes 0–31 are non-printing control characters (like 10, the line feed), and 32 is the space.",
   "date_published": "2026-06-12",
-  "date_modified": "2026-06-12",
+  "date_modified": "2026-07-10",
   "copy_pattern": "single",
   "sections": [
     {

--- a/js/ascii/asciiBannerController.js
+++ b/js/ascii/asciiBannerController.js
@@ -1,0 +1,113 @@
+/* ==========================================================================
+   UltraTextGen — asciiBannerController.js
+   Wires the /ascii-art-generator/ page to asciiBannerFonts.js. Live-renders a
+   FIGlet-style block-letter banner as the user types and lets them switch
+   between font styles one at a time. Reuses the shared copy/toast helper from
+   symbol-explorer.js (UltraTextGen.copyText) rather than reinventing clipboard
+   handling — same as asciiConverterController.js.
+
+   Requires (loaded before this): asciiBannerFonts.js, and symbol-explorer.js
+   for the shared copy/toast helper (falls back to the Clipboard API alone if
+   it isn't present).
+   ========================================================================== */
+
+(function () {
+  "use strict";
+
+  var Banner = window.UTG_ASCII_BANNER_FONTS;
+  if (!Banner) return;
+
+  var el = {};
+  var currentFont = Banner.fonts.length ? Banner.fonts[0].key : "block";
+  var lastArt = "";
+
+  function $(sel, root) { return (root || document).querySelector(sel); }
+
+  function ready(fn) {
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", fn);
+    } else {
+      fn();
+    }
+  }
+
+  function renderArt() {
+    var raw = el.input ? el.input.value : "";
+    lastArt = Banner.render(raw, currentFont);
+    if (el.output) {
+      el.output.textContent = lastArt || "";
+    }
+    if (el.empty) {
+      el.empty.hidden = !!raw.trim();
+    }
+  }
+
+  function buildPicker() {
+    if (!el.picker) return;
+    Banner.fonts.forEach(function (font) {
+      var btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = "ascii-font-tab" + (font.key === currentFont ? " active" : "");
+      btn.setAttribute("data-font", font.key);
+      btn.setAttribute("aria-pressed", font.key === currentFont ? "true" : "false");
+
+      var name = document.createElement("span");
+      name.className = "ascii-font-tab-name";
+      name.textContent = font.name;
+      btn.appendChild(name);
+
+      var desc = document.createElement("span");
+      desc.className = "ascii-font-tab-desc";
+      desc.textContent = font.description;
+      btn.appendChild(desc);
+
+      el.picker.appendChild(btn);
+    });
+
+    el.picker.addEventListener("click", function (e) {
+      var btn = e.target.closest(".ascii-font-tab");
+      if (!btn) return;
+      var key = btn.getAttribute("data-font");
+      if (!key || key === currentFont) return;
+      currentFont = key;
+
+      Array.prototype.forEach.call(el.picker.querySelectorAll(".ascii-font-tab"), function (b) {
+        var isActive = b === btn;
+        b.classList.toggle("active", isActive);
+        b.setAttribute("aria-pressed", isActive ? "true" : "false");
+      });
+
+      renderArt();
+    });
+  }
+
+  function copyArt(btn) {
+    if (!lastArt) return;
+    var ns = window.UltraTextGen;
+    if (ns && typeof ns.copyText === "function") {
+      ns.copyText(lastArt, btn, "ASCII art");
+    } else if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(lastArt);
+    }
+    btn.classList.add("copied");
+    window.clearTimeout(btn._copiedTimer);
+    btn._copiedTimer = window.setTimeout(function () {
+      btn.classList.remove("copied");
+    }, 1500);
+  }
+
+  ready(function () {
+    el.input = $("#asciiBannerInput");
+    el.picker = $("#asciiFontPicker");
+    el.output = $("#asciiBannerOutput");
+    el.empty = $("#asciiBannerEmpty");
+    el.copyBtn = $("#asciiBannerCopy");
+
+    buildPicker();
+
+    if (el.input) el.input.addEventListener("input", renderArt);
+    if (el.copyBtn) el.copyBtn.addEventListener("click", function () { copyArt(el.copyBtn); });
+
+    renderArt();
+  });
+})();

--- a/js/ascii/asciiBannerFonts.js
+++ b/js/ascii/asciiBannerFonts.js
@@ -197,8 +197,20 @@
     var lines = [];
     for (var r = 0; r < height; r += 1) {
       var parts = blocks.map(function (block) { return block[r] || ""; });
-      // rstrip trailing spaces so lines don't carry dead width on mobile.
-      lines.push(parts.join(gap).replace(/\s+$/, ""));
+      lines.push(parts.join(gap));
+    }
+
+    // Trim only the trailing whitespace every row shares in common, so
+    // dead width is dropped without leaving rows ragged relative to each
+    // other (a glyph like "I" is narrower than "#####" on some of its own
+    // rows, so per-row rstrip made those rows shorter than their neighbors).
+    var minTrailing = Infinity;
+    for (var i = 0; i < lines.length; i += 1) {
+      var m = lines[i].match(/\s+$/);
+      minTrailing = Math.min(minTrailing, m ? m[0].length : 0);
+    }
+    if (minTrailing > 0 && minTrailing !== Infinity) {
+      lines = lines.map(function (line) { return line.slice(0, line.length - minTrailing); });
     }
     return lines.join("\n");
   }

--- a/js/ascii/asciiBannerFonts.js
+++ b/js/ascii/asciiBannerFonts.js
@@ -1,0 +1,207 @@
+/* ==========================================================================
+   UltraTextGen — asciiBannerFonts.js
+   FIGlet-style block-letter ASCII art fonts. Pure logic, no DOM — so it can
+   be reused or eyeballed in Node exactly like asciiConverter.js /
+   verticalLayouts.js (the "one feature, one self-contained pure-logic
+   module" pattern).
+
+   Font-binary rule (see CLAUDE.md): no .ttf/.otf is bundled. Every glyph is
+   hand-authored as a monospace bitmap here in plain JS. All five visible
+   "fonts" are *derived transforms* of ONE validated 5x5 source bitmap, so
+   they are aligned by construction — a letter can never go ragged in one
+   style while looking fine in another.
+
+   Exposes: window.UTG_ASCII_BANNER_FONTS = {
+     fonts: [ { key, name, description }, ... ]  // picker order
+     render(text, fontKey) -> string             // multi-line banner
+   }
+   ========================================================================== */
+
+(function () {
+  "use strict";
+
+  /* --------------------------------------------------------------------
+     Source bitmaps. Each glyph is an array of 5 equal-width rows; '#' is
+     an "on" cell, '.' is "off". Widths may differ between glyphs (the art
+     is variable-width, like real FIGlet) but every row inside one glyph is
+     the same length, which is what keeps columns aligned.
+     -------------------------------------------------------------------- */
+  var BITMAPS = {
+    "A": [".###.", "#...#", "#####", "#...#", "#...#"],
+    "B": ["####.", "#...#", "####.", "#...#", "####."],
+    "C": [".####", "#....", "#....", "#....", ".####"],
+    "D": ["###..", "#..#.", "#...#", "#..#.", "###.."],
+    "E": ["#####", "#....", "###..", "#....", "#####"],
+    "F": ["#####", "#....", "###..", "#....", "#...."],
+    "G": [".####", "#....", "#..##", "#...#", ".###."],
+    "H": ["#...#", "#...#", "#####", "#...#", "#...#"],
+    "I": ["#####", "..#..", "..#..", "..#..", "#####"],
+    "J": ["..###", "...#.", "...#.", "#..#.", ".##.."],
+    "K": ["#...#", "#..#.", "###..", "#..#.", "#...#"],
+    "L": ["#....", "#....", "#....", "#....", "#####"],
+    "M": ["#...#", "##.##", "#.#.#", "#...#", "#...#"],
+    "N": ["#...#", "##..#", "#.#.#", "#..##", "#...#"],
+    "O": [".###.", "#...#", "#...#", "#...#", ".###."],
+    "P": ["####.", "#...#", "####.", "#....", "#...."],
+    "Q": [".###.", "#...#", "#...#", "#..#.", ".##.#"],
+    "R": ["####.", "#...#", "####.", "#..#.", "#...#"],
+    "S": [".####", "#....", ".###.", "....#", "####."],
+    "T": ["#####", "..#..", "..#..", "..#..", "..#.."],
+    "U": ["#...#", "#...#", "#...#", "#...#", ".###."],
+    "V": ["#...#", "#...#", "#...#", ".#.#.", "..#.."],
+    "W": ["#...#", "#...#", "#.#.#", "##.##", "#...#"],
+    "X": ["#...#", ".#.#.", "..#..", ".#.#.", "#...#"],
+    "Y": ["#...#", ".#.#.", "..#..", "..#..", "..#.."],
+    "Z": ["#####", "...#.", "..#..", ".#...", "#####"],
+    "0": [".###.", "#..##", "#.#.#", "##..#", ".###."],
+    "1": ["..#..", ".##..", "..#..", "..#..", ".###."],
+    "2": [".###.", "#...#", "..##.", ".#...", "#####"],
+    "3": ["####.", "....#", ".###.", "....#", "####."],
+    "4": ["#..#.", "#..#.", "#####", "...#.", "...#."],
+    "5": ["#####", "#....", "####.", "....#", "####."],
+    "6": [".###.", "#....", "####.", "#...#", ".###."],
+    "7": ["#####", "...#.", "..#..", ".#...", ".#..."],
+    "8": [".###.", "#...#", ".###.", "#...#", ".###."],
+    "9": [".###.", "#...#", ".####", "....#", ".###."],
+    " ": ["....", "....", "....", "....", "...."],
+    "!": ["..#..", "..#..", "..#..", ".....", "..#.."],
+    "?": [".###.", "#...#", "..##.", ".....", "..#.."],
+    ".": [".....", ".....", ".....", ".....", "..#.."],
+    "-": [".....", ".....", ".###.", ".....", "....."]
+  };
+
+  var SRC_ROWS = 5;
+
+  /* Turn a glyph's string rows into a boolean grid [row][col]. */
+  function toGrid(rows) {
+    return rows.map(function (row) {
+      return row.split("").map(function (ch) { return ch === "#"; });
+    });
+  }
+
+  function repeat(ch, n) {
+    var s = "";
+    for (var i = 0; i < n; i += 1) s += ch;
+    return s;
+  }
+
+  /* --------------------------------------------------------------------
+     Style renderers. Each takes a boolean grid (5 rows) for one glyph and
+     returns an array of output rows (all equal width). Height is fixed per
+     style so glyphs stack on a shared baseline.
+     -------------------------------------------------------------------- */
+
+  // Solid full-block letters.
+  function renderBlock(grid, on) {
+    return grid.map(function (row) {
+      return row.map(function (cell) { return cell ? on : " "; }).join("");
+    });
+  }
+
+  // Classic "banner" hash letters (same shapes, '#' fill).
+  function styleBlock(grid) { return renderBlock(grid, "█"); } // █
+  function styleBanner(grid) { return renderBlock(grid, "#"); }
+
+  // Italic shear: top rows pushed right, bottom rows flush left. Constant
+  // total width (SRC_ROWS-1 extra columns) keeps every row equal length.
+  function styleSlant(grid) {
+    var lean = SRC_ROWS - 1;
+    return grid.map(function (row, r) {
+      var lead = lean - r;
+      var trail = r;
+      var body = row.map(function (cell) { return cell ? "█" : " "; }).join("");
+      return repeat(" ", lead) + body + repeat(" ", trail);
+    });
+  }
+
+  // Drop-shadow / 3D: solid block plus a light-shade ghost one cell down-right.
+  function styleShadow(grid) {
+    var h = SRC_ROWS + 1;
+    var w = grid[0].length + 1;
+    var out = [];
+    var r, c;
+    for (r = 0; r < h; r += 1) out.push(new Array(w).fill(" "));
+    // shadow first…
+    for (r = 0; r < SRC_ROWS; r += 1) {
+      for (c = 0; c < grid[r].length; c += 1) {
+        if (grid[r][c]) out[r + 1][c + 1] = "░"; // ░
+      }
+    }
+    // …then the solid face on top.
+    for (r = 0; r < SRC_ROWS; r += 1) {
+      for (c = 0; c < grid[r].length; c += 1) {
+        if (grid[r][c]) out[r][c] = "█"; // █
+      }
+    }
+    return out.map(function (row) { return row.join(""); });
+  }
+
+  // Compact half-height: pair each two source rows into one row using
+  // half-block glyphs. 5 rows -> 3 rows, same width. Stays readable.
+  function styleMini(grid) {
+    var padded = grid.slice();
+    if (padded.length % 2 === 1) {
+      padded = padded.concat([grid[0].map(function () { return false; })]);
+    }
+    var out = [];
+    for (var r = 0; r < padded.length; r += 2) {
+      var top = padded[r];
+      var bot = padded[r + 1];
+      var line = "";
+      for (var c = 0; c < top.length; c += 1) {
+        var t = top[c];
+        var b = bot[c];
+        line += t && b ? "█" : t ? "▀" : b ? "▄" : " "; // █ ▀ ▄
+      }
+      out.push(line);
+    }
+    return out;
+  }
+
+  var STYLES = {
+    block: { render: styleBlock, gap: 1 },
+    slant: { render: styleSlant, gap: 1 },
+    shadow: { render: styleShadow, gap: 1 },
+    banner: { render: styleBanner, gap: 2 },
+    mini: { render: styleMini, gap: 1 }
+  };
+
+  var FONTS = [
+    { key: "block", name: "Block", description: "Solid full-block capitals" },
+    { key: "slant", name: "Slant", description: "Leaning italic block letters" },
+    { key: "shadow", name: "Shadow", description: "3D letters with a drop shadow" },
+    { key: "banner", name: "Banner", description: "Classic hash-mark banner style" },
+    { key: "mini", name: "Mini", description: "Compact half-height letters" }
+  ];
+
+  function glyphFor(ch) {
+    if (Object.prototype.hasOwnProperty.call(BITMAPS, ch)) return BITMAPS[ch];
+    return BITMAPS[" "];
+  }
+
+  /* Render a whole string into a multi-line banner in the given style.
+     Unknown characters fall back to a blank glyph; input is upper-cased
+     because this genre reuses one set of capital shapes for both cases. */
+  function render(text, fontKey) {
+    var style = STYLES[fontKey] || STYLES.block;
+    var chars = String(text == null ? "" : text).toUpperCase().split("");
+    if (!chars.length) return "";
+
+    // Render each glyph to its block of rows.
+    var blocks = chars.map(function (ch) {
+      return style.render(toGrid(glyphFor(ch)));
+    });
+
+    var height = blocks.length ? blocks[0].length : 0;
+    var gap = repeat(" ", style.gap);
+    var lines = [];
+    for (var r = 0; r < height; r += 1) {
+      var parts = blocks.map(function (block) { return block[r] || ""; });
+      // rstrip trailing spaces so lines don't carry dead width on mobile.
+      lines.push(parts.join(gap).replace(/\s+$/, ""));
+    }
+    return lines.join("\n");
+  }
+
+  window.UTG_ASCII_BANNER_FONTS = { fonts: FONTS, render: render };
+})();

--- a/js/ascii/asciiConverter.js
+++ b/js/ascii/asciiConverter.js
@@ -1,0 +1,152 @@
+/* ==========================================================================
+   UltraTextGen — asciiConverter.js
+   Pure text <-> ASCII/Unicode code-point converter. No DOM dependencies, so
+   it can be reused or unit-tested anywhere it's loaded.
+
+   Pairs with curvedText.js / verticalLayouts.js: same "one feature, one
+   self-contained pure-logic module" pattern.
+
+   Exposes: window.UltraAsciiConverter = {
+     encode(text) -> { decimal, hex, binary, octal, charCount, nonAsciiCount }
+     decode(input, mode) -> { text, ok, mode, invalidTokens }
+     detectMode(input) -> 'decimal' | 'hex' | 'binary' | 'octal' | null
+   }
+   ========================================================================== */
+
+(function () {
+  "use strict";
+
+  var MAX_CODE_POINT = 0x10ffff; // highest valid Unicode code point
+
+  function toChars(text) {
+    // Array.from iterates by Unicode code point, so surrogate pairs
+    // (emoji, etc.) are handled as single "characters".
+    return Array.from(String(text == null ? "" : text));
+  }
+
+  /* Text -> codes. Every character is encoded, ASCII (0-127) or not; codes
+     above 127 use the character's full Unicode code point. */
+  function encode(text) {
+    var chars = toChars(text);
+    var decimal = [];
+    var hex = [];
+    var binary = [];
+    var octal = [];
+    var nonAsciiCount = 0;
+
+    chars.forEach(function (ch) {
+      var cp = ch.codePointAt(0);
+      if (cp > 127) nonAsciiCount += 1;
+      decimal.push(String(cp));
+      hex.push(cp.toString(16).toUpperCase().padStart(2, "0"));
+      binary.push(cp.toString(2).padStart(8, "0"));
+      octal.push(cp.toString(8).padStart(3, "0"));
+    });
+
+    return {
+      decimal: decimal.join(" "),
+      hex: hex.join(" "),
+      binary: binary.join(" "),
+      octal: octal.join(" "),
+      charCount: chars.length,
+      nonAsciiCount: nonAsciiCount
+    };
+  }
+
+  function stripPrefix(tok) {
+    return tok.replace(/^0[xXbBoO]/, "");
+  }
+
+  function splitTokens(input) {
+    return input.trim().split(/[\s,;]+/).filter(Boolean);
+  }
+
+  function chunk(str, size) {
+    var out = [];
+    for (var i = 0; i < str.length; i += size) out.push(str.slice(i, i + size));
+    return out;
+  }
+
+  function isValidToken(tok, mode) {
+    if (!tok) return false;
+    if (mode === "hex") return /^[0-9a-f]+$/i.test(tok);
+    if (mode === "binary") return /^[01]+$/.test(tok);
+    if (mode === "octal") return /^[0-7]+$/.test(tok);
+    return /^[0-9]+$/.test(tok);
+  }
+
+  /* Guess the most likely code format for a pasted string. Decimal is
+     preferred over octal when a set of tokens is ambiguous (all digits
+     0-7), since "ascii to decimal" / "decimal to ascii" is the far more
+     common query — octal needs an explicit mode pick. */
+  function detectMode(input) {
+    var trimmed = String(input == null ? "" : input).trim();
+    if (!trimmed) return null;
+
+    var tokens = splitTokens(trimmed);
+
+    if (tokens.length > 1) {
+      if (tokens.every(function (t) { return /^[01]{1,8}$/.test(t); })) return "binary";
+
+      var hexLike = tokens.every(function (t) { return /^(0x)?[0-9a-f]{1,2}$/i.test(t); });
+      var hasHexLetter = tokens.some(function (t) { return /[a-f]/i.test(t); });
+      if (hexLike && hasHexLetter) return "hex";
+
+      var decimalLike = tokens.every(function (t) {
+        return /^[0-9]{1,7}$/.test(t) && parseInt(t, 10) <= MAX_CODE_POINT;
+      });
+      if (decimalLike) return "decimal";
+
+      if (tokens.every(function (t) { return /^[0-7]{1,3}$/.test(t); })) return "octal";
+      return null;
+    }
+
+    // Single contiguous token, no separators — only binary and hex have an
+    // unambiguous fixed width to chunk by without extra hints.
+    var single = stripPrefix(tokens[0] || "");
+    if (/^[01]+$/.test(single) && single.length % 8 === 0) return "binary";
+    if (/^[0-9a-f]+$/i.test(single) && single.length % 2 === 0) return "hex";
+    return null;
+  }
+
+  /* Codes -> text. mode is 'auto' | 'decimal' | 'hex' | 'binary' | 'octal'. */
+  function decode(input, mode) {
+    var trimmed = String(input == null ? "" : input).trim();
+    var requested = mode && mode !== "auto" ? mode : null;
+
+    if (!trimmed) {
+      return { text: "", ok: true, mode: requested, invalidTokens: [] };
+    }
+
+    var useMode = requested || detectMode(trimmed);
+    if (!useMode) {
+      return { text: "", ok: false, mode: null, invalidTokens: [] };
+    }
+
+    var tokens = splitTokens(trimmed);
+    if (tokens.length === 1) {
+      var single = stripPrefix(tokens[0]);
+      var size = useMode === "hex" ? 2 : useMode === "binary" ? 8 : useMode === "octal" ? 3 : 0;
+      tokens = size && single.length > size && single.length % size === 0
+        ? chunk(single, size)
+        : [single];
+    } else {
+      tokens = tokens.map(stripPrefix);
+    }
+
+    var base = useMode === "hex" ? 16 : useMode === "binary" ? 2 : useMode === "octal" ? 8 : 10;
+    var invalidTokens = [];
+    var text = "";
+
+    tokens.forEach(function (tok) {
+      if (!isValidToken(tok, useMode)) { invalidTokens.push(tok); return; }
+      var n = parseInt(tok, base);
+      if (!isFinite(n) || n < 0 || n > MAX_CODE_POINT) { invalidTokens.push(tok); return; }
+      text += String.fromCodePoint(n);
+    });
+
+    return { text: text, ok: invalidTokens.length === 0, mode: useMode, invalidTokens: invalidTokens };
+  }
+
+  window.UltraAsciiConverter = { encode: encode, decode: decode, detectMode: detectMode };
+})();

--- a/js/ascii/asciiConverterController.js
+++ b/js/ascii/asciiConverterController.js
@@ -1,0 +1,136 @@
+/* ==========================================================================
+   UltraTextGen — asciiConverterController.js
+   Wires the /ascii-converter/ page controls to asciiConverter.js. Reuses the
+   shared copy/toast helper from symbol-explorer.js (UltraTextGen.copyText /
+   .toast) instead of reinventing clipboard handling.
+
+   Requires (loaded before this): asciiConverter.js, and symbol-explorer.js
+   for the shared copy/toast helper (falls back to the Clipboard API alone
+   if it isn't present).
+   ========================================================================== */
+
+(function () {
+  "use strict";
+
+  var Ascii = window.UltraAsciiConverter;
+  if (!Ascii) return;
+
+  var MODE_LABEL = {
+    decimal: "decimal",
+    hex: "hexadecimal",
+    binary: "binary",
+    octal: "octal"
+  };
+
+  var el = {};
+  var lastValues = {};
+
+  function $(sel, root) { return (root || document).querySelector(sel); }
+  function $all(sel, root) { return Array.prototype.slice.call((root || document).querySelectorAll(sel)); }
+
+  function ready(fn) {
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", fn);
+    } else {
+      fn();
+    }
+  }
+
+  function renderEncode() {
+    var raw = el.textInput ? el.textInput.value : "";
+    var result = Ascii.encode(raw);
+
+    lastValues.asciiDecimalOut = result.decimal;
+    lastValues.asciiHexOut = result.hex;
+    lastValues.asciiBinaryOut = result.binary;
+    lastValues.asciiOctalOut = result.octal;
+
+    if (el.decimalOut) el.decimalOut.textContent = result.decimal;
+    if (el.hexOut) el.hexOut.textContent = result.hex;
+    if (el.binaryOut) el.binaryOut.textContent = result.binary;
+    if (el.octalOut) el.octalOut.textContent = result.octal;
+
+    if (el.nonAsciiNote) {
+      if (result.nonAsciiCount > 0) {
+        var noun = result.nonAsciiCount === 1 ? "character" : "characters";
+        el.nonAsciiNote.textContent =
+          result.nonAsciiCount + " non-ASCII " + noun +
+          " in your text — shown using their full Unicode code point instead of a standard ASCII code.";
+        el.nonAsciiNote.hidden = false;
+      } else {
+        el.nonAsciiNote.textContent = "";
+        el.nonAsciiNote.hidden = true;
+      }
+    }
+  }
+
+  function renderDecode() {
+    var raw = el.codeInput ? el.codeInput.value : "";
+    var mode = el.decodeMode ? el.decodeMode.value : "auto";
+    var result = Ascii.decode(raw, mode);
+
+    lastValues.asciiDecodedOut = result.text;
+    if (el.decodedOut) el.decodedOut.textContent = result.text;
+
+    if (el.decodeNote) {
+      if (!raw.trim()) {
+        el.decodeNote.textContent = "";
+      } else if (!result.mode) {
+        el.decodeNote.textContent =
+          "Couldn't detect a format — separate codes with spaces or commas, or pick a format above.";
+      } else if (!result.ok) {
+        el.decodeNote.textContent =
+          "Decoded as " + MODE_LABEL[result.mode] + ", but skipped invalid code(s): " + result.invalidTokens.join(", ");
+      } else if (mode === "auto") {
+        el.decodeNote.textContent = "Auto-detected as " + MODE_LABEL[result.mode] + ".";
+      } else {
+        el.decodeNote.textContent = "";
+      }
+    }
+  }
+
+  function copyOutput(btn) {
+    var targetId = btn.getAttribute("data-copy-target");
+    var label = btn.getAttribute("data-label") || "text";
+    var text = targetId ? lastValues[targetId] : "";
+    if (!text) return;
+
+    var ns = window.UltraTextGen;
+    if (ns && typeof ns.copyText === "function") {
+      ns.copyText(text, btn, label);
+    } else if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text);
+    }
+
+    btn.classList.add("copied");
+    window.clearTimeout(btn._copiedTimer);
+    btn._copiedTimer = window.setTimeout(function () {
+      btn.classList.remove("copied");
+    }, 1500);
+  }
+
+  ready(function () {
+    el.textInput = $("#asciiTextInput");
+    el.decimalOut = $("#asciiDecimalOut");
+    el.hexOut = $("#asciiHexOut");
+    el.binaryOut = $("#asciiBinaryOut");
+    el.octalOut = $("#asciiOctalOut");
+    el.nonAsciiNote = $("#asciiNonAsciiNote");
+
+    el.codeInput = $("#asciiCodeInput");
+    el.decodeMode = $("#asciiDecodeMode");
+    el.decodeNote = $("#asciiDecodeNote");
+    el.decodedOut = $("#asciiDecodedOut");
+
+    if (el.textInput) el.textInput.addEventListener("input", renderEncode);
+    if (el.codeInput) el.codeInput.addEventListener("input", renderDecode);
+    if (el.decodeMode) el.decodeMode.addEventListener("change", renderDecode);
+
+    $all(".ascii-copy-btn").forEach(function (btn) {
+      btn.addEventListener("click", function () { copyOutput(btn); });
+    });
+
+    renderEncode();
+    renderDecode();
+  });
+})();

--- a/library/ascii-table/index.html
+++ b/library/ascii-table/index.html
@@ -412,6 +412,10 @@
 <section class="editorial-section">
   <span class="article-section-label">Related Resources</span>
   <div class="compare-grid">
+    <a href="/ascii-art-generator/" class="compare-card variant-muted u-no-underline">
+      <h4>ASCII Art Generator</h4>
+      <p>Turn a word into big multi-line block-letter ASCII art, live, in several font styles.</p>
+    </a>
     <a href="/ascii-converter/" class="compare-card variant-muted u-no-underline">
       <h4>ASCII Converter</h4>
       <p>Convert text to decimal, hex, binary, or octal codes — and decode codes back to text — live.</p>

--- a/library/ascii-table/index.html
+++ b/library/ascii-table/index.html
@@ -13,8 +13,8 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>ASCII Table: Copy &amp; Paste ASCII Codes &amp; Characters</title>
-<meta name="description" content="ASCII table with decimal and hex codes for punctuation, digits, letters, and symbols — a quick developer reference chart. Click any character to copy it instantly.">
+<title>ASCII Table &amp; Chart: Copy &amp; Paste ASCII Codes &amp; Characters</title>
+<meta name="description" content="ASCII table and chart with decimal and hex codes for punctuation, digits, letters, and symbols — a quick developer reference. Click any character to copy it instantly.">
 
 <link rel="canonical" href="https://ultratextgen.com/library/ascii-table/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/library-ascii-table.png">
@@ -22,11 +22,11 @@
 <meta property="og:image:height" content="630">
 <meta property="og:image:type" content="image/png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="ASCII Table: Copy &amp; Paste ASCII Codes &amp; Characters">
-<meta name="twitter:description" content="ASCII table with decimal and hex codes for punctuation, digits, letters, and symbols — a quick developer reference chart. Click any character to copy it instantly.">
+<meta name="twitter:title" content="ASCII Table &amp; Chart: Copy &amp; Paste ASCII Codes &amp; Characters">
+<meta name="twitter:description" content="ASCII table and chart with decimal and hex codes for punctuation, digits, letters, and symbols — a quick developer reference. Click any character to copy it instantly.">
 <meta name="twitter:image" content="https://ultratextgen.com/assets/og/library-ascii-table.png">
-<meta property="og:title" content="ASCII Table: Copy &amp; Paste ASCII Codes &amp; Characters">
-<meta property="og:description" content="ASCII table with decimal and hex codes for punctuation, digits, letters, and symbols — a quick developer reference chart. Click any character to copy it instantly.">
+<meta property="og:title" content="ASCII Table &amp; Chart: Copy &amp; Paste ASCII Codes &amp; Characters">
+<meta property="og:description" content="ASCII table and chart with decimal and hex codes for punctuation, digits, letters, and symbols — a quick developer reference. Click any character to copy it instantly.">
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://ultratextgen.com/library/ascii-table/">
 
@@ -41,9 +41,9 @@
 {
   "@context": "https://schema.org",
   "@type": "Article",
-  "headline": "ASCII Table: Copy & Paste ASCII Codes & Characters",
+  "headline": "ASCII Table & Chart: Copy & Paste ASCII Codes & Characters",
   "alternateName": ["ASCII Table Chart", "ASCII Character Codes", "ASCII Code List", "Full ASCII Table", "ASCII Codes Reference", "ASCII Characters Copy Paste", "ASCII Code Chart"],
-  "description": "ASCII table with decimal and hex codes for punctuation, digits, letters, and symbols — a quick developer reference chart. Click any character to copy it instantly.",
+  "description": "ASCII table and chart with decimal and hex codes for punctuation, digits, letters, and symbols — a quick developer reference. Click any character to copy it instantly.",
   "author": {
     "@type": "Organization",
     "name": "UltraTextGen",
@@ -57,7 +57,7 @@
   "image": "https://ultratextgen.com/assets/og/library-ascii-table.png",
   "mainEntityOfPage": "https://ultratextgen.com/library/ascii-table/",
   "datePublished": "2026-06-12",
-  "dateModified": "2026-06-12"
+  "dateModified": "2026-07-10"
 }
 </script>
 

--- a/library/ascii-table/index.html
+++ b/library/ascii-table/index.html
@@ -113,7 +113,7 @@
 <!-- INTRO -->
 <section class="editorial-section">
   <div class="editorial-block">
-    <p>The ASCII table maps the 128 characters of the American Standard Code for Information Interchange to the numbers 0–127 — the foundation of modern text encoding and the first 128 code points of Unicode. This reference covers the printable range (33–126) grouped by type, with each character labeled by its decimal and hex code. Codes 0–31 are non-printing control characters (like 10, the line feed), and 32 is the space.</p>
+    <p>The ASCII table maps the 128 characters of the American Standard Code for Information Interchange to the numbers 0–127 — the foundation of modern text encoding and the first 128 code points of Unicode. This reference covers the printable range (33–126) grouped by type, with each character labeled by its decimal and hex code. Codes 0–31 are non-printing control characters (like 10, the line feed), and 32 is the space. Need to convert a whole word or message instead of looking up single characters? Use the interactive <a href="/ascii-converter/">ASCII converter</a> to turn text into decimal, hex, binary, or octal codes (and back) instantly.</p>
   </div>
 </section>
 
@@ -412,6 +412,10 @@
 <section class="editorial-section">
   <span class="article-section-label">Related Resources</span>
   <div class="compare-grid">
+    <a href="/ascii-converter/" class="compare-card variant-muted u-no-underline">
+      <h4>ASCII Converter</h4>
+      <p>Convert text to decimal, hex, binary, or octal codes — and decode codes back to text — live.</p>
+    </a>
     <a href="/library/alt-codes/" class="compare-card variant-muted u-no-underline">
       <h4>Alt Codes</h4>
       <p>Keyboard Alt key codes for typing special characters.</p>

--- a/library/cat-ascii-art/index.html
+++ b/library/cat-ascii-art/index.html
@@ -1,0 +1,290 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Cat ASCII Art 🐱 Copy &amp; Paste</title>
+<meta name="description" content="Copy and paste cat ASCII art — original multi-line text cats including cat faces, cat loafs, long cats, and sitting cats drawn in plain keyboard characters.">
+
+<link rel="canonical" href="https://ultratextgen.com/library/cat-ascii-art/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/category.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Cat ASCII Art 🐱 Copy &amp; Paste">
+<meta name="twitter:description" content="Copy and paste cat ASCII art — original multi-line text cats including cat faces, cat loafs, long cats, and sitting cats drawn in plain keyboard characters.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/category.png">
+<meta property="og:title" content="Cat ASCII Art 🐱 Copy &amp; Paste">
+<meta property="og:description" content="Copy and paste cat ASCII art — original multi-line text cats including cat faces, cat loafs, long cats, and sitting cats drawn in plain keyboard characters.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/library/cat-ascii-art/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Cat ASCII Art 🐱 Copy & Paste",
+  "alternateName": ["ASCII Cat Art", "Cat Text Art", "ASCII Cat Copy and Paste", "Text Cat"],
+  "description": "Copy and paste cat ASCII art — original multi-line text cats including cat faces, cat loafs, long cats, and sitting cats drawn in plain keyboard characters.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/category.png",
+  "mainEntityOfPage": "https://ultratextgen.com/library/cat-ascii-art/",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://ultratextgen.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Library",
+      "item": "https://ultratextgen.com/library/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Cat ASCII Art",
+      "item": "https://ultratextgen.com/library/cat-ascii-art/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Cat ASCII Art</h1>
+    <p class="hero-tagline">Original multi-line text cats — cat faces, cat loafs, long cats, and sitting cats drawn in plain characters. Click Copy on any card.</p>
+  </div>
+</section>
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Cat ASCII art draws a whole cat — ears, whiskers, paws, tail — out of nothing but keyboard characters. These are full multi-line pictures, not single-line faces; if you want compact Japanese-style cat emoticons instead, see the <a href="/library/cat-kaomoji/">cat kaomoji collection</a>. Multi-line cats keep their shape wherever text renders in a fixed-width (monospace) font — Discord code blocks, terminals, README files, and plain-text editors. Every piece below is an original drawing; click Copy to grab it with its spacing and line breaks intact.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="small-cats">
+  <span class="article-section-label">Small &amp; One-Line</span>
+  <h2>Small Cat ASCII Art</h2>
+  <p class="u-secondary-tight">Three-line kittens and a one-line whisker face for chats and comments.</p>
+  <div class="art-piece-grid">
+    <div class="art-piece-card">
+      <div class="art-piece-head">
+        <span class="art-piece-label">One-Line Cat</span>
+        <button class="art-piece-copy" type="button" data-label="One-Line Cat" aria-label="Copy One-Line Cat ASCII art">Copy</button>
+      </div>
+      <div class="art-piece-body">
+<pre class="art-piece-pre">=^..^=</pre>
+      </div>
+    </div>
+    <div class="art-piece-card">
+      <div class="art-piece-head">
+        <span class="art-piece-label">Small Cat Face</span>
+        <button class="art-piece-copy" type="button" data-label="Small Cat Face" aria-label="Copy Small Cat Face ASCII art">Copy</button>
+      </div>
+      <div class="art-piece-body">
+<pre class="art-piece-pre">  /\_/\
+ ( o_o )
+  (&gt;x&lt;)</pre>
+      </div>
+    </div>
+    <div class="art-piece-card">
+      <div class="art-piece-head">
+        <span class="art-piece-label">Peeking Cat</span>
+        <button class="art-piece-copy" type="button" data-label="Peeking Cat" aria-label="Copy Peeking Cat ASCII art">Copy</button>
+      </div>
+      <div class="art-piece-body">
+<pre class="art-piece-pre"> /\_/\
+( o o )
+_| ^  |_____</pre>
+      </div>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="classic-cats">
+  <span class="article-section-label">Classic Pieces</span>
+  <h2>Classic Cat Pictures</h2>
+  <p class="u-secondary-tight">Mid-size cats with more detail — loafs, big faces, and a chunky sitting cat.</p>
+  <div class="art-piece-grid">
+    <div class="art-piece-card">
+      <div class="art-piece-head">
+        <span class="art-piece-label">Cat Loaf</span>
+        <button class="art-piece-copy" type="button" data-label="Cat Loaf" aria-label="Copy Cat Loaf ASCII art">Copy</button>
+      </div>
+      <div class="art-piece-body">
+<pre class="art-piece-pre">   /\_/\
+  ( -.- )
+ /       \
+|         |
+ \_______/</pre>
+      </div>
+    </div>
+    <div class="art-piece-card">
+      <div class="art-piece-head">
+        <span class="art-piece-label">Big Cat Face</span>
+        <button class="art-piece-copy" type="button" data-label="Big Cat Face" aria-label="Copy Big Cat Face ASCII art">Copy</button>
+      </div>
+      <div class="art-piece-body">
+<pre class="art-piece-pre">   /\_______/\
+  /   o   o   \
+ =|     ^     |=
+  |  \_____/  |
+   \         /
+    \_______/</pre>
+      </div>
+    </div>
+    <div class="art-piece-card">
+      <div class="art-piece-head">
+        <span class="art-piece-label">Chunky Sitting Cat</span>
+        <button class="art-piece-copy" type="button" data-label="Chunky Sitting Cat" aria-label="Copy Chunky Sitting Cat ASCII art">Copy</button>
+      </div>
+      <div class="art-piece-body">
+<pre class="art-piece-pre">    /\_____/\
+   /  o   o  \
+  ( ==  ^  == )
+   )         (
+  (           )
+ ( (  )   (  ) )
+(__(__)___(__)__)</pre>
+      </div>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="big-cats">
+  <span class="article-section-label">Big Pieces</span>
+  <h2>Big Cat ASCII Art</h2>
+  <p class="u-secondary-tight">Larger cats — best in Discord code blocks, terminals, and anywhere else with a fixed-width font.</p>
+  <div class="art-piece-grid">
+    <div class="art-piece-card">
+      <div class="art-piece-head">
+        <span class="art-piece-label">Cat from Behind</span>
+        <button class="art-piece-copy" type="button" data-label="Cat from Behind" aria-label="Copy Cat from Behind ASCII art">Copy</button>
+      </div>
+      <div class="art-piece-body">
+<pre class="art-piece-pre">   /\_/\
+  (     )    ,
+  (     )    |\
+  (     )    | |
+ (       )   | |
+ (       )   | |
+ (       )__/ /
+  (__________/</pre>
+      </div>
+    </div>
+    <div class="art-piece-card">
+      <div class="art-piece-head">
+        <span class="art-piece-label">Long Cat</span>
+        <button class="art-piece-copy" type="button" data-label="Long Cat" aria-label="Copy Long Cat ASCII art">Copy</button>
+      </div>
+      <div class="art-piece-body">
+<pre class="art-piece-pre">  /\_/\
+ ( o.o )
+ |     |
+ |     |
+ |     |
+ |     |
+ |     |
+ (     )
+ (_____)</pre>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Transform text with Unicode fonts</h3>
+  <p>Use UltraTextGen to convert plain text into bold, italic, cursive, and 100+ other Unicode font styles — free and instant.</p>
+  <a href="https://ultratextgen.com/" class="cta-btn">Open UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Related Resources</span>
+  <div class="compare-grid">
+    <a href="/library/text-art/" class="compare-card variant-muted u-no-underline">
+      <h4>Text Art</h4>
+      <p>ASCII and Unicode art collections plus drawing blocks.</p>
+    </a>
+    <a href="/library/cat-kaomoji/" class="compare-card variant-muted u-no-underline">
+      <h4>Cat Kaomoji</h4>
+      <p>One-line Japanese cat text faces with whiskers and paws.</p>
+    </a>
+    <a href="/library/ascii-table/" class="compare-card variant-muted u-no-underline">
+      <h4>ASCII Table &amp; Chart</h4>
+      <p>Every printable ASCII character with its decimal and hex code.</p>
+    </a>
+    <a href="/library/dog-ascii-art/" class="compare-card variant-muted u-no-underline">
+      <h4>Dog ASCII Art</h4>
+      <p>Multi-line ASCII dogs — puppy faces, bones, and sitting dogs.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/library/dog-ascii-art/index.html
+++ b/library/dog-ascii-art/index.html
@@ -1,0 +1,303 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Dog ASCII Art 🐶 Copy &amp; Paste</title>
+<meta name="description" content="Copy and paste dog ASCII art — original multi-line text dogs including puppy faces, floppy ears, sitting dogs, and dog bones drawn in plain characters.">
+
+<link rel="canonical" href="https://ultratextgen.com/library/dog-ascii-art/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/category.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Dog ASCII Art 🐶 Copy &amp; Paste">
+<meta name="twitter:description" content="Copy and paste dog ASCII art — original multi-line text dogs including puppy faces, floppy ears, sitting dogs, and dog bones drawn in plain characters.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/category.png">
+<meta property="og:title" content="Dog ASCII Art 🐶 Copy &amp; Paste">
+<meta property="og:description" content="Copy and paste dog ASCII art — original multi-line text dogs including puppy faces, floppy ears, sitting dogs, and dog bones drawn in plain characters.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/library/dog-ascii-art/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Dog ASCII Art 🐶 Copy & Paste",
+  "alternateName": ["ASCII Dog Art", "Dog Text Art", "ASCII Dog Copy and Paste", "Puppy Text Art"],
+  "description": "Copy and paste dog ASCII art — original multi-line text dogs including puppy faces, floppy ears, sitting dogs, and dog bones drawn in plain characters.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/category.png",
+  "mainEntityOfPage": "https://ultratextgen.com/library/dog-ascii-art/",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://ultratextgen.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Library",
+      "item": "https://ultratextgen.com/library/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Dog ASCII Art",
+      "item": "https://ultratextgen.com/library/dog-ascii-art/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Dog ASCII Art</h1>
+    <p class="hero-tagline">Original multi-line text dogs — puppy faces, floppy ears, sitting dogs, and bones drawn in plain characters. Click Copy on any card.</p>
+  </div>
+</section>
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Dog ASCII art draws a whole pup — ears, snout, paws, wagging tail — out of nothing but keyboard characters. These are full multi-line pictures; for compact one-line Japanese-style dog faces, see the <a href="/library/dog-kaomoji/">dog kaomoji collection</a> instead. Multi-line dogs hold their shape wherever text renders in a fixed-width (monospace) font — Discord code blocks, terminals, README files, and plain-text editors. Every piece below is an original drawing; click Copy to grab it with its spacing and line breaks intact.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="small-dogs">
+  <span class="article-section-label">Small &amp; One-Line</span>
+  <h2>Small Dog ASCII Art</h2>
+  <p class="u-secondary-tight">Three-line puppies and bones for chats and comments.</p>
+  <div class="art-piece-grid">
+    <div class="art-piece-card">
+      <div class="art-piece-head">
+        <span class="art-piece-label">One-Line Bone</span>
+        <button class="art-piece-copy" type="button" data-label="One-Line Bone" aria-label="Copy One-Line Bone ASCII art">Copy</button>
+      </div>
+      <div class="art-piece-body">
+<pre class="art-piece-pre">(o)=======(o)</pre>
+      </div>
+    </div>
+    <div class="art-piece-card">
+      <div class="art-piece-head">
+        <span class="art-piece-label">Puppy Face</span>
+        <button class="art-piece-copy" type="button" data-label="Puppy Face" aria-label="Copy Puppy Face ASCII art">Copy</button>
+      </div>
+      <div class="art-piece-body">
+<pre class="art-piece-pre"> /^ ^\
+( o o )
+ \_o_/</pre>
+      </div>
+    </div>
+    <div class="art-piece-card">
+      <div class="art-piece-head">
+        <span class="art-piece-label">Peeking Puppy</span>
+        <button class="art-piece-copy" type="button" data-label="Peeking Puppy" aria-label="Copy Peeking Puppy ASCII art">Copy</button>
+      </div>
+      <div class="art-piece-body">
+<pre class="art-piece-pre">  /\ ___ /\
+ (  o   o  )
+_(_)_____(_)_</pre>
+      </div>
+    </div>
+    <div class="art-piece-card">
+      <div class="art-piece-head">
+        <span class="art-piece-label">Dog Bone</span>
+        <button class="art-piece-copy" type="button" data-label="Dog Bone" aria-label="Copy Dog Bone ASCII art">Copy</button>
+      </div>
+      <div class="art-piece-body">
+<pre class="art-piece-pre"> __          __
+(  \________/  )
+(__/        \__)</pre>
+      </div>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="classic-dogs">
+  <span class="article-section-label">Classic Pieces</span>
+  <h2>Classic Dog Pictures</h2>
+  <p class="u-secondary-tight">Mid-size dogs with more detail — happy puppies and big dog faces.</p>
+  <div class="art-piece-grid">
+    <div class="art-piece-card">
+      <div class="art-piece-head">
+        <span class="art-piece-label">Happy Puppy</span>
+        <button class="art-piece-copy" type="button" data-label="Happy Puppy" aria-label="Copy Happy Puppy ASCII art">Copy</button>
+      </div>
+      <div class="art-piece-body">
+<pre class="art-piece-pre">   __      __
+  ( _\    /_ )
+   \ \.--./ /
+    ( o  o )
+     ) __ (
+    (_/  \_)</pre>
+      </div>
+    </div>
+    <div class="art-piece-card">
+      <div class="art-piece-head">
+        <span class="art-piece-label">Big Dog Face</span>
+        <button class="art-piece-copy" type="button" data-label="Big Dog Face" aria-label="Copy Big Dog Face ASCII art">Copy</button>
+      </div>
+      <div class="art-piece-body">
+<pre class="art-piece-pre">    ______
+   /      \
+  | (o)(o) |
+ /|   __   |\
+( |  (__)  | )
+ \|        |/
+   \______/</pre>
+      </div>
+    </div>
+    <div class="art-piece-card">
+      <div class="art-piece-head">
+        <span class="art-piece-label">Floppy-Ear Dog</span>
+        <button class="art-piece-copy" type="button" data-label="Floppy-Ear Dog" aria-label="Copy Floppy-Ear Dog ASCII art">Copy</button>
+      </div>
+      <div class="art-piece-body">
+<pre class="art-piece-pre">  ___         ___
+ /   \_______/   \
+|    /  o o  \    |
+|   |    ..   |   |
+ \  |  \___/  |  /
+  \_|         |_/
+    \_________/</pre>
+      </div>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="big-dogs">
+  <span class="article-section-label">Big Pieces</span>
+  <h2>Big Dog ASCII Art</h2>
+  <p class="u-secondary-tight">Full-body dogs — best in Discord code blocks, terminals, and anywhere else with a fixed-width font.</p>
+  <div class="art-piece-grid">
+    <div class="art-piece-card">
+      <div class="art-piece-head">
+        <span class="art-piece-label">Sitting Dog</span>
+        <button class="art-piece-copy" type="button" data-label="Sitting Dog" aria-label="Copy Sitting Dog ASCII art">Copy</button>
+      </div>
+      <div class="art-piece-body">
+<pre class="art-piece-pre">     __
+    /  \______
+   ( o        \  /
+    \   ______ \/
+     | |      | |
+     | |      | |
+    _| |_    _| |_</pre>
+      </div>
+    </div>
+    <div class="art-piece-card">
+      <div class="art-piece-head">
+        <span class="art-piece-label">Begging Dog</span>
+        <button class="art-piece-copy" type="button" data-label="Begging Dog" aria-label="Copy Begging Dog ASCII art">Copy</button>
+      </div>
+      <div class="art-piece-body">
+<pre class="art-piece-pre">      /\____/\
+     /  o  o  \
+     |   ..   |
+      \ \__/ /
+      /      \
+     / |    | \
+    (  |    |  )
+     \ |    | /
+      \|    |/
+      (______)</pre>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Transform text with Unicode fonts</h3>
+  <p>Use UltraTextGen to convert plain text into bold, italic, cursive, and 100+ other Unicode font styles — free and instant.</p>
+  <a href="https://ultratextgen.com/" class="cta-btn">Open UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Related Resources</span>
+  <div class="compare-grid">
+    <a href="/library/text-art/" class="compare-card variant-muted u-no-underline">
+      <h4>Text Art</h4>
+      <p>ASCII and Unicode art collections plus drawing blocks.</p>
+    </a>
+    <a href="/library/dog-kaomoji/" class="compare-card variant-muted u-no-underline">
+      <h4>Dog Kaomoji</h4>
+      <p>One-line Japanese puppy text faces with floppy ears.</p>
+    </a>
+    <a href="/ascii-art-generator/" class="compare-card variant-muted u-no-underline">
+      <h4>ASCII Art Generator</h4>
+      <p>Type a word and turn it into big block-letter ASCII art.</p>
+    </a>
+    <a href="/library/cat-ascii-art/" class="compare-card variant-muted u-no-underline">
+      <h4>Cat ASCII Art</h4>
+      <p>Multi-line ASCII cats — loafs, long cats, and cat faces.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/library/heart-ascii-art/index.html
+++ b/library/heart-ascii-art/index.html
@@ -1,0 +1,293 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Heart ASCII Art ♥ Copy &amp; Paste</title>
+<meta name="description" content="Copy and paste heart ASCII art — original multi-line heart pictures drawn in plain characters, from a tiny one-line &lt;3 to big solid and outline hearts.">
+
+<link rel="canonical" href="https://ultratextgen.com/library/heart-ascii-art/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/category.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Heart ASCII Art ♥ Copy &amp; Paste">
+<meta name="twitter:description" content="Copy and paste heart ASCII art — original multi-line heart pictures drawn in plain characters, from a tiny one-line &lt;3 to big solid and outline hearts.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/category.png">
+<meta property="og:title" content="Heart ASCII Art ♥ Copy &amp; Paste">
+<meta property="og:description" content="Copy and paste heart ASCII art — original multi-line heart pictures drawn in plain characters, from a tiny one-line &lt;3 to big solid and outline hearts.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/library/heart-ascii-art/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Heart ASCII Art ♥ Copy & Paste",
+  "alternateName": ["ASCII Heart Art", "Heart Text Art", "ASCII Heart Copy and Paste", "Heart Made of Symbols"],
+  "description": "Copy and paste heart ASCII art — original multi-line heart pictures drawn in plain characters, from a tiny one-line <3 to big solid and outline hearts.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/category.png",
+  "mainEntityOfPage": "https://ultratextgen.com/library/heart-ascii-art/",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://ultratextgen.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Library",
+      "item": "https://ultratextgen.com/library/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Heart ASCII Art",
+      "item": "https://ultratextgen.com/library/heart-ascii-art/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Heart ASCII Art</h1>
+    <p class="hero-tagline">Original heart pictures drawn entirely in plain text — one-line hearts, small hearts, and big multi-line pieces. Click Copy on any card.</p>
+  </div>
+</section>
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Heart ASCII art draws a heart shape entirely out of keyboard characters — from the two-keystroke classic &lt;3 to large multi-line hearts built from asterisks, colons, and slashes. One-line hearts paste cleanly anywhere; the bigger multi-line pieces keep their shape only where text renders in a fixed-width (monospace) font, such as Discord code blocks, terminals, and plain-text editors. Every piece below is an original drawing — click Copy to grab it with its line breaks and spacing intact.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="small-hearts">
+  <span class="article-section-label">Small &amp; One-Line</span>
+  <h2>Small Heart ASCII Art</h2>
+  <p class="u-secondary-tight">Compact hearts for chats, bios, and comments — including one-line pieces that work in any font.</p>
+  <div class="art-piece-grid">
+    <div class="art-piece-card">
+      <div class="art-piece-head">
+        <span class="art-piece-label">Classic Heart</span>
+        <button class="art-piece-copy" type="button" data-label="Classic Heart" aria-label="Copy Classic Heart ASCII art">Copy</button>
+      </div>
+      <div class="art-piece-body">
+<pre class="art-piece-pre">&lt;3</pre>
+      </div>
+    </div>
+    <div class="art-piece-card">
+      <div class="art-piece-head">
+        <span class="art-piece-label">Arrow &amp; Heart</span>
+        <button class="art-piece-copy" type="button" data-label="Arrow &amp; Heart" aria-label="Copy Arrow and Heart ASCII art">Copy</button>
+      </div>
+      <div class="art-piece-body">
+<pre class="art-piece-pre">&gt;&gt;&gt;-----&gt; &lt;3</pre>
+      </div>
+    </div>
+    <div class="art-piece-card">
+      <div class="art-piece-head">
+        <span class="art-piece-label">Tiny Heart</span>
+        <button class="art-piece-copy" type="button" data-label="Tiny Heart" aria-label="Copy Tiny Heart ASCII art">Copy</button>
+      </div>
+      <div class="art-piece-body">
+<pre class="art-piece-pre"> __  __
+/  \/  \
+\      /
+ \    /
+  \  /
+   \/</pre>
+      </div>
+    </div>
+    <div class="art-piece-card">
+      <div class="art-piece-head">
+        <span class="art-piece-label">Puffy Heart</span>
+        <button class="art-piece-copy" type="button" data-label="Puffy Heart" aria-label="Copy Puffy Heart ASCII art">Copy</button>
+      </div>
+      <div class="art-piece-body">
+<pre class="art-piece-pre">,d88b.d88b,
+88888888888
+`Y8888888Y'
+  `Y888Y'
+    `Y'</pre>
+      </div>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="classic-hearts">
+  <span class="article-section-label">Classic Pieces</span>
+  <h2>Classic Heart Pictures</h2>
+  <p class="u-secondary-tight">Mid-size hearts with a little more detail — paste them where a monospace font keeps the columns aligned.</p>
+  <div class="art-piece-grid">
+    <div class="art-piece-card">
+      <div class="art-piece-head">
+        <span class="art-piece-label">Dotted Heart</span>
+        <button class="art-piece-copy" type="button" data-label="Dotted Heart" aria-label="Copy Dotted Heart ASCII art">Copy</button>
+      </div>
+      <div class="art-piece-body">
+<pre class="art-piece-pre"> .:::.   .:::.
+:::::::.:::::::
+':::::::::::::'
+  ':::::::::'
+    ':::::'
+      ':'</pre>
+      </div>
+    </div>
+    <div class="art-piece-card">
+      <div class="art-piece-head">
+        <span class="art-piece-label">Love Banner</span>
+        <button class="art-piece-copy" type="button" data-label="Love Banner" aria-label="Copy Love Banner ASCII art">Copy</button>
+      </div>
+      <div class="art-piece-body">
+<pre class="art-piece-pre">&lt;3&lt;3&lt;3&lt;3&lt;3&lt;3&lt;3&lt;3
+&lt;3            &lt;3
+&lt;3  LOVE YOU  &lt;3
+&lt;3            &lt;3
+&lt;3&lt;3&lt;3&lt;3&lt;3&lt;3&lt;3&lt;3</pre>
+      </div>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="big-hearts">
+  <span class="article-section-label">Big Pieces</span>
+  <h2>Big Heart ASCII Art</h2>
+  <p class="u-secondary-tight">Larger, more detailed hearts — best in Discord code blocks, terminals, and anywhere else with a fixed-width font.</p>
+  <div class="art-piece-grid">
+    <div class="art-piece-card">
+      <div class="art-piece-head">
+        <span class="art-piece-label">Solid Heart</span>
+        <button class="art-piece-copy" type="button" data-label="Solid Heart" aria-label="Copy Solid Heart ASCII art">Copy</button>
+      </div>
+      <div class="art-piece-body">
+<pre class="art-piece-pre">   ****       ****
+ ********   ********
+*********************
+*********************
+ *******************
+   ***************
+     ***********
+       *******
+         ***
+          *</pre>
+      </div>
+    </div>
+    <div class="art-piece-card">
+      <div class="art-piece-head">
+        <span class="art-piece-label">Heart Outline</span>
+        <button class="art-piece-copy" type="button" data-label="Heart Outline" aria-label="Copy Heart Outline ASCII art">Copy</button>
+      </div>
+      <div class="art-piece-body">
+<pre class="art-piece-pre">  .-""-.  .-""-.
+ /      \/      \
+|                |
+ \              /
+  \            /
+   \          /
+    \        /
+     \      /
+      \    /
+       \  /
+        \/</pre>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Transform text with Unicode fonts</h3>
+  <p>Use UltraTextGen to convert plain text into bold, italic, cursive, and 100+ other Unicode font styles — free and instant.</p>
+  <a href="https://ultratextgen.com/" class="cta-btn">Open UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Related Resources</span>
+  <div class="compare-grid">
+    <a href="/library/text-art/" class="compare-card variant-muted u-no-underline">
+      <h4>Text Art</h4>
+      <p>ASCII and Unicode art collections plus drawing blocks.</p>
+    </a>
+    <a href="/library/heart-symbols/" class="compare-card variant-muted u-no-underline">
+      <h4>Heart Symbols</h4>
+      <p>Single heart characters in every color and style, ready to copy.</p>
+    </a>
+    <a href="/ascii-art-generator/" class="compare-card variant-muted u-no-underline">
+      <h4>ASCII Art Generator</h4>
+      <p>Type a word and turn it into big block-letter ASCII art.</p>
+    </a>
+    <a href="/library/cat-ascii-art/" class="compare-card variant-muted u-no-underline">
+      <h4>Cat ASCII Art</h4>
+      <p>Multi-line ASCII cats — loafs, long cats, and cat faces.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/library/index.html
+++ b/library/index.html
@@ -602,6 +602,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <li><a href="/library/cameroon-emoji-combos/">Cameroon Emoji Combos</a></li>
       <li><a href="/library/canada-emoji-combos/">Canada Emoji Combos</a></li>
       <li><a href="/library/card-suit-symbols/">Card Suit Symbols</a></li>
+      <li><a href="/library/cat-ascii-art/">Cat ASCII Art</a></li>
       <li><a href="/library/checkmark-symbols/">Checkmark Symbols</a></li>
       <li><a href="/library/chess-symbols/">Chess Symbols</a></li>
       <li><a href="/library/chile-emoji-combos/">Chile Emoji Combos</a></li>
@@ -629,6 +630,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <li><a href="/library/dice-domino-symbols/">Dice &amp; Domino Symbols</a></li>
       <li><a href="/library/discord-symbols/">Discord Symbols</a></li>
       <li><a href="/library/diwali-symbols/">Diwali Symbols</a></li>
+      <li><a href="/library/dog-ascii-art/">Dog ASCII Art</a></li>
       <li><a href="/library/dreamcore-weirdcore-symbols/">Dreamcore &amp; Weirdcore Symbols</a></li>
       <li><a href="/library/easter-symbols/">Easter Symbols</a></li>
       <li><a href="/library/ecuador-emoji-combos/">Ecuador Emoji Combos</a></li>
@@ -680,6 +682,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <li><a href="/library/hand-symbols/">Hand Symbols &amp; Gestures</a></li>
       <li><a href="/library/happy-emoji/">Happy Emoji &amp; Kaomoji</a></li>
       <li><a href="/library/hazard-warning-symbols/">Hazard &amp; Warning Symbols</a></li>
+      <li><a href="/library/heart-ascii-art/">Heart ASCII Art</a></li>
       <li><a href="/library/heart-symbols/">Heart Symbols</a></li>
       <li><a href="/library/hindi-symbols/">Hindi Symbols</a></li>
       <li><a href="/library/honduras-emoji-combos/">Honduras Emoji Combos</a></li>
@@ -774,6 +777,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <li><a href="/library/serbia-emoji-combos/">Serbia Emoji Combos</a></li>
       <li><a href="/library/shocked-emoji/">Shocked Emoji &amp; Kaomoji</a></li>
       <li><a href="/library/side-eye-emoji/">Side Eye Emoji &amp; Kaomoji</a></li>
+      <li><a href="/library/skull-ascii-art/">Skull ASCII Art</a></li>
       <li><a href="/library/slash-backslash-symbols/">Slash &amp; Backslash Symbols</a></li>
       <li><a href="/library/smiley-face-guide/">Smiley Face Guide</a></li>
       <li><a href="/library/soccer-emoji-copy-paste/">Soccer Emoji List</a></li>
@@ -784,6 +788,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <li><a href="/library/sparkle-symbols/">Sparkle Symbols</a></li>
       <li><a href="/library/special-characters/">Special Characters</a></li>
       <li><a href="/library/sports-emojis/">Sports Emojis</a></li>
+      <li><a href="/library/star-ascii-art/">Star ASCII Art</a></li>
       <li><a href="/library/star-symbols/">Star Symbol Collection</a></li>
       <li><a href="/library/suarez-emoji-combos/">Suarez Emoji Combos</a></li>
       <li><a href="/library/sweden-emoji-combos/">Sweden Emoji Combos</a></li>
@@ -1214,6 +1219,17 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       alpha: "C"
     },
     {
+      title: "Cat ASCII Art",
+      slug: "cat-ascii-art",
+      description: "Original multi-line ASCII cats — cat faces, loafs, long cats, and sitting cats.",
+      preview: "/\\_/\\  ( o.o )  =^..^=",
+      useCases: ["Comments", "Captions"],
+      platforms: ["Discord", "X", "Universal"],
+      type: "Symbols",
+      subject: "Nature & Animals",
+      alpha: "C"
+    },
+    {
       title: "Cat Kaomoji",
       slug: "cat-kaomoji",
       description: "Cute Japanese cat text faces with whiskers and paws.",
@@ -1541,6 +1557,17 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       platforms: ["WhatsApp", "Instagram", "Universal"],
       type: "Emojis",
       subject: "Arts & Culture",
+      alpha: "D"
+    },
+    {
+      title: "Dog ASCII Art",
+      slug: "dog-ascii-art",
+      description: "Original multi-line ASCII dogs — puppy faces, floppy ears, sitting dogs, and bones.",
+      preview: "/^ ^\\  ( o o )  \\_o_/",
+      useCases: ["Comments", "Captions"],
+      platforms: ["Discord", "X", "Universal"],
+      type: "Symbols",
+      subject: "Nature & Animals",
       alpha: "D"
     },
     {
@@ -2157,6 +2184,17 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       platforms: ["Universal", "Instagram"],
       type: "Symbols",
       subject: "Marks & Indicators",
+      alpha: "H"
+    },
+    {
+      title: "Heart ASCII Art",
+      slug: "heart-ascii-art",
+      description: "Original multi-line ASCII hearts — from a tiny <3 to big solid and outline hearts.",
+      preview: "<3  ,d88b.  ****",
+      useCases: ["Comments", "Captions"],
+      platforms: ["Discord", "X", "Universal"],
+      type: "Symbols",
+      subject: "Emotions & Expressions",
       alpha: "H"
     },
     {
@@ -3326,6 +3364,17 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       alpha: "S"
     },
     {
+      title: "Skull ASCII Art",
+      slug: "skull-ascii-art",
+      description: "Original multi-line ASCII skulls — tiny skulls, crossbones, and pixel skulls.",
+      preview: "[x_x]  (o.o)  |=|",
+      useCases: ["Comments", "Captions"],
+      platforms: ["Discord", "X", "Universal"],
+      type: "Symbols",
+      subject: "Decorative & Aesthetic",
+      alpha: "S"
+    },
+    {
       title: "Sleepy Kaomoji",
       slug: "sleepy-kaomoji",
       description: "Drowsy, dozing, and fast-asleep Japanese text faces.",
@@ -3444,6 +3493,17 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       platforms: ["Universal", "Instagram", "TikTok", "X"],
       type: "Emojis",
       subject: "Activities & Games",
+      alpha: "S"
+    },
+    {
+      title: "Star ASCII Art",
+      slug: "star-ascii-art",
+      description: "Original multi-line ASCII stars — sparkles, shooting stars, and a giant five-point star.",
+      preview: "*  \\ /  --*--  / \\",
+      useCases: ["Comments", "Captions"],
+      platforms: ["Discord", "X", "Universal"],
+      type: "Symbols",
+      subject: "Decorative & Aesthetic",
       alpha: "S"
     },
     {

--- a/library/skull-ascii-art/index.html
+++ b/library/skull-ascii-art/index.html
@@ -1,0 +1,276 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Skull ASCII Art 💀 Copy &amp; Paste</title>
+<meta name="description" content="Copy and paste skull ASCII art — original multi-line skull pictures in plain characters, from a tiny one-line skull to crossbones and a big detailed skull.">
+
+<link rel="canonical" href="https://ultratextgen.com/library/skull-ascii-art/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/category.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Skull ASCII Art 💀 Copy &amp; Paste">
+<meta name="twitter:description" content="Copy and paste skull ASCII art — original multi-line skull pictures in plain characters, from a tiny one-line skull to crossbones and a big detailed skull.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/category.png">
+<meta property="og:title" content="Skull ASCII Art 💀 Copy &amp; Paste">
+<meta property="og:description" content="Copy and paste skull ASCII art — original multi-line skull pictures in plain characters, from a tiny one-line skull to crossbones and a big detailed skull.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/library/skull-ascii-art/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Skull ASCII Art 💀 Copy & Paste",
+  "alternateName": ["ASCII Skull Art", "Skull Text Art", "ASCII Skull Copy and Paste", "Skull and Crossbones Text Art"],
+  "description": "Copy and paste skull ASCII art — original multi-line skull pictures in plain characters, from a tiny one-line skull to crossbones and a big detailed skull.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/category.png",
+  "mainEntityOfPage": "https://ultratextgen.com/library/skull-ascii-art/",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://ultratextgen.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Library",
+      "item": "https://ultratextgen.com/library/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Skull ASCII Art",
+      "item": "https://ultratextgen.com/library/skull-ascii-art/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Skull ASCII Art</h1>
+    <p class="hero-tagline">Original skull pictures drawn entirely in plain text — tiny skulls, crossbones, pixel skulls, and a big detailed skull. Click Copy on any card.</p>
+  </div>
+</section>
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Skull ASCII art builds a skull out of ordinary keyboard characters — parentheses for eye sockets, pipes for teeth, slashes for the jawline. The one-line pieces paste cleanly into any chat or bio, while the bigger multi-line skulls only hold their shape where text renders in a fixed-width (monospace) font, such as Discord code blocks, terminals, and plain-text files. Every piece below is an original drawing — click Copy to grab it with its spacing and line breaks intact.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="small-skulls">
+  <span class="article-section-label">Small &amp; One-Line</span>
+  <h2>Small Skull ASCII Art</h2>
+  <p class="u-secondary-tight">Mini skulls and dividers that fit in any message.</p>
+  <div class="art-piece-grid">
+    <div class="art-piece-card">
+      <div class="art-piece-head">
+        <span class="art-piece-label">Mini Skull</span>
+        <button class="art-piece-copy" type="button" data-label="Mini Skull" aria-label="Copy Mini Skull ASCII art">Copy</button>
+      </div>
+      <div class="art-piece-body">
+<pre class="art-piece-pre">[x_x]</pre>
+      </div>
+    </div>
+    <div class="art-piece-card">
+      <div class="art-piece-head">
+        <span class="art-piece-label">Skull Divider</span>
+        <button class="art-piece-copy" type="button" data-label="Skull Divider" aria-label="Copy Skull Divider ASCII art">Copy</button>
+      </div>
+      <div class="art-piece-body">
+<pre class="art-piece-pre">=[x_x]=[x_x]=[x_x]=</pre>
+      </div>
+    </div>
+    <div class="art-piece-card">
+      <div class="art-piece-head">
+        <span class="art-piece-label">Tiny Skull</span>
+        <button class="art-piece-copy" type="button" data-label="Tiny Skull" aria-label="Copy Tiny Skull ASCII art">Copy</button>
+      </div>
+      <div class="art-piece-body">
+<pre class="art-piece-pre"> .-.
+(o.o)
+ |=|</pre>
+      </div>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="classic-skulls">
+  <span class="article-section-label">Classic Pieces</span>
+  <h2>Classic Skull Pictures</h2>
+  <p class="u-secondary-tight">Mid-size skulls — paste them where a monospace font keeps the columns aligned.</p>
+  <div class="art-piece-grid">
+    <div class="art-piece-card">
+      <div class="art-piece-head">
+        <span class="art-piece-label">Classic Skull</span>
+        <button class="art-piece-copy" type="button" data-label="Classic Skull" aria-label="Copy Classic Skull ASCII art">Copy</button>
+      </div>
+      <div class="art-piece-body">
+<pre class="art-piece-pre">  _____
+ /     \
+| () () |
+ \  ^  /
+  |||||</pre>
+      </div>
+    </div>
+    <div class="art-piece-card">
+      <div class="art-piece-head">
+        <span class="art-piece-label">Skull &amp; Crossbones</span>
+        <button class="art-piece-copy" type="button" data-label="Skull &amp; Crossbones" aria-label="Copy Skull and Crossbones ASCII art">Copy</button>
+      </div>
+      <div class="art-piece-body">
+<pre class="art-piece-pre"> \\    _____    //
+  \\  /     \  //
+   \\| () () |//
+     |   ^   |
+    //\ === /\\
+   //   ---   \\
+  //           \\</pre>
+      </div>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="big-skulls">
+  <span class="article-section-label">Big Pieces</span>
+  <h2>Big Skull ASCII Art</h2>
+  <p class="u-secondary-tight">Larger, more detailed skulls — best in Discord code blocks, terminals, and anywhere else with a fixed-width font.</p>
+  <div class="art-piece-grid">
+    <div class="art-piece-card">
+      <div class="art-piece-head">
+        <span class="art-piece-label">Pixel Skull</span>
+        <button class="art-piece-copy" type="button" data-label="Pixel Skull" aria-label="Copy Pixel Skull ASCII art">Copy</button>
+      </div>
+      <div class="art-piece-body">
+<pre class="art-piece-pre">  #######
+ #########
+##  ###  ##
+##  ###  ##
+###########
+ ### # ###
+  ## # ##
+   #####</pre>
+      </div>
+    </div>
+    <div class="art-piece-card">
+      <div class="art-piece-head">
+        <span class="art-piece-label">Big Skull</span>
+        <button class="art-piece-copy" type="button" data-label="Big Skull" aria-label="Copy Big Skull ASCII art">Copy</button>
+      </div>
+      <div class="art-piece-body">
+<pre class="art-piece-pre">     _______
+    /       \
+   /         \
+  |           |
+  |  .-. .-.  |
+  |  (o) (o)  |
+  |     ^     |
+   \   ___   /
+    | (___) |
+    |=======|
+     |=|=|=|</pre>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Transform text with Unicode fonts</h3>
+  <p>Use UltraTextGen to convert plain text into bold, italic, cursive, and 100+ other Unicode font styles — free and instant.</p>
+  <a href="https://ultratextgen.com/" class="cta-btn">Open UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Related Resources</span>
+  <div class="compare-grid">
+    <a href="/library/text-art/" class="compare-card variant-muted u-no-underline">
+      <h4>Text Art</h4>
+      <p>ASCII and Unicode art collections plus drawing blocks.</p>
+    </a>
+    <a href="/library/halloween-symbols/" class="compare-card variant-muted u-no-underline">
+      <h4>Halloween Symbols</h4>
+      <p>Spooky symbols, skull characters, and Halloween combos.</p>
+    </a>
+    <a href="/library/ascii-table/" class="compare-card variant-muted u-no-underline">
+      <h4>ASCII Table &amp; Chart</h4>
+      <p>Every printable ASCII character with its decimal and hex code.</p>
+    </a>
+    <a href="/library/star-ascii-art/" class="compare-card variant-muted u-no-underline">
+      <h4>Star ASCII Art</h4>
+      <p>Multi-line ASCII stars — sparkles, shooting stars, and more.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/library/star-ascii-art/index.html
+++ b/library/star-ascii-art/index.html
@@ -1,0 +1,287 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Star ASCII Art ★ Copy &amp; Paste</title>
+<meta name="description" content="Copy and paste star ASCII art — original multi-line star pictures in plain characters, from tiny sparkles and shooting stars to a giant five-point star.">
+
+<link rel="canonical" href="https://ultratextgen.com/library/star-ascii-art/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/category.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Star ASCII Art ★ Copy &amp; Paste">
+<meta name="twitter:description" content="Copy and paste star ASCII art — original multi-line star pictures in plain characters, from tiny sparkles and shooting stars to a giant five-point star.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/category.png">
+<meta property="og:title" content="Star ASCII Art ★ Copy &amp; Paste">
+<meta property="og:description" content="Copy and paste star ASCII art — original multi-line star pictures in plain characters, from tiny sparkles and shooting stars to a giant five-point star.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/library/star-ascii-art/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Star ASCII Art ★ Copy & Paste",
+  "alternateName": ["ASCII Star Art", "Star Text Art", "ASCII Star Copy and Paste", "Shooting Star Text Art"],
+  "description": "Copy and paste star ASCII art — original multi-line star pictures in plain characters, from tiny sparkles and shooting stars to a giant five-point star.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/category.png",
+  "mainEntityOfPage": "https://ultratextgen.com/library/star-ascii-art/",
+  "datePublished": "2026-07-10",
+  "dateModified": "2026-07-10"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://ultratextgen.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Library",
+      "item": "https://ultratextgen.com/library/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Star ASCII Art",
+      "item": "https://ultratextgen.com/library/star-ascii-art/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Star ASCII Art</h1>
+    <p class="hero-tagline">Original star pictures drawn entirely in plain text — sparkles, shooting stars, and a giant five-point star. Click Copy on any card.</p>
+  </div>
+</section>
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Star ASCII art builds star shapes out of ordinary keyboard characters — asterisks, slashes, dashes, and underscores. The small one-line pieces paste cleanly into any bio or chat, while the bigger multi-line stars keep their points sharp only where text renders in a fixed-width (monospace) font, such as Discord code blocks, terminals, and plain-text files. Every piece below is an original drawing — click Copy to grab it with its spacing and line breaks intact. For single star characters like ★ and ✦, see the <a href="/library/star-symbols/">star symbol collection</a>.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="small-stars">
+  <span class="article-section-label">Small &amp; One-Line</span>
+  <h2>Small Star ASCII Art</h2>
+  <p class="u-secondary-tight">Twinkles, dividers, and compact stars that fit anywhere.</p>
+  <div class="art-piece-grid">
+    <div class="art-piece-card">
+      <div class="art-piece-head">
+        <span class="art-piece-label">Twinkle Line</span>
+        <button class="art-piece-copy" type="button" data-label="Twinkle Line" aria-label="Copy Twinkle Line ASCII art">Copy</button>
+      </div>
+      <div class="art-piece-body">
+<pre class="art-piece-pre">. * . + . * .</pre>
+      </div>
+    </div>
+    <div class="art-piece-card">
+      <div class="art-piece-head">
+        <span class="art-piece-label">Star Divider</span>
+        <button class="art-piece-copy" type="button" data-label="Star Divider" aria-label="Copy Star Divider ASCII art">Copy</button>
+      </div>
+      <div class="art-piece-body">
+<pre class="art-piece-pre">*--*--*--*--*--*--*</pre>
+      </div>
+    </div>
+    <div class="art-piece-card">
+      <div class="art-piece-head">
+        <span class="art-piece-label">Tiny Sparkle</span>
+        <button class="art-piece-copy" type="button" data-label="Tiny Sparkle" aria-label="Copy Tiny Sparkle ASCII art">Copy</button>
+      </div>
+      <div class="art-piece-body">
+<pre class="art-piece-pre"> \ /
+--*--
+ / \</pre>
+      </div>
+    </div>
+    <div class="art-piece-card">
+      <div class="art-piece-head">
+        <span class="art-piece-label">Shooting Star</span>
+        <button class="art-piece-copy" type="button" data-label="Shooting Star" aria-label="Copy Shooting Star ASCII art">Copy</button>
+      </div>
+      <div class="art-piece-body">
+<pre class="art-piece-pre">              __/\__
+    ~ ~ ~ ~ ~ \    /
+  ~ ~ ~ ~ ~ ~ /_  _\
+                \/</pre>
+      </div>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="classic-stars">
+  <span class="article-section-label">Classic Pieces</span>
+  <h2>Classic Star Pictures</h2>
+  <p class="u-secondary-tight">Mid-size stars and bursts — paste them where a monospace font keeps the points aligned.</p>
+  <div class="art-piece-grid">
+    <div class="art-piece-card">
+      <div class="art-piece-head">
+        <span class="art-piece-label">Twin Stars</span>
+        <button class="art-piece-copy" type="button" data-label="Twin Stars" aria-label="Copy Twin Stars ASCII art">Copy</button>
+      </div>
+      <div class="art-piece-body">
+<pre class="art-piece-pre">  __/\__
+  \    /   __/\__
+  /_  _\   \    /
+    \/     /_  _\
+             \/</pre>
+      </div>
+    </div>
+    <div class="art-piece-card">
+      <div class="art-piece-head">
+        <span class="art-piece-label">Classic Star</span>
+        <button class="art-piece-copy" type="button" data-label="Classic Star" aria-label="Copy Classic Star ASCII art">Copy</button>
+      </div>
+      <div class="art-piece-body">
+<pre class="art-piece-pre">     *
+    ***
+***********
+  *******
+   *****
+  *** ***
+ **     **</pre>
+      </div>
+    </div>
+    <div class="art-piece-card">
+      <div class="art-piece-head">
+        <span class="art-piece-label">Sparkle Burst</span>
+        <button class="art-piece-copy" type="button" data-label="Sparkle Burst" aria-label="Copy Sparkle Burst ASCII art">Copy</button>
+      </div>
+      <div class="art-piece-body">
+<pre class="art-piece-pre">          |
+      \   |   /
+        \ | /
+   ------ * ------
+        / | \
+      /   |   \
+          |</pre>
+      </div>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="big-stars">
+  <span class="article-section-label">Big Pieces</span>
+  <h2>Big Star ASCII Art</h2>
+  <p class="u-secondary-tight">A large filled five-point star — best in Discord code blocks, terminals, and anywhere else with a fixed-width font.</p>
+  <div class="art-piece-grid">
+    <div class="art-piece-card">
+      <div class="art-piece-head">
+        <span class="art-piece-label">Giant Star</span>
+        <button class="art-piece-copy" type="button" data-label="Giant Star" aria-label="Copy Giant Star ASCII art">Copy</button>
+      </div>
+      <div class="art-piece-body">
+<pre class="art-piece-pre">        *
+       ***
+      *****
+*****************
+ ***************
+   ***********
+    *********
+   ***********
+  *****   *****
+ ****       ****
+***           ***</pre>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Transform text with Unicode fonts</h3>
+  <p>Use UltraTextGen to convert plain text into bold, italic, cursive, and 100+ other Unicode font styles — free and instant.</p>
+  <a href="https://ultratextgen.com/" class="cta-btn">Open UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Related Resources</span>
+  <div class="compare-grid">
+    <a href="/library/text-art/" class="compare-card variant-muted u-no-underline">
+      <h4>Text Art</h4>
+      <p>ASCII and Unicode art collections plus drawing blocks.</p>
+    </a>
+    <a href="/library/star-symbols/" class="compare-card variant-muted u-no-underline">
+      <h4>Star Symbol Collection</h4>
+      <p>Single star characters — ★ ☆ ✦ ✧ — ready to copy.</p>
+    </a>
+    <a href="/ascii-art-generator/" class="compare-card variant-muted u-no-underline">
+      <h4>ASCII Art Generator</h4>
+      <p>Type a word and turn it into big block-letter ASCII art.</p>
+    </a>
+    <a href="/library/heart-ascii-art/" class="compare-card variant-muted u-no-underline">
+      <h4>Heart ASCII Art</h4>
+      <p>Multi-line ASCII hearts, from a tiny &lt;3 to big solid hearts.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/library/text-art/index.html
+++ b/library/text-art/index.html
@@ -365,6 +365,14 @@
       <h4>Braille Pattern Symbols</h4>
       <p>Every braille dot pattern used in high-resolution dot art.</p>
     </a>
+    <a href="/library/ascii-table/" class="compare-card variant-muted u-no-underline">
+      <h4>ASCII Table &amp; Chart</h4>
+      <p>Every printable ASCII character with its decimal and hex code.</p>
+    </a>
+    <a href="/library/football-ascii-art/" class="compare-card variant-muted u-no-underline">
+      <h4>Football ASCII Art</h4>
+      <p>Copy-paste ASCII art for football fans and team chats.</p>
+    </a>
   </div>
 </section>
 

--- a/library/text-art/index.html
+++ b/library/text-art/index.html
@@ -349,6 +349,18 @@
 <section class="editorial-section">
   <span class="article-section-label">Related Resources</span>
   <div class="compare-grid">
+    <a href="/library/heart-ascii-art/" class="compare-card variant-muted u-no-underline">
+      <h4>Heart ASCII Art</h4>
+      <p>Original multi-line ASCII hearts, from a tiny &lt;3 to big solid hearts.</p>
+    </a>
+    <a href="/library/cat-ascii-art/" class="compare-card variant-muted u-no-underline">
+      <h4>Cat ASCII Art</h4>
+      <p>Multi-line ASCII cats — cat faces, loafs, long cats, and sitting cats.</p>
+    </a>
+    <a href="/library/star-ascii-art/" class="compare-card variant-muted u-no-underline">
+      <h4>Star ASCII Art</h4>
+      <p>Multi-line ASCII stars — sparkles, shooting stars, and a giant star.</p>
+    </a>
     <a href="/library/meme-text-art/" class="compare-card variant-muted u-no-underline">
       <h4>Meme Text Art</h4>
       <p>Dot art faces, lenny packs, and meme-style text pieces.</p>

--- a/scripts/validate_library_pages.py
+++ b/scripts/validate_library_pages.py
@@ -41,6 +41,7 @@ REPO = SCRIPT_DIR.parent
 LIBRARY_DIR = REPO / "library"
 
 MIN_SINGLE_BUTTONS = 6
+MIN_ART_PIECES = 6
 MIN_H2 = 3
 
 TITLE_RE = re.compile(r"<title>(.*?)</title>", re.IGNORECASE | re.DOTALL)
@@ -58,6 +59,10 @@ SYMBOL_TILE_RE = re.compile(r"<button[^>]*\bclass=[\"'][^\"']*\bsymbol-tile\b[^\
 # Matches both `UltraTextGen.buildGrids(` and the `ns.buildGrids(` alias used
 # on existing pages (where `var ns = window.UltraTextGen`).
 BUILDGRIDS_RE = re.compile(r"\.buildGrids\s*\(")
+# Multi-line ASCII art pages (e.g. /library/heart-ascii-art/) use per-piece
+# copy buttons that read an adjacent <pre>, not data-symbol tiles.
+ART_COPY_RE = re.compile(r"<button[^>]*\bclass=[\"'][^\"']*\bart-piece-copy\b[^\"']*[\"'][^>]*>",
+                         re.IGNORECASE)
 SYMBOL_TOAST_RE = re.compile(r'id=["\']symbolToast["\']')
 EXPLORER_JS_RE = re.compile(r'src=["\']/symbol-explorer\.js["\']')
 RELATED_RE = re.compile(r'Related Resources|class=["\'][^"\']*compare-card',
@@ -108,8 +113,22 @@ def validate_page(path):
     if h2_count < MIN_H2:
         issues.append(Issue("ERROR", f"expected >= {MIN_H2} <h2>, found {h2_count}"))
 
-    # Collection vs single
+    # Collection vs single vs multi-line art
     is_collection = bool(BUILDGRIDS_RE.search(html))
+    art_buttons = ART_COPY_RE.findall(html)
+    is_art = bool(art_buttons)
+
+    # art-piece copy buttons must have data-label + aria-label
+    art_missing_attr = 0
+    for btn in art_buttons:
+        if "data-label=" not in btn or "aria-label=" not in btn:
+            art_missing_attr += 1
+    if art_missing_attr:
+        issues.append(
+            Issue("ERROR",
+                  f"{art_missing_attr} .art-piece-copy button(s) missing "
+                  "data-label or aria-label")
+        )
 
     # symbol-tile buttons must have data-symbol + aria-label
     tile_buttons = SYMBOL_TILE_RE.findall(html)
@@ -124,8 +143,16 @@ def validate_page(path):
                   "data-symbol or aria-label")
         )
 
+    # Minimum pieces for multi-line art pages
+    if is_art and len(art_buttons) < MIN_ART_PIECES:
+        issues.append(
+            Issue("ERROR",
+                  f"art page has {len(art_buttons)} .art-piece-copy "
+                  f"button(s); need >= {MIN_ART_PIECES}")
+        )
+
     # Minimum buttons for single-copy pages
-    if not is_collection:
+    if not is_collection and not is_art:
         if len(tile_buttons) < MIN_SINGLE_BUTTONS:
             issues.append(
                 Issue("ERROR",
@@ -159,6 +186,7 @@ def validate_page(path):
         "title_norm": normalize_text(title),
         "desc_norm": normalize_text(desc),
         "is_collection": is_collection,
+        "is_art": is_art,
         "issues": issues,
     }
 
@@ -221,7 +249,12 @@ def main(argv=None):
         total_warns += len(warns)
         if result["issues"]:
             pages_with_issues += 1
-            kind = "collection" if result["is_collection"] else "single"
+            if result["is_collection"]:
+                kind = "collection"
+            elif result["is_art"]:
+                kind = "art"
+            else:
+                kind = "single"
             print(f"{rel(path)}  ({kind})")
             for issue in result["issues"]:
                 print(issue)

--- a/style.css
+++ b/style.css
@@ -6655,3 +6655,72 @@ body.dark-mode .kana-cell-empty { opacity: 0.35; }
   .kao-dec-role { grid-column: 2; }
   .kao-dec-glyph { grid-row: span 2; }
 }
+
+/* ==========================================================================
+   ASCII ART LIBRARY PIECES  (/library/heart-ascii-art/, /library/cat-ascii-art/, …)
+   Cards for finished multi-line ASCII pictures: a whitespace-preserving
+   monospace <pre> plus a per-piece Copy button (wired in symbol-explorer.js).
+   Wide pieces scroll inside their own card so the page never scrolls
+   horizontally. Theme tokens only, so dark mode needs no extra overrides.
+   ========================================================================== */
+.art-piece-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 16px;
+  margin-top: 18px;
+}
+.art-piece-card {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-lg);
+  background: var(--bg-white);
+  box-shadow: var(--shadow-soft);
+  overflow: hidden;
+}
+.art-piece-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border-light);
+}
+.art-piece-label {
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+.art-piece-copy {
+  flex-shrink: 0;
+  font-family: inherit;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  background: var(--bg-base);
+  border: 1px solid var(--border-light);
+  border-radius: 8px;
+  padding: 5px 12px;
+  cursor: pointer;
+  transition: border-color 0.15s ease, color 0.15s ease;
+}
+.art-piece-copy:hover,
+.art-piece-copy.is-copied {
+  border-color: var(--accent-purple);
+  color: var(--accent-purple);
+}
+.art-piece-body {
+  flex: 1;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  background: var(--bg-base);
+}
+.art-piece-pre {
+  margin: 0;
+  padding: 14px 16px;
+  font-family: 'Space Mono', ui-monospace, 'Courier New', monospace;
+  font-size: 0.8125rem;
+  line-height: 1.3;
+  white-space: pre;
+  color: var(--text-primary);
+}

--- a/style.css
+++ b/style.css
@@ -6009,6 +6009,13 @@ body.dark-mode .pt-paper { background: #fff; border-color: var(--border-light); 
   font-weight: 600;
   color: var(--text-secondary);
 }
+/* Override the unscoped mobile ".copy-btn { width: 100% }" rule (~line 1049)
+   which was written for full-width style-card buttons; here the button sits
+   in a space-between row next to a label and must stay content-sized or it
+   overflows the panel on narrow viewports. */
+.ascii-output-head .copy-btn {
+  width: auto;
+}
 .ascii-output {
   min-height: 44px;
   border: 1px solid var(--border-light);
@@ -6111,6 +6118,11 @@ body.dark-mode .pt-paper { background: #fff; border-color: var(--border-light); 
   justify-content: space-between;
   gap: 8px;
   margin-bottom: 6px;
+}
+/* Same override as .ascii-output-head .copy-btn above - keep this button
+   content-sized instead of inheriting the unscoped mobile full-width rule. */
+.ascii-art-output-head .copy-btn {
+  width: auto;
 }
 .ascii-art-output-head label {
   font-size: 0.8125rem;

--- a/style.css
+++ b/style.css
@@ -6028,6 +6028,119 @@ body.dark-mode .pt-paper { background: #fff; border-color: var(--border-light); 
   .ascii-tool { grid-template-columns: 1fr; }
 }
 
+/* ==========================================================================
+   ASCII ART GENERATOR  (/ascii-art-generator/)
+   Type a word -> live FIGlet-style block-letter banner, switchable between
+   hand-authored font styles. Monospace <pre> output scrolls inside its own
+   container so wide banners never break the mobile page layout. Theme tokens
+   only, so dark mode needs no extra overrides.
+   ========================================================================== */
+.ascii-art-tool {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  margin-top: 8px;
+}
+.ascii-art-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.ascii-art-field > label {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+.ascii-art-field input {
+  width: 100%;
+  border: 1px solid var(--border-light);
+  border-radius: 8px;
+  background: var(--bg-base);
+  color: var(--text-primary);
+  font-family: inherit;
+  font-size: 1rem;
+  padding: 10px 12px;
+}
+.ascii-font-picker-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-secondary);
+  margin-bottom: 8px;
+}
+.ascii-font-picker {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 10px;
+}
+.ascii-font-tab {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  text-align: left;
+  padding: 12px 14px;
+  border: 1px solid var(--border-light);
+  border-radius: 10px;
+  background: var(--bg-white);
+  color: var(--text-primary);
+  font-family: inherit;
+  cursor: pointer;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+}
+.ascii-font-tab:hover {
+  border-color: var(--accent-purple);
+}
+.ascii-font-tab.active {
+  border-color: var(--accent-purple);
+  box-shadow: 0 0 0 1px var(--accent-purple);
+  background: var(--bg-base);
+}
+.ascii-font-tab-name {
+  font-size: 0.9375rem;
+  font-weight: 700;
+}
+.ascii-font-tab-desc {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+.ascii-art-output-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+.ascii-art-output-head label {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+.ascii-art-output-wrap {
+  position: relative;
+  border: 1px solid var(--border-light);
+  border-radius: 10px;
+  background: var(--bg-base);
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+.ascii-art-output {
+  margin: 0;
+  padding: 16px;
+  min-height: 120px;
+  font-family: 'Space Mono', ui-monospace, 'Courier New', monospace;
+  font-size: 0.875rem;
+  line-height: 1.15;
+  white-space: pre;
+  color: var(--text-primary);
+}
+.ascii-art-empty {
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+  margin: 8px 2px 0;
+}
+
 /* ===========================================================
    Kana charts (/hiragana-chart/, /katakana-chart/)
    Interactive click-to-copy kana grid + print sheet + PNG.

--- a/style.css
+++ b/style.css
@@ -5937,6 +5937,97 @@ body.dark-mode .pt-paper { background: #fff; border-color: var(--border-light); 
   .curved-tool { grid-template-columns: 1fr; }
 }
 
+/* ==========================================================================
+   ASCII CONVERTER TOOL  (/ascii-converter/)
+   Two independent live panels: text -> codes (decimal/hex/binary/octal) and
+   codes -> text (auto-detect or explicit format). Uses theme tokens only,
+   so dark mode needs no extra overrides. Collapses to one column on mobile.
+   ========================================================================== */
+.ascii-tool {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+  align-items: start;
+  margin-top: 8px;
+}
+.ascii-panel {
+  background: var(--bg-white);
+  border: 1px solid var(--border-light);
+  border-radius: 14px;
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.ascii-panel-title {
+  font-size: 1.0625rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0;
+}
+.ascii-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.ascii-field > label {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+.ascii-field select,
+.ascii-field textarea {
+  width: 100%;
+  border: 1px solid var(--border-light);
+  border-radius: 8px;
+  background: var(--bg-base);
+  color: var(--text-primary);
+  font-family: inherit;
+  font-size: 0.9375rem;
+  padding: 8px 10px;
+}
+.ascii-field textarea { resize: vertical; min-height: 72px; }
+.ascii-note {
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+  margin: -8px 0 0;
+  line-height: 1.5;
+}
+.ascii-output-row {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.ascii-output-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+.ascii-output-head label {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+.ascii-output {
+  min-height: 44px;
+  border: 1px solid var(--border-light);
+  border-radius: 8px;
+  background: var(--bg-base);
+  color: var(--text-primary);
+  padding: 10px 12px;
+  font-family: 'Space Mono', ui-monospace, 'Courier New', monospace;
+  font-size: 0.875rem;
+  line-height: 1.6;
+  word-break: break-all;
+  white-space: pre-wrap;
+}
+.ascii-output-text { font-family: inherit; }
+
+@media (max-width: 780px) {
+  .ascii-tool { grid-template-columns: 1fr; }
+}
+
 /* ===========================================================
    Kana charts (/hiragana-chart/, /katakana-chart/)
    Interactive click-to-copy kana grid + print sheet + PNG.

--- a/symbol-explorer.js
+++ b/symbol-explorer.js
@@ -331,6 +331,21 @@
     if (tile) copySymbol(tile);
   });
 
+  /* ============================
+     Auto-wire: per-piece copy buttons on multi-line ASCII art pages.
+     A .art-piece-copy button copies the whitespace-preserved text of the
+     <pre class="art-piece-pre"> inside the same .art-piece-card.
+     ============================ */
+  document.addEventListener("click", function (e) {
+    const btn = e.target.closest(".art-piece-copy");
+    if (!btn) return;
+    const card = btn.closest(".art-piece-card");
+    const pre = card ? card.querySelector(".art-piece-pre") : null;
+    if (!pre) return;
+    const label = btn.getAttribute("data-label") || "ASCII art";
+    copyText(pre.textContent.replace(/\s+$/, ""), btn, label);
+  });
+
   document.addEventListener("keydown", function (e) {
     if (e.key !== "Enter" && e.key !== " ") return;
     var tile = e.target.closest(".symbol-tile");


### PR DESCRIPTION
## Summary

This PR adds four new ASCII art library pages (Dog, Heart, Cat, Star, Skull) and two interactive tools (ASCII Converter and ASCII Art Generator) to expand UltraTextGen's text-generation capabilities beyond Unicode fonts into ASCII art and code-point conversion.

## Key Changes

**New Library Pages:**
- `library/dog-ascii-art/index.html` — Multi-line dog ASCII art (puppy faces, floppy ears, sitting dogs, bones)
- `library/heart-ascii-art/index.html` — Heart ASCII art (tiny one-line to big solid/outline hearts)
- `library/cat-ascii-art/index.html` — Cat ASCII art (cat faces, loafs, long cats, sitting cats)
- `library/star-ascii-art/index.html` — Star ASCII art (sparkles, shooting stars, five-point star)
- `library/skull-ascii-art/index.html` — Skull ASCII art (tiny skull to crossbones and detailed skull)

Each page follows the standard library template with SEO metadata, structured data (Article + BreadcrumbList), and per-piece copy buttons wired to `symbol-explorer.js`.

**New Interactive Tools:**
- `ascii-converter/index.html` — Two-panel live converter: text ↔ decimal/hex/binary/octal codes with auto-detect mode selection
- `ascii-art-generator/index.html` — FIGlet-style block-letter banner generator with switchable font styles

**Core Modules:**
- `js/ascii/asciiConverter.js` — Pure logic text ↔ code-point converter (no DOM dependencies, reusable)
- `js/ascii/asciiConverterController.js` — Wires converter UI to the converter module; reuses shared copy/toast helpers from `symbol-explorer.js`
- `js/ascii/asciiBannerFonts.js` — Hand-authored 5×5 monospace bitmap glyphs for five derived font styles (block, outline, shadow, bold, italic); all derived from one validated source bitmap to ensure alignment
- `js/ascii/asciiBannerController.js` — Wires banner generator UI to the fonts module; live-renders as user types

**Styling:**
- Added `.ascii-tool`, `.ascii-panel`, `.ascii-field`, `.ascii-output` classes to `style.css` for the converter's two-column layout (collapses to one column on mobile)
- Added `.ascii-art-tool`, `.ascii-art-field`, `.ascii-font-picker`, `.ascii-font-tab` classes for the generator's input, font picker, and output display
- All new styles use existing theme tokens (`--bg-white`, `--border-light`, `--text-primary`, etc.) so dark mode works without extra overrides

**Library Index & Validation:**
- Updated `library/index.html` to add links to the five new ASCII art pages in alphabetical order
- Updated `scripts/validate_library_pages.py` to recognize ASCII art pages (which use per-piece copy buttons reading adjacent `<pre>` elements instead of data-symbol tiles) and enforce a minimum of 6 art pieces per page
- Updated `data/library_page_specs/ascii-table.json` with refined title/description

**Related Content:**
- Updated `library/text-art/index.html` to link to the new ASCII art library pages in a "Related Resources" section

## Implementation Details

- **ASCII art pages** use a `.art-piece-copy` button class auto-wired by `symbol-explorer.js` to copy the whitespace-preserved text of an adjacent `<pre>` element — no data-symbol attributes needed
- **Converter module** handles Unicode code points (0–0x10FFFF), not just ASCII (0–127), so emoji and non-ASCII characters are encoded using their full Unicode code point
- **Banner fonts** follow the "one feature, one self-contained pure-logic module" pattern: all five visible font styles are *derived transforms* of a single validated 5×5 source bitmap, ensuring glyphs stay aligned across styles
- **Controllers** reuse the shared `UltraTextGen.copyText()` and `.toast()` helpers from

https://claude.ai/code/session_01BaBnnxpRp4JJFGoZCDL43Q