### PR TITLE
Add three new tip cards to French homepage

### DIFF
--- a/fr/index.html
+++ b/fr/index.html
@@ -661,6 +661,21 @@
         <h3>Texte Zalgo</h3>
         <p>L'écriture glitchée et maudite pour les pseudos dark et les mèmes.</p>
       </a>
+      <a class="tip-card" href="/fr/police-discord/" aria-label="Police Discord">
+        <div class="tip-icon">💜</div>
+        <h3>Police Discord</h3>
+        <p>Pseudo, bio et messages Discord stylés — sans Nitro, gras, italique, cursive et gothique.</p>
+      </a>
+      <a class="tip-card" href="/fr/texte-invisible/" aria-label="Texte invisible">
+        <div class="tip-icon">🫥</div>
+        <h3>Texte Invisible</h3>
+        <p>Un caractère invisible à copier-coller pour un pseudo vide sur Free Fire, Instagram ou WhatsApp.</p>
+      </a>
+      <a class="tip-card" href="/fr/combos-emoji/" aria-label="Combos emoji">
+        <div class="tip-icon">🦋</div>
+        <h3>Combos Emoji</h3>
+        <p>Combinaisons d'emoji prêtes à coller — mignon, coquette, amour, dark et plage.</p>
+      </a>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
Added three new feature cards to the French homepage (`fr/index.html`) in the tips section: Police Discord, Texte Invisible, and Combos Emoji.

## Changes
- **Police Discord** — Card linking to `/fr/police-discord/` with description of Discord-styled text (bold, italic, cursive, gothic) without Nitro
- **Texte Invisible** — Card linking to `/fr/texte-invisible/` with description of invisible character for empty usernames on Free Fire, Instagram, WhatsApp
- **Combos Emoji** — Card linking to `/fr/combos-emoji/` with description of pre-made emoji combinations (cute, coquette, love, dark, beach themes)

Each card follows the existing `.tip-card` pattern with icon emoji, heading, and description text.

## Implementation Details
- Cards inserted after the existing "Texte Zalgo" card in the tips section
- Consistent with existing card structure: `<a class="tip-card">` wrapper, `.tip-icon` div, `<h3>` heading, `<p>` description
- Proper `aria-label` attributes for accessibility
- Icons chosen to match feature themes (💜 for Discord, 🫥 for invisible, 🦋 for emoji combos)

https://claude.ai/code/session_01TH5qXEaqWNYtKxkKXBiB4A