### PR TITLE
Fix hreflang wiring across PUBG, Roblox, and FF guild page clusters

### DIFF
--- a/ar/usecase/asmaa-pubg/index.html
+++ b/ar/usecase/asmaa-pubg/index.html
@@ -17,7 +17,10 @@
   <meta name="description" content="اسماء ببجي مزخرفة جاهزة للنسخ: اسماء مرعبة وفخمة واسماء قروبات وكلانات، مع إطارات ꧁꧂ ورموز ☠ 亗 メ. اكتب اسمك، زخرفه، افحصه (14 حرفاً كحد أقصى)، ثم الصقه في ببجي موبايل — مجاناً وبدون تطبيقات.">
   <link rel="canonical" href="https://ultratextgen.com/ar/usecase/asmaa-pubg/">
   <link rel="alternate" hreflang="ar" href="https://ultratextgen.com/ar/usecase/asmaa-pubg/">
-  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/usecase/stylish-name/">
+  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/usecase/nama-pubg-keren/">
+  <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/usecase/pubg-nick/">
+  <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/usecase/ten-pubg-dep/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/usecase/nickname-generator/">
 
   <meta property="og:image" content="https://ultratextgen.com/assets/og/usecase-clan-tag-generator.png">
   <meta property="og:image:width" content="1200">

--- a/es/usecase/nombres-para-roblox/index.html
+++ b/es/usecase/nombres-para-roblox/index.html
@@ -16,9 +16,10 @@
   <title>Nombres para Roblox aesthetic con letras y símbolos — generador de nicks</title>
   <meta name="description" content="Nombres para Roblox con letras bonitas y símbolos: escribe tu nombre, elige el estilo, copia y pégalo en tu nombre para mostrar de Roblox. Ideas de nombres aesthetic, de chico, de chica y cómo funciona el filtro de Roblox — gratis.">
   <link rel="canonical" href="https://ultratextgen.com/es/usecase/nombres-para-roblox/">
-  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/usecase/nickname-generator/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/roblox/name-generator/">
   <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/usecase/nombres-para-roblox/">
-  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/usecase/nickname-generator/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/usecase/nomes-para-roblox/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/roblox/name-generator/">
 
   <meta property="og:image" content="https://ultratextgen.com/assets/og/usecase-nickname-generator.png">
   <meta property="og:image:width" content="1200">

--- a/id/usecase/nama-guild-ff-keren/index.html
+++ b/id/usecase/nama-guild-ff-keren/index.html
@@ -18,6 +18,7 @@
   <link rel="canonical" href="https://ultratextgen.com/id/usecase/nama-guild-ff-keren/">
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/usecase/free-fire-guild-name-generator/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/usecase/nama-guild-ff-keren/">
+  <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/usecase/ten-quan-doan-ff/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/usecase/free-fire-guild-name-generator/">
 
   <meta property="og:image" content="https://ultratextgen.com/assets/og/id-usecase-nama-guild-ff-keren.png">

--- a/id/usecase/nama-pubg-keren/index.html
+++ b/id/usecase/nama-pubg-keren/index.html
@@ -16,6 +16,11 @@
   <title>Nama PUBG Keren: Simbol Jepang 亗 メ &amp; Generator Nickname PUBG</title>
   <meta name="description" content="Bikin nama PUBG keren pakai simbol jepang 亗 メ 彡, payung ꧁꧂, dan font Unicode. Ketik nickname kamu, salin, tempel ke PUBG Mobile. Ada kumpulan nama sangar, katakana, cewek, dan clan tag — gratis, tanpa aplikasi.">
   <link rel="canonical" href="https://ultratextgen.com/id/usecase/nama-pubg-keren/">
+  <link rel="alternate" hreflang="ar" href="https://ultratextgen.com/ar/usecase/asmaa-pubg/">
+  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/usecase/nama-pubg-keren/">
+  <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/usecase/pubg-nick/">
+  <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/usecase/ten-pubg-dep/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/usecase/nickname-generator/">
 
   <meta property="og:image" content="https://ultratextgen.com/assets/og/usecase-clan-tag-generator.png">
   <meta property="og:image:width" content="1200">

--- a/pt/usecase/nomes-para-roblox/index.html
+++ b/pt/usecase/nomes-para-roblox/index.html
@@ -17,9 +17,10 @@
   <meta name="description" content="Gerador de nomes para Roblox grátis: nome estilizado com símbolos ꧁༒꧂, coroa ♛ e letras diferentes. Digite, copie e cole no seu nome de exibição — sem app, sem cadastro.">
   <link rel="canonical" href="https://ultratextgen.com/pt/usecase/nomes-para-roblox/">
 
-  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/usecase/nickname-generator/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/roblox/name-generator/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/usecase/nombres-para-roblox/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/usecase/nomes-para-roblox/">
-  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/usecase/nickname-generator/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/roblox/name-generator/">
 
   <meta property="og:image" content="https://ultratextgen.com/assets/og/fancy-text-generator-preview.png">
   <meta property="og:image:width" content="1200">

--- a/roblox/name-generator/index.html
+++ b/roblox/name-generator/index.html
@@ -15,6 +15,10 @@
   <title>Roblox Username Generator — Available Name Ideas (Not-Taken Check) | UltraTextGen</title>
   <meta name="description" content="Generate Roblox username ideas by vibe or length, then check instantly if they're available — cute, funny, cool, aesthetic, OG short names, and more.">
   <link rel="canonical" href="https://ultratextgen.com/roblox/name-generator/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/roblox/name-generator/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/usecase/nombres-para-roblox/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/usecase/nomes-para-roblox/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/roblox/name-generator/">
   <meta property="og:title" content="Roblox Username Generator — Available Name Ideas (Not-Taken Check)">
   <meta property="og:description" content="Generate Roblox username ideas by vibe or length and see which ones are actually available.">
   <meta property="og:url" content="https://ultratextgen.com/roblox/name-generator/">

--- a/tr/usecase/pubg-nick/index.html
+++ b/tr/usecase/pubg-nick/index.html
@@ -16,6 +16,11 @@
   <title>PUBG Şekilli Nick ꧁꧂ — PUBG Mobile İsimleri ve Sembolleri</title>
   <meta name="description" content="PUBG şekilli nick oluşturucu: adını yaz, ꧁༒꧂ çerçeveli ve şekilli PUBG Mobile isimleri anında hazır. Nick sembolleri, boşluklu nick hilesi ve isim değiştirme adımları — ücretsiz.">
   <link rel="canonical" href="https://ultratextgen.com/tr/usecase/pubg-nick/">
+  <link rel="alternate" hreflang="ar" href="https://ultratextgen.com/ar/usecase/asmaa-pubg/">
+  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/usecase/nama-pubg-keren/">
+  <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/usecase/pubg-nick/">
+  <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/usecase/ten-pubg-dep/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/usecase/nickname-generator/">
 
   <meta property="og:image" content="https://ultratextgen.com/assets/og/tr-usecase-pubg-nick.png">
   <meta property="og:image:width" content="1200">

--- a/usecase/free-fire-guild-name-generator/index.html
+++ b/usecase/free-fire-guild-name-generator/index.html
@@ -18,6 +18,7 @@
   <link rel="canonical" href="https://ultratextgen.com/usecase/free-fire-guild-name-generator/">
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/usecase/free-fire-guild-name-generator/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/usecase/nama-guild-ff-keren/">
+  <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/usecase/ten-quan-doan-ff/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/usecase/free-fire-guild-name-generator/">
 
   <meta property="og:image" content="https://ultratextgen.com/assets/og/fancy-text-generator-preview.png">

--- a/vi/usecase/ten-pubg-dep/index.html
+++ b/vi/usecase/ten-pubg-dep/index.html
@@ -16,6 +16,11 @@
   <title>Tên PUBG Đẹp ꧁꧂ — Kí Tự Đặc Biệt PUBG, Tên Ngầu | UltraTextGen</title>
   <meta name="description" content="Tạo tên PUBG đẹp với kí tự đặc biệt PUBG 亗, khung ꧁꧂, katakana メ彡 và font ngầu. Gõ tên, copy, dán vào PUBG Mobile. Kèm kho nickname ngầu, hài — miễn phí.">
   <link rel="canonical" href="https://ultratextgen.com/vi/usecase/ten-pubg-dep/">
+  <link rel="alternate" hreflang="ar" href="https://ultratextgen.com/ar/usecase/asmaa-pubg/">
+  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/usecase/nama-pubg-keren/">
+  <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/usecase/pubg-nick/">
+  <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/usecase/ten-pubg-dep/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/usecase/nickname-generator/">
 
   <meta name="robots" content="index, follow">
   <meta property="og:image" content="https://ultratextgen.com/assets/og/library-nickname-symbols.png">

--- a/vi/usecase/ten-quan-doan-ff/index.html
+++ b/vi/usecase/ten-quan-doan-ff/index.html
@@ -16,6 +16,10 @@
   <title>Tên Quân Đoàn FF ꧁꧂ — Tên Guild Free Fire Đẹp | UltraTextGen</title>
   <meta name="description" content="Kho tên quân đoàn FF đẹp: ngầu ꧁༒꧂, tryhard esports, cute, tên guild ff kí tự đặc biệt và tag team. Bấm để copy, dán vào mục quân đoàn Free Fire — miễn phí.">
   <link rel="canonical" href="https://ultratextgen.com/vi/usecase/ten-quan-doan-ff/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/usecase/free-fire-guild-name-generator/">
+  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/usecase/nama-guild-ff-keren/">
+  <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/usecase/ten-quan-doan-ff/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/usecase/free-fire-guild-name-generator/">
 
   <meta name="robots" content="index, follow">
   <meta property="og:image" content="https://ultratextgen.com/assets/og/library-free-fire-name-symbols.png">
@@ -308,7 +312,7 @@
 
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="Language switcher">
-      <a class="lang-option" href="/usecase/clan-tag-generator/" hreflang="en">EN</a>
+      <a class="lang-option" href="/usecase/free-fire-guild-name-generator/" hreflang="en">EN</a>
       <a class="lang-option active" href="/vi/usecase/ten-quan-doan-ff/" hreflang="vi">VI</a>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- PUBG (ar/id/tr/vi): add missing `<head>` hreflang, cross-linking all 4 live language pages; fix the `ar` page's `x-default` from a mismatched generic page (`stylish-name`) to the site's standard EN fallback (`nickname-generator`).
- Roblox (en/es/pt): point the ES/PT pages' EN alternate at the real dedicated `/roblox/name-generator/` page instead of the generic nickname-generator page; add the missing hreflang block to the EN page.
- Free Fire guild (en/id/vi): add `vi` to the existing en/id hreflang set, add a full head hreflang block to the `vi` page (it had none), and fix its visible language switcher, which linked to the wrong game (`clan-tag-generator` / Call of Duty) instead of the correct `free-fire-guild-name-generator` EN page.

These were found while auditing the site's per-game nickname-generator page cluster for a games/languages coverage review — the pages themselves were already live and indexed, this only repairs the cross-language linking between them.

## Test plan
- [ ] Spot-check each edited page's `<head>` renders valid `<link rel="alternate" hreflang="...">` tags with no duplicates
- [ ] Confirm the `vi/usecase/ten-quan-doan-ff` language switcher now links to `/usecase/free-fire-guild-name-generator/`
- [ ] Confirm `/roblox/name-generator/`, its ES and PT counterparts reciprocally reference each other

---
_Generated by [Claude Code](https://claude.ai/code/session_012tyvSJ1Z9dW8tHxtS3djqX)_