### PR TITLE
Link ASCII Art Generator from homepage and site-wide footer

### DIFF
--- a/footer.js
+++ b/footer.js
@@ -20,6 +20,7 @@
         '<a href="/usecase/bio-font/" class="footer-link">Bio Font</a>' +
         '<a href="/usecase/vertical-text/" class="footer-link">Vertical Text</a>' +
         '<a href="/usecase/zalgo-text/" class="footer-link">Zalgo Text</a>' +
+        '<a href="/ascii-art-generator/" class="footer-link">ASCII Art Generator</a>' +
       '</div>' +
       '<div class="footer-col">' +
         '<span class="footer-col-title">Popular Categories</span>' +

--- a/index.html
+++ b/index.html
@@ -382,6 +382,11 @@
         <h3>Zalgo &amp; cursed glitch text</h3>
         <p>Corrupt any text with stacked Unicode marks — one-click presets from subtle to full chaos, a "will it fit?" check for Discord and X limits, plus a decoder that un-zalgos text back to normal.</p>
       </a>
+      <a class="tip-card" href="/ascii-art-generator/" aria-label="ASCII art generator">
+        <div class="tip-icon">🖥️</div>
+        <h3>ASCII art &amp; banners</h3>
+        <p>Turn a word into big block-letter ASCII art with six font styles — plus a live text-to-code converter and a library of copy-paste ASCII pictures.</p>
+      </a>
     </div>
     <p class="u-mt-15 u-text-center"><a class="cat-cta" href="/usecase/" data-i18n="useCases.viewAll">View all use cases →</a></p>
   </section>


### PR DESCRIPTION
## Summary

Follow-up to #453 and #455 (both already merged) — this is a ranking/internal-linking fix, not new content.

The entire ASCII cluster (converter, generator, art library, reference table, answer page) had **zero links from the homepage or main nav** — by far the highest-authority pages on the site. Confirmed via a link-count audit: `/ascii-converter/` and `/ascii-art-generator/` had 5–8 site-wide internal links each, versus **93** for the comparable sibling feature `/usecase/vertical-text/`, which is linked from both the homepage's "Popular Use Cases" grid and the site-wide footer's "Popular Tools" column. This lines up with the GSC data pulled earlier in this work: `ascii-table` sits at position ~75 for its 49,500/mo head term despite solid content — weak internal link equity is a plausible contributor.

## Changes

- `index.html` — added a 6th card to the homepage's "Popular Use Cases" grid (`repeat(auto-fit, minmax(220px, 1fr))`, confirmed safe to extend without layout changes) linking to `/ascii-art-generator/`, matching the existing card format (icon, title, description).
- `footer.js` — added `/ascii-art-generator/` to the site-wide "Popular Tools" footer column, alongside Vertical Text and Zalgo Text.

Both point at `/ascii-art-generator/` as the flagship page of the cluster (highest-volume unclaimed term, `ascii art generator` at 12,100/mo), which itself cross-links to the converter, reference table, and art library — so link equity flows through from there.

## Verification

- Headless-Chromium screenshot check: card renders correctly in the auto-fit grid (reflows to 3×2), footer link renders correctly, 0px horizontal overflow at 375px mobile viewport.
- `node -c footer.js` clean.
- No other homepage/nav links were touched.

https://claude.ai/code/session_01BaBnnxpRp4JJFGoZCDL43Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01BaBnnxpRp4JJFGoZCDL43Q)_