### PR TITLE
Add French localization for printables pages and engine

### DIFF
--- a/es/imprimibles/abecedario-para-colorear/index.html
+++ b/es/imprimibles/abecedario-para-colorear/index.html
@@ -1,0 +1,241 @@
+<!DOCTYPE html><html lang="es"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Abecedario para colorear A–Z — Letras para imprimir gratis | UltraTextGen</title>
+  <meta name="description" content="Abecedario para colorear A–Z para imprimir gratis. Grandes contornos de letras para colorear e imprimir, una página para cada letra de la A a la Z. Imprime todo el alfabeto o descarga cualquier letra en PNG.">
+  <link rel="canonical" href="https://ultratextgen.com/es/imprimibles/abecedario-para-colorear/">
+
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/printables/alphabet-coloring-pages/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/imprimables/coloriage-alphabet/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/imprimibles/abecedario-para-colorear/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/imprimiveis/alfabeto-para-colorir/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/alphabet-coloring-pages/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Abecedario para colorear A–Z | UltraTextGen">
+  <meta property="og:description" content="Abecedario para colorear A–Z para imprimir gratis. Colorea e imprime grandes contornos de letras, o abre la página de una letra.">
+  <meta property="og:url" content="https://ultratextgen.com/es/imprimibles/abecedario-para-colorear/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Abecedario para colorear A–Z | UltraTextGen">
+  <meta name="twitter:description" content="Abecedario para colorear A–Z para imprimir gratis. Colorea e imprime grandes contornos de letras.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;family=Baloo+2:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Inicio", "item": "https://ultratextgen.com/es/" },
+    { "@type": "ListItem", "position": 2, "name": "Imprimibles", "item": "https://ultratextgen.com/es/imprimibles/" },
+    { "@type": "ListItem", "position": 3, "name": "Abecedario para colorear", "item": "https://ultratextgen.com/es/imprimibles/abecedario-para-colorear/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "es",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "¿Estos abecedarios para colorear son gratis para imprimir?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Sí. Cada abecedario para colorear aquí es totalmente gratis, sin registro, sin marca de agua y sin límites. Elige una letra para un gran contorno y usa Imprimir esta letra para enviarla a tu impresora o Descargar PNG para guardar una imagen en alta resolución."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Cómo imprimo todo el alfabeto ABC de una vez?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Desplázate hasta la sección Alfabeto para imprimir y pulsa Imprimir el alfabeto para enviar los 26 contornos de letras a tu impresora en una sola hoja — práctico para un juego de clase o una actividad de día lluvioso."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Puedo obtener una página para colorear de una sola letra?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Sí. Toca cualquier letra A–Z en el selector para previsualizarla y luego usa Imprimir esta letra o Descargar PNG para un gran contorno de una sola letra para colorear."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿En qué se diferencian de las letras burbuja?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Estos abecedarios usan contornos finos y nítidos, fáciles de colorear por dentro. Las letras burbuja son redondeadas e infladas. Ambas son contornos para imprimir gratis — elige el estilo que prefieras."
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Ruta de navegación">
+  <a href="/es/">Inicio</a>
+  <span class="breadcrumb-separator">›</span>
+  <a href="/es/imprimibles/">Imprimibles</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Abecedario para colorear</span>
+</nav>
+
+  <section class="hero">
+    <div class="hero-inner" style="max-width:820px;">
+      <h1 class="hero-headline">Abecedario para colorear (A–Z)</h1>
+      <p class="hero-tagline">
+        Abecedarios ABC para imprimir gratis. Elige una letra para un gran contorno nítido para colorear, imprime todo el alfabeto de una vez, o previsualiza cualquier letra — sin registro.
+      </p>
+    </div>
+  </section>
+
+  <main class="container">
+
+    <!-- Picker + selected-letter detail -->
+    <section class="bubble-az" aria-labelledby="ptPickHeading">
+      <h2 class="bubble-az-heading" id="ptPickHeading">Elige una letra para colorear</h2>
+      <p class="bubble-az-intro">Toca cualquier letra A–Z para ver su gran contorno para colorear, imprimirlo o descargar un PNG.</p>
+      <div class="bubble-strip" id="pt-strip" role="tablist" aria-label="Elegir una letra para colorear"></div>
+      <div class="bubble-letter-panel" id="pt-panel" aria-live="polite"></div>
+    </section>
+
+    <!-- Full printable alphabet -->
+    <section class="bubble-alphabet" aria-labelledby="ptAlphaHeading">
+      <div class="bubble-alphabet-head">
+        <h2 id="ptAlphaHeading">Alfabeto para imprimir</h2>
+        <button class="bubble-btn bubble-btn-primary" type="button" id="pt-alphabet-print">Imprimir el alfabeto</button>
+      </div>
+      <p class="bubble-az-intro">El alfabeto A–Z completo en contornos nítidos para colorear. Imprime toda la hoja para colorear, o toca cualquier letra para abrir sus opciones de impresión y descarga.</p>
+      <div class="bubble-alphabet-grid" id="pt-alphabet-grid"></div>
+    </section>
+
+    <!-- Editorial -->
+    <section class="editorial-section">
+      <h2>Cómo usar el abecedario para colorear</h2>
+      <ul class="compat-list">
+        <li><span class="ts-pill-safe">Aprender</span> Di la letra y su sonido en voz alta mientras se colorea — una forma sencilla de relacionar las letras con los sonidos.</li>
+        <li><span class="ts-pill-safe">Colorear</span> Los contornos finos dejan mucho espacio para lápices, rotuladores y lápices de colores.</li>
+        <li><span class="ts-pill-safe">En clase</span> Imprime todo el alfabeto para un taller, o una sola letra para la letra de la semana.</li>
+      </ul>
+      <h3>¿Prefieres letras para copiar y pegar en vez de para colorear?</h3>
+      <p>Estos contornos están hechos para el papel. Si quieres bonitas letras para pegar en una biografía o un pie de foto, usa los
+        <a href="/es/fuentes-de-letras/">generadores de fuentes</a>. Para otros estilos para imprimir, prueba las
+        <a href="/es/imprimibles/letras-burbuja/">letras burbuja</a>.</p>
+    </section>
+
+    <div class="cta-card">
+      <h3>¿Buscas más bien práctica de escritura?</h3>
+      <p>Escribe cualquier nombre e imprime una ficha para trazar con líneas modelo y líneas para repasar — perfecto para preescolar y primero de primaria.</p>
+      <a class="cta-btn" href="/es/imprimibles/nombre-para-trazar/">Abrir las fichas para trazar el nombre →</a>
+    </div>
+
+    <div class="cta-card">
+      <h3>¿Quieres letra ligada?</h3>
+      <p>Pasa al alfabeto en cursiva con fichas de caligrafía para trazar y la descarga en PNG de cada letra.</p>
+      <a class="cta-btn" href="/es/imprimibles/alfabeto-cursiva/">Abrir el alfabeto en cursiva →</a>
+    </div>
+  </main>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <h2 class="faq-category">Abecedario para colorear — FAQ</h2>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          ¿Estos abecedarios para colorear son gratis para imprimir?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Sí — cada abecedario para colorear aquí es totalmente gratis, sin registro, sin marca de agua y sin límites. Elige una letra para un gran contorno y usa <strong>Imprimir esta letra</strong> para enviarla a tu impresora o <strong>Descargar PNG</strong> para guardar una imagen en alta resolución.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          ¿Cómo imprimo todo el alfabeto ABC de una vez?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Desplázate hasta la sección <strong>Alfabeto para imprimir</strong> y pulsa <strong>Imprimir el alfabeto</strong> para enviar los 26 contornos de letras a tu impresora en una sola hoja — práctico para un juego de clase o una actividad de día lluvioso.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          ¿Puedo obtener una página para colorear de una sola letra?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Sí. Toca cualquier letra A–Z en el selector para previsualizarla y luego usa <strong>Imprimir esta letra</strong> o <strong>Descargar PNG</strong> para un gran contorno de una sola letra para colorear.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          ¿En qué se diferencian de las letras burbuja?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Estos abecedarios usan contornos finos y nítidos, fáciles de colorear por dentro. Las <a href="/es/imprimibles/letras-burbuja/">letras burbuja</a> son redondeadas e infladas. Ambas son contornos para imprimir gratis — elige el estilo que prefieras.
+        </div>
+      </div>
+
+    </div>
+  </footer>
+
+  <!-- Print surface (hidden on screen, isolated when printing) -->
+  <div id="pt-print-root" aria-hidden="true"></div>
+
+  <script>
+    window.UTG_PRINTABLE = {
+      key: "alphabet-coloring-pages",
+      lang: "es",
+      render: "outline",
+      noun: "colorear",
+      pngPrefix: "colorear",
+      font: "'Baloo 2', 'Plus Jakarta Sans', sans-serif",
+      strokeWidth: 4,
+    };
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/js/printables/printablesEngine.js" defer></script>
+
+  <!-- FAQ toggle -->
+  <script>
+    document.querySelectorAll('.faq-question').forEach(function(btn) {
+      btn.addEventListener('click', function() { this.closest('.faq-item').classList.toggle('open'); });
+    });
+  </script>
+<script src="/footer.js" defer></script>
+</body></html>

--- a/es/imprimibles/alfabeto-cursiva/index.html
+++ b/es/imprimibles/alfabeto-cursiva/index.html
@@ -1,0 +1,258 @@
+<!DOCTYPE html><html lang="es"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Alfabeto en cursiva A–Z — Fichas de caligrafía para imprimir | UltraTextGen</title>
+  <meta name="description" content="El alfabeto en cursiva A–Z con fichas de caligrafía para imprimir gratis — letras modelo y espacio para trazar — la descarga en PNG de cada letra y una ficha para trazar el nombre en cursiva. Sin registro.">
+  <link rel="canonical" href="https://ultratextgen.com/es/imprimibles/alfabeto-cursiva/">
+
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/printables/cursive-alphabet/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/imprimables/alphabet-cursif/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/imprimibles/alfabeto-cursiva/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/imprimiveis/alfabeto-cursivo/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/cursive-alphabet/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Alfabeto en cursiva A–Z — Fichas de caligrafía para imprimir | UltraTextGen">
+  <meta property="og:description" content="El alfabeto en cursiva A–Z con fichas de caligrafía para imprimir y trazar, la descarga en PNG de cada letra y una ficha para trazar el nombre en cursiva.">
+  <meta property="og:url" content="https://ultratextgen.com/es/imprimibles/alfabeto-cursiva/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category-cursive-fonts.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Alfabeto en cursiva A–Z — Fichas de caligrafía para imprimir | UltraTextGen">
+  <meta name="twitter:description" content="El alfabeto en cursiva A–Z con fichas de caligrafía para imprimir y trazar, la descarga en PNG de cada letra y una ficha para trazar el nombre en cursiva.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category-cursive-fonts.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Inicio", "item": "https://ultratextgen.com/es/" },
+    { "@type": "ListItem", "position": 2, "name": "Imprimibles", "item": "https://ultratextgen.com/es/imprimibles/" },
+    { "@type": "ListItem", "position": 3, "name": "Alfabeto en cursiva", "item": "https://ultratextgen.com/es/imprimibles/alfabeto-cursiva/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "es",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "¿Puedo imprimir fichas de caligrafía en cursiva?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Sí. Haz clic en Imprimir la hoja de práctica para obtener una página A–Z para imprimir: cada línea muestra las letras modelo en cursiva más un espacio para trazarlas y repetirlas — práctico para profesores, familias y cualquiera que aprenda la letra ligada."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Cómo imprimo una sola letra en cursiva, como una S o una G mayúscula?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Toca cualquier letra del selector para ver su forma cursiva en mayúscula y en minúscula. Usa Imprimir esta letra para una gran página de una sola letra, o Descargar PNG para guardar una imagen en alta resolución para imprimir o reutilizar."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Puedo crear una ficha para trazar el nombre en cursiva?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Sí. Escribe un nombre en el campo previsto e imprime una ficha con una línea modelo más líneas atenuadas para repasar — una manera sencilla de practicar la escritura de un nombre o una firma en cursiva."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿La cursiva Unicode es lo mismo que la escritura cursiva real?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "La cursiva en pantalla se compone de caracteres script Unicode, que también sirven como modelos nítidos para la forma de las letras. Las fichas impresas los usan como modelos para trazar. Para texto cursivo para copiar y pegar en biografías y pies de foto, usa mejor el generador de letra cursiva."
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Ruta de navegación">
+  <a href="/es/">Inicio</a>
+  <span class="breadcrumb-separator">›</span>
+  <a href="/es/imprimibles/">Imprimibles</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Alfabeto en cursiva</span>
+</nav>
+
+  <section class="hero">
+    <div class="hero-inner" style="max-width:820px;">
+      <h1 class="hero-headline">Alfabeto en cursiva — Fichas de caligrafía para imprimir</h1>
+      <p class="hero-tagline">
+        El alfabeto en cursiva completo A–Z. Imprime una hoja de práctica con letras modelo y espacio para trazar,
+        descarga cualquier letra en PNG, o crea una ficha para trazar el nombre en cursiva. Gratis, sin registro.
+      </p>
+    </div>
+  </section>
+
+  <main class="container">
+
+    <!-- Practice sheet CTA -->
+    <section class="bubble-alphabet" aria-labelledby="ptPracticeHeading">
+      <div class="bubble-alphabet-head">
+        <h2 id="ptPracticeHeading">Ficha de caligrafía en cursiva para imprimir</h2>
+        <button class="bubble-btn bubble-btn-primary" type="button" id="pt-practice-print">Imprimir la hoja de práctica</button>
+      </div>
+      <p class="bubble-az-intro">Un clic imprime una página A–Z donde cada línea muestra las letras modelo en cursiva más un espacio para trazarlas y repetirlas — lista para el aula, la educación en casa o tu propia práctica.</p>
+    </section>
+
+    <!-- Picker + selected-letter detail -->
+    <section class="bubble-az" aria-labelledby="ptPickHeading">
+      <h2 class="bubble-az-heading" id="ptPickHeading">Letras cursivas A–Z</h2>
+      <p class="bubble-az-intro">Toca una letra para ver su forma cursiva en mayúscula y en minúscula, imprimir una gran letra única, descargar un PNG o copiar los estilos cursivos Unicode correspondientes.</p>
+      <div class="bubble-strip" id="pt-strip" role="tablist" aria-label="Elegir una letra cursiva"></div>
+      <div class="bubble-letter-panel" id="pt-panel" aria-live="polite"></div>
+    </section>
+
+    <!-- Cursive name worksheet -->
+    <section class="bubble-alphabet" aria-labelledby="ptNameHeading">
+      <h2 id="ptNameHeading">Ficha para trazar el nombre en cursiva</h2>
+      <p class="bubble-az-intro">Escribe un nombre para previsualizarlo en cursiva, luego imprime una ficha con una línea modelo y líneas atenuadas para repasar — ideal para firmas y práctica del nombre.</p>
+      <div class="pt-name-tool">
+        <div class="input-wrapper">
+          <input type="text" class="main-input pt-name-input" id="pt-name-input" placeholder="Escribe un nombre… p. ej. Olivia" maxlength="40">
+        </div>
+        <div class="pt-name-preview" id="pt-name-preview" aria-live="polite"></div>
+        <div class="bubble-actions pt-name-actions">
+          <button type="button" class="bubble-btn bubble-btn-primary" id="pt-name-print">Imprimir la ficha</button>
+          <button type="button" class="bubble-btn" id="pt-name-png">Descargar PNG</button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Editorial -->
+    <section class="editorial-section">
+      <h2>Aprender la cursiva con la hoja de práctica</h2>
+      <p>Imprime la <strong>hoja de práctica</strong> y repasa cada letra modelo hasta que las uniones se vuelvan
+        naturales, luego pasa al espacio en blanco para escribirla a mano alzada. Fíjate en cómo se une cada mayúscula, y mantén
+        sesiones cortas y frecuentes — unas pocas letras al día valen más que una sesión larga.</p>
+      <h3>Cursiva para imprimir vs. cursiva para copiar y pegar</h3>
+      <p>Estas fichas están hechas para el <em>papel</em> — el trazado y la escritura. Si quieres texto cursivo para pegar en una
+        biografía de Instagram, un pie de foto o un documento, usa el <a href="/es/letra-cursiva/">generador de letra cursiva</a>, que
+        convierte tus palabras en script Unicode para copiar y pegar. Para un nombre decorativo para colorear, prueba las
+        <a href="/es/imprimibles/letras-burbuja/">letras burbuja</a>.</p>
+    </section>
+
+    <div class="cta-card">
+      <h3>¿Quieres cursiva para copiar y pegar?</h3>
+      <p>Escribe una vez y copia script Unicode fluido para tus biografías, pies de foto, nombres y firmas.</p>
+      <a class="cta-btn" href="/es/letra-cursiva/">Abrir el generador de letra cursiva →</a>
+    </div>
+  </main>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <h2 class="faq-category">Cursiva para imprimir — FAQ</h2>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          ¿Puedo imprimir fichas de caligrafía en cursiva?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Sí. Haz clic en <strong>Imprimir la hoja de práctica</strong> para obtener una página A–Z para imprimir: cada línea muestra las letras
+          modelo en cursiva más un espacio para trazarlas y repetirlas — práctico para profesores, familias y cualquiera que aprenda la letra ligada.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          ¿Cómo imprimo una sola letra en cursiva, como una S o una G mayúscula?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Toca cualquier letra del selector para ver su forma cursiva en mayúscula y en minúscula. Usa <strong>Imprimir esta letra</strong>
+          para una gran página de una sola letra, o <strong>Descargar PNG</strong> para guardar una imagen en alta resolución para imprimir o reutilizar.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          ¿Puedo crear una ficha para trazar el nombre en cursiva?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Sí. Escribe un nombre en el campo previsto e imprime una ficha con una línea modelo más líneas atenuadas para repasar — una manera sencilla
+          de practicar la escritura de un nombre o una firma en cursiva.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          ¿La cursiva Unicode es lo mismo que la escritura cursiva real?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          La cursiva en pantalla se compone de caracteres script Unicode, que también sirven como modelos nítidos para la forma de las letras. Las fichas impresas
+          los usan como modelos para trazar. Para texto cursivo para copiar y pegar en biografías y pies de foto, usa mejor el
+          <a href="/es/letra-cursiva/">generador de letra cursiva</a>.
+        </div>
+      </div>
+
+    </div>
+  </footer>
+
+  <!-- Print surface (hidden on screen, isolated when printing) -->
+  <div id="pt-print-root" aria-hidden="true"></div>
+
+  <script>
+    window.UTG_PRINTABLE = {
+      key: "cursive-alphabet",
+      lang: "es",
+      render: "glyph",
+      noun: "cursiva",
+      pngPrefix: "cursiva",
+      font: "'Plus Jakarta Sans', 'Segoe UI Symbol', 'Noto Sans Symbols 2', sans-serif",
+      charset: "alpha",
+      variantFamily: "cursive",
+      glyphStyle: "Ultra Script",
+      nameDemo: "Olivia"
+    };
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/js/printables/printablesEngine.js" defer></script>
+
+  <!-- FAQ toggle -->
+  <script>
+    document.querySelectorAll('.faq-question').forEach(function(btn) {
+      btn.addEventListener('click', function() { this.closest('.faq-item').classList.toggle('open'); });
+    });
+  </script>
+<script src="/footer.js" defer></script>
+</body></html>

--- a/es/imprimibles/index.html
+++ b/es/imprimibles/index.html
@@ -1,0 +1,289 @@
+<!DOCTYPE html><html lang="es"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Letras y alfabetos para imprimir — PDF/PNG gratis | UltraTextGen</title>
+  <meta name="description" content="Letras y alfabetos para imprimir gratis: letras burbuja, fichas de caligrafía en cursiva, abecedario para colorear y fichas para trazar el nombre. Imprime o descarga en PNG — sin registro.">
+  <link rel="canonical" href="https://ultratextgen.com/es/imprimibles/">
+
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/printables/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/imprimables/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/imprimibles/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/imprimiveis/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Letras y alfabetos para imprimir &amp; fichas para trazar | UltraTextGen">
+  <meta property="og:description" content="Letras y alfabetos para imprimir gratis: letras burbuja, fichas de caligrafía en cursiva, abecedario para colorear y fichas para trazar el nombre. Imprime o descarga en PNG.">
+  <meta property="og:url" content="https://ultratextgen.com/es/imprimibles/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Letras y alfabetos para imprimir &amp; fichas para trazar | UltraTextGen">
+  <meta name="twitter:description" content="Letras y alfabetos para imprimir gratis: letras burbuja, fichas de caligrafía en cursiva, abecedario para colorear y fichas para trazar el nombre.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "name": "Letras & alfabetos para imprimir",
+  "url": "https://ultratextgen.com/es/imprimibles/",
+  "description": "Letras, alfabetos, fichas para trazar y descargas en PNG para imprimir gratis.",
+  "inLanguage": "es",
+  "mainEntity": {
+    "@type": "ItemList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Fichas para trazar el nombre", "url": "https://ultratextgen.com/es/imprimibles/nombre-para-trazar/" },
+      { "@type": "ListItem", "position": 2, "name": "Alfabeto en cursiva & fichas de caligrafía", "url": "https://ultratextgen.com/es/imprimibles/alfabeto-cursiva/" },
+      { "@type": "ListItem", "position": 3, "name": "Abecedario para colorear", "url": "https://ultratextgen.com/es/imprimibles/abecedario-para-colorear/" },
+      { "@type": "ListItem", "position": 4, "name": "Letras burbuja para imprimir", "url": "https://ultratextgen.com/es/imprimibles/letras-burbuja/" }
+    ]
+  }
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Inicio", "item": "https://ultratextgen.com/es/" },
+    { "@type": "ListItem", "position": 2, "name": "Imprimibles", "item": "https://ultratextgen.com/es/imprimibles/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "es",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "¿Estas letras para imprimir son gratis?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Sí. Todos los imprimibles de UltraTextGen son totalmente gratis, sin registro, sin marca de agua y sin límites. Elige una letra o escribe un nombre y usa el botón Imprimir para enviarlo a tu impresora, o Descargar PNG para guardar una imagen en alta resolución."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Cuál es la diferencia entre los imprimibles y los generadores de fuentes?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Los generadores de fuentes convierten tu texto en fuentes Unicode para copiar y pegar en biografías, pies de foto y comentarios. Los imprimibles convierten las letras en grandes contornos y fichas que imprimes en papel para trazar, colorear, recortar o practicar la escritura. Están relacionados, pero uno es para pantallas y el otro para papel."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Necesito descargar una app o instalar una fuente?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. Todo funciona en tu navegador. Los contornos y las fichas se generan en la página — haz clic en Imprimir para abrir el cuadro de diálogo de impresión, o en Descargar PNG para guardar una imagen lista para imprimir o reutilizar."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Puedo crear una ficha para trazar con el nombre de mi hijo?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Sí. Abre las Fichas para trazar el nombre, escribe cualquier nombre e imprime una ficha con una línea modelo completa, líneas atenuadas para repasar y líneas en blanco para practicar libremente."
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Ruta de navegación">
+  <a href="/es/">Inicio</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Imprimibles</span>
+</nav>
+
+  <!-- Hero Section -->
+  <section class="hero">
+    <div class="hero-inner" style="max-width:800px;">
+      <h1 class="hero-headline">Letras &amp; alfabetos para imprimir</h1>
+      <p class="hero-tagline">
+        Letras y alfabetos pensados para el papel, no solo para las pantallas.<br>
+        Imprime grandes contornos para trazar y colorear, fichas de caligrafía,
+        o una ficha para trazar con cualquier nombre — luego imprímela o guarda un PNG.
+      </p>
+    </div>
+  </section>
+
+  <!-- Main Content -->
+  <main class="container" style="max-width:900px;">
+
+    <section class="editorial-section" id="imprimibles">
+      <h2>Elige un imprimible</h2>
+      <div class="printable-hub-grid">
+
+        <a class="printable-card" href="/es/imprimibles/nombre-para-trazar/">
+          <span class="printable-card-art" aria-hidden="true">✎ abc</span>
+          <h3>Fichas para trazar el nombre</h3>
+          <p>Escribe cualquier nombre e imprime una ficha de caligrafía: una línea modelo completa, líneas atenuadas para repasar y líneas en blanco para practicar. Perfecto para preescolar y primero de primaria.</p>
+          <span class="printable-card-cta">Abrir las fichas de nombre →</span>
+        </a>
+
+        <a class="printable-card" href="/es/imprimibles/alfabeto-cursiva/">
+          <span class="printable-card-art" aria-hidden="true">𝒜 𝒷 𝒸</span>
+          <h3>Alfabeto en cursiva &amp; fichas de caligrafía</h3>
+          <p>El alfabeto en cursiva completo con fichas de caligrafía para imprimir — letras modelo y espacio para trazar — y la descarga en PNG de cada letra para aprender la letra ligada.</p>
+          <span class="printable-card-cta">Abrir el alfabeto en cursiva →</span>
+        </a>
+
+        <a class="printable-card" href="/es/imprimibles/abecedario-para-colorear/">
+          <span class="printable-card-art" aria-hidden="true">A B C</span>
+          <h3>Abecedario para colorear</h3>
+          <p>Grandes contornos de letras A–Z para colorear e imprimir — una página para cada letra con una palabra de ejemplo, más la impresión de todo el alfabeto con un clic.</p>
+          <span class="printable-card-cta">Abrir el abecedario para colorear →</span>
+        </a>
+
+        <a class="printable-card" href="/es/imprimibles/letras-burbuja/">
+          <span class="printable-card-art" aria-hidden="true">Ⓐ Ⓑ Ⓒ</span>
+          <h3>Letras burbuja para imprimir</h3>
+          <p>Grandes contornos de letras burbuja A–Z y 0–9 para trazar, colorear e imprimir — más el PNG de cualquier letra para carteles, tarjetas y bullet journals.</p>
+          <span class="printable-card-cta">Abrir las letras burbuja →</span>
+        </a>
+
+      </div>
+    </section>
+
+    <section class="editorial-section">
+      <h2>Cómo funcionan los imprimibles</h2>
+      <p>Cada imprimible viene de dos formas. Hay <strong>fichas listas para usar</strong> — planchas
+        de alfabeto A–Z completas y páginas por letra para imprimir tal cual:
+        <a href="/es/imprimibles/letras-burbuja/">letras burbuja</a> para colorear,
+        fichas de <a href="/es/imprimibles/alfabeto-cursiva/">caligrafía en cursiva</a> con líneas modelo para repasar,
+        y <a href="/es/imprimibles/abecedario-para-colorear/">abecedarios para colorear</a>.
+        Elige una letra y listo — nada que configurar.</p>
+      <p>Y hay un <strong>generador</strong> en cada página para crear tus propias fichas. Escribe una palabra o un
+        <a href="/es/imprimibles/nombre-para-trazar/">nombre</a> completo y la herramienta compone una ficha nueva al instante — una
+        línea modelo completa, líneas atenuadas para repasar y líneas en blanco para practicar. Cuando el resultado te
+        convenza, <strong>Imprímelo</strong> directamente desde tu navegador o <strong>Descarga el PNG</strong> para
+        una imagen en alta resolución. Todo ocurre en el navegador: es gratis, instantáneo y sin registro.</p>
+    </section>
+
+    <!-- Cross-family Navigation -->
+    <section class="related-pages">
+      <h2>Para explorar también</h2>
+      <div class="related-pages-grid">
+        <a href="/es/fuentes-de-letras/" class="related-page-card">
+          <span class="related-page-label">Generadores</span>
+          <h4>Fuentes para copiar y pegar</h4>
+        </a>
+        <a href="/es/letra-cursiva/" class="related-page-card">
+          <span class="related-page-label">Generador</span>
+          <h4>Letra cursiva</h4>
+        </a>
+        <a href="/es/letras-negritas/" class="related-page-card">
+          <span class="related-page-label">Generador</span>
+          <h4>Letras en negrita</h4>
+        </a>
+        <a href="/es/" class="related-page-card">
+          <span class="related-page-label">Inicio</span>
+          <h4>UltraTextGen en español</h4>
+        </a>
+      </div>
+    </section>
+  </main>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-inner">
+      <h2 class="faq-category">FAQ Imprimibles</h2>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          ¿Estas letras para imprimir son gratis?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+          </svg>
+        </button>
+        <div class="faq-answer">
+          Sí — totalmente gratis, sin registro, sin marca de agua, sin límites. Elige una letra o escribe un nombre y usa
+          <strong>Imprimir</strong> para enviarlo a tu impresora o <strong>Descargar PNG</strong> para guardar una imagen en alta resolución.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          ¿Cuál es la diferencia entre los imprimibles y los generadores de fuentes?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+          </svg>
+        </button>
+        <div class="faq-answer">
+          Los <a href="/es/fuentes-de-letras/">generadores de fuentes</a> convierten tu texto en fuentes Unicode para copiar y pegar en biografías,
+          pies de foto y comentarios. Los imprimibles convierten las letras en grandes contornos y fichas que imprimes en papel para
+          trazar, colorear, recortar o practicar la escritura. Están relacionados, pero uno es para pantallas y el otro para papel.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          ¿Necesito descargar una app o instalar una fuente?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+          </svg>
+        </button>
+        <div class="faq-answer">
+          No. Todo funciona en tu navegador. Haz clic en <strong>Imprimir</strong> para abrir el cuadro de diálogo de impresión, o en
+          <strong>Descargar PNG</strong> para guardar una imagen lista para imprimir o reutilizar.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          ¿Puedo crear una ficha para trazar con el nombre de mi hijo?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+          </svg>
+        </button>
+        <div class="faq-answer">
+          Sí. Abre las <a href="/es/imprimibles/nombre-para-trazar/">Fichas para trazar el nombre</a>, escribe cualquier nombre e imprime una ficha
+          con una línea modelo completa, líneas atenuadas para repasar y líneas en blanco para practicar libremente.
+        </div>
+      </div>
+
+    </div>
+  </footer>
+
+  <!-- FAQ toggle -->
+  <script>
+    document.querySelectorAll('.faq-question').forEach(function(btn) {
+      btn.addEventListener('click', function() {
+        this.closest('.faq-item').classList.toggle('open');
+      });
+    });
+  </script>
+<script src="/footer.js" defer></script>
+</body></html>

--- a/es/imprimibles/letras-burbuja/index.html
+++ b/es/imprimibles/letras-burbuja/index.html
@@ -1,0 +1,285 @@
+<!DOCTYPE html><html lang="es"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Letras burbuja para imprimir A–Z y 0–9 — Trazar, colorear, PNG | UltraTextGen</title>
+  <meta name="description" content="Letras burbuja para imprimir gratis A–Z y números 0–9. Grandes contornos inflados para trazar y colorear, la impresión de todo el alfabeto, o la descarga de cualquier letra en PNG. Sin registro.">
+  <link rel="canonical" href="https://ultratextgen.com/es/imprimibles/letras-burbuja/">
+
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/printables/bubble-letters/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/imprimables/lettres-bulles/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/imprimibles/letras-burbuja/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/imprimiveis/letras-bolha/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/bubble-letters/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Letras burbuja para imprimir A–Z &amp; 0–9 | UltraTextGen">
+  <meta property="og:description" content="Letras burbuja para imprimir gratis. Grandes contornos para trazar y colorear, la impresión del alfabeto, o la descarga en PNG.">
+  <meta property="og:url" content="https://ultratextgen.com/es/imprimibles/letras-burbuja/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category-bubble-fonts.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Letras burbuja para imprimir A–Z &amp; 0–9 | UltraTextGen">
+  <meta name="twitter:description" content="Letras burbuja para imprimir gratis. Grandes contornos para trazar y colorear, la impresión del alfabeto, o la descarga en PNG.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category-bubble-fonts.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;family=Fredoka:wght@500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Inicio", "item": "https://ultratextgen.com/es/" },
+    { "@type": "ListItem", "position": 2, "name": "Imprimibles", "item": "https://ultratextgen.com/es/imprimibles/" },
+    { "@type": "ListItem", "position": 3, "name": "Letras burbuja", "item": "https://ultratextgen.com/es/imprimibles/letras-burbuja/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Cómo dibujar una letra burbuja",
+  "description": "Convierte cualquier letra simple en una letra burbuja redondeada e inflada para trazar y colorear.",
+  "step": [
+    { "@type": "HowToStep", "position": 1, "name": "Esbozar el esqueleto", "text": "Esboza la letra simple a lápiz como un esqueleto fino." },
+    { "@type": "HowToStep", "position": 2, "name": "Inflar el contorno", "text": "Dibuja un contorno redondeado e inflado, a un dedo de distancia alrededor de cada trazo de la letra." },
+    { "@type": "HowToStep", "position": 3, "name": "Entintar y colorear", "text": "Redondea las esquinas, borra el esqueleto y luego entinta el contorno y coloréalo." }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "es",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "¿Cómo consigo letras burbuja para imprimir y trazar o colorear?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Elige cualquier letra (A–Z) o número (0–9) en el selector para ver un gran contorno de burbuja. Usa Imprimir esta letra para enviar solo ese contorno a tu impresora, o Descargar PNG para guardar una imagen en alta resolución. También puedes imprimir todo el alfabeto A–Z y 0–9 de una vez. Los contornos son blancos con un borde redondeado y grueso, listos para trazar o colorear para carteles, pancartas, tarjetas, actividades de clase y bullet journals."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Cómo dibujo una letra burbuja a mano?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Esboza la letra simple a lápiz como un esqueleto fino, dibuja un contorno redondeado e inflado a un dedo de distancia alrededor de cada trazo, luego redondea las esquinas, borra el esqueleto, entinta y colorea. Una forma rápida de aprender la forma es imprimir el contorno de una letra y repasarlo unas cuantas veces hasta que salga natural."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Puedo imprimir mi nombre en letras burbuja?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Sí. Escribe cualquier nombre o palabra en el campo e imprime una hoja de grandes contornos de burbujas para trazar y colorear, o descárgala como banner PNG para tarjetas, carteles y letreros de puerta."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿También tenéis texto burbuja para copiar y pegar en Instagram o TikTok?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Sí. Si quieres texto burbuja para pegar en una biografía o un pie de foto en vez de para imprimir, usa el generador de fuentes, que convierte tu texto en letras burbuja Unicode para copiar y pegar."
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Ruta de navegación">
+  <a href="/es/">Inicio</a>
+  <span class="breadcrumb-separator">›</span>
+  <a href="/es/imprimibles/">Imprimibles</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Letras burbuja</span>
+</nav>
+
+  <section class="hero">
+    <div class="hero-inner" style="max-width:820px;">
+      <h1 class="hero-headline">Letras burbuja para imprimir A–Z &amp; 0–9</h1>
+      <p class="hero-tagline">
+        Elige una letra o un número para un gran contorno de burbuja inflado para trazar, colorear, imprimir
+        o descargar en PNG — o escribe un nombre para una hoja entera. Gratis, sin registro.
+      </p>
+    </div>
+  </section>
+
+  <main class="container">
+
+    <!-- Picker + selected-letter detail -->
+    <section class="bubble-az" aria-labelledby="ptPickHeading">
+      <h2 class="bubble-az-heading" id="ptPickHeading">Elige una letra burbuja</h2>
+      <p class="bubble-az-intro">Toca una letra (A–Z) o un número (0–9) para ver su gran contorno de burbuja, imprimirlo, descargar un PNG o copiar los estilos burbuja Unicode correspondientes.</p>
+      <div class="bubble-strip" id="pt-strip" role="tablist" aria-label="Elegir una letra o un número burbuja"></div>
+      <div class="bubble-letter-panel" id="pt-panel" aria-live="polite"></div>
+    </section>
+
+    <!-- Name / word worksheet -->
+    <section class="bubble-alphabet" aria-labelledby="ptNameHeading">
+      <h2 id="ptNameHeading">Imprime un nombre en letras burbuja</h2>
+      <p class="bubble-az-intro">Escribe un nombre o una palabra corta, luego imprime una hoja de contornos de burbujas para trazar y colorear, o guárdala como banner PNG.</p>
+      <div class="pt-name-tool">
+        <div class="input-wrapper">
+          <input type="text" class="main-input pt-name-input" id="pt-name-input" placeholder="Escribe un nombre… p. ej. Mia" maxlength="40">
+        </div>
+        <div class="pt-name-preview" id="pt-name-preview" aria-live="polite"></div>
+        <div class="bubble-actions pt-name-actions">
+          <button type="button" class="bubble-btn bubble-btn-primary" id="pt-name-print">Imprimir la hoja</button>
+          <button type="button" class="bubble-btn" id="pt-name-png">Descargar PNG</button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Full printable alphabet -->
+    <section class="bubble-alphabet" aria-labelledby="ptAlphaHeading">
+      <div class="bubble-alphabet-head">
+        <h2 id="ptAlphaHeading">Alfabeto burbuja para imprimir</h2>
+        <button class="bubble-btn bubble-btn-primary" type="button" id="pt-alphabet-print">Imprimir el alfabeto</button>
+      </div>
+      <p class="bubble-az-intro">El alfabeto burbuja A–Z y 0–9 completo en contornos. Imprime toda la hoja para trazar o colorear, o toca cualquier letra para abrir sus opciones de impresión y descarga.</p>
+      <div class="bubble-alphabet-grid" id="pt-alphabet-grid"></div>
+    </section>
+
+    <!-- Editorial -->
+    <section class="editorial-section">
+      <h2>Cómo usar las letras burbuja para imprimir</h2>
+      <ul class="compat-list">
+        <li><span class="ts-pill-safe">Trazar</span> Imprime un contorno y repásalo para aprender la forma inflada a mano.</li>
+        <li><span class="ts-pill-safe">Colorear</span> El interior blanco está listo para rotuladores, lápices o pintura — perfecto para niños y clases.</li>
+        <li><span class="ts-pill-safe">Manualidades</span> Recorta las letras para guirnaldas, letreros de puerta, tarjetas de cumpleaños, álbumes y bullet journals.</li>
+      </ul>
+      <h3>¿Prefieres copiar y pegar en vez de imprimir?</h3>
+      <p>Estos contornos están hechos para el papel. Si quieres texto burbuja para pegar en una biografía de Instagram, un pie de foto de TikTok
+        o un apodo de Discord, usa el <a href="/es/fuentes-de-letras/">generador de fuentes</a> — convierte tu texto
+        en letras burbuja Unicode que mantienen su aspecto en todas partes.</p>
+    </section>
+
+    <div class="cta-card">
+      <h3>¿Quieres texto burbuja para tu biografía o tus pies de foto?</h3>
+      <p>Escribe una vez y copia alegres letras burbuja Unicode que se pegan en todas partes — sin imagen.</p>
+      <a class="cta-btn" href="/es/fuentes-de-letras/">Abrir el generador de fuentes →</a>
+    </div>
+  </main>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <h2 class="faq-category">Letras burbuja para imprimir — FAQ</h2>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          ¿Cómo consigo letras burbuja para imprimir y trazar o colorear?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Elige cualquier letra (A–Z) o número (0–9) en el selector para ver un gran contorno de burbuja. Usa <strong>Imprimir esta letra</strong>
+          para enviar solo ese contorno a tu impresora, o <strong>Descargar PNG</strong> para guardar una imagen en alta resolución. También puedes
+          imprimir todo el alfabeto A–Z y 0–9 de una vez. Los contornos son blancos con un borde redondeado y grueso, listos para trazar o colorear para carteles, pancartas, tarjetas, actividades de clase y bullet journals.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          ¿Cómo dibujo una letra burbuja a mano?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Esboza la letra simple a lápiz como un esqueleto fino, dibuja un contorno redondeado e inflado a un dedo de distancia alrededor de cada trazo,
+          luego redondea las esquinas, borra el esqueleto, entinta y colorea. Una forma rápida de aprender la forma es imprimir el contorno de una letra y repasarlo unas cuantas veces hasta que salga natural.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          ¿Puedo imprimir mi nombre en letras burbuja?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Sí. Escribe cualquier nombre o palabra en el campo e imprime una hoja de grandes contornos de burbujas para trazar y colorear, o descárgala
+          como banner PNG para tarjetas, carteles y letreros de puerta.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          ¿También tenéis texto burbuja para copiar y pegar en Instagram o TikTok?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Sí. Si quieres texto burbuja para pegar en una biografía o un pie de foto en vez de para imprimir, usa el
+          <a href="/es/fuentes-de-letras/">generador de fuentes</a>, que convierte tu texto en letras burbuja Unicode para copiar y pegar.
+        </div>
+      </div>
+
+    </div>
+  </footer>
+
+  <!-- Print surface (hidden on screen, isolated when printing) -->
+  <div id="pt-print-root" aria-hidden="true"></div>
+
+  <script>
+    window.UTG_PRINTABLE = {
+      key: "bubble-letters",
+      lang: "es",
+      render: "outline",
+      noun: "burbuja",
+      pngPrefix: "burbuja",
+      font: "Fredoka, 'Plus Jakarta Sans', sans-serif",
+      strokeWidth: 9,
+      letterSpacing: 0.1,
+      charset: "alnum",
+      variantFamily: "bubble",
+      glyphStyle: "Ultra Bubble",
+      nameDemo: "Mia",
+      howto: {
+        title: "Cómo dibujar {ch} en burbuja",
+        steps: [
+          "Dibuja {ch} a lápiz como un esqueleto fino.",
+          "Traza un contorno redondeado e inflado, a un dedo de distancia alrededor de cada trazo.",
+          "Redondea las esquinas, borra el esqueleto y luego entinta el contorno y coloréalo."
+        ],
+        tip: "Consejo: imprime el contorno de arriba y repásalo varias veces hasta que la forma salga natural."
+      }
+    };
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/js/printables/printablesEngine.js" defer></script>
+
+  <!-- FAQ toggle -->
+  <script>
+    document.querySelectorAll('.faq-question').forEach(function(btn) {
+      btn.addEventListener('click', function() { this.closest('.faq-item').classList.toggle('open'); });
+    });
+  </script>
+<script src="/footer.js" defer></script>
+</body></html>

--- a/es/imprimibles/nombre-para-trazar/index.html
+++ b/es/imprimibles/nombre-para-trazar/index.html
@@ -1,0 +1,284 @@
+<!DOCTYPE html><html lang="es"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Fichas para trazar el nombre — Caligrafía para imprimir gratis | UltraTextGen</title>
+  <meta name="description" content="Escribe un nombre para crear una ficha de caligrafía para imprimir gratis: una línea modelo completa, líneas atenuadas para repasar y líneas en blanco para practicar. Además, el trazado de las letras A–Z y los números 0–9. Sin registro.">
+  <link rel="canonical" href="https://ultratextgen.com/es/imprimibles/nombre-para-trazar/">
+
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/printables/name-tracing/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/imprimables/prenom-a-tracer/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/imprimibles/nombre-para-trazar/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/imprimiveis/nome-para-tracar/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/name-tracing/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Fichas para trazar el nombre — Caligrafía para imprimir gratis | UltraTextGen">
+  <meta property="og:description" content="Escribe un nombre para crear una ficha para trazar gratis: línea modelo, líneas atenuadas para repasar y líneas en blanco. Además, el trazado de las letras A–Z y los números 0–9.">
+  <meta property="og:url" content="https://ultratextgen.com/es/imprimibles/nombre-para-trazar/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Fichas para trazar el nombre — Caligrafía para imprimir gratis | UltraTextGen">
+  <meta name="twitter:description" content="Escribe un nombre para crear una ficha para trazar gratis: línea modelo, líneas atenuadas para repasar y líneas en blanco.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;family=Quicksand:wght@500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Inicio", "item": "https://ultratextgen.com/es/" },
+    { "@type": "ListItem", "position": 2, "name": "Imprimibles", "item": "https://ultratextgen.com/es/imprimibles/" },
+    { "@type": "ListItem", "position": 3, "name": "Nombre para trazar", "item": "https://ultratextgen.com/es/imprimibles/nombre-para-trazar/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "es",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "¿Cómo creo una ficha para trazar el nombre?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Escribe un nombre en el campo y haz clic en Imprimir la ficha. La ficha incluye una línea modelo completa que muestra el nombre, varias líneas atenuadas para repasar y líneas en blanco para practicar libremente. También puedes descargarla en PNG. Elige el número de líneas para repasar antes de imprimir."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Las fichas para trazar el nombre son gratis?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Sí — totalmente gratis, sin registro, sin marca de agua y sin límites. Crea todas las fichas que quieras, para cualquier nombre o palabra."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿También puedo crear fichas de letras y números para trazar?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Sí. Usa el selector de letras para trazar una sola letra A–Z o un número 0–9, o imprime la ficha completa A–Z y 0–9 con líneas modelo y líneas para repasar. Funciona para nombres en mayúsculas, práctica en minúsculas y formación de los números."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "¿Para qué edad es adecuado el trazado del nombre?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "El trazado del nombre es adecuado para niños de preescolar y primero de primaria que construyen la formación de las letras y la motricidad fina, así como para cualquiera que practique una escritura cuidada. Imprime varias copias y prioriza sesiones cortas y frecuentes para mejores resultados."
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Ruta de navegación">
+  <a href="/es/">Inicio</a>
+  <span class="breadcrumb-separator">›</span>
+  <a href="/es/imprimibles/">Imprimibles</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Nombre para trazar</span>
+</nav>
+
+  <section class="hero">
+    <div class="hero-inner" style="max-width:820px;">
+      <h1 class="hero-headline">Fichas para trazar el nombre</h1>
+      <p class="hero-tagline">
+        Escribe cualquier nombre e imprime una ficha de caligrafía: una línea modelo completa, líneas atenuadas para repasar
+        y líneas en blanco para practicar. Además, el trazado de las letras A–Z y los números 0–9. Gratis, sin registro.
+      </p>
+    </div>
+  </section>
+
+  <main class="container">
+
+    <div class="pt-stroke-toggle-row">
+      <label class="pt-check" for="pt-stroke-toggle">
+        <input type="checkbox" id="pt-stroke-toggle">
+        Mostrar el sentido de los trazos
+      </label>
+      <span class="pt-stroke-toggle-hint">Añade un punto de partida numerado y flechas en cada letra trazada, para mostrar en qué sentido dibujar cada trazo — opcional, porque no todos los niños necesitan la misma guía según su nivel.</span>
+    </div>
+
+    <!-- Name worksheet (primary) -->
+    <section class="bubble-alphabet" aria-labelledby="ptNameHeading">
+      <h2 id="ptNameHeading">Crea una ficha para trazar el nombre</h2>
+      <p class="bubble-az-intro">Escribe un nombre o una palabra corta, previsualízalo abajo y luego imprime — o descarga un PNG. La ficha ofrece un modelo completo para seguir, líneas atenuadas para repasar y líneas en blanco para practicar libremente.</p>
+      <div class="pt-name-tool">
+        <div class="input-wrapper">
+          <input type="text" class="main-input pt-name-input" id="pt-name-input" placeholder="Escribe un nombre… p. ej. Emma" maxlength="40">
+        </div>
+        <div class="pt-name-controls">
+          <label class="pt-name-rows-label" for="pt-name-rows">Líneas para repasar</label>
+          <select id="pt-name-rows" class="pt-name-rows-select">
+            <option value="2">2</option>
+            <option value="3" selected>3</option>
+            <option value="4">4</option>
+            <option value="5">5</option>
+            <option value="6">6</option>
+          </select>
+        </div>
+        <div class="pt-name-preview" id="pt-name-preview" aria-live="polite"></div>
+        <div class="bubble-actions pt-name-actions">
+          <button type="button" class="bubble-btn bubble-btn-primary" id="pt-name-print">Imprimir la ficha</button>
+          <button type="button" class="bubble-btn" id="pt-name-png">Descargar PNG</button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Letter / number tracing -->
+    <section class="bubble-az" aria-labelledby="ptPickHeading">
+      <h2 class="bubble-az-heading" id="ptPickHeading">Trazar letras &amp; números A–Z, 0–9</h2>
+      <p class="bubble-az-intro">Toca cualquier letra o número para trazarlo solo, imprimir un gran carácter único o descargar un PNG.</p>
+      <div class="bubble-strip" id="pt-strip" role="tablist" aria-label="Elegir una letra o un número para trazar"></div>
+      <div class="bubble-letter-panel" id="pt-panel" aria-live="polite"></div>
+    </section>
+
+    <!-- Full practice sheet + alphabet -->
+    <section class="bubble-alphabet" aria-labelledby="ptAlphaHeading">
+      <div class="bubble-alphabet-head">
+        <h2 id="ptAlphaHeading">Fichas para trazar A–Z &amp; 0–9 para imprimir</h2>
+        <button class="bubble-btn bubble-btn-primary" type="button" id="pt-practice-print">Imprimir la hoja de práctica</button>
+      </div>
+      <p class="bubble-az-intro">Imprime una ficha pautada A–Z y 0–9 — un modelo más un espacio para repasar en cada línea — o imprime el alfabeto en contorno de abajo para trazar las letras enteras.</p>
+      <div class="bubble-alphabet-grid" id="pt-alphabet-grid"></div>
+      <div class="pt-alpha-print-row">
+        <button class="bubble-btn" type="button" id="pt-alphabet-print">Imprimir el alfabeto en contorno</button>
+      </div>
+    </section>
+
+    <!-- Editorial -->
+    <section class="editorial-section">
+      <h2>Sacar el máximo partido al trazado del nombre</h2>
+      <ul class="compat-list">
+        <li><span class="ts-pill-safe">El modelo primero</span> Muestra la línea completa de arriba y di el nombre antes de empezar a trazar.</li>
+        <li><span class="ts-pill-safe">Trazar despacio</span> Anima a mantenerse dentro del contorno — el control importa más que la velocidad.</li>
+        <li><span class="ts-pill-safe">Luego a mano alzada</span> Termina en las líneas en blanco escribiéndolo sin la guía.</li>
+      </ul>
+      <p>¿Listo para subir la dificultad a medida que avanza? Las
+        <a href="/es/imprimibles/alfabeto-cursiva/">fichas de caligrafía en cursiva</a> permiten pasar a la letra ligada,
+        y puedes componer un nombre decorativo en
+        <a href="/es/imprimibles/letras-burbuja/">letras burbuja</a> para colorear.</p>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <h2 class="faq-category">Nombre para trazar — FAQ</h2>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          ¿Cómo creo una ficha para trazar el nombre?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Escribe un nombre en el campo y haz clic en <strong>Imprimir la ficha</strong>. La ficha incluye una línea modelo completa que muestra el
+          nombre, varias líneas atenuadas para repasar y líneas en blanco para practicar libremente. También puedes descargarla en PNG, y
+          elegir el número de líneas para repasar antes de imprimir.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          ¿Las fichas para trazar el nombre son gratis?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Sí — totalmente gratis, sin registro, sin marca de agua y sin límites. Crea todas las fichas que quieras, para cualquier nombre o palabra.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          ¿También puedo crear fichas de letras y números para trazar?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Sí. Usa el selector de letras para trazar una sola letra A–Z o un número 0–9, o imprime la ficha completa A–Z y 0–9 con
+          líneas modelo y líneas para repasar. Funciona para nombres en mayúsculas, práctica en minúsculas y formación de los números.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          ¿Para qué edad es adecuado el trazado del nombre?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          El trazado del nombre es adecuado para niños de preescolar y primero de primaria que construyen la formación de las letras y la motricidad fina, así como para
+          cualquiera que practique una escritura cuidada. Imprime varias copias y prioriza sesiones cortas y frecuentes para mejores resultados.
+        </div>
+      </div>
+
+    </div>
+  </footer>
+
+  <!-- Print surface (hidden on screen, isolated when printing) -->
+  <div id="pt-print-root" aria-hidden="true"></div>
+
+  <script>
+    window.UTG_PRINTABLE = {
+      key: "name-tracing",
+      lang: "es",
+      render: "outline",
+      noun: "trazo",
+      pngPrefix: "nombre",
+      font: "Quicksand, 'Plus Jakarta Sans', sans-serif",
+      strokeWidth: 4,
+      charset: "alnum",
+      variantFamily: "",
+      nameDemo: "Emma",
+      howto: {
+        title: "Cómo trazar {ch}",
+        steps: [
+          "Empieza arriba del contorno gris y síguelo despacio.",
+          "Mantén el lápiz dentro de las líneas — ve despacio para controlar el trazo.",
+          "Trázala varias veces y luego escríbela sola en la línea en blanco."
+        ],
+        tip: "Imprime varias copias para que el niño practique toda la semana."
+      }
+    };
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/js/printables/strokeDirectionData.js" defer></script>
+  <script src="/js/printables/printablesEngine.js" defer></script>
+
+  <!-- FAQ toggle -->
+  <script>
+    document.querySelectorAll('.faq-question').forEach(function(btn) {
+      btn.addEventListener('click', function() { this.closest('.faq-item').classList.toggle('open'); });
+    });
+  </script>
+<script src="/footer.js" defer></script>
+</body></html>

--- a/es/index.html
+++ b/es/index.html
@@ -594,6 +594,7 @@
       <a href="/es/simbolos-de-corazon/" class="compare-card variant-muted u-no-underline"><h4>Símbolos de corazón</h4><p>Corazones de todos los estilos para copiar y pegar.</p></a>
       <a href="/es/fuentes-para-instagram/" class="compare-card variant-muted u-no-underline"><h4>Fuentes para Instagram</h4><p>Los estilos que mejor se ven en bios, captions y nombres.</p></a>
       <a href="/es/decorador-de-texto/" class="compare-card variant-muted u-no-underline"><h4>Decorador de texto</h4><p>Marcos, separadores y adornos alrededor de tu texto.</p></a>
+      <a href="/es/imprimibles/" class="compare-card variant-muted u-no-underline"><h4>Imprimibles</h4><p>Letras burbuja, alfabeto en cursiva, abecedario para colorear y fichas para trazar el nombre — imprime o guarda en PNG.</p></a>
     </div>
   </section>
 

--- a/fr/imprimables/alphabet-cursif/index.html
+++ b/fr/imprimables/alphabet-cursif/index.html
@@ -16,6 +16,8 @@
 
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/printables/cursive-alphabet/">
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/imprimables/alphabet-cursif/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/imprimibles/alfabeto-cursiva/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/imprimiveis/alfabeto-cursivo/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/cursive-alphabet/">
 
   <meta name="robots" content="index, follow">

--- a/fr/imprimables/alphabet-cursif/index.html
+++ b/fr/imprimables/alphabet-cursif/index.html
@@ -1,0 +1,256 @@
+<!DOCTYPE html><html lang="fr"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Alphabet cursif A–Z — Fiches d'écriture attachée à imprimer | UltraTextGen</title>
+  <meta name="description" content="L'alphabet cursif A–Z avec des fiches d'écriture à imprimer gratuites — lettres modèles et espace pour tracer — le téléchargement PNG de chaque lettre et une fiche de prénom en cursive. Sans inscription.">
+  <link rel="canonical" href="https://ultratextgen.com/fr/imprimables/alphabet-cursif/">
+
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/printables/cursive-alphabet/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/imprimables/alphabet-cursif/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/cursive-alphabet/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Alphabet cursif A–Z — Fiches d'écriture attachée à imprimer | UltraTextGen">
+  <meta property="og:description" content="L'alphabet cursif A–Z avec des fiches d'écriture à imprimer pour tracer, le téléchargement PNG de chaque lettre et une fiche de prénom en cursive.">
+  <meta property="og:url" content="https://ultratextgen.com/fr/imprimables/alphabet-cursif/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category-cursive-fonts.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Alphabet cursif A–Z — Fiches d'écriture attachée à imprimer | UltraTextGen">
+  <meta name="twitter:description" content="L'alphabet cursif A–Z avec des fiches d'écriture à imprimer pour tracer, le téléchargement PNG de chaque lettre et une fiche de prénom en cursive.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category-cursive-fonts.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Accueil", "item": "https://ultratextgen.com/fr/" },
+    { "@type": "ListItem", "position": 2, "name": "Imprimables", "item": "https://ultratextgen.com/fr/imprimables/" },
+    { "@type": "ListItem", "position": 3, "name": "Alphabet cursif", "item": "https://ultratextgen.com/fr/imprimables/alphabet-cursif/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "fr",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Puis-je imprimer des fiches d'écriture cursive ?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Oui. Cliquez sur Imprimer la fiche d'entraînement pour obtenir une page A–Z à imprimer : chaque ligne montre les lettres modèles en cursive plus un espace pour les tracer et les répéter — pratique pour les enseignants, les parents et toute personne qui apprend l'écriture attachée."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Comment imprimer une seule lettre cursive, comme un S ou un G majuscule ?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Touchez n'importe quelle lettre du sélecteur pour voir sa forme cursive en majuscule et en minuscule. Utilisez Imprimer cette lettre pour une grande page d'une seule lettre, ou Télécharger le PNG pour enregistrer une image en haute résolution à imprimer ou réutiliser."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Puis-je créer une fiche de prénom à tracer en cursive ?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Oui. Tapez un prénom dans le champ prévu et imprimez une fiche avec une ligne modèle plus des lignes estompées à repasser — une manière simple de s'entraîner à écrire un prénom ou une signature en cursive."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "La cursive Unicode est-elle la même chose que la vraie écriture cursive ?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "La cursive à l'écran est composée de caractères script Unicode, qui servent aussi de modèles nets pour la forme des lettres. Les fiches imprimées les utilisent comme modèles à tracer. Pour du texte cursif à copier-coller dans les bios et les légendes, utilisez plutôt le générateur d'écriture cursive."
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Fil d'Ariane">
+  <a href="/fr/">Accueil</a>
+  <span class="breadcrumb-separator">›</span>
+  <a href="/fr/imprimables/">Imprimables</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Alphabet cursif</span>
+</nav>
+
+  <section class="hero">
+    <div class="hero-inner" style="max-width:820px;">
+      <h1 class="hero-headline">Alphabet cursif — Fiches d'écriture à imprimer</h1>
+      <p class="hero-tagline">
+        L'alphabet cursif complet A–Z. Imprimez une fiche d'entraînement avec lettres modèles et espace pour tracer,
+        téléchargez n'importe quelle lettre en PNG, ou créez une fiche de prénom en cursive. Gratuit, sans inscription.
+      </p>
+    </div>
+  </section>
+
+  <main class="container">
+
+    <!-- Practice sheet CTA -->
+    <section class="bubble-alphabet" aria-labelledby="ptPracticeHeading">
+      <div class="bubble-alphabet-head">
+        <h2 id="ptPracticeHeading">Fiche d'écriture cursive à imprimer</h2>
+        <button class="bubble-btn bubble-btn-primary" type="button" id="pt-practice-print">Imprimer la fiche d'entraînement</button>
+      </div>
+      <p class="bubble-az-intro">Un clic imprime une page A–Z où chaque ligne montre les lettres modèles en cursive plus un espace pour les tracer et les répéter — prête pour la classe, l'école à la maison ou votre propre entraînement.</p>
+    </section>
+
+    <!-- Picker + selected-letter detail -->
+    <section class="bubble-az" aria-labelledby="ptPickHeading">
+      <h2 class="bubble-az-heading" id="ptPickHeading">Lettres cursives A–Z</h2>
+      <p class="bubble-az-intro">Touchez une lettre pour voir sa forme cursive en majuscule et en minuscule, imprimer une grande lettre unique, télécharger un PNG ou copier les styles cursifs Unicode correspondants.</p>
+      <div class="bubble-strip" id="pt-strip" role="tablist" aria-label="Choisir une lettre cursive"></div>
+      <div class="bubble-letter-panel" id="pt-panel" aria-live="polite"></div>
+    </section>
+
+    <!-- Cursive name worksheet -->
+    <section class="bubble-alphabet" aria-labelledby="ptNameHeading">
+      <h2 id="ptNameHeading">Fiche de prénom à tracer en cursive</h2>
+      <p class="bubble-az-intro">Tapez un prénom pour le prévisualiser en cursive, puis imprimez une fiche avec une ligne modèle et des lignes estompées à repasser — idéal pour les signatures et l'entraînement du prénom.</p>
+      <div class="pt-name-tool">
+        <div class="input-wrapper">
+          <input type="text" class="main-input pt-name-input" id="pt-name-input" placeholder="Tapez un prénom… ex. Olivia" maxlength="40">
+        </div>
+        <div class="pt-name-preview" id="pt-name-preview" aria-live="polite"></div>
+        <div class="bubble-actions pt-name-actions">
+          <button type="button" class="bubble-btn bubble-btn-primary" id="pt-name-print">Imprimer la fiche</button>
+          <button type="button" class="bubble-btn" id="pt-name-png">Télécharger le PNG</button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Editorial -->
+    <section class="editorial-section">
+      <h2>Apprendre la cursive avec la fiche d'entraînement</h2>
+      <p>Imprimez la <strong>fiche d'entraînement</strong> et repassez chaque lettre modèle jusqu'à ce que les liaisons deviennent
+        naturelles, puis passez à l'espace vierge pour l'écrire à main levée. Observez comment chaque majuscule se relie, et gardez
+        des séances courtes et fréquentes — quelques lettres par jour valent mieux qu'une longue séance.</p>
+      <h3>Cursive à imprimer vs. cursive à copier-coller</h3>
+      <p>Ces fiches sont faites pour le <em>papier</em> — le tracé et l'écriture. Si vous voulez du texte cursif à coller dans une
+        bio Instagram, une légende ou un document, utilisez le <a href="/fr/ecriture-cursive/">générateur d'écriture cursive</a>, qui
+        transforme vos mots en script Unicode à copier-coller. Pour un prénom décoratif à colorier, essayez les
+        <a href="/fr/imprimables/lettres-bulles/">lettres bulles</a>.</p>
+    </section>
+
+    <div class="cta-card">
+      <h3>Vous voulez de la cursive à copier-coller ?</h3>
+      <p>Tapez une fois et copiez du script Unicode fluide pour vos bios, légendes, prénoms et signatures.</p>
+      <a class="cta-btn" href="/fr/ecriture-cursive/">Ouvrir le générateur d'écriture cursive →</a>
+    </div>
+  </main>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <h2 class="faq-category">Cursive à imprimer — FAQ</h2>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Puis-je imprimer des fiches d'écriture cursive ?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Oui. Cliquez sur <strong>Imprimer la fiche d'entraînement</strong> pour obtenir une page A–Z à imprimer : chaque ligne montre les lettres
+          modèles en cursive plus un espace pour les tracer et les répéter — pratique pour les enseignants, les parents et toute personne qui apprend l'écriture attachée.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Comment imprimer une seule lettre cursive, comme un S ou un G majuscule ?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Touchez n'importe quelle lettre du sélecteur pour voir sa forme cursive en majuscule et en minuscule. Utilisez <strong>Imprimer cette lettre</strong>
+          pour une grande page d'une seule lettre, ou <strong>Télécharger le PNG</strong> pour enregistrer une image en haute résolution à imprimer ou réutiliser.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Puis-je créer une fiche de prénom à tracer en cursive ?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Oui. Tapez un prénom dans le champ prévu et imprimez une fiche avec une ligne modèle plus des lignes estompées à repasser — une manière simple
+          de s'entraîner à écrire un prénom ou une signature en cursive.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          La cursive Unicode est-elle la même chose que la vraie écriture cursive ?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          La cursive à l'écran est composée de caractères script Unicode, qui servent aussi de modèles nets pour la forme des lettres. Les fiches imprimées
+          les utilisent comme modèles à tracer. Pour du texte cursif à copier-coller dans les bios et les légendes, utilisez plutôt le
+          <a href="/fr/ecriture-cursive/">générateur d'écriture cursive</a>.
+        </div>
+      </div>
+
+    </div>
+  </footer>
+
+  <!-- Print surface (hidden on screen, isolated when printing) -->
+  <div id="pt-print-root" aria-hidden="true"></div>
+
+  <script>
+    window.UTG_PRINTABLE = {
+      key: "cursive-alphabet",
+      lang: "fr",
+      render: "glyph",
+      noun: "cursive",
+      pngPrefix: "cursive",
+      font: "'Plus Jakarta Sans', 'Segoe UI Symbol', 'Noto Sans Symbols 2', sans-serif",
+      charset: "alpha",
+      variantFamily: "cursive",
+      glyphStyle: "Ultra Script",
+      nameDemo: "Olivia"
+    };
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/js/printables/printablesEngine.js" defer></script>
+
+  <!-- FAQ toggle -->
+  <script>
+    document.querySelectorAll('.faq-question').forEach(function(btn) {
+      btn.addEventListener('click', function() { this.closest('.faq-item').classList.toggle('open'); });
+    });
+  </script>
+<script src="/footer.js" defer></script>
+</body></html>

--- a/fr/imprimables/coloriage-alphabet/index.html
+++ b/fr/imprimables/coloriage-alphabet/index.html
@@ -16,6 +16,8 @@
 
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/printables/alphabet-coloring-pages/">
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/imprimables/coloriage-alphabet/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/imprimibles/abecedario-para-colorear/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/imprimiveis/alfabeto-para-colorir/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/alphabet-coloring-pages/">
 
   <meta name="robots" content="index, follow">

--- a/fr/imprimables/coloriage-alphabet/index.html
+++ b/fr/imprimables/coloriage-alphabet/index.html
@@ -1,0 +1,239 @@
+<!DOCTYPE html><html lang="fr"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Coloriages alphabet A–Z — Lettres à colorier à imprimer gratuites | UltraTextGen</title>
+  <meta name="description" content="Coloriages alphabet A–Z à imprimer gratuits. De grands contours de lettres à colorier et à imprimer, une page pour chaque lettre A à Z. Imprimez tout l'alphabet ou téléchargez n'importe quelle lettre en PNG.">
+  <link rel="canonical" href="https://ultratextgen.com/fr/imprimables/coloriage-alphabet/">
+
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/printables/alphabet-coloring-pages/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/imprimables/coloriage-alphabet/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/alphabet-coloring-pages/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Coloriages alphabet A–Z | UltraTextGen">
+  <meta property="og:description" content="Coloriages alphabet A–Z à imprimer gratuits. Coloriez et imprimez de grands contours de lettres, ou ouvrez la page d'une lettre.">
+  <meta property="og:url" content="https://ultratextgen.com/fr/imprimables/coloriage-alphabet/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Coloriages alphabet A–Z | UltraTextGen">
+  <meta name="twitter:description" content="Coloriages alphabet A–Z à imprimer gratuits. Coloriez et imprimez de grands contours de lettres.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;family=Baloo+2:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Accueil", "item": "https://ultratextgen.com/fr/" },
+    { "@type": "ListItem", "position": 2, "name": "Imprimables", "item": "https://ultratextgen.com/fr/imprimables/" },
+    { "@type": "ListItem", "position": 3, "name": "Coloriage alphabet", "item": "https://ultratextgen.com/fr/imprimables/coloriage-alphabet/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "fr",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Ces coloriages alphabet sont-ils gratuits à imprimer ?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Oui. Chaque coloriage alphabet ici est entièrement gratuit, sans inscription, sans filigrane et sans limite. Choisissez une lettre pour un grand contour, puis utilisez Imprimer cette lettre pour l'envoyer à votre imprimante ou Télécharger le PNG pour enregistrer une image en haute résolution."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Comment imprimer tout l'alphabet ABC d'un coup ?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Faites défiler jusqu'à la section Alphabet à imprimer et appuyez sur Imprimer l'alphabet pour envoyer les 26 contours de lettres à votre imprimante sur une seule feuille — pratique pour un jeu de classe ou une activité de jour de pluie."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Puis-je obtenir un coloriage pour une seule lettre ?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Oui. Touchez n'importe quelle lettre A–Z dans le sélecteur pour la prévisualiser, puis utilisez Imprimer cette lettre ou Télécharger le PNG pour un grand contour d'une seule lettre à colorier."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "En quoi sont-ils différents des lettres bulles ?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ces coloriages utilisent des contours fins et nets, faciles à colorier à l'intérieur. Les lettres bulles sont arrondies et gonflées. Toutes deux sont des contours à imprimer gratuits — choisissez le style que vous préférez."
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Fil d'Ariane">
+  <a href="/fr/">Accueil</a>
+  <span class="breadcrumb-separator">›</span>
+  <a href="/fr/imprimables/">Imprimables</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Coloriage alphabet</span>
+</nav>
+
+  <section class="hero">
+    <div class="hero-inner" style="max-width:820px;">
+      <h1 class="hero-headline">Coloriages alphabet (A–Z)</h1>
+      <p class="hero-tagline">
+        Coloriages ABC à imprimer gratuits. Choisissez une lettre pour un grand contour net à colorier, imprimez tout l'alphabet d'un coup, ou prévisualisez n'importe quelle lettre — sans inscription.
+      </p>
+    </div>
+  </section>
+
+  <main class="container">
+
+    <!-- Picker + selected-letter detail -->
+    <section class="bubble-az" aria-labelledby="ptPickHeading">
+      <h2 class="bubble-az-heading" id="ptPickHeading">Choisissez une lettre à colorier</h2>
+      <p class="bubble-az-intro">Touchez n'importe quelle lettre A–Z pour voir son grand contour de coloriage, l'imprimer ou télécharger un PNG.</p>
+      <div class="bubble-strip" id="pt-strip" role="tablist" aria-label="Choisir une lettre à colorier"></div>
+      <div class="bubble-letter-panel" id="pt-panel" aria-live="polite"></div>
+    </section>
+
+    <!-- Full printable alphabet -->
+    <section class="bubble-alphabet" aria-labelledby="ptAlphaHeading">
+      <div class="bubble-alphabet-head">
+        <h2 id="ptAlphaHeading">Alphabet à imprimer</h2>
+        <button class="bubble-btn bubble-btn-primary" type="button" id="pt-alphabet-print">Imprimer l'alphabet</button>
+      </div>
+      <p class="bubble-az-intro">L'alphabet A–Z complet en contours de coloriage nets. Imprimez toute la feuille à colorier, ou touchez n'importe quelle lettre pour ouvrir ses options d'impression et de téléchargement.</p>
+      <div class="bubble-alphabet-grid" id="pt-alphabet-grid"></div>
+    </section>
+
+    <!-- Editorial -->
+    <section class="editorial-section">
+      <h2>Comment utiliser les coloriages alphabet</h2>
+      <ul class="compat-list">
+        <li><span class="ts-pill-safe">Apprendre</span> Dites la lettre et son son à voix haute pendant le coloriage — une façon simple de relier les lettres aux sons.</li>
+        <li><span class="ts-pill-safe">Colorier</span> Les contours fins laissent beaucoup de place pour les crayons, feutres et crayons de couleur.</li>
+        <li><span class="ts-pill-safe">En classe</span> Imprimez tout l'alphabet pour un atelier, ou une seule lettre pour la lettre de la semaine.</li>
+      </ul>
+      <h3>Vous préférez des lettres à copier-coller plutôt qu'un coloriage ?</h3>
+      <p>Ces contours sont faits pour le papier. Si vous voulez de belles lettres à coller dans une bio ou une légende, utilisez les
+        <a href="/fr/generateur-de-texte/">générateurs de police</a>. Pour d'autres styles à imprimer, essayez les
+        <a href="/fr/imprimables/lettres-bulles/">lettres bulles</a>.</p>
+    </section>
+
+    <div class="cta-card">
+      <h3>Vous cherchez plutôt de l'entraînement à l'écriture ?</h3>
+      <p>Tapez n'importe quel prénom et imprimez une fiche à tracer avec lignes modèles et lignes à repasser — parfait pour la maternelle et le CP.</p>
+      <a class="cta-btn" href="/fr/imprimables/prenom-a-tracer/">Ouvrir les fiches de prénom à tracer →</a>
+    </div>
+
+    <div class="cta-card">
+      <h3>Envie d'écriture attachée ?</h3>
+      <p>Passez à l'alphabet cursif avec des fiches d'écriture à tracer et le téléchargement PNG de chaque lettre.</p>
+      <a class="cta-btn" href="/fr/imprimables/alphabet-cursif/">Ouvrir l'alphabet cursif →</a>
+    </div>
+  </main>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <h2 class="faq-category">Coloriages alphabet — FAQ</h2>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Ces coloriages alphabet sont-ils gratuits à imprimer ?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Oui — chaque coloriage alphabet ici est entièrement gratuit, sans inscription, sans filigrane et sans limite. Choisissez une lettre pour un grand contour, puis utilisez <strong>Imprimer cette lettre</strong> pour l'envoyer à votre imprimante ou <strong>Télécharger le PNG</strong> pour enregistrer une image en haute résolution.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Comment imprimer tout l'alphabet ABC d'un coup ?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Faites défiler jusqu'à la section <strong>Alphabet à imprimer</strong> et appuyez sur <strong>Imprimer l'alphabet</strong> pour envoyer les 26 contours de lettres à votre imprimante sur une seule feuille — pratique pour un jeu de classe ou une activité de jour de pluie.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Puis-je obtenir un coloriage pour une seule lettre ?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Oui. Touchez n'importe quelle lettre A–Z dans le sélecteur pour la prévisualiser, puis utilisez <strong>Imprimer cette lettre</strong> ou <strong>Télécharger le PNG</strong> pour un grand contour d'une seule lettre à colorier.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          En quoi sont-ils différents des lettres bulles ?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Ces coloriages utilisent des contours fins et nets, faciles à colorier à l'intérieur. Les <a href="/fr/imprimables/lettres-bulles/">lettres bulles</a> sont arrondies et gonflées. Toutes deux sont des contours à imprimer gratuits — choisissez le style que vous préférez.
+        </div>
+      </div>
+
+    </div>
+  </footer>
+
+  <!-- Print surface (hidden on screen, isolated when printing) -->
+  <div id="pt-print-root" aria-hidden="true"></div>
+
+  <script>
+    window.UTG_PRINTABLE = {
+      key: "alphabet-coloring-pages",
+      lang: "fr",
+      render: "outline",
+      noun: "coloriage",
+      pngPrefix: "coloriage",
+      font: "'Baloo 2', 'Plus Jakarta Sans', sans-serif",
+      strokeWidth: 4,
+    };
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/js/printables/printablesEngine.js" defer></script>
+
+  <!-- FAQ toggle -->
+  <script>
+    document.querySelectorAll('.faq-question').forEach(function(btn) {
+      btn.addEventListener('click', function() { this.closest('.faq-item').classList.toggle('open'); });
+    });
+  </script>
+<script src="/footer.js" defer></script>
+</body></html>

--- a/fr/imprimables/index.html
+++ b/fr/imprimables/index.html
@@ -16,6 +16,8 @@
 
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/printables/">
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/imprimables/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/imprimibles/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/imprimiveis/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/">
 
   <meta name="robots" content="index, follow">

--- a/fr/imprimables/index.html
+++ b/fr/imprimables/index.html
@@ -1,0 +1,287 @@
+<!DOCTYPE html><html lang="fr"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Lettres à imprimer, alphabets &amp; fiches à tracer — PDF/PNG gratuits | UltraTextGen</title>
+  <meta name="description" content="Lettres et alphabets à imprimer gratuits : lettres bulles, fiches d'écriture cursive, coloriages alphabet et fiches de prénom à tracer. Imprimez ou téléchargez en PNG — sans inscription.">
+  <link rel="canonical" href="https://ultratextgen.com/fr/imprimables/">
+
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/printables/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/imprimables/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Lettres à imprimer, alphabets &amp; fiches à tracer | UltraTextGen">
+  <meta property="og:description" content="Lettres et alphabets à imprimer gratuits : lettres bulles, fiches d'écriture cursive, coloriages alphabet et fiches de prénom à tracer. Imprimez ou téléchargez en PNG.">
+  <meta property="og:url" content="https://ultratextgen.com/fr/imprimables/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Lettres à imprimer, alphabets &amp; fiches à tracer | UltraTextGen">
+  <meta name="twitter:description" content="Lettres et alphabets à imprimer gratuits : lettres bulles, fiches d'écriture cursive, coloriages alphabet et fiches de prénom à tracer.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "name": "Lettres & alphabets à imprimer",
+  "url": "https://ultratextgen.com/fr/imprimables/",
+  "description": "Lettres, alphabets, fiches à tracer et téléchargements PNG à imprimer gratuitement.",
+  "inLanguage": "fr",
+  "mainEntity": {
+    "@type": "ItemList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Fiches de prénom à tracer", "url": "https://ultratextgen.com/fr/imprimables/prenom-a-tracer/" },
+      { "@type": "ListItem", "position": 2, "name": "Alphabet cursif & fiches d'écriture", "url": "https://ultratextgen.com/fr/imprimables/alphabet-cursif/" },
+      { "@type": "ListItem", "position": 3, "name": "Coloriages alphabet", "url": "https://ultratextgen.com/fr/imprimables/coloriage-alphabet/" },
+      { "@type": "ListItem", "position": 4, "name": "Lettres bulles à imprimer", "url": "https://ultratextgen.com/fr/imprimables/lettres-bulles/" }
+    ]
+  }
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Accueil", "item": "https://ultratextgen.com/fr/" },
+    { "@type": "ListItem", "position": 2, "name": "Imprimables", "item": "https://ultratextgen.com/fr/imprimables/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "fr",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Ces lettres à imprimer sont-elles gratuites ?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Oui. Tous les imprimables d'UltraTextGen sont entièrement gratuits, sans inscription, sans filigrane et sans limite. Choisissez une lettre ou tapez un prénom, puis utilisez le bouton Imprimer pour l'envoyer à votre imprimante, ou Télécharger le PNG pour enregistrer une image en haute résolution."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Quelle est la différence entre les imprimables et les générateurs de police ?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Les générateurs de police transforment votre texte en polices Unicode à copier-coller pour les bios, les légendes et les commentaires. Les imprimables transforment les lettres en grands contours et en fiches que vous imprimez sur papier pour tracer, colorier, découper ou vous entraîner à écrire. Ils sont liés, mais l'un est fait pour les écrans, l'autre pour le papier."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Dois-je télécharger une application ou installer une police ?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Non. Tout fonctionne dans votre navigateur. Les contours et les fiches sont générés sur la page — cliquez sur Imprimer pour ouvrir la boîte de dialogue d'impression, ou sur Télécharger le PNG pour enregistrer une image à imprimer ou à réutiliser."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Puis-je créer une fiche à tracer avec le prénom de mon enfant ?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Oui. Ouvrez les Fiches de prénom à tracer, tapez n'importe quel prénom et imprimez une fiche avec une ligne modèle pleine, des lignes estompées à repasser et des lignes vierges pour s'entraîner librement."
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Fil d'Ariane">
+  <a href="/fr/">Accueil</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Imprimables</span>
+</nav>
+
+  <!-- Hero Section -->
+  <section class="hero">
+    <div class="hero-inner" style="max-width:800px;">
+      <h1 class="hero-headline">Lettres &amp; alphabets à imprimer</h1>
+      <p class="hero-tagline">
+        Des lettres et des alphabets pensés pour le papier, pas seulement pour les écrans.<br>
+        Imprimez de grands contours à tracer et à colorier, des fiches d'écriture,
+        ou une fiche à tracer avec n'importe quel prénom — puis imprimez-la ou enregistrez un PNG.
+      </p>
+    </div>
+  </section>
+
+  <!-- Main Content -->
+  <main class="container" style="max-width:900px;">
+
+    <section class="editorial-section" id="imprimables">
+      <h2>Choisissez un imprimable</h2>
+      <div class="printable-hub-grid">
+
+        <a class="printable-card" href="/fr/imprimables/prenom-a-tracer/">
+          <span class="printable-card-art" aria-hidden="true">✎ abc</span>
+          <h3>Fiches de prénom à tracer</h3>
+          <p>Tapez n'importe quel prénom et imprimez une fiche d'écriture : une ligne modèle pleine, des lignes estompées à repasser et des lignes vierges pour s'entraîner. Parfait pour la maternelle et le CP.</p>
+          <span class="printable-card-cta">Ouvrir les fiches de prénom →</span>
+        </a>
+
+        <a class="printable-card" href="/fr/imprimables/alphabet-cursif/">
+          <span class="printable-card-art" aria-hidden="true">𝒜 𝒷 𝒸</span>
+          <h3>Alphabet cursif &amp; fiches d'écriture</h3>
+          <p>L'alphabet cursif complet avec des fiches d'écriture à imprimer — lettres modèles et espace pour tracer — et le téléchargement PNG de chaque lettre pour apprendre l'écriture attachée.</p>
+          <span class="printable-card-cta">Ouvrir l'alphabet cursif →</span>
+        </a>
+
+        <a class="printable-card" href="/fr/imprimables/coloriage-alphabet/">
+          <span class="printable-card-art" aria-hidden="true">A B C</span>
+          <h3>Coloriages alphabet</h3>
+          <p>De grands contours de lettres A–Z à colorier et à imprimer — une page pour chaque lettre avec un mot exemple, plus l'impression de tout l'alphabet en un clic.</p>
+          <span class="printable-card-cta">Ouvrir les coloriages alphabet →</span>
+        </a>
+
+        <a class="printable-card" href="/fr/imprimables/lettres-bulles/">
+          <span class="printable-card-art" aria-hidden="true">Ⓐ Ⓑ Ⓒ</span>
+          <h3>Lettres bulles à imprimer</h3>
+          <p>De grands contours de lettres bulles A–Z et 0–9 à tracer, colorier et imprimer — plus le PNG de n'importe quelle lettre pour affiches, cartes et bullet journals.</p>
+          <span class="printable-card-cta">Ouvrir les lettres bulles →</span>
+        </a>
+
+      </div>
+    </section>
+
+    <section class="editorial-section">
+      <h2>Comment fonctionnent les imprimables</h2>
+      <p>Chaque imprimable se décline de deux façons. Il y a des <strong>fiches prêtes à l'emploi</strong> — des planches
+        d'alphabet A–Z complètes et des pages par lettre à imprimer telles quelles :
+        <a href="/fr/imprimables/lettres-bulles/">lettres bulles</a> à colorier,
+        fiches d'<a href="/fr/imprimables/alphabet-cursif/">écriture cursive</a> avec des lignes modèles à repasser,
+        et <a href="/fr/imprimables/coloriage-alphabet/">coloriages alphabet</a>.
+        Choisissez une lettre et c'est parti — rien à configurer.</p>
+      <p>Et il y a un <strong>générateur</strong> sur chaque page pour créer vos propres fiches. Tapez un mot ou un
+        <a href="/fr/imprimables/prenom-a-tracer/">prénom</a> entier et l'outil compose une fiche neuve sur-le-champ — une
+        ligne modèle pleine, des lignes estompées à repasser et des lignes vierges pour s'entraîner. Quand le résultat vous
+        convient, <strong>Imprimez</strong>-le directement depuis votre navigateur ou <strong>Téléchargez le PNG</strong> pour
+        une image en haute résolution. Tout se passe côté navigateur : c'est gratuit, instantané et sans inscription.</p>
+    </section>
+
+    <!-- Cross-family Navigation -->
+    <section class="related-pages">
+      <h2>À explorer aussi</h2>
+      <div class="related-pages-grid">
+        <a href="/fr/generateur-de-texte/" class="related-page-card">
+          <span class="related-page-label">Générateurs</span>
+          <h4>Polices à copier-coller</h4>
+        </a>
+        <a href="/fr/ecriture-cursive/" class="related-page-card">
+          <span class="related-page-label">Générateur</span>
+          <h4>Écriture cursive</h4>
+        </a>
+        <a href="/fr/texte-en-gras/" class="related-page-card">
+          <span class="related-page-label">Générateur</span>
+          <h4>Texte en gras</h4>
+        </a>
+        <a href="/fr/" class="related-page-card">
+          <span class="related-page-label">Accueil</span>
+          <h4>UltraTextGen en français</h4>
+        </a>
+      </div>
+    </section>
+  </main>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-inner">
+      <h2 class="faq-category">FAQ Imprimables</h2>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Ces lettres à imprimer sont-elles gratuites ?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+          </svg>
+        </button>
+        <div class="faq-answer">
+          Oui — entièrement gratuites, sans inscription, sans filigrane, sans limite. Choisissez une lettre ou tapez un prénom, puis utilisez
+          <strong>Imprimer</strong> pour l'envoyer à votre imprimante ou <strong>Télécharger le PNG</strong> pour enregistrer une image en haute résolution.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Quelle est la différence entre les imprimables et les générateurs de police ?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+          </svg>
+        </button>
+        <div class="faq-answer">
+          Les <a href="/fr/generateur-de-texte/">générateurs de police</a> transforment votre texte en polices Unicode à copier-coller pour les bios,
+          les légendes et les commentaires. Les imprimables transforment les lettres en grands contours et en fiches que vous imprimez sur papier pour
+          tracer, colorier, découper ou vous entraîner à écrire. Ils sont liés, mais l'un est fait pour les écrans, l'autre pour le papier.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Dois-je télécharger une application ou installer une police ?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+          </svg>
+        </button>
+        <div class="faq-answer">
+          Non. Tout fonctionne dans votre navigateur. Cliquez sur <strong>Imprimer</strong> pour ouvrir la boîte de dialogue d'impression, ou sur
+          <strong>Télécharger le PNG</strong> pour enregistrer une image à imprimer ou à réutiliser.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Puis-je créer une fiche à tracer avec le prénom de mon enfant ?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+          </svg>
+        </button>
+        <div class="faq-answer">
+          Oui. Ouvrez les <a href="/fr/imprimables/prenom-a-tracer/">Fiches de prénom à tracer</a>, tapez n'importe quel prénom et imprimez une fiche
+          avec une ligne modèle pleine, des lignes estompées à repasser et des lignes vierges pour s'entraîner librement.
+        </div>
+      </div>
+
+    </div>
+  </footer>
+
+  <!-- FAQ toggle -->
+  <script>
+    document.querySelectorAll('.faq-question').forEach(function(btn) {
+      btn.addEventListener('click', function() {
+        this.closest('.faq-item').classList.toggle('open');
+      });
+    });
+  </script>
+<script src="/footer.js" defer></script>
+</body></html>

--- a/fr/imprimables/lettres-bulles/index.html
+++ b/fr/imprimables/lettres-bulles/index.html
@@ -1,0 +1,283 @@
+<!DOCTYPE html><html lang="fr"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Lettres bulles à imprimer A–Z &amp; 0–9 — Tracer, colorier, PNG | UltraTextGen</title>
+  <meta name="description" content="Lettres bulles à imprimer gratuites A–Z et chiffres 0–9. De grands contours gonflés à tracer et à colorier, l'impression de tout l'alphabet, ou le téléchargement de n'importe quelle lettre en PNG. Sans inscription.">
+  <link rel="canonical" href="https://ultratextgen.com/fr/imprimables/lettres-bulles/">
+
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/printables/bubble-letters/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/imprimables/lettres-bulles/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/bubble-letters/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Lettres bulles à imprimer A–Z &amp; 0–9 | UltraTextGen">
+  <meta property="og:description" content="Lettres bulles à imprimer gratuites. De grands contours à tracer et à colorier, l'impression de l'alphabet, ou le téléchargement en PNG.">
+  <meta property="og:url" content="https://ultratextgen.com/fr/imprimables/lettres-bulles/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category-bubble-fonts.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Lettres bulles à imprimer A–Z &amp; 0–9 | UltraTextGen">
+  <meta name="twitter:description" content="Lettres bulles à imprimer gratuites. De grands contours à tracer et à colorier, l'impression de l'alphabet, ou le téléchargement en PNG.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category-bubble-fonts.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;family=Fredoka:wght@500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Accueil", "item": "https://ultratextgen.com/fr/" },
+    { "@type": "ListItem", "position": 2, "name": "Imprimables", "item": "https://ultratextgen.com/fr/imprimables/" },
+    { "@type": "ListItem", "position": 3, "name": "Lettres bulles", "item": "https://ultratextgen.com/fr/imprimables/lettres-bulles/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Comment dessiner une lettre bulle",
+  "description": "Transformez n'importe quelle lettre simple en une lettre bulle arrondie et gonflée à tracer et à colorier.",
+  "step": [
+    { "@type": "HowToStep", "position": 1, "name": "Esquisser le squelette", "text": "Esquissez la lettre simple au crayon en un fin squelette." },
+    { "@type": "HowToStep", "position": 2, "name": "Gonfler le contour", "text": "Dessinez un contour arrondi et gonflé, à environ une largeur de doigt autour de chaque trait de la lettre." },
+    { "@type": "HowToStep", "position": 3, "name": "Encrer et colorier", "text": "Arrondissez les coins, effacez le squelette, puis encrez le contour et coloriez-le." }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "fr",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Comment obtenir des lettres bulles à imprimer pour tracer ou colorier ?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Choisissez n'importe quelle lettre (A–Z) ou chiffre (0–9) dans le sélecteur pour voir un grand contour de bulle. Utilisez Imprimer cette lettre pour n'envoyer que ce contour à votre imprimante, ou Télécharger le PNG pour enregistrer une image en haute résolution. Vous pouvez aussi imprimer tout l'alphabet A–Z et 0–9 d'un coup. Les contours sont blancs avec une bordure arrondie et épaisse, prêts à tracer ou à colorier pour affiches, pancartes, cartes, activités de classe et bullet journals."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Comment dessiner une lettre bulle à la main ?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Esquissez la lettre simple au crayon en un fin squelette, dessinez un contour arrondi et gonflé à environ une largeur de doigt autour de chaque trait, puis arrondissez les coins, effacez le squelette, encrez et coloriez. Une façon rapide d'apprendre la forme est d'imprimer le contour d'une lettre et de le repasser quelques fois jusqu'à ce qu'il devienne naturel."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Puis-je imprimer mon prénom en lettres bulles ?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Oui. Tapez n'importe quel prénom ou mot dans le champ et imprimez une feuille de grands contours de bulles à tracer et à colorier, ou téléchargez-la en bannière PNG pour cartes, affiches et pancartes de porte."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Avez-vous aussi du texte bulle à copier-coller pour Instagram ou TikTok ?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Oui. Si vous voulez du texte bulle à coller dans une bio ou une légende plutôt qu'à imprimer, utilisez le générateur de police, qui transforme votre texte en lettres bulles Unicode à copier-coller."
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Fil d'Ariane">
+  <a href="/fr/">Accueil</a>
+  <span class="breadcrumb-separator">›</span>
+  <a href="/fr/imprimables/">Imprimables</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Lettres bulles</span>
+</nav>
+
+  <section class="hero">
+    <div class="hero-inner" style="max-width:820px;">
+      <h1 class="hero-headline">Lettres bulles à imprimer A–Z &amp; 0–9</h1>
+      <p class="hero-tagline">
+        Choisissez une lettre ou un chiffre pour un grand contour de bulle gonflé à tracer, colorier, imprimer
+        ou télécharger en PNG — ou tapez un prénom pour une feuille entière. Gratuit, sans inscription.
+      </p>
+    </div>
+  </section>
+
+  <main class="container">
+
+    <!-- Picker + selected-letter detail -->
+    <section class="bubble-az" aria-labelledby="ptPickHeading">
+      <h2 class="bubble-az-heading" id="ptPickHeading">Choisissez une lettre bulle</h2>
+      <p class="bubble-az-intro">Touchez une lettre (A–Z) ou un chiffre (0–9) pour voir son grand contour de bulle, l'imprimer, télécharger un PNG ou copier les styles bulles Unicode correspondants.</p>
+      <div class="bubble-strip" id="pt-strip" role="tablist" aria-label="Choisir une lettre ou un chiffre bulle"></div>
+      <div class="bubble-letter-panel" id="pt-panel" aria-live="polite"></div>
+    </section>
+
+    <!-- Name / word worksheet -->
+    <section class="bubble-alphabet" aria-labelledby="ptNameHeading">
+      <h2 id="ptNameHeading">Imprimez un prénom en lettres bulles</h2>
+      <p class="bubble-az-intro">Tapez un prénom ou un mot court, puis imprimez une feuille de contours de bulles à tracer et à colorier, ou enregistrez-la en bannière PNG.</p>
+      <div class="pt-name-tool">
+        <div class="input-wrapper">
+          <input type="text" class="main-input pt-name-input" id="pt-name-input" placeholder="Tapez un prénom… ex. Mia" maxlength="40">
+        </div>
+        <div class="pt-name-preview" id="pt-name-preview" aria-live="polite"></div>
+        <div class="bubble-actions pt-name-actions">
+          <button type="button" class="bubble-btn bubble-btn-primary" id="pt-name-print">Imprimer la feuille</button>
+          <button type="button" class="bubble-btn" id="pt-name-png">Télécharger le PNG</button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Full printable alphabet -->
+    <section class="bubble-alphabet" aria-labelledby="ptAlphaHeading">
+      <div class="bubble-alphabet-head">
+        <h2 id="ptAlphaHeading">Alphabet bulle à imprimer</h2>
+        <button class="bubble-btn bubble-btn-primary" type="button" id="pt-alphabet-print">Imprimer l'alphabet</button>
+      </div>
+      <p class="bubble-az-intro">L'alphabet bulle A–Z et 0–9 complet en contours. Imprimez toute la feuille à tracer ou à colorier, ou touchez n'importe quelle lettre pour ouvrir ses options d'impression et de téléchargement.</p>
+      <div class="bubble-alphabet-grid" id="pt-alphabet-grid"></div>
+    </section>
+
+    <!-- Editorial -->
+    <section class="editorial-section">
+      <h2>Comment utiliser les lettres bulles à imprimer</h2>
+      <ul class="compat-list">
+        <li><span class="ts-pill-safe">Tracer</span> Imprimez un contour et repassez-le pour apprendre la forme gonflée à la main.</li>
+        <li><span class="ts-pill-safe">Colorier</span> L'intérieur blanc est prêt pour les feutres, crayons ou la peinture — parfait pour les enfants et les classes.</li>
+        <li><span class="ts-pill-safe">Bricoler</span> Découpez les lettres pour des banderoles, pancartes de porte, cartes d'anniversaire, scrapbooks et bullet journals.</li>
+      </ul>
+      <h3>Vous préférez copier-coller plutôt qu'imprimer ?</h3>
+      <p>Ces contours sont faits pour le papier. Si vous voulez du texte bulle à coller dans une bio Instagram, une légende TikTok
+        ou un pseudo Discord, utilisez le <a href="/fr/generateur-de-texte/">générateur de police</a> — il transforme votre texte
+        en lettres bulles Unicode qui gardent leur allure partout.</p>
+    </section>
+
+    <div class="cta-card">
+      <h3>Vous voulez du texte bulle pour votre bio ou vos légendes ?</h3>
+      <p>Tapez une fois et copiez de joyeuses lettres bulles Unicode qui se collent partout — sans image.</p>
+      <a class="cta-btn" href="/fr/generateur-de-texte/">Ouvrir le générateur de police →</a>
+    </div>
+  </main>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <h2 class="faq-category">Lettres bulles à imprimer — FAQ</h2>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Comment obtenir des lettres bulles à imprimer pour tracer ou colorier ?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Choisissez n'importe quelle lettre (A–Z) ou chiffre (0–9) dans le sélecteur pour voir un grand contour de bulle. Utilisez <strong>Imprimer cette lettre</strong>
+          pour n'envoyer que ce contour à votre imprimante, ou <strong>Télécharger le PNG</strong> pour enregistrer une image en haute résolution. Vous pouvez aussi
+          imprimer tout l'alphabet A–Z et 0–9 d'un coup. Les contours sont blancs avec une bordure arrondie et épaisse, prêts à tracer ou à colorier pour affiches, pancartes, cartes, activités de classe et bullet journals.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Comment dessiner une lettre bulle à la main ?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Esquissez la lettre simple au crayon en un fin squelette, dessinez un contour arrondi et gonflé à environ une largeur de doigt autour de chaque trait,
+          puis arrondissez les coins, effacez le squelette, encrez et coloriez. Une façon rapide d'apprendre la forme est d'imprimer le contour d'une lettre et de le repasser quelques fois jusqu'à ce qu'il devienne naturel.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Puis-je imprimer mon prénom en lettres bulles ?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Oui. Tapez n'importe quel prénom ou mot dans le champ et imprimez une feuille de grands contours de bulles à tracer et à colorier, ou téléchargez-la
+          en bannière PNG pour cartes, affiches et pancartes de porte.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Avez-vous aussi du texte bulle à copier-coller pour Instagram ou TikTok ?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Oui. Si vous voulez du texte bulle à coller dans une bio ou une légende plutôt qu'à imprimer, utilisez le
+          <a href="/fr/generateur-de-texte/">générateur de police</a>, qui transforme votre texte en lettres bulles Unicode à copier-coller.
+        </div>
+      </div>
+
+    </div>
+  </footer>
+
+  <!-- Print surface (hidden on screen, isolated when printing) -->
+  <div id="pt-print-root" aria-hidden="true"></div>
+
+  <script>
+    window.UTG_PRINTABLE = {
+      key: "bubble-letters",
+      lang: "fr",
+      render: "outline",
+      noun: "bulle",
+      pngPrefix: "bulle",
+      font: "Fredoka, 'Plus Jakarta Sans', sans-serif",
+      strokeWidth: 9,
+      letterSpacing: 0.1,
+      charset: "alnum",
+      variantFamily: "bubble",
+      glyphStyle: "Ultra Bubble",
+      nameDemo: "Mia",
+      howto: {
+        title: "Comment dessiner {ch} en bulle",
+        steps: [
+          "Esquissez {ch} au crayon en un fin squelette.",
+          "Dessinez un contour arrondi et gonflé, à environ une largeur de doigt autour de chaque trait.",
+          "Arrondissez les coins, effacez le squelette, puis encrez le contour et coloriez-le."
+        ],
+        tip: "Astuce : imprimez le contour ci-dessus et repassez-le plusieurs fois jusqu'à ce que la forme devienne naturelle."
+      }
+    };
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/js/printables/printablesEngine.js" defer></script>
+
+  <!-- FAQ toggle -->
+  <script>
+    document.querySelectorAll('.faq-question').forEach(function(btn) {
+      btn.addEventListener('click', function() { this.closest('.faq-item').classList.toggle('open'); });
+    });
+  </script>
+<script src="/footer.js" defer></script>
+</body></html>

--- a/fr/imprimables/lettres-bulles/index.html
+++ b/fr/imprimables/lettres-bulles/index.html
@@ -16,6 +16,8 @@
 
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/printables/bubble-letters/">
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/imprimables/lettres-bulles/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/imprimibles/letras-burbuja/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/imprimiveis/letras-bolha/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/bubble-letters/">
 
   <meta name="robots" content="index, follow">

--- a/fr/imprimables/prenom-a-tracer/index.html
+++ b/fr/imprimables/prenom-a-tracer/index.html
@@ -1,0 +1,282 @@
+<!DOCTYPE html><html lang="fr"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Fiches de prénom à tracer — Écriture à imprimer gratuite | UltraTextGen</title>
+  <meta name="description" content="Tapez un prénom pour créer une fiche d'écriture à imprimer gratuite : une ligne modèle pleine, des lignes estompées à repasser et des lignes vierges pour s'entraîner. Plus le tracé des lettres A–Z et des chiffres 0–9. Sans inscription.">
+  <link rel="canonical" href="https://ultratextgen.com/fr/imprimables/prenom-a-tracer/">
+
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/printables/name-tracing/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/imprimables/prenom-a-tracer/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/name-tracing/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Fiches de prénom à tracer — Écriture à imprimer gratuite | UltraTextGen">
+  <meta property="og:description" content="Tapez un prénom pour créer une fiche à tracer gratuite : ligne modèle, lignes estompées à repasser et lignes vierges. Plus le tracé des lettres A–Z et des chiffres 0–9.">
+  <meta property="og:url" content="https://ultratextgen.com/fr/imprimables/prenom-a-tracer/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Fiches de prénom à tracer — Écriture à imprimer gratuite | UltraTextGen">
+  <meta name="twitter:description" content="Tapez un prénom pour créer une fiche à tracer gratuite : ligne modèle, lignes estompées à repasser et lignes vierges.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;family=Quicksand:wght@500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Accueil", "item": "https://ultratextgen.com/fr/" },
+    { "@type": "ListItem", "position": 2, "name": "Imprimables", "item": "https://ultratextgen.com/fr/imprimables/" },
+    { "@type": "ListItem", "position": 3, "name": "Prénom à tracer", "item": "https://ultratextgen.com/fr/imprimables/prenom-a-tracer/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "fr",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Comment créer une fiche de prénom à tracer ?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Tapez un prénom dans le champ et cliquez sur Imprimer la fiche. La fiche comporte une ligne modèle pleine qui montre le prénom, plusieurs lignes estompées à repasser et des lignes vierges pour s'entraîner librement. Vous pouvez aussi la télécharger en PNG. Choisissez le nombre de lignes à repasser avant d'imprimer."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Les fiches de prénom à tracer sont-elles gratuites ?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Oui — entièrement gratuites, sans inscription, sans filigrane et sans limite. Créez autant de fiches que vous voulez, pour n'importe quel prénom ou mot."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Puis-je aussi créer des fiches de lettres et de chiffres à tracer ?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Oui. Utilisez le sélecteur de lettres pour tracer une seule lettre A–Z ou un chiffre 0–9, ou imprimez la fiche complète A–Z et 0–9 avec lignes modèles et lignes à repasser. Cela fonctionne pour les prénoms en majuscules, l'entraînement en minuscules et la formation des chiffres."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "À quel âge le tracé du prénom convient-il ?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Le tracé du prénom convient aux enfants de maternelle et de CP qui construisent la formation des lettres et la motricité fine, ainsi qu'à toute personne qui s'entraîne à une écriture soignée. Imprimez plusieurs copies et privilégiez des séances courtes et fréquentes pour de meilleurs résultats."
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Fil d'Ariane">
+  <a href="/fr/">Accueil</a>
+  <span class="breadcrumb-separator">›</span>
+  <a href="/fr/imprimables/">Imprimables</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Prénom à tracer</span>
+</nav>
+
+  <section class="hero">
+    <div class="hero-inner" style="max-width:820px;">
+      <h1 class="hero-headline">Fiches de prénom à tracer</h1>
+      <p class="hero-tagline">
+        Tapez n'importe quel prénom et imprimez une fiche d'écriture : une ligne modèle pleine, des lignes estompées à repasser
+        et des lignes vierges pour s'entraîner. Plus le tracé des lettres A–Z et des chiffres 0–9. Gratuit, sans inscription.
+      </p>
+    </div>
+  </section>
+
+  <main class="container">
+
+    <div class="pt-stroke-toggle-row">
+      <label class="pt-check" for="pt-stroke-toggle">
+        <input type="checkbox" id="pt-stroke-toggle">
+        Afficher le sens des tracés
+      </label>
+      <span class="pt-stroke-toggle-hint">Ajoute un point de départ numéroté et des flèches sur chaque lettre tracée, pour montrer dans quel sens dessiner chaque trait — activé au choix, car les enfants n'ont pas tous besoin du même guidage selon leur niveau.</span>
+    </div>
+
+    <!-- Name worksheet (primary) -->
+    <section class="bubble-alphabet" aria-labelledby="ptNameHeading">
+      <h2 id="ptNameHeading">Créez une fiche de prénom à tracer</h2>
+      <p class="bubble-az-intro">Tapez un prénom ou un mot court, prévisualisez-le ci-dessous, puis imprimez — ou téléchargez un PNG. La fiche offre un modèle plein à suivre, des lignes estompées à repasser et des lignes vierges pour s'entraîner librement.</p>
+      <div class="pt-name-tool">
+        <div class="input-wrapper">
+          <input type="text" class="main-input pt-name-input" id="pt-name-input" placeholder="Tapez un prénom… ex. Emma" maxlength="40">
+        </div>
+        <div class="pt-name-controls">
+          <label class="pt-name-rows-label" for="pt-name-rows">Lignes à repasser</label>
+          <select id="pt-name-rows" class="pt-name-rows-select">
+            <option value="2">2</option>
+            <option value="3" selected>3</option>
+            <option value="4">4</option>
+            <option value="5">5</option>
+            <option value="6">6</option>
+          </select>
+        </div>
+        <div class="pt-name-preview" id="pt-name-preview" aria-live="polite"></div>
+        <div class="bubble-actions pt-name-actions">
+          <button type="button" class="bubble-btn bubble-btn-primary" id="pt-name-print">Imprimer la fiche</button>
+          <button type="button" class="bubble-btn" id="pt-name-png">Télécharger le PNG</button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Letter / number tracing -->
+    <section class="bubble-az" aria-labelledby="ptPickHeading">
+      <h2 class="bubble-az-heading" id="ptPickHeading">Tracer lettres &amp; chiffres A–Z, 0–9</h2>
+      <p class="bubble-az-intro">Touchez n'importe quelle lettre ou chiffre pour le tracer seul, imprimer un grand caractère unique ou télécharger un PNG.</p>
+      <div class="bubble-strip" id="pt-strip" role="tablist" aria-label="Choisir une lettre ou un chiffre à tracer"></div>
+      <div class="bubble-letter-panel" id="pt-panel" aria-live="polite"></div>
+    </section>
+
+    <!-- Full practice sheet + alphabet -->
+    <section class="bubble-alphabet" aria-labelledby="ptAlphaHeading">
+      <div class="bubble-alphabet-head">
+        <h2 id="ptAlphaHeading">Fiches à tracer A–Z &amp; 0–9 à imprimer</h2>
+        <button class="bubble-btn bubble-btn-primary" type="button" id="pt-practice-print">Imprimer la fiche d'entraînement</button>
+      </div>
+      <p class="bubble-az-intro">Imprimez une fiche réglée A–Z et 0–9 — un modèle plus un espace à repasser sur chaque ligne — ou imprimez l'alphabet en contour ci-dessous pour tracer les lettres entières.</p>
+      <div class="bubble-alphabet-grid" id="pt-alphabet-grid"></div>
+      <div class="pt-alpha-print-row">
+        <button class="bubble-btn" type="button" id="pt-alphabet-print">Imprimer l'alphabet en contour</button>
+      </div>
+    </section>
+
+    <!-- Editorial -->
+    <section class="editorial-section">
+      <h2>Tirer le meilleur du tracé de prénom</h2>
+      <ul class="compat-list">
+        <li><span class="ts-pill-safe">Le modèle d'abord</span> Montrez la ligne pleine du haut et dites le prénom avant de commencer à tracer.</li>
+        <li><span class="ts-pill-safe">Tracer lentement</span> Encouragez à rester dans le contour — le contrôle compte plus que la vitesse.</li>
+        <li><span class="ts-pill-safe">Puis à main levée</span> Terminez sur les lignes vierges en l'écrivant sans le guide.</li>
+      </ul>
+      <p>Prêt à corser la difficulté à mesure des progrès ? Les
+        <a href="/fr/imprimables/alphabet-cursif/">fiches d'écriture cursive</a> permettent de passer à l'écriture attachée,
+        et vous pouvez composer un prénom décoratif en
+        <a href="/fr/imprimables/lettres-bulles/">lettres bulles</a> à colorier.</p>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <h2 class="faq-category">Prénom à tracer — FAQ</h2>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Comment créer une fiche de prénom à tracer ?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Tapez un prénom dans le champ et cliquez sur <strong>Imprimer la fiche</strong>. La fiche comporte une ligne modèle pleine qui montre le
+          prénom, plusieurs lignes estompées à repasser et des lignes vierges pour s'entraîner librement. Vous pouvez aussi la télécharger en PNG, et
+          choisir le nombre de lignes à repasser avant d'imprimer.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Les fiches de prénom à tracer sont-elles gratuites ?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Oui — entièrement gratuites, sans inscription, sans filigrane et sans limite. Créez autant de fiches que vous voulez, pour n'importe quel prénom ou mot.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Puis-je aussi créer des fiches de lettres et de chiffres à tracer ?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Oui. Utilisez le sélecteur de lettres pour tracer une seule lettre A–Z ou un chiffre 0–9, ou imprimez la fiche complète A–Z et 0–9 avec
+          lignes modèles et lignes à repasser. Cela fonctionne pour les prénoms en majuscules, l'entraînement en minuscules et la formation des chiffres.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          À quel âge le tracé du prénom convient-il ?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Le tracé du prénom convient aux enfants de maternelle et de CP qui construisent la formation des lettres et la motricité fine, ainsi qu'à toute
+          personne qui s'entraîne à une écriture soignée. Imprimez plusieurs copies et privilégiez des séances courtes et fréquentes pour de meilleurs résultats.
+        </div>
+      </div>
+
+    </div>
+  </footer>
+
+  <!-- Print surface (hidden on screen, isolated when printing) -->
+  <div id="pt-print-root" aria-hidden="true"></div>
+
+  <script>
+    window.UTG_PRINTABLE = {
+      key: "name-tracing",
+      lang: "fr",
+      render: "outline",
+      noun: "tracé",
+      pngPrefix: "prenom",
+      font: "Quicksand, 'Plus Jakarta Sans', sans-serif",
+      strokeWidth: 4,
+      charset: "alnum",
+      variantFamily: "",
+      nameDemo: "Emma",
+      howto: {
+        title: "Comment tracer {ch}",
+        steps: [
+          "Commencez en haut du contour gris et suivez-le lentement.",
+          "Gardez le crayon à l'intérieur des lignes — allez doucement pour bien contrôler.",
+          "Repassez-la plusieurs fois, puis écrivez-la seul sur la ligne vierge."
+        ],
+        tip: "Imprimez plusieurs copies pour que l'enfant s'entraîne toute la semaine."
+      }
+    };
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/js/printables/strokeDirectionData.js" defer></script>
+  <script src="/js/printables/printablesEngine.js" defer></script>
+
+  <!-- FAQ toggle -->
+  <script>
+    document.querySelectorAll('.faq-question').forEach(function(btn) {
+      btn.addEventListener('click', function() { this.closest('.faq-item').classList.toggle('open'); });
+    });
+  </script>
+<script src="/footer.js" defer></script>
+</body></html>

--- a/fr/imprimables/prenom-a-tracer/index.html
+++ b/fr/imprimables/prenom-a-tracer/index.html
@@ -16,6 +16,8 @@
 
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/printables/name-tracing/">
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/imprimables/prenom-a-tracer/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/imprimibles/nombre-para-trazar/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/imprimiveis/nome-para-tracar/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/name-tracing/">
 
   <meta name="robots" content="index, follow">

--- a/fr/index.html
+++ b/fr/index.html
@@ -684,6 +684,11 @@
         <h3>Combos Emoji</h3>
         <p>Combinaisons d'emoji prêtes à coller — mignon, coquette, amour, dark et plage.</p>
       </a>
+      <a class="tip-card" href="/fr/imprimables/" aria-label="Imprimables">
+        <div class="tip-icon">🖨️</div>
+        <h3>Imprimables</h3>
+        <p>Lettres bulles, alphabet cursif, coloriages et fiches de prénom à tracer — à imprimer ou en PNG.</p>
+      </a>
     </div>
   </section>
 

--- a/js/printables/printablesEngine.js
+++ b/js/printables/printablesEngine.js
@@ -51,6 +51,72 @@
   const CFG = window.UTG_PRINTABLE;
   if (!CFG) return;
 
+  /* ---------------------------------------------------------------
+     Localization. All engine-injected UI text flows through T, keyed
+     off the page's language (html lang="…", or an explicit CFG.lang).
+     English is the default and its values are the original strings, so
+     existing English pages render byte-for-byte the same. New locales
+     add a block here and only need to set <html lang> + a translated
+     UTG_PRINTABLE config (noun, howto, headings) on the page itself.
+     --------------------------------------------------------------- */
+  const LANG = String(CFG.lang || document.documentElement.getAttribute("lang") || "en")
+    .slice(0, 2).toLowerCase();
+  const I18N = {
+    en: {
+      letterWord: "letter", numberWord: "number",
+      copied: "Copied!",
+      printThisLetter: "Print this letter", printThisNumber: "Print this number",
+      downloadPng: "Download PNG",
+      copyPaste: "Copy-paste", copy: "Copy", howToDraw: "How to draw it", lowerSuffix: " · lower",
+      level: "Level", nameLabel: "Name:", dateLabel: "Date:", space: "space",
+      dotToDot: "dot to dot", bannerFlag: "Banner flag —",
+      bannerInstr: "Cut each flag along its dashed line, punch a hole at each dot, then thread string or ribbon through in order (1, 2, 3…) to spell it out.",
+      puzzleCut: "Cut along the dashed lines to separate each letter piece.",
+      trace: {
+        solid:    { label: "Solid model", hint: "Full dark letters — trace right on top" },
+        "bold-dot": { label: "Bold dotted", hint: "Thick, closely-spaced dots to join" },
+        "fine-dot": { label: "Fine dotted", hint: "Thinner dots with a little more space" },
+        dashed:   { label: "Dashed", hint: "Broken dashes — more line to complete" },
+        faded:    { label: "Faded ghost", hint: "Light gray letters to write over" },
+        faint:    { label: "Faint guide", hint: "Barely-there outline — almost solo" },
+        blank:    { label: "Blank line", hint: "No guide — write it from memory" }
+      },
+      dot: {
+        easy:   { label: "Easy", hint: "Big gaps, few dots — the youngest kids" },
+        medium: { label: "Medium", hint: "A balanced connect-the-dots" },
+        hard:   { label: "Hard", hint: "More dots and finer letter detail" },
+        expert: { label: "Expert", hint: "Lots of dots — a real challenge" }
+      }
+    },
+    fr: {
+      letterWord: "lettre", numberWord: "chiffre",
+      copied: "Copié !",
+      printThisLetter: "Imprimer cette lettre", printThisNumber: "Imprimer ce chiffre",
+      downloadPng: "Télécharger le PNG",
+      copyPaste: "Copier-coller", copy: "Copier", howToDraw: "Comment la dessiner", lowerSuffix: " · min.",
+      level: "Niveau", nameLabel: "Prénom :", dateLabel: "Date :", space: "espace",
+      dotToDot: "point à point", bannerFlag: "Fanion —",
+      bannerInstr: "Découpez chaque fanion le long de sa ligne pointillée, percez un trou à chaque point, puis passez une ficelle ou un ruban dans l'ordre (1, 2, 3…) pour former le mot.",
+      puzzleCut: "Découpez le long des lignes pointillées pour séparer chaque pièce-lettre.",
+      trace: {
+        solid:    { label: "Modèle plein", hint: "Lettres pleines et foncées — tracez par-dessus" },
+        "bold-dot": { label: "Pointillé épais", hint: "Points épais et rapprochés à relier" },
+        "fine-dot": { label: "Pointillé fin", hint: "Points plus fins, un peu plus espacés" },
+        dashed:   { label: "Tirets", hint: "Tirets espacés — plus de trait à compléter" },
+        faded:    { label: "Fantôme pâle", hint: "Lettres gris clair à repasser" },
+        faint:    { label: "Guide léger", hint: "Contour à peine visible — presque en autonomie" },
+        blank:    { label: "Ligne vierge", hint: "Aucun guide — à écrire de mémoire" }
+      },
+      dot: {
+        easy:   { label: "Facile", hint: "Grands écarts, peu de points — les plus jeunes" },
+        medium: { label: "Moyen", hint: "Un point à point équilibré" },
+        hard:   { label: "Difficile", hint: "Plus de points et de détails dans la lettre" },
+        expert: { label: "Expert", hint: "Beaucoup de points — un vrai défi" }
+      }
+    }
+  };
+  const T = I18N[LANG] || I18N.en;
+
   const $ = (sel, root) => (root || document).querySelector(sel);
   const $$ = (sel, root) => Array.from((root || document).querySelectorAll(sel));
   const SVGNS = "http://www.w3.org/2000/svg";
@@ -137,7 +203,7 @@
      Small helpers
      --------------------------------------------------------------- */
 
-  function charLabel(ch) { return /[0-9]/.test(ch) ? ("number " + ch) : ("letter " + ch); }
+  function charLabel(ch) { return /[0-9]/.test(ch) ? (T.numberWord + " " + ch) : (T.letterWord + " " + ch); }
   function charSlug(ch) { return /[0-9]/.test(ch) ? ("number-" + ch) : ("letter-" + ch.toLowerCase()); }
   function slugify(s) {
     return String(s || "").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
@@ -186,7 +252,7 @@
       if (!btn) return;
       const prev = btn.textContent;
       btn.classList.add("is-copied");
-      btn.textContent = "Copied!";
+      btn.textContent = T.copied;
       setTimeout(() => { btn.textContent = prev; btn.classList.remove("is-copied"); }, 1400);
     };
     if (navigator.clipboard && navigator.clipboard.writeText) {
@@ -586,7 +652,7 @@
     const printBtn = document.createElement("button");
     printBtn.type = "button";
     printBtn.className = "bubble-btn bubble-btn-primary";
-    printBtn.textContent = "Print this " + (/[0-9]/.test(ch) ? "number" : "letter");
+    printBtn.textContent = /[0-9]/.test(ch) ? T.printThisNumber : T.printThisLetter;
     printBtn.addEventListener("click", () => {
       const holder = document.createElement("div");
       holder.className = "bubble-print-single";
@@ -596,7 +662,7 @@
     const pngBtn = document.createElement("button");
     pngBtn.type = "button";
     pngBtn.className = "bubble-btn";
-    pngBtn.textContent = "Download PNG";
+    pngBtn.textContent = T.downloadPng;
     pngBtn.addEventListener("click", () => letterPNG(ch));
     actions.appendChild(printBtn);
     actions.appendChild(pngBtn);
@@ -610,7 +676,7 @@
     if (variants) {
       const title = document.createElement("h3");
       title.className = "bubble-detail-title";
-      title.textContent = "Copy-paste " + NOUN + " " + charLabel(ch);
+      title.textContent = T.copyPaste + " " + NOUN + " " + charLabel(ch);
       detail.appendChild(title);
       detail.appendChild(variants);
     }
@@ -620,7 +686,7 @@
       how.className = "bubble-howto";
       const ht = document.createElement("h3");
       ht.className = "bubble-detail-title";
-      ht.textContent = (CFG.howto.title || "How to draw it").replace("{ch}", charLabel(ch));
+      ht.textContent = (CFG.howto.title || T.howToDraw).replace("{ch}", charLabel(ch));
       how.appendChild(ht);
       const ol = document.createElement("ol");
       ol.className = "bubble-howto-steps";
@@ -674,16 +740,16 @@
         row.type = "button";
         row.className = "bubble-variant glyph-copy";
         row.dataset.text = rendered;
-        row.setAttribute("aria-label", "Copy " + name + " " + NOUN + " " + charLabel(src));
+        row.setAttribute("aria-label", T.copy + " " + name + " " + NOUN + " " + charLabel(src));
         const glyph = document.createElement("span");
         glyph.className = "bubble-variant-glyph";
         glyph.textContent = rendered;
         const meta = document.createElement("span");
         meta.className = "bubble-variant-name";
-        meta.textContent = name.replace(/^Ultra /, "") + (kind === "upper" ? "" : " · lower");
+        meta.textContent = name.replace(/^Ultra /, "") + (kind === "upper" ? "" : T.lowerSuffix);
         const cta = document.createElement("span");
         cta.className = "bubble-variant-copy";
-        cta.textContent = "Copy";
+        cta.textContent = T.copy;
         row.appendChild(glyph); row.appendChild(meta); row.appendChild(cta);
         row.addEventListener("click", () => copyText(rendered, cta));
         list.appendChild(row);
@@ -866,19 +932,19 @@
   // Level 1 (easiest) → 7 (hardest). Round caps + a near-zero dash render
   // the stroke as a row of dots; longer dashes read as a broken guideline.
   const TRACE_LEVELS = [
-    { key: "solid",    label: "Solid model",  hint: "Full dark letters — trace right on top",
+    { key: "solid",    label: T.trace.solid.label,      hint: T.trace.solid.hint,
       fill: INK,   stroke: "none", sw: 0, dash: "",        cap: "round", opacity: 1 },
-    { key: "bold-dot", label: "Bold dotted",  hint: "Thick, closely-spaced dots to join",
+    { key: "bold-dot", label: T.trace["bold-dot"].label, hint: T.trace["bold-dot"].hint,
       fill: "none", stroke: INK,   sw: 8, dash: "0.1 11",  cap: "round", opacity: 1 },
-    { key: "fine-dot", label: "Fine dotted",  hint: "Thinner dots with a little more space",
+    { key: "fine-dot", label: T.trace["fine-dot"].label, hint: T.trace["fine-dot"].hint,
       fill: "none", stroke: INK,   sw: 5, dash: "0.1 16",  cap: "round", opacity: 0.92 },
-    { key: "dashed",   label: "Dashed",       hint: "Broken dashes — more line to complete",
+    { key: "dashed",   label: T.trace.dashed.label,     hint: T.trace.dashed.hint,
       fill: "none", stroke: INK,   sw: 4, dash: "15 15",   cap: "butt",  opacity: 0.85 },
-    { key: "faded",    label: "Faded ghost",  hint: "Light gray letters to write over",
+    { key: "faded",    label: T.trace.faded.label,      hint: T.trace.faded.hint,
       fill: GHOST,  stroke: "none", sw: 0, dash: "",        cap: "round", opacity: 1 },
-    { key: "faint",    label: "Faint guide",  hint: "Barely-there outline — almost solo",
+    { key: "faint",    label: T.trace.faint.label,      hint: T.trace.faint.hint,
       fill: "none", stroke: FAINT, sw: 2, dash: "0.1 22",  cap: "round", opacity: 1 },
-    { key: "blank",    label: "Blank line",   hint: "No guide — write it from memory",
+    { key: "blank",    label: T.trace.blank.label,      hint: T.trace.blank.hint,
       blank: true }
   ];
 
@@ -1023,7 +1089,7 @@
   function updateGenUI() {
     const level = genLevel();
     const spec = levelSpec(level);
-    if (el.genLevel) el.genLevel.textContent = "Level " + level + " · " + spec.label;
+    if (el.genLevel) el.genLevel.textContent = T.level + " " + level + " · " + spec.label;
     if (el.genHint) el.genHint.textContent = spec.hint;
     // Level ladder buttons.
     $$(".pt-level", el.genLevels || document).forEach((b) => {
@@ -1291,8 +1357,8 @@
       t.textContent = label;
       svgMake("line", { x1: x + 110, y1: y + 6, x2: lineEnd, y2: y + 6, stroke: "#9aa3b2", "stroke-width": 2 }, svg);
     };
-    field(90, "Name:", 470);
-    field(560, "Date:", 910);
+    field(90, T.nameLabel, 470);
+    field(560, T.dateLabel, 910);
   }
 
   /* ---------------------------------------------------------------
@@ -1331,10 +1397,10 @@
   // Difficulty ladder: more dots = harder / more detail. `total` is the
   // whole-name target dot budget, shared out across the letters.
   const DOT_LEVELS = [
-    { key: "easy",   label: "Easy",   total: 26, hint: "Big gaps, few dots — the youngest kids" },
-    { key: "medium", label: "Medium", total: 42, hint: "A balanced connect-the-dots" },
-    { key: "hard",   label: "Hard",   total: 60, hint: "More dots and finer letter detail" },
-    { key: "expert", label: "Expert", total: 84, hint: "Lots of dots — a real challenge" }
+    { key: "easy",   label: T.dot.easy.label,   total: 26, hint: T.dot.easy.hint },
+    { key: "medium", label: T.dot.medium.label, total: 42, hint: T.dot.medium.hint },
+    { key: "hard",   label: T.dot.hard.label,   total: 60, hint: T.dot.hard.hint },
+    { key: "expert", label: T.dot.expert.label, total: 84, hint: T.dot.expert.hint }
   ];
   function dotLevel(key) {
     for (let i = 0; i < DOT_LEVELS.length; i++) if (DOT_LEVELS[i].key === key) return DOT_LEVELS[i];
@@ -1643,7 +1709,7 @@
     svg.setAttribute("viewBox", "0 0 800 960");
     svg.setAttribute("class", "bubble-outline" + (o.small ? " is-small" : ""));
     svg.setAttribute("role", "img");
-    svg.setAttribute("aria-label", "dot to dot " + charLabel(ch));
+    svg.setAttribute("aria-label", T.dotToDot + " " + charLabel(ch));
     addDotWordSVG(svg, ch.toUpperCase(), CFG.dotDifficulty || "medium", { x: 70, y: 70, w: 660, h: 820 }, CFG.dotHint !== false);
     return svg;
   }
@@ -1787,7 +1853,7 @@
       if (designFooterOn()) {
         ctx.textAlign = "left"; ctx.font = "600 30px " + FONT; ctx.fillStyle = INK;
         const fy = H - 150;
-        ctx.fillText("Name:", 90, fy); ctx.fillText("Date:", 560, fy);
+        ctx.fillText(T.nameLabel, 90, fy); ctx.fillText(T.dateLabel, 560, fy);
         ctx.strokeStyle = "#9aa3b2"; ctx.lineWidth = 2;
         ctx.beginPath(); ctx.moveTo(200, fy + 16); ctx.lineTo(470, fy + 16);
         ctx.moveTo(670, fy + 16); ctx.lineTo(910, fy + 16); ctx.stroke();
@@ -1954,7 +2020,7 @@
     svg.setAttribute("viewBox", "0 0 " + FLAG_W + " " + FLAG_H);
     svg.setAttribute("class", "pt-banner-flag");
     svg.setAttribute("role", "img");
-    svg.setAttribute("aria-label", "Banner flag — " + ch);
+    svg.setAttribute("aria-label", T.bannerFlag + " " + ch);
 
     const shape = document.createElementNS(SVGNS, "polygon");
     shape.setAttribute("points", FLAG_LEFT + "," + FLAG_TOP + " " + FLAG_RIGHT + "," + FLAG_TOP + " " + FLAG_APEX_X + "," + FLAG_APEX_Y);
@@ -2013,7 +2079,7 @@
       if (pi === 0) {
         const instr = document.createElement("p");
         instr.className = "pt-banner-instructions";
-        instr.textContent = "Cut each flag along its dashed line, punch a hole at each dot, then thread string or ribbon through in order (1, 2, 3…) to spell it out.";
+        instr.textContent = T.bannerInstr;
         head.appendChild(instr);
       }
       page.appendChild(head);
@@ -2025,7 +2091,7 @@
           const gap = document.createElement("div");
           gap.className = "pt-banner-gap";
           const label = document.createElement("span");
-          label.textContent = "space";
+          label.textContent = T.space;
           gap.appendChild(label);
           grid.appendChild(gap);
           return;
@@ -2143,7 +2209,7 @@
           ctx.fillStyle = "#94a3b8";
           ctx.font = "600 20px " + FONT;
           ctx.textAlign = "center";
-          ctx.fillText("space", x + w / 2, pad + flagH + 30);
+          ctx.fillText(T.space, x + w / 2, pad + flagH + 30);
           ctx.restore();
         }
         x += w + gap;
@@ -2219,8 +2285,8 @@
       f.appendChild(l); f.appendChild(line);
       return f;
     };
-    row.appendChild(field("Name:"));
-    row.appendChild(field("Date:"));
+    row.appendChild(field(T.nameLabel));
+    row.appendChild(field(T.dateLabel));
     return row;
   }
 
@@ -2276,7 +2342,7 @@
 
     const cap = document.createElement("p");
     cap.className = "pt-puzzle-caption";
-    cap.textContent = "Cut along the dashed lines to separate each letter piece.";
+    cap.textContent = T.puzzleCut;
     sheet.appendChild(cap);
 
     if (footer) sheet.appendChild(puzzleFooterRow());
@@ -2376,8 +2442,8 @@
         ctx.font = "600 30px " + FONT;
         ctx.fillStyle = INK;
         const fy = 700;
-        ctx.fillText("Name:", pad, fy);
-        ctx.fillText("Date:", W / 2 + 40, fy);
+        ctx.fillText(T.nameLabel, pad, fy);
+        ctx.fillText(T.dateLabel, W / 2 + 40, fy);
         ctx.strokeStyle = "#9aa3b2"; ctx.lineWidth = 2;
         ctx.beginPath();
         ctx.moveTo(pad + 110, fy + 12); ctx.lineTo(W / 2 - 40, fy + 12);

--- a/js/printables/printablesEngine.js
+++ b/js/printables/printablesEngine.js
@@ -113,6 +113,58 @@
         hard:   { label: "Difficile", hint: "Plus de points et de détails dans la lettre" },
         expert: { label: "Expert", hint: "Beaucoup de points — un vrai défi" }
       }
+    },
+    es: {
+      letterWord: "letra", numberWord: "número",
+      copied: "¡Copiado!",
+      printThisLetter: "Imprimir esta letra", printThisNumber: "Imprimir este número",
+      downloadPng: "Descargar PNG",
+      copyPaste: "Copiar y pegar", copy: "Copiar", howToDraw: "Cómo dibujarla", lowerSuffix: " · min.",
+      level: "Nivel", nameLabel: "Nombre:", dateLabel: "Fecha:", space: "espacio",
+      dotToDot: "unir los puntos", bannerFlag: "Banderín —",
+      bannerInstr: "Recorta cada banderín por su línea punteada, haz un agujero en cada punto y pasa un cordel o cinta en orden (1, 2, 3…) para formar la palabra.",
+      puzzleCut: "Recorta por las líneas punteadas para separar cada pieza-letra.",
+      trace: {
+        solid:    { label: "Modelo sólido", hint: "Letras oscuras y llenas — traza justo encima" },
+        "bold-dot": { label: "Punteado grueso", hint: "Puntos gruesos y juntos para unir" },
+        "fine-dot": { label: "Punteado fino", hint: "Puntos más finos con un poco más de espacio" },
+        dashed:   { label: "Discontinuo", hint: "Guiones discontinuos — más línea que completar" },
+        faded:    { label: "Fantasma tenue", hint: "Letras gris claro para repasar" },
+        faint:    { label: "Guía tenue", hint: "Contorno apenas visible — casi solo" },
+        blank:    { label: "Línea en blanco", hint: "Sin guía — escríbela de memoria" }
+      },
+      dot: {
+        easy:   { label: "Fácil", hint: "Huecos grandes, pocos puntos — los más pequeños" },
+        medium: { label: "Medio", hint: "Un unir-los-puntos equilibrado" },
+        hard:   { label: "Difícil", hint: "Más puntos y más detalle en la letra" },
+        expert: { label: "Experto", hint: "Muchos puntos — todo un reto" }
+      }
+    },
+    pt: {
+      letterWord: "letra", numberWord: "número",
+      copied: "Copiado!",
+      printThisLetter: "Imprimir esta letra", printThisNumber: "Imprimir este número",
+      downloadPng: "Baixar PNG",
+      copyPaste: "Copiar e colar", copy: "Copiar", howToDraw: "Como desenhar", lowerSuffix: " · min.",
+      level: "Nível", nameLabel: "Nome:", dateLabel: "Data:", space: "espaço",
+      dotToDot: "ligar os pontos", bannerFlag: "Bandeirinha —",
+      bannerInstr: "Recorte cada bandeirinha na linha pontilhada, faça um furo em cada ponto e passe um barbante ou fita na ordem (1, 2, 3…) para formar a palavra.",
+      puzzleCut: "Recorte nas linhas pontilhadas para separar cada peça-letra.",
+      trace: {
+        solid:    { label: "Modelo cheio", hint: "Letras escuras e cheias — trace por cima" },
+        "bold-dot": { label: "Pontilhado grosso", hint: "Pontos grossos e juntos para ligar" },
+        "fine-dot": { label: "Pontilhado fino", hint: "Pontos mais finos, um pouco mais espaçados" },
+        dashed:   { label: "Tracejado", hint: "Traços interrompidos — mais linha para completar" },
+        faded:    { label: "Fantasma claro", hint: "Letras cinza-claro para cobrir" },
+        faint:    { label: "Guia leve", hint: "Contorno quase invisível — quase sozinho" },
+        blank:    { label: "Linha em branco", hint: "Sem guia — escreva de memória" }
+      },
+      dot: {
+        easy:   { label: "Fácil", hint: "Espaços grandes, poucos pontos — os menores" },
+        medium: { label: "Médio", hint: "Um ligar-os-pontos equilibrado" },
+        hard:   { label: "Difícil", hint: "Mais pontos e mais detalhe na letra" },
+        expert: { label: "Expert", hint: "Muitos pontos — um baita desafio" }
+      }
     }
   };
   const T = I18N[LANG] || I18N.en;

--- a/printables/alphabet-coloring-pages/index.html
+++ b/printables/alphabet-coloring-pages/index.html
@@ -13,6 +13,9 @@
   <title>Alphabet Coloring Pages A–Z — Free Printable ABC Sheets | UltraTextGen</title>
   <meta name="description" content="Free printable alphabet coloring pages A–Z. Big single-line letter outlines to color and print, plus a page for every letter A to Z. Print the whole ABC or download any letter as a PNG.">
   <link rel="canonical" href="https://ultratextgen.com/printables/alphabet-coloring-pages/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/printables/alphabet-coloring-pages/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/imprimables/coloriage-alphabet/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/alphabet-coloring-pages/">
   <meta property="og:title" content="Alphabet Coloring Pages A–Z | UltraTextGen">
   <meta property="og:description" content="Free printable alphabet coloring pages A–Z. Color and print big letter outlines, or open a page for any letter.">
   <meta property="og:url" content="https://ultratextgen.com/printables/alphabet-coloring-pages/">

--- a/printables/alphabet-coloring-pages/index.html
+++ b/printables/alphabet-coloring-pages/index.html
@@ -15,6 +15,8 @@
   <link rel="canonical" href="https://ultratextgen.com/printables/alphabet-coloring-pages/">
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/printables/alphabet-coloring-pages/">
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/imprimables/coloriage-alphabet/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/imprimibles/abecedario-para-colorear/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/imprimiveis/alfabeto-para-colorir/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/alphabet-coloring-pages/">
   <meta property="og:title" content="Alphabet Coloring Pages A–Z | UltraTextGen">
   <meta property="og:description" content="Free printable alphabet coloring pages A–Z. Color and print big letter outlines, or open a page for any letter.">

--- a/printables/bubble-letters/index.html
+++ b/printables/bubble-letters/index.html
@@ -15,6 +15,8 @@
   <link rel="canonical" href="https://ultratextgen.com/printables/bubble-letters/">
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/printables/bubble-letters/">
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/imprimables/lettres-bulles/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/imprimibles/letras-burbuja/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/imprimiveis/letras-bolha/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/bubble-letters/">
   <meta property="og:title" content="Printable Bubble Letters A–Z &amp; 0–9 | UltraTextGen">
   <meta property="og:description" content="Free printable bubble letters and numbers. Large outlines to trace and color, print the alphabet, or download PNGs.">

--- a/printables/bubble-letters/index.html
+++ b/printables/bubble-letters/index.html
@@ -13,6 +13,9 @@
   <title>Printable Bubble Letters A–Z &amp; 0–9 — Trace, Color, Download PNG | UltraTextGen</title>
   <meta name="description" content="Free printable bubble letters A–Z and numbers 0–9. Large puffy outlines to trace and color, print the whole alphabet, or download any letter as a PNG. No sign-up.">
   <link rel="canonical" href="https://ultratextgen.com/printables/bubble-letters/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/printables/bubble-letters/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/imprimables/lettres-bulles/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/bubble-letters/">
   <meta property="og:title" content="Printable Bubble Letters A–Z &amp; 0–9 | UltraTextGen">
   <meta property="og:description" content="Free printable bubble letters and numbers. Large outlines to trace and color, print the alphabet, or download PNGs.">
   <meta property="og:url" content="https://ultratextgen.com/printables/bubble-letters/">

--- a/printables/cursive-alphabet/index.html
+++ b/printables/cursive-alphabet/index.html
@@ -15,6 +15,8 @@
   <link rel="canonical" href="https://ultratextgen.com/printables/cursive-alphabet/">
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/printables/cursive-alphabet/">
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/imprimables/alphabet-cursif/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/imprimibles/alfabeto-cursiva/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/imprimiveis/alfabeto-cursivo/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/cursive-alphabet/">
   <meta property="og:title" content="Cursive Alphabet A–Z — Free Printable Practice Sheets | UltraTextGen">
   <meta property="og:description" content="The cursive alphabet A–Z with printable practice sheets to trace, per-letter PNG downloads, and a cursive name worksheet.">

--- a/printables/cursive-alphabet/index.html
+++ b/printables/cursive-alphabet/index.html
@@ -13,6 +13,9 @@
   <title>Cursive Alphabet A–Z — Free Printable Practice Sheets &amp; Letters | UltraTextGen</title>
   <meta name="description" content="The cursive alphabet A–Z with free printable practice sheets — model letters plus space to trace — per-letter PNG downloads, and a cursive name worksheet. No sign-up.">
   <link rel="canonical" href="https://ultratextgen.com/printables/cursive-alphabet/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/printables/cursive-alphabet/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/imprimables/alphabet-cursif/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/cursive-alphabet/">
   <meta property="og:title" content="Cursive Alphabet A–Z — Free Printable Practice Sheets | UltraTextGen">
   <meta property="og:description" content="The cursive alphabet A–Z with printable practice sheets to trace, per-letter PNG downloads, and a cursive name worksheet.">
   <meta property="og:url" content="https://ultratextgen.com/printables/cursive-alphabet/">

--- a/printables/index.html
+++ b/printables/index.html
@@ -15,6 +15,8 @@
   <link rel="canonical" href="https://ultratextgen.com/printables/">
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/printables/">
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/imprimables/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/imprimibles/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/imprimiveis/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/">
   <meta property="og:title" content="Printable Letters, Alphabets &amp; Tracing Sheets | UltraTextGen">
   <meta property="og:description" content="Free printable letters and alphabets: bubble letters, cursive practice sheets, block letter stencils, and name tracing worksheets. Print or download as PNG.">

--- a/printables/index.html
+++ b/printables/index.html
@@ -13,6 +13,9 @@
   <title>Printable Letters, Alphabets &amp; Tracing Sheets — Free PDF/PNG | UltraTextGen</title>
   <meta name="description" content="Free printable letters and alphabets: bubble letters, cursive practice sheets, block letter stencils, and name tracing worksheets. Print or download as PNG — no sign-up.">
   <link rel="canonical" href="https://ultratextgen.com/printables/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/printables/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/imprimables/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/">
   <meta property="og:title" content="Printable Letters, Alphabets &amp; Tracing Sheets | UltraTextGen">
   <meta property="og:description" content="Free printable letters and alphabets: bubble letters, cursive practice sheets, block letter stencils, and name tracing worksheets. Print or download as PNG.">
   <meta property="og:url" content="https://ultratextgen.com/printables/">

--- a/printables/name-tracing/index.html
+++ b/printables/name-tracing/index.html
@@ -15,6 +15,8 @@
   <link rel="canonical" href="https://ultratextgen.com/printables/name-tracing/">
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/printables/name-tracing/">
   <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/imprimables/prenom-a-tracer/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/imprimibles/nombre-para-trazar/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/imprimiveis/nome-para-tracar/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/name-tracing/">
   <meta property="og:title" content="Name Tracing Worksheets — Free Printable Handwriting Practice | UltraTextGen">
   <meta property="og:description" content="Type any name to make a free printable tracing worksheet: model row, faded trace rows, and blank practice lines. Plus A–Z and 0–9 letter tracing.">

--- a/printables/name-tracing/index.html
+++ b/printables/name-tracing/index.html
@@ -13,6 +13,9 @@
   <title>Name Tracing Worksheets — Free Printable Handwriting Practice | UltraTextGen</title>
   <meta name="description" content="Type any name to make a free printable name tracing worksheet: a solid model row, faded rows to trace, and blank lines to practice. Plus A–Z and 0–9 letter tracing. No sign-up.">
   <link rel="canonical" href="https://ultratextgen.com/printables/name-tracing/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/printables/name-tracing/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/imprimables/prenom-a-tracer/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/name-tracing/">
   <meta property="og:title" content="Name Tracing Worksheets — Free Printable Handwriting Practice | UltraTextGen">
   <meta property="og:description" content="Type any name to make a free printable tracing worksheet: model row, faded trace rows, and blank practice lines. Plus A–Z and 0–9 letter tracing.">
   <meta property="og:url" content="https://ultratextgen.com/printables/name-tracing/">

--- a/pt/imprimiveis/alfabeto-cursivo/index.html
+++ b/pt/imprimiveis/alfabeto-cursivo/index.html
@@ -1,0 +1,258 @@
+<!DOCTYPE html><html lang="pt"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Alfabeto cursivo A–Z — Fichas de caligrafia para imprimir | UltraTextGen</title>
+  <meta name="description" content="O alfabeto cursivo A–Z com fichas de caligrafia para imprimir grátis — letras-modelo e espaço para traçar — o download em PNG de cada letra e uma ficha de nome em cursiva. Sem cadastro.">
+  <link rel="canonical" href="https://ultratextgen.com/pt/imprimiveis/alfabeto-cursivo/">
+
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/printables/cursive-alphabet/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/imprimables/alphabet-cursif/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/imprimibles/alfabeto-cursiva/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/imprimiveis/alfabeto-cursivo/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/cursive-alphabet/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Alfabeto cursivo A–Z — Fichas de caligrafia para imprimir | UltraTextGen">
+  <meta property="og:description" content="O alfabeto cursivo A–Z com fichas de caligrafia para imprimir e traçar, o download em PNG de cada letra e uma ficha de nome em cursiva.">
+  <meta property="og:url" content="https://ultratextgen.com/pt/imprimiveis/alfabeto-cursivo/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category-cursive-fonts.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Alfabeto cursivo A–Z — Fichas de caligrafia para imprimir | UltraTextGen">
+  <meta name="twitter:description" content="O alfabeto cursivo A–Z com fichas de caligrafia para imprimir e traçar, o download em PNG de cada letra e uma ficha de nome em cursiva.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category-cursive-fonts.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Início", "item": "https://ultratextgen.com/pt/" },
+    { "@type": "ListItem", "position": 2, "name": "Imprimíveis", "item": "https://ultratextgen.com/pt/imprimiveis/" },
+    { "@type": "ListItem", "position": 3, "name": "Alfabeto cursivo", "item": "https://ultratextgen.com/pt/imprimiveis/alfabeto-cursivo/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "pt",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Posso imprimir fichas de caligrafia cursiva?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Sim. Clique em Imprimir a folha de treino para obter uma página A–Z para imprimir: cada linha mostra as letras-modelo em cursiva mais um espaço para traçá-las e repeti-las — prático para professores, pais e qualquer pessoa que aprende a letra emendada."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Como imprimir uma única letra cursiva, como um S ou um G maiúsculo?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Toque em qualquer letra do seletor para ver sua forma cursiva em maiúscula e minúscula. Use Imprimir esta letra para uma página grande de uma única letra, ou Baixar PNG para salvar uma imagem em alta resolução para imprimir ou reutilizar."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Posso criar uma ficha de nome para traçar em cursiva?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Sim. Digite um nome no campo indicado e imprima uma ficha com uma linha-modelo mais linhas pontilhadas para cobrir — uma maneira simples de treinar a escrita de um nome ou uma assinatura em cursiva."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "A cursiva Unicode é a mesma coisa que a escrita cursiva de verdade?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "A cursiva na tela é composta por caracteres script Unicode, que também servem de modelos nítidos para a forma das letras. As fichas impressas os usam como modelos para traçar. Para texto cursivo para copiar e colar em bios e legendas, use o gerador de letra cursiva."
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Trilha de navegação">
+  <a href="/pt/">Início</a>
+  <span class="breadcrumb-separator">›</span>
+  <a href="/pt/imprimiveis/">Imprimíveis</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Alfabeto cursivo</span>
+</nav>
+
+  <section class="hero">
+    <div class="hero-inner" style="max-width:820px;">
+      <h1 class="hero-headline">Alfabeto cursivo — Fichas de caligrafia para imprimir</h1>
+      <p class="hero-tagline">
+        O alfabeto cursivo completo A–Z. Imprima uma folha de treino com letras-modelo e espaço para traçar,
+        baixe qualquer letra em PNG, ou crie uma ficha de nome em cursiva. Grátis, sem cadastro.
+      </p>
+    </div>
+  </section>
+
+  <main class="container">
+
+    <!-- Practice sheet CTA -->
+    <section class="bubble-alphabet" aria-labelledby="ptPracticeHeading">
+      <div class="bubble-alphabet-head">
+        <h2 id="ptPracticeHeading">Ficha de caligrafia cursiva para imprimir</h2>
+        <button class="bubble-btn bubble-btn-primary" type="button" id="pt-practice-print">Imprimir a folha de treino</button>
+      </div>
+      <p class="bubble-az-intro">Um clique imprime uma página A–Z onde cada linha mostra as letras-modelo em cursiva mais um espaço para traçá-las e repeti-las — pronta para a sala de aula, o ensino em casa ou seu próprio treino.</p>
+    </section>
+
+    <!-- Picker + selected-letter detail -->
+    <section class="bubble-az" aria-labelledby="ptPickHeading">
+      <h2 class="bubble-az-heading" id="ptPickHeading">Letras cursivas A–Z</h2>
+      <p class="bubble-az-intro">Toque em uma letra para ver sua forma cursiva em maiúscula e minúscula, imprimir uma letra única grande, baixar um PNG ou copiar os estilos cursivos Unicode correspondentes.</p>
+      <div class="bubble-strip" id="pt-strip" role="tablist" aria-label="Escolher uma letra cursiva"></div>
+      <div class="bubble-letter-panel" id="pt-panel" aria-live="polite"></div>
+    </section>
+
+    <!-- Cursive name worksheet -->
+    <section class="bubble-alphabet" aria-labelledby="ptNameHeading">
+      <h2 id="ptNameHeading">Ficha de nome para traçar em cursiva</h2>
+      <p class="bubble-az-intro">Digite um nome para vê-lo em cursiva na prévia, depois imprima uma ficha com uma linha-modelo e linhas pontilhadas para cobrir — ideal para assinaturas e o treino do nome.</p>
+      <div class="pt-name-tool">
+        <div class="input-wrapper">
+          <input type="text" class="main-input pt-name-input" id="pt-name-input" placeholder="Digite um nome… ex. Olivia" maxlength="40">
+        </div>
+        <div class="pt-name-preview" id="pt-name-preview" aria-live="polite"></div>
+        <div class="bubble-actions pt-name-actions">
+          <button type="button" class="bubble-btn bubble-btn-primary" id="pt-name-print">Imprimir a ficha</button>
+          <button type="button" class="bubble-btn" id="pt-name-png">Baixar PNG</button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Editorial -->
+    <section class="editorial-section">
+      <h2>Aprender cursiva com a folha de treino</h2>
+      <p>Imprima a <strong>folha de treino</strong> e cubra cada letra-modelo até as ligações ficarem
+        naturais, depois passe para o espaço em branco para escrevê-la sozinho. Observe como cada maiúscula se liga, e mantenha
+        sessões curtas e frequentes — algumas letras por dia valem mais que uma sessão longa.</p>
+      <h3>Cursiva para imprimir vs. cursiva para copiar e colar</h3>
+      <p>Estas fichas são feitas para o <em>papel</em> — o traço e a escrita. Se você quer texto cursivo para colar em uma
+        bio do Instagram, uma legenda ou um documento, use o <a href="/pt/letra-cursiva/">gerador de letra cursiva</a>, que
+        transforma suas palavras em script Unicode para copiar e colar. Para um nome decorativo para colorir, experimente as
+        <a href="/pt/imprimiveis/letras-bolha/">letras bolha</a>.</p>
+    </section>
+
+    <div class="cta-card">
+      <h3>Quer cursiva para copiar e colar?</h3>
+      <p>Digite uma vez e copie script Unicode fluido para suas bios, legendas, nomes e assinaturas.</p>
+      <a class="cta-btn" href="/pt/letra-cursiva/">Abrir o gerador de letra cursiva →</a>
+    </div>
+  </main>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <h2 class="faq-category">Cursiva para imprimir — FAQ</h2>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Posso imprimir fichas de caligrafia cursiva?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Sim. Clique em <strong>Imprimir a folha de treino</strong> para obter uma página A–Z para imprimir: cada linha mostra as letras
+          modelo em cursiva mais um espaço para traçá-las e repeti-las — prático para professores, pais e qualquer pessoa que aprende a letra emendada.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Como imprimir uma única letra cursiva, como um S ou um G maiúsculo?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Toque em qualquer letra do seletor para ver sua forma cursiva em maiúscula e minúscula. Use <strong>Imprimir esta letra</strong>
+          para uma página grande de uma única letra, ou <strong>Baixar PNG</strong> para salvar uma imagem em alta resolução para imprimir ou reutilizar.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Posso criar uma ficha de nome para traçar em cursiva?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Sim. Digite um nome no campo indicado e imprima uma ficha com uma linha-modelo mais linhas pontilhadas para cobrir — uma maneira simples
+          de treinar a escrita de um nome ou uma assinatura em cursiva.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          A cursiva Unicode é a mesma coisa que a escrita cursiva de verdade?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          A cursiva na tela é composta por caracteres script Unicode, que também servem de modelos nítidos para a forma das letras. As fichas impressas
+          os usam como modelos para traçar. Para texto cursivo para copiar e colar em bios e legendas, use o
+          <a href="/pt/letra-cursiva/">gerador de letra cursiva</a>.
+        </div>
+      </div>
+
+    </div>
+  </footer>
+
+  <!-- Print surface (hidden on screen, isolated when printing) -->
+  <div id="pt-print-root" aria-hidden="true"></div>
+
+  <script>
+    window.UTG_PRINTABLE = {
+      key: "cursive-alphabet",
+      lang: "pt",
+      render: "glyph",
+      noun: "cursiva",
+      pngPrefix: "cursiva",
+      font: "'Plus Jakarta Sans', 'Segoe UI Symbol', 'Noto Sans Symbols 2', sans-serif",
+      charset: "alpha",
+      variantFamily: "cursive",
+      glyphStyle: "Ultra Script",
+      nameDemo: "Olivia"
+    };
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/js/printables/printablesEngine.js" defer></script>
+
+  <!-- FAQ toggle -->
+  <script>
+    document.querySelectorAll('.faq-question').forEach(function(btn) {
+      btn.addEventListener('click', function() { this.closest('.faq-item').classList.toggle('open'); });
+    });
+  </script>
+<script src="/footer.js" defer></script>
+</body></html>

--- a/pt/imprimiveis/alfabeto-para-colorir/index.html
+++ b/pt/imprimiveis/alfabeto-para-colorir/index.html
@@ -1,0 +1,241 @@
+<!DOCTYPE html><html lang="pt"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Alfabeto para colorir A–Z — Letras para imprimir grátis | UltraTextGen</title>
+  <meta name="description" content="Alfabeto para colorir A–Z para imprimir grátis. Grandes contornos de letras para colorir e imprimir, uma página para cada letra A a Z. Imprima todo o alfabeto ou baixe qualquer letra em PNG.">
+  <link rel="canonical" href="https://ultratextgen.com/pt/imprimiveis/alfabeto-para-colorir/">
+
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/printables/alphabet-coloring-pages/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/imprimables/coloriage-alphabet/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/imprimibles/abecedario-para-colorear/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/imprimiveis/alfabeto-para-colorir/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/alphabet-coloring-pages/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Alfabeto para colorir A–Z | UltraTextGen">
+  <meta property="og:description" content="Alfabeto para colorir A–Z para imprimir grátis. Colora e imprima grandes contornos de letras, ou abra a página de uma letra.">
+  <meta property="og:url" content="https://ultratextgen.com/pt/imprimiveis/alfabeto-para-colorir/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Alfabeto para colorir A–Z | UltraTextGen">
+  <meta name="twitter:description" content="Alfabeto para colorir A–Z para imprimir grátis. Colora e imprima grandes contornos de letras.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;family=Baloo+2:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Início", "item": "https://ultratextgen.com/pt/" },
+    { "@type": "ListItem", "position": 2, "name": "Imprimíveis", "item": "https://ultratextgen.com/pt/imprimiveis/" },
+    { "@type": "ListItem", "position": 3, "name": "Alfabeto para colorir", "item": "https://ultratextgen.com/pt/imprimiveis/alfabeto-para-colorir/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "pt",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Este alfabeto para colorir é grátis para imprimir?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Sim. Cada página do alfabeto para colorir aqui é totalmente grátis, sem cadastro, sem marca d'água e sem limite. Escolha uma letra para um grande contorno e use Imprimir esta letra para enviar à sua impressora ou Baixar PNG para salvar uma imagem em alta resolução."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Como imprimir todo o alfabeto ABC de uma vez?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Role até a seção Alfabeto para imprimir e toque em Imprimir o alfabeto para enviar os 26 contornos de letras à sua impressora em uma única folha — prático para uma atividade em sala de aula ou uma brincadeira de dia de chuva."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Posso obter uma página para colorir de uma única letra?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Sim. Toque em qualquer letra A–Z no seletor para vê-la na prévia, depois use Imprimir esta letra ou Baixar PNG para um grande contorno de uma única letra para colorir."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Qual a diferença em relação às letras bolha?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Estas páginas para colorir usam contornos finos e nítidos, fáceis de colorir por dentro. As letras bolha são arredondadas e infladas. As duas são contornos para imprimir grátis — escolha o estilo que você preferir."
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Trilha de navegação">
+  <a href="/pt/">Início</a>
+  <span class="breadcrumb-separator">›</span>
+  <a href="/pt/imprimiveis/">Imprimíveis</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Alfabeto para colorir</span>
+</nav>
+
+  <section class="hero">
+    <div class="hero-inner" style="max-width:820px;">
+      <h1 class="hero-headline">Alfabeto para colorir (A–Z)</h1>
+      <p class="hero-tagline">
+        Páginas ABC para colorir e imprimir grátis. Escolha uma letra para um grande contorno nítido para colorir, imprima todo o alfabeto de uma vez, ou veja qualquer letra na prévia — sem cadastro.
+      </p>
+    </div>
+  </section>
+
+  <main class="container">
+
+    <!-- Picker + selected-letter detail -->
+    <section class="bubble-az" aria-labelledby="ptPickHeading">
+      <h2 class="bubble-az-heading" id="ptPickHeading">Escolha uma letra para colorir</h2>
+      <p class="bubble-az-intro">Toque em qualquer letra A–Z para ver seu grande contorno para colorir, imprimi-lo ou baixar um PNG.</p>
+      <div class="bubble-strip" id="pt-strip" role="tablist" aria-label="Escolher uma letra para colorir"></div>
+      <div class="bubble-letter-panel" id="pt-panel" aria-live="polite"></div>
+    </section>
+
+    <!-- Full printable alphabet -->
+    <section class="bubble-alphabet" aria-labelledby="ptAlphaHeading">
+      <div class="bubble-alphabet-head">
+        <h2 id="ptAlphaHeading">Alfabeto para imprimir</h2>
+        <button class="bubble-btn bubble-btn-primary" type="button" id="pt-alphabet-print">Imprimir o alfabeto</button>
+      </div>
+      <p class="bubble-az-intro">O alfabeto A–Z completo em contornos nítidos para colorir. Imprima toda a folha para colorir, ou toque em qualquer letra para abrir suas opções de impressão e download.</p>
+      <div class="bubble-alphabet-grid" id="pt-alphabet-grid"></div>
+    </section>
+
+    <!-- Editorial -->
+    <section class="editorial-section">
+      <h2>Como usar o alfabeto para colorir</h2>
+      <ul class="compat-list">
+        <li><span class="ts-pill-safe">Aprender</span> Diga a letra e o som dela em voz alta durante o colorir — uma forma simples de ligar as letras aos sons.</li>
+        <li><span class="ts-pill-safe">Colorir</span> Os contornos finos deixam bastante espaço para lápis, canetinhas e lápis de cor.</li>
+        <li><span class="ts-pill-safe">Na sala de aula</span> Imprima todo o alfabeto para uma oficina, ou uma única letra para a letra da semana.</li>
+      </ul>
+      <h3>Prefere letras para copiar e colar em vez de colorir?</h3>
+      <p>Estes contornos são feitos para o papel. Se você quer letras bonitas para colar em uma bio ou legenda, use os
+        <a href="/pt/letras-para-copiar/">geradores de fonte</a>. Para outros estilos para imprimir, experimente as
+        <a href="/pt/imprimiveis/letras-bolha/">letras bolha</a>.</p>
+    </section>
+
+    <div class="cta-card">
+      <h3>Procura antes por treino de escrita?</h3>
+      <p>Digite qualquer nome e imprima uma ficha para traçar com linhas-modelo e linhas para cobrir — perfeito para a educação infantil e o 1º ano.</p>
+      <a class="cta-btn" href="/pt/imprimiveis/nome-para-tracar/">Abrir as fichas de nome para traçar →</a>
+    </div>
+
+    <div class="cta-card">
+      <h3>Quer letra emendada?</h3>
+      <p>Passe para o alfabeto cursivo com fichas de caligrafia para traçar e o download em PNG de cada letra.</p>
+      <a class="cta-btn" href="/pt/imprimiveis/alfabeto-cursivo/">Abrir o alfabeto cursivo →</a>
+    </div>
+  </main>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <h2 class="faq-category">Alfabeto para colorir — FAQ</h2>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Este alfabeto para colorir é grátis para imprimir?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Sim — cada página do alfabeto para colorir aqui é totalmente grátis, sem cadastro, sem marca d'água e sem limite. Escolha uma letra para um grande contorno e use <strong>Imprimir esta letra</strong> para enviar à sua impressora ou <strong>Baixar PNG</strong> para salvar uma imagem em alta resolução.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Como imprimir todo o alfabeto ABC de uma vez?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Role até a seção <strong>Alfabeto para imprimir</strong> e toque em <strong>Imprimir o alfabeto</strong> para enviar os 26 contornos de letras à sua impressora em uma única folha — prático para uma atividade em sala de aula ou uma brincadeira de dia de chuva.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Posso obter uma página para colorir de uma única letra?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Sim. Toque em qualquer letra A–Z no seletor para vê-la na prévia, depois use <strong>Imprimir esta letra</strong> ou <strong>Baixar PNG</strong> para um grande contorno de uma única letra para colorir.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Qual a diferença em relação às letras bolha?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Estas páginas para colorir usam contornos finos e nítidos, fáceis de colorir por dentro. As <a href="/pt/imprimiveis/letras-bolha/">letras bolha</a> são arredondadas e infladas. As duas são contornos para imprimir grátis — escolha o estilo que você preferir.
+        </div>
+      </div>
+
+    </div>
+  </footer>
+
+  <!-- Print surface (hidden on screen, isolated when printing) -->
+  <div id="pt-print-root" aria-hidden="true"></div>
+
+  <script>
+    window.UTG_PRINTABLE = {
+      key: "alphabet-coloring-pages",
+      lang: "pt",
+      render: "outline",
+      noun: "colorir",
+      pngPrefix: "colorir",
+      font: "'Baloo 2', 'Plus Jakarta Sans', sans-serif",
+      strokeWidth: 4,
+    };
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/js/printables/printablesEngine.js" defer></script>
+
+  <!-- FAQ toggle -->
+  <script>
+    document.querySelectorAll('.faq-question').forEach(function(btn) {
+      btn.addEventListener('click', function() { this.closest('.faq-item').classList.toggle('open'); });
+    });
+  </script>
+<script src="/footer.js" defer></script>
+</body></html>

--- a/pt/imprimiveis/index.html
+++ b/pt/imprimiveis/index.html
@@ -1,0 +1,289 @@
+<!DOCTYPE html><html lang="pt"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Letras e alfabetos para imprimir — PDF/PNG grátis | UltraTextGen</title>
+  <meta name="description" content="Letras e alfabetos para imprimir grátis: letras bolha, fichas de caligrafia cursiva, alfabeto para colorir e fichas de nome para traçar. Imprima ou baixe em PNG — sem cadastro.">
+  <link rel="canonical" href="https://ultratextgen.com/pt/imprimiveis/">
+
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/printables/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/imprimables/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/imprimibles/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/imprimiveis/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Letras e alfabetos para imprimir &amp; fichas para traçar | UltraTextGen">
+  <meta property="og:description" content="Letras e alfabetos para imprimir grátis: letras bolha, fichas de caligrafia cursiva, alfabeto para colorir e fichas de nome para traçar. Imprima ou baixe em PNG.">
+  <meta property="og:url" content="https://ultratextgen.com/pt/imprimiveis/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Letras e alfabetos para imprimir &amp; fichas para traçar | UltraTextGen">
+  <meta name="twitter:description" content="Letras e alfabetos para imprimir grátis: letras bolha, fichas de caligrafia cursiva, alfabeto para colorir e fichas de nome para traçar.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "name": "Letras & alfabetos para imprimir",
+  "url": "https://ultratextgen.com/pt/imprimiveis/",
+  "description": "Letras, alfabetos, fichas para traçar e downloads em PNG para imprimir grátis.",
+  "inLanguage": "pt",
+  "mainEntity": {
+    "@type": "ItemList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Fichas de nome para traçar", "url": "https://ultratextgen.com/pt/imprimiveis/nome-para-tracar/" },
+      { "@type": "ListItem", "position": 2, "name": "Alfabeto cursivo & fichas de caligrafia", "url": "https://ultratextgen.com/pt/imprimiveis/alfabeto-cursivo/" },
+      { "@type": "ListItem", "position": 3, "name": "Alfabeto para colorir", "url": "https://ultratextgen.com/pt/imprimiveis/alfabeto-para-colorir/" },
+      { "@type": "ListItem", "position": 4, "name": "Letras bolha para imprimir", "url": "https://ultratextgen.com/pt/imprimiveis/letras-bolha/" }
+    ]
+  }
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Início", "item": "https://ultratextgen.com/pt/" },
+    { "@type": "ListItem", "position": 2, "name": "Imprimíveis", "item": "https://ultratextgen.com/pt/imprimiveis/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "pt",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Estas letras para imprimir são grátis?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Sim. Todos os imprimíveis do UltraTextGen são totalmente grátis, sem cadastro, sem marca d'água e sem limite. Escolha uma letra ou digite um nome e use o botão Imprimir para enviar à sua impressora, ou Baixar PNG para salvar uma imagem em alta resolução."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Qual é a diferença entre os imprimíveis e os geradores de fonte?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Os geradores de fonte transformam seu texto em fontes Unicode para copiar e colar em bios, legendas e comentários. Os imprimíveis transformam as letras em grandes contornos e fichas que você imprime no papel para traçar, colorir, recortar ou treinar a escrita. Estão ligados, mas um é feito para telas e o outro para o papel."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Preciso baixar um aplicativo ou instalar uma fonte?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Não. Tudo funciona no seu navegador. Os contornos e as fichas são gerados na página — clique em Imprimir para abrir a caixa de diálogo de impressão, ou em Baixar PNG para salvar uma imagem para imprimir ou reutilizar."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Posso criar uma ficha para traçar com o nome do meu filho?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Sim. Abra as Fichas de nome para traçar, digite qualquer nome e imprima uma ficha com uma linha-modelo cheia, linhas pontilhadas para cobrir e linhas em branco para treinar livremente."
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Trilha de navegação">
+  <a href="/pt/">Início</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Imprimíveis</span>
+</nav>
+
+  <!-- Hero Section -->
+  <section class="hero">
+    <div class="hero-inner" style="max-width:800px;">
+      <h1 class="hero-headline">Letras &amp; alfabetos para imprimir</h1>
+      <p class="hero-tagline">
+        Letras e alfabetos pensados para o papel, não só para as telas.<br>
+        Imprima grandes contornos para traçar e colorir, fichas de caligrafia,
+        ou uma ficha para traçar com qualquer nome — depois imprima ou salve um PNG.
+      </p>
+    </div>
+  </section>
+
+  <!-- Main Content -->
+  <main class="container" style="max-width:900px;">
+
+    <section class="editorial-section" id="imprimiveis">
+      <h2>Escolha um imprimível</h2>
+      <div class="printable-hub-grid">
+
+        <a class="printable-card" href="/pt/imprimiveis/nome-para-tracar/">
+          <span class="printable-card-art" aria-hidden="true">✎ abc</span>
+          <h3>Fichas de nome para traçar</h3>
+          <p>Digite qualquer nome e imprima uma ficha de caligrafia: uma linha-modelo cheia, linhas pontilhadas para cobrir e linhas em branco para treinar. Perfeito para a educação infantil e o 1º ano.</p>
+          <span class="printable-card-cta">Abrir as fichas de nome →</span>
+        </a>
+
+        <a class="printable-card" href="/pt/imprimiveis/alfabeto-cursivo/">
+          <span class="printable-card-art" aria-hidden="true">𝒜 𝒷 𝒸</span>
+          <h3>Alfabeto cursivo &amp; fichas de caligrafia</h3>
+          <p>O alfabeto cursivo completo com fichas de caligrafia para imprimir — letras-modelo e espaço para traçar — e o download em PNG de cada letra para aprender a letra emendada.</p>
+          <span class="printable-card-cta">Abrir o alfabeto cursivo →</span>
+        </a>
+
+        <a class="printable-card" href="/pt/imprimiveis/alfabeto-para-colorir/">
+          <span class="printable-card-art" aria-hidden="true">A B C</span>
+          <h3>Alfabeto para colorir</h3>
+          <p>Grandes contornos de letras A–Z para colorir e imprimir — uma página para cada letra com uma palavra de exemplo, mais a impressão de todo o alfabeto com um clique.</p>
+          <span class="printable-card-cta">Abrir o alfabeto para colorir →</span>
+        </a>
+
+        <a class="printable-card" href="/pt/imprimiveis/letras-bolha/">
+          <span class="printable-card-art" aria-hidden="true">Ⓐ Ⓑ Ⓒ</span>
+          <h3>Letras bolha para imprimir</h3>
+          <p>Grandes contornos de letras bolha A–Z e 0–9 para traçar, colorir e imprimir — mais o PNG de qualquer letra para pôsteres, cartões e bullet journals.</p>
+          <span class="printable-card-cta">Abrir as letras bolha →</span>
+        </a>
+
+      </div>
+    </section>
+
+    <section class="editorial-section">
+      <h2>Como funcionam os imprimíveis</h2>
+      <p>Cada imprimível vem de duas formas. Há as <strong>fichas prontas para usar</strong> — pranchas
+        de alfabeto A–Z completas e páginas por letra para imprimir do jeito que estão:
+        <a href="/pt/imprimiveis/letras-bolha/">letras bolha</a> para colorir,
+        fichas de <a href="/pt/imprimiveis/alfabeto-cursivo/">caligrafia cursiva</a> com linhas-modelo para cobrir,
+        e <a href="/pt/imprimiveis/alfabeto-para-colorir/">alfabeto para colorir</a>.
+        Escolha uma letra e pronto — nada para configurar.</p>
+      <p>E há um <strong>gerador</strong> em cada página para criar suas próprias fichas. Digite uma palavra ou um
+        <a href="/pt/imprimiveis/nome-para-tracar/">nome</a> inteiro e a ferramenta monta uma ficha nova na hora — uma
+        linha-modelo cheia, linhas pontilhadas para cobrir e linhas em branco para treinar. Quando o resultado te
+        agradar, <strong>Imprima</strong> direto do seu navegador ou <strong>Baixe o PNG</strong> para
+        uma imagem em alta resolução. Tudo acontece no navegador: é grátis, instantâneo e sem cadastro.</p>
+    </section>
+
+    <!-- Cross-family Navigation -->
+    <section class="related-pages">
+      <h2>Explore também</h2>
+      <div class="related-pages-grid">
+        <a href="/pt/letras-para-copiar/" class="related-page-card">
+          <span class="related-page-label">Geradores</span>
+          <h4>Fontes para copiar e colar</h4>
+        </a>
+        <a href="/pt/letra-cursiva/" class="related-page-card">
+          <span class="related-page-label">Gerador</span>
+          <h4>Letra cursiva</h4>
+        </a>
+        <a href="/pt/letras-negrito/" class="related-page-card">
+          <span class="related-page-label">Gerador</span>
+          <h4>Texto em negrito</h4>
+        </a>
+        <a href="/pt/" class="related-page-card">
+          <span class="related-page-label">Início</span>
+          <h4>UltraTextGen em português</h4>
+        </a>
+      </div>
+    </section>
+  </main>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-inner">
+      <h2 class="faq-category">FAQ Imprimíveis</h2>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Estas letras para imprimir são grátis?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+          </svg>
+        </button>
+        <div class="faq-answer">
+          Sim — totalmente grátis, sem cadastro, sem marca d'água, sem limite. Escolha uma letra ou digite um nome e use
+          <strong>Imprimir</strong> para enviar à sua impressora ou <strong>Baixar PNG</strong> para salvar uma imagem em alta resolução.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Qual é a diferença entre os imprimíveis e os geradores de fonte?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+          </svg>
+        </button>
+        <div class="faq-answer">
+          Os <a href="/pt/letras-para-copiar/">geradores de fonte</a> transformam seu texto em fontes Unicode para copiar e colar em bios,
+          legendas e comentários. Os imprimíveis transformam as letras em grandes contornos e fichas que você imprime no papel para
+          traçar, colorir, recortar ou treinar a escrita. Estão ligados, mas um é feito para telas e o outro para o papel.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Preciso baixar um aplicativo ou instalar uma fonte?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+          </svg>
+        </button>
+        <div class="faq-answer">
+          Não. Tudo funciona no seu navegador. Clique em <strong>Imprimir</strong> para abrir a caixa de diálogo de impressão, ou em
+          <strong>Baixar PNG</strong> para salvar uma imagem para imprimir ou reutilizar.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Posso criar uma ficha para traçar com o nome do meu filho?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+          </svg>
+        </button>
+        <div class="faq-answer">
+          Sim. Abra as <a href="/pt/imprimiveis/nome-para-tracar/">Fichas de nome para traçar</a>, digite qualquer nome e imprima uma ficha
+          com uma linha-modelo cheia, linhas pontilhadas para cobrir e linhas em branco para treinar livremente.
+        </div>
+      </div>
+
+    </div>
+  </footer>
+
+  <!-- FAQ toggle -->
+  <script>
+    document.querySelectorAll('.faq-question').forEach(function(btn) {
+      btn.addEventListener('click', function() {
+        this.closest('.faq-item').classList.toggle('open');
+      });
+    });
+  </script>
+<script src="/footer.js" defer></script>
+</body></html>

--- a/pt/imprimiveis/letras-bolha/index.html
+++ b/pt/imprimiveis/letras-bolha/index.html
@@ -1,0 +1,285 @@
+<!DOCTYPE html><html lang="pt"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Letras bolha para imprimir A–Z e 0–9 — Traçar, colorir, PNG | UltraTextGen</title>
+  <meta name="description" content="Letras bolha para imprimir grátis A–Z e números 0–9. Grandes contornos inflados para traçar e colorir, a impressão de todo o alfabeto, ou o download de qualquer letra em PNG. Sem cadastro.">
+  <link rel="canonical" href="https://ultratextgen.com/pt/imprimiveis/letras-bolha/">
+
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/printables/bubble-letters/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/imprimables/lettres-bulles/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/imprimibles/letras-burbuja/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/imprimiveis/letras-bolha/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/bubble-letters/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Letras bolha para imprimir A–Z &amp; 0–9 | UltraTextGen">
+  <meta property="og:description" content="Letras bolha para imprimir grátis. Grandes contornos para traçar e colorir, a impressão do alfabeto, ou o download em PNG.">
+  <meta property="og:url" content="https://ultratextgen.com/pt/imprimiveis/letras-bolha/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category-bubble-fonts.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Letras bolha para imprimir A–Z &amp; 0–9 | UltraTextGen">
+  <meta name="twitter:description" content="Letras bolha para imprimir grátis. Grandes contornos para traçar e colorir, a impressão do alfabeto, ou o download em PNG.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category-bubble-fonts.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;family=Fredoka:wght@500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Início", "item": "https://ultratextgen.com/pt/" },
+    { "@type": "ListItem", "position": 2, "name": "Imprimíveis", "item": "https://ultratextgen.com/pt/imprimiveis/" },
+    { "@type": "ListItem", "position": 3, "name": "Letras bolha", "item": "https://ultratextgen.com/pt/imprimiveis/letras-bolha/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "Como desenhar uma letra bolha",
+  "description": "Transforme qualquer letra simples em uma letra bolha arredondada e inflada para traçar e colorir.",
+  "step": [
+    { "@type": "HowToStep", "position": 1, "name": "Esboçar o esqueleto", "text": "Esboce a letra simples a lápis como um esqueleto fino." },
+    { "@type": "HowToStep", "position": 2, "name": "Inflar o contorno", "text": "Desenhe um contorno arredondado e inflado, a cerca de um dedo de distância ao redor de cada traço da letra." },
+    { "@type": "HowToStep", "position": 3, "name": "Cobrir e pintar", "text": "Arredonde os cantos, apague o esqueleto e depois cubra o contorno com caneta e pinte." }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "pt",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Como obter letras bolha para imprimir e traçar ou colorir?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Escolha qualquer letra (A–Z) ou número (0–9) no seletor para ver um grande contorno de bolha. Use Imprimir esta letra para enviar só esse contorno à sua impressora, ou Baixar PNG para salvar uma imagem em alta resolução. Você também pode imprimir todo o alfabeto A–Z e 0–9 de uma vez. Os contornos são brancos com uma borda arredondada e grossa, prontos para traçar ou colorir para pôsteres, cartazes, cartões, atividades de sala de aula e bullet journals."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Como desenhar uma letra bolha à mão?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Esboce a letra simples a lápis como um esqueleto fino, desenhe um contorno arredondado e inflado a cerca de um dedo de distância ao redor de cada traço, depois arredonde os cantos, apague o esqueleto, cubra com caneta e pinte. Uma forma rápida de aprender a forma é imprimir o contorno de uma letra e cobri-lo algumas vezes até ficar natural."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Posso imprimir meu nome em letras bolha?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Sim. Digite qualquer nome ou palavra no campo e imprima uma folha de grandes contornos de bolha para traçar e colorir, ou baixe-a como banner PNG para cartões, pôsteres e placas de porta."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Vocês também têm texto bolha para copiar e colar no Instagram ou TikTok?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Sim. Se você quer texto bolha para colar em uma bio ou legenda em vez de imprimir, use o gerador de fonte, que transforma seu texto em letras bolha Unicode para copiar e colar."
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Trilha de navegação">
+  <a href="/pt/">Início</a>
+  <span class="breadcrumb-separator">›</span>
+  <a href="/pt/imprimiveis/">Imprimíveis</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Letras bolha</span>
+</nav>
+
+  <section class="hero">
+    <div class="hero-inner" style="max-width:820px;">
+      <h1 class="hero-headline">Letras bolha para imprimir A–Z &amp; 0–9</h1>
+      <p class="hero-tagline">
+        Escolha uma letra ou um número para um grande contorno de bolha inflado para traçar, colorir, imprimir
+        ou baixar em PNG — ou digite um nome para uma folha inteira. Grátis, sem cadastro.
+      </p>
+    </div>
+  </section>
+
+  <main class="container">
+
+    <!-- Picker + selected-letter detail -->
+    <section class="bubble-az" aria-labelledby="ptPickHeading">
+      <h2 class="bubble-az-heading" id="ptPickHeading">Escolha uma letra bolha</h2>
+      <p class="bubble-az-intro">Toque em uma letra (A–Z) ou número (0–9) para ver seu grande contorno de bolha, imprimi-lo, baixar um PNG ou copiar os estilos bolha Unicode correspondentes.</p>
+      <div class="bubble-strip" id="pt-strip" role="tablist" aria-label="Escolher uma letra ou número bolha"></div>
+      <div class="bubble-letter-panel" id="pt-panel" aria-live="polite"></div>
+    </section>
+
+    <!-- Name / word worksheet -->
+    <section class="bubble-alphabet" aria-labelledby="ptNameHeading">
+      <h2 id="ptNameHeading">Imprima um nome em letras bolha</h2>
+      <p class="bubble-az-intro">Digite um nome ou uma palavra curta, depois imprima uma folha de contornos de bolha para traçar e colorir, ou salve-a como banner PNG.</p>
+      <div class="pt-name-tool">
+        <div class="input-wrapper">
+          <input type="text" class="main-input pt-name-input" id="pt-name-input" placeholder="Digite um nome… ex. Mia" maxlength="40">
+        </div>
+        <div class="pt-name-preview" id="pt-name-preview" aria-live="polite"></div>
+        <div class="bubble-actions pt-name-actions">
+          <button type="button" class="bubble-btn bubble-btn-primary" id="pt-name-print">Imprimir a folha</button>
+          <button type="button" class="bubble-btn" id="pt-name-png">Baixar PNG</button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Full printable alphabet -->
+    <section class="bubble-alphabet" aria-labelledby="ptAlphaHeading">
+      <div class="bubble-alphabet-head">
+        <h2 id="ptAlphaHeading">Alfabeto bolha para imprimir</h2>
+        <button class="bubble-btn bubble-btn-primary" type="button" id="pt-alphabet-print">Imprimir o alfabeto</button>
+      </div>
+      <p class="bubble-az-intro">O alfabeto bolha A–Z e 0–9 completo em contornos. Imprima toda a folha para traçar ou colorir, ou toque em qualquer letra para abrir suas opções de impressão e download.</p>
+      <div class="bubble-alphabet-grid" id="pt-alphabet-grid"></div>
+    </section>
+
+    <!-- Editorial -->
+    <section class="editorial-section">
+      <h2>Como usar as letras bolha para imprimir</h2>
+      <ul class="compat-list">
+        <li><span class="ts-pill-safe">Traçar</span> Imprima um contorno e cubra-o para aprender a forma inflada à mão.</li>
+        <li><span class="ts-pill-safe">Colorir</span> O interior branco está pronto para canetinhas, lápis ou tinta — perfeito para crianças e salas de aula.</li>
+        <li><span class="ts-pill-safe">Artesanato</span> Recorte as letras para bandeirolas, placas de porta, cartões de aniversário, scrapbooks e bullet journals.</li>
+      </ul>
+      <h3>Prefere copiar e colar em vez de imprimir?</h3>
+      <p>Estes contornos são feitos para o papel. Se você quer texto bolha para colar em uma bio do Instagram, uma legenda do TikTok
+        ou um nick do Discord, use o <a href="/pt/letras-para-copiar/">gerador de fonte</a> — ele transforma seu texto
+        em letras bolha Unicode que mantêm o visual em qualquer lugar.</p>
+    </section>
+
+    <div class="cta-card">
+      <h3>Quer texto bolha para sua bio ou suas legendas?</h3>
+      <p>Digite uma vez e copie letras bolha Unicode alegres que se colam em qualquer lugar — sem imagem.</p>
+      <a class="cta-btn" href="/pt/letras-para-copiar/">Abrir o gerador de fonte →</a>
+    </div>
+  </main>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <h2 class="faq-category">Letras bolha para imprimir — FAQ</h2>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Como obter letras bolha para imprimir e traçar ou colorir?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Escolha qualquer letra (A–Z) ou número (0–9) no seletor para ver um grande contorno de bolha. Use <strong>Imprimir esta letra</strong>
+          para enviar só esse contorno à sua impressora, ou <strong>Baixar PNG</strong> para salvar uma imagem em alta resolução. Você também pode
+          imprimir todo o alfabeto A–Z e 0–9 de uma vez. Os contornos são brancos com uma borda arredondada e grossa, prontos para traçar ou colorir para pôsteres, cartazes, cartões, atividades de sala de aula e bullet journals.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Como desenhar uma letra bolha à mão?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Esboce a letra simples a lápis como um esqueleto fino, desenhe um contorno arredondado e inflado a cerca de um dedo de distância ao redor de cada traço,
+          depois arredonde os cantos, apague o esqueleto, cubra com caneta e pinte. Uma forma rápida de aprender a forma é imprimir o contorno de uma letra e cobri-lo algumas vezes até ficar natural.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Posso imprimir meu nome em letras bolha?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Sim. Digite qualquer nome ou palavra no campo e imprima uma folha de grandes contornos de bolha para traçar e colorir, ou baixe-a
+          como banner PNG para cartões, pôsteres e placas de porta.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Vocês também têm texto bolha para copiar e colar no Instagram ou TikTok?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Sim. Se você quer texto bolha para colar em uma bio ou legenda em vez de imprimir, use o
+          <a href="/pt/letras-para-copiar/">gerador de fonte</a>, que transforma seu texto em letras bolha Unicode para copiar e colar.
+        </div>
+      </div>
+
+    </div>
+  </footer>
+
+  <!-- Print surface (hidden on screen, isolated when printing) -->
+  <div id="pt-print-root" aria-hidden="true"></div>
+
+  <script>
+    window.UTG_PRINTABLE = {
+      key: "bubble-letters",
+      lang: "pt",
+      render: "outline",
+      noun: "bolha",
+      pngPrefix: "bolha",
+      font: "Fredoka, 'Plus Jakarta Sans', sans-serif",
+      strokeWidth: 9,
+      letterSpacing: 0.1,
+      charset: "alnum",
+      variantFamily: "bubble",
+      glyphStyle: "Ultra Bubble",
+      nameDemo: "Mia",
+      howto: {
+        title: "Como desenhar {ch} em bolha",
+        steps: [
+          "Desenhe {ch} a lápis como um esqueleto fino.",
+          "Faça um contorno arredondado e inflado, a cerca de um dedo de distância ao redor de cada traço.",
+          "Arredonde os cantos, apague o esqueleto e depois cubra o contorno com caneta e pinte."
+        ],
+        tip: "Dica: imprima o contorno acima e cubra várias vezes até a forma ficar natural."
+      }
+    };
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/js/printables/printablesEngine.js" defer></script>
+
+  <!-- FAQ toggle -->
+  <script>
+    document.querySelectorAll('.faq-question').forEach(function(btn) {
+      btn.addEventListener('click', function() { this.closest('.faq-item').classList.toggle('open'); });
+    });
+  </script>
+<script src="/footer.js" defer></script>
+</body></html>

--- a/pt/imprimiveis/nome-para-tracar/index.html
+++ b/pt/imprimiveis/nome-para-tracar/index.html
@@ -1,0 +1,284 @@
+<!DOCTYPE html><html lang="pt"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Nome para traçar — Atividade de caligrafia para imprimir grátis | UltraTextGen</title>
+  <meta name="description" content="Digite um nome para criar uma ficha de caligrafia para imprimir grátis: uma linha-modelo cheia, linhas pontilhadas para cobrir e linhas em branco para treinar. Mais o traço das letras A–Z e dos números 0–9. Sem cadastro.">
+  <link rel="canonical" href="https://ultratextgen.com/pt/imprimiveis/nome-para-tracar/">
+
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/printables/name-tracing/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/imprimables/prenom-a-tracer/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/imprimibles/nombre-para-trazar/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/imprimiveis/nome-para-tracar/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/name-tracing/">
+
+  <meta name="robots" content="index, follow">
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Nome para traçar — Atividade de caligrafia para imprimir grátis | UltraTextGen">
+  <meta property="og:description" content="Digite um nome para criar uma ficha para traçar grátis: linha-modelo, linhas pontilhadas para cobrir e linhas em branco. Mais o traço das letras A–Z e dos números 0–9.">
+  <meta property="og:url" content="https://ultratextgen.com/pt/imprimiveis/nome-para-tracar/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/category.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Nome para traçar — Atividade de caligrafia para imprimir grátis | UltraTextGen">
+  <meta name="twitter:description" content="Digite um nome para criar uma ficha para traçar grátis: linha-modelo, linhas pontilhadas para cobrir e linhas em branco.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;family=Quicksand:wght@500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Início", "item": "https://ultratextgen.com/pt/" },
+    { "@type": "ListItem", "position": 2, "name": "Imprimíveis", "item": "https://ultratextgen.com/pt/imprimiveis/" },
+    { "@type": "ListItem", "position": 3, "name": "Nome para traçar", "item": "https://ultratextgen.com/pt/imprimiveis/nome-para-tracar/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "pt",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Como criar uma ficha de nome para traçar?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Digite um nome no campo e clique em Imprimir a ficha. A ficha tem uma linha-modelo cheia que mostra o nome, várias linhas pontilhadas para cobrir e linhas em branco para treinar livremente. Você também pode baixá-la em PNG. Escolha quantas linhas para cobrir antes de imprimir."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "As fichas de nome para traçar são grátis?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Sim — totalmente grátis, sem cadastro, sem marca d'água e sem limite. Crie quantas fichas quiser, para qualquer nome ou palavra."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Também posso criar fichas de letras e números para traçar?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Sim. Use o seletor de letras para traçar uma única letra A–Z ou um número 0–9, ou imprima a ficha completa A–Z e 0–9 com linhas-modelo e linhas para cobrir. Funciona para nomes em maiúsculas, o treino em minúsculas e a formação dos números."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Para que idade o traço do nome é indicado?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "O traço do nome é indicado para crianças da educação infantil e do 1º ano que estão construindo a formação das letras e a coordenação motora fina, além de qualquer pessoa que treina uma escrita caprichada. Imprima várias cópias e prefira sessões curtas e frequentes para melhores resultados."
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Trilha de navegação">
+  <a href="/pt/">Início</a>
+  <span class="breadcrumb-separator">›</span>
+  <a href="/pt/imprimiveis/">Imprimíveis</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Nome para traçar</span>
+</nav>
+
+  <section class="hero">
+    <div class="hero-inner" style="max-width:820px;">
+      <h1 class="hero-headline">Fichas de nome para traçar</h1>
+      <p class="hero-tagline">
+        Digite qualquer nome e imprima uma ficha de caligrafia: uma linha-modelo cheia, linhas pontilhadas para cobrir
+        e linhas em branco para treinar. Mais o traço das letras A–Z e dos números 0–9. Grátis, sem cadastro.
+      </p>
+    </div>
+  </section>
+
+  <main class="container">
+
+    <div class="pt-stroke-toggle-row">
+      <label class="pt-check" for="pt-stroke-toggle">
+        <input type="checkbox" id="pt-stroke-toggle">
+        Mostrar o sentido dos traços
+      </label>
+      <span class="pt-stroke-toggle-hint">Adiciona um ponto de partida numerado e setas em cada letra traçada, para mostrar em que sentido desenhar cada traço — opcional, porque nem toda criança precisa do mesmo apoio conforme o nível.</span>
+    </div>
+
+    <!-- Name worksheet (primary) -->
+    <section class="bubble-alphabet" aria-labelledby="ptNameHeading">
+      <h2 id="ptNameHeading">Crie uma ficha de nome para traçar</h2>
+      <p class="bubble-az-intro">Digite um nome ou uma palavra curta, veja a prévia abaixo e imprima — ou baixe um PNG. A ficha oferece um modelo cheio para acompanhar, linhas pontilhadas para cobrir e linhas em branco para treinar livremente.</p>
+      <div class="pt-name-tool">
+        <div class="input-wrapper">
+          <input type="text" class="main-input pt-name-input" id="pt-name-input" placeholder="Digite um nome… ex. Ana" maxlength="40">
+        </div>
+        <div class="pt-name-controls">
+          <label class="pt-name-rows-label" for="pt-name-rows">Linhas para cobrir</label>
+          <select id="pt-name-rows" class="pt-name-rows-select">
+            <option value="2">2</option>
+            <option value="3" selected>3</option>
+            <option value="4">4</option>
+            <option value="5">5</option>
+            <option value="6">6</option>
+          </select>
+        </div>
+        <div class="pt-name-preview" id="pt-name-preview" aria-live="polite"></div>
+        <div class="bubble-actions pt-name-actions">
+          <button type="button" class="bubble-btn bubble-btn-primary" id="pt-name-print">Imprimir a ficha</button>
+          <button type="button" class="bubble-btn" id="pt-name-png">Baixar PNG</button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Letter / number tracing -->
+    <section class="bubble-az" aria-labelledby="ptPickHeading">
+      <h2 class="bubble-az-heading" id="ptPickHeading">Traçar letras &amp; números A–Z, 0–9</h2>
+      <p class="bubble-az-intro">Toque em qualquer letra ou número para traçá-lo sozinho, imprimir um único caractere grande ou baixar um PNG.</p>
+      <div class="bubble-strip" id="pt-strip" role="tablist" aria-label="Escolher uma letra ou número para traçar"></div>
+      <div class="bubble-letter-panel" id="pt-panel" aria-live="polite"></div>
+    </section>
+
+    <!-- Full practice sheet + alphabet -->
+    <section class="bubble-alphabet" aria-labelledby="ptAlphaHeading">
+      <div class="bubble-alphabet-head">
+        <h2 id="ptAlphaHeading">Fichas para traçar A–Z &amp; 0–9 para imprimir</h2>
+        <button class="bubble-btn bubble-btn-primary" type="button" id="pt-practice-print">Imprimir a folha de treino</button>
+      </div>
+      <p class="bubble-az-intro">Imprima uma ficha pautada A–Z e 0–9 — um modelo mais um espaço para cobrir em cada linha — ou imprima o alfabeto em contorno abaixo para traçar as letras inteiras.</p>
+      <div class="bubble-alphabet-grid" id="pt-alphabet-grid"></div>
+      <div class="pt-alpha-print-row">
+        <button class="bubble-btn" type="button" id="pt-alphabet-print">Imprimir o alfabeto em contorno</button>
+      </div>
+    </section>
+
+    <!-- Editorial -->
+    <section class="editorial-section">
+      <h2>Aproveite ao máximo o traço do nome</h2>
+      <ul class="compat-list">
+        <li><span class="ts-pill-safe">O modelo primeiro</span> Mostre a linha cheia de cima e diga o nome antes de começar a traçar.</li>
+        <li><span class="ts-pill-safe">Traçar devagar</span> Incentive a criança a permanecer dentro do contorno — o controle importa mais que a velocidade.</li>
+        <li><span class="ts-pill-safe">Depois sozinho</span> Termine nas linhas em branco, escrevendo sem o guia.</li>
+      </ul>
+      <p>Pronto para aumentar a dificuldade conforme o progresso? As
+        <a href="/pt/imprimiveis/alfabeto-cursivo/">fichas de caligrafia cursiva</a> permitem passar para a letra emendada,
+        e você pode montar um nome decorativo em
+        <a href="/pt/imprimiveis/letras-bolha/">letras bolha</a> para colorir.</p>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <h2 class="faq-category">Nome para traçar — FAQ</h2>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Como criar uma ficha de nome para traçar?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Digite um nome no campo e clique em <strong>Imprimir a ficha</strong>. A ficha tem uma linha-modelo cheia que mostra o
+          nome, várias linhas pontilhadas para cobrir e linhas em branco para treinar livremente. Você também pode baixá-la em PNG, e
+          escolher quantas linhas para cobrir antes de imprimir.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          As fichas de nome para traçar são grátis?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Sim — totalmente grátis, sem cadastro, sem marca d'água e sem limite. Crie quantas fichas quiser, para qualquer nome ou palavra.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Também posso criar fichas de letras e números para traçar?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Sim. Use o seletor de letras para traçar uma única letra A–Z ou um número 0–9, ou imprima a ficha completa A–Z e 0–9 com
+          linhas-modelo e linhas para cobrir. Funciona para nomes em maiúsculas, o treino em minúsculas e a formação dos números.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Para que idade o traço do nome é indicado?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          O traço do nome é indicado para crianças da educação infantil e do 1º ano que estão construindo a formação das letras e a coordenação
+          motora fina, além de qualquer pessoa que treina uma escrita caprichada. Imprima várias cópias e prefira sessões curtas e frequentes para melhores resultados.
+        </div>
+      </div>
+
+    </div>
+  </footer>
+
+  <!-- Print surface (hidden on screen, isolated when printing) -->
+  <div id="pt-print-root" aria-hidden="true"></div>
+
+  <script>
+    window.UTG_PRINTABLE = {
+      key: "name-tracing",
+      lang: "pt",
+      render: "outline",
+      noun: "traço",
+      pngPrefix: "nome",
+      font: "Quicksand, 'Plus Jakarta Sans', sans-serif",
+      strokeWidth: 4,
+      charset: "alnum",
+      variantFamily: "",
+      nameDemo: "Ana",
+      howto: {
+        title: "Como traçar {ch}",
+        steps: [
+          "Comece no topo do contorno cinza e siga devagar.",
+          "Mantenha o lápis dentro das linhas — vá devagar para ter controle.",
+          "Trace várias vezes e depois escreva sozinho na linha em branco."
+        ],
+        tip: "Imprima várias cópias para a criança treinar a semana toda."
+      }
+    };
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/js/printables/strokeDirectionData.js" defer></script>
+  <script src="/js/printables/printablesEngine.js" defer></script>
+
+  <!-- FAQ toggle -->
+  <script>
+    document.querySelectorAll('.faq-question').forEach(function(btn) {
+      btn.addEventListener('click', function() { this.closest('.faq-item').classList.toggle('open'); });
+    });
+  </script>
+<script src="/footer.js" defer></script>
+</body></html>

--- a/pt/index.html
+++ b/pt/index.html
@@ -418,6 +418,11 @@
         <h3>Texto zalgo</h3>
         <p>Letra bugada e amaldiçoada (glitch) pra meme de terror, post de Halloween e nick assustador.</p>
       </a>
+      <a class="tip-card" href="/pt/imprimiveis/" aria-label="Imprimíveis">
+        <div class="tip-icon">🖨️</div>
+        <h3>Imprimíveis</h3>
+        <p>Letras bolha, alfabeto cursivo, alfabeto para colorir e nome para traçar — imprima ou baixe em PNG.</p>
+      </a>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
This PR adds full French language support to the printables feature, including five new French printables pages and comprehensive i18n support in the printables engine.

## Changes

### New French Printables Pages
- **`fr/imprimables/index.html`** — Hub page listing all printable categories (name tracing, cursive alphabet, alphabet coloring, bubble letters)
- **`fr/imprimables/prenom-a-tracer/index.html`** — Name tracing worksheets with customizable tracing guides
- **`fr/imprimables/alphabet-cursif/index.html`** — Cursive alphabet practice sheets and individual letter downloads
- **`fr/imprimables/coloriage-alphabet/index.html`** — Alphabet coloring pages (A–Z)
- **`fr/imprimables/lettres-bulles/index.html`** — Bubble letter generator with full alphabet and custom name support

All pages include:
- Proper French metadata (title, description, og:* tags)
- Breadcrumb navigation in French
- Structured data (BreadcrumbList, FAQPage, HowTo schemas) in French
- Google Tag Manager and analytics integration
- Dark mode support

### Printables Engine Localization
Modified **`js/printables/printablesEngine.js`** to add comprehensive i18n support:
- Added `I18N` object with English (`en`) and French (`fr`) translation blocks
- Translations cover all UI text: button labels, form fields, trace mode labels, difficulty levels, instructions
- Language detection via `CFG.lang` config or `document.documentElement.lang` attribute
- All engine-injected UI text now flows through the `T` (translation) object
- Maintains byte-for-byte compatibility with existing English pages (English is the default)

### Homepage Update
Modified **`fr/index.html`** to add a new tip card linking to `/fr/imprimables/` in the main feature grid.

Modified English printables pages to add French hreflang alternates:
- `printables/index.html`
- `printables/name-tracing/index.html`
- `printables/cursive-alphabet/index.html`
- `printables/bubble-letters/index.html`
- `printables/alphabet-coloring-pages/index.html`

## Implementation Details
- Language selection is automatic: pages detect their language from the `lang` attribute on `<html>` and pass it to the engine via `CFG.lang`
- The i18n system is extensible: new locales can be added by creating a new language block in `I18N` and setting the appropriate `lang` attribute
- All French content uses proper typography (guillemets, accents, etc.)
- Maintains the existing printables engine architecture with zero breaking changes to English functionality

https://claude.ai/code/session_01PiM3sxEiejDKNGjnytQoVV