### PR TITLE
Add French Alt Codes library page (fr/library/codes-alt/)

### DIFF
--- a/fr/library/codes-alt/index.html
+++ b/fr/library/codes-alt/index.html
@@ -1,0 +1,610 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Codes Alt Windows — Raccourcis Clavier pour Caractères Spéciaux (©, °, É, « »)</title>
+<meta name="description" content="Liste des codes Alt Windows pour taper les majuscules accentuées (É, È, À), les guillemets français « », le degré °, © et plus — introuvables en direct sur AZERTY. Clique pour copier.">
+
+<link rel="canonical" href="https://ultratextgen.com/fr/library/codes-alt/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/alt-codes/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/codes-alt/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/alt-codes/">
+
+<meta property="og:image" content="https://ultratextgen.com/assets/og/library-alt-codes.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Codes Alt Windows — Raccourcis Clavier pour Caractères Spéciaux (©, °, É, « »)">
+<meta name="twitter:description" content="Liste des codes Alt Windows pour taper les majuscules accentuées (É, È, À), les guillemets français « », le degré °, © et plus. Clique pour copier.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/library-alt-codes.png">
+<meta property="og:title" content="Codes Alt Windows — Raccourcis Clavier pour Caractères Spéciaux (©, °, É, « »)">
+<meta property="og:description" content="Liste des codes Alt Windows pour taper les majuscules accentuées (É, È, À), les guillemets français « », le degré °, © et plus — introuvables en direct sur AZERTY.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/fr/library/codes-alt/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Codes Alt Windows — Raccourcis Clavier pour Caractères Spéciaux",
+  "alternateName": ["Codes Alt", "Liste des Codes Alt", "Codes Alt Windows", "Raccourcis Clavier Alt", "Caractères Spéciaux Windows", "Codes Alt Clavier Français"],
+  "description": "Liste des codes Alt Windows pour taper les majuscules accentuées (É, È, À), les guillemets français « », le degré °, © et plus — introuvables en direct sur AZERTY. Clique pour copier.",
+  "inLanguage": "fr",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/library-alt-codes.png",
+  "mainEntityOfPage": "https://ultratextgen.com/fr/library/codes-alt/",
+  "datePublished": "2026-07-11",
+  "dateModified": "2026-07-11"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Accueil",
+      "item": "https://ultratextgen.com/fr/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Codes Alt",
+      "item": "https://ultratextgen.com/fr/library/codes-alt/"
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "fr",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Comment taper une majuscule accentuée (É, È, À) sur un clavier français ?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Le clavier AZERTY donne un accès direct aux minuscules accentuées, mais pas aux majuscules. Le plus fiable reste le code Alt : maintiens Alt et tape 0201 sur le pavé numérique pour obtenir É, 0200 pour È, 0192 pour À. Ça fonctionne dans n'importe quel logiciel Windows, contrairement aux raccourcis Maj + Verr Maj qui varient selon les claviers."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Comment taper les guillemets français « » ?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Certains pilotes de clavier AZERTY placent « et » sur AltGr + 4 et AltGr + Maj + 4, mais ce n'est pas garanti partout. Le code Alt est universel : Alt + 0171 pour « et Alt + 0187 pour »."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Les codes Alt fonctionnent-ils sur Mac ou sur un portable sans pavé numérique ?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Non — les codes Alt sont une fonctionnalité Windows qui nécessite un pavé numérique, physique ou activé via la touche Fn sur un portable. Sur Mac, les raccourcis sont différents (touche Option). Sans pavé numérique, clique directement sur le caractère voulu sur cette page pour le copier."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Pourquoi mon code Alt ne fonctionne pas ?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Trois causes fréquentes : le Verr Num n'est pas activé, tu tapes sur la rangée de chiffres du haut au lieu du pavé numérique, ou le pavé numérique du portable n'est pas activé. Si rien ne fonctionne, chaque caractère de cette page se copie aussi en un clic, sans code."
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Fil d'Ariane">
+  <a href="/fr/">Accueil</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Codes Alt</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Codes Alt Windows</h1>
+    <p class="hero-tagline">Les codes Alt utiles pour taper les majuscules accentuées, les guillemets français et les symboles que le clavier AZERTY ne propose pas directement. Clique sur un caractère pour le copier instantanément.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/library-alt-codes.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Les codes Alt permettent de taper des caractères spéciaux sous Windows en maintenant Alt et en saisissant un nombre sur le pavé numérique — Alt+0201 donne É, Alt+0171 donne «. Le clavier AZERTY facilite les accents minuscules, mais laisse les majuscules accentuées, les guillemets français et plusieurs symboles hors d'atteinte directe : cette page les classe par usage, en commençant par ce que l'AZERTY rend le plus difficile. Pas de pavé numérique ? Chaque caractère est aussi cliquer-pour-copier, donc ça marche sur portable, Mac et mobile.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="majuscules-accentuees">
+  <span class="article-section-label">Priorité n°1</span>
+  <h2>Majuscules Accentuées</h2>
+  <p class="u-secondary-tight">Le point faible numéro un de l'AZERTY : aucune touche directe pour les majuscules accentuées. Ces codes Alt les tapent instantanément.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="É" aria-label="Copier Alt+0201 — E Majuscule Accent Aigu">É</button>
+      <span class="flag-label">Alt+0201 — E Majuscule Accent Aigu</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="È" aria-label="Copier Alt+0200 — E Majuscule Accent Grave">È</button>
+      <span class="flag-label">Alt+0200 — E Majuscule Accent Grave</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="À" aria-label="Copier Alt+0192 — A Majuscule Accent Grave">À</button>
+      <span class="flag-label">Alt+0192 — A Majuscule Accent Grave</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="Ç" aria-label="Copier Alt+0199 — C Majuscule Cédille">Ç</button>
+      <span class="flag-label">Alt+0199 — C Majuscule Cédille</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="Ê" aria-label="Copier Alt+0202 — E Majuscule Accent Circonflexe">Ê</button>
+      <span class="flag-label">Alt+0202 — E Majuscule Accent Circonflexe</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="Î" aria-label="Copier Alt+0206 — I Majuscule Accent Circonflexe">Î</button>
+      <span class="flag-label">Alt+0206 — I Majuscule Accent Circonflexe</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="Ô" aria-label="Copier Alt+0212 — O Majuscule Accent Circonflexe">Ô</button>
+      <span class="flag-label">Alt+0212 — O Majuscule Accent Circonflexe</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="Û" aria-label="Copier Alt+0219 — U Majuscule Accent Circonflexe">Û</button>
+      <span class="flag-label">Alt+0219 — U Majuscule Accent Circonflexe</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="Ù" aria-label="Copier Alt+0217 — U Majuscule Accent Grave">Ù</button>
+      <span class="flag-label">Alt+0217 — U Majuscule Accent Grave</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="Ë" aria-label="Copier Alt+0203 — E Majuscule Tréma">Ë</button>
+      <span class="flag-label">Alt+0203 — E Majuscule Tréma</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="Ï" aria-label="Copier Alt+0207 — I Majuscule Tréma">Ï</button>
+      <span class="flag-label">Alt+0207 — I Majuscule Tréma</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="Œ" aria-label="Copier Alt+0140 — Ligature O-E Majuscule">Œ</button>
+      <span class="flag-label">Alt+0140 — Ligature O-E Majuscule</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="Æ" aria-label="Copier Alt+0198 — Ligature A-E Majuscule">Æ</button>
+      <span class="flag-label">Alt+0198 — Ligature A-E Majuscule</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="typographie-francaise">
+  <span class="article-section-label">Typographie française</span>
+  <h2>Guillemets &amp; Typographie Française</h2>
+  <p class="u-secondary-tight">Les guillemets français « » et les tirets typographiques ne sont pas non plus des touches directes sur AZERTY — voici leurs codes Alt.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="«" aria-label="Copier Alt+0171 — Guillemet Français Ouvrant">«</button>
+      <span class="flag-label">Alt+0171 — Guillemet Français Ouvrant</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="»" aria-label="Copier Alt+0187 — Guillemet Français Fermant">»</button>
+      <span class="flag-label">Alt+0187 — Guillemet Français Fermant</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="—" aria-label="Copier Alt+0151 — Tiret Cadratin">—</button>
+      <span class="flag-label">Alt+0151 — Tiret Cadratin</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="–" aria-label="Copier Alt+0150 — Tiret Demi-Cadratin">–</button>
+      <span class="flag-label">Alt+0150 — Tiret Demi-Cadratin</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="“" aria-label="Copier Alt+0147 — Guillemet Anglais Ouvrant">“</button>
+      <span class="flag-label">Alt+0147 — Guillemet Anglais Ouvrant</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="”" aria-label="Copier Alt+0148 — Guillemet Anglais Fermant">”</button>
+      <span class="flag-label">Alt+0148 — Guillemet Anglais Fermant</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="…" aria-label="Copier Alt+0133 — Points de Suspension">…</button>
+      <span class="flag-label">Alt+0133 — Points de Suspension</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="§" aria-label="Copier Alt+0167 — Symbole Paragraphe (Juridique)">§</button>
+      <span class="flag-label">Alt+0167 — Symbole Paragraphe (Juridique)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="¶" aria-label="Copier Alt+0182 — Pied-de-Mouche">¶</button>
+      <span class="flag-label">Alt+0182 — Pied-de-Mouche</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="•" aria-label="Copier Alt+0149 — Puce">•</button>
+      <span class="flag-label">Alt+0149 — Puce</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="copyright-marque-degre">
+  <span class="article-section-label">Symboles courants</span>
+  <h2>Copyright, Marque &amp; Degré</h2>
+  <p class="u-secondary-tight">Les symboles les plus recherchés pour un document, un contrat ou une météo à copier.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="©" aria-label="Copier Alt+0169 — Copyright">©</button>
+      <span class="flag-label">Alt+0169 — Copyright</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="®" aria-label="Copier Alt+0174 — Marque Déposée">®</button>
+      <span class="flag-label">Alt+0174 — Marque Déposée</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="™" aria-label="Copier Alt+0153 — Marque de Commerce">™</button>
+      <span class="flag-label">Alt+0153 — Marque de Commerce</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="°" aria-label="Copier Alt+0176 — Degré">°</button>
+      <span class="flag-label">Alt+0176 — Degré</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="±" aria-label="Copier Alt+0177 — Plus ou Moins">±</button>
+      <span class="flag-label">Alt+0177 — Plus ou Moins</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="µ" aria-label="Copier Alt+0181 — Micro (µ)">µ</button>
+      <span class="flag-label">Alt+0181 — Micro (µ)</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="minuscules-accentuees">
+  <span class="article-section-label">Référence complète</span>
+  <h2>Lettres Minuscules Accentuées</h2>
+  <p class="u-secondary-tight">Déjà accessibles en direct sur la plupart des claviers AZERTY, mais utiles en référence ou sur un clavier QWERTY.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="à" aria-label="Copier Alt+0224 — A Minuscule Accent Grave">à</button>
+      <span class="flag-label">Alt+0224 — A Minuscule Accent Grave</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="â" aria-label="Copier Alt+0226 — A Minuscule Accent Circonflexe">â</button>
+      <span class="flag-label">Alt+0226 — A Minuscule Accent Circonflexe</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ç" aria-label="Copier Alt+0231 — C Minuscule Cédille">ç</button>
+      <span class="flag-label">Alt+0231 — C Minuscule Cédille</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="é" aria-label="Copier Alt+0233 — E Minuscule Accent Aigu">é</button>
+      <span class="flag-label">Alt+0233 — E Minuscule Accent Aigu</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="è" aria-label="Copier Alt+0232 — E Minuscule Accent Grave">è</button>
+      <span class="flag-label">Alt+0232 — E Minuscule Accent Grave</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ê" aria-label="Copier Alt+0234 — E Minuscule Accent Circonflexe">ê</button>
+      <span class="flag-label">Alt+0234 — E Minuscule Accent Circonflexe</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ë" aria-label="Copier Alt+0235 — E Minuscule Tréma">ë</button>
+      <span class="flag-label">Alt+0235 — E Minuscule Tréma</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="î" aria-label="Copier Alt+0238 — I Minuscule Accent Circonflexe">î</button>
+      <span class="flag-label">Alt+0238 — I Minuscule Accent Circonflexe</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ï" aria-label="Copier Alt+0239 — I Minuscule Tréma">ï</button>
+      <span class="flag-label">Alt+0239 — I Minuscule Tréma</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ô" aria-label="Copier Alt+0244 — O Minuscule Accent Circonflexe">ô</button>
+      <span class="flag-label">Alt+0244 — O Minuscule Accent Circonflexe</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ù" aria-label="Copier Alt+0249 — U Minuscule Accent Grave">ù</button>
+      <span class="flag-label">Alt+0249 — U Minuscule Accent Grave</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="û" aria-label="Copier Alt+0251 — U Minuscule Accent Circonflexe">û</button>
+      <span class="flag-label">Alt+0251 — U Minuscule Accent Circonflexe</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ü" aria-label="Copier Alt+0252 — U Minuscule Tréma">ü</button>
+      <span class="flag-label">Alt+0252 — U Minuscule Tréma</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="œ" aria-label="Copier Alt+0156 — Ligature O-E Minuscule">œ</button>
+      <span class="flag-label">Alt+0156 — Ligature O-E Minuscule</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="æ" aria-label="Copier Alt+0230 — Ligature A-E Minuscule">æ</button>
+      <span class="flag-label">Alt+0230 — Ligature A-E Minuscule</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="devises">
+  <span class="article-section-label">Devises</span>
+  <h2>Codes Alt des Devises</h2>
+  <p class="u-secondary-tight">Symboles monétaires et leurs codes Alt Windows.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="¢" aria-label="Copier Alt+0162 — Cent">¢</button>
+      <span class="flag-label">Alt+0162 — Cent</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="£" aria-label="Copier Alt+0163 — Livre Sterling">£</button>
+      <span class="flag-label">Alt+0163 — Livre Sterling</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="¥" aria-label="Copier Alt+0165 — Yen">¥</button>
+      <span class="flag-label">Alt+0165 — Yen</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="€" aria-label="Copier Alt+0128 — Euro">€</button>
+      <span class="flag-label">Alt+0128 — Euro</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ƒ" aria-label="Copier Alt+0131 — Florin">ƒ</button>
+      <span class="flag-label">Alt+0131 — Florin</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="maths-fractions">
+  <span class="article-section-label">Maths</span>
+  <h2>Maths &amp; Fractions</h2>
+  <p class="u-secondary-tight">Opérateurs mathématiques, fractions et exposants — dont des codes historiques de la page de code 437.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="×" aria-label="Copier Alt+0215 — Multiplication">×</button>
+      <span class="flag-label">Alt+0215 — Multiplication</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="÷" aria-label="Copier Alt+0247 — Division">÷</button>
+      <span class="flag-label">Alt+0247 — Division</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="¼" aria-label="Copier Alt+0188 — Fraction Un Quart">¼</button>
+      <span class="flag-label">Alt+0188 — Fraction Un Quart</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="½" aria-label="Copier Alt+0189 — Fraction Un Demi">½</button>
+      <span class="flag-label">Alt+0189 — Fraction Un Demi</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="¾" aria-label="Copier Alt+0190 — Fraction Trois Quarts">¾</button>
+      <span class="flag-label">Alt+0190 — Fraction Trois Quarts</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="²" aria-label="Copier Alt+0178 — Exposant Deux">²</button>
+      <span class="flag-label">Alt+0178 — Exposant Deux</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="³" aria-label="Copier Alt+0179 — Exposant Trois">³</button>
+      <span class="flag-label">Alt+0179 — Exposant Trois</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="π" aria-label="Copier Alt+227 — Pi">π</button>
+      <span class="flag-label">Alt+227 — Pi</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="∞" aria-label="Copier Alt+236 — Infini">∞</button>
+      <span class="flag-label">Alt+236 — Infini</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="√" aria-label="Copier Alt+251 — Racine Carrée">√</button>
+      <span class="flag-label">Alt+251 — Racine Carrée</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="≥" aria-label="Copier Alt+242 — Supérieur ou Égal">≥</button>
+      <span class="flag-label">Alt+242 — Supérieur ou Égal</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="≤" aria-label="Copier Alt+243 — Inférieur ou Égal">≤</button>
+      <span class="flag-label">Alt+243 — Inférieur ou Égal</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="≈" aria-label="Copier Alt+247 — Presque Égal">≈</button>
+      <span class="flag-label">Alt+247 — Presque Égal</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="codes-dos-classiques">
+  <span class="article-section-label">Codes DOS Classiques</span>
+  <h2>Codes DOS Classiques (1–31)</h2>
+  <p class="u-secondary-tight">Les codes historiques du PC IBM des débuts — smileys, symboles de cartes et flèches. Rarement nécessaires aujourd'hui, mais toujours actifs sous Windows.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☺" aria-label="Copier Alt+1 — Visage Souriant">☺</button>
+      <span class="flag-label">Alt+1 — Visage Souriant</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♥" aria-label="Copier Alt+3 — Cœur Plein">♥</button>
+      <span class="flag-label">Alt+3 — Cœur Plein</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♦" aria-label="Copier Alt+4 — Carreau Plein">♦</button>
+      <span class="flag-label">Alt+4 — Carreau Plein</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♣" aria-label="Copier Alt+5 — Trèfle Plein">♣</button>
+      <span class="flag-label">Alt+5 — Trèfle Plein</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♠" aria-label="Copier Alt+6 — Pique Plein">♠</button>
+      <span class="flag-label">Alt+6 — Pique Plein</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♪" aria-label="Copier Alt+13 — Croche">♪</button>
+      <span class="flag-label">Alt+13 — Croche</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♫" aria-label="Copier Alt+14 — Doubles Croches Reliées">♫</button>
+      <span class="flag-label">Alt+14 — Doubles Croches Reliées</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☼" aria-label="Copier Alt+15 — Soleil Rayonnant">☼</button>
+      <span class="flag-label">Alt+15 — Soleil Rayonnant</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="►" aria-label="Copier Alt+16 — Pointeur Droit Plein">►</button>
+      <span class="flag-label">Alt+16 — Pointeur Droit Plein</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="↑" aria-label="Copier Alt+24 — Flèche Vers le Haut">↑</button>
+      <span class="flag-label">Alt+24 — Flèche Vers le Haut</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="↓" aria-label="Copier Alt+25 — Flèche Vers le Bas">↓</button>
+      <span class="flag-label">Alt+25 — Flèche Vers le Bas</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="→" aria-label="Copier Alt+26 — Flèche Vers la Droite">→</button>
+      <span class="flag-label">Alt+26 — Flèche Vers la Droite</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="←" aria-label="Copier Alt+27 — Flèche Vers la Gauche">←</button>
+      <span class="flag-label">Alt+27 — Flèche Vers la Gauche</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- FAQ -->
+<section class="editorial-section" id="faq">
+  <span class="article-section-label">FAQ</span>
+  <h2>Codes Alt, questions fréquentes</h2>
+  <details class="faq-item">
+    <summary class="faq-question">Comment taper une majuscule accentuée (É, È, À) sur un clavier français ?</summary>
+    <p class="faq-answer">Le clavier AZERTY donne un accès direct aux minuscules accentuées, mais pas aux majuscules. Le plus fiable reste le code Alt : maintiens Alt et tape 0201 sur le pavé numérique pour obtenir É, 0200 pour È, 0192 pour À. Ça fonctionne dans n'importe quel logiciel Windows, contrairement aux raccourcis Maj + Verr Maj qui varient selon les claviers.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">Comment taper les guillemets français « » ?</summary>
+    <p class="faq-answer">Certains pilotes de clavier AZERTY placent « et » sur AltGr + 4 et AltGr + Maj + 4, mais ce n'est pas garanti partout. Le code Alt est universel : Alt + 0171 pour « et Alt + 0187 pour ».</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">Les codes Alt fonctionnent-ils sur Mac ou sur un portable sans pavé numérique ?</summary>
+    <p class="faq-answer">Non — les codes Alt sont une fonctionnalité Windows qui nécessite un pavé numérique, physique ou activé via la touche Fn sur un portable. Sur Mac, les raccourcis sont différents (touche Option). Sans pavé numérique, clique directement sur le caractère voulu sur cette page pour le copier.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">Pourquoi mon code Alt ne fonctionne pas ?</summary>
+    <p class="faq-answer">Trois causes fréquentes : le Verr Num n'est pas activé, tu tapes sur la rangée de chiffres du haut au lieu du pavé numérique, ou le pavé numérique du portable n'est pas activé. Si rien ne fonctionne, chaque caractère de cette page se copie aussi en un clic, sans code.</p>
+  </details>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Transforme ton texte avec des polices Unicode</h3>
+  <p>Utilise UltraTextGen pour transformer du texte simple en gras, italique, cursive et plus de 100 autres styles Unicode — gratuit et instantané.</p>
+  <a href="https://ultratextgen.com/fr/" class="cta-btn">Ouvrir UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Pages liées</span>
+  <div class="compare-grid">
+    <a href="/fr/library/symboles/" class="compare-card variant-muted u-no-underline">
+      <h4>Symboles Aesthetic</h4>
+      <p>Caractères Unicode aesthetic pour bios et pseudos.</p>
+    </a>
+    <a href="/fr/police-d-ecriture/" class="compare-card variant-muted u-no-underline">
+      <h4>Police d'Écriture</h4>
+      <p>Toutes les polices Unicode — pour pseudo, bio et légendes.</p>
+    </a>
+    <a href="/library/ascii-table/" class="compare-card variant-muted u-no-underline">
+      <h4>ASCII Table</h4>
+      <p>Codes décimaux et hexadécimaux pour chaque caractère ASCII imprimable.</p>
+    </a>
+    <a href="/library/special-characters/" class="compare-card variant-muted u-no-underline">
+      <h4>Special Characters</h4>
+      <p>Une liste principale de caractères Unicode spéciaux à copier.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Sélecteur de langue">
+      <a class="lang-option" href="/library/alt-codes/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/fr/library/codes-alt/" hreflang="fr">FR</a>
+    </div>
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/library/alt-codes/index.html
+++ b/library/alt-codes/index.html
@@ -17,6 +17,9 @@
 <meta name="description" content="Full list of keyboard Alt codes — Alt+0169 for ©, currency, math, accented letters, and classic DOS symbols with codes. Click any character to copy it instantly.">
 
 <link rel="canonical" href="https://ultratextgen.com/library/alt-codes/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/alt-codes/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/codes-alt/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/alt-codes/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/library-alt-codes.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">


### PR DESCRIPTION
## Summary
Added a new French-language library page documenting Windows Alt codes for special characters commonly needed by French keyboard users. This is the French equivalent of the existing English `/library/alt-codes/` page.

## Changes
- **New file:** `fr/library/codes-alt/index.html` (610 lines)
  - Complete French translation of Alt codes reference
  - Organized into 8 sections: accented capitals (É, È, À), French typography (« », em/en dashes), copyright/trademark/degree symbols, accented lowercase letters, currency symbols, math/fractions, and classic DOS codes
  - Includes structured data (JSON-LD): `Article`, `BreadcrumbList`, and `FAQPage` schemas
  - 4 FAQ items covering common questions about Alt codes on French AZERTY keyboards
  - Copy-to-clipboard functionality via `.symbol-tile` buttons (reuses existing `symbol-explorer.js`)
  - Hreflang links to English equivalent and self-reference
  - Related links section pointing to other French library pages

- **Modified file:** `library/alt-codes/index.html` (817 lines)
  - Added hreflang link to new French page: `<link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/codes-alt/">`

## Implementation Details
- Follows existing library page patterns (hero section, editorial intro, flag-rows layout, FAQ details, CTA card, related links, footer with language switcher)
- Reuses existing CSS classes (`symbol-tile`, `flag-rows`, `faq-item`, etc.) — no new styles required
- All 60+ Alt codes are presented with French descriptions and aria-labels for accessibility
- Prioritizes codes most problematic on AZERTY (accented capitals first, then French typography)
- Maintains parity with English page structure while adapting content and examples to French context

https://claude.ai/code/session_01CCEfksrsdpxtJ513zPZGAp