### PR TITLE
Add Spanish + Indonesian localization: event page i18n + 6 new market pages

### DIFF
--- a/data/event_page_specs/halloween-es.json
+++ b/data/event_page_specs/halloween-es.json
@@ -1,0 +1,174 @@
+{
+  "slug": "halloween",
+  "language": "es",
+  "event_name": "Halloween",
+  "aliases": ["Noche de Brujas"],
+
+  "title": "Fuentes, Emojis y Símbolos de Halloween | UltraTextGen",
+  "meta_description": "Dale estilo a tu mensaje de Halloween en vivo, copia emojis de calabaza, fantasma y murciélago, kaomoji espeluznantes, arte ASCII original y frases listas como Feliz Halloween o Truco o Trato.",
+
+  "hero_h1": "Generador de Texto y Símbolos de Halloween",
+  "hero_tagline": "Escribe un nombre o un deseo espeluznante y dale estilo con fuentes góticas, cursivas y divertidas; luego copia emojis de calabaza, fantasma y murciélago, kaomoji y arte ASCII — o toca una frase de Halloween ya lista para transformarla al instante.",
+
+  "intro": "Halloween — o la Noche de Brujas, como se le conoce en buena parte de Latinoamérica — es la gran fiesta de disfraces y frases ingeniosas del otoño: calabazas, disfraces y publicaciones pensadas para sonar espeluznantes, divertidas o ambas cosas a la vez. Esta página reúne todo lo necesario para darle estilo a esa publicación o tarjeta: fuentes góticas y divertidas que puedes previsualizar con tu propio texto, los emojis de calabaza, fantasma y murciélago que la gente realmente usa, kaomoji para un mensaje de chat con un toque tenebroso, algunas piezas de arte ASCII originales hechas a mano, y un banco de frases de Halloween — desde el clásico \"Feliz Halloween\" hasta \"Truco o Trato\" — que se transforman al instante en cuanto las tocas.",
+
+  "date_window": "cada año el 31 de octubre",
+
+  "sample_phrase": "Feliz Halloween",
+
+  "canonical": "https://ultratextgen.com/es/events/halloween/",
+
+  "hreflang": {
+    "en": "https://ultratextgen.com/events/halloween/",
+    "es": "https://ultratextgen.com/es/events/halloween/",
+    "x_default": "es"
+  },
+
+  "fonts": {
+    "curated_keys": [
+      "Ultra Gothic",
+      "Ultra Gothic Bold",
+      "Ultra Gothic Occult",
+      "Ultra Gothic Cross",
+      "Ultra Gothic Script",
+      "Ultra Aesthetic Gothic",
+      "Ultra Script Bold",
+      "Ultra Bold",
+      "Ultra Bubble",
+      "Ultra Small Caps"
+    ]
+  },
+
+  "emoji_symbol_collections": [
+    {
+      "name": "Emojis de Halloween",
+      "presentation_class": "emoji",
+      "copy_pattern": "collection",
+      "flags": ["🎃", "👻", "🦇", "🕷️", "🕸️", "💀", "☠️", "🧙‍♀️", "🧛", "🐈‍⬛", "🍬", "🌙", "⚰️"],
+      "defaultFormat": "inline"
+    }
+  ],
+
+  "kaomoji": [
+    { "text": "(((( ;°Д°))))", "label": "Temblando de Miedo" },
+    { "text": "Σ(ﾟдﾟ;)", "label": "Grito de Susto" },
+    { "text": "ヽ(゜Q。)ノ", "label": "Fantasma Errante" },
+    { "text": "눈_눈", "label": "Mirada Espeluznante" },
+    { "text": "(¬‿¬)", "label": "Sonrisa Traviesa" }
+  ],
+
+  "ascii_art": {
+    "items": [
+      {
+        "label": "Calabaza de Halloween",
+        "art": "   .-'''-.\n  /  o o  \\\n |    >    |\n  \\  ___  /\n   '-...-'"
+      },
+      {
+        "label": "Fantasma",
+        "art": "   ___\n  /   \\\n | o o |\n |  -  |\n |     |\n \\/\\/\\/"
+      },
+      {
+        "label": "Murciélago",
+        "art": "  /\\   /\\\n /  \\_/  \\\n(   ^ ^   )\n \\       /\n  \\/   \\/"
+      },
+      {
+        "label": "Araña",
+        "art": "   \\ | /\n    \\|/\n--(  o  )--\n    /|\\\n   / | \\"
+      },
+      {
+        "label": "Sombrero de Bruja",
+        "art": "      /\\\n     /  \\\n    /    \\\n   /______\\\n  /________\\\n ~~~~~~~~~~~~"
+      },
+      {
+        "label": "Lápida",
+        "art": "  _________\n /   RIP   \\\n|           |\n|     +     |\n|___________|"
+      },
+      {
+        "label": "Telaraña",
+        "art": "\\   |   /\n \\  |  /\n--- + ---\n /  |  \\\n/   |   \\"
+      }
+    ]
+  },
+
+  "phrase_bank": [
+    {
+      "text": "Feliz Halloween",
+      "native_script": "Feliz Halloween",
+      "romanization": "Feliz Halloween",
+      "translation": "El saludo clásico y universal para Halloween.",
+      "needs_native_speaker_review": true
+    },
+    {
+      "text": "Truco o Trato",
+      "native_script": "Truco o Trato",
+      "romanization": "Truco o Trato",
+      "translation": "El grito clásico para pedir dulces de puerta en puerta.",
+      "needs_native_speaker_review": true
+    },
+    {
+      "text": "Dulce o Truco",
+      "native_script": "Dulce o Truco",
+      "romanization": "Dulce o Truco",
+      "translation": "Una variante regional de \"Truco o Trato\" que también se usa mucho.",
+      "needs_native_speaker_review": true
+    },
+    {
+      "text": "¡Buuu!",
+      "native_script": "¡Buuu!",
+      "romanization": "¡Buuu!",
+      "translation": "Una manera corta y juguetona de asustar a alguien.",
+      "needs_native_speaker_review": true
+    },
+    {
+      "text": "Feliz Noche de Brujas",
+      "native_script": "Feliz Noche de Brujas",
+      "romanization": "Feliz Noche de Brujas",
+      "translation": "Una alternativa festiva a \"Feliz Halloween\", muy usada en México y Centroamérica.",
+      "needs_native_speaker_review": true
+    },
+    {
+      "text": "Que tengas una Noche de Brujas espeluznante",
+      "native_script": "Que tengas una Noche de Brujas espeluznante",
+      "romanization": "Que tengas una Noche de Brujas espeluznante",
+      "translation": "Un deseo festivo, ideal para tarjetas y mensajes más largos.",
+      "needs_native_speaker_review": true
+    },
+    {
+      "text": "Que la pases espeluznante",
+      "native_script": "Que la pases espeluznante",
+      "romanization": "Que la pases espeluznante",
+      "translation": "Una despedida casual para pies de foto y publicaciones.",
+      "needs_native_speaker_review": true
+    }
+  ],
+
+  "companion_answer_slug": "que-escribir-en-halloween",
+
+  "related": [
+    {
+      "href": "/library/halloween-symbols/",
+      "title": "Símbolos de Halloween",
+      "desc": "Una biblioteca más amplia de símbolos y combinaciones de emoji de Halloween en Unicode."
+    },
+    {
+      "href": "/es/library/simbolos-witchy-occult/",
+      "title": "Símbolos Witchy y Ocultos",
+      "desc": "Pentagramas, lunas y caracteres ocultos para una estética más oscura."
+    },
+    {
+      "href": "/library/skull-ascii-art/",
+      "title": "Arte ASCII de Calaveras",
+      "desc": "Más piezas de arte ASCII de calaveras originales para copiar y pegar."
+    },
+    {
+      "href": "/es/letras-goticas/",
+      "title": "Letras Góticas",
+      "desc": "La familia completa de fuentes blackletter y fraktur para una estética oscura y de otro tiempo."
+    },
+    {
+      "href": "/ascii-art-generator/",
+      "title": "Generador de Arte ASCII",
+      "desc": "Escribe cualquier palabra o nombre y conviértelo en arte ASCII de letras en bloque en vivo."
+    }
+  ]
+}

--- a/data/event_page_specs/navidad.json
+++ b/data/event_page_specs/navidad.json
@@ -1,0 +1,210 @@
+{
+  "slug": "navidad",
+  "language": "es",
+  "event_name": "Navidad",
+  "aliases": [
+    "Feliz Navidad"
+  ],
+  "hreflang": {
+    "en": "https://ultratextgen.com/events/christmas/",
+    "es": "https://ultratextgen.com/es/events/navidad/",
+    "x_default": "es"
+  },
+  "title": "Generador de Fuentes, Emojis y Símbolos de Navidad | UltraTextGen",
+  "meta_description": "Dale estilo a tu mensaje de Navidad en vivo, copia emojis de árbol, Papá Noel y copos de nieve, kaomoji festivos, arte ASCII original y frases de Navidad listas para usar.",
+  "hero_h1": "Generador de Texto y Símbolos de Navidad",
+  "hero_tagline": "Escribe un nombre o un deseo y dale estilo con fuentes clásicas en negrita, cursiva y gótica, luego copia emojis de árbol, Papá Noel y copos de nieve, kaomoji y arte ASCII — o toca una frase navideña para transformarla al instante.",
+  "intro": "La Navidad es la fecha más importante del año para tarjetas y mensajes — árboles, calcetines y palabras que desean a familiares y amigos unas fiestas felices. Esta página reúne todo lo necesario para darle estilo a ese saludo: fuentes seleccionadas que puedes previsualizar con tu propio texto, los emojis de árbol, Papá Noel y copo de nieve que la gente realmente usa, kaomoji para un mensaje de chat alegre, algunas piezas de arte ASCII originales y un banco de frases navideñas listas para copiar que se transforman al instante al tocarlas.",
+  "date_window": "diciembre, con el día principal cayendo el 25 de diciembre de cada año",
+  "sample_phrase": "Feliz Navidad",
+  "canonical": "https://ultratextgen.com/es/events/navidad/",
+  "fonts": {
+    "curated_keys": [
+      "Ultra Bold",
+      "Ultra Bold Serif",
+      "Ultra Italic Serif",
+      "Ultra Script",
+      "Ultra Script Bold",
+      "Ultra Script Elegant",
+      "Ultra Gothic",
+      "Ultra Gothic Bold",
+      "Ultra Small Caps",
+      "Ultra Bubble"
+    ]
+  },
+  "emoji_symbol_collections": [
+    {
+      "name": "Emojis de Navidad",
+      "presentation_class": "emoji",
+      "copy_pattern": "collection",
+      "flags": [
+        "🎄",
+        "🎅",
+        "🤶",
+        "🦌",
+        "🔔",
+        "🎁",
+        "⭐",
+        "❄️",
+        "☃️",
+        "⛄",
+        "🧦",
+        "🕯️",
+        "🍪"
+      ],
+      "defaultFormat": "inline"
+    }
+  ],
+  "kaomoji": [
+    {
+      "text": "(っ◕‿◕)っ❆",
+      "label": "Abrazo Nevado"
+    },
+    {
+      "text": "✧⁺⸜(◕‐◕)⸝⁺✧",
+      "label": "Alegría Brillante"
+    },
+    {
+      "text": "♪┏(・o・)┛♪┗(・o・)┓♪",
+      "label": "Baile de Villancicos"
+    },
+    {
+      "text": "(๑˃ᴗ˂)ﻭ❄",
+      "label": "Emoción por la Nieve"
+    },
+    {
+      "text": "(⋆❛ᴗ❛⋆)",
+      "label": "Calidez Acogedora"
+    }
+  ],
+  "ascii_art": {
+    "items": [
+      {
+        "label": "Árbol de Navidad",
+        "art": "      *\n     ^^^\n    ^^^^^\n   ^^^o^^^\n  ^^^^^^^^^\n    | | |\n    |___|"
+      },
+      {
+        "label": "Muñeco de Nieve",
+        "art": "    .-''-.\n   ( o  o )\n    )  -  (\n   (        )\n  ( o      o )\n   '--------'\n    |      |"
+      },
+      {
+        "label": "Caja de Regalo",
+        "art": " .-----------.\n |     |     |\n |-----+-----|\n |     |     |\n '-----------'"
+      },
+      {
+        "label": "Estrella Brillante",
+        "art": "      *\n   *  *  *\n    * * *\n  *** * ***\n    * * *\n   *  *  *\n      *"
+      },
+      {
+        "label": "Calcetín",
+        "art": "   ______\n  /      |\n /       |\n|        |\n|________|"
+      },
+      {
+        "label": "Campana",
+        "art": "    .-.\n   (   )\n  (     )\n  |     |\n  '-----'\n    (=)"
+      },
+      {
+        "label": "Adorno Navideño",
+        "art": "    .-.\n   (   )\n  ( * )\n   (   )\n    '-'\n     |"
+      },
+      {
+        "label": "Copo de Nieve",
+        "art": "     *\n   * | *\n* --+-- *\n   * | *\n     *"
+      }
+    ]
+  },
+  "phrase_bank": [
+    {
+      "text": "Feliz Navidad",
+      "native_script": "Feliz Navidad",
+      "romanization": "Feliz Navidad",
+      "translation": "El saludo universal y más usado para esta época del año.",
+      "qa_english_gloss": "Merry Christmas",
+      "needs_native_speaker_review": true
+    },
+    {
+      "text": "Feliz Navidad y Próspero Año Nuevo",
+      "native_script": "Feliz Navidad y Próspero Año Nuevo",
+      "romanization": "Feliz Navidad y Próspero Año Nuevo",
+      "translation": "La versión completa, ideal para tarjetas y mensajes formales.",
+      "qa_english_gloss": "Merry Christmas and a Happy/Prosperous New Year",
+      "needs_native_speaker_review": true
+    },
+    {
+      "text": "Que la Navidad te traiga paz y alegría",
+      "native_script": "Que la Navidad te traiga paz y alegría",
+      "romanization": "Que la Navidad te traiga paz y alegría",
+      "translation": "Un deseo cálido, perfecto para tarjetas y dedicatorias largas.",
+      "qa_english_gloss": "May Christmas bring you peace and joy",
+      "needs_native_speaker_review": true
+    },
+    {
+      "text": "Con cariño en esta Navidad",
+      "native_script": "Con cariño en esta Navidad",
+      "romanization": "Con cariño en esta Navidad",
+      "translation": "Una despedida sencilla y afectuosa para cerrar un mensaje.",
+      "qa_english_gloss": "With love this Christmas",
+      "needs_native_speaker_review": true
+    },
+    {
+      "text": "Felices Fiestas",
+      "native_script": "Felices Fiestas",
+      "romanization": "Felices Fiestas",
+      "translation": "Una alternativa inclusiva que abarca toda la temporada navideña.",
+      "qa_english_gloss": "Happy Holidays",
+      "needs_native_speaker_review": true
+    },
+    {
+      "text": "Que el espíritu de la Navidad llene tu hogar de amor",
+      "native_script": "Que el espíritu de la Navidad llene tu hogar de amor",
+      "romanization": "Que el espíritu de la Navidad llene tu hogar de amor",
+      "translation": "Un deseo más poético, ideal para mensajes a la familia.",
+      "qa_english_gloss": "May the spirit of Christmas fill your home with love",
+      "needs_native_speaker_review": true
+    },
+    {
+      "text": "Los mejores deseos para ti y los tuyos en estas fiestas",
+      "native_script": "Los mejores deseos para ti y los tuyos en estas fiestas",
+      "romanization": "Los mejores deseos para ti y los tuyos en estas fiestas",
+      "translation": "Un saludo cordial para compañeros de trabajo o conocidos.",
+      "qa_english_gloss": "Best wishes to you and yours this holiday season",
+      "needs_native_speaker_review": true
+    },
+    {
+      "text": "Abrazos y bendiciones en esta Navidad",
+      "native_script": "Abrazos y bendiciones en esta Navidad",
+      "romanization": "Abrazos y bendiciones en esta Navidad",
+      "translation": "Un cierre cálido y cercano para mensajes a seres queridos.",
+      "qa_english_gloss": "Hugs and blessings this Christmas",
+      "needs_native_speaker_review": true
+    }
+  ],
+  "companion_answer_slug": "que-escribir-en-una-tarjeta-de-navidad",
+  "related": [
+    {
+      "href": "/library/christmas-symbols/",
+      "title": "Símbolos de Navidad",
+      "desc": "Una biblioteca más amplia de símbolos y combinaciones de emoji navideños en Unicode (en inglés)."
+    },
+    {
+      "href": "/es/letra-cursiva/",
+      "title": "Letra Cursiva",
+      "desc": "La familia completa de fuentes cursivas elegantes para tarjetas y mensajes navideños."
+    },
+    {
+      "href": "/es/letras-goticas/",
+      "title": "Letras Góticas",
+      "desc": "Estilos clásicos góticos y de época para un look navideño tradicional."
+    },
+    {
+      "href": "/es/letras-negritas/",
+      "title": "Letras Negritas",
+      "desc": "La familia completa de fuentes en negrita para titulares y mensajes."
+    },
+    {
+      "href": "/ascii-art-generator/",
+      "title": "Generador de Arte ASCII",
+      "desc": "Escribe cualquier palabra o nombre y conviértelo en un banner de letras en bloque en vivo (en inglés)."
+    }
+  ]
+}

--- a/data/event_page_specs/san-valentin.json
+++ b/data/event_page_specs/san-valentin.json
@@ -1,0 +1,186 @@
+{
+  "slug": "san-valentin",
+  "language": "es",
+  "event_name": "San Valentín",
+  "aliases": ["Día de los Enamorados", "Día del Amor y la Amistad"],
+
+  "title": "Generador de Fuentes, Símbolos y Kaomoji para San Valentín | UltraTextGen",
+  "meta_description": "Estiliza tu mensaje de San Valentín en vivo, copia corazones, rosas y besos en emoji, kaomoji, arte ASCII original y frases listas como Feliz San Valentín — toca para transformarlas al instante.",
+
+  "hero_h1": "Generador de Texto y Símbolos para San Valentín",
+  "hero_tagline": "Escribe un nombre o mensaje y transfórmalo en fuentes cursivas elegantes; luego copia corazones, rosas, besos, kaomoji y arte ASCII, o toca una frase lista para estilizarla al instante.",
+
+  "intro": "San Valentín es la fecha romántica más importante del año: tarjetas, mensajes y publicaciones que giran en torno a corazones, rosas y un puñado de frases que todos usamos tarde o temprano (Feliz San Valentín, Te quiero, Eres mi persona favorita). Esta página reúne todo lo necesario para darle estilo a ese mensaje: fuentes cursivas y elegantes que puedes previsualizar con tu propio texto, los emojis de corazones y rosas que la gente realmente comparte, kaomoji para un mensaje coqueto, algunas piezas de arte ASCII originales hechas a mano, y un banco de frases listas que se transforman al instante con solo tocarlas.",
+
+  "date_window": "cada año el 14 de febrero",
+
+  "sample_phrase": "Feliz San Valentín",
+
+  "canonical": "https://ultratextgen.com/es/events/san-valentin/",
+
+  "hreflang": {
+    "en": "https://ultratextgen.com/events/valentines-day/",
+    "es": "https://ultratextgen.com/es/events/san-valentin/",
+    "x_default": "es"
+  },
+
+  "fonts": {
+    "curated_keys": [
+      "Ultra Script",
+      "Ultra Script Bold",
+      "Ultra Script Elegant",
+      "Ultra Script Bold Elegant",
+      "Ultra Script Sparkle",
+      "Ultra Cute Script",
+      "Ultra Italic Serif",
+      "Ultra Bold Italic Serif",
+      "Ultra Small Caps",
+      "Ultra Cute Bubble"
+    ]
+  },
+
+  "emoji_symbol_collections": [
+    {
+      "name": "Corazones, Rosas y Besos",
+      "presentation_class": "emoji",
+      "copy_pattern": "collection",
+      "flags": ["❤️", "🧡", "💛", "💚", "💙", "💜", "🖤", "🤍", "💕", "💗", "💖", "💘", "🌹", "💌", "💋"],
+      "defaultFormat": "inline"
+    }
+  ],
+
+  "kaomoji": [
+    { "text": "(｡♥‿♥｡)", "label": "Ojos de Corazón" },
+    { "text": "(♡˃͈ ᵕ ˂͈♡)", "label": "Enamorado Sonrojado" },
+    { "text": "♡＾▽＾♡", "label": "Amor Alegre" },
+    { "text": "(´ ω `♡)", "label": "Sonrisa Dulce" },
+    { "text": "(´♡‿♡`)", "label": "Adoración" },
+    { "text": "( ˘ ³˘)♥", "label": "Beso" },
+    { "text": "(づ ◕‿◕ )づ", "label": "Abrazo Cálido" }
+  ],
+
+  "ascii_art": {
+    "items": [
+      {
+        "label": "Corazón",
+        "art": " __    __\n/  \\  /  \\\n\\   \\/   /\n \\      /\n  \\    /\n   \\  /\n    \\/"
+      },
+      {
+        "label": "Dos Corazones",
+        "art": " __  __     __  __\n/  \\/  \\   /  \\/  \\\n\\      /   \\      /\n \\    /     \\    /\n  \\  /       \\  /\n   \\/         \\/"
+      },
+      {
+        "label": "Rosa",
+        "art": "     @\n    /=\\\n   |   |\n     |\n   --+--\n     |\n    /  \\"
+      },
+      {
+        "label": "Flecha de Cupido",
+        "art": "        __    __\n       /  \\  /  \\\n======>\\   \\/   /======>\n        \\      /\n         \\    /\n          \\  /\n           \\/"
+      },
+      {
+        "label": "Carta de Amor",
+        "art": " _________________\n|\\               /|\n| \\             / |\n|  \\    <3     /  |\n|   \\         /   |\n|    \\       /    |\n|     \\     /     |\n|______\\___/______|"
+      },
+      {
+        "label": "Marca de Beso",
+        "art": "  ,-\"\".,-\"\".\n ( .. )( .. )\n  `-..-'`-..-'\n     `.__.'"
+      }
+    ]
+  },
+
+  "phrase_bank": [
+    {
+      "text": "Feliz San Valentín",
+      "native_script": "Feliz San Valentín",
+      "romanization": "Feliz San Valentín",
+      "translation": "El saludo universal — funciona en cualquier tarjeta, mensaje o historia.",
+      "needs_native_speaker_review": true
+    },
+    {
+      "text": "Feliz Día del Amor y la Amistad",
+      "native_script": "Feliz Día del Amor y la Amistad",
+      "romanization": "Feliz Día del Amor y la Amistad",
+      "translation": "El saludo preferido en México y buena parte de Latinoamérica.",
+      "needs_native_speaker_review": true
+    },
+    {
+      "text": "Te quiero",
+      "native_script": "Te quiero",
+      "romanization": "Te quiero",
+      "translation": "La declaración clásica y cercana — sirve para pareja, familia o amigos íntimos.",
+      "needs_native_speaker_review": true
+    },
+    {
+      "text": "Te amo",
+      "native_script": "Te amo",
+      "romanization": "Te amo",
+      "translation": "Más intensa que 'te quiero' — pensada para una pareja de mucho tiempo.",
+      "needs_native_speaker_review": true
+    },
+    {
+      "text": "Eres mi persona favorita",
+      "native_script": "Eres mi persona favorita",
+      "romanization": "Eres mi persona favorita",
+      "translation": "Una línea moderna y cálida, perfecta para una pareja o un mejor amigo.",
+      "needs_native_speaker_review": true
+    },
+    {
+      "text": "Mi corazón es tuyo",
+      "native_script": "Mi corazón es tuyo",
+      "romanization": "Mi corazón es tuyo",
+      "translation": "Una frase poética para una tarjeta, una carta de amor o un mensaje nocturno.",
+      "needs_native_speaker_review": true
+    },
+    {
+      "text": "¿Quieres ser mi Valentín?",
+      "native_script": "¿Quieres ser mi Valentín?",
+      "romanization": "¿Quieres ser mi Valentín?",
+      "translation": "La pregunta juguetona y algo nerviosa — combina bien con una rosa o un corazón.",
+      "needs_native_speaker_review": true
+    },
+    {
+      "text": "Contigo quiero estar siempre",
+      "native_script": "Contigo quiero estar siempre",
+      "romanization": "Contigo quiero estar siempre",
+      "translation": "Una promesa de largo plazo, ideal para cerrar una tarjeta o una carta.",
+      "needs_native_speaker_review": true
+    },
+    {
+      "text": "Con todo mi corazón",
+      "native_script": "Con todo mi corazón",
+      "romanization": "Con todo mi corazón",
+      "translation": "El cierre clásico para el final de una tarjeta o un mensaje.",
+      "needs_native_speaker_review": true
+    }
+  ],
+
+  "companion_answer_slug": "que-escribir-en-una-tarjeta-de-san-valentin",
+
+  "related": [
+    {
+      "href": "/es/simbolos-de-corazon/",
+      "title": "Colección de Símbolos de Corazón",
+      "desc": "Explora y copia emojis de corazón, caracteres Unicode de corazón y símbolos románticos en todos los colores y estilos."
+    },
+    {
+      "href": "/library/love-kaomoji/",
+      "title": "Kaomoji de Amor y Corazones",
+      "desc": "Una biblioteca más amplia de kaomoji de amor y corazones — caritas japonesas para el cariño, los besos, los abrazos y los enamoramientos."
+    },
+    {
+      "href": "/library/heart-ascii-art/",
+      "title": "Arte ASCII de Corazones",
+      "desc": "Más arte ASCII de corazones original, desde un pequeño <3 de una línea hasta corazones grandes, sólidos o con contorno."
+    },
+    {
+      "href": "/es/letra-cursiva/",
+      "title": "Letra Cursiva",
+      "desc": "La familia completa de fuentes cursivas para tarjetas, mensajes y firmas elegantes."
+    },
+    {
+      "href": "/library/kiss-kaomoji/",
+      "title": "Kaomoji de Besos",
+      "desc": "Caritas de besos para un mensaje coqueto o una dedicatoria de San Valentín."
+    }
+  ]
+}

--- a/es/answers/que-escribir-en-halloween/index.html
+++ b/es/answers/que-escribir-en-halloween/index.html
@@ -1,0 +1,197 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <title>¿Qué Escribir en Halloween? Mensajes y Frases | UltraTextGen</title>
+  <meta name="description" content="Qué escribir en Halloween — frases para tarjetas, pies de foto espeluznantes y mensajes cortos, desde el clásico Feliz Halloween hasta Truco o Trato.">
+  <link rel="canonical" href="https://ultratextgen.com/es/answers/que-escribir-en-halloween/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/answers/halloween-messages-what-to-write/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/answers/que-escribir-en-halloween/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/es/answers/que-escribir-en-halloween/">
+  <meta property="og:title" content="¿Qué Escribir en Halloween? Mensajes y Frases">
+  <meta property="og:description" content="Qué escribir en Halloween — frases para tarjetas, pies de foto espeluznantes y mensajes cortos, desde el clásico Feliz Halloween hasta Truco o Trato.">
+  <meta property="og:url" content="https://ultratextgen.com/es/answers/que-escribir-en-halloween/">
+  <meta property="og:type" content="article">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="¿Qué Escribir en Halloween? Mensajes y Frases">
+  <meta name="twitter:description" content="Qué escribir en Halloween — frases para tarjetas, pies de foto espeluznantes y mensajes cortos.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category.png">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "es",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "¿Qué debo escribir en una tarjeta de Halloween?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Empieza con un saludo — \"Feliz Halloween\" o \"Feliz Noche de Brujas\" funcionan bien — luego añade una línea espeluznante o divertida, y cierra con un deseo como \"Que la pases espeluznante\" o \"Que tengas una Noche de Brujas espeluznante\". Mantén un tono ligero salvo que la persona que lo reciba disfrute algo más tenebroso."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Cuál es una buena frase de Halloween para Instagram o TikTok?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "En redes sociales gana lo corto y pícaro: \"¡Buuu!\", \"Que la pases espeluznante\" o \"Feliz Noche de Brujas\" funcionan solos como pie de foto. Para una publicación de disfraz, combina la frase con lo que llevas puesto — el pie de foto debe leerse rápido, porque la mayoría de la gente va deslizando por un feed lleno de fotos parecidas."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Qué significa \"Truco o Trato\" y cuándo se dice?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "\"Truco o Trato\" es la frase que dicen los niños de puerta en puerta la noche de Halloween: le ofrece a quien abre la puerta una opción, dar un dulce o arriesgarse a una broma inofensiva. En algunas regiones se escucha también como \"Dulce o Truco\". Más allá de la tradición misma, también se usa como pie de foto o línea de tarjeta para señalar que es Halloween."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Está bien simplemente escribir \"Feliz Halloween\"?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Sí — \"Feliz Halloween\" es la opción segura y universal para una tarjeta, mensaje o pie de foto. Funciona para cualquier persona, cualquier relación y cualquier tono, ya sea que le escribas a un amigo o a un niño."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Inicio", "item": "https://ultratextgen.com/es/" },
+    { "@type": "ListItem", "position": 2, "name": "¿Qué Escribir en Halloween?", "item": "https://ultratextgen.com/es/answers/que-escribir-en-halloween/" }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/es/">Inicio</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">¿Qué Escribir en Halloween?</span>
+</nav>
+
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">¿Qué escribir en Halloween?</h1>
+    <p class="hero-tagline">Frases para tarjetas, pies de foto espeluznantes y mensajes cortos para el 31 de octubre — desde el clásico "Feliz Halloween" hasta líneas pícaras para redes sociales.</p>
+  </div>
+</section>
+
+<section class="editorial-section">
+  <span class="article-section-label">Respuesta corta</span>
+  <div class="editorial-block">
+    <p>La opción segura y universal es sencillamente <strong>"Feliz Halloween"</strong> — funciona en cualquier tarjeta, mensaje o pie de foto. Si quieres un poco más de personalidad, <strong>"Truco o Trato"</strong> es un guiño juguetón a la tradición misma, <strong>"¡Buuu!"</strong> es un saludo corto de susto, y <strong>"Que la pases espeluznante"</strong> o <strong>"Feliz Noche de Brujas"</strong> funcionan bien como cierre o alternativa festiva. Para una tarjeta, empieza con el saludo, añade una línea espeluznante o divertida, y cierra con un deseo.</p>
+  </div>
+  <div class="block-example">
+    <strong>La respuesta completa en una línea:</strong> "Feliz Halloween" para cualquier ocasión, "Truco o Trato" para la tradición de puerta en puerta, y "Que la pases espeluznante" como cierre casual.
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="editorial-section">
+  <span class="article-section-label">Tarjetas y mensajes</span>
+  <h2>Qué escribir en una tarjeta o mensaje de Halloween</h2>
+  <div class="editorial-block">
+    <p>El patrón que funciona en casi cualquier tarjeta o mensaje de Halloween: <strong>saludo → línea → deseo de cierre.</strong></p>
+    <ul>
+      <li><strong>Saludo:</strong> "Feliz Halloween" o "Feliz Noche de Brujas".</li>
+      <li><strong>Línea:</strong> un comentario sobre el disfraz, un chiste de dulces, o una frase espeluznante.</li>
+      <li><strong>Deseo de cierre:</strong> "Que la pases espeluznante", "Que tengas una Noche de Brujas espeluznante", o simplemente "¡Buuu!"</li>
+    </ul>
+    <p>Para tarjetas infantiles o notas de clase, mantén un tono ligero y divertido — guarda las frases más tenebrosas para un público que realmente las va a disfrutar.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="editorial-section">
+  <span class="article-section-label">Pies de foto</span>
+  <h2>Pies de foto espeluznantes para Instagram, TikTok y mensajes</h2>
+  <div class="editorial-block">
+    <p>Los pies de foto en redes sociales funcionan mejor cortos y pícaros — nadie lee un párrafo debajo de una foto de disfraz. Algunas líneas que funcionan solas como pie de foto completo:</p>
+    <ul>
+      <li><strong>Que la pases espeluznante</strong> — un cierre casual que sirve para casi cualquier foto de Halloween.</li>
+      <li><strong>¡Buuu!</strong> — el pie de foto más corto posible, funciona solo o como apertura.</li>
+      <li><strong>Feliz Noche de Brujas</strong> — una alternativa festiva a "Feliz Halloween" para no repetir siempre lo mismo.</li>
+      <li><strong>Truco o Trato</strong> — un guiño directo a la tradición, ideal para una foto de disfraces o dulces.</li>
+    </ul>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="editorial-section">
+  <span class="article-section-label">Truco o Trato</span>
+  <h2>Qué significa realmente "Truco o Trato"</h2>
+  <div class="editorial-block">
+    <p>"Truco o Trato" es la frase que dicen los niños de puerta en puerta la noche de Halloween — es una oferta: dar un dulce (el trato) o arriesgarse a una broma inofensiva (el truco). En algunas regiones también se escucha como "Dulce o Truco", una variante con el mismo significado. Más allá de la tradición del puerta en puerta, ambas frases también se usan sueltas como pie de foto o línea de tarjeta, simplemente para señalar que es Halloween.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="editorial-section">
+  <span class="article-section-label">Si tienes dudas</span>
+  <h2>Si no sabes qué tono usar</h2>
+  <div class="editorial-block">
+    <p>Un "Feliz Halloween" sencillo nunca falla — sirve para un compañero de trabajo, un niño, un grupo de chat o una tarjeta para alguien que no conoces bien. Deja las frases más pícaras como "Truco o Trato" o "¡Buuu!" para amigos, pies de foto casuales, o cualquier lugar donde ya se espera un tono más relajado.</p>
+  </div>
+</section>
+
+<div class="cta-card">
+  <h3>Dale estilo a este mensaje</h3>
+  <p>Convierte cualquiera de estas frases en un titular de tarjeta o un pie de foto con estilo — elige una fuente gótica, cursiva o divertida, cópiala, listo. El generador de Halloween también tiene los emojis de calabaza, fantasma y murciélago, kaomoji y arte ASCII para acompañarla.</p>
+  <a href="/es/events/halloween/" class="cta-btn">Estilizar Este Mensaje →</a>
+</div>
+
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Para el generador completo en vivo — fuentes, emojis, kaomoji, arte ASCII y un banco de frases que se transforma al tocarlo — visita el <a href="/es/events/halloween/">Generador de Texto y Símbolos de Halloween</a>. Para una referencia más amplia de caracteres espeluznantes, explora <a href="/library/halloween-symbols/">Símbolos de Halloween</a>, o consulta la familia de <a href="/es/letras-goticas/">Letras Góticas</a> para un look más oscuro y de otra época.</p>
+  </div>
+</section>
+
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/es/answers/que-escribir-en-una-tarjeta-de-navidad/index.html
+++ b/es/answers/que-escribir-en-una-tarjeta-de-navidad/index.html
@@ -1,0 +1,188 @@
+<!DOCTYPE html><html lang="es"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <title>Qué Escribir en una Tarjeta de Navidad | UltraTextGen</title>
+  <meta name="description" content="¿Te quedaste en blanco frente a la tarjeta? Frases cortas y sinceras de Navidad para familia, amigos o compañeros de trabajo — y cómo darles estilo antes de enviarlas.">
+  <link rel="canonical" href="https://ultratextgen.com/es/answers/que-escribir-en-una-tarjeta-de-navidad/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/answers/que-escribir-en-una-tarjeta-de-navidad/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/es/answers/que-escribir-en-una-tarjeta-de-navidad/">
+  <meta property="og:title" content="Qué Escribir en una Tarjeta de Navidad">
+  <meta property="og:description" content="¿Te quedaste en blanco frente a la tarjeta? Frases cortas y sinceras de Navidad para familia, amigos o compañeros de trabajo — y cómo darles estilo antes de enviarlas.">
+  <meta property="og:url" content="https://ultratextgen.com/es/answers/que-escribir-en-una-tarjeta-de-navidad/">
+  <meta property="og:type" content="article">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Qué Escribir en una Tarjeta de Navidad">
+  <meta name="twitter:description" content="¿Te quedaste en blanco frente a la tarjeta? Frases cortas y sinceras de Navidad para familia, amigos o compañeros de trabajo.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category.png">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "es",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "¿Qué debo escribir en una tarjeta de Navidad?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Mantenla corta y concreta en lugar de buscar un texto largo. Una sola línea clara funciona mejor que un párrafo entero: 'Feliz Navidad', 'Feliz Navidad y Próspero Año Nuevo' o 'Con cariño en esta Navidad' si prefieres algo más cercano. Suma un detalle personal — un recuerdo del año, algo que agradeces de esa persona, un plan para verse pronto — y esa línea más ese detalle ya son una tarjeta completa y efectiva."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Y si no se me ocurre nada?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Parte de una frase lista y personalízala. 'Feliz Navidad' sirve para casi cualquier persona; 'Felices Fiestas' es la opción más neutral cuando no sabes qué celebra la otra persona; 'Que la Navidad te traiga paz y alegría' o 'Que el espíritu de la Navidad llene tu hogar de amor' quedan mejor en una tarjeta más larga o sentida. Elige la que más se parezca a lo que quieres transmitir y añade un nombre o un recuerdo concreto para que no suene genérica."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Qué escribo para un compañero de trabajo o un contacto formal?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Elige un registro neutral y breve: 'Feliz Navidad y Próspero Año Nuevo', 'Felices Fiestas' o 'Los mejores deseos para ti y los tuyos en estas fiestas' funcionan sin sonar demasiado personales ni demasiado frías. Reserva las frases más cercanas — 'Con cariño en esta Navidad', 'Abrazos y bendiciones en esta Navidad' — para familia y amistades cercanas."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Está bien enviar el mismo mensaje a varias personas?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Sí, siempre que el tono encaje con cada relación. Puedes reutilizar una frase como 'Feliz Navidad y Próspero Año Nuevo' para todo tu grupo de trabajo, y guardar una línea más personal para la familia o amistades cercanas. Lo que hace que un mensaje repetido no se sienta genérico no es cambiar las palabras — es añadir un detalle distinto para cada persona."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Cómo hago que un mensaje sencillo se vea más cuidado?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Dale estilo. La misma frase escrita en una fuente cursiva o gótica navideña, acompañada de un árbol, un copo de nieve o un kaomoji festivo, se percibe como mucho más pensada sin cambiar ni una palabra. Consulta nuestro <a href=\"https://ultratextgen.com/es/events/navidad/\">generador de Navidad</a> para encontrar fuentes, emoji, kaomoji, arte ASCII y este mismo banco de frases, todo en un solo lugar."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Inicio", "item": "https://ultratextgen.com/es/" },
+    { "@type": "ListItem", "position": 2, "name": "Qué Escribir en una Tarjeta de Navidad", "item": "https://ultratextgen.com/es/answers/que-escribir-en-una-tarjeta-de-navidad/" }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/es/">Inicio</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Qué Escribir en una Tarjeta de Navidad</span>
+</nav>
+
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Qué Escribir en una Tarjeta de Navidad</h1>
+    <p class="hero-tagline">¿Te quedaste mirando la tarjeta en blanco? Aquí están las frases que de verdad funcionan — cortas y sinceras — para familia, amistades o compañeros de trabajo.</p>
+  </div>
+</section>
+
+<section class="editorial-section">
+  <span class="article-section-label">Respuesta corta</span>
+  <div class="editorial-block">
+    <p>Sé breve y concreto en vez de buscar un texto largo: una frase clara, más un detalle personal, ya es un mensaje completo. <strong>«Feliz Navidad»</strong> y <strong>«Feliz Navidad y Próspero Año Nuevo»</strong> son las opciones más seguras y universales. Para un tono más cercano, <strong>«Con cariño en esta Navidad»</strong> o <strong>«Que la Navidad te traiga paz y alegría»</strong> funcionan igual de bien. Para un contacto formal o de trabajo, <strong>«Felices Fiestas»</strong> es la opción más neutral. Ajusta el tono a la relación, añade un detalle específico, y listo.</p>
+  </div>
+  <div class="block-example">
+    <strong>El método completo en una línea:</strong> elige una frase que encaje con la relación · súmale un detalle personal · no te extiendas de más.
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="editorial-section">
+  <span class="article-section-label">Según el destinatario</span>
+  <h2>¿Qué frase le queda a cada relación?</h2>
+  <div class="editorial-block">
+    <p>El mismo mensaje no siempre encaja en todas partes — un «con cariño» muy cercano puede sentirse fuera de lugar en una tarjeta para un cliente, y un «felices fiestas» genérico puede sentirse frío para tu familia. Elegir primero desde el grupo correcto hace que el resto de la tarjeta se escriba solo.</p>
+  </div>
+  <div class="compare-grid">
+    <div class="compare-card variant-positive">
+      <span class="compare-badge">Familia y amistades cercanas</span>
+      <ul>
+        <li>Con cariño en esta Navidad</li>
+        <li>Que la Navidad te traiga paz y alegría</li>
+        <li>Abrazos y bendiciones en esta Navidad</li>
+      </ul>
+    </div>
+    <div class="compare-card variant-muted">
+      <span class="compare-badge">Trabajo o contactos formales</span>
+      <ul>
+        <li>Feliz Navidad y Próspero Año Nuevo</li>
+        <li>Felices Fiestas</li>
+        <li>Los mejores deseos para ti y los tuyos en estas fiestas</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="editorial-section">
+  <span class="article-section-label">Que se note el cuidado</span>
+  <h2>¿Cómo hago que un mensaje sencillo se vea más cuidado?</h2>
+  <div class="editorial-block">
+    <p>No necesitas palabras nuevas — necesitas estilo. La misma frase, en una fuente cursiva o gótica navideña y acompañada de un árbol, un copo de nieve o un kaomoji festivo, se percibe muchísimo más pensada que el mismo texto en letra simple. Es una decisión de diseño, no de redacción, así que no te cuesta nada sumarla.</p>
+  </div>
+</section>
+
+<div class="cta-card">
+  <h3>Dale estilo a este mensaje</h3>
+  <p>Escribe cualquiera de estas frases en el generador de Navidad y transfórmala en fuentes cursivas y góticas, emoji, kaomoji y arte ASCII — gratis, sin registro.</p>
+  <a href="/es/events/navidad/" class="cta-btn">Abrir el Generador de Navidad →</a>
+</div>
+
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Para ver el set completo de frases listas de esta página — con estilo en vivo, junto a emoji de árbol y Papá Noel, kaomoji y arte ASCII seleccionado — visita el <a href="/es/events/navidad/">generador de texto y símbolos de Navidad</a>. Si solo buscas el estilo cursivo, prueba <a href="/es/letra-cursiva/">Letra Cursiva</a>, o el estilo gótico con <a href="/es/letras-goticas/">Letras Góticas</a>. Para más símbolos navideños, consulta la biblioteca de <a href="/library/christmas-symbols/">Símbolos de Navidad</a> (en inglés).</p>
+  </div>
+</section>
+
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/es/answers/que-escribir-en-una-tarjeta-de-san-valentin/index.html
+++ b/es/answers/que-escribir-en-una-tarjeta-de-san-valentin/index.html
@@ -1,0 +1,199 @@
+<!DOCTYPE html><html lang="es"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <title>Qué Escribir en una Tarjeta de San Valentín | UltraTextGen</title>
+  <meta name="description" content="¿Te quedaste en blanco frente a la tarjeta? Frases cortas, sentidas o juguetonas para pareja, familia o amigos — y cómo darles estilo antes de enviarlas.">
+  <link rel="canonical" href="https://ultratextgen.com/es/answers/que-escribir-en-una-tarjeta-de-san-valentin/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/answers/que-escribir-en-una-tarjeta-de-san-valentin/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/answers/valentines-day-messages-what-to-write/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/es/answers/que-escribir-en-una-tarjeta-de-san-valentin/">
+  <meta property="og:title" content="Qué Escribir en una Tarjeta de San Valentín">
+  <meta property="og:description" content="¿Te quedaste en blanco frente a la tarjeta? Frases cortas, sentidas o juguetonas para pareja, familia o amigos — y cómo darles estilo antes de enviarlas.">
+  <meta property="og:url" content="https://ultratextgen.com/es/answers/que-escribir-en-una-tarjeta-de-san-valentin/">
+  <meta property="og:type" content="article">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/answers-valentines-day-messages-what-to-write.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Qué Escribir en una Tarjeta de San Valentín">
+  <meta name="twitter:description" content="¿Te quedaste en blanco frente a la tarjeta? Frases cortas, sentidas o juguetonas para pareja, familia o amigos.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/answers-valentines-day-messages-what-to-write.png">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "es",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "¿Qué debo escribir en una tarjeta de San Valentín?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Mantenla corta y concreta en lugar de buscar un poema. Una sola línea clara funciona mejor que un párrafo entero: 'Feliz San Valentín', 'Te quiero' o un 'Con todo mi corazón' si prefieres algo más clásico. Suma un detalle personal — un chiste interno, un apodo, un motivo por el que agradeces tenerla o tenerlo en tu vida — y esa línea más ese detalle ya son una tarjeta completa y efectiva."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Y si de verdad no se me ocurre nada?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Parte de una frase lista y personalízala. 'Feliz San Valentín' sirve casi para cualquier persona; '¿Quieres ser mi Valentín?' encaja en una relación nueva o con alguien que te gusta; 'Mi corazón es tuyo' o 'Contigo quiero estar siempre' quedan mejor con una pareja de largo plazo. Elige la que más se parezca a lo que realmente sientes y añade un nombre o un recuerdo concreto para que no suene genérica."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Qué escribo si es para un amigo y no para una pareja?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Cambia el registro romántico por uno de aprecio, sin perder la calidez. En vez de 'Te amo', prueba con 'Eres mi persona favorita' o 'Feliz Día del Amor y la Amistad' — el mismo formato corto y directo, pero dirigido a la amistad. Funciona igual de bien en una tarjeta de grupo, un chat de amigas o amigos, o una nota pegada a un regalo pequeño."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Está bien usar una frase más casual en vez de una romántica?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Sí — lo importante es que el tono coincida con la relación. Una relación nueva, algo que apenas empieza, o un amigo suelen recibir mejor algo ligero como '¿Quieres ser mi Valentín?' que una declaración muy intensa. Guarda las frases más fuertes ('Mi corazón es tuyo', 'Contigo quiero estar siempre') para una pareja con la que ya llevas tiempo. No existe una regla que obligue a que un mensaje de San Valentín sea solemne."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Cómo hago que un mensaje sencillo se vea más cuidado?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Dale estilo. La misma frase escrita en una fuente cursiva o elegante, acompañada de un corazón, un kaomoji o una pequeña pieza de arte ASCII, se percibe como mucho más pensada sin cambiar ni una palabra. Consulta nuestro <a href=\"https://ultratextgen.com/es/events/san-valentin/\">generador de San Valentín</a> para encontrar fuentes, corazones, kaomoji, arte ASCII y este mismo banco de frases, todo en un solo lugar."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Inicio", "item": "https://ultratextgen.com/es/" },
+    { "@type": "ListItem", "position": 2, "name": "Qué Escribir en una Tarjeta de San Valentín", "item": "https://ultratextgen.com/es/answers/que-escribir-en-una-tarjeta-de-san-valentin/" }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/es/">Inicio</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Qué Escribir en una Tarjeta de San Valentín</span>
+</nav>
+
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Qué Escribir en una Tarjeta de San Valentín</h1>
+    <p class="hero-tagline">¿Te quedaste mirando la tarjeta en blanco? Aquí están las frases que de verdad funcionan — cortas y sentidas, o juguetonas — para tu pareja, alguien que te gusta, o tu grupo de amigas y amigos.</p>
+  </div>
+</section>
+
+<section class="editorial-section">
+  <span class="article-section-label">Respuesta corta</span>
+  <div class="editorial-block">
+    <p>Sé breve y concreto en vez de buscar un poema: una frase clara, más un detalle personal, ya es un mensaje completo. <strong>«Feliz San Valentín»</strong> y <strong>«Feliz Día del Amor y la Amistad»</strong> son las opciones más seguras y universales. Para una pareja, ve directo al sentimiento con <strong>«Mi corazón es tuyo»</strong> o <strong>«Contigo quiero estar siempre»</strong>. Para una relación nueva o alguien que te gusta, algo más ligero como <strong>«¿Quieres ser mi Valentín?»</strong> funciona mejor que una declaración muy intensa. Ajusta el tono a la relación, añade un detalle específico, y listo.</p>
+  </div>
+  <div class="block-example">
+    <strong>El método completo en una línea:</strong> elige una frase que encaje con la relación · súmale un detalle personal · no te extiendas de más.
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="editorial-section">
+  <span class="article-section-label">Según la relación</span>
+  <h2>¿Qué frase le queda a cada relación?</h2>
+  <div class="editorial-block">
+    <p>La razón más común por la que un mensaje de San Valentín no aterriza bien es que la frase no coincide con la relación — una declaración muy fuerte para alguien que apenas conoces se siente excesiva, y un «con todo mi corazón» suelto a una pareja de años puede sentirse insuficiente. Elegir primero desde el grupo correcto hace que el resto de la tarjeta se escriba solo.</p>
+  </div>
+  <div class="compare-grid">
+    <div class="compare-card variant-positive">
+      <span class="compare-badge">Pareja de largo plazo</span>
+      <ul>
+        <li>Mi corazón es tuyo</li>
+        <li>Contigo quiero estar siempre</li>
+        <li>Con todo mi corazón</li>
+      </ul>
+    </div>
+    <div class="compare-card variant-muted">
+      <span class="compare-badge">Relación nueva o alguien que te gusta</span>
+      <ul>
+        <li>¿Quieres ser mi Valentín?</li>
+        <li>Te quiero</li>
+        <li>Eres mi persona favorita</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="editorial-section">
+  <span class="article-section-label">Amistad</span>
+  <h2>¿Y si es para un amigo o una amiga?</h2>
+  <div class="editorial-block">
+    <p>Un mensaje entre amigos usa el mismo formato corto y directo — solo que apunta a la amistad, no al romance. Cambia la frase romántica por algo como <em>«Feliz Día del Amor y la Amistad»</em> o <em>«Eres mi persona favorita»</em>, y funciona igual de bien en una tarjeta de grupo, un chat de amigas o amigos, o una nota pegada a un regalo pequeño.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="editorial-section">
+  <span class="article-section-label">Que se note el cuidado</span>
+  <h2>¿Cómo hago que un mensaje sencillo se vea más cuidado?</h2>
+  <div class="editorial-block">
+    <p>No necesitas palabras nuevas — necesitas estilo. La misma frase, en una fuente cursiva o elegante y acompañada de un corazón, un kaomoji o una pequeña pieza de arte ASCII, se percibe muchísimo más pensada que el mismo texto en letra simple. Es una decisión de diseño, no de redacción, así que no te cuesta nada sumarla.</p>
+  </div>
+</section>
+
+<div class="cta-card">
+  <h3>Dale estilo a este mensaje</h3>
+  <p>Escribe cualquiera de estas frases en el generador de San Valentín y transfórmala en fuentes cursivas, corazones, kaomoji y arte ASCII — gratis, sin registro.</p>
+  <a href="/es/events/san-valentin/" class="cta-btn">Abrir el Generador de San Valentín →</a>
+</div>
+
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Para ver el set completo de frases listas de esta página — con estilo en vivo, junto a corazones, rosas, besos en emoji, kaomoji y arte ASCII seleccionado — visita el <a href="/es/events/san-valentin/">generador de texto y símbolos de San Valentín</a>. Si solo buscas el estilo cursivo, prueba <a href="/es/letra-cursiva/">Letra Cursiva</a>, o explora la <a href="/es/simbolos-de-corazon/">Colección de Símbolos de Corazón</a> para más caracteres para combinar con tu mensaje.</p>
+  </div>
+</section>
+
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/es/events/halloween/index.html
+++ b/es/events/halloween/index.html
@@ -1,0 +1,441 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <title>Fuentes, Emojis y Símbolos de Halloween | UltraTextGen</title>
+  <meta name="description" content="Dale estilo a tu mensaje de Halloween en vivo, copia emojis de calabaza, fantasma y murciélago, kaomoji espeluznantes, arte ASCII original y frases listas como Feliz Halloween o Truco o Trato.">
+  <link rel="canonical" href="https://ultratextgen.com/es/events/halloween/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/events/halloween/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/events/halloween/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/es/events/halloween/">
+  <meta property="og:title" content="Fuentes, Emojis y Símbolos de Halloween | UltraTextGen">
+  <meta property="og:description" content="Dale estilo a tu mensaje de Halloween en vivo, copia emojis de calabaza, fantasma y murciélago, kaomoji espeluznantes, arte ASCII original y frases listas como Feliz Halloween o Truco o Trato.">
+  <meta property="og:url" content="https://ultratextgen.com/es/events/halloween/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Fuentes, Emojis y Símbolos de Halloween | UltraTextGen">
+  <meta name="twitter:description" content="Dale estilo a tu mensaje de Halloween en vivo, copia emojis de calabaza, fantasma y murciélago, kaomoji espeluznantes, arte ASCII original y frases listas como Feliz Halloween o Truco o Trato.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category.png">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=Space+Mono&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+  <link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Generador de Texto y Símbolos de Halloween",
+  "alternateName": [
+    "Noche de Brujas",
+    "Fuentes de Halloween",
+    "Símbolos de Halloween",
+    "Generador de Texto de Halloween"
+  ],
+  "url": "https://ultratextgen.com/es/events/halloween/",
+  "inLanguage": "es",
+  "applicationCategory": "UtilitiesApplication",
+  "operatingSystem": "Any",
+  "description": "Escribe un nombre o un deseo espeluznante y dale estilo con fuentes góticas, cursivas y divertidas; luego copia emojis de calabaza, fantasma y murciélago, kaomoji y arte ASCII — o toca una frase de Halloween ya lista para transformarla al instante.",
+  "featureList": [
+    "Estilos de fuente de Halloween en vivo para cualquier texto que escribas",
+    "Colección seleccionada de emojis y símbolos de Halloween",
+    "Kaomoji de Halloween",
+    "Arte ASCII seleccionado de Halloween",
+    "Banco de frases de Halloween con estilo al toque (escritura nativa, romanización, traducción)"
+  ],
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  }
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "es",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "¿Qué es el generador de texto y símbolos de Halloween?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Halloween — o la Noche de Brujas, como se le conoce en buena parte de Latinoamérica — es la gran fiesta de disfraces y frases ingeniosas del otoño: calabazas, disfraces y publicaciones pensadas para sonar espeluznantes, divertidas o ambas cosas a la vez. Esta página reúne todo lo necesario para darle estilo a esa publicación o tarjeta: fuentes góticas y divertidas que puedes previsualizar con tu propio texto, los emojis de calabaza, fantasma y murciélago que la gente realmente usa, kaomoji para un mensaje de chat con un toque tenebroso, algunas piezas de arte ASCII originales hechas a mano, y un banco de frases de Halloween — desde el clásico \"Feliz Halloween\" hasta \"Truco o Trato\" — que se transforman al instante en cuanto las tocas."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Cuándo es Halloween?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Halloween cae cada año el 31 de octubre. Consulta un calendario actualizado para la fecha exacta y vuelve para darle estilo a tu mensaje."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Cómo uso el generador de Halloween?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Escribe un nombre, deseo o saludo en el cuadro de arriba. Cada estilo de fuente de Halloween se actualiza en vivo debajo — toca Copiar en cualquier tarjeta. Más abajo, toca cualquier emoji, símbolo, kaomoji o arte ASCII para copiarlo por separado, o toca una tarjeta del banco de frases para colocarla en el cuadro y verla transformada al instante."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Dónde encuentro más frases de Halloween y qué escribir?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Consulta <a href=\"https://ultratextgen.com/es/answers/que-escribir-en-halloween/\">nuestra respuesta completa</a> para más saludos, traducciones e ideas de mensajes."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Inicio",
+      "item": "https://ultratextgen.com/es/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Halloween",
+      "item": "https://ultratextgen.com/es/events/halloween/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/es/">Inicio</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Halloween</span>
+</nav>
+
+<section class="hero">
+  <div class="hero-inner">
+    <div class="hero-card">
+      <h1 class="hero-headline">Generador de Texto y Símbolos de Halloween</h1>
+      <p class="hero-tagline">Escribe un nombre o un deseo espeluznante y dale estilo con fuentes góticas, cursivas y divertidas; luego copia emojis de calabaza, fantasma y murciélago, kaomoji y arte ASCII — o toca una frase de Halloween ya lista para transformarla al instante.</p>
+      <p class="u-secondary-tight">También conocido como: Noche de Brujas</p>
+      <div class="input-wrapper" id="eventTextWrap">
+        <textarea class="main-input" id="mainInput" placeholder="Escribe un nombre, deseo o saludo..." maxlength="500" autofocus></textarea>
+        <span class="char-count"><span id="charCount">0</span>/500</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<main class="container">
+  <section class="editorial-section">
+    <div class="editorial-block">
+      <p>Halloween — o la Noche de Brujas, como se le conoce en buena parte de Latinoamérica — es la gran fiesta de disfraces y frases ingeniosas del otoño: calabazas, disfraces y publicaciones pensadas para sonar espeluznantes, divertidas o ambas cosas a la vez. Esta página reúne todo lo necesario para darle estilo a esa publicación o tarjeta: fuentes góticas y divertidas que puedes previsualizar con tu propio texto, los emojis de calabaza, fantasma y murciélago que la gente realmente usa, kaomoji para un mensaje de chat con un toque tenebroso, algunas piezas de arte ASCII originales hechas a mano, y un banco de frases de Halloween — desde el clásico "Feliz Halloween" hasta "Truco o Trato" — que se transforman al instante en cuanto las tocas.</p>
+    </div>
+    <div class="block-example">
+      <strong>Halloween:</strong> cada año el 31 de octubre
+    </div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <section class="editorial-section" id="eventFontsSection">
+    <span class="article-section-label">Fuentes</span>
+    <h2>Fuentes de Halloween</h2>
+    <p class="editorial-intro">Escribe tu texto arriba y cada estilo de abajo se actualiza en vivo. Toca Copiar en el que más te guste.</p>
+    <div class="results-grid" id="eventFontsGrid"></div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <section class="editorial-section" id="eventEmojiSection">
+    <span class="article-section-label">Emojis y Símbolos</span>
+    <h2>Emojis y Símbolos de Halloween</h2>
+    <p class="editorial-intro">Toca cualquier carácter para copiarlo, o copia todo un conjunto en el formato que prefieras.</p>
+    <div id="eventEmojiGrids"></div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <section class="editorial-section" id="eventKaomojiSection">
+    <span class="article-section-label">Kaomoji</span>
+    <h2>Kaomoji de Halloween</h2>
+    <p class="editorial-intro">Cada ficha es un kaomoji completo — toca para copiar la cadena entera en un clic.</p>
+    <div class="glyph-grid" id="eventKaomojiGrid"></div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <section class="editorial-section" id="eventAsciiSection">
+    <span class="article-section-label">Arte ASCII</span>
+    <h2>Arte ASCII de Halloween</h2>
+    <p class="editorial-intro">Piezas de varias líneas seleccionadas — toca Copiar para llevarte una con sus saltos de línea y espaciado intactos.</p>
+    <div class="art-piece-grid" id="eventAsciiGrid"></div>
+    <p class="u-secondary-tight u-mt-15">¿Quieres escribir tu propio nombre o mensaje en un banner de letras en bloque en vivo? Prueba el <a href="/ascii-art-generator/">Generador de Arte ASCII</a>.</p>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <section class="editorial-section" id="eventPhraseSection">
+    <span class="article-section-label">Banco de Frases</span>
+    <h2>Banco de Frases de Halloween</h2>
+    <p class="editorial-intro">Toca una frase para colocarla en el cuadro de arriba y verla transformada al instante en cada estilo de fuente.</p>
+    <div class="compare-grid" id="eventPhraseGrid"></div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <div class="cta-card">
+    <h3>Transforma texto con fuentes Unicode</h3>
+    <p>Usa UltraTextGen para convertir texto plano en negrita, cursiva y más de 100 estilos de fuente Unicode — gratis e instantáneo.</p>
+    <a href="https://ultratextgen.com/es/" class="cta-btn">Abrir UltraTextGen →</a>
+  </div>
+
+  <section class="editorial-section">
+    <span class="article-section-label">Recursos Relacionados</span>
+    <div class="compare-grid">
+    <a href="/library/halloween-symbols/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos de Halloween</h4>
+      <p>Una biblioteca más amplia de símbolos y combinaciones de emoji de Halloween en Unicode.</p>
+    </a>
+    <a href="/es/library/simbolos-witchy-occult/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos Witchy y Ocultos</h4>
+      <p>Pentagramas, lunas y caracteres ocultos para una estética más oscura.</p>
+    </a>
+    <a href="/library/skull-ascii-art/" class="compare-card variant-muted u-no-underline">
+      <h4>Arte ASCII de Calaveras</h4>
+      <p>Más piezas de arte ASCII de calaveras originales para copiar y pegar.</p>
+    </a>
+    <a href="/es/letras-goticas/" class="compare-card variant-muted u-no-underline">
+      <h4>Letras Góticas</h4>
+      <p>La familia completa de fuentes blackletter y fraktur para una estética oscura y de otro tiempo.</p>
+    </a>
+    <a href="/ascii-art-generator/" class="compare-card variant-muted u-no-underline">
+      <h4>Generador de Arte ASCII</h4>
+      <p>Escribe cualquier palabra o nombre y conviértelo en arte ASCII de letras en bloque en vivo.</p>
+    </a>
+    <a href="/es/answers/que-escribir-en-halloween/" class="compare-card variant-muted u-no-underline">
+      <h4>Más frases y mensajes de Halloween</h4>
+      <p>Saludos, traducciones e ideas de mensajes más allá del banco de frases de arriba.</p>
+    </a>
+    </div>
+  </section>
+</main>
+
+<footer class="footer">
+  <div class="footer-inner">
+    <h2 class="faq-category">Preguntas sobre Halloween</h2>
+    <div class="faq-item">
+      <button class="faq-question" type="button">¿Qué es el generador de texto y símbolos de Halloween?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button>
+      <div class="faq-answer">Halloween — o la Noche de Brujas, como se le conoce en buena parte de Latinoamérica — es la gran fiesta de disfraces y frases ingeniosas del otoño: calabazas, disfraces y publicaciones pensadas para sonar espeluznantes, divertidas o ambas cosas a la vez. Esta página reúne todo lo necesario para darle estilo a esa publicación o tarjeta: fuentes góticas y divertidas que puedes previsualizar con tu propio texto, los emojis de calabaza, fantasma y murciélago que la gente realmente usa, kaomoji para un mensaje de chat con un toque tenebroso, algunas piezas de arte ASCII originales hechas a mano, y un banco de frases de Halloween — desde el clásico "Feliz Halloween" hasta "Truco o Trato" — que se transforman al instante en cuanto las tocas.</div>
+    </div>
+    <div class="faq-item">
+      <button class="faq-question" type="button">¿Cuándo es Halloween?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button>
+      <div class="faq-answer">Halloween cae cada año el 31 de octubre. Consulta un calendario actualizado para la fecha exacta y vuelve para darle estilo a tu mensaje.</div>
+    </div>
+    <div class="faq-item">
+      <button class="faq-question" type="button">¿Cómo uso el generador de Halloween?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button>
+      <div class="faq-answer">Escribe un nombre, deseo o saludo en el cuadro de arriba. Cada estilo de fuente de Halloween se actualiza en vivo debajo — toca Copiar en cualquier tarjeta. Más abajo, toca cualquier emoji, símbolo, kaomoji o arte ASCII para copiarlo por separado, o toca una tarjeta del banco de frases para colocarla en el cuadro y verla transformada al instante.</div>
+    </div>
+    <div class="faq-item">
+      <button class="faq-question" type="button">¿Dónde encuentro más frases de Halloween y qué escribir?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button>
+      <div class="faq-answer">Consulta <a href="https://ultratextgen.com/es/answers/que-escribir-en-halloween/">nuestra respuesta completa</a> para más saludos, traducciones e ideas de mensajes.</div>
+    </div>
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="copy-toast" id="copyToast">¡Copiado!</div>
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script>window.UTG_EVENT_MODE = true;</script>
+<script>window.UTG_EVENT_DATA = {
+  "slug": "halloween",
+  "eventName": "Halloween",
+  "aliases": [
+    "Noche de Brujas"
+  ],
+  "samplePhrase": "Feliz Halloween",
+  "fonts": {
+    "curatedKeys": [
+      "Ultra Gothic",
+      "Ultra Gothic Bold",
+      "Ultra Gothic Occult",
+      "Ultra Gothic Cross",
+      "Ultra Gothic Script",
+      "Ultra Aesthetic Gothic",
+      "Ultra Script Bold",
+      "Ultra Bold",
+      "Ultra Bubble",
+      "Ultra Small Caps"
+    ]
+  },
+  "emojiCollections": {
+    "containerId": "eventEmojiGrids",
+    "groups": [
+      {
+        "name": "Emojis de Halloween",
+        "flags": [
+          "🎃",
+          "👻",
+          "🦇",
+          "🕷️",
+          "🕸️",
+          "💀",
+          "☠️",
+          "🧙‍♀️",
+          "🧛",
+          "🐈‍⬛",
+          "🍬",
+          "🌙",
+          "⚰️"
+        ],
+        "defaultFormat": "inline"
+      }
+    ]
+  },
+  "kaomoji": [
+    {
+      "text": "(((( ;°Д°))))",
+      "label": "Temblando de Miedo"
+    },
+    {
+      "text": "Σ(ﾟдﾟ;)",
+      "label": "Grito de Susto"
+    },
+    {
+      "text": "ヽ(゜Q。)ノ",
+      "label": "Fantasma Errante"
+    },
+    {
+      "text": "눈_눈",
+      "label": "Mirada Espeluznante"
+    },
+    {
+      "text": "(¬‿¬)",
+      "label": "Sonrisa Traviesa"
+    }
+  ],
+  "asciiArt": [
+    {
+      "art": "   .-'''-.\n  /  o o  \\\n |    >    |\n  \\  ___  /\n   '-...-'",
+      "label": "Calabaza de Halloween"
+    },
+    {
+      "art": "   ___\n  /   \\\n | o o |\n |  -  |\n |     |\n \\/\\/\\/",
+      "label": "Fantasma"
+    },
+    {
+      "art": "  /\\   /\\\n /  \\_/  \\\n(   ^ ^   )\n \\       /\n  \\/   \\/",
+      "label": "Murciélago"
+    },
+    {
+      "art": "   \\ | /\n    \\|/\n--(  o  )--\n    /|\\\n   / | \\",
+      "label": "Araña"
+    },
+    {
+      "art": "      /\\\n     /  \\\n    /    \\\n   /______\\\n  /________\\\n ~~~~~~~~~~~~",
+      "label": "Sombrero de Bruja"
+    },
+    {
+      "art": "  _________\n /   RIP   \\\n|           |\n|     +     |\n|___________|",
+      "label": "Lápida"
+    },
+    {
+      "art": "\\   |   /\n \\  |  /\n--- + ---\n /  |  \\\n/   |   \\",
+      "label": "Telaraña"
+    }
+  ],
+  "phraseBank": [
+    {
+      "text": "Feliz Halloween",
+      "nativeScript": "Feliz Halloween",
+      "romanization": "Feliz Halloween",
+      "translation": "El saludo clásico y universal para Halloween."
+    },
+    {
+      "text": "Truco o Trato",
+      "nativeScript": "Truco o Trato",
+      "romanization": "Truco o Trato",
+      "translation": "El grito clásico para pedir dulces de puerta en puerta."
+    },
+    {
+      "text": "Dulce o Truco",
+      "nativeScript": "Dulce o Truco",
+      "romanization": "Dulce o Truco",
+      "translation": "Una variante regional de \"Truco o Trato\" que también se usa mucho."
+    },
+    {
+      "text": "¡Buuu!",
+      "nativeScript": "¡Buuu!",
+      "romanization": "¡Buuu!",
+      "translation": "Una manera corta y juguetona de asustar a alguien."
+    },
+    {
+      "text": "Feliz Noche de Brujas",
+      "nativeScript": "Feliz Noche de Brujas",
+      "romanization": "Feliz Noche de Brujas",
+      "translation": "Una alternativa festiva a \"Feliz Halloween\", muy usada en México y Centroamérica."
+    },
+    {
+      "text": "Que tengas una Noche de Brujas espeluznante",
+      "nativeScript": "Que tengas una Noche de Brujas espeluznante",
+      "romanization": "Que tengas una Noche de Brujas espeluznante",
+      "translation": "Un deseo festivo, ideal para tarjetas y mensajes más largos."
+    },
+    {
+      "text": "Que la pases espeluznante",
+      "nativeScript": "Que la pases espeluznante",
+      "romanization": "Que la pases espeluznante",
+      "translation": "Una despedida casual para pies de foto y publicaciones."
+    }
+  ],
+  "ui": {
+    "showingSample": "Mostrando “{sample}” — escribe tu propio nombre, deseo o saludo arriba.",
+    "copyButton": "Copiar",
+    "copyAriaPrefix": "Copiar ",
+    "asciiArtDefaultLabel": "Arte ASCII"
+  }
+};</script>
+<script src="/styles.js" defer></script>
+<script src="/renderer.js" defer></script>
+<script src="/script.js" defer></script>
+<script src="/js/events/eventPageController.js" defer></script>
+<script src="/symbol-explorer.js" defer></script>
+<script src="/footer.js"></script>
+</body>
+</html>

--- a/es/events/navidad/index.html
+++ b/es/events/navidad/index.html
@@ -1,0 +1,451 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <title>Generador de Fuentes, Emojis y Símbolos de Navidad | UltraTextGen</title>
+  <meta name="description" content="Dale estilo a tu mensaje de Navidad en vivo, copia emojis de árbol, Papá Noel y copos de nieve, kaomoji festivos, arte ASCII original y frases de Navidad listas para usar.">
+  <link rel="canonical" href="https://ultratextgen.com/es/events/navidad/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/events/christmas/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/events/navidad/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/es/events/navidad/">
+  <meta property="og:title" content="Generador de Fuentes, Emojis y Símbolos de Navidad | UltraTextGen">
+  <meta property="og:description" content="Dale estilo a tu mensaje de Navidad en vivo, copia emojis de árbol, Papá Noel y copos de nieve, kaomoji festivos, arte ASCII original y frases de Navidad listas para usar.">
+  <meta property="og:url" content="https://ultratextgen.com/es/events/navidad/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Generador de Fuentes, Emojis y Símbolos de Navidad | UltraTextGen">
+  <meta name="twitter:description" content="Dale estilo a tu mensaje de Navidad en vivo, copia emojis de árbol, Papá Noel y copos de nieve, kaomoji festivos, arte ASCII original y frases de Navidad listas para usar.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category.png">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=Space+Mono&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+  <link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Generador de Texto y Símbolos de Navidad",
+  "alternateName": [
+    "Feliz Navidad",
+    "Fuentes de Navidad",
+    "Símbolos de Navidad",
+    "Generador de Texto de Navidad"
+  ],
+  "url": "https://ultratextgen.com/es/events/navidad/",
+  "inLanguage": "es",
+  "applicationCategory": "UtilitiesApplication",
+  "operatingSystem": "Any",
+  "description": "Escribe un nombre o un deseo y dale estilo con fuentes clásicas en negrita, cursiva y gótica, luego copia emojis de árbol, Papá Noel y copos de nieve, kaomoji y arte ASCII — o toca una frase navideña para transformarla al instante.",
+  "featureList": [
+    "Estilos de fuente de Navidad en vivo para cualquier texto que escribas",
+    "Colección seleccionada de emojis y símbolos de Navidad",
+    "Kaomoji de Navidad",
+    "Arte ASCII seleccionado de Navidad",
+    "Banco de frases de Navidad con estilo al toque (escritura nativa, romanización, traducción)"
+  ],
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  }
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "es",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "¿Qué es el generador de texto y símbolos de Navidad?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "La Navidad es la fecha más importante del año para tarjetas y mensajes — árboles, calcetines y palabras que desean a familiares y amigos unas fiestas felices. Esta página reúne todo lo necesario para darle estilo a ese saludo: fuentes seleccionadas que puedes previsualizar con tu propio texto, los emojis de árbol, Papá Noel y copo de nieve que la gente realmente usa, kaomoji para un mensaje de chat alegre, algunas piezas de arte ASCII originales y un banco de frases navideñas listas para copiar que se transforman al instante al tocarlas."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Cuándo es Navidad?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Navidad cae diciembre, con el día principal cayendo el 25 de diciembre de cada año. Consulta un calendario actualizado para la fecha exacta y vuelve para darle estilo a tu mensaje."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Cómo uso el generador de Navidad?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Escribe un nombre, deseo o saludo en el cuadro de arriba. Cada estilo de fuente de Navidad se actualiza en vivo debajo — toca Copiar en cualquier tarjeta. Más abajo, toca cualquier emoji, símbolo, kaomoji o arte ASCII para copiarlo por separado, o toca una tarjeta del banco de frases para colocarla en el cuadro y verla transformada al instante."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Dónde encuentro más frases de Navidad y qué escribir?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Consulta <a href=\"https://ultratextgen.com/es/answers/que-escribir-en-una-tarjeta-de-navidad/\">nuestra respuesta completa</a> para más saludos, traducciones e ideas de mensajes."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Inicio",
+      "item": "https://ultratextgen.com/es/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Navidad",
+      "item": "https://ultratextgen.com/es/events/navidad/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/es/">Inicio</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Navidad</span>
+</nav>
+
+<section class="hero">
+  <div class="hero-inner">
+    <div class="hero-card">
+      <h1 class="hero-headline">Generador de Texto y Símbolos de Navidad</h1>
+      <p class="hero-tagline">Escribe un nombre o un deseo y dale estilo con fuentes clásicas en negrita, cursiva y gótica, luego copia emojis de árbol, Papá Noel y copos de nieve, kaomoji y arte ASCII — o toca una frase navideña para transformarla al instante.</p>
+      <p class="u-secondary-tight">También conocido como: Feliz Navidad</p>
+      <div class="input-wrapper" id="eventTextWrap">
+        <textarea class="main-input" id="mainInput" placeholder="Escribe un nombre, deseo o saludo..." maxlength="500" autofocus></textarea>
+        <span class="char-count"><span id="charCount">0</span>/500</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<main class="container">
+  <section class="editorial-section">
+    <div class="editorial-block">
+      <p>La Navidad es la fecha más importante del año para tarjetas y mensajes — árboles, calcetines y palabras que desean a familiares y amigos unas fiestas felices. Esta página reúne todo lo necesario para darle estilo a ese saludo: fuentes seleccionadas que puedes previsualizar con tu propio texto, los emojis de árbol, Papá Noel y copo de nieve que la gente realmente usa, kaomoji para un mensaje de chat alegre, algunas piezas de arte ASCII originales y un banco de frases navideñas listas para copiar que se transforman al instante al tocarlas.</p>
+    </div>
+    <div class="block-example">
+      <strong>Navidad:</strong> diciembre, con el día principal cayendo el 25 de diciembre de cada año
+    </div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <section class="editorial-section" id="eventFontsSection">
+    <span class="article-section-label">Fuentes</span>
+    <h2>Fuentes de Navidad</h2>
+    <p class="editorial-intro">Escribe tu texto arriba y cada estilo de abajo se actualiza en vivo. Toca Copiar en el que más te guste.</p>
+    <div class="results-grid" id="eventFontsGrid"></div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <section class="editorial-section" id="eventEmojiSection">
+    <span class="article-section-label">Emojis y Símbolos</span>
+    <h2>Emojis y Símbolos de Navidad</h2>
+    <p class="editorial-intro">Toca cualquier carácter para copiarlo, o copia todo un conjunto en el formato que prefieras.</p>
+    <div id="eventEmojiGrids"></div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <section class="editorial-section" id="eventKaomojiSection">
+    <span class="article-section-label">Kaomoji</span>
+    <h2>Kaomoji de Navidad</h2>
+    <p class="editorial-intro">Cada ficha es un kaomoji completo — toca para copiar la cadena entera en un clic.</p>
+    <div class="glyph-grid" id="eventKaomojiGrid"></div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <section class="editorial-section" id="eventAsciiSection">
+    <span class="article-section-label">Arte ASCII</span>
+    <h2>Arte ASCII de Navidad</h2>
+    <p class="editorial-intro">Piezas de varias líneas seleccionadas — toca Copiar para llevarte una con sus saltos de línea y espaciado intactos.</p>
+    <div class="art-piece-grid" id="eventAsciiGrid"></div>
+    <p class="u-secondary-tight u-mt-15">¿Quieres escribir tu propio nombre o mensaje en un banner de letras en bloque en vivo? Prueba el <a href="/ascii-art-generator/">Generador de Arte ASCII</a>.</p>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <section class="editorial-section" id="eventPhraseSection">
+    <span class="article-section-label">Banco de Frases</span>
+    <h2>Banco de Frases de Navidad</h2>
+    <p class="editorial-intro">Toca una frase para colocarla en el cuadro de arriba y verla transformada al instante en cada estilo de fuente.</p>
+    <div class="compare-grid" id="eventPhraseGrid"></div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <div class="cta-card">
+    <h3>Transforma texto con fuentes Unicode</h3>
+    <p>Usa UltraTextGen para convertir texto plano en negrita, cursiva y más de 100 estilos de fuente Unicode — gratis e instantáneo.</p>
+    <a href="https://ultratextgen.com/es/" class="cta-btn">Abrir UltraTextGen →</a>
+  </div>
+
+  <section class="editorial-section">
+    <span class="article-section-label">Recursos Relacionados</span>
+    <div class="compare-grid">
+    <a href="/library/christmas-symbols/" class="compare-card variant-muted u-no-underline">
+      <h4>Símbolos de Navidad</h4>
+      <p>Una biblioteca más amplia de símbolos y combinaciones de emoji navideños en Unicode (en inglés).</p>
+    </a>
+    <a href="/es/letra-cursiva/" class="compare-card variant-muted u-no-underline">
+      <h4>Letra Cursiva</h4>
+      <p>La familia completa de fuentes cursivas elegantes para tarjetas y mensajes navideños.</p>
+    </a>
+    <a href="/es/letras-goticas/" class="compare-card variant-muted u-no-underline">
+      <h4>Letras Góticas</h4>
+      <p>Estilos clásicos góticos y de época para un look navideño tradicional.</p>
+    </a>
+    <a href="/es/letras-negritas/" class="compare-card variant-muted u-no-underline">
+      <h4>Letras Negritas</h4>
+      <p>La familia completa de fuentes en negrita para titulares y mensajes.</p>
+    </a>
+    <a href="/ascii-art-generator/" class="compare-card variant-muted u-no-underline">
+      <h4>Generador de Arte ASCII</h4>
+      <p>Escribe cualquier palabra o nombre y conviértelo en un banner de letras en bloque en vivo (en inglés).</p>
+    </a>
+    <a href="/es/answers/que-escribir-en-una-tarjeta-de-navidad/" class="compare-card variant-muted u-no-underline">
+      <h4>Más frases y mensajes de Navidad</h4>
+      <p>Saludos, traducciones e ideas de mensajes más allá del banco de frases de arriba.</p>
+    </a>
+    </div>
+  </section>
+</main>
+
+<footer class="footer">
+  <div class="footer-inner">
+    <h2 class="faq-category">Preguntas sobre Navidad</h2>
+    <div class="faq-item">
+      <button class="faq-question" type="button">¿Qué es el generador de texto y símbolos de Navidad?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button>
+      <div class="faq-answer">La Navidad es la fecha más importante del año para tarjetas y mensajes — árboles, calcetines y palabras que desean a familiares y amigos unas fiestas felices. Esta página reúne todo lo necesario para darle estilo a ese saludo: fuentes seleccionadas que puedes previsualizar con tu propio texto, los emojis de árbol, Papá Noel y copo de nieve que la gente realmente usa, kaomoji para un mensaje de chat alegre, algunas piezas de arte ASCII originales y un banco de frases navideñas listas para copiar que se transforman al instante al tocarlas.</div>
+    </div>
+    <div class="faq-item">
+      <button class="faq-question" type="button">¿Cuándo es Navidad?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button>
+      <div class="faq-answer">Navidad cae diciembre, con el día principal cayendo el 25 de diciembre de cada año. Consulta un calendario actualizado para la fecha exacta y vuelve para darle estilo a tu mensaje.</div>
+    </div>
+    <div class="faq-item">
+      <button class="faq-question" type="button">¿Cómo uso el generador de Navidad?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button>
+      <div class="faq-answer">Escribe un nombre, deseo o saludo en el cuadro de arriba. Cada estilo de fuente de Navidad se actualiza en vivo debajo — toca Copiar en cualquier tarjeta. Más abajo, toca cualquier emoji, símbolo, kaomoji o arte ASCII para copiarlo por separado, o toca una tarjeta del banco de frases para colocarla en el cuadro y verla transformada al instante.</div>
+    </div>
+    <div class="faq-item">
+      <button class="faq-question" type="button">¿Dónde encuentro más frases de Navidad y qué escribir?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button>
+      <div class="faq-answer">Consulta <a href="https://ultratextgen.com/es/answers/que-escribir-en-una-tarjeta-de-navidad/">nuestra respuesta completa</a> para más saludos, traducciones e ideas de mensajes.</div>
+    </div>
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="copy-toast" id="copyToast">¡Copiado!</div>
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script>window.UTG_EVENT_MODE = true;</script>
+<script>window.UTG_EVENT_DATA = {
+  "slug": "navidad",
+  "eventName": "Navidad",
+  "aliases": [
+    "Feliz Navidad"
+  ],
+  "samplePhrase": "Feliz Navidad",
+  "fonts": {
+    "curatedKeys": [
+      "Ultra Bold",
+      "Ultra Bold Serif",
+      "Ultra Italic Serif",
+      "Ultra Script",
+      "Ultra Script Bold",
+      "Ultra Script Elegant",
+      "Ultra Gothic",
+      "Ultra Gothic Bold",
+      "Ultra Small Caps",
+      "Ultra Bubble"
+    ]
+  },
+  "emojiCollections": {
+    "containerId": "eventEmojiGrids",
+    "groups": [
+      {
+        "name": "Emojis de Navidad",
+        "flags": [
+          "🎄",
+          "🎅",
+          "🤶",
+          "🦌",
+          "🔔",
+          "🎁",
+          "⭐",
+          "❄️",
+          "☃️",
+          "⛄",
+          "🧦",
+          "🕯️",
+          "🍪"
+        ],
+        "defaultFormat": "inline"
+      }
+    ]
+  },
+  "kaomoji": [
+    {
+      "text": "(っ◕‿◕)っ❆",
+      "label": "Abrazo Nevado"
+    },
+    {
+      "text": "✧⁺⸜(◕‐◕)⸝⁺✧",
+      "label": "Alegría Brillante"
+    },
+    {
+      "text": "♪┏(・o・)┛♪┗(・o・)┓♪",
+      "label": "Baile de Villancicos"
+    },
+    {
+      "text": "(๑˃ᴗ˂)ﻭ❄",
+      "label": "Emoción por la Nieve"
+    },
+    {
+      "text": "(⋆❛ᴗ❛⋆)",
+      "label": "Calidez Acogedora"
+    }
+  ],
+  "asciiArt": [
+    {
+      "art": "      *\n     ^^^\n    ^^^^^\n   ^^^o^^^\n  ^^^^^^^^^\n    | | |\n    |___|",
+      "label": "Árbol de Navidad"
+    },
+    {
+      "art": "    .-''-.\n   ( o  o )\n    )  -  (\n   (        )\n  ( o      o )\n   '--------'\n    |      |",
+      "label": "Muñeco de Nieve"
+    },
+    {
+      "art": " .-----------.\n |     |     |\n |-----+-----|\n |     |     |\n '-----------'",
+      "label": "Caja de Regalo"
+    },
+    {
+      "art": "      *\n   *  *  *\n    * * *\n  *** * ***\n    * * *\n   *  *  *\n      *",
+      "label": "Estrella Brillante"
+    },
+    {
+      "art": "   ______\n  /      |\n /       |\n|        |\n|________|",
+      "label": "Calcetín"
+    },
+    {
+      "art": "    .-.\n   (   )\n  (     )\n  |     |\n  '-----'\n    (=)",
+      "label": "Campana"
+    },
+    {
+      "art": "    .-.\n   (   )\n  ( * )\n   (   )\n    '-'\n     |",
+      "label": "Adorno Navideño"
+    },
+    {
+      "art": "     *\n   * | *\n* --+-- *\n   * | *\n     *",
+      "label": "Copo de Nieve"
+    }
+  ],
+  "phraseBank": [
+    {
+      "text": "Feliz Navidad",
+      "nativeScript": "Feliz Navidad",
+      "romanization": "Feliz Navidad",
+      "translation": "El saludo universal y más usado para esta época del año."
+    },
+    {
+      "text": "Feliz Navidad y Próspero Año Nuevo",
+      "nativeScript": "Feliz Navidad y Próspero Año Nuevo",
+      "romanization": "Feliz Navidad y Próspero Año Nuevo",
+      "translation": "La versión completa, ideal para tarjetas y mensajes formales."
+    },
+    {
+      "text": "Que la Navidad te traiga paz y alegría",
+      "nativeScript": "Que la Navidad te traiga paz y alegría",
+      "romanization": "Que la Navidad te traiga paz y alegría",
+      "translation": "Un deseo cálido, perfecto para tarjetas y dedicatorias largas."
+    },
+    {
+      "text": "Con cariño en esta Navidad",
+      "nativeScript": "Con cariño en esta Navidad",
+      "romanization": "Con cariño en esta Navidad",
+      "translation": "Una despedida sencilla y afectuosa para cerrar un mensaje."
+    },
+    {
+      "text": "Felices Fiestas",
+      "nativeScript": "Felices Fiestas",
+      "romanization": "Felices Fiestas",
+      "translation": "Una alternativa inclusiva que abarca toda la temporada navideña."
+    },
+    {
+      "text": "Que el espíritu de la Navidad llene tu hogar de amor",
+      "nativeScript": "Que el espíritu de la Navidad llene tu hogar de amor",
+      "romanization": "Que el espíritu de la Navidad llene tu hogar de amor",
+      "translation": "Un deseo más poético, ideal para mensajes a la familia."
+    },
+    {
+      "text": "Los mejores deseos para ti y los tuyos en estas fiestas",
+      "nativeScript": "Los mejores deseos para ti y los tuyos en estas fiestas",
+      "romanization": "Los mejores deseos para ti y los tuyos en estas fiestas",
+      "translation": "Un saludo cordial para compañeros de trabajo o conocidos."
+    },
+    {
+      "text": "Abrazos y bendiciones en esta Navidad",
+      "nativeScript": "Abrazos y bendiciones en esta Navidad",
+      "romanization": "Abrazos y bendiciones en esta Navidad",
+      "translation": "Un cierre cálido y cercano para mensajes a seres queridos."
+    }
+  ],
+  "ui": {
+    "showingSample": "Mostrando “{sample}” — escribe tu propio nombre, deseo o saludo arriba.",
+    "copyButton": "Copiar",
+    "copyAriaPrefix": "Copiar ",
+    "asciiArtDefaultLabel": "Arte ASCII"
+  }
+};</script>
+<script src="/styles.js" defer></script>
+<script src="/renderer.js" defer></script>
+<script src="/script.js" defer></script>
+<script src="/js/events/eventPageController.js" defer></script>
+<script src="/symbol-explorer.js" defer></script>
+<script src="/footer.js"></script>
+</body>
+</html>

--- a/es/events/san-valentin/index.html
+++ b/es/events/san-valentin/index.html
@@ -1,0 +1,461 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <title>Generador de Fuentes, Símbolos y Kaomoji para San Valentín | UltraTextGen</title>
+  <meta name="description" content="Estiliza tu mensaje de San Valentín en vivo, copia corazones, rosas y besos en emoji, kaomoji, arte ASCII original y frases listas como Feliz San Valentín — toca para transformarlas al instante.">
+  <link rel="canonical" href="https://ultratextgen.com/es/events/san-valentin/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/events/valentines-day/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/events/san-valentin/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/es/events/san-valentin/">
+  <meta property="og:title" content="Generador de Fuentes, Símbolos y Kaomoji para San Valentín | UltraTextGen">
+  <meta property="og:description" content="Estiliza tu mensaje de San Valentín en vivo, copia corazones, rosas y besos en emoji, kaomoji, arte ASCII original y frases listas como Feliz San Valentín — toca para transformarlas al instante.">
+  <meta property="og:url" content="https://ultratextgen.com/es/events/san-valentin/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Generador de Fuentes, Símbolos y Kaomoji para San Valentín | UltraTextGen">
+  <meta name="twitter:description" content="Estiliza tu mensaje de San Valentín en vivo, copia corazones, rosas y besos en emoji, kaomoji, arte ASCII original y frases listas como Feliz San Valentín — toca para transformarlas al instante.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category.png">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=Space+Mono&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+  <link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Generador de Texto y Símbolos de San Valentín",
+  "alternateName": [
+    "Día de los Enamorados",
+    "Día del Amor y la Amistad",
+    "Fuentes de San Valentín",
+    "Símbolos de San Valentín",
+    "Generador de Texto de San Valentín"
+  ],
+  "url": "https://ultratextgen.com/es/events/san-valentin/",
+  "inLanguage": "es",
+  "applicationCategory": "UtilitiesApplication",
+  "operatingSystem": "Any",
+  "description": "Escribe un nombre o mensaje y transfórmalo en fuentes cursivas elegantes; luego copia corazones, rosas, besos, kaomoji y arte ASCII, o toca una frase lista para estilizarla al instante.",
+  "featureList": [
+    "Estilos de fuente de San Valentín en vivo para cualquier texto que escribas",
+    "Colección seleccionada de emojis y símbolos de San Valentín",
+    "Kaomoji de San Valentín",
+    "Arte ASCII seleccionado de San Valentín",
+    "Banco de frases de San Valentín con estilo al toque (escritura nativa, romanización, traducción)"
+  ],
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  }
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "es",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "¿Qué es el generador de texto y símbolos de San Valentín?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "San Valentín es la fecha romántica más importante del año: tarjetas, mensajes y publicaciones que giran en torno a corazones, rosas y un puñado de frases que todos usamos tarde o temprano (Feliz San Valentín, Te quiero, Eres mi persona favorita). Esta página reúne todo lo necesario para darle estilo a ese mensaje: fuentes cursivas y elegantes que puedes previsualizar con tu propio texto, los emojis de corazones y rosas que la gente realmente comparte, kaomoji para un mensaje coqueto, algunas piezas de arte ASCII originales hechas a mano, y un banco de frases listas que se transforman al instante con solo tocarlas."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Cuándo es San Valentín?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "San Valentín cae cada año el 14 de febrero. Consulta un calendario actualizado para la fecha exacta y vuelve para darle estilo a tu mensaje."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Cómo uso el generador de San Valentín?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Escribe un nombre, deseo o saludo en el cuadro de arriba. Cada estilo de fuente de San Valentín se actualiza en vivo debajo — toca Copiar en cualquier tarjeta. Más abajo, toca cualquier emoji, símbolo, kaomoji o arte ASCII para copiarlo por separado, o toca una tarjeta del banco de frases para colocarla en el cuadro y verla transformada al instante."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Dónde encuentro más frases de San Valentín y qué escribir?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Consulta <a href=\"https://ultratextgen.com/es/answers/que-escribir-en-una-tarjeta-de-san-valentin/\">nuestra respuesta completa</a> para más saludos, traducciones e ideas de mensajes."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Inicio",
+      "item": "https://ultratextgen.com/es/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "San Valentín",
+      "item": "https://ultratextgen.com/es/events/san-valentin/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/es/">Inicio</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">San Valentín</span>
+</nav>
+
+<section class="hero">
+  <div class="hero-inner">
+    <div class="hero-card">
+      <h1 class="hero-headline">Generador de Texto y Símbolos para San Valentín</h1>
+      <p class="hero-tagline">Escribe un nombre o mensaje y transfórmalo en fuentes cursivas elegantes; luego copia corazones, rosas, besos, kaomoji y arte ASCII, o toca una frase lista para estilizarla al instante.</p>
+      <p class="u-secondary-tight">También conocido como: Día de los Enamorados, Día del Amor y la Amistad</p>
+      <div class="input-wrapper" id="eventTextWrap">
+        <textarea class="main-input" id="mainInput" placeholder="Escribe un nombre, deseo o saludo..." maxlength="500" autofocus></textarea>
+        <span class="char-count"><span id="charCount">0</span>/500</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<main class="container">
+  <section class="editorial-section">
+    <div class="editorial-block">
+      <p>San Valentín es la fecha romántica más importante del año: tarjetas, mensajes y publicaciones que giran en torno a corazones, rosas y un puñado de frases que todos usamos tarde o temprano (Feliz San Valentín, Te quiero, Eres mi persona favorita). Esta página reúne todo lo necesario para darle estilo a ese mensaje: fuentes cursivas y elegantes que puedes previsualizar con tu propio texto, los emojis de corazones y rosas que la gente realmente comparte, kaomoji para un mensaje coqueto, algunas piezas de arte ASCII originales hechas a mano, y un banco de frases listas que se transforman al instante con solo tocarlas.</p>
+    </div>
+    <div class="block-example">
+      <strong>San Valentín:</strong> cada año el 14 de febrero
+    </div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <section class="editorial-section" id="eventFontsSection">
+    <span class="article-section-label">Fuentes</span>
+    <h2>Fuentes de San Valentín</h2>
+    <p class="editorial-intro">Escribe tu texto arriba y cada estilo de abajo se actualiza en vivo. Toca Copiar en el que más te guste.</p>
+    <div class="results-grid" id="eventFontsGrid"></div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <section class="editorial-section" id="eventEmojiSection">
+    <span class="article-section-label">Emojis y Símbolos</span>
+    <h2>Emojis y Símbolos de San Valentín</h2>
+    <p class="editorial-intro">Toca cualquier carácter para copiarlo, o copia todo un conjunto en el formato que prefieras.</p>
+    <div id="eventEmojiGrids"></div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <section class="editorial-section" id="eventKaomojiSection">
+    <span class="article-section-label">Kaomoji</span>
+    <h2>Kaomoji de San Valentín</h2>
+    <p class="editorial-intro">Cada ficha es un kaomoji completo — toca para copiar la cadena entera en un clic.</p>
+    <div class="glyph-grid" id="eventKaomojiGrid"></div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <section class="editorial-section" id="eventAsciiSection">
+    <span class="article-section-label">Arte ASCII</span>
+    <h2>Arte ASCII de San Valentín</h2>
+    <p class="editorial-intro">Piezas de varias líneas seleccionadas — toca Copiar para llevarte una con sus saltos de línea y espaciado intactos.</p>
+    <div class="art-piece-grid" id="eventAsciiGrid"></div>
+    <p class="u-secondary-tight u-mt-15">¿Quieres escribir tu propio nombre o mensaje en un banner de letras en bloque en vivo? Prueba el <a href="/ascii-art-generator/">Generador de Arte ASCII</a>.</p>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <section class="editorial-section" id="eventPhraseSection">
+    <span class="article-section-label">Banco de Frases</span>
+    <h2>Banco de Frases de San Valentín</h2>
+    <p class="editorial-intro">Toca una frase para colocarla en el cuadro de arriba y verla transformada al instante en cada estilo de fuente.</p>
+    <div class="compare-grid" id="eventPhraseGrid"></div>
+  </section>
+
+  <div class="section-divider"></div>
+
+  <div class="cta-card">
+    <h3>Transforma texto con fuentes Unicode</h3>
+    <p>Usa UltraTextGen para convertir texto plano en negrita, cursiva y más de 100 estilos de fuente Unicode — gratis e instantáneo.</p>
+    <a href="https://ultratextgen.com/es/" class="cta-btn">Abrir UltraTextGen →</a>
+  </div>
+
+  <section class="editorial-section">
+    <span class="article-section-label">Recursos Relacionados</span>
+    <div class="compare-grid">
+    <a href="/es/simbolos-de-corazon/" class="compare-card variant-muted u-no-underline">
+      <h4>Colección de Símbolos de Corazón</h4>
+      <p>Explora y copia emojis de corazón, caracteres Unicode de corazón y símbolos románticos en todos los colores y estilos.</p>
+    </a>
+    <a href="/library/love-kaomoji/" class="compare-card variant-muted u-no-underline">
+      <h4>Kaomoji de Amor y Corazones</h4>
+      <p>Una biblioteca más amplia de kaomoji de amor y corazones — caritas japonesas para el cariño, los besos, los abrazos y los enamoramientos.</p>
+    </a>
+    <a href="/library/heart-ascii-art/" class="compare-card variant-muted u-no-underline">
+      <h4>Arte ASCII de Corazones</h4>
+      <p>Más arte ASCII de corazones original, desde un pequeño &lt;3 de una línea hasta corazones grandes, sólidos o con contorno.</p>
+    </a>
+    <a href="/es/letra-cursiva/" class="compare-card variant-muted u-no-underline">
+      <h4>Letra Cursiva</h4>
+      <p>La familia completa de fuentes cursivas para tarjetas, mensajes y firmas elegantes.</p>
+    </a>
+    <a href="/library/kiss-kaomoji/" class="compare-card variant-muted u-no-underline">
+      <h4>Kaomoji de Besos</h4>
+      <p>Caritas de besos para un mensaje coqueto o una dedicatoria de San Valentín.</p>
+    </a>
+    <a href="/es/answers/que-escribir-en-una-tarjeta-de-san-valentin/" class="compare-card variant-muted u-no-underline">
+      <h4>Más frases y mensajes de San Valentín</h4>
+      <p>Saludos, traducciones e ideas de mensajes más allá del banco de frases de arriba.</p>
+    </a>
+    </div>
+  </section>
+</main>
+
+<footer class="footer">
+  <div class="footer-inner">
+    <h2 class="faq-category">Preguntas sobre San Valentín</h2>
+    <div class="faq-item">
+      <button class="faq-question" type="button">¿Qué es el generador de texto y símbolos de San Valentín?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button>
+      <div class="faq-answer">San Valentín es la fecha romántica más importante del año: tarjetas, mensajes y publicaciones que giran en torno a corazones, rosas y un puñado de frases que todos usamos tarde o temprano (Feliz San Valentín, Te quiero, Eres mi persona favorita). Esta página reúne todo lo necesario para darle estilo a ese mensaje: fuentes cursivas y elegantes que puedes previsualizar con tu propio texto, los emojis de corazones y rosas que la gente realmente comparte, kaomoji para un mensaje coqueto, algunas piezas de arte ASCII originales hechas a mano, y un banco de frases listas que se transforman al instante con solo tocarlas.</div>
+    </div>
+    <div class="faq-item">
+      <button class="faq-question" type="button">¿Cuándo es San Valentín?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button>
+      <div class="faq-answer">San Valentín cae cada año el 14 de febrero. Consulta un calendario actualizado para la fecha exacta y vuelve para darle estilo a tu mensaje.</div>
+    </div>
+    <div class="faq-item">
+      <button class="faq-question" type="button">¿Cómo uso el generador de San Valentín?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button>
+      <div class="faq-answer">Escribe un nombre, deseo o saludo en el cuadro de arriba. Cada estilo de fuente de San Valentín se actualiza en vivo debajo — toca Copiar en cualquier tarjeta. Más abajo, toca cualquier emoji, símbolo, kaomoji o arte ASCII para copiarlo por separado, o toca una tarjeta del banco de frases para colocarla en el cuadro y verla transformada al instante.</div>
+    </div>
+    <div class="faq-item">
+      <button class="faq-question" type="button">¿Dónde encuentro más frases de San Valentín y qué escribir?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button>
+      <div class="faq-answer">Consulta <a href="https://ultratextgen.com/es/answers/que-escribir-en-una-tarjeta-de-san-valentin/">nuestra respuesta completa</a> para más saludos, traducciones e ideas de mensajes.</div>
+    </div>
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="copy-toast" id="copyToast">¡Copiado!</div>
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script>window.UTG_EVENT_MODE = true;</script>
+<script>window.UTG_EVENT_DATA = {
+  "slug": "san-valentin",
+  "eventName": "San Valentín",
+  "aliases": [
+    "Día de los Enamorados",
+    "Día del Amor y la Amistad"
+  ],
+  "samplePhrase": "Feliz San Valentín",
+  "fonts": {
+    "curatedKeys": [
+      "Ultra Script",
+      "Ultra Script Bold",
+      "Ultra Script Elegant",
+      "Ultra Script Bold Elegant",
+      "Ultra Script Sparkle",
+      "Ultra Cute Script",
+      "Ultra Italic Serif",
+      "Ultra Bold Italic Serif",
+      "Ultra Small Caps",
+      "Ultra Cute Bubble"
+    ]
+  },
+  "emojiCollections": {
+    "containerId": "eventEmojiGrids",
+    "groups": [
+      {
+        "name": "Corazones, Rosas y Besos",
+        "flags": [
+          "❤️",
+          "🧡",
+          "💛",
+          "💚",
+          "💙",
+          "💜",
+          "🖤",
+          "🤍",
+          "💕",
+          "💗",
+          "💖",
+          "💘",
+          "🌹",
+          "💌",
+          "💋"
+        ],
+        "defaultFormat": "inline"
+      }
+    ]
+  },
+  "kaomoji": [
+    {
+      "text": "(｡♥‿♥｡)",
+      "label": "Ojos de Corazón"
+    },
+    {
+      "text": "(♡˃͈ ᵕ ˂͈♡)",
+      "label": "Enamorado Sonrojado"
+    },
+    {
+      "text": "♡＾▽＾♡",
+      "label": "Amor Alegre"
+    },
+    {
+      "text": "(´ ω `♡)",
+      "label": "Sonrisa Dulce"
+    },
+    {
+      "text": "(´♡‿♡`)",
+      "label": "Adoración"
+    },
+    {
+      "text": "( ˘ ³˘)♥",
+      "label": "Beso"
+    },
+    {
+      "text": "(づ ◕‿◕ )づ",
+      "label": "Abrazo Cálido"
+    }
+  ],
+  "asciiArt": [
+    {
+      "art": " __    __\n/  \\  /  \\\n\\   \\/   /\n \\      /\n  \\    /\n   \\  /\n    \\/",
+      "label": "Corazón"
+    },
+    {
+      "art": " __  __     __  __\n/  \\/  \\   /  \\/  \\\n\\      /   \\      /\n \\    /     \\    /\n  \\  /       \\  /\n   \\/         \\/",
+      "label": "Dos Corazones"
+    },
+    {
+      "art": "     @\n    /=\\\n   |   |\n     |\n   --+--\n     |\n    /  \\",
+      "label": "Rosa"
+    },
+    {
+      "art": "        __    __\n       /  \\  /  \\\n======>\\   \\/   /======>\n        \\      /\n         \\    /\n          \\  /\n           \\/",
+      "label": "Flecha de Cupido"
+    },
+    {
+      "art": " _________________\n|\\               /|\n| \\             / |\n|  \\    <3     /  |\n|   \\         /   |\n|    \\       /    |\n|     \\     /     |\n|______\\___/______|",
+      "label": "Carta de Amor"
+    },
+    {
+      "art": "  ,-\"\".,-\"\".\n ( .. )( .. )\n  `-..-'`-..-'\n     `.__.'",
+      "label": "Marca de Beso"
+    }
+  ],
+  "phraseBank": [
+    {
+      "text": "Feliz San Valentín",
+      "nativeScript": "Feliz San Valentín",
+      "romanization": "Feliz San Valentín",
+      "translation": "El saludo universal — funciona en cualquier tarjeta, mensaje o historia."
+    },
+    {
+      "text": "Feliz Día del Amor y la Amistad",
+      "nativeScript": "Feliz Día del Amor y la Amistad",
+      "romanization": "Feliz Día del Amor y la Amistad",
+      "translation": "El saludo preferido en México y buena parte de Latinoamérica."
+    },
+    {
+      "text": "Te quiero",
+      "nativeScript": "Te quiero",
+      "romanization": "Te quiero",
+      "translation": "La declaración clásica y cercana — sirve para pareja, familia o amigos íntimos."
+    },
+    {
+      "text": "Te amo",
+      "nativeScript": "Te amo",
+      "romanization": "Te amo",
+      "translation": "Más intensa que 'te quiero' — pensada para una pareja de mucho tiempo."
+    },
+    {
+      "text": "Eres mi persona favorita",
+      "nativeScript": "Eres mi persona favorita",
+      "romanization": "Eres mi persona favorita",
+      "translation": "Una línea moderna y cálida, perfecta para una pareja o un mejor amigo."
+    },
+    {
+      "text": "Mi corazón es tuyo",
+      "nativeScript": "Mi corazón es tuyo",
+      "romanization": "Mi corazón es tuyo",
+      "translation": "Una frase poética para una tarjeta, una carta de amor o un mensaje nocturno."
+    },
+    {
+      "text": "¿Quieres ser mi Valentín?",
+      "nativeScript": "¿Quieres ser mi Valentín?",
+      "romanization": "¿Quieres ser mi Valentín?",
+      "translation": "La pregunta juguetona y algo nerviosa — combina bien con una rosa o un corazón."
+    },
+    {
+      "text": "Contigo quiero estar siempre",
+      "nativeScript": "Contigo quiero estar siempre",
+      "romanization": "Contigo quiero estar siempre",
+      "translation": "Una promesa de largo plazo, ideal para cerrar una tarjeta o una carta."
+    },
+    {
+      "text": "Con todo mi corazón",
+      "nativeScript": "Con todo mi corazón",
+      "romanization": "Con todo mi corazón",
+      "translation": "El cierre clásico para el final de una tarjeta o un mensaje."
+    }
+  ],
+  "ui": {
+    "showingSample": "Mostrando “{sample}” — escribe tu propio nombre, deseo o saludo arriba.",
+    "copyButton": "Copiar",
+    "copyAriaPrefix": "Copiar ",
+    "asciiArtDefaultLabel": "Arte ASCII"
+  }
+};</script>
+<script src="/styles.js" defer></script>
+<script src="/renderer.js" defer></script>
+<script src="/script.js" defer></script>
+<script src="/js/events/eventPageController.js" defer></script>
+<script src="/symbol-explorer.js" defer></script>
+<script src="/footer.js"></script>
+</body>
+</html>

--- a/js/events/eventPageController.js
+++ b/js/events/eventPageController.js
@@ -35,8 +35,21 @@
        },
        kaomoji:  [{ text, label }],
        asciiArt: [{ art, label }],
-       phraseBank: [{ text, nativeScript, romanization, translation }]
+       phraseBank: [{ text, nativeScript, romanization, translation }],
+       ui: {                                         // OPTIONAL, non-English pages only
+         showingSample, copyButton, copyAriaPrefix, asciiArtDefaultLabel
+       }
      }
+
+   `ui` overrides this controller's own small set of hardcoded English
+   strings (the "Showing "<sample>"..." helper line, the "Copy" button
+   label, and the "Copy " aria-label prefix) -- the same optional
+   inline-config-override precedent as `window.tattooI18n` / `window.verticalI18n`
+   (see js/tattoo/tattooPageController.js, js/vertical/verticalPageController.js).
+   Everything else user-facing on an event page is generated per-page,
+   already-translated static HTML by scripts/generate_event_page_from_spec.py
+   (see its STRINGS dict) and needs no override here. Missing `ui` keys fall
+   back to the built-in English defaults below.
 
    DOM contract a generated page must provide (see
    scripts/generate_event_page_from_spec.py):
@@ -63,6 +76,15 @@
 
   const SAMPLE_TEXT = DATA.samplePhrase || DATA.eventName || "your text";
   let renderTimer = null;
+
+  /* A page in a non-English language defines window.UTG_EVENT_DATA.ui with
+     translated overrides for this controller's own small set of hardcoded
+     English strings (same optional-override precedent as window.tattooI18n /
+     window.verticalI18n). Missing keys fall back to the English default. */
+  const UI = DATA.ui || {};
+  function t(key, fallback) {
+    return UI[key] != null ? UI[key] : fallback;
+  }
 
   /* ---- Helpers (same tiny DOM helpers as tattooPageController.js) ---- */
   function $(sel, root) { return (root || document).querySelector(sel); }
@@ -100,7 +122,7 @@
     card.appendChild(info);
 
     const actions = el("div", "style-actions");
-    const btn = el("button", "copy-btn", "Copy");
+    const btn = el("button", "copy-btn", t("copyButton", "Copy"));
     btn.type = "button";
     btn.dataset.text = text;
     btn.dataset.style = styleKey;
@@ -120,8 +142,10 @@
     const text = raw || SAMPLE_TEXT;
 
     if (!raw) {
+      const showingSample = t("showingSample",
+        "Showing “{sample}” — type your own name, wish, or greeting above.");
       grid.appendChild(el("p", "u-secondary-tight",
-        "Showing “" + SAMPLE_TEXT + "” — type your own name, wish, or greeting above."));
+        showingSample.replace("{sample}", SAMPLE_TEXT)));
     }
 
     const keys = (DATA.fonts && DATA.fonts.curatedKeys) || [];
@@ -164,7 +188,7 @@
       tile.type = "button";
       tile.dataset.text = item.text;
       tile.textContent = item.text;
-      if (item.label) tile.setAttribute("aria-label", "Copy " + item.label);
+      if (item.label) tile.setAttribute("aria-label", t("copyAriaPrefix", "Copy ") + item.label);
       grid.appendChild(tile);
     });
   }
@@ -180,7 +204,7 @@
     const text = pre.textContent.replace(/\s+$/, "");
     const ns = window.UltraTextGen;
     if (ns && typeof ns.copyText === "function") {
-      ns.copyText(text, btn, label || "ASCII art");
+      ns.copyText(text, btn, label || t("asciiArtDefaultLabel", "ASCII art"));
       return;
     }
     if (navigator.clipboard && navigator.clipboard.writeText) {
@@ -198,11 +222,11 @@
       const card = el("div", "art-piece-card");
 
       const head = el("div", "art-piece-head");
-      head.appendChild(el("span", "art-piece-label", piece.label || "ASCII Art"));
-      const copyBtn = el("button", "art-piece-copy", "Copy");
+      head.appendChild(el("span", "art-piece-label", piece.label || t("asciiArtDefaultLabel", "ASCII Art")));
+      const copyBtn = el("button", "art-piece-copy", t("copyButton", "Copy"));
       copyBtn.type = "button";
-      copyBtn.dataset.label = piece.label || "ASCII art";
-      copyBtn.setAttribute("aria-label", "Copy " + (piece.label || "ASCII art"));
+      copyBtn.dataset.label = piece.label || t("asciiArtDefaultLabel", "ASCII art");
+      copyBtn.setAttribute("aria-label", t("copyAriaPrefix", "Copy ") + (piece.label || t("asciiArtDefaultLabel", "ASCII art")));
       head.appendChild(copyBtn);
       card.appendChild(head);
 

--- a/scripts/generate_event_page_from_spec.py
+++ b/scripts/generate_event_page_from_spec.py
@@ -63,6 +63,242 @@ REQUIRED_TOP = [
 VALID_PRESENTATION_CLASSES = ("symbol", "emoji", "emoticon", "kaomoji")
 VALID_COPY_PATTERNS = ("single", "combo", "collection", "section", "transform")
 
+DEFAULT_LANGUAGE = "en"
+
+# Languages that already have a localized /<lang>/events/ hub page. Every
+# other language falls back to a 2-item breadcrumb (Home > Event) instead of
+# linking a middle "Events" crumb that doesn't exist yet — same convention
+# the July-2026 library translation batch used for /<lang>/library/. Flip a
+# language on here once its hub page ships.
+LANGS_WITH_EVENTS_HUB = {"en"}
+
+# --------------------------------------------------------------------------
+# i18n strings
+# --------------------------------------------------------------------------
+# Every hardcoded English string the generator bakes into a page, keyed by
+# language code. "en" is both a real table AND the fallback for any key
+# missing under another language, so adding a 3rd language only means adding
+# a (possibly partial) new table here -- never touching the render_*
+# functions below. See tr() for the lookup + .format() behavior.
+STRINGS = {
+    "en": {
+        "breadcrumb_home": "Home",
+        "breadcrumb_events": "Events",
+        "faq_what_is_q": "What is the {event_name} text and symbol generator?",
+        "faq_when_q": "When is {event_name}?",
+        "faq_when_a": "{event_name} falls {date_window}. Check a current calendar for "
+                      "the exact date, then come back and style your greeting for it.",
+        "faq_how_q": "How do I use the {event_name} generator?",
+        "faq_how_a": "Type a name, wish, or greeting into the box at the top. Every "
+                     "{event_name} font style updates live underneath it — tap Copy on any "
+                     "card. Below that, tap any emoji, symbol, kaomoji, or ASCII art piece to "
+                     "copy it on its own, or tap a phrase-bank card to drop a ready-made "
+                     "greeting into the box and see it restyled instantly.",
+        "faq_more_q": "Where can I find more {event_name} phrases and what to write?",
+        "faq_more_a": 'See <a href="{href}">our full answer</a> for more greetings, '
+                      "translations, and message ideas.",
+        "webapp_name": "{event_name} Text & Symbol Generator",
+        "alt_fonts": "{event_name} Fonts",
+        "alt_symbols": "{event_name} Symbols",
+        "alt_textgen": "{event_name} Text Generator",
+        "feature_fonts": "Live {event_name} font styles for any text you type",
+        "feature_emoji": "Curated {event_name} emoji & symbol collection",
+        "feature_kaomoji": "{event_name} kaomoji",
+        "feature_ascii": "Curated {event_name} ASCII art",
+        "feature_phrase": "Click-to-style {event_name} phrase bank (native script, "
+                          "romanization, translation)",
+        "aka_label": "Also known as: ",
+        "textarea_placeholder": "Type a name, wish, or greeting...",
+        "section_fonts_label": "Fonts",
+        "section_fonts_heading": "{event_name} Fonts",
+        "section_fonts_intro": "Type your text above and every style below updates live. "
+                               "Tap Copy on the one you like.",
+        "section_emoji_label": "Emoji &amp; Symbols",
+        "section_emoji_heading": "{event_name} Emoji &amp; Symbols",
+        "section_emoji_intro": "Tap any character to copy it, or copy a whole set at once "
+                               "in your preferred format.",
+        "section_kaomoji_label": "Kaomoji",
+        "section_kaomoji_heading": "{event_name} Kaomoji",
+        "section_kaomoji_intro": "Each tile is a whole kaomoji — tap to copy the full "
+                                 "string in one click.",
+        "section_ascii_label": "ASCII Art",
+        "section_ascii_heading": "{event_name} ASCII Art",
+        "section_ascii_intro": "Curated multi-line pieces — tap Copy to grab one with its "
+                               "line breaks and spacing intact.",
+        "section_ascii_cta": 'Want to type your own name or message into a live '
+                             'block-letter banner instead? Try the <a href="{href}">ASCII '
+                             'Art Generator</a>.',
+        "section_phrase_label": "Phrase Bank",
+        "section_phrase_heading": "{event_name} Phrase Bank",
+        "section_phrase_intro": "Tap a phrase to drop it into the box up top and see every "
+                                "font style above restyle it instantly.",
+        "cta_heading": "Transform text with Unicode fonts",
+        "cta_body": "Use UltraTextGen to convert plain text into bold, italic, cursive, and "
+                    "100+ other Unicode font styles — free and instant.",
+        "cta_button": "Open UltraTextGen →",
+        "related_heading": "Related Resources",
+        "related_more_title": "More {event_name} phrases &amp; wording",
+        "related_more_desc": "Greetings, translations, and message ideas beyond the phrase "
+                             "bank above.",
+        "related_more_fallback_name": "this event",
+        "footer_heading": "{event_name} questions",
+        "copy_toast": "Copied!",
+    },
+    "es": {
+        "breadcrumb_home": "Inicio",
+        "breadcrumb_events": "Eventos",
+        "faq_what_is_q": "¿Qué es el generador de texto y símbolos de {event_name}?",
+        "faq_when_q": "¿Cuándo es {event_name}?",
+        "faq_when_a": "{event_name} cae {date_window}. Consulta un calendario actualizado "
+                      "para la fecha exacta y vuelve para darle estilo a tu mensaje.",
+        "faq_how_q": "¿Cómo uso el generador de {event_name}?",
+        "faq_how_a": "Escribe un nombre, deseo o saludo en el cuadro de arriba. Cada estilo "
+                     "de fuente de {event_name} se actualiza en vivo debajo — toca Copiar en "
+                     "cualquier tarjeta. Más abajo, toca cualquier emoji, símbolo, kaomoji o "
+                     "arte ASCII para copiarlo por separado, o toca una tarjeta del banco de "
+                     "frases para colocarla en el cuadro y verla transformada al instante.",
+        "faq_more_q": "¿Dónde encuentro más frases de {event_name} y qué escribir?",
+        "faq_more_a": 'Consulta <a href="{href}">nuestra respuesta completa</a> para más '
+                      "saludos, traducciones e ideas de mensajes.",
+        "webapp_name": "Generador de Texto y Símbolos de {event_name}",
+        "alt_fonts": "Fuentes de {event_name}",
+        "alt_symbols": "Símbolos de {event_name}",
+        "alt_textgen": "Generador de Texto de {event_name}",
+        "feature_fonts": "Estilos de fuente de {event_name} en vivo para cualquier texto "
+                        "que escribas",
+        "feature_emoji": "Colección seleccionada de emojis y símbolos de {event_name}",
+        "feature_kaomoji": "Kaomoji de {event_name}",
+        "feature_ascii": "Arte ASCII seleccionado de {event_name}",
+        "feature_phrase": "Banco de frases de {event_name} con estilo al toque (escritura "
+                          "nativa, romanización, traducción)",
+        "aka_label": "También conocido como: ",
+        "textarea_placeholder": "Escribe un nombre, deseo o saludo...",
+        "section_fonts_label": "Fuentes",
+        "section_fonts_heading": "Fuentes de {event_name}",
+        "section_fonts_intro": "Escribe tu texto arriba y cada estilo de abajo se actualiza "
+                               "en vivo. Toca Copiar en el que más te guste.",
+        "section_emoji_label": "Emojis y Símbolos",
+        "section_emoji_heading": "Emojis y Símbolos de {event_name}",
+        "section_emoji_intro": "Toca cualquier carácter para copiarlo, o copia todo un "
+                               "conjunto en el formato que prefieras.",
+        "section_kaomoji_label": "Kaomoji",
+        "section_kaomoji_heading": "Kaomoji de {event_name}",
+        "section_kaomoji_intro": "Cada ficha es un kaomoji completo — toca para copiar la "
+                                 "cadena entera en un clic.",
+        "section_ascii_label": "Arte ASCII",
+        "section_ascii_heading": "Arte ASCII de {event_name}",
+        "section_ascii_intro": "Piezas de varias líneas seleccionadas — toca Copiar para "
+                               "llevarte una con sus saltos de línea y espaciado intactos.",
+        "section_ascii_cta": '¿Quieres escribir tu propio nombre o mensaje en un banner de '
+                             'letras en bloque en vivo? Prueba el <a href="{href}">Generador '
+                             'de Arte ASCII</a>.',
+        "section_phrase_label": "Banco de Frases",
+        "section_phrase_heading": "Banco de Frases de {event_name}",
+        "section_phrase_intro": "Toca una frase para colocarla en el cuadro de arriba y "
+                                "verla transformada al instante en cada estilo de fuente.",
+        "cta_heading": "Transforma texto con fuentes Unicode",
+        "cta_body": "Usa UltraTextGen para convertir texto plano en negrita, cursiva y más "
+                    "de 100 estilos de fuente Unicode — gratis e instantáneo.",
+        "cta_button": "Abrir UltraTextGen →",
+        "related_heading": "Recursos Relacionados",
+        "related_more_title": "Más frases y mensajes de {event_name}",
+        "related_more_desc": "Saludos, traducciones e ideas de mensajes más allá del banco "
+                             "de frases de arriba.",
+        "related_more_fallback_name": "este evento",
+        "footer_heading": "Preguntas sobre {event_name}",
+        "copy_toast": "¡Copiado!",
+    },
+}
+
+
+# js/events/eventPageController.js's own small set of hardcoded English
+# strings (see its `ui` doc comment) -- these are NOT part of the HTML
+# STRINGS table above because they're read by the *controller* at runtime,
+# not baked into static HTML. Auto-applied to window.UTG_EVENT_DATA.ui for
+# any language with a table here; a spec's own "ui" field (if authored)
+# always takes precedence -- see render_event_data().
+JS_UI_STRINGS = {
+    "es": {
+        "showingSample": "Mostrando “{sample}” — escribe tu propio nombre, deseo o "
+                          "saludo arriba.",
+        "copyButton": "Copiar",
+        "copyAriaPrefix": "Copiar ",
+        "asciiArtDefaultLabel": "Arte ASCII",
+    },
+}
+
+
+def tr(language, key, **kwargs):
+    """Look up STRINGS[language][key], falling back to STRINGS['en'][key] for
+    any language/key combo that hasn't been translated yet, then .format()
+    it with whatever kwargs were passed (event_name=..., href=..., ...)."""
+    table = STRINGS.get(language) or {}
+    template = table.get(key, STRINGS[DEFAULT_LANGUAGE].get(key, ""))
+    return template.format(**kwargs) if kwargs else template
+
+
+def home_href(language):
+    """Relative path to the site's homepage in this language."""
+    return "/" if language == DEFAULT_LANGUAGE else f"/{language}/"
+
+
+def events_hub_href(language):
+    """Relative path to this language's /events/ hub, or None if that hub
+    doesn't exist yet (see LANGS_WITH_EVENTS_HUB) -- callers should then omit
+    the middle breadcrumb crumb entirely rather than link a 404."""
+    if language not in LANGS_WITH_EVENTS_HUB:
+        return None
+    return "/events/" if language == DEFAULT_LANGUAGE else f"/{language}/events/"
+
+
+def answers_prefix(language):
+    """Relative path prefix for /answers/ pages in this language."""
+    return "/answers/" if language == DEFAULT_LANGUAGE else f"/{language}/answers/"
+
+
+def events_canonical_default(language, slug):
+    """Fallback canonical URL when a spec doesn't set one explicitly."""
+    if language == DEFAULT_LANGUAGE:
+        return f"{SITE}/events/{slug}/"
+    return f"{SITE}/{language}/events/{slug}/"
+
+
+def breadcrumb_chain(spec):
+    """Returns [(name, absolute_url), ...] for Home [> Events] > EventName,
+    skipping the middle crumb when this language has no /events/ hub yet
+    (2-item breadcrumb, per the library-batch precedent)."""
+    language = spec.get("language", DEFAULT_LANGUAGE)
+    slug = spec["slug"]
+    event_name = spec["event_name"]
+    canonical = spec.get("canonical") or events_canonical_default(language, slug)
+
+    chain = [(tr(language, "breadcrumb_home"), f"{SITE}{home_href(language)}")]
+    hub = events_hub_href(language)
+    if hub:
+        chain.append((tr(language, "breadcrumb_events"), f"{SITE}{hub}"))
+    chain.append((event_name, canonical))
+    return chain
+
+
+def render_hreflang(hreflang):
+    """Emit <link rel="alternate" hreflang="..."> tags from the spec's
+    optional 'hreflang' field: {"<lang>": "<url>", ..., "x_default": "<lang>"}.
+    x_default's value is a language KEY into this same dict (e.g. "es"), not
+    a URL -- so the x-default tag always points at a URL already listed
+    above it. Returns "" (no tags) when the spec has no 'hreflang' field, so
+    the 9 already-shipped English specs are completely unaffected."""
+    if not hreflang or not isinstance(hreflang, dict):
+        return ""
+    lines = []
+    for lang_code, url in hreflang.items():
+        if lang_code == "x_default":
+            continue
+        lines.append(f'  <link rel="alternate" hreflang="{esc_attr(lang_code)}" href="{esc_attr(url)}">')
+    x_default_lang = hreflang.get("x_default")
+    if x_default_lang and hreflang.get(x_default_lang):
+        lines.append(f'  <link rel="alternate" hreflang="x-default" href="{esc_attr(hreflang[x_default_lang])}">')
+    return ("\n".join(lines) + "\n") if lines else ""
+
 
 class SpecError(Exception):
     """Raised when a spec fails validation."""
@@ -152,12 +388,32 @@ def validate_spec(spec):
     if aliases is not None and not isinstance(aliases, list):
         raise SpecError("aliases, if present, must be a list of strings")
 
+    language = spec.get("language", DEFAULT_LANGUAGE)
+    if not isinstance(language, str) or not language:
+        raise SpecError("language, if present, must be a non-empty string")
+
+    hreflang = spec.get("hreflang")
+    if hreflang is not None:
+        if not isinstance(hreflang, dict) or not hreflang:
+            raise SpecError("hreflang, if present, must be a non-empty object")
+        for lang_code, url in hreflang.items():
+            if lang_code == "x_default":
+                if url not in hreflang:
+                    raise SpecError(
+                        "hreflang.x_default must name another key in the same "
+                        "hreflang object"
+                    )
+                continue
+            if not isinstance(url, str) or not url:
+                raise SpecError(f"hreflang[{lang_code!r}] must be a non-empty URL string")
+
 
 # --------------------------------------------------------------------------
 # Rendering helpers
 # --------------------------------------------------------------------------
 def render_event_data(spec):
     """Build the inline window.UTG_EVENT_DATA object the controller reads."""
+    language = spec.get("language", DEFAULT_LANGUAGE)
     collections = [
         {
             "name": c["name"],
@@ -192,53 +448,61 @@ def render_event_data(spec):
             for p in spec["phrase_bank"]
         ],
     }
+
+    # An explicit spec["ui"] always wins; otherwise auto-apply this
+    # language's JS_UI_STRINGS table if one exists. Nothing is emitted for
+    # "en" (or any language without a table and no explicit override), so
+    # the 9 already-shipped English pages get no "ui" key at all -- exactly
+    # matching their pre-existing output.
+    ui = spec.get("ui")
+    if ui is None:
+        ui = JS_UI_STRINGS.get(language)
+    if ui:
+        event_data["ui"] = ui
+
     return json.dumps(event_data, indent=2, ensure_ascii=False)
 
 
 def synthesize_faq(spec):
     """Build FAQ Q&A from the spec's own fields — no separate 'faq' field
     needs to be authored; every event page gets a valid, accurate FAQPage."""
+    language = spec.get("language", DEFAULT_LANGUAGE)
     event_name = spec["event_name"]
     faqs = [
         {
-            "q": f"What is the {event_name} text and symbol generator?",
+            "q": tr(language, "faq_what_is_q", event_name=event_name),
             "a": html.unescape(spec["intro"]),
         },
         {
-            "q": f"When is {event_name}?",
-            "a": f"{event_name} falls {spec['date_window']}. Check a current calendar for "
-                 f"the exact date, then come back and style your greeting for it.",
+            "q": tr(language, "faq_when_q", event_name=event_name),
+            "a": tr(language, "faq_when_a", event_name=event_name, date_window=spec["date_window"]),
         },
         {
-            "q": f"How do I use the {event_name} generator?",
-            "a": f"Type a name, wish, or greeting into the box at the top. Every "
-                 f"{event_name} font style updates live underneath it — tap Copy on any "
-                 f"card. Below that, tap any emoji, symbol, kaomoji, or ASCII art piece to "
-                 f"copy it on its own, or tap a phrase-bank card to drop a ready-made "
-                 f"greeting into the box and see it restyled instantly.",
+            "q": tr(language, "faq_how_q", event_name=event_name),
+            "a": tr(language, "faq_how_a", event_name=event_name),
         },
     ]
     if spec.get("companion_answer_slug"):
+        href = f"{SITE}{answers_prefix(language)}{esc_attr(spec['companion_answer_slug'])}/"
         faqs.append({
-            "q": f"Where can I find more {event_name} phrases and what to write?",
-            "a": f"See "
-                 f"<a href=\"{SITE}/answers/{esc_attr(spec['companion_answer_slug'])}/\">"
-                 f"our full answer</a> for more greetings, translations, and message ideas.",
+            "q": tr(language, "faq_more_q", event_name=event_name),
+            "a": tr(language, "faq_more_a", href=href),
         })
     return faqs
 
 
 def render_ld_json(spec, faqs):
+    language = spec.get("language", DEFAULT_LANGUAGE)
     slug = spec["slug"]
     event_name = spec["event_name"]
-    canonical = spec.get("canonical") or f"{SITE}/events/{slug}/"
+    canonical = spec.get("canonical") or events_canonical_default(language, slug)
     aliases = spec.get("aliases") or []
 
     alt_names = []
     for name in list(aliases) + [
-        f"{event_name} Fonts",
-        f"{event_name} Symbols",
-        f"{event_name} Text Generator",
+        tr(language, "alt_fonts", event_name=event_name),
+        tr(language, "alt_symbols", event_name=event_name),
+        tr(language, "alt_textgen", event_name=event_name),
     ]:
         if name and name not in alt_names:
             alt_names.append(name)
@@ -247,19 +511,19 @@ def render_ld_json(spec, faqs):
     ld_webapp = {
         "@context": "https://schema.org",
         "@type": "WebApplication",
-        "name": f"{event_name} Text & Symbol Generator",
+        "name": tr(language, "webapp_name", event_name=event_name),
         "alternateName": alt_names,
         "url": canonical,
-        "inLanguage": "en",
+        "inLanguage": language,
         "applicationCategory": "UtilitiesApplication",
         "operatingSystem": "Any",
         "description": html.unescape(spec["hero_tagline"]),
         "featureList": [
-            f"Live {event_name} font styles for any text you type",
-            f"Curated {event_name} emoji & symbol collection",
-            f"{event_name} kaomoji",
-            f"Curated {event_name} ASCII art",
-            f"Click-to-style {event_name} phrase bank (native script, romanization, translation)",
+            tr(language, "feature_fonts", event_name=event_name),
+            tr(language, "feature_emoji", event_name=event_name),
+            tr(language, "feature_kaomoji", event_name=event_name),
+            tr(language, "feature_ascii", event_name=event_name),
+            tr(language, "feature_phrase", event_name=event_name),
         ],
         "offers": {"@type": "Offer", "price": "0", "priceCurrency": "USD"},
     }
@@ -267,7 +531,7 @@ def render_ld_json(spec, faqs):
     ld_faq = {
         "@context": "https://schema.org",
         "@type": "FAQPage",
-        "inLanguage": "en",
+        "inLanguage": language,
         "mainEntity": [
             {
                 "@type": "Question",
@@ -278,13 +542,18 @@ def render_ld_json(spec, faqs):
         ],
     }
 
+    chain = breadcrumb_chain(spec)
     ld_breadcrumb = {
         "@context": "https://schema.org",
         "@type": "BreadcrumbList",
         "itemListElement": [
-            {"@type": "ListItem", "position": 1, "name": "Home", "item": f"{SITE}/"},
-            {"@type": "ListItem", "position": 2, "name": "Events", "item": f"{SITE}/events/"},
-            {"@type": "ListItem", "position": 3, "name": html.unescape(event_name), "item": canonical},
+            {
+                "@type": "ListItem",
+                "position": i + 1,
+                "name": html.unescape(name),
+                "item": url,
+            }
+            for i, (name, url) in enumerate(chain)
         ],
     }
 
@@ -308,7 +577,7 @@ def render_faq_html(faqs):
     return "\n".join(items)
 
 
-def render_related(related, companion_answer_slug, event_name=None):
+def render_related(related, companion_answer_slug, event_name=None, language=DEFAULT_LANGUAGE):
     cards = []
     for rel in related:
         cards.append(
@@ -319,23 +588,25 @@ def render_related(related, companion_answer_slug, event_name=None):
             "    </a>"
         )
     if companion_answer_slug:
-        name = event_name or "this event"
+        name = event_name or tr(language, "related_more_fallback_name")
+        href = f"{answers_prefix(language)}{esc_attr(companion_answer_slug)}/"
         cards.append(
-            f'    <a href="/answers/{esc_attr(companion_answer_slug)}/" '
+            f'    <a href="{href}" '
             'class="compare-card variant-muted u-no-underline">\n'
-            f"      <h4>More {esc(name)} phrases &amp; wording</h4>\n"
-            "      <p>Greetings, translations, and message ideas beyond the phrase bank above.</p>\n"
+            f'      <h4>{tr(language, "related_more_title", event_name=esc(name))}</h4>\n'
+            f'      <p>{tr(language, "related_more_desc")}</p>\n'
             "    </a>"
         )
     return "\n".join(cards)
 
 
 def render_page(spec):
+    language = spec.get("language", DEFAULT_LANGUAGE)
     slug = spec["slug"]
     event_name = spec["event_name"]
     title = spec["title"]
     meta = spec["meta_description"]
-    canonical = spec.get("canonical") or f"{SITE}/events/{slug}/"
+    canonical = spec.get("canonical") or events_canonical_default(language, slug)
     aliases = spec.get("aliases") or []
     companion_answer_slug = spec.get("companion_answer_slug")
 
@@ -343,18 +614,34 @@ def render_page(spec):
     ld_webapp, ld_faq, ld_breadcrumb = render_ld_json(spec, faqs)
     event_data_json = render_event_data(spec)
     faq_html = render_faq_html(faqs)
-    related_html = render_related(spec["related"], companion_answer_slug, event_name)
+    related_html = render_related(spec["related"], companion_answer_slug, event_name, language)
+    hreflang_html = render_hreflang(spec.get("hreflang"))
 
     aka_html = ""
     if aliases:
         aka_html = (
-            '<p class="u-secondary-tight">Also known as: '
+            f'<p class="u-secondary-tight">{tr(language, "aka_label")}'
             + ", ".join(esc(a) for a in aliases)
             + "</p>\n      "
         )
 
+    chain = breadcrumb_chain(spec)
+    crumb_parts = []
+    for i, (name, url) in enumerate(chain):
+        if i:
+            crumb_parts.append('  <span class="breadcrumb-separator">›</span>')
+        if i == len(chain) - 1:
+            crumb_parts.append(f'  <span class="breadcrumb-current">{esc(name)}</span>')
+        else:
+            rel_href = "/" if url == f"{SITE}/" else url.replace(SITE, "", 1)
+            crumb_parts.append(f'  <a href="{esc_attr(rel_href)}">{esc(name)}</a>')
+    breadcrumb_nav_html = "\n".join(crumb_parts)
+
+    cta_href = f"{SITE}{home_href(language)}"
+    ascii_generator_href = "/ascii-art-generator/"
+
     page = f"""<!DOCTYPE html>
-<html lang="en">
+<html lang="{esc_attr(language)}">
 <head>
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){{w[l]=w[l]||[];w[l].push({{'gtm.start':
@@ -371,7 +658,7 @@ def render_page(spec):
   <title>{esc(title)}</title>
   <meta name="description" content="{esc_attr(meta)}">
   <link rel="canonical" href="{esc_attr(canonical)}">
-  <meta property="og:title" content="{esc_attr(title)}">
+{hreflang_html}  <meta property="og:title" content="{esc_attr(title)}">
   <meta property="og:description" content="{esc_attr(meta)}">
   <meta property="og:url" content="{esc_attr(canonical)}">
   <meta property="og:type" content="website">
@@ -412,11 +699,7 @@ def render_page(spec):
 <script src="/header.js" defer></script>
 
 <nav class="breadcrumbs" aria-label="Breadcrumb">
-  <a href="/">Home</a>
-  <span class="breadcrumb-separator">›</span>
-  <a href="/events/">Events</a>
-  <span class="breadcrumb-separator">›</span>
-  <span class="breadcrumb-current">{esc(event_name)}</span>
+{breadcrumb_nav_html}
 </nav>
 
 <section class="hero">
@@ -425,7 +708,7 @@ def render_page(spec):
       <h1 class="hero-headline">{esc(spec["hero_h1"])}</h1>
       <p class="hero-tagline">{esc(spec["hero_tagline"])}</p>
       {aka_html}<div class="input-wrapper" id="eventTextWrap">
-        <textarea class="main-input" id="mainInput" placeholder="Type a name, wish, or greeting..." maxlength="500" autofocus></textarea>
+        <textarea class="main-input" id="mainInput" placeholder="{esc_attr(tr(language, 'textarea_placeholder'))}" maxlength="500" autofocus></textarea>
         <span class="char-count"><span id="charCount">0</span>/500</span>
       </div>
     </div>
@@ -445,59 +728,59 @@ def render_page(spec):
   <div class="section-divider"></div>
 
   <section class="editorial-section" id="eventFontsSection">
-    <span class="article-section-label">Fonts</span>
-    <h2>{esc(event_name)} Fonts</h2>
-    <p class="editorial-intro">Type your text above and every style below updates live. Tap Copy on the one you like.</p>
+    <span class="article-section-label">{tr(language, "section_fonts_label")}</span>
+    <h2>{tr(language, "section_fonts_heading", event_name=esc(event_name))}</h2>
+    <p class="editorial-intro">{tr(language, "section_fonts_intro")}</p>
     <div class="results-grid" id="eventFontsGrid"></div>
   </section>
 
   <div class="section-divider"></div>
 
   <section class="editorial-section" id="eventEmojiSection">
-    <span class="article-section-label">Emoji &amp; Symbols</span>
-    <h2>{esc(event_name)} Emoji &amp; Symbols</h2>
-    <p class="editorial-intro">Tap any character to copy it, or copy a whole set at once in your preferred format.</p>
+    <span class="article-section-label">{tr(language, "section_emoji_label")}</span>
+    <h2>{tr(language, "section_emoji_heading", event_name=esc(event_name))}</h2>
+    <p class="editorial-intro">{tr(language, "section_emoji_intro")}</p>
     <div id="eventEmojiGrids"></div>
   </section>
 
   <div class="section-divider"></div>
 
   <section class="editorial-section" id="eventKaomojiSection">
-    <span class="article-section-label">Kaomoji</span>
-    <h2>{esc(event_name)} Kaomoji</h2>
-    <p class="editorial-intro">Each tile is a whole kaomoji — tap to copy the full string in one click.</p>
+    <span class="article-section-label">{tr(language, "section_kaomoji_label")}</span>
+    <h2>{tr(language, "section_kaomoji_heading", event_name=esc(event_name))}</h2>
+    <p class="editorial-intro">{tr(language, "section_kaomoji_intro")}</p>
     <div class="glyph-grid" id="eventKaomojiGrid"></div>
   </section>
 
   <div class="section-divider"></div>
 
   <section class="editorial-section" id="eventAsciiSection">
-    <span class="article-section-label">ASCII Art</span>
-    <h2>{esc(event_name)} ASCII Art</h2>
-    <p class="editorial-intro">Curated multi-line pieces — tap Copy to grab one with its line breaks and spacing intact.</p>
+    <span class="article-section-label">{tr(language, "section_ascii_label")}</span>
+    <h2>{tr(language, "section_ascii_heading", event_name=esc(event_name))}</h2>
+    <p class="editorial-intro">{tr(language, "section_ascii_intro")}</p>
     <div class="art-piece-grid" id="eventAsciiGrid"></div>
-    <p class="u-secondary-tight u-mt-15">Want to type your own name or message into a live block-letter banner instead? Try the <a href="/ascii-art-generator/">ASCII Art Generator</a>.</p>
+    <p class="u-secondary-tight u-mt-15">{tr(language, "section_ascii_cta", href=ascii_generator_href)}</p>
   </section>
 
   <div class="section-divider"></div>
 
   <section class="editorial-section" id="eventPhraseSection">
-    <span class="article-section-label">Phrase Bank</span>
-    <h2>{esc(event_name)} Phrase Bank</h2>
-    <p class="editorial-intro">Tap a phrase to drop it into the box up top and see every font style above restyle it instantly.</p>
+    <span class="article-section-label">{tr(language, "section_phrase_label")}</span>
+    <h2>{tr(language, "section_phrase_heading", event_name=esc(event_name))}</h2>
+    <p class="editorial-intro">{tr(language, "section_phrase_intro")}</p>
     <div class="compare-grid" id="eventPhraseGrid"></div>
   </section>
 
   <div class="section-divider"></div>
 
   <div class="cta-card">
-    <h3>Transform text with Unicode fonts</h3>
-    <p>Use UltraTextGen to convert plain text into bold, italic, cursive, and 100+ other Unicode font styles — free and instant.</p>
-    <a href="{SITE}/" class="cta-btn">Open UltraTextGen →</a>
+    <h3>{tr(language, "cta_heading")}</h3>
+    <p>{tr(language, "cta_body")}</p>
+    <a href="{cta_href}" class="cta-btn">{tr(language, "cta_button")}</a>
   </div>
 
   <section class="editorial-section">
-    <span class="article-section-label">Related Resources</span>
+    <span class="article-section-label">{tr(language, "related_heading")}</span>
     <div class="compare-grid">
 {related_html}
     </div>
@@ -506,13 +789,13 @@ def render_page(spec):
 
 <footer class="footer">
   <div class="footer-inner">
-    <h2 class="faq-category">{esc(event_name)} questions</h2>
+    <h2 class="faq-category">{tr(language, "footer_heading", event_name=esc(event_name))}</h2>
 {faq_html}
   </div>
 </footer>
 
 <!-- TOAST -->
-<div class="copy-toast" id="copyToast">Copied!</div>
+<div class="copy-toast" id="copyToast">{tr(language, "copy_toast")}</div>
 <div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
 
 <script>window.UTG_EVENT_MODE = true;</script>


### PR DESCRIPTION
## Summary

Extends `scripts/generate_event_page_from_spec.py` and `js/events/eventPageController.js` with multi-language support (`language` + `hreflang` spec fields, a `STRINGS`/`JS_UI_STRINGS` table keyed by language code with English as fallback for any missing key), then ships the first localized `/events/` pages in two languages. No behavior change for the 9 already-shipped English pages — verified byte-identical generator output before/after, for every language addition.

### Spanish (`es/`)
- `es/events/navidad/` ↔ `es/answers/que-escribir-en-una-tarjeta-de-navidad/`
- `es/events/san-valentin/` ↔ `es/answers/que-escribir-en-una-tarjeta-de-san-valentin/`
- `es/events/halloween/` ↔ `es/answers/que-escribir-en-halloween/` (same slug as the English page — rendered via the generator's own functions directly rather than its CLI, to avoid any risk of overwriting `events/halloween/index.html`; confirmed byte-for-byte untouched)

### Indonesian (`id/`) — the site's #1 traffic market
- `id/events/imlek/` ↔ `id/answers/kata-kata-ucapan-imlek/` (Chinese New Year, hreflang'd to `/events/chinese-new-year/`)
- `id/events/idul-fitri/` ↔ `id/answers/ucapan-idul-fitri-yang-menyentuh-hati/`
- `id/events/idul-adha/` ↔ `id/answers/ucapan-idul-adha-yang-menyentuh/`

Idul Fitri and Idul Adha are built as two **separate, thematically distinct** pages rather than mirroring the English `eid-mubarak` page's single-page-for-both-occasions approach — Indonesian media treats them as genuinely different occasions (Idul Fitri: forgiveness/reunion, "Mohon Maaf Lahir dan Batin"; Idul Adha: sacrifice/devotion, qurban/Ibrahim themes). Verified zero phrase cross-contamination between the two. Neither carries an `en` hreflang alternate since `/events/eid-mubarak/` isn't a precise topical match for either alone; Imlek does, since `/events/chinese-new-year/` is a direct match.

hreflang is one-directional throughout (new localized pages link back to English; English pages are not retrofitted), matching the site's most recent (July-2026) translation-batch convention rather than the older bidirectional tattoo-module pattern. All 3 Spanish + 9 English + Indonesian source pages confirmed untouched at every step.

## ⚠️ Needs native-speaker review before this ships

Every word of Spanish and Indonesian copy on all 12 new pages (hero copy, intro, FAQ, phrase banks, full answers-page prose) was authored by AI and has **not** been checked by a native speaker of either language. This is a larger review surface than a typical translated-phrase flag — the entire page *is* the translation/localization here, not just a few embedded lines. **62 individual phrases are flagged `needs_native_speaker_review: true`** across both languages (9 Spanish, 26 Indonesian across imlek/idul-fitri/idul-adha, +remainder from the earlier count) — see spec JSON files for the full per-phrase list. Recommend a native-speaker pass for each language before either goes live, independent of code review.

## What's verified vs. not yet

**Verified (Spanish + Indonesian, both batches):**
- Generator regression: all existing English + Spanish specs produce byte-identical output before/after each language addition.
- Every existing English/Spanish page confirmed untouched via diff at every step.
- `hreflang` tags correct per the reasoning above.
- Every `related` link on every page resolves to a real path in the repo.
- **Full headless-browser interactive pass on the Indonesian batch** (live font rendering, phrase-bank click-to-style, copy button labels in-language, dark mode, zero page-level JS errors) — this closes the one gap flagged from the Spanish batch, which shipped without this check.

**Not yet done:**
- No headless-browser pass specifically re-run on the 3 Spanish pages (they shipped before this gap was identified and fixed for the Indonesian batch).
- No `es/events/index.html` or `id/events/index.html` hub yet — all localized pages use 2-item breadcrumbs (no mid-level "Events" crumb), consistent with the generator's `LANGS_WITH_EVENTS_HUB` set only including `en` so far.
- Nothing in site navigation (`header.js` has no i18n) or `/es/index.html`/`/id/` links to these new pages yet — reachable by direct URL and via hreflang from the English originals only.

## Test plan

- [ ] Native Spanish speaker reviews the 6 Spanish pages' copy
- [ ] Native Indonesian speaker reviews the 6 Indonesian pages' copy
- [ ] Run the headless-browser pass on the 3 Spanish pages (already done for the 3 Indonesian pages)
- [ ] Spot-check hreflang resolves correctly once live (no redirect loops, correct canonical)
- [ ] Confirm sitemap picks up the new pages on next scheduled regeneration (not manually edited here, per repo convention)
