### PR TITLE
docs: weekly infrastructure review 2026-07-11

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@ workflow that produces it.
 | **Answers** (Q&A) | `/answers/` | `QAPage` / `FAQPage` | [`jtbd-build-spec.md`](./jtbd-build-spec.md) (strategy) | `library_opportunities.csv` (`page_type=answers`) | ❌ none | ⚠️ backlog + strategy, no generator |
 | **Usecase** | `/usecase/` | `WebApplication` | ❌ undocumented | ❌ none | ❌ none | ❌ undocumented |
 | **Guide** (articles) | `/guide/` | `Article` | [`guide-content-workflow.md`](./guide-content-workflow.md) | `data/library_opportunities.csv` (`page_type=guide`) + `guide-opportunity-map-<date>.md` | ❌ none (hand-built) | ⚠️ workflow + backlog, no generator |
+| **Events** (seasonal/holiday pages) | `/events/` (+ locale variants, e.g. `/es/events/`) | `WebApplication` + `FAQPage` | ❌ undocumented | `data/event_page_specs/*.json` (no CSV backlog row) | `generate_event_page_from_spec.py` (mirrors `generate_library_page_from_spec.py`; validation is built into the generator, no separate validator script) | ⚠️ generator exists, no backlog/governing doc — new this review (PR #457 + Spanish `es/events/` pages) |
 | **Printables** (bubble/cursive/block/tracing/coloring sheets) | `/printables/` | `WebApplication` (+ `CollectionPage` hub) | [`coloring-sheet-generator-strategy.md`](./coloring-sheet-generator-strategy.md) (strategy) + `CLAUDE.md` scope note | `library_opportunities.csv` (`page_type=printables`, added 2026-07-09 — other-language/other-script backlog) | ❌ none (hand-built, on `js/printables/printablesEngine.js`) | ⚠️ backlog + strategy, no generator |
 | **Platform** (social-network generators) | `/discord/`, `/instagram/`, `/x/`, … | `WebApplication` | ❌ undocumented | ❌ none | ❌ none | ❌ undocumented |
 | **Root pages** (homepage, 404, legal) | `index.html`, `_root.html`, `404.html`, `about/`, `contact/`, `privacy/`, `terms/`, site icons | `WebSite` (homepage) | ❌ undocumented | ❌ none | ❌ none (hand-built) | ❌ undocumented |
@@ -128,6 +129,17 @@ here so they aren't lost. Update as they're closed or new ones appear.
    prefix was in `LANE_RULES`, so both PRs surfaced as unclassified; both
    prefixes are now added. The locale count (12+ and growing weekly) makes
    the missing i18n governing doc the most pressing item in this gap.
+   **Update (2026-07-11):** the pace accelerated sharply — twelve more locales
+   landed in a single week (Arabic `/ar/`, Bosnian `/bs/`, Czech `/cs/`, Hindi
+   `/hi/`, Croatian `/hr/`, Japanese `/ja/`, Korean `/ko/`, Romanian `/ro/`,
+   Russian `/ru/`, Slovak `/sk/`, Serbian `/sr/`, Thai `/th/` — PRs #414, #415,
+   #422, #431, #432, #435, #436, #448, #450, #451, #454, #466, #467), none of
+   which were in `LANE_RULES`, so every file under them surfaced as
+   "Unclassified." All twelve are now added. With ~26 locale prefixes now
+   hardcoded one-by-one in `LANE_RULES`, the classifier itself is becoming the
+   symptom: a governing i18n doc that defines the locale-directory convention
+   (so the classifier can match a pattern instead of an enumerated list) is
+   now the single most pressing gap in this file.
 5. **Platform pages lane is undocumented** — the eleven social-network generator
    pages (`/discord/`, `/instagram/`, `/x/`, …) receive active SEO updates
    (`alternateName`: PR #277; FAQ structured data: PR #290) but have no
@@ -159,7 +171,16 @@ here so they aren't lost. Update as they're closed or new ones appear.
    "Visual & printable assets" lane — but the `/curved-text/` top-level namespace
    is still absent from the page-type table. Decide: promote to a full lane
    (shared export util + a governing doc) or keep it a principle-governed
-   cross-cutting track.
+   cross-cutting track. **Update (2026-07-11):** the *other* half of this gap
+   just surfaced hard — the `/printables/` page-type namespace (already a row
+   in the table above) had **no** `LANE_RULES` entry at all, so every
+   printables PR this week classified as "Unclassified" (15 of ~73 merged
+   PRs: #420, #423–#426, #428, #429, #440–#445, #447, #468 — coloring pages,
+   dot-to-dot, tracing, banner/name-puzzle makers, bubble letters, all A–Z
+   variants). Added `("printables/", "Printables")` to `LANE_RULES` to close
+   the classifier gap; the underlying gap (no shared export helper, no
+   generator/validator, no governing doc, still fully hand-built) remains
+   open and is now the highest-volume hand-built lane in the repo.
 9. **New this week: Ads / monetization track has no governing doc.** PRs
    #366–#368 stood up Journey ads as a real operational track — site-wide tag
    injection via `header.js`, a CI gate (`ads-check.yml` / `check-ads.js`),
@@ -167,6 +188,29 @@ here so they aren't lost. Update as they're closed or new ones appear.
    replacing Google AdSense. Added to the operational-tracks table this
    review; no strategy/decision doc exists yet (e.g. why Journey over
    AdSense, revenue-share terms, page exclusions). Flagging so it isn't lost.
+10. **New this week: Events (seasonal/holiday pages) is a genuinely new lane,
+    not just an unclassified PR.** PR #457 added ten English `/events/<slug>/`
+    pages (Christmas, Halloween, Diwali, Eid Mubarak, Lunar New Year, etc.)
+    plus a hub, and companion Spanish pages already exist at `/es/events/`
+    with three matching `/es/answers/` spokes. It runs on real infrastructure
+    — `scripts/generate_event_page_from_spec.py` (mirrors the library
+    generator, validation built in) reading `data/event_page_specs/*.json`,
+    and a dedicated `js/events/eventPageController.js` — but has no page-type
+    row, no governing doc, and no demand-backlog entry (no `page_type=events`
+    rows exist in `library_opportunities.csv`). Added a row to the page-type
+    table above and a `LANE_RULES` entry (`events/` → "Events"); the
+    governing doc and backlog integration are still open.
+11. **New this week: root-level standalone tool pages, no naming
+    convention.** `/ascii-art-generator/`, `/ascii-converter/` (PRs #453,
+    #455) and `/kaomoji-dictionary/`, `/kaomoji-generator/` (PR #438) are four
+    new `WebApplication` tool pages hand-built at the repo root instead of
+    under `/category/` — the same JTBD as a Category page, different URL
+    shape. Added their exact directory names to `LANE_RULES` as "Category
+    pages" (case-by-case, same pattern already used for `roblox/` under
+    Platform pages) so they stop surfacing as unclassified, but the actual
+    question — should root-level tool pages be folded under `/category/`, or
+    is "shorter root slug" an intentional SEO pattern that needs its own
+    naming rule — is undecided. Revisit if more of these appear.
 
 ---
 

--- a/scripts/weekly_pr_digest.py
+++ b/scripts/weekly_pr_digest.py
@@ -34,6 +34,8 @@ LANE_RULES = [
     ("answers/", "Answer pages"),
     ("usecase/", "Usecase pages"),
     ("guide/", "Guide pages"),
+    ("printables/", "Printables"),
+    ("events/", "Events"),
     ("curved-text/", "Visual & printable assets"),
     # Root-level site-wide pages (homepage, legal, 404, site icons) — no
     # dedicated page-type namespace; see docs/README.md Known gaps.
@@ -58,6 +60,13 @@ LANE_RULES = [
     ("x/", "Platform pages"),
     ("youtube/", "Platform pages"),
     ("roblox/", "Platform pages"),
+    # Root-level single-purpose tool pages (WebApplication, same pattern as
+    # /category/ generators, just hosted at the repo root) — added one at a
+    # time as they appear; see docs/README.md Known gaps.
+    ("ascii-art-generator/", "Category pages"),
+    ("ascii-converter/", "Category pages"),
+    ("kaomoji-dictionary/", "Category pages"),
+    ("kaomoji-generator/", "Category pages"),
     ("embed/", "Image backlinks"),
     ("assets/", "Image SEO"),
     ("data/library_opportunities", "Opportunity backlog"),
@@ -73,6 +82,7 @@ LANE_RULES = [
     ("styles.js", "Core JS"),
     ("script.js", "Core JS"),
     ("header.js", "Core JS"),
+    ("footer.js", "Core JS"),
     ("fonts.json", "Core JS"),
     ("gothic-tools.js", "Core JS"),
     ("accent-notice.js", "Core JS"),
@@ -102,6 +112,18 @@ LANE_RULES = [
     ("vi/", "i18n"),
     ("sv/", "i18n"),
     ("no/", "i18n"),
+    ("ar/", "i18n"),
+    ("bs/", "i18n"),
+    ("cs/", "i18n"),
+    ("hi/", "i18n"),
+    ("hr/", "i18n"),
+    ("ja/", "i18n"),
+    ("ko/", "i18n"),
+    ("ro/", "i18n"),
+    ("ru/", "i18n"),
+    ("sk/", "i18n"),
+    ("sr/", "i18n"),
+    ("th/", "i18n"),
 ]
 
 # A lane label used when no rule matched any of a PR's files. These are the


### PR DESCRIPTION
## Summary

Reviewed all merged PRs to `main` in the last 7 days (2026-07-04 → 2026-07-11, ~73 PRs, #390–#468 excluding infra-review PRs #394/#446). The automated digest (`docs/infra-review/latest.md`) was 5 days stale, so PRs were re-classified directly against `LANE_RULES` (via GitHub's merged-PR search + file lists) rather than trusting the cached digest.

**Findings and fixes (small, additive diff to `docs/README.md` + `scripts/weekly_pr_digest.py`):**

- **`/printables/` had no `LANE_RULES` entry** despite already being a documented page-type row — 15 of ~73 PRs this week (#420, #423–#426, #428, #429, #440–#445, #447, #468: coloring pages, dot-to-dot, tracing, banner/name-puzzle makers, bubble letters, A–Z variants) misclassified as "Unclassified." Added `("printables/", "Printables")`.
- **Twelve new locales shipped this week** with none in `LANE_RULES`: Arabic, Bosnian, Czech, Hindi, Croatian, Japanese, Korean, Romanian, Russian, Slovak, Serbian, Thai. Added all twelve; updated the i18n Known Gap — with ~26 locale prefixes now hand-enumerated, the missing governing doc (that would let the classifier match a convention instead of a growing list) is now the most pressing gap.
- **Events (seasonal/holiday pages) is a genuinely new, fairly systematized lane** — PR #457 plus existing `/es/events/` pages, backed by `generate_event_page_from_spec.py` (mirrors the library generator) and `js/events/eventPageController.js`, but no page-type row, governing doc, or backlog entry. Added the page-type row and a `LANE_RULES` entry.
- **Four new root-level standalone tool pages** (`ascii-art-generator/`, `ascii-converter/`, `kaomoji-dictionary/`, `kaomoji-generator/`) classified case-by-case as Category pages (same precedent as the existing `roblox/` rule); flagged the root-vs-`/category/` naming question as open in Known Gaps.
- `footer.js` added alongside the existing `header.js` → Core JS rule.

**Not changed:** no lane's governing workflow/generator/maturity needed updating this week beyond the two rows above; no known gap was fully closed.

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('scripts/weekly_pr_digest.py').read())"` — syntax check
- [x] Sanity-checked `classify_paths()` against sample paths from this week's PRs (printables/, events/, es/events/, ascii-art-generator/, kaomoji-dictionary/, footer.js, new locale prefixes, and confirmed no rule-ordering collision with existing `roblox/`)
- [ ] Human review — per the weekly-review process, this PR is **not merged automatically**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qa7zjBjCGAP7U8jZg5fXwq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qa7zjBjCGAP7U8jZg5fXwq)_