### PR TITLE
feat: link aesthetic symbol pages to the live combo generator

### DIFF
--- a/js/decorator/decoratorData.js
+++ b/js/decorator/decoratorData.js
@@ -139,6 +139,20 @@
     },
 
     {
+      key: 'cottagecore', label: 'Cottagecore', icon: '🍄',
+      pairs: [
+        ['🌾', '🌾'],
+        ['🍄', '🍄'],
+        ['🧺 ·', '· 🧺'],
+        ['𓂃', '𓂃'],
+        ['⋆｡🐝', '🐝｡⋆']
+      ],
+      charms: ['🍄', '🌿', '🍯', '🐌', '✦'],
+      sprinkles: ['🌿', '🍄', '·'],
+      lines: ['🌾 ⋆ 🍄 ⋆ 🌾 ⋆ 🍄 ⋆ 🌾', '🐝 · 🌿 · 🐝 · 🌿 · 🐝']
+    },
+
+    {
       key: 'birthday', label: 'Birthday', icon: '🎂',
       pairs: [
         ['🎉', '🎉'],

--- a/library/coquette-symbols/index.html
+++ b/library/coquette-symbols/index.html
@@ -352,6 +352,13 @@
   </div>
 </section>
 
+<!-- GENERATOR CTA -->
+<div class="cta-card">
+  <h3>Want a live coquette combo generator?</h3>
+  <p>Type your name or bio text into the Text Decorator, pick the Coquette vibe, and get dozens of ready-to-copy combos instantly — no clicking through tiles one by one.</p>
+  <a href="https://ultratextgen.com/category/text-decorator/?vibe=coquette" class="cta-btn">Try the Coquette Generator →</a>
+</div>
+
 <!-- CTA -->
 <div class="cta-card">
   <h3>Transform text with Unicode fonts</h3>

--- a/library/cottagecore-symbols/index.html
+++ b/library/cottagecore-symbols/index.html
@@ -343,6 +343,13 @@
 
 <div class="section-divider"></div>
 
+<!-- GENERATOR CTA -->
+<div class="cta-card">
+  <h3>Want a live cottagecore combo generator?</h3>
+  <p>Type your name or bio text into the Text Decorator, pick the Cottagecore vibe, and get dozens of ready-to-copy combos instantly — no clicking through tiles one by one.</p>
+  <a href="https://ultratextgen.com/category/text-decorator/?vibe=cottagecore" class="cta-btn">Try the Cottagecore Generator →</a>
+</div>
+
 <!-- CTA -->
 <div class="cta-card">
   <h3>Transform text with Unicode fonts</h3>

--- a/library/goth-grunge-symbols/index.html
+++ b/library/goth-grunge-symbols/index.html
@@ -295,6 +295,13 @@
 </section>
 
 
+<!-- GENERATOR CTA -->
+<div class="cta-card">
+  <h3>Want a live gothic combo generator?</h3>
+  <p>Type your name or bio text into the Text Decorator, pick the Gothic vibe, and get dozens of ready-to-copy combos instantly — no clicking through tiles one by one.</p>
+  <a href="https://ultratextgen.com/category/text-decorator/?vibe=gothic" class="cta-btn">Try the Gothic Generator →</a>
+</div>
+
 <!-- CTA -->
 <div class="cta-card">
   <h3>Transform text with Unicode fonts</h3>

--- a/library/kawaii-cute-symbols/index.html
+++ b/library/kawaii-cute-symbols/index.html
@@ -347,6 +347,13 @@
 <div class="section-divider"></div>
 
 
+<!-- GENERATOR CTA -->
+<div class="cta-card">
+  <h3>Want a live kawaii combo generator?</h3>
+  <p>Type your name or bio text into the Text Decorator, pick the Kawaii vibe, and get dozens of ready-to-copy combos instantly — no clicking through tiles one by one.</p>
+  <a href="https://ultratextgen.com/category/text-decorator/?vibe=kawaii" class="cta-btn">Try the Kawaii Generator →</a>
+</div>
+
 <!-- CTA -->
 <div class="cta-card">
   <h3>Transform text with Unicode fonts</h3>

--- a/library/y2k-symbols/index.html
+++ b/library/y2k-symbols/index.html
@@ -723,6 +723,13 @@
 
 <div class="section-divider"></div>
 
+<!-- GENERATOR CTA -->
+<div class="cta-card">
+  <h3>Want a live Y2K combo generator?</h3>
+  <p>Type your name or bio text into the Text Decorator, pick the Y2K vibe, and get dozens of ready-to-copy combos instantly — no clicking through tiles one by one.</p>
+  <a href="https://ultratextgen.com/category/text-decorator/?vibe=y2k" class="cta-btn">Try the Y2K Generator →</a>
+</div>
+
 <!-- CTA -->
 <div class="cta-card">
   <h3>Transform text with Unicode fonts</h3>


### PR DESCRIPTION
## Summary

- Cross-links the `coquette-symbols`, `y2k-symbols`, `goth-grunge-symbols`, `kawaii-cute-symbols`, and `cottagecore-symbols` library pages to the existing `/category/text-decorator/` generator, deep-linked with `?vibe=<theme>` so the correct vibe is preselected on arrival.
- Adds a new `cottagecore` theme to the shared decorator engine (`js/decorator/decoratorData.js`), since no matching vibe previously existed. Symbols were reused from the live `cottagecore-symbols` page (🍄🌾🧺🐌🍯) for consistency and known-good rendering.
- `goth-grunge-symbols` maps to the `gothic` vibe (closest existing match — no separate "grunge" theme exists in the engine).

Context: these five pages already had static symbol-tile grids and a pre-made "Collections" (`buildGrids`) combo-set section. What they lacked was a path to the site's existing live generator — someone landing on a "coquette emoji combo" search still had to hand-assemble combos from individual tiles. This wires them to the generator that already exists (`/category/text-decorator/`) instead of building new functionality, so the fix is five small HTML additions plus one new theme entry in a shared, already-proven engine.

## Test plan

- [x] `scripts/validate_library_pages.py` run against all 5 changed library pages — 0 issues, 0 errors, 0 warnings.
- [x] Headless-Chromium pass on all 5 library pages: new CTA renders with the correct `?vibe=` href, existing symbol-tile copy-to-clipboard still works, existing Collections section still renders (no regressions from the added markup).
- [x] Headless-Chromium pass on `/category/text-decorator/?vibe=cottagecore` and `?vibe=coquette`: correct vibe chip pre-activates from the URL param, decorator results render with correct theme glyphs (no mojibake), no app-code console errors (only pre-existing GTM/analytics calls blocked by the sandbox's lack of outbound network, unrelated to this change).


---
_Generated by [Claude Code](https://claude.ai/code/session_01LUYX97Vi6bRhdpYpT5YRh7)_