### PR TITLE
fix: link orphaned vi pages from homepage, de-dupe vi title vs ki-tu-…

### DIFF
--- a/locales/vi.json
+++ b/locales/vi.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "title": "Chữ Kiểu Đẹp & Kí Tự Đặc Biệt — Tạo Font Chữ Copy Paste",
+    "title": "Chữ Kiểu Đẹp & Kí Tự Trang Trí — Tạo Font Chữ Copy Paste",
     "description": "Tạo chữ kiểu đẹp, font chữ aesthetic và kí tự đặc biệt cho tên Free Fire, Liên Quân, bio Facebook, Instagram, Zalo, caption TikTok. Gõ một dòng - ra hàng trăm kiểu chữ để copy paste. Miễn phí, không cần tải app."
   },
   "hero": {
-    "title": "Chữ Kiểu Đẹp & Kí Tự Đặc Biệt",
+    "title": "Chữ Kiểu Đẹp & Kí Tự Trang Trí",
     "subtitle": "Gõ một dòng chữ thường, ra cả kho font chữ đẹp và kí tự đặc biệt để copy paste vào tên game, bio Facebook, Instagram, caption TikTok hay status Zalo. Không cần tải app, không cần đăng ký."
   },
   "decorations": {

--- a/vi/index.html
+++ b/vi/index.html
@@ -12,7 +12,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title data-i18n="meta.title">Chữ Kiểu Đẹp &amp; Kí Tự Đặc Biệt — Tạo Font Chữ Copy Paste</title>
+<title data-i18n="meta.title">Chữ Kiểu Đẹp &amp; Kí Tự Trang Trí — Tạo Font Chữ Copy Paste</title>
 <meta name="description" data-i18n-content="meta.description" content="Tạo chữ kiểu đẹp, font chữ aesthetic và kí tự đặc biệt cho tên Free Fire, Liên Quân, bio Facebook, Instagram, Zalo, caption TikTok. Gõ một dòng - ra hàng trăm kiểu chữ để copy paste. Miễn phí, không cần tải app.">
 
 <link rel="canonical" href="https://ultratextgen.com/vi/">
@@ -38,7 +38,7 @@
 <meta name="robots" content="index, follow">
 
 <meta property="og:site_name" content="UltraTextGen">
-<meta property="og:title" content="Chữ Kiểu Đẹp &amp; Kí Tự Đặc Biệt — Tạo Font Chữ Copy Paste">
+<meta property="og:title" content="Chữ Kiểu Đẹp &amp; Kí Tự Trang Trí — Tạo Font Chữ Copy Paste">
 <meta property="og:description" content="Tạo chữ kiểu đẹp, font chữ aesthetic và kí tự đặc biệt cho tên Free Fire, Liên Quân, bio Facebook, Instagram, Zalo, caption TikTok. Gõ một dòng - ra hàng trăm kiểu chữ để copy paste.">
 <meta property="og:url" content="https://ultratextgen.com/vi/">
 <meta property="og:type" content="website">
@@ -48,7 +48,7 @@
 <meta property="og:image:type" content="image/png">
 
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Chữ Kiểu Đẹp &amp; Kí Tự Đặc Biệt — Tạo Font Chữ Copy Paste">
+<meta name="twitter:title" content="Chữ Kiểu Đẹp &amp; Kí Tự Trang Trí — Tạo Font Chữ Copy Paste">
 <meta name="twitter:description" content="Tạo chữ kiểu đẹp, font chữ aesthetic và kí tự đặc biệt cho tên Free Fire, Liên Quân, bio Facebook, Instagram, Zalo, caption TikTok. Gõ một dòng - ra hàng trăm kiểu chữ để copy paste.">
 <meta name="twitter:image" content="https://ultratextgen.com/assets/og/tao-chu-kieu-dep-preview.png">
 
@@ -343,7 +343,7 @@
   <section class="hero">
     <div class="hero-inner">
       <div class="hero-card">
-        <h1 class="hero-headline" data-i18n="hero.title">Chữ Kiểu Đẹp &amp; Kí Tự Đặc Biệt</h1>
+        <h1 class="hero-headline" data-i18n="hero.title">Chữ Kiểu Đẹp &amp; Kí Tự Trang Trí</h1>
         <p class="hero-tagline" data-i18n="hero.subtitle">Gõ một dòng chữ thường, ra cả kho font chữ đẹp và kí tự đặc biệt để copy paste vào tên game, bio Facebook, Instagram, caption TikTok hay status Zalo. Không cần tải app, không cần đăng ký.</p>
         <div class="input-wrapper">
           <textarea class="main-input" id="mainInput" placeholder="Nhập chữ bạn muốn đổi font..." data-i18n-placeholder="ui.placeholder" maxlength="500" autofocus=""></textarea>
@@ -652,6 +652,30 @@
       <a href="/vi/ki-tu-ngoi-sao/" class="compare-card variant-muted u-no-underline">
         <h4>Kí Tự Ngôi Sao</h4>
         <p>Kho kí tự ngôi sao ★ ✦ ⋆˙⟡ và combo sao lấp lánh cho tên, bio.</p>
+      </a>
+      <a href="/vi/combo-emoji/" class="compare-card variant-muted u-no-underline">
+        <h4>Combo Emoji</h4>
+        <p>Combo icon cute, tình yêu, dark, cool cho bio và tên — bấm là copy.</p>
+      </a>
+      <a href="/vi/font-gothic/" class="compare-card variant-muted u-no-underline">
+        <h4>Font Gothic</h4>
+        <p>Chữ gothic Fraktur 𝔞𝔟𝔠 cho bio, tên nhân vật game và Discord.</p>
+      </a>
+      <a href="/vi/font-whatsapp/" class="compare-card variant-muted u-no-underline">
+        <h4>Font WhatsApp</h4>
+        <p>Kiểu chữ đẹp cho tên hiển thị, tiểu sử và tin nhắn WhatsApp.</p>
+      </a>
+      <a href="/vi/ki-tu-discord/" class="compare-card variant-muted u-no-underline">
+        <h4>Kí Tự Discord</h4>
+        <p>Symbol trang trí tên kênh, server và profile Discord ▸┊➤ — bấm là copy.</p>
+      </a>
+      <a href="/vi/ki-tu-roblox/" class="compare-card variant-muted u-no-underline">
+        <h4>Kí Tự Roblox</h4>
+        <p>Symbol dán được vào tên hiển thị Roblox — qua bộ lọc, không bị chặn.</p>
+      </a>
+      <a href="/vi/ki-tu-y2k/" class="compare-card variant-muted u-no-underline">
+        <h4>Kí Tự Y2K</h4>
+        <p>80+ symbol aesthetic Y2K ✰⋆｡° cho bio và caption cyber.</p>
       </a>
     </div>
   </section>


### PR DESCRIPTION
…dac-biet

6 pages (combo-emoji, font-gothic, font-whatsapp, ki-tu-discord, ki-tu-roblox, ki-tu-y2k) had zero internal links anywhere in /vi/, relying solely on sitemap.xml for crawl discovery. Added them to the vi/index.html compare-grid hub.

vi/index.html's title/og/twitter/h1 duplicated ki-tu-dac-biet's exact target phrase ("Kí Tự Đặc Biệt"), likely causing Google to fold the subpage into the homepage (ki-tu-dac-biet was ranking at position 33 despite decent CTR). Swapped to "Kí Tự Trang Trí" in the title-level tags and locales/vi.json to differentiate. Body copy, meta description, and JSON-LD descriptions left untouched since they aren't exact-title collisions.


Claude-Session: https://claude.ai/code/session_014owrXbq6w61mDTgd4xaTSG