### PR TITLE
Expand curved text to 15 shapes with multi-line support

### DIFF
--- a/curved-text/index.html
+++ b/curved-text/index.html
@@ -11,10 +11,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Curved & Arc Text Generator — Bend Text on a Circle | UltraTextGen</title>
-  <meta name="description" content="Free curved text generator. Bend text into an arch, valley, or full circle and download it as an SVG or PNG. Style it bold, script, or runic, then export for logos, stickers, and social posts.">
+  <meta name="description" content="Free curved text generator. Bend text into 15 shapes — arch, wave, spiral, heart, star, and more — across single or multiple lines, then download it as an SVG or PNG. Style it bold, script, or runic, then export for logos, stickers, and social posts.">
   <link rel="canonical" href="https://ultratextgen.com/curved-text/">
   <meta property="og:title" content="Curved & Arc Text Generator | UltraTextGen">
-  <meta property="og:description" content="Bend text into an arch, valley, or circle and download it as SVG or PNG.">
+  <meta property="og:description" content="Bend text into 15 shapes, including arches, waves, spirals, and hearts, across single or multiple lines, then download as SVG or PNG.">
   <meta property="og:url" content="https://ultratextgen.com/curved-text/">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://ultratextgen.com/assets/og/category.png">
@@ -23,7 +23,7 @@
   <meta property="og:image:type" content="image/png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Curved & Arc Text Generator | UltraTextGen">
-  <meta name="twitter:description" content="Bend text into an arch, valley, or circle. Download as SVG or PNG.">
+  <meta name="twitter:description" content="Bend text into 15 shapes across single or multiple lines. Download as SVG or PNG.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
@@ -38,7 +38,7 @@
   "url": "https://ultratextgen.com/curved-text/",
   "applicationCategory": "DesignApplication",
   "operatingSystem": "Any",
-  "description": "Bend text into an arch, valley, or full circle and export it as SVG or PNG.",
+  "description": "Bend text into 15 shapes across circular, flow, geometric, and novelty families, with multi-line support, and export it as SVG or PNG.",
   "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
 }
 </script>
@@ -48,7 +48,7 @@
   "@context": "https://schema.org",
   "@type": "FAQPage",
   "mainEntity": [
-    {"@type":"Question","name":"How does the curved text generator work?","acceptedAnswer":{"@type":"Answer","text":"It lays your text along an SVG arc. Choose an arch, valley, or full circle, set the curve amount and size, then copy or download the result as an SVG or PNG image."}},
+    {"@type":"Question","name":"How does the curved text generator work?","acceptedAnswer":{"@type":"Answer","text":"It lays your text along an SVG path. Pick a shape from the picker — circular (arch, valley, circle, oval), flow (wave, ripple, zigzag, spiral), geometric (heart, star, diamond, bulge), or novelty (fan, twist) — set the curve amount and size, then copy or download the result as an SVG or PNG image. On shapes that support it, press Enter in the text box to add another curved line."}},
     {"@type":"Question","name":"Can I copy curved text as plain characters?","acceptedAnswer":{"@type":"Answer","text":"No. A curve is a visual layout, not a Unicode property, so curved text is an image (SVG or PNG). For copy-paste plain text, use one of the Unicode font styles on the homepage instead."}},
     {"@type":"Question","name":"Can I make the curved text bold or script?","acceptedAnswer":{"@type":"Answer","text":"Yes. Pick a Unicode style such as Bold, Script, or Runic before curving, and combine it with the SVG bold and font options for extra weight."}},
     {"@type":"Question","name":"Is the curved text generator free?","acceptedAnswer":{"@type":"Answer","text":"Yes. You can create and download curved, arced, and circular text as SVG or PNG with no signup."}}
@@ -83,7 +83,7 @@
 
 <section class="hero"><div class="hero-inner"><div class="hero-card">
   <h1 class="hero-headline">Curved &amp; Arc Text Generator</h1>
-  <p class="hero-sub">Bend text into an arch, valley, or full circle, style it, and download it as an SVG or PNG.</p>
+  <p class="hero-sub">Bend text into 15 shapes — arch, wave, spiral, heart, star, and more — across single or multiple lines, then download it as an SVG or PNG.</p>
 </div></div></section>
 
 <main class="container">
@@ -91,16 +91,13 @@
     <div class="curved-controls">
       <div class="curved-field">
         <label for="curvedInput">Your text</label>
-        <textarea id="curvedInput" maxlength="120" placeholder="Type your text…">UltraTextGen</textarea>
+        <textarea id="curvedInput" maxlength="220" placeholder="Type your text… (press Enter for another line)">UltraTextGen</textarea>
+        <span class="curved-hint" id="curvedLinesHint" aria-live="polite"></span>
       </div>
       <div class="curved-row">
         <div class="curved-field">
           <label for="curvedDirection">Shape</label>
-          <select id="curvedDirection">
-            <option value="up" selected>Arch (∩)</option>
-            <option value="down">Valley (∪)</option>
-            <option value="circle">Circle (○)</option>
-          </select>
+          <select id="curvedDirection"></select>
         </div>
         <div class="curved-field">
           <label for="curvedStyle">Font style</label>
@@ -146,7 +143,7 @@
 
 <footer class="footer"><div class="footer-inner">
   <h2 class="faq-category">Curved Text Tips</h2>
-  <div class="faq-item"><button class="faq-question" type="button">How does the curved text generator work?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">It lays your text along an SVG arc. Choose an arch, valley, or full circle, set the curve amount and size, then copy or download the result as an SVG or PNG image.</div></div>
+  <div class="faq-item"><button class="faq-question" type="button">How does the curved text generator work?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">It lays your text along an SVG path. Pick a shape from the picker — circular (arch, valley, circle, oval), flow (wave, ripple, zigzag, spiral), geometric (heart, star, diamond, bulge), or novelty (fan, twist) — set the curve amount and size, then copy or download the result as an SVG or PNG image. On shapes that support it, press Enter in the text box to add another curved line.</div></div>
   <div class="faq-item"><button class="faq-question" type="button">Can I copy curved text as plain characters?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">No. A curve is a visual layout, not a Unicode property, so curved text is exported as an image. For copy-paste plain text, use one of the Unicode font styles on the homepage instead.</div></div>
   <div class="faq-item"><button class="faq-question" type="button">Can I make the curved text bold or script?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Yes. Pick a Unicode style such as Bold, Script, or Runic before curving, and combine it with the SVG bold and typeface options for extra weight.</div></div>
   <div class="faq-item"><button class="faq-question" type="button">Is the curved text generator free?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Yes. You can create and download curved, arced, and circular text as SVG or PNG with no signup.</div></div>

--- a/js/curved/curvedText.js
+++ b/js/curved/curvedText.js
@@ -1,105 +1,774 @@
 /* ==========================================================================
    UltraTextGen — curvedText.js
-   Pure SVG arc / curved text builder. No DOM dependencies beyond returning
+   Pure SVG shape-registry text builder. No DOM dependencies beyond returning
    markup, so it can be unit-tested in isolation and reused anywhere.
 
    Pairs with the vertical-text module: same "one feature, one self-contained
    module" pattern. Output is an <svg> string (not copy-paste plain text),
-   because curved layout can only be expressed visually.
+   because curved/shaped layout can only be expressed visually.
+
+   Architecture: every named shape is a `layout(params)` function registered
+   in SHAPES. Most shapes are `mode: "path"` — they hand back one SVG <path>
+   "d" string per input line (the caller drives a <textPath> along each), and
+   support multiple lines via a family-appropriate stacking rule (concentric
+   rings for the circular family, parallel offset for the flow family).
+   `mode: "glyph"` shapes (fan, twist) can't be expressed as text-on-one-path,
+   so they hand back one {x,y,rotation} per grapheme instead, rendered as
+   individually positioned/rotated <text> elements.
 
    Exposes: window.UltraCurvedText.build(options) -> { svg, width, height }
+            window.UltraCurvedText.SHAPES  (for populating a shape picker UI)
+            window.UltraCurvedText.FAMILY_LABELS
    ========================================================================== */
 
 (function () {
   "use strict";
 
-  var XML_ESCAPE = { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&apos;" };
+  let XML_ESCAPE = { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&apos;" };
   function esc(s) {
     return String(s).replace(/[&<>"']/g, function (c) { return XML_ESCAPE[c]; });
   }
 
   // Deterministic id so re-renders with the same inputs are stable and two
   // SVGs on one page never collide. (No Math.random — keeps output pure.)
-  var idSeq = 0;
+  let idSeq = 0;
   function nextId() { idSeq += 1; return "utg-arc-" + idSeq; }
 
   function num(v, fallback) {
-    var n = parseFloat(v);
+    let n = parseFloat(v);
     return isFinite(n) ? n : fallback;
+  }
+
+  // Grapheme-safe splitting for glyph-mode shapes (emoji/combining marks stay
+  // intact as one "character"), matching the Intl.Segmenter convention the
+  // flair engine already uses elsewhere in this codebase.
+  let segmenter = (typeof Intl !== "undefined" && typeof Intl.Segmenter === "function")
+    ? new Intl.Segmenter(undefined, { granularity: "grapheme" })
+    : null;
+  function toGraphemes(str) {
+    if (!str) return [];
+    if (segmenter) {
+      let out = [];
+      let iter = segmenter.segment(str)[Symbol.iterator]();
+      let next = iter.next();
+      while (!next.done) {
+        out.push(next.value.segment);
+        next = iter.next();
+      }
+      return out;
+    }
+    return str.split("");
+  }
+
+  /* ------------------------------------------------------------------------
+     Path-mode shapes.
+     Each layout(params) receives:
+       { lines: string[], fontSize: number, letterSpacing: number,
+         intensity: number (0..1, 1 = most pronounced), lineGap: number }
+     and returns:
+       { paths: [ { d, startOffset, textAnchor } ... ] (one per line),
+         width: number, height: number }
+     ------------------------------------------------------------------------ */
+
+  // Circular family — concentric stacking (same center, shrinking radius).
+  // baseRadius formula preserves the original single-shape 40 (tight) .. 420
+  // (flat) range so `intensity` is exactly the old 0-100 curve-amount slider
+  // fraction, unchanged.
+
+  function layout_arch(params) {
+    let fontSize = params.fontSize;
+    let intensity = params.intensity;
+    let lineGap = params.lineGap;
+    let lines = params.lines;
+    let baseRadius = 40 + (1 - intensity) * 380;
+    let pad = fontSize;
+    let cx = pad + baseRadius;
+    let cy = pad + fontSize + baseRadius;
+    let width = 2 * (pad + baseRadius);
+    let height = pad + fontSize + baseRadius + pad;
+    let paths = lines.map(function (line, i) {
+      let r = Math.max(20, baseRadius - i * lineGap);
+      let d = "M " + (cx - r) + " " + cy + " A " + r + " " + r + " 0 0 1 " + (cx + r) + " " + cy;
+      return { d: d, startOffset: "50%", textAnchor: "middle" };
+    });
+    return { paths: paths, width: width, height: height };
+  }
+
+  function layout_valley(params) {
+    let fontSize = params.fontSize;
+    let intensity = params.intensity;
+    let lineGap = params.lineGap;
+    let lines = params.lines;
+    let baseRadius = 40 + (1 - intensity) * 380;
+    let pad = fontSize;
+    let cx = pad + baseRadius;
+    let cy = pad;
+    let width = 2 * (pad + baseRadius);
+    let height = pad + baseRadius + fontSize + pad;
+    let paths = lines.map(function (line, i) {
+      let r = Math.max(20, baseRadius - i * lineGap);
+      let d = "M " + (cx - r) + " " + cy + " A " + r + " " + r + " 0 0 0 " + (cx + r) + " " + cy;
+      return { d: d, startOffset: "50%", textAnchor: "middle" };
+    });
+    return { paths: paths, width: width, height: height };
+  }
+
+  function layout_circle(params) {
+    let fontSize = params.fontSize;
+    let intensity = params.intensity;
+    let lineGap = params.lineGap;
+    let lines = params.lines;
+    let baseRadius = 40 + (1 - intensity) * 380;
+    let pad = fontSize;
+    let cx = pad + fontSize + baseRadius;
+    let cy = pad + fontSize + baseRadius;
+    let width = 2 * (pad + fontSize + baseRadius);
+    let height = width;
+    let paths = lines.map(function (line, i) {
+      let r = Math.max(20, baseRadius - i * lineGap);
+      let d =
+        "M " + cx + " " + (cy + r) +
+        " A " + r + " " + r + " 0 1 1 " + cx + " " + (cy - r) +
+        " A " + r + " " + r + " 0 1 1 " + cx + " " + (cy + r) + " Z";
+      return { d: d, startOffset: "50%", textAnchor: "middle" };
+    });
+    return { paths: paths, width: width, height: height };
+  }
+
+  // circle-in / oval contributed against the same "circular / concentric"
+  // contract as arch/valley/circle above (circle-in's radius range aligned to
+  // the same 40..420 span for a consistent feel across the family).
+  function layout_circleIn(params) {
+    let lines = params.lines;
+    let fontSize = params.fontSize;
+    let intensity = params.intensity;
+    let lineGap = params.lineGap;
+
+    let baseRadius = 40 + (1 - intensity) * 380;
+
+    let pad = fontSize;
+    let cx = pad + fontSize + baseRadius;
+    let cy = pad + fontSize + baseRadius;
+    let width = 2 * (pad + fontSize + baseRadius);
+    let height = width;
+
+    let paths = lines.map(function (line, i) {
+      let r = Math.max(20, baseRadius - i * lineGap);
+      // Same full-circle path as the outward "circle" shape but with both
+      // sweep flags flipped (1 -> 0), which reverses the path's direction of
+      // travel and moves the rendered text to the inner side of the ring,
+      // upright, with baselines curving toward the center.
+      let d =
+        "M " + cx + " " + (cy + r) +
+        " A " + r + " " + r + " 0 1 0 " + cx + " " + (cy - r) +
+        " A " + r + " " + r + " 0 1 0 " + cx + " " + (cy + r) + " Z";
+      return { d: d, startOffset: "50%", textAnchor: "middle" };
+    });
+
+    return { paths: paths, width: width, height: height };
+  }
+
+  function layout_oval(params) {
+    let lines = params.lines;
+    let fontSize = params.fontSize;
+    let letterSpacing = params.letterSpacing;
+    let intensity = params.intensity;
+    let lineGap = params.lineGap;
+
+    let estCharWidth = fontSize * 0.62 + letterSpacing;
+    let longestLineLen = Math.max(1, lines.reduce(function (max, line) {
+      return Math.max(max, line.length);
+    }, 1));
+    let estLineWidth0 = longestLineLen * estCharWidth;
+
+    // Outer horizontal radius: sized to comfortably fit the LONGEST line's estimated
+    // width (not just line 0) so a longer second/third line never overflows its ring.
+    let rx0 = Math.max(80, estLineWidth0 * 0.55);
+    // Outer vertical radius: intensity 0 -> near-circular arch (ry ~= rx), intensity 1 ->
+    // a wide, shallow oval (ry ~= 0.25 * rx).
+    let ry0 = Math.max(14, rx0 * (1 - intensity * 0.75));
+    let aspect = ry0 / rx0;
+
+    let pad = fontSize;
+    let cx = pad + fontSize + rx0;
+    let cy = pad + fontSize + ry0;
+    let width = 2 * (pad + fontSize + rx0);
+    let height = cy + fontSize + pad;
+
+    let paths = lines.map(function (line, i) {
+      // Concentric shrink: each subsequent line uses a smaller oval, same aspect ratio,
+      // sharing the same center point as line 0.
+      let rx = Math.max(20, rx0 - i * lineGap);
+      let ry = Math.max(10, rx * aspect);
+      let d =
+        "M " + (cx - rx) + " " + cy +
+        " A " + rx + " " + ry + " 0 0 1 " + (cx + rx) + " " + cy;
+      return { d: d, startOffset: "50%", textAnchor: "middle" };
+    });
+
+    return { paths: paths, width: width, height: height };
+  }
+
+  // Flow family — parallel stacking (each line is the same curve translated
+  // straight down by lineGap). Contributed as-is against the shared contract.
+
+  function layout_wave(params) {
+    let lines = params.lines;
+    let fontSize = params.fontSize;
+    let letterSpacing = params.letterSpacing;
+    let intensity = params.intensity;
+    let lineGap = params.lineGap;
+
+    function r2(n) { return Math.round(n * 100) / 100; }
+
+    let estCharWidth = fontSize * 0.62 + letterSpacing;
+    let longest = 0;
+    for (let i = 0; i < lines.length; i++) {
+      let w = Math.max(1, lines[i].length) * estCharWidth;
+      if (w > longest) longest = w;
+    }
+
+    let amplitude = 6 + intensity * 34; // single hump-then-dip swing
+    let pad = fontSize;
+    let ampRoom = amplitude + fontSize; // amplitude swing + glyph ascender/descender room
+    let spanWidth = longest;
+    let width = pad * 2 + spanWidth;
+    let height = pad * 2 + ampRoom * 2 + (lines.length - 1) * lineGap;
+
+    let x0 = pad;
+    let x1 = pad + spanWidth;
+    let xMid = pad + spanWidth / 2;
+    let span1 = spanWidth / 2;
+    let span2 = spanWidth / 2;
+    let ybBase = pad + ampRoom; // baseline y for line 0
+
+    let paths = [];
+    for (let li = 0; li < lines.length; li++) {
+      let yb = ybBase + li * lineGap; // parallel translation for stacked lines
+      let d = "M " + r2(x0) + " " + r2(yb) +
+        " C " + r2(x0 + span1 / 3) + " " + r2(yb - amplitude) + " " + r2(x0 + 2 * span1 / 3) + " " + r2(yb - amplitude) + " " + r2(xMid) + " " + r2(yb) +
+        " C " + r2(xMid + span2 / 3) + " " + r2(yb + amplitude) + " " + r2(xMid + 2 * span2 / 3) + " " + r2(yb + amplitude) + " " + r2(x1) + " " + r2(yb);
+      paths.push({ d: d, startOffset: "50%", textAnchor: "middle" });
+    }
+
+    return { paths: paths, width: width, height: height };
+  }
+
+  function layout_ripple(params) {
+    let lines = params.lines;
+    let fontSize = params.fontSize;
+    let letterSpacing = params.letterSpacing;
+    let intensity = params.intensity;
+    let lineGap = params.lineGap;
+
+    function r2(n) { return Math.round(n * 100) / 100; }
+
+    let estCharWidth = fontSize * 0.62 + letterSpacing;
+    let longest = 0;
+    for (let i = 0; i < lines.length; i++) {
+      let w = Math.max(1, lines[i].length) * estCharWidth;
+      if (w > longest) longest = w;
+    }
+
+    let periods = 2 + Math.round(intensity * 2); // 2..4 repeated sine periods, more intensity = more/tighter ripples
+    let amplitude = 4 + intensity * 22; // shallower swing than "wave"
+    let pad = fontSize;
+    let ampRoom = amplitude + fontSize;
+    let spanWidth = longest;
+    let width = pad * 2 + spanWidth;
+    let height = pad * 2 + ampRoom * 2 + (lines.length - 1) * lineGap;
+
+    let x0 = pad;
+    let ybBase = pad + ampRoom;
+    let periodWidth = spanWidth / periods;
+    let half = periodWidth / 2;
+
+    let paths = [];
+    for (let li = 0; li < lines.length; li++) {
+      let yb = ybBase + li * lineGap; // parallel translation for stacked lines
+      let d = "M " + r2(x0) + " " + r2(yb);
+      let cx = x0;
+      for (let p = 0; p < periods; p++) {
+        let xMid = cx + half;
+        let xEnd = cx + periodWidth;
+        d += " C " + r2(cx + half / 3) + " " + r2(yb - amplitude) + " " + r2(cx + 2 * half / 3) + " " + r2(yb - amplitude) + " " + r2(xMid) + " " + r2(yb);
+        d += " C " + r2(xMid + half / 3) + " " + r2(yb + amplitude) + " " + r2(xMid + 2 * half / 3) + " " + r2(yb + amplitude) + " " + r2(xEnd) + " " + r2(yb);
+        cx = xEnd;
+      }
+      paths.push({ d: d, startOffset: "50%", textAnchor: "middle" });
+    }
+
+    return { paths: paths, width: width, height: height };
+  }
+
+  function layout_zigzag(params) {
+    let lines = params.lines;
+    let fontSize = params.fontSize;
+    let letterSpacing = params.letterSpacing;
+    let intensity = params.intensity;
+    let lineGap = params.lineGap;
+
+    function r2(n) { return Math.round(n * 100) / 100; }
+
+    let estCharWidth = fontSize * 0.62 + letterSpacing;
+    let longest = 0;
+    for (let i = 0; i < lines.length; i++) {
+      let w = Math.max(1, lines[i].length) * estCharWidth;
+      if (w > longest) longest = w;
+    }
+
+    let peaks = 3 + Math.round(intensity * 5); // 3..8 sharp up/down repeats
+    let amplitude = 8 + intensity * 28;
+    let pad = fontSize;
+    let ampRoom = amplitude + fontSize;
+    let spanWidth = longest;
+    let width = pad * 2 + spanWidth;
+    let height = pad * 2 + ampRoom * 2 + (lines.length - 1) * lineGap;
+
+    let x0 = pad;
+    let ybBase = pad + ampRoom;
+    let segments = peaks * 2;
+    let segWidth = spanWidth / segments;
+
+    let paths = [];
+    for (let li = 0; li < lines.length; li++) {
+      let yb = ybBase + li * lineGap; // parallel translation for stacked lines
+      let d = "M " + r2(x0) + " " + r2(yb);
+      for (let s = 1; s <= segments; s++) {
+        let x = x0 + s * segWidth;
+        let y = (s % 2 === 1) ? (yb - amplitude) : (yb + amplitude);
+        d += " L " + r2(x) + " " + r2(y);
+      }
+      paths.push({ d: d, startOffset: "50%", textAnchor: "middle" });
+    }
+
+    return { paths: paths, width: width, height: height };
+  }
+
+  function layout_spiral(params) {
+    let lines = params.lines;
+    let fontSize = params.fontSize;
+    let letterSpacing = params.letterSpacing;
+    let intensity = params.intensity;
+
+    function r2(n) { return Math.round(n * 100) / 100; }
+
+    let estCharWidth = fontSize * 0.62 + letterSpacing;
+
+    let turns = 1.5 + intensity * 2.5; // more intensity = more turns = visually tighter coil
+    let thetaMax = turns * 2 * Math.PI;
+    let pitch = fontSize * 0.95; // radial growth per full turn, keeps successive rings from overlapping glyphs
+    let rMin = Math.max(fontSize * 1.3, estCharWidth * 0.5); // clamp so innermost text doesn't overlap itself
+    let rMax = rMin + pitch * turns;
+    let spiralSpan = rMax - rMin; // radial thickness of one full spiral track
+
+    let pad = fontSize;
+    // Multi-line choice: rather than nesting a second full spiral inside the first (visually messy) or
+    // rotating its start angle on the same track (can still cross), give each extra line its own spiral
+    // track offset radially just outside the previous one's outer edge, so tracks never overlap.
+    let lineOffset = spiralSpan + fontSize * 0.4;
+    let maxOuterRadius = rMax + (lines.length - 1) * lineOffset;
+    let size = (maxOuterRadius + pad) * 2;
+    let cx = maxOuterRadius + pad;
+    let cy = maxOuterRadius + pad;
+
+    let samples = 72;
+
+    let paths = [];
+    for (let li = 0; li < lines.length; li++) {
+      let rMinLine = rMin + li * lineOffset;
+      let rMaxLine = rMax + li * lineOffset;
+      let d = "";
+      for (let s = 0; s <= samples; s++) {
+        let theta = (s / samples) * thetaMax;
+        let rad = rMinLine + (rMaxLine - rMinLine) * (theta / thetaMax);
+        let x = cx + rad * Math.cos(theta);
+        let y = cy + rad * Math.sin(theta);
+        d += (s === 0 ? "M " : " L ") + r2(x) + " " + r2(y);
+      }
+      paths.push({ d: d, startOffset: "50%", textAnchor: "middle" });
+    }
+
+    return { paths: paths, width: size, height: size };
+  }
+
+  // Geometric family — single-outline decorative shapes, one line only
+  // (maxLines enforced by the SHAPES table / build() below).
+
+  function layout_heart(params) {
+    // Classic two-lobed heart curve: 4 cubic Beziers on a 100-unit template (top notch at (50,15),
+    // bottom point at (50,95)), scaled by k = s/50 where s = 24 + intensity*90. Path starts at the
+    // top-center notch, so startOffset "0%" begins the text right there.
+    let fontSize = params.fontSize;
+    let intensity = params.intensity;
+    let s = 24 + intensity * 90;
+    let k = s / 50;
+    let pad = fontSize;
+    function fx(tx) { return pad + tx * k; }
+    function fy(ty) { return pad + (ty + 5) * k; }
+    let pathD =
+      "M " + fx(50) + " " + fy(15) +
+      " C " + fx(35) + " " + fy(-5) + ", " + fx(0) + " " + fy(10) + ", " + fx(0) + " " + fy(40) +
+      " C " + fx(0) + " " + fy(60) + ", " + fx(25) + " " + fy(80) + ", " + fx(50) + " " + fy(95) +
+      " C " + fx(75) + " " + fy(80) + ", " + fx(100) + " " + fy(60) + ", " + fx(100) + " " + fy(40) +
+      " C " + fx(100) + " " + fy(10) + ", " + fx(65) + " " + fy(-5) + ", " + fx(50) + " " + fy(15) +
+      " Z";
+    let width = pad * 2 + 100 * k;
+    let height = pad * 2 + 100 * k;
+    return {
+      paths: [{ d: pathD, startOffset: "0%", textAnchor: "start" }],
+      width: width,
+      height: height
+    };
+  }
+
+  function layout_star(params) {
+    // 5-point star: 10 vertices alternating outer/inner radius, 36 degrees apart, starting at the
+    // top outer point (angle -90deg) so startOffset "0%" begins the text there.
+    // outerR = 24 + intensity*90; innerR = outerR*0.45 (classic 5-point star proportion).
+    let fontSize = params.fontSize;
+    let intensity = params.intensity;
+    let outerR = 24 + intensity * 90;
+    let innerR = outerR * 0.45;
+    let pad = fontSize;
+    let cx = pad + outerR;
+    let cy = pad + outerR;
+    let points = [];
+    for (let i = 0; i < 10; i++) {
+      let r = i % 2 === 0 ? outerR : innerR;
+      let angle = (-90 + i * 36) * (Math.PI / 180);
+      let x = cx + r * Math.cos(angle);
+      let y = cy + r * Math.sin(angle);
+      points.push(x + " " + y);
+    }
+    let pathD = "M " + points[0] + " L " + points.slice(1).join(" L ") + " Z";
+    let width = 2 * (pad + outerR);
+    let height = width;
+    return {
+      paths: [{ d: pathD, startOffset: "0%", textAnchor: "start" }],
+      width: width,
+      height: height
+    };
+  }
+
+  function layout_diamond(params) {
+    // Simple rhombus: top/right/bottom/left vertices, starting at the top vertex.
+    // halfW = 24 + intensity*90; halfH = halfW*1.3 for classic taller-than-wide diamond proportions.
+    let fontSize = params.fontSize;
+    let intensity = params.intensity;
+    let halfW = 24 + intensity * 90;
+    let halfH = halfW * 1.3;
+    let pad = fontSize;
+    let cx = pad + halfW;
+    let cy = pad + halfH;
+    let top = cx + " " + (cy - halfH);
+    let right = (cx + halfW) + " " + cy;
+    let bottom = cx + " " + (cy + halfH);
+    let left = (cx - halfW) + " " + cy;
+    let pathD = "M " + top + " L " + right + " L " + bottom + " L " + left + " Z";
+    let width = 2 * (pad + halfW);
+    let height = 2 * (pad + halfH);
+    return {
+      paths: [{ d: pathD, startOffset: "0%", textAnchor: "start" }],
+      width: width,
+      height: height
+    };
+  }
+
+  function layout_bulge(params) {
+    // Open lens/eye "bulge": a single cubic Bezier hump from a left baseline point to a right
+    // baseline point. base = 24 + intensity*90; totalWidth = base*2.4 (wide); amp = base*0.75 is the
+    // peak height above baseline. Control points are offset by h = amp*4/3 so the Bezier's t=0.5
+    // point (peak) lands exactly `amp` above the baseline. startOffset "50%" centers text on the peak.
+    let fontSize = params.fontSize;
+    let intensity = params.intensity;
+    let base = 24 + intensity * 90;
+    let totalWidth = base * 2.4;
+    let amp = base * 0.75;
+    let h = amp * (4 / 3);
+    let pad = fontSize;
+    let x0 = pad;
+    let x1 = pad + totalWidth;
+    let y0 = pad + amp;
+    let cp1x = x0 + totalWidth * 0.15;
+    let cp2x = x1 - totalWidth * 0.15;
+    let cpy = y0 - h;
+    let pathD =
+      "M " + x0 + " " + y0 +
+      " C " + cp1x + " " + cpy + ", " + cp2x + " " + cpy + ", " + x1 + " " + y0;
+    let width = totalWidth + 2 * pad;
+    let height = amp + 2 * pad;
+    return {
+      paths: [{ d: pathD, startOffset: "50%", textAnchor: "middle" }],
+      width: width,
+      height: height
+    };
+  }
+
+  /* ------------------------------------------------------------------------
+     Glyph-mode shapes.
+     Each layout(params) receives:
+       { graphemesPerLine: string[][], fontSize: number, letterSpacing: number,
+         intensity: number (0..1), lineGap: number }
+     and returns:
+       { lines: [ { glyphs: [ {ch, x, y, rotation} ... ] } ... ],
+         width: number, height: number }
+     ------------------------------------------------------------------------ */
+
+  function layout_fan(params) {
+    let graphemesPerLine = params.graphemesPerLine;
+    let fontSize = params.fontSize;
+    let letterSpacing = params.letterSpacing;
+    let intensity = params.intensity;
+    let lineGap = params.lineGap;
+
+    let advance = fontSize * 0.62 + letterSpacing;
+    let radius = 260 - intensity * 160 + letterSpacing * 2;
+
+    let rawLines = [];
+    let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+
+    for (let li = 0; li < graphemesPerLine.length; li++) {
+      let glyphsSrc = graphemesPerLine[li];
+      let n = glyphsSrc.length;
+      let rawGlyphs = [];
+      let lineOffsetY = li * lineGap;
+
+      if (n > 0) {
+        let sweepDeg = Math.min(140, n * (4 + intensity * 10) + letterSpacing * 0.5);
+        let angleStep = n > 1 ? sweepDeg / (n - 1) : 0;
+        let startAngle = -sweepDeg / 2;
+
+        for (let i = 0; i < n; i++) {
+          let thetaDeg = n > 1 ? startAngle + i * angleStep : 0;
+          let thetaRad = (thetaDeg * Math.PI) / 180;
+          let x = radius * Math.sin(thetaRad);
+          let y = -radius * Math.cos(thetaRad) + lineOffsetY;
+
+          rawGlyphs.push({ ch: glyphsSrc[i], x: x, y: y, rotation: thetaDeg });
+
+          if (x < minX) minX = x;
+          if (x > maxX) maxX = x;
+          if (y < minY) minY = y;
+          if (y > maxY) maxY = y;
+        }
+      }
+
+      rawLines.push(rawGlyphs);
+    }
+
+    if (minX === Infinity) { minX = 0; maxX = 0; minY = 0; maxY = 0; }
+
+    let margin = Math.max(fontSize * 1.5, advance);
+    let shiftX = margin - minX;
+    let shiftY = margin - minY;
+
+    let lines = rawLines.map(function (rawGlyphs) {
+      return {
+        glyphs: rawGlyphs.map(function (g) {
+          return { ch: g.ch, x: g.x + shiftX, y: g.y + shiftY, rotation: g.rotation };
+        })
+      };
+    });
+
+    let width = maxX - minX + margin * 2;
+    let height = maxY - minY + margin * 2;
+
+    return { lines: lines, width: width, height: height };
+  }
+
+  function layout_twist(params) {
+    let graphemesPerLine = params.graphemesPerLine;
+    let fontSize = params.fontSize;
+    let letterSpacing = params.letterSpacing;
+    let intensity = params.intensity;
+    let lineGap = params.lineGap;
+
+    let advance = fontSize * 0.62 + letterSpacing;
+    let angle = 6 + intensity * 24;
+
+    let rawLines = [];
+    let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+
+    for (let li = 0; li < graphemesPerLine.length; li++) {
+      let glyphsSrc = graphemesPerLine[li];
+      let n = glyphsSrc.length;
+      let rawGlyphs = [];
+      let lineOffsetY = li * lineGap;
+
+      if (n > 0) {
+        let totalWidth = (n - 1) * advance;
+        let startX = -totalWidth / 2;
+
+        for (let i = 0; i < n; i++) {
+          let x = startX + i * advance;
+          let wobble = Math.sin(i * 1.3) * (2 + intensity * 6);
+          let y = lineOffsetY + wobble;
+          let rotation = i % 2 === 0 ? angle : -angle;
+
+          rawGlyphs.push({ ch: glyphsSrc[i], x: x, y: y, rotation: rotation });
+
+          if (x < minX) minX = x;
+          if (x > maxX) maxX = x;
+          if (y < minY) minY = y;
+          if (y > maxY) maxY = y;
+        }
+      }
+
+      rawLines.push(rawGlyphs);
+    }
+
+    if (minX === Infinity) { minX = 0; maxX = 0; minY = 0; maxY = 0; }
+
+    let margin = Math.max(fontSize * 1.2, advance);
+    let shiftX = margin - minX;
+    let shiftY = margin - minY;
+
+    let lines = rawLines.map(function (rawGlyphs) {
+      return {
+        glyphs: rawGlyphs.map(function (g) {
+          return { ch: g.ch, x: g.x + shiftX, y: g.y + shiftY, rotation: g.rotation };
+        })
+      };
+    });
+
+    let width = maxX - minX + margin * 2;
+    let height = maxY - minY + margin * 2;
+
+    return { lines: lines, width: width, height: height };
+  }
+
+  /* ------------------------------------------------------------------------
+     Registry
+     ------------------------------------------------------------------------ */
+
+  let SHAPES = [
+    { key: "arch", label: "Arch (∩)", family: "circular", mode: "path", maxLines: 4, layout: layout_arch },
+    { key: "valley", label: "Valley (∪)", family: "circular", mode: "path", maxLines: 4, layout: layout_valley },
+    { key: "circle", label: "Circle – outside (○)", family: "circular", mode: "path", maxLines: 4, layout: layout_circle },
+    { key: "circle-in", label: "Circle – inside (◐)", family: "circular", mode: "path", maxLines: 4, layout: layout_circleIn },
+    { key: "oval", label: "Oval (⬭)", family: "circular", mode: "path", maxLines: 4, layout: layout_oval },
+    { key: "wave", label: "Wave (∿)", family: "flow", mode: "path", maxLines: 4, layout: layout_wave },
+    { key: "ripple", label: "Ripple (≈)", family: "flow", mode: "path", maxLines: 4, layout: layout_ripple },
+    { key: "zigzag", label: "Zigzag (⚡)", family: "flow", mode: "path", maxLines: 4, layout: layout_zigzag },
+    { key: "spiral", label: "Spiral (@)", family: "flow", mode: "path", maxLines: 2, layout: layout_spiral },
+    { key: "heart", label: "Heart (♡)", family: "geometric", mode: "path", maxLines: 1, layout: layout_heart },
+    { key: "star", label: "Star (★)", family: "geometric", mode: "path", maxLines: 1, layout: layout_star },
+    { key: "diamond", label: "Diamond (◆)", family: "geometric", mode: "path", maxLines: 1, layout: layout_diamond },
+    { key: "bulge", label: "Bulge", family: "geometric", mode: "path", maxLines: 1, layout: layout_bulge },
+    { key: "fan", label: "Fan", family: "novelty", mode: "glyph", maxLines: 3, layout: layout_fan },
+    { key: "twist", label: "Twist", family: "novelty", mode: "glyph", maxLines: 3, layout: layout_twist }
+  ];
+
+  let FAMILY_LABELS = { circular: "Circular", flow: "Flow", geometric: "Geometric", novelty: "Novelty" };
+
+  // Back-compat for the pre-existing "direction" option values.
+  let SHAPE_ALIASES = { up: "arch", down: "valley" };
+
+  function findShape(key) {
+    let k = SHAPE_ALIASES[key] || key || "arch";
+    for (let i = 0; i < SHAPES.length; i++) {
+      if (SHAPES[i].key === k) return SHAPES[i];
+    }
+    return SHAPES[0];
   }
 
   /* Build the curved-text SVG.
      options:
-       text        {string}  the (already Unicode-transformed) text
-       direction   {'up'|'down'|'circle'}  arch shape (default 'up')
-       radius      {number}  circle radius in px (default 120)
-       fontSize    {number}  px (default 32)
-       fontFamily  {string}  CSS font-family (default sans-serif)
-       fontWeight  {'normal'|'bold'} (default 'normal')
-       fill        {string}  text color (default '#111111')
-       letterSpacing {number} px (default 0)
+       text          {string}  the (already Unicode-transformed) text. "\n" splits into
+                                multiple curved/stacked lines, up to the shape's maxLines.
+       shape         {string}  a SHAPES[].key (default 'arch'). `direction` ('up'|'down'|'circle')
+                                is still accepted for back-compat.
+       intensity     {number}  0..1, how pronounced the shape is (default derived from `radius`)
+       radius        {number}  legacy px control (40..420); used only if `intensity` is absent
+       fontSize      {number}  px (default 32)
+       fontFamily    {string}  CSS font-family (default sans-serif)
+       fontWeight    {'normal'|'bold'} (default 'normal')
+       fill          {string}  text color (default '#111111')
+       letterSpacing {number}  px (default 0)
   */
   function build(options) {
-    var o = options || {};
-    var text = (o.text == null ? "" : String(o.text));
-    var dir = o.direction === "down" || o.direction === "circle" ? o.direction : "up";
-    var r = Math.max(20, num(o.radius, 120));
-    var fs = Math.max(8, num(o.fontSize, 32));
-    var family = o.fontFamily || "system-ui, sans-serif";
-    var weight = o.fontWeight === "bold" ? "bold" : "normal";
-    var fill = o.fill || "#111111";
-    var spacing = num(o.letterSpacing, 0);
+    let o = options || {};
+    let rawText = (o.text == null ? "" : String(o.text));
+    let shape = findShape(o.shape || o.direction);
+    let fs = Math.max(8, num(o.fontSize, 32));
+    let fontFamily = o.fontFamily || "system-ui, sans-serif";
+    let weight = o.fontWeight === "bold" ? "bold" : "normal";
+    let fill = o.fill || "#111111";
+    let spacing = num(o.letterSpacing, 0);
 
-    var pad = fs; // breathing room so glyphs never clip the viewBox
-    var id = nextId();
-    var pathD, width, height, startOffset, cx, cy;
-
-    if (dir === "circle") {
-      cx = pad + fs + r;
-      cy = pad + fs + r;
-      width = 2 * (pad + fs + r);
-      height = width;
-      // Start at the bottom, sweep clockwise; 50% along lands at the top so
-      // the text reads left-to-right across the top of the ring.
-      pathD =
-        "M " + cx + " " + (cy + r) +
-        " A " + r + " " + r + " 0 1 1 " + cx + " " + (cy - r) +
-        " A " + r + " " + r + " 0 1 1 " + cx + " " + (cy + r) + " Z";
-      startOffset = "50%";
-    } else if (dir === "down") {
-      // Valley (∪): text hangs along the lower half, room needed below.
-      cx = pad + r;
-      cy = pad;
-      width = 2 * r + 2 * pad;
-      height = r + fs + 2 * pad;
-      pathD = "M " + pad + " " + cy + " A " + r + " " + r + " 0 0 0 " + (pad + 2 * r) + " " + cy;
-      startOffset = "50%";
+    let intensity;
+    if (o.intensity != null) {
+      intensity = Math.max(0, Math.min(1, num(o.intensity, 0.55)));
     } else {
-      // Arch up (∩ / rainbow): text rides the upper half, room needed above.
-      cx = pad + r;
-      cy = pad + fs + r;
-      width = 2 * r + 2 * pad;
-      height = r + fs + 2 * pad;
-      pathD = "M " + pad + " " + cy + " A " + r + " " + r + " 0 0 1 " + (pad + 2 * r) + " " + cy;
-      startOffset = "50%";
+      let legacyRadius = Math.max(20, num(o.radius, 211));
+      intensity = Math.max(0, Math.min(1, (420 - legacyRadius) / 380));
     }
 
-    var spacingAttr = spacing ? ' letter-spacing="' + spacing + '"' : "";
+    let lines = rawText.split("\n");
+    if (lines.length > shape.maxLines) lines = lines.slice(0, shape.maxLines);
+    if (lines.length === 0) lines = [""];
 
-    var svg =
+    let lineGap = fs * 1.2;
+    let svgBody, width, height;
+
+    if (shape.mode === "glyph") {
+      let graphemesPerLine = lines.map(toGraphemes);
+      let glyphResult = shape.layout({
+        graphemesPerLine: graphemesPerLine,
+        fontSize: fs,
+        letterSpacing: spacing,
+        intensity: intensity,
+        lineGap: lineGap
+      });
+      width = glyphResult.width;
+      height = glyphResult.height;
+      let glyphMarkup = "";
+      glyphResult.lines.forEach(function (lineResult) {
+        lineResult.glyphs.forEach(function (g) {
+          let rot = g.rotation || 0;
+          let transformAttr = rot ? ' transform="rotate(' + rot + " " + g.x + " " + g.y + ')"' : "";
+          glyphMarkup +=
+            '<text x="' + g.x + '" y="' + g.y + '" text-anchor="middle" dominant-baseline="middle" ' +
+            'font-family="' + esc(fontFamily) + '" font-size="' + fs + '" font-weight="' + weight + '" ' +
+            'fill="' + esc(fill) + '"' + transformAttr + ">" + esc(g.ch) + "</text>";
+        });
+      });
+      svgBody = glyphMarkup;
+    } else {
+      let pathResult = shape.layout({
+        lines: lines,
+        fontSize: fs,
+        letterSpacing: spacing,
+        intensity: intensity,
+        lineGap: lineGap
+      });
+      width = pathResult.width;
+      height = pathResult.height;
+      let spacingAttr = spacing ? ' letter-spacing="' + spacing + '"' : "";
+      let defsMarkup = "";
+      let textMarkup = "";
+      pathResult.paths.forEach(function (p, i) {
+        let id = nextId();
+        defsMarkup += '<path id="' + id + '" d="' + p.d + '" fill="none"/>';
+        textMarkup +=
+          '<text font-family="' + esc(fontFamily) + '" font-size="' + fs + '" font-weight="' + weight + '" ' +
+          'fill="' + esc(fill) + '"' + spacingAttr + '>' +
+          '<textPath href="#' + id + '" xlink:href="#' + id + '" startOffset="' + p.startOffset + '" ' +
+          'text-anchor="' + p.textAnchor + '" dominant-baseline="middle">' + esc(lines[i] || "") + "</textPath></text>";
+      });
+      svgBody = "<defs>" + defsMarkup + "</defs>" + textMarkup;
+    }
+
+    let ariaLabel = esc(lines.join(" ").trim() || rawText);
+    let svg =
       '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" ' +
       'viewBox="0 0 ' + width + " " + height + '" ' +
       'width="' + width + '" height="' + height + '" class="utg-curved-svg" role="img" ' +
-      'aria-label="' + esc(text) + '">' +
-      '<defs><path id="' + id + '" d="' + pathD + '" fill="none"/></defs>' +
-      '<text font-family="' + esc(family) + '" font-size="' + fs + '" font-weight="' + weight + '" ' +
-      'fill="' + esc(fill) + '"' + spacingAttr + '>' +
-      '<textPath href="#' + id + '" xlink:href="#' + id + '" startOffset="' + startOffset + '" ' +
-      'text-anchor="middle" dominant-baseline="middle">' + esc(text) + "</textPath>" +
-      "</text></svg>";
+      'aria-label="' + ariaLabel + '">' + svgBody + "</svg>";
 
     return { svg: svg, width: width, height: height };
   }
 
-  window.UltraCurvedText = { build: build };
+  window.UltraCurvedText = { build: build, SHAPES: SHAPES, FAMILY_LABELS: FAMILY_LABELS };
 })();

--- a/js/curved/curvedText.js
+++ b/js/curved/curvedText.js
@@ -60,6 +60,21 @@
     return str.split("");
   }
 
+  // Shared text-width estimator for text-length-driven path shapes (wave,
+  // ripple, zigzag, oval). 0.62em/char covers typical proportional glyph
+  // advance; the 1.15x safety margin covers wider styles this page also
+  // offers (e.g. the "Fullwidth" Unicode option renders closer to 1em/char),
+  // so a line doesn't run past the end of its own path.
+  function estimateLongestLineSpan(lines, fontSize, letterSpacing) {
+    let estCharWidth = (fontSize * 0.62 + letterSpacing) * 1.15;
+    let longest = 1;
+    for (let i = 0; i < lines.length; i++) {
+      let w = Math.max(1, lines[i].length) * estCharWidth;
+      if (w > longest) longest = w;
+    }
+    return longest;
+  }
+
   /* ------------------------------------------------------------------------
      Path-mode shapes.
      Each layout(params) receives:
@@ -156,13 +171,17 @@
       let r = Math.max(20, baseRadius - i * lineGap);
       // Same full-circle path as the outward "circle" shape but with both
       // sweep flags flipped (1 -> 0), which reverses the path's direction of
-      // travel and moves the rendered text to the inner side of the ring,
-      // upright, with baselines curving toward the center.
+      // travel. That reversed direction only reads upright with ascenders
+      // toward the center at this path's OWN START point — the bottom of the
+      // ring — not at 50% (the top), where the same reversal instead renders
+      // upside-down and back-to-front. So this anchors text to start right at
+      // the bottom (startOffset "0%" + text-anchor "start", same pattern as
+      // the geometric family) rather than centering it at the top.
       let d =
         "M " + cx + " " + (cy + r) +
         " A " + r + " " + r + " 0 1 0 " + cx + " " + (cy - r) +
         " A " + r + " " + r + " 0 1 0 " + cx + " " + (cy + r) + " Z";
-      return { d: d, startOffset: "50%", textAnchor: "middle" };
+      return { d: d, startOffset: "0%", textAnchor: "start" };
     });
 
     return { paths: paths, width: width, height: height };
@@ -175,15 +194,9 @@
     let intensity = params.intensity;
     let lineGap = params.lineGap;
 
-    let estCharWidth = fontSize * 0.62 + letterSpacing;
-    let longestLineLen = Math.max(1, lines.reduce(function (max, line) {
-      return Math.max(max, line.length);
-    }, 1));
-    let estLineWidth0 = longestLineLen * estCharWidth;
-
     // Outer horizontal radius: sized to comfortably fit the LONGEST line's estimated
     // width (not just line 0) so a longer second/third line never overflows its ring.
-    let rx0 = Math.max(80, estLineWidth0 * 0.55);
+    let rx0 = Math.max(80, estimateLongestLineSpan(lines, fontSize, letterSpacing) * 0.55);
     // Outer vertical radius: intensity 0 -> near-circular arch (ry ~= rx), intensity 1 ->
     // a wide, shallow oval (ry ~= 0.25 * rx).
     let ry0 = Math.max(14, rx0 * (1 - intensity * 0.75));
@@ -221,12 +234,7 @@
 
     function r2(n) { return Math.round(n * 100) / 100; }
 
-    let estCharWidth = fontSize * 0.62 + letterSpacing;
-    let longest = 0;
-    for (let i = 0; i < lines.length; i++) {
-      let w = Math.max(1, lines[i].length) * estCharWidth;
-      if (w > longest) longest = w;
-    }
+    let longest = estimateLongestLineSpan(lines, fontSize, letterSpacing);
 
     let amplitude = 6 + intensity * 34; // single hump-then-dip swing
     let pad = fontSize;
@@ -263,12 +271,7 @@
 
     function r2(n) { return Math.round(n * 100) / 100; }
 
-    let estCharWidth = fontSize * 0.62 + letterSpacing;
-    let longest = 0;
-    for (let i = 0; i < lines.length; i++) {
-      let w = Math.max(1, lines[i].length) * estCharWidth;
-      if (w > longest) longest = w;
-    }
+    let longest = estimateLongestLineSpan(lines, fontSize, letterSpacing);
 
     let periods = 2 + Math.round(intensity * 2); // 2..4 repeated sine periods, more intensity = more/tighter ripples
     let amplitude = 4 + intensity * 22; // shallower swing than "wave"
@@ -310,12 +313,7 @@
 
     function r2(n) { return Math.round(n * 100) / 100; }
 
-    let estCharWidth = fontSize * 0.62 + letterSpacing;
-    let longest = 0;
-    for (let i = 0; i < lines.length; i++) {
-      let w = Math.max(1, lines[i].length) * estCharWidth;
-      if (w > longest) longest = w;
-    }
+    let longest = estimateLongestLineSpan(lines, fontSize, letterSpacing);
 
     let peaks = 3 + Math.round(intensity * 5); // 3..8 sharp up/down repeats
     let amplitude = 8 + intensity * 28;
@@ -403,7 +401,7 @@
     let intensity = params.intensity;
     let s = 24 + intensity * 90;
     let k = s / 50;
-    let pad = fontSize;
+    let pad = fontSize * 2; // extra cushion: these fixed-outline shapes previously matched other shapes' single-fontSize margin, half the safety headroom they need for tall glyphs/emoji/bold weight
     function fx(tx) { return pad + tx * k; }
     function fy(ty) { return pad + (ty + 5) * k; }
     let pathD =
@@ -430,7 +428,7 @@
     let intensity = params.intensity;
     let outerR = 24 + intensity * 90;
     let innerR = outerR * 0.45;
-    let pad = fontSize;
+    let pad = fontSize * 2;
     let cx = pad + outerR;
     let cy = pad + outerR;
     let points = [];
@@ -458,7 +456,7 @@
     let intensity = params.intensity;
     let halfW = 24 + intensity * 90;
     let halfH = halfW * 1.3;
-    let pad = fontSize;
+    let pad = fontSize * 2;
     let cx = pad + halfW;
     let cy = pad + halfH;
     let top = cx + " " + (cy - halfH);
@@ -483,10 +481,10 @@
     let fontSize = params.fontSize;
     let intensity = params.intensity;
     let base = 24 + intensity * 90;
-    let totalWidth = base * 2.4;
+    let totalWidth = base * 2.9; // wide enough that the page's own default text ("UltraTextGen") fits at default settings
     let amp = base * 0.75;
     let h = amp * (4 / 3);
-    let pad = fontSize;
+    let pad = fontSize * 2;
     let x0 = pad;
     let x1 = pad + totalWidth;
     let y0 = pad + amp;

--- a/js/curved/curvedTextController.js
+++ b/js/curved/curvedTextController.js
@@ -62,10 +62,41 @@
     });
   }
 
-  // Slider 0..100 -> radius. Higher slider = more curved = smaller radius.
-  function sliderToRadius(v) {
-    var t = Math.max(0, Math.min(100, num(v, 55))) / 100;
-    return Math.round(420 - t * 380); // 420 (flat) .. 40 (tight)
+  var FAMILY_ORDER = ["circular", "flow", "geometric", "novelty"];
+
+  function populateShapeSelect(select) {
+    if (!select) return;
+    select.innerHTML = "";
+    var shapes = Curved.SHAPES || [];
+    var familyLabels = Curved.FAMILY_LABELS || {};
+    FAMILY_ORDER.forEach(function (familyKey) {
+      var inFamily = shapes.filter(function (shape) { return shape.family === familyKey; });
+      if (!inFamily.length) return;
+      var group = document.createElement("optgroup");
+      group.label = familyLabels[familyKey] || familyKey;
+      inFamily.forEach(function (shape) {
+        var opt = document.createElement("option");
+        opt.value = shape.key;
+        opt.textContent = shape.label;
+        group.appendChild(opt);
+      });
+      select.appendChild(group);
+    });
+  }
+
+  function updateLinesHint() {
+    var hint = el.linesHint;
+    if (!hint) return;
+    var key = el.direction ? el.direction.value : "arch";
+    var shapes = Curved.SHAPES || [];
+    var shape = null;
+    for (var i = 0; i < shapes.length; i++) {
+      if (shapes[i].key === key) { shape = shapes[i]; break; }
+    }
+    var maxLines = shape ? shape.maxLines : 1;
+    hint.textContent = maxLines === 1
+      ? "This shape supports up to 1 line"
+      : "This shape supports up to " + maxLines + " lines";
   }
 
   function num(v, fallback) {
@@ -90,8 +121,8 @@
 
     var result = Curved.build({
       text: text,
-      direction: el.direction ? el.direction.value : "up",
-      radius: sliderToRadius(el.curve ? el.curve.value : 55),
+      shape: el.direction ? el.direction.value : "arch",
+      intensity: num(el.curve ? el.curve.value : 55, 55) / 100,
       fontSize: num(el.size ? el.size.value : 36, 36),
       fontFamily: el.font ? el.font.value : "system-ui, sans-serif",
       fontWeight: el.bold && el.bold.checked ? "bold" : "normal",
@@ -101,6 +132,7 @@
 
     lastSvg = result.svg;
     el.preview.innerHTML = result.svg;
+    updateLinesHint();
   }
 
   function toast(msg) {
@@ -189,9 +221,11 @@
     el.spacing = $("#curvedSpacing");
     el.preview = $("#curvedPreview");
     el.toast = $("#curvedToast");
+    el.linesHint = $("#curvedLinesHint");
 
     fillSelect(el.style, STYLE_CHOICES, true);
     fillSelect(el.font, FONT_CHOICES, false);
+    populateShapeSelect(el.direction);
 
     [el.input, el.style, el.direction, el.curve, el.size, el.bold, el.font, el.color, el.spacing]
       .forEach(function (node) {

--- a/js/curved/curvedTextController.js
+++ b/js/curved/curvedTextController.js
@@ -84,6 +84,30 @@
     });
   }
 
+  // Real browser measurement (not an estimate): compares each rendered
+  // <textPath>'s actual advance width against its <path>'s actual length, so
+  // shapes with a fixed, non-text-scaling outline (heart/star/diamond/bulge)
+  // can warn instead of silently dropping characters past the path's end.
+  function hasPathOverflow() {
+    if (!el.preview) return false;
+    var svg = el.preview.querySelector("svg");
+    if (!svg) return false;
+    var textPaths = svg.querySelectorAll("textPath");
+    for (var i = 0; i < textPaths.length; i++) {
+      var textPathEl = textPaths[i];
+      var href = textPathEl.getAttribute("href") || textPathEl.getAttribute("xlink:href");
+      if (!href) continue;
+      var pathEl = svg.querySelector(href);
+      if (!pathEl) continue;
+      try {
+        var textLen = textPathEl.getComputedTextLength();
+        var pathLen = pathEl.getTotalLength();
+        if (textLen > pathLen + 1) return true;
+      } catch (e) { /* pre-layout measurement can throw in rare cases; ignore */ }
+    }
+    return false;
+  }
+
   function updateLinesHint() {
     var hint = el.linesHint;
     if (!hint) return;
@@ -94,9 +118,13 @@
       if (shapes[i].key === key) { shape = shapes[i]; break; }
     }
     var maxLines = shape ? shape.maxLines : 1;
-    hint.textContent = maxLines === 1
+    var lineMsg = maxLines === 1
       ? "This shape supports up to 1 line"
       : "This shape supports up to " + maxLines + " lines";
+    var overflowMsg = hasPathOverflow()
+      ? " — your text is longer than this shape's outline, so some characters may not display. Try a shorter phrase or a higher curve amount."
+      : "";
+    hint.textContent = lineMsg + overflowMsg;
   }
 
   function num(v, fallback) {

--- a/style.css
+++ b/style.css
@@ -5990,6 +5990,7 @@ body.dark-mode .pt-banner-index { color: var(--text-secondary); }
   padding: 8px 10px;
 }
 .curved-field textarea { resize: vertical; min-height: 64px; }
+.curved-hint { font-size: 0.75rem; color: var(--text-muted); }
 .curved-row { display: flex; gap: 12px; }
 .curved-row .curved-field { flex: 1; }
 .curved-check {


### PR DESCRIPTION
## Summary

Refactored `curvedText.js` from a single-shape arc/circle renderer into a **shape registry system** supporting 15 distinct layouts across 4 families (circular, flow, geometric, novelty). Added multi-line text support with family-appropriate stacking rules, grapheme-safe glyph rendering for novelty shapes, and intensity-based parameterization replacing the legacy radius slider.

## Key Changes

**Core Architecture**
- Introduced `SHAPES` registry: each shape is a `layout(params)` function returning SVG paths or glyph coordinates
- Two rendering modes:
  - `mode: "path"` — text-on-path via `<textPath>` (circular, flow, geometric families)
  - `mode: "glyph"` — individually positioned/rotated `<text>` elements (fan, twist)
- Replaced `direction` option (up/down/circle) with `shape` key; kept aliases for back-compat

**Shape Families**
- **Circular** (5 shapes): arch, valley, circle, circle-in, oval — concentric stacking with shared center
- **Flow** (4 shapes): wave, ripple, zigzag, spiral — parallel offset stacking
- **Geometric** (4 shapes): heart, star, diamond, bulge — fixed outlines, single-line only
- **Novelty** (2 shapes): fan, twist — glyph-mode with per-character rotation

**Multi-line Support**
- Text split on `\n`; each shape enforces `maxLines` limit
- Circular/flow families stack lines via `lineGap` (1.2× fontSize)
- Geometric shapes reject multi-line input (maxLines: 1)

**Intensity Parameter**
- Unified 0..1 intensity replaces legacy 40..420 radius range
- Formula: `intensity = (420 - radius) / 380` for back-compat
- Controls shape "pronouncedness": 0 = flat/wide, 1 = tight/pronounced

**Glyph Rendering**
- Added `Intl.Segmenter` support for grapheme-safe splitting (emoji/combining marks stay intact)
- Fallback to `String.split("")` for older browsers
- Fan/twist shapes compute per-grapheme `{x, y, rotation}` and render as transformed `<text>` elements

**Text Measurement**
- New `estimateLongestLineSpan()` helper: 0.62em/char × 1.15 safety margin
- Ensures text-on-path doesn't overflow for shapes like oval, wave, ripple, zigzag

## Controller & UI Updates

- `populateShapeSelect()`: dynamically builds `<optgroup>` by family from `SHAPES` registry
- `updateLinesHint()`: displays max-lines limit and warns if text overflows path length
- `hasPathOverflow()`: real browser measurement via `getComputedTextLength()` vs `getTotalLength()`
- Curve slider now maps to intensity (0..100 → 0..1) instead of radius

## Metadata & SEO

- Updated `index.html` meta descriptions to reflect 15 shapes and multi-line capability
- Exposed `window.UltraCurvedText.SHAPES` and `FAMILY_LABELS` for UI population

## Implementation Notes

- All shapes use deterministic IDs (`nextId()`) for stable re-renders
- Path `d` strings use `r2()` rounding (0.01 precision) for readable SVG output
- Glyph-mode shapes compute bounding boxes and apply margins to prevent clipping
- Back-compat preserved: `direction: "up"|"down"|"circle"` still works via `SHAPE_ALIASES`

https://claude.ai/code/session_012WEYTFvodDZvHCmeJ6gJPd