### PR TITLE
Add recently made faces history & copy link feature to kaomoji

### DIFF
--- a/js/kaomoji/kaomojiData.js
+++ b/js/kaomoji/kaomojiData.js
@@ -82,7 +82,8 @@
         { id: "cat",   label: "ᴥ", c: "ᴥ", m: ["cute"] },
         { id: "vv",    label: "v", c: "v", m: ["cute", "silly"] },
         { id: "delta", label: "Δ", c: "Δ", m: ["chaotic", "angry"] },
-        { id: "wave",  label: "〜", c: "〜", m: ["silly", "chaotic"] }
+        { id: "wave",  label: "〜", c: "〜", m: ["silly", "chaotic"] },
+        { id: "sara",  label: "皿", c: "皿", m: ["angry"] }
       ],
 
       cheeks: [

--- a/js/kaomoji/kaomojiDict.js
+++ b/js/kaomoji/kaomojiDict.js
@@ -96,7 +96,16 @@
       "＾":    { role: "Eyes",  meaning: "a happy, closed eye" },
       "•":    { role: "Eyes",  meaning: "a small round eye" },
       ">":    { role: "Eyes",  meaning: "a squinting eye" },
-      "<":    { role: "Eyes",  meaning: "a squinting eye" }
+      "<":    { role: "Eyes",  meaning: "a squinting eye" },
+      "°":    { role: "Eyes",  meaning: "a round, open eye" },
+      "O":    { role: "Eyes",  meaning: "a wide, surprised eye" },
+      "@":    { role: "Eyes",  meaning: "a dizzy, spinning eye" },
+      "x":    { role: "Eyes",  meaning: "an x-shaped, dazed eye" },
+      "-":    { role: "Eyes",  meaning: "a flat, unimpressed eye" },
+      "□":    { role: "Mouth", meaning: "an open, shocked mouth" },
+      "皿":    { role: "Mouth", meaning: "a wide, gritted, angry mouth" },
+      "o":    { role: "Mouth", meaning: "an open, surprised mouth" },
+      "_":    { role: "Mouth", meaning: "a flat, neutral mouth" }
     }
   };
 })();

--- a/js/kaomoji/kaomojiPageController.js
+++ b/js/kaomoji/kaomojiPageController.js
@@ -49,6 +49,42 @@
 
   var refs = {};
 
+  /* ---- recently made faces (localStorage, like the site's other "recent"
+     lists) ---------------------------------------------------------------- */
+  var RECENT_KEY = "utg_kaomoji_recent";
+  var RECENT_MAX = 8;
+
+  function loadRecent() {
+    try {
+      var list = JSON.parse(localStorage.getItem(RECENT_KEY) || "[]");
+      return Array.isArray(list) ? list : [];
+    } catch (e) { return []; }
+  }
+  function pushRecent(face) {
+    if (!face) return;
+    var list = loadRecent().filter(function (f) { return f !== face; });
+    list.unshift(face);
+    try { localStorage.setItem(RECENT_KEY, JSON.stringify(list.slice(0, RECENT_MAX))); } catch (e) { /* no-op */ }
+    renderRecent();
+  }
+  function renderRecent() {
+    if (!refs.recent) return;
+    var list = loadRecent();
+    refs.recent.innerHTML = "";
+    if (refs.recentWrap) refs.recentWrap.classList.toggle("u-hidden", !list.length);
+    list.forEach(function (face) {
+      var b = el("button", "kao-recent-face", face);
+      b.type = "button";
+      b.setAttribute("aria-label", t("loadFace", "Load face") + ": " + face);
+      b.addEventListener("click", function () {
+        freeform = face;
+        render();
+        syncUrl(face);
+      });
+      refs.recent.appendChild(b);
+    });
+  }
+
   /* ---- part lookup ------------------------------------------------------- */
   function part(cat, id) {
     var list = DATA.PARTS[cat] || [];
@@ -105,8 +141,10 @@
       var o = opts[i];
       var cat = o.getAttribute("data-cat");
       var id = o.getAttribute("data-id");
-      o.classList.toggle("is-selected", freeform == null && sel[cat] === id);
+      var isSelected = freeform == null && sel[cat] === id;
+      o.classList.toggle("is-selected", isSelected);
       o.classList.toggle("is-hidden", !fitsMood(part(cat, id), activeMood));
+      o.setAttribute("aria-pressed", isSelected ? "true" : "false");
     }
   }
 
@@ -153,7 +191,9 @@
     activeMood = mood;
     var chips = refs.moods.querySelectorAll(".kao-mood");
     for (var i = 0; i < chips.length; i++) {
-      chips[i].classList.toggle("is-active", chips[i].getAttribute("data-mood") === mood);
+      var isActive = chips[i].getAttribute("data-mood") === mood;
+      chips[i].classList.toggle("is-active", isActive);
+      chips[i].setAttribute("aria-pressed", isActive ? "true" : "false");
     }
     // A mood is a dial: reselect a coherent face in that mood (unless "All").
     if (mood !== "all") randomFace(mood); else render();
@@ -173,6 +213,19 @@
       window.UltraTextGen.copyText(face, btn, face);
     }
     syncUrl(face);
+    pushRecent(face);
+  }
+
+  /* Copy the shareable ?q= link (not the face text) so a creation can be
+     handed off/posted, same job as a competitor's "unique URL" callout. */
+  function copyLink(btn) {
+    var face = currentFace();
+    if (!face) return;
+    syncUrl(face);
+    if (window.UltraTextGen && window.UltraTextGen.copyText) {
+      window.UltraTextGen.copyText(window.location.href, btn, t("linkCopied", "link"));
+    }
+    pushRecent(face);
   }
 
   /* ---- UI construction --------------------------------------------------- */
@@ -181,11 +234,13 @@
     var all = el("button", "kao-mood is-active", t("moodAll", "All"));
     all.type = "button";
     all.setAttribute("data-mood", "all");
+    all.setAttribute("aria-pressed", "true");
     frag.appendChild(all);
     DATA.MOODS.forEach(function (m) {
       var b = el("button", "kao-mood", m.label);
       b.type = "button";
       b.setAttribute("data-mood", m.id);
+      b.setAttribute("aria-pressed", "false");
       frag.appendChild(b);
     });
     refs.moods.appendChild(frag);
@@ -248,17 +303,20 @@
 
   /* ---- init -------------------------------------------------------------- */
   function init() {
-    refs.preview   = $("#kaomojiPreview");
-    refs.faceInput = $("#kaomojiFaceInput");
-    refs.parts     = $("#kaomojiParts");
-    refs.moods     = $("#kaomojiMoods");
-    refs.presets   = $("#kaomojiPresets");
-    refs.hint      = $("#kaomojiHint");
+    refs.preview    = $("#kaomojiPreview");
+    refs.faceInput  = $("#kaomojiFaceInput");
+    refs.parts      = $("#kaomojiParts");
+    refs.moods      = $("#kaomojiMoods");
+    refs.presets    = $("#kaomojiPresets");
+    refs.hint       = $("#kaomojiHint");
+    refs.recent     = $("#kaomojiRecent");
+    refs.recentWrap = $("#kaomojiRecentWrap");
     if (!refs.preview || !refs.parts || !refs.moods) return;
 
     buildMoods();
     buildParts();
     buildPresets();
+    renderRecent();
 
     // Deep link / "edit in generator": ?q=<face> preloads the face.
     try {
@@ -268,6 +326,9 @@
 
     var copyBtn = $("#kaomojiCopyBtn");
     if (copyBtn) copyBtn.addEventListener("click", function () { copyFace(copyBtn); });
+
+    var copyLinkBtn = $("#kaomojiCopyLinkBtn");
+    if (copyLinkBtn) copyLinkBtn.addEventListener("click", function () { copyLink(copyLinkBtn); });
 
     var surprise = $("#kaomojiSurpriseBtn");
     if (surprise) surprise.addEventListener("click", function () { randomFace(activeMood); });

--- a/kaomoji-generator/index.html
+++ b/kaomoji-generator/index.html
@@ -101,6 +101,7 @@
     <input id="kaomojiFaceInput" class="kao-face-input" type="text" spellcheck="false" autocomplete="off" aria-label="Your kaomoji — edit or paste a face here">
     <div class="kao-actions">
       <button id="kaomojiCopyBtn" class="kao-btn kao-btn-primary" type="button">Copy Kaomoji</button>
+      <button id="kaomojiCopyLinkBtn" class="kao-btn" type="button">Copy Link</button>
       <button id="kaomojiSurpriseBtn" class="kao-btn" type="button">Surprise Me</button>
       <button id="kaomojiClearBtn" class="kao-btn" type="button">Reset</button>
     </div>
@@ -111,6 +112,11 @@
 
   <span class="kao-block-label">Start from a preset</span>
   <div id="kaomojiPresets" class="kao-presets" role="group" aria-label="Preset faces"></div>
+
+  <div id="kaomojiRecentWrap" class="u-hidden">
+    <span class="kao-block-label">Recently Made</span>
+    <div id="kaomojiRecent" class="kao-recent" role="group" aria-label="Recently made faces"></div>
+  </div>
 
   <span class="kao-block-label">Build it part by part</span>
   <div id="kaomojiParts" aria-label="Kaomoji parts"></div>

--- a/style.css
+++ b/style.css
@@ -6699,6 +6699,19 @@ body.dark-mode .kana-cell-empty { opacity: 0.35; }
 }
 .kao-part-opt.is-hidden { display: none; }
 
+.kao-recent { display: flex; flex-wrap: wrap; gap: 0.4rem; }
+.kao-recent-face {
+  border: 1px solid var(--border-light);
+  background: var(--bg-white);
+  color: var(--text-secondary);
+  border-radius: 8px;
+  padding: 0.35rem 0.6rem;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: border-color 0.12s;
+}
+.kao-recent-face:hover { border-color: var(--accent-purple); color: var(--text-primary); }
+
 @media (max-width: 560px) {
   .kao-part-row { flex-direction: column; align-items: flex-start; gap: 0.35rem; }
   .kao-part-label { flex-basis: auto; }


### PR DESCRIPTION
## Summary
Adds a "Recently Made" history section to the kaomoji generator that persists user-created faces to localStorage, and introduces a "Copy Link" button to share the shareable `?q=` URL of a creation.

## Key Changes

- **Recently Made History**
  - New `loadRecent()`, `pushRecent()`, and `renderRecent()` functions manage a localStorage-backed list of up to 8 recently created faces
  - Faces are deduplicated and stored in reverse chronological order
  - History section appears only when non-empty (uses `u-hidden` toggle)
  - Each recent face is a clickable button that loads the face into the editor
  - Added `.kao-recent` and `.kao-recent-face` styles with hover effects

- **Copy Link Feature**
  - New `copyLink()` function copies the full shareable URL (`window.location.href` with `?q=` parameter) instead of just the face text
  - New "Copy Link" button in the UI that triggers the copy action
  - Reuses existing `window.UltraTextGen.copyText()` infrastructure for consistent UX
  - Also calls `pushRecent()` to track the shared face

- **Accessibility Improvements**
  - Added `aria-pressed` attributes to mood chips and part options to reflect selected state
  - Refactored selection state logic to compute `isSelected`/`isActive` once and use consistently
  - Added `aria-label` to recent face buttons with localized "Load face" text

- **Dictionary & Data Expansions**
  - Added 8 new kaomoji parts to `kaomojiDict.js`: eyes (`°`, `O`, `@`, `x`, `-`) and mouths (`□`, `皿`, `o`, `_`)
  - Added `sara` (皿) mouth preset to `kaomojiData.js` with "angry" mood tag

- **HTML & Init Updates**
  - Added `kaomojiRecentWrap` and `kaomojiRecent` container elements to index.html
  - Added "Copy Link" button to the action buttons row
  - Updated `init()` to cache recent refs and call `renderRecent()` on load
  - Added event listener for the new copy link button

## Implementation Notes

- Recent faces are stored as a JSON array in localStorage under key `utg_kaomoji_recent`
- Graceful error handling: JSON parse failures and localStorage quota errors are silently caught
- Recent history is rendered on every `pushRecent()` call to keep UI in sync
- The feature integrates seamlessly with existing `freeform` editing and `syncUrl()` deep-linking

https://claude.ai/code/session_01BDD1jRrvuBuSPJk7EHHL7v