### PR TITLE
Add persona translators, printable generators, and cursive landing pages

### DIFF
--- a/js/printables/crossStitchEngine.js
+++ b/js/printables/crossStitchEngine.js
@@ -1,0 +1,468 @@
+/* ══════════════════════════════════════════════════════════════════
+   Cross-Stitch Letter Generator — crossStitchEngine.js
+   Self-contained page controller. Pure vanilla JS, no dependencies,
+   no framework, no external font. Renders a 5×7 bitmap alphabet as a
+   client-side SVG cross-stitch chart, with PNG export and print.
+   ══════════════════════════════════════════════════════════════════ */
+
+(function () {
+  "use strict";
+
+  /* ── The 5×7 stitch alphabet ──────────────────────────────────────
+     Each glyph is 7 rows of a 5-character string: '1' = a stitch,
+     '0' = empty. Uppercase + digits + a blank space column. This is a
+     classic cross-stitch letter grid — intentionally simple and blocky. */
+  const STITCH_FONT = {
+    "A": ["01110","10001","10001","11111","10001","10001","10001"],
+    "B": ["11110","10001","10001","11110","10001","10001","11110"],
+    "C": ["01111","10000","10000","10000","10000","10000","01111"],
+    "D": ["11110","10001","10001","10001","10001","10001","11110"],
+    "E": ["11111","10000","10000","11110","10000","10000","11111"],
+    "F": ["11111","10000","10000","11110","10000","10000","10000"],
+    "G": ["01111","10000","10000","10011","10001","10001","01111"],
+    "H": ["10001","10001","10001","11111","10001","10001","10001"],
+    "I": ["01110","00100","00100","00100","00100","00100","01110"],
+    "J": ["00111","00010","00010","00010","00010","10010","01100"],
+    "K": ["10001","10010","10100","11000","10100","10010","10001"],
+    "L": ["10000","10000","10000","10000","10000","10000","11111"],
+    "M": ["10001","11011","10101","10101","10001","10001","10001"],
+    "N": ["10001","11001","10101","10101","10011","10001","10001"],
+    "O": ["01110","10001","10001","10001","10001","10001","01110"],
+    "P": ["11110","10001","10001","11110","10000","10000","10000"],
+    "Q": ["01110","10001","10001","10001","10101","10010","01101"],
+    "R": ["11110","10001","10001","11110","10100","10010","10001"],
+    "S": ["01111","10000","10000","01110","00001","00001","11110"],
+    "T": ["11111","00100","00100","00100","00100","00100","00100"],
+    "U": ["10001","10001","10001","10001","10001","10001","01110"],
+    "V": ["10001","10001","10001","10001","10001","01010","00100"],
+    "W": ["10001","10001","10001","10101","10101","10101","01010"],
+    "X": ["10001","10001","01010","00100","01010","10001","10001"],
+    "Y": ["10001","10001","01010","00100","00100","00100","00100"],
+    "Z": ["11111","00001","00010","00100","01000","10000","11111"],
+    "0": ["01110","10001","10011","10101","11001","10001","01110"],
+    "1": ["00100","01100","00100","00100","00100","00100","01110"],
+    "2": ["01110","10001","00001","00010","00100","01000","11111"],
+    "3": ["11110","00001","00001","00110","00001","00001","11110"],
+    "4": ["00010","00110","01010","10010","11111","00010","00010"],
+    "5": ["11111","10000","11110","00001","00001","10001","01110"],
+    "6": ["00110","01000","10000","11110","10001","10001","01110"],
+    "7": ["11111","00001","00010","00100","01000","01000","01000"],
+    "8": ["01110","10001","10001","01110","10001","10001","01110"],
+    "9": ["01110","10001","10001","01111","00001","00010","01100"],
+    " ": ["00000","00000","00000","00000","00000","00000","00000"]
+  };
+
+  const GLYPH_ROWS = 7;      // every glyph is 7 rows tall
+  const GLYPH_COLS = 5;      // …and 5 columns wide
+  const LETTER_GAP = 1;      // blank columns between adjacent letters
+  const CELL = 16;           // SVG grid unit (px) for the on-screen chart
+  const GRID_LINE = "#d3d7de";   // light neutral gray — crisp on white in both themes
+  const TITLE_INK = "#1a1a2e";   // print/PNG title colour (matches --text-primary light)
+
+  /* ── DOM helpers ──────────────────────────────────────────────── */
+  const $ = (sel) => document.querySelector(sel);
+
+  function svgNode(str) {
+    const tpl = document.createElement("template");
+    tpl.innerHTML = String(str).trim();
+    return tpl.content.firstElementChild;
+  }
+
+  function slugify(s) {
+    return String(s || "").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+  }
+
+  /* ── State ─────────────────────────────────────────────────────── */
+  const state = {
+    text: "HOME",
+    color: "#2b2b2b",
+    style: "x-stitch"
+  };
+
+  /* ── Grid model ────────────────────────────────────────────────────
+     Turn the input word into 7 equal-length row strings of '0'/'1'.
+     Unknown characters fall back to a blank space column (never a made-up
+     glyph); lowercase is uppercased first (charts are uppercase-only). */
+  function buildRows(text) {
+    // Keep every input char; map anything without a glyph (punctuation,
+    // accents, symbols) to a blank space column — never invent a glyph.
+    const chars = String(text).toUpperCase().split("");
+    const rows = ["", "", "", "", "", "", ""];
+    chars.forEach((ch, idx) => {
+      const glyph = STITCH_FONT[ch] || STITCH_FONT[" "];
+      for (let r = 0; r < GLYPH_ROWS; r++) {
+        rows[r] += glyph[r];
+        if (idx < chars.length - 1) {
+          for (let g = 0; g < LETTER_GAP; g++) rows[r] += "0";
+        }
+      }
+    });
+    return { rows: rows, cols: rows[0] ? rows[0].length : 0, empty: chars.length === 0 };
+  }
+
+  function countStitches(rows) {
+    let n = 0;
+    for (let r = 0; r < rows.length; r++) {
+      for (let c = 0; c < rows[r].length; c++) {
+        if (rows[r][c] === "1") n++;
+      }
+    }
+    return n;
+  }
+
+  /* ── SVG chart builder ─────────────────────────────────────────────
+     Returns an <svg> string: white background, light-gray grid lines, and
+     one X-stitch (two diagonals) or filled square per set cell. Sized with
+     an explicit width/height + inline max-width so it scales inside the
+     card and prints to page width, staying crisp regardless of site theme. */
+  function buildChartSVG(rows, color, style, label) {
+    const cols = rows[0] ? rows[0].length : 0;
+    const rc = rows.length;
+    const w = cols * CELL;
+    const h = rc * CELL;
+
+    let grid = "";
+    for (let c = 0; c <= cols; c++) {
+      const x = c * CELL;
+      grid += '<line x1="' + x + '" y1="0" x2="' + x + '" y2="' + h + '"/>';
+    }
+    for (let r = 0; r <= rc; r++) {
+      const y = r * CELL;
+      grid += '<line x1="0" y1="' + y + '" x2="' + w + '" y2="' + y + '"/>';
+    }
+
+    let marks = "";
+    const pad = CELL * 0.17;
+    const inset = CELL * 0.1;
+    for (let r = 0; r < rc; r++) {
+      const row = rows[r];
+      for (let c = 0; c < cols; c++) {
+        if (row[c] !== "1") continue;
+        const x = c * CELL;
+        const y = r * CELL;
+        if (style === "filled") {
+          marks += '<rect x="' + (x + inset) + '" y="' + (y + inset) +
+            '" width="' + (CELL - 2 * inset) + '" height="' + (CELL - 2 * inset) +
+            '" rx="' + (CELL * 0.12) + '"/>';
+        } else {
+          const x1 = x + pad, y1 = y + pad, x2 = x + CELL - pad, y2 = y + CELL - pad;
+          marks += '<path d="M' + x1 + ' ' + y1 + ' L' + x2 + ' ' + y2 +
+            ' M' + x2 + ' ' + y1 + ' L' + x1 + ' ' + y2 + '"/>';
+        }
+      }
+    }
+
+    const stitchLayer = style === "filled"
+      ? '<g fill="' + color + '">' + marks + "</g>"
+      : '<g stroke="' + color + '" stroke-width="' + (CELL * 0.17) +
+        '" stroke-linecap="round" fill="none">' + marks + "</g>";
+
+    const aria = label ? ' role="img" aria-label="Cross-stitch chart for ' + label + '"' : ' aria-hidden="true"';
+
+    return '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ' + w + ' ' + h +
+      '" width="' + w + '" height="' + h + '"' + aria +
+      ' style="max-width:100%;height:auto;display:block;margin:0 auto;">' +
+      '<rect x="0" y="0" width="' + w + '" height="' + h + '" fill="#ffffff"/>' +
+      '<g stroke="' + GRID_LINE + '" stroke-width="1">' + grid + "</g>" +
+      stitchLayer +
+      "</svg>";
+  }
+
+  /* Small symbol swatch used in the legend + PNG/print. */
+  function symbolSVG(color, style, size) {
+    if (style === "filled") {
+      return '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" width="' + size + '" height="' + size +
+        '" aria-hidden="true"><rect x="4" y="4" width="12" height="12" rx="2" fill="' + color + '"/></svg>';
+    }
+    return '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" width="' + size + '" height="' + size +
+      '" aria-hidden="true"><path d="M5 5 L15 15 M15 5 L5 15" stroke="' + color +
+      '" stroke-width="2.6" stroke-linecap="round" fill="none"/></svg>';
+  }
+
+  function legendHTML(rows, color, style) {
+    const cols = rows[0] ? rows[0].length : 0;
+    const stitches = countStitches(rows);
+    return '<div class="cross-stitch-legend" ' +
+      'style="display:flex;flex-wrap:wrap;align-items:center;gap:0.5rem 0.9rem;' +
+      'margin-top:0.85rem;font-size:0.85rem;font-weight:600;color:#334155;">' +
+      '<span style="display:inline-flex;align-items:center;gap:0.4rem;">' +
+      '<span style="display:inline-flex;width:20px;height:20px;">' + symbolSVG(color, style, 20) + "</span>" +
+      "<span>= 1 stitch</span></span>" +
+      '<span style="color:#64748b;">' + cols + " columns × " + GLYPH_ROWS + " rows · " +
+      stitches + " stitch" + (stitches === 1 ? "" : "es") + "</span>" +
+      "</div>";
+  }
+
+  /* ── Live preview ──────────────────────────────────────────────── */
+  function render() {
+    const chart = $("#cs-chart");
+    const legend = $("#cs-legend");
+    if (!chart) return;
+
+    const model = buildRows(state.text);
+    if (model.empty || model.cols === 0) {
+      chart.innerHTML = '<p class="cross-stitch-empty" ' +
+        'style="text-align:center;color:#94a3b8;font-weight:600;padding:1.5rem 0;margin:0;">' +
+        "Type a word or name above to see its cross-stitch chart.</p>";
+      if (legend) legend.innerHTML = "";
+      return;
+    }
+
+    const label = state.text.trim().replace(/"/g, "”");
+    chart.innerHTML = buildChartSVG(model.rows, state.color, state.style, label);
+    if (legend) legend.innerHTML = legendHTML(model.rows, state.color, state.style);
+  }
+
+  /* ── Canvas / PNG export ───────────────────────────────────────────
+     Redraws the identical grid onto a canvas at a larger fixed px-per-cell,
+     with a word title on top and a legend at the bottom, then downloads it. */
+  function drawSymbolOnCanvas(ctx, x, y, size, color, style) {
+    if (style === "filled") {
+      const inset = size * 0.16;
+      ctx.fillStyle = color;
+      ctx.fillRect(x + inset, y + inset, size - 2 * inset, size - 2 * inset);
+    } else {
+      const pad = size * 0.2;
+      ctx.strokeStyle = color;
+      ctx.lineWidth = Math.max(2, size * 0.13);
+      ctx.lineCap = "round";
+      ctx.beginPath();
+      ctx.moveTo(x + pad, y + pad);
+      ctx.lineTo(x + size - pad, y + size - pad);
+      ctx.moveTo(x + size - pad, y + pad);
+      ctx.lineTo(x + pad, y + size - pad);
+      ctx.stroke();
+    }
+  }
+
+  function drawChartOnCanvas(ctx, ox, oy, rows, color, style, cell) {
+    const cols = rows[0] ? rows[0].length : 0;
+    const rc = rows.length;
+    const w = cols * cell;
+    const h = rc * cell;
+
+    // Grid lines.
+    ctx.strokeStyle = GRID_LINE;
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    for (let c = 0; c <= cols; c++) {
+      const x = Math.round(ox + c * cell) + 0.5;
+      ctx.moveTo(x, oy);
+      ctx.lineTo(x, oy + h);
+    }
+    for (let r = 0; r <= rc; r++) {
+      const y = Math.round(oy + r * cell) + 0.5;
+      ctx.moveTo(ox, y);
+      ctx.lineTo(ox + w, y);
+    }
+    ctx.stroke();
+
+    // Stitches.
+    const pad = cell * 0.17;
+    const inset = cell * 0.1;
+    ctx.strokeStyle = color;
+    ctx.fillStyle = color;
+    ctx.lineWidth = cell * 0.17;
+    ctx.lineCap = "round";
+    for (let r = 0; r < rc; r++) {
+      const row = rows[r];
+      for (let c = 0; c < cols; c++) {
+        if (row[c] !== "1") continue;
+        const x = ox + c * cell;
+        const y = oy + r * cell;
+        if (style === "filled") {
+          ctx.fillRect(x + inset, y + inset, cell - 2 * inset, cell - 2 * inset);
+        } else {
+          ctx.beginPath();
+          ctx.moveTo(x + pad, y + pad);
+          ctx.lineTo(x + cell - pad, y + cell - pad);
+          ctx.moveTo(x + cell - pad, y + pad);
+          ctx.lineTo(x + pad, y + cell - pad);
+          ctx.stroke();
+        }
+      }
+    }
+  }
+
+  function downloadPNG() {
+    const model = buildRows(state.text);
+    if (model.empty || model.cols === 0) return;
+
+    const cell = 40;
+    const margin = 40;
+    const titleH = 64;
+    const legendH = 72;
+    const chartW = model.cols * cell;
+    const chartH = GLYPH_ROWS * cell;
+    const canvasW = Math.max(chartW + margin * 2, 520);
+    const canvasH = titleH + chartH + legendH + margin;
+
+    const canvas = document.createElement("canvas");
+    canvas.width = canvasW;
+    canvas.height = canvasH;
+    const ctx = canvas.getContext("2d");
+
+    // White page.
+    ctx.fillStyle = "#ffffff";
+    ctx.fillRect(0, 0, canvasW, canvasH);
+
+    // Title (the word).
+    const word = state.text.toUpperCase().trim();
+    ctx.fillStyle = TITLE_INK;
+    ctx.font = "700 34px 'Plus Jakarta Sans', system-ui, sans-serif";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.fillText(word, canvasW / 2, titleH * 0.55);
+
+    // Chart, centred.
+    const ox = Math.round((canvasW - chartW) / 2);
+    const oy = titleH;
+    drawChartOnCanvas(ctx, ox, oy, model.rows, state.color, state.style, cell);
+
+    // Legend at the bottom: symbol swatch + text.
+    const stitches = countStitches(model.rows);
+    const legendText = "= 1 stitch     ·     " + model.cols + " columns × " +
+      GLYPH_ROWS + " rows · " + stitches + " stitch" + (stitches === 1 ? "" : "es");
+    const symSize = 26;
+    const gap = 10;
+    ctx.font = "600 20px 'Plus Jakarta Sans', system-ui, sans-serif";
+    const textW = ctx.measureText(legendText).width;
+    const total = symSize + gap + textW;
+    const startX = (canvasW - total) / 2;
+    const legendMidY = titleH + chartH + margin * 0.5 + legendH * 0.4;
+    drawSymbolOnCanvas(ctx, startX, legendMidY - symSize / 2, symSize, state.color, state.style);
+    ctx.fillStyle = "#334155";
+    ctx.textAlign = "left";
+    ctx.fillText(legendText, startX + symSize + gap, legendMidY);
+
+    canvas.toBlob(function (blob) {
+      if (!blob) return;
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "cross-stitch-" + (slugify(state.text) || "pattern") + ".png";
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      setTimeout(function () { URL.revokeObjectURL(url); }, 1000);
+    }, "image/png");
+  }
+
+  /* ── Print ─────────────────────────────────────────────────────────
+     Build title + chart + legend into #pt-print-root, flip the global
+     print class (CSS isolates that root), print, then clean up. */
+  function printPattern() {
+    const model = buildRows(state.text);
+    if (model.empty || model.cols === 0) return;
+
+    const root = $("#pt-print-root");
+    if (!root) { window.print(); return; }
+    root.innerHTML = "";
+
+    const wrap = document.createElement("div");
+    wrap.className = "bubble-print-wrap";
+
+    const h = document.createElement("h2");
+    h.className = "bubble-print-title";
+    h.textContent = "Cross-Stitch Pattern — " + state.text.toUpperCase().trim();
+    wrap.appendChild(h);
+
+    const label = state.text.trim().replace(/"/g, "”");
+    const chartHolder = document.createElement("div");
+    chartHolder.innerHTML = buildChartSVG(model.rows, state.color, state.style, label);
+    wrap.appendChild(chartHolder);
+
+    const legend = document.createElement("div");
+    legend.innerHTML = legendHTML(model.rows, state.color, state.style);
+    wrap.appendChild(legend);
+
+    root.appendChild(wrap);
+    document.body.classList.add("is-printing");
+    window.print();
+    document.body.classList.remove("is-printing");
+    root.innerHTML = "";
+  }
+
+  /* ── Swatch groups ─────────────────────────────────────────────────
+     Inject each swatch's mini preview, reflect active state, and pick on
+     click (toggles is-active + aria-checked) — the shared printables pattern. */
+  function wireSwatchGroup(group, artFn, onPick) {
+    if (!group) return;
+    const buttons = Array.prototype.slice.call(group.querySelectorAll(".pt-swatch"));
+    const preset = buttons.filter(function (b) { return b.classList.contains("is-active"); })[0] || buttons[0];
+    buttons.forEach(function (b) {
+      const slot = b.querySelector(".pt-swatch-art");
+      if (slot && artFn) {
+        slot.innerHTML = "";
+        const node = artFn(b.dataset.value);
+        if (node) slot.appendChild(node);
+      }
+      const on = b === preset;
+      b.classList.toggle("is-active", on);
+      b.setAttribute("aria-checked", on ? "true" : "false");
+      b.addEventListener("click", function () {
+        buttons.forEach(function (o) {
+          const active = o === b;
+          o.classList.toggle("is-active", active);
+          o.setAttribute("aria-checked", active ? "true" : "false");
+        });
+        onPick(b.dataset.value);
+      });
+    });
+    if (preset) onPick(preset.dataset.value, true);
+  }
+
+  function colorArt(value) {
+    return svgNode('<svg viewBox="0 0 40 40" class="pt-swatch-svg" aria-hidden="true">' +
+      '<circle cx="20" cy="20" r="14" fill="' + value + '"/></svg>');
+  }
+
+  function styleArt(value) {
+    if (value === "filled") {
+      return svgNode('<svg viewBox="0 0 40 40" class="pt-swatch-svg" aria-hidden="true">' +
+        '<rect x="11" y="11" width="18" height="18" rx="3" fill="#2b2b2b"/></svg>');
+    }
+    return svgNode('<svg viewBox="0 0 40 40" class="pt-swatch-svg" aria-hidden="true">' +
+      '<path d="M12 12 L28 28 M28 12 L12 28" stroke="#2b2b2b" stroke-width="4" ' +
+      'stroke-linecap="round" fill="none"/></svg>');
+  }
+
+  /* ── Init ──────────────────────────────────────────────────────── */
+  function init() {
+    const input = $("#cs-input");
+    if (input) {
+      state.text = input.value || state.text;
+      let timer = null;
+      input.addEventListener("input", function () {
+        state.text = input.value;
+        clearTimeout(timer);
+        timer = setTimeout(render, 120);
+      });
+    }
+
+    wireSwatchGroup($("#cs-color-group"), colorArt, function (value, silent) {
+      state.color = value;
+      if (!silent) render();
+    });
+
+    wireSwatchGroup($("#cs-style-group"), styleArt, function (value, silent) {
+      state.style = value;
+      if (!silent) render();
+    });
+
+    const printBtn = $("#cs-print");
+    if (printBtn) printBtn.addEventListener("click", printPattern);
+
+    const pngBtn = $("#cs-png");
+    if (pngBtn) pngBtn.addEventListener("click", downloadPNG);
+
+    render();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+
+})();

--- a/js/printables/monogramEngine.js
+++ b/js/printables/monogramEngine.js
@@ -1,0 +1,436 @@
+/*
+ * monogramEngine.js — self-contained controller for /printables/monogram-maker/.
+ *
+ * Turns up to three initials (left / center / right) into a printable monogram
+ * in one of three layouts (classic three-letter, stacked, circle frame) and one
+ * of two styles (solid ink, or white-fill traceable outline). Everything is
+ * rendered client-side as native SVG (live preview + print) and Canvas 2D (PNG
+ * download) — no server render, no image library, no bundled font binary. The
+ * elegant serif is Playfair Display, loaded on the page via a Google Fonts
+ * <link> tag; this tool does NOT use the site's Unicode font registry, so the
+ * output is for print / PNG only, not copy-paste.
+ *
+ * Mount points on the page:
+ *   #mono-left #mono-center #mono-right   the three 1-char initial inputs
+ *   #mono-layout-group                    .pt-swatches radiogroup (classic|stacked|circle)
+ *   #mono-style-group                     .pt-swatches radiogroup (solid|outline)
+ *   #mono-preview                         live SVG preview surface (.pt-paper)
+ *   #mono-print #mono-png                 print + PNG download buttons
+ *   #pt-print-root                        hidden print surface (shared, print CSS wired)
+ */
+(function () {
+  "use strict";
+
+  const SVGNS = "http://www.w3.org/2000/svg";
+  const INK = "#1a1a2e";
+  const FONT = "'Playfair Display', Georgia, 'Times New Roman', serif";
+  const WEIGHT = "700";
+  const VB = 400; // SVG viewBox is 0 0 400 400
+
+  // State the swatch groups drive. Initials are always read live from the DOM.
+  const state = { layout: "classic", style: "solid" };
+
+  /* ---------- tiny DOM / SVG helpers ---------- */
+
+  function byId(id) { return document.getElementById(id); }
+
+  function svgEl(name, attrs) {
+    const n = document.createElementNS(SVGNS, name);
+    if (attrs) {
+      Object.keys(attrs).forEach((k) => { n.setAttribute(k, attrs[k]); });
+    }
+    return n;
+  }
+
+  // Current initials, uppercased, one char each, in [left, center, right] order.
+  function vals() {
+    const read = (id) => {
+      const el = byId(id);
+      return el ? el.value.trim().slice(0, 1).toUpperCase() : "";
+    };
+    return { l: read("mono-left"), c: read("mono-center"), r: read("mono-right") };
+  }
+
+  /* ---------- glyph measurement (shared canvas) ---------- */
+
+  let measureCtx = null;
+  function measure(ch, px) {
+    if (!measureCtx) measureCtx = document.createElement("canvas").getContext("2d");
+    measureCtx.font = WEIGHT + " " + px + "px " + FONT;
+    return measureCtx.measureText(ch).width;
+  }
+
+  /* ---------- SVG letter builder ---------- */
+
+  // A single monogram letter as an SVG <text>, inked per the active style.
+  function letterText(ch, x, y, size, opts) {
+    const o = opts || {};
+    const t = svgEl("text", {
+      x: x, y: y,
+      "text-anchor": o.anchor || "middle",
+      "font-family": FONT,
+      "font-weight": WEIGHT,
+      "font-size": size
+    });
+    if (o.central) t.setAttribute("dominant-baseline", "central");
+    if (state.style === "outline") {
+      t.setAttribute("fill", "#ffffff");
+      t.setAttribute("stroke", INK);
+      t.setAttribute("stroke-width", String(Math.max(3, size * 0.045)));
+      t.setAttribute("stroke-linejoin", "round");
+      t.setAttribute("paint-order", "stroke");
+    } else {
+      t.setAttribute("fill", INK);
+    }
+    t.textContent = ch;
+    return t;
+  }
+
+  // Lay a horizontal row of letters, centered on x=200, sitting on baseline `y`
+  // (or vertically centered at `y` when central). Widths are measured so wide
+  // center letters (M, W) never collide with the side letters.
+  function layoutRow(svg, items, y, central) {
+    if (!items.length) return;
+    const gap = central ? 8 : 10;
+    const widths = items.map((it) => measure(it.ch, it.size));
+    const total = widths.reduce((a, b) => a + b, 0) + gap * (items.length - 1);
+    let x = VB / 2 - total / 2;
+    items.forEach((it, i) => {
+      const w = widths[i];
+      svg.appendChild(letterText(it.ch, x + w / 2, y, it.size, { anchor: "middle", central: central }));
+      x += w + gap;
+    });
+  }
+
+  // Classic three-letter: small · BIG center (~1.7x) · small, on one baseline.
+  function buildClassic(svg, v) {
+    const items = [];
+    if (v.l) items.push({ ch: v.l, size: 116 });
+    if (v.c) items.push({ ch: v.c, size: 196 });
+    if (v.r) items.push({ ch: v.r, size: 116 });
+    if (!items.length) return;
+    const maxSize = Math.max.apply(null, items.map((it) => it.size));
+    const baselineY = 200 + maxSize * 0.36; // vertically centers the tallest cap
+    layoutRow(svg, items, baselineY, false);
+  }
+
+  // Stacked: the provided initials stacked vertically, centered, tight leading.
+  function buildStacked(svg, v) {
+    const present = [v.l, v.c, v.r].filter(Boolean);
+    const n = present.length;
+    if (!n) return;
+    const size = n >= 3 ? 150 : (n === 2 ? 180 : 220);
+    const lineH = size * 0.82;
+    const firstCY = 200 - (n - 1) * lineH / 2;
+    present.forEach((ch, i) => {
+      svg.appendChild(letterText(ch, 200, firstCY + i * lineH, size, { anchor: "middle", central: true }));
+    });
+  }
+
+  // Circle frame: small · BIG · small centered inside a double ring (wax-seal look).
+  function buildCircle(svg, v) {
+    const ringW = state.style === "solid" ? 6 : 5;
+    svg.appendChild(svgEl("circle", { cx: 200, cy: 200, r: 186, fill: "none", stroke: INK, "stroke-width": ringW }));
+    svg.appendChild(svgEl("circle", { cx: 200, cy: 200, r: 171, fill: "none", stroke: INK, "stroke-width": 2.5 }));
+    const items = [];
+    if (v.l) items.push({ ch: v.l, size: 78 });
+    if (v.c) items.push({ ch: v.c, size: 132 });
+    if (v.r) items.push({ ch: v.r, size: 78 });
+    layoutRow(svg, items, 200, true);
+  }
+
+  function buildMonogramSVG() {
+    const v = vals();
+    const svg = svgEl("svg", {
+      viewBox: "0 0 " + VB + " " + VB,
+      class: "pt-design-sheet-svg",
+      role: "img"
+    });
+    const initials = (v.l + v.c + v.r);
+    svg.setAttribute("aria-label", initials ? ("Monogram " + initials + " — " + state.layout + " layout") : "Monogram preview");
+
+    if (!v.l && !v.c && !v.r) {
+      const hint = svgEl("text", {
+        x: 200, y: 200, "text-anchor": "middle", "dominant-baseline": "central",
+        "font-family": FONT, "font-size": 26, fill: "#9aa2b1"
+      });
+      hint.textContent = "Type initials";
+      svg.appendChild(hint);
+      return svg;
+    }
+
+    if (state.layout === "stacked") buildStacked(svg, v);
+    else if (state.layout === "circle") buildCircle(svg, v);
+    else buildClassic(svg, v);
+    return svg;
+  }
+
+  /* ---------- live preview ---------- */
+
+  function render() {
+    const host = byId("mono-preview");
+    if (!host) return;
+    host.innerHTML = "";
+    host.appendChild(buildMonogramSVG());
+  }
+
+  let debounceTimer = null;
+  function schedule() {
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(render, 120);
+  }
+
+  /* ---------- fonts ---------- */
+
+  // Playfair Display arrives asynchronously via the page's Google Fonts <link>.
+  // Canvas measuring/drawing before it loads would use fallback metrics, so we
+  // re-run `cb` once the face is ready.
+  function whenFontReady(cb) {
+    if (document.fonts && document.fonts.load) {
+      document.fonts.load('700 40px "Playfair Display"').then(cb).catch(cb);
+    } else {
+      cb();
+    }
+  }
+
+  /* ---------- PNG export (Canvas 2D, 1600x1600) ---------- */
+
+  function inkCanvas(ctx, ch, x, y, px) {
+    if (state.style === "outline") {
+      ctx.fillStyle = "#ffffff";
+      ctx.fillText(ch, x, y);
+      ctx.lineWidth = Math.max(3, px * 0.045);
+      ctx.strokeStyle = INK;
+      ctx.strokeText(ch, x, y);
+    } else {
+      ctx.fillStyle = INK;
+      ctx.fillText(ch, x, y);
+    }
+  }
+
+  function drawRowCanvas(ctx, s, items, y, central) {
+    if (!items.length) return;
+    const gap = (central ? 8 : 10) * s;
+    ctx.textBaseline = central ? "middle" : "alphabetic";
+    const widths = items.map((it) => {
+      ctx.font = WEIGHT + " " + (it.size * s) + "px " + FONT;
+      return ctx.measureText(it.ch).width;
+    });
+    const total = widths.reduce((a, b) => a + b, 0) + gap * (items.length - 1);
+    let x = (VB / 2) * s - total / 2;
+    items.forEach((it, i) => {
+      const w = widths[i];
+      ctx.font = WEIGHT + " " + (it.size * s) + "px " + FONT;
+      inkCanvas(ctx, it.ch, x + w / 2, y, it.size * s);
+      x += w + gap;
+    });
+  }
+
+  function drawClassicCanvas(ctx, s, v) {
+    const items = [];
+    if (v.l) items.push({ ch: v.l, size: 116 });
+    if (v.c) items.push({ ch: v.c, size: 196 });
+    if (v.r) items.push({ ch: v.r, size: 116 });
+    if (!items.length) return;
+    const maxSize = Math.max.apply(null, items.map((it) => it.size));
+    drawRowCanvas(ctx, s, items, (200 + maxSize * 0.36) * s, false);
+  }
+
+  function drawStackedCanvas(ctx, s, v) {
+    const present = [v.l, v.c, v.r].filter(Boolean);
+    const n = present.length;
+    if (!n) return;
+    ctx.textBaseline = "middle";
+    const size = n >= 3 ? 150 : (n === 2 ? 180 : 220);
+    const lineH = size * 0.82 * s;
+    const firstCY = 200 * s - (n - 1) * lineH / 2;
+    ctx.font = WEIGHT + " " + (size * s) + "px " + FONT;
+    present.forEach((ch, i) => {
+      inkCanvas(ctx, ch, 200 * s, firstCY + i * lineH, size * s);
+    });
+  }
+
+  function drawCircleCanvas(ctx, s, v) {
+    ctx.strokeStyle = INK;
+    ctx.lineWidth = (state.style === "solid" ? 6 : 5) * s;
+    ctx.beginPath();
+    ctx.arc(200 * s, 200 * s, 186 * s, 0, Math.PI * 2);
+    ctx.stroke();
+    ctx.lineWidth = 2.5 * s;
+    ctx.beginPath();
+    ctx.arc(200 * s, 200 * s, 171 * s, 0, Math.PI * 2);
+    ctx.stroke();
+    const items = [];
+    if (v.l) items.push({ ch: v.l, size: 78 });
+    if (v.c) items.push({ ch: v.c, size: 132 });
+    if (v.r) items.push({ ch: v.r, size: 78 });
+    drawRowCanvas(ctx, s, items, 200 * s, true);
+  }
+
+  function downloadPNG() {
+    whenFontReady(function () {
+      const v = vals();
+      const size = 1600;
+      const s = size / VB; // 4x
+      const canvas = document.createElement("canvas");
+      canvas.width = size;
+      canvas.height = size;
+      const ctx = canvas.getContext("2d");
+      ctx.fillStyle = "#ffffff";
+      ctx.fillRect(0, 0, size, size);
+      ctx.textAlign = "center";
+      ctx.lineJoin = "round";
+
+      if (v.l || v.c || v.r) {
+        if (state.layout === "stacked") drawStackedCanvas(ctx, s, v);
+        else if (state.layout === "circle") drawCircleCanvas(ctx, s, v);
+        else drawClassicCanvas(ctx, s, v);
+      }
+
+      const slug = (v.l + v.c + v.r).toLowerCase() || "initials";
+      canvas.toBlob(function (blob) {
+        if (!blob) return;
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = "monogram-" + slug + ".png";
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        setTimeout(function () { URL.revokeObjectURL(url); }, 1000);
+      }, "image/png");
+    });
+  }
+
+  /* ---------- print (isolated #pt-print-root surface) ---------- */
+
+  function printMonogram() {
+    const root = byId("pt-print-root");
+    if (!root) { window.print(); return; }
+    const v = vals();
+    const initials = (v.l + v.c + v.r) || "Monogram";
+    root.innerHTML = "";
+    const wrap = document.createElement("div");
+    wrap.className = "bubble-print-wrap";
+    const h = document.createElement("h2");
+    h.className = "bubble-print-title";
+    h.textContent = "Monogram — " + initials;
+    wrap.appendChild(h);
+    const holder = document.createElement("div");
+    holder.className = "pt-design-print-holder";
+    holder.appendChild(buildMonogramSVG());
+    wrap.appendChild(holder);
+    root.appendChild(wrap);
+    document.body.classList.add("is-printing");
+    window.print();
+    document.body.classList.remove("is-printing");
+    root.innerHTML = "";
+  }
+
+  /* ---------- swatch groups (radiogroup pill pattern) ---------- */
+
+  // Small preview icons injected into each swatch's .pt-swatch-art slot.
+  function miniSVG() {
+    return svgEl("svg", { viewBox: "0 0 44 44", class: "pt-swatch-svg", "aria-hidden": "true" });
+  }
+  function miniText(parent, ch, x, y, size, outline) {
+    const t = svgEl("text", {
+      x: x, y: y, "text-anchor": "middle",
+      "font-family": FONT, "font-weight": WEIGHT, "font-size": size
+    });
+    if (outline) {
+      t.setAttribute("fill", "#ffffff");
+      t.setAttribute("stroke", INK);
+      t.setAttribute("stroke-width", "2");
+      t.setAttribute("stroke-linejoin", "round");
+      t.setAttribute("paint-order", "stroke");
+    } else {
+      t.setAttribute("fill", INK);
+    }
+    t.textContent = ch;
+    parent.appendChild(t);
+  }
+  function layoutIcon(value) {
+    const s = miniSVG();
+    if (value === "stacked") {
+      miniText(s, "A", 22, 15, 12);
+      miniText(s, "B", 22, 27, 12);
+      miniText(s, "C", 22, 39, 12);
+    } else if (value === "circle") {
+      s.appendChild(svgEl("circle", { cx: 22, cy: 22, r: 19, fill: "none", stroke: INK, "stroke-width": 2.5 }));
+      s.appendChild(svgEl("circle", { cx: 22, cy: 22, r: 15.5, fill: "none", stroke: INK, "stroke-width": 1.2 }));
+      miniText(s, "B", 22, 28, 17);
+    } else {
+      miniText(s, "A", 9, 30, 13);
+      miniText(s, "B", 22, 32, 22);
+      miniText(s, "C", 35, 30, 13);
+    }
+    return s;
+  }
+  function styleIcon(value) {
+    const s = miniSVG();
+    miniText(s, "M", 22, 33, 30, value === "outline");
+    return s;
+  }
+
+  function wireSwatchGroup(group, field, iconFor) {
+    if (!group) return;
+    const buttons = Array.prototype.slice.call(group.querySelectorAll(".pt-swatch"));
+    if (!buttons.length) return;
+    const preset = buttons.filter((b) => b.classList.contains("is-active"))[0] || buttons[0];
+    if (preset) state[field] = preset.dataset.value;
+    buttons.forEach((b) => {
+      const slot = b.querySelector(".pt-swatch-art");
+      if (slot && iconFor) { slot.innerHTML = ""; slot.appendChild(iconFor(b.dataset.value)); }
+      const on = b === preset;
+      b.classList.toggle("is-active", on);
+      b.setAttribute("aria-checked", on ? "true" : "false");
+      b.addEventListener("click", function () {
+        state[field] = b.dataset.value;
+        buttons.forEach((o) => {
+          const active = o === b;
+          o.classList.toggle("is-active", active);
+          o.setAttribute("aria-checked", active ? "true" : "false");
+        });
+        render();
+      });
+    });
+  }
+
+  /* ---------- inputs ---------- */
+
+  function wireInput(id) {
+    const el = byId(id);
+    if (!el) return;
+    el.addEventListener("input", function () {
+      const up = el.value.toUpperCase();
+      if (el.value !== up) el.value = up;
+      schedule();
+    });
+  }
+
+  /* ---------- init ---------- */
+
+  function init() {
+    wireInput("mono-left");
+    wireInput("mono-center");
+    wireInput("mono-right");
+    wireSwatchGroup(byId("mono-layout-group"), "layout", layoutIcon);
+    wireSwatchGroup(byId("mono-style-group"), "style", styleIcon);
+
+    const printBtn = byId("mono-print");
+    if (printBtn) printBtn.addEventListener("click", printMonogram);
+    const pngBtn = byId("mono-png");
+    if (pngBtn) pngBtn.addEventListener("click", downloadPNG);
+
+    render();
+    // Re-render once Playfair loads so measured positions are exact.
+    whenFontReady(render);
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/js/translator/personaTranslator.js
+++ b/js/translator/personaTranslator.js
@@ -1,0 +1,369 @@
+/*
+ * personaTranslator.js — shared, config-driven engine + page controller for the
+ * curated persona / dialect text translators (Pirate Speak, Old English).
+ *
+ * DELIBERATELY SCOPED DOWN: this is word/phrase substitution ONLY. Every
+ * translation is fully deterministic — the same input always produces the same
+ * output. There is no randomness in the translation, no sentence reordering,
+ * and no grammar engine (true grammar inversion was considered and rejected as
+ * too complex / low-fidelity for this build). The only "flourish" is a single
+ * fixed, always-on suffix per persona.
+ *
+ * One engine powers every persona page. A page declares
+ *   window.UTG_PERSONA_PAGE = { key: "pirate" | "oldEnglish", demoText: "…" };
+ * and includes the mount points it wants; the controller wires them up only if
+ * they exist on the page (same gate-on-presence pattern as printablesEngine.js):
+ *   #persona-input   (textarea)          — user text
+ *   #persona-output  (display element)   — live translated output
+ *   #persona-copy    (button)            — copy the current output
+ *   #persona-clear   (button, optional)  — clear the input
+ *   #persona-count   (element, optional) — character counter
+ *
+ * The engine (dictionaries + UTG_personaTranslate) is defined unconditionally so
+ * other scripts / pages can reuse it; only the DOM controller gates on the page
+ * config. Self-contained IIFE — no imports, no dependencies.
+ */
+(function () {
+  "use strict";
+
+  /* =================================================================
+     Dictionaries — [matchPhrase, replacement], matched case-insensitively.
+     Curated; do not "improve" the word choices. Phrases may be 1–4 words.
+     ================================================================= */
+
+  const PIRATE_DICT = [
+    ["how are you", "how be ye"],
+    ["you are", "ye be"],
+    ["you're", "ye're"],
+    ["i am", "I be"],
+    ["is not", "ain't"],
+    ["are not", "ain't"],
+    ["excuse me", "avast"],
+    ["hello", "ahoy"],
+    ["hi", "ahoy"],
+    ["hey", "arr"],
+    ["greetings", "ahoy"],
+    ["yes", "aye"],
+    ["no", "nay"],
+    ["your", "yer"],
+    ["yours", "yers"],
+    ["you", "ye"],
+    ["my", "me"],
+    ["mine", "me own"],
+    ["friends", "mateys"],
+    ["friend", "matey"],
+    ["mister", "cap'n"],
+    ["mr", "cap'n"],
+    ["sir", "cap'n"],
+    ["madam", "milady"],
+    ["boy", "lad"],
+    ["girl", "lass"],
+    ["woman", "lass"],
+    ["man", "matey"],
+    ["money", "doubloons"],
+    ["gold", "doubloons"],
+    ["treasure", "booty"],
+    ["stop", "avast"],
+    ["listen", "hark"],
+    ["old", "auld"],
+    ["drink", "grog"],
+    ["beer", "grog"],
+    ["food", "grub"],
+    ["ship", "vessel"],
+    ["boat", "vessel"],
+    ["bathroom", "head"],
+    ["toilet", "head"],
+    ["here", "o'er here"],
+    ["there", "yonder"],
+    ["before", "afore"],
+    ["are", "be"],
+    ["is", "be"],
+    ["am", "be"],
+    ["was", "were"],
+    ["very", "mighty"],
+    ["big", "mighty"],
+    ["strong", "hearty"],
+    ["good", "fine"],
+    ["excellent", "grand"],
+    ["crazy", "mad"],
+    ["because", "fer"],
+    ["for", "fer"],
+    ["never", "ne'er"],
+    ["over", "o'er"],
+    ["sailor", "sea dog"],
+    ["enemy", "scurvy dog"],
+    ["idiot", "scallywag"],
+    ["coward", "bilge rat"]
+  ];
+
+  const OLD_ENGLISH_DICT = [
+    ["you are", "thou art"],
+    ["are you", "art thou"],
+    ["will you", "wilt thou"],
+    ["do you", "dost thou"],
+    ["you have", "thou hast"],
+    ["you will", "thou shalt"],
+    ["you would", "thou wouldst"],
+    ["yourself", "thyself"],
+    ["yours", "thine"],
+    ["your", "thy"],
+    ["you", "thou"],
+    ["am", "art"],
+    ["have", "hast"],
+    ["has", "hath"],
+    ["will", "shall"],
+    ["would", "wouldst"],
+    ["does", "doth"],
+    ["do", "dost"],
+    ["did", "didst"],
+    ["yes", "yea"],
+    ["no", "nay"],
+    ["hello", "hail"],
+    ["hi", "hail"],
+    ["goodbye", "farewell"],
+    ["bye", "farewell"],
+    ["friend", "good fellow"],
+    ["friends", "good fellows"],
+    ["my", "mine"],
+    ["before", "ere"],
+    ["soon", "anon"],
+    ["always", "evermore"],
+    ["never", "nevermore"],
+    ["very", "most"],
+    ["children", "babes"],
+    ["child", "babe"],
+    ["man", "gentleman"],
+    ["woman", "maiden"],
+    ["people", "folk"],
+    ["here", "hither"],
+    ["there", "thither"],
+    ["where", "whither"],
+    ["why", "wherefore"],
+    ["please", "prithee"],
+    ["sorry", "forgive me"],
+    ["stupid", "foolish"],
+    ["crazy", "mad"],
+    ["cool", "wondrous"],
+    ["awesome", "wondrous"],
+    ["great", "grand"],
+    ["okay", "well enough"],
+    ["alright", "well enough"],
+    ["now", "anon"],
+    ["today", "this day"],
+    ["tomorrow", "the morrow"],
+    ["yesterday", "yestermorn"],
+    ["old", "olden"],
+    ["love", "adore"],
+    ["like", "fancy"],
+    ["know", "ken"]
+  ];
+
+  window.UTG_PERSONA_DICTS = { pirate: PIRATE_DICT, oldEnglish: OLD_ENGLISH_DICT };
+
+  /* =================================================================
+     Matcher builder
+     -----------------------------------------------------------------
+     Longest-phrase-first: sort by word count DESCENDING so multi-word
+     phrases ("how are you") are tried before the single words they contain
+     ("you", "are"). Within the same word count, authored order is preserved.
+
+     One big case-insensitive regex alternation is built, wrapped in a leading
+     \b and a trailing (?![A-Za-z']) lookahead. That trailing lookahead does
+     two jobs at once:
+       1. Contractions: it stops "you" firing inside "you're" (the ' would
+          otherwise be a word boundary), so the dedicated "you're" entry wins.
+       2. Prefix words: it stops "friend" firing inside "friends" and "do"
+          inside "does", so the longer/base entry wins regardless of order.
+     A single global text.replace() pass applies every substitution.
+     ================================================================= */
+
+  function escapeRegex(s) {
+    return String(s).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  }
+
+  function wordCount(phrase) {
+    const t = String(phrase).trim();
+    return t ? t.split(/\s+/).length : 0;
+  }
+
+  // Normalize a matched slice to the dictionary key form (lowercase, single
+  // spaces) so the replacement lookup is robust to case and extra whitespace.
+  function normalizePhrase(match) {
+    return String(match).toLowerCase().replace(/\s+/g, " ").trim();
+  }
+
+  function buildMatcher(dict) {
+    // Stable sort by word count DESC (index tiebreaker keeps authored order).
+    const sorted = dict
+      .map(function (pair, i) { return { pair: pair, i: i }; })
+      .sort(function (a, b) {
+        return (wordCount(b.pair[0]) - wordCount(a.pair[0])) || (a.i - b.i);
+      })
+      .map(function (x) { return x.pair; });
+
+    const map = Object.create(null);
+    const patterns = [];
+    sorted.forEach(function (entry) {
+      const phrase = entry[0];
+      const repl = entry[1];
+      const key = normalizePhrase(phrase);
+      if (!(key in map)) map[key] = repl; // first (longest/earliest) wins on dup
+      // Each word escaped; run-of-whitespace between words matches as \s+.
+      const body = phrase
+        .trim()
+        .split(/\s+/)
+        .map(escapeRegex)
+        .join("\\s+");
+      patterns.push(body);
+    });
+
+    const regex = new RegExp("\\b(?:" + patterns.join("|") + ")(?![A-Za-z'])", "gi");
+    return { regex: regex, map: map };
+  }
+
+  /* =================================================================
+     Capitalization preservation
+     -----------------------------------------------------------------
+     Map the ORIGINAL matched text's casing pattern onto the replacement:
+       ALL CAPS  -> uppercase the whole replacement
+       First cap -> uppercase only the replacement's first letter
+       otherwise -> leave the replacement exactly as authored
+     ================================================================= */
+
+  function applyCase(matched, repl) {
+    const hasLetter = /[A-Za-z]/.test(matched);
+    if (hasLetter && matched === matched.toUpperCase() && matched !== matched.toLowerCase()) {
+      return repl.toUpperCase();
+    }
+    const firstLetter = matched.match(/[A-Za-z]/);
+    if (firstLetter && firstLetter[0] === firstLetter[0].toUpperCase()) {
+      return repl.replace(/[A-Za-z]/, function (c) { return c.toUpperCase(); });
+    }
+    return repl;
+  }
+
+  /* =================================================================
+     Deterministic per-persona flourish (applied AFTER substitution).
+     Pirate: always append a fixed "arrr". Old English: nothing.
+     ================================================================= */
+
+  function pirateFlourish(s) {
+    let trimmed = s.replace(/\s+$/, "");
+    if (!trimmed) return s;
+    const last = trimmed.charAt(trimmed.length - 1);
+    if (last === "!" || last === "?") return trimmed + " Arrr!";
+    if (last === ".") trimmed = trimmed.slice(0, -1);
+    return trimmed + ", arrr!";
+  }
+
+  const MATCHERS = {
+    pirate: buildMatcher(PIRATE_DICT),
+    oldEnglish: buildMatcher(OLD_ENGLISH_DICT)
+  };
+
+  // Pure/deterministic: same (text, personaKey) always yields the same string.
+  function translate(text, personaKey) {
+    const str = String(text == null ? "" : text);
+    const built = MATCHERS[personaKey];
+    if (!built || !str.trim()) return str;
+    let out = str.replace(built.regex, function (match) {
+      const repl = built.map[normalizePhrase(match)];
+      if (repl == null) return match; // safety: shouldn't happen
+      return applyCase(match, repl);
+    });
+    if (personaKey === "pirate") out = pirateFlourish(out);
+    return out;
+  }
+
+  window.UTG_personaTranslate = translate;
+
+  /* =================================================================
+     Generic page controller (gated on window.UTG_PERSONA_PAGE + mounts)
+     ================================================================= */
+
+  const CFG = window.UTG_PERSONA_PAGE;
+  if (!CFG) return;
+
+  let copyTimer = null;
+
+  // Clipboard copy with an execCommand fallback and a "Copied!" label swap,
+  // mirroring the copyText()/copyToClipboard helpers used elsewhere in the repo
+  // (js/printables/printablesEngine.js, usecase/zalgo-text). Standalone here.
+  function copyToClipboard(value, btn) {
+    const done = function () {
+      if (!btn) return;
+      if (btn.dataset.origLabel == null) btn.dataset.origLabel = btn.textContent;
+      btn.classList.add("is-copied");
+      btn.textContent = "Copied!";
+      if (copyTimer) clearTimeout(copyTimer);
+      copyTimer = setTimeout(function () {
+        btn.textContent = btn.dataset.origLabel;
+        btn.classList.remove("is-copied");
+      }, 1400);
+    };
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(value).then(done).catch(done);
+    } else {
+      const ta = document.createElement("textarea");
+      ta.value = value;
+      ta.style.position = "fixed";
+      ta.style.opacity = "0";
+      document.body.appendChild(ta);
+      ta.select();
+      try { document.execCommand("copy"); } catch (e) { /* noop */ }
+      document.body.removeChild(ta);
+      done();
+    }
+  }
+
+  function initController() {
+    const input = document.getElementById("persona-input");
+    const output = document.getElementById("persona-output");
+    if (!input || !output) return; // nothing to wire up on this page
+
+    const copyBtn = document.getElementById("persona-copy");
+    const clearBtn = document.getElementById("persona-clear");
+    const counter = document.getElementById("persona-count");
+    const key = CFG.key;
+    const demoText = CFG.demoText || "";
+    let currentOutput = "";
+
+    function render() {
+      const raw = input.value;
+      // Fall back to the demo sentence when the box is empty, so the page never
+      // shows a blank output on first load.
+      const source = (raw && raw.trim()) ? raw : demoText;
+      currentOutput = translate(source, key);
+      output.textContent = currentOutput;
+      if (counter) counter.textContent = String(input.value.length);
+    }
+
+    let timer = null;
+    input.addEventListener("input", function () {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(render, 120);
+    });
+
+    if (clearBtn) {
+      clearBtn.addEventListener("click", function () {
+        input.value = "";
+        render();
+        input.focus();
+      });
+    }
+
+    if (copyBtn) {
+      copyBtn.addEventListener("click", function () {
+        copyToClipboard(currentOutput, copyBtn);
+      });
+    }
+
+    render();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initController);
+  } else {
+    initController();
+  }
+})();

--- a/printables/best-friend-in-cursive/index.html
+++ b/printables/best-friend-in-cursive/index.html
@@ -1,0 +1,204 @@
+<!DOCTYPE html><html lang="en"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Best Friend in Cursive — Free Printable | UltraTextGen</title>
+  <meta name="description" content="See and print “Best Friend” in cursive — a ready-made worksheet to trace or download as a PNG for BFF notes, bracelets, and yearbooks. Free, no sign-up.">
+  <link rel="canonical" href="https://ultratextgen.com/printables/best-friend-in-cursive/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/best-friend-in-cursive/">
+  <meta property="og:title" content="Best Friend in Cursive — Free Printable | UltraTextGen">
+  <meta property="og:description" content="See “Best Friend” in flowing cursive script, print or trace it, or download a PNG — for BFF notes, friendship bracelets, and yearbook signing.">
+  <meta property="og:url" content="https://ultratextgen.com/printables/best-friend-in-cursive/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/printables-best-friend-in-cursive.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Best Friend in Cursive — Free Printable | UltraTextGen">
+  <meta name="twitter:description" content="See “Best Friend” in flowing cursive script, print or trace it, or download a PNG — for BFF notes, friendship bracelets, and yearbook signing.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/printables-best-friend-in-cursive.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ultratextgen.com/" },
+    { "@type": "ListItem", "position": 2, "name": "Printables", "item": "https://ultratextgen.com/printables/" },
+    { "@type": "ListItem", "position": 3, "name": "Best Friend in Cursive", "item": "https://ultratextgen.com/printables/best-friend-in-cursive/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "How do I write and print \"Best Friend\" in cursive?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The phrase Best Friend already appears in cursive in the preview on this page. Tap Print the worksheet for a page with a model row plus faded rows to trace, or Download PNG to save it as an image. Everything happens in your browser — no account and no watermark."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I use this for BFF notes, bracelets, or yearbook signing?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Trace the model row so \"Best Friend\" looks neat when you sign a yearbook or write a note, or download the PNG to plan a friendship-bracelet layout, a matching sticker, or a scrapbook page. Swap in \"Best Friends Forever\", \"BFF\", or your friend's name any time."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I type a different word instead?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. The input box is fully editable — clear it and type any name or phrase (up to 40 characters) and the on-screen preview, the printable worksheet, and the PNG download all update instantly."
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/">Home</a>
+  <span class="breadcrumb-separator">›</span>
+  <a href="/printables/">Printables</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Best Friend in Cursive</span>
+</nav>
+
+  <section class="hero">
+    <div class="hero-inner" style="max-width:820px;">
+      <h1 class="hero-headline">Best Friend in Cursive</h1>
+      <p class="hero-tagline">
+        See “Best Friend” written in elegant cursive script — print a ready-made tracing worksheet,
+        download it as a PNG, or type a friend’s name below.
+      </p>
+    </div>
+  </section>
+
+  <main class="container">
+
+    <section class="bubble-alphabet" aria-labelledby="ptNameHeading">
+      <h2 id="ptNameHeading">Print “Best Friend” in cursive</h2>
+      <p class="bubble-az-intro">A ready-made cursive worksheet for the phrase “Best Friend”, with a model row and faded rows to trace. Type a name or a different phrase any time — the preview, print, and PNG all update instantly.</p>
+      <div class="pt-name-tool">
+        <div class="input-wrapper">
+          <input type="text" class="main-input pt-name-input" id="pt-name-input" placeholder="Type a name or phrase…" maxlength="40" value="Best Friend">
+        </div>
+        <div class="pt-name-preview" id="pt-name-preview" aria-live="polite"></div>
+        <div class="bubble-actions pt-name-actions">
+          <button type="button" class="bubble-btn bubble-btn-primary" id="pt-name-print">Print the worksheet</button>
+          <button type="button" class="bubble-btn" id="pt-name-png">Download PNG</button>
+        </div>
+      </div>
+    </section>
+
+    <section class="editorial-section">
+      <h2>Best Friend in cursive for BFF notes and keepsakes</h2>
+      <p>“Best Friend” is a phrase that shows up everywhere between friends — passed notes, yearbook signatures, matching
+        stickers, and handmade cards. Cursive makes it feel personal and a little grown-up, and tracing the model row a few
+        times means you can write it cleanly by hand when it counts, like signing a yearbook or a keepsake card.</p>
+      <p>Download the PNG when you want the words as artwork: sketch out a friendship-bracelet pattern, add it to a scrapbook
+        spread, or drop it into a photo collage for a friend’s birthday. Want “Best Friends Forever”, “BFF”, or your friend’s
+        name instead? Type it in and the cursive redraws right away.</p>
+      <p>Want the full alphabet, or a name worksheet with more trace rows? Open the <a href="/printables/cursive-alphabet/">Cursive Alphabet &amp; Practice Sheets</a> tool. For copy-paste cursive text you can use in an Instagram bio or caption, try the <a href="/category/cursive-fonts/">cursive text generator</a>.</p>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <h2 class="faq-category">Best Friend in Cursive — FAQ</h2>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          How do I write and print "Best Friend" in cursive?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          The phrase Best Friend already appears in cursive in the preview on this page. Tap <strong>Print the worksheet</strong>
+          for a page with a model row plus faded rows to trace, or <strong>Download PNG</strong> to save it as an image.
+          Everything happens in your browser — no account and no watermark.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Can I use this for BFF notes, bracelets, or yearbook signing?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Yes. Trace the model row so “Best Friend” looks neat when you sign a yearbook or write a note, or download the PNG to
+          plan a friendship-bracelet layout, a matching sticker, or a scrapbook page. Swap in “Best Friends Forever”, “BFF”, or
+          your friend’s name any time.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Can I type a different word instead?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Yes. The input box is fully editable — clear it and type any name or phrase (up to 40 characters) and the on-screen
+          preview, the printable worksheet, and the PNG download all update instantly.
+        </div>
+      </div>
+
+    </div>
+  </footer>
+
+  <!-- Print surface (hidden on screen, isolated when printing) -->
+  <div id="pt-print-root" aria-hidden="true"></div>
+
+  <script>
+    window.UTG_PRINTABLE = {
+      key: "best-friend-in-cursive",
+      render: "glyph",
+      noun: "cursive",
+      pngPrefix: "cursive-best-friend-in-cursive",
+      font: "'Plus Jakarta Sans', 'Segoe UI Symbol', 'Noto Sans Symbols 2', sans-serif",
+      charset: "alpha",
+      variantFamily: "cursive",
+      glyphStyle: "Ultra Script",
+      nameDemo: "Best Friend"
+    };
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/js/printables/printablesEngine.js" defer></script>
+
+  <!-- FAQ toggle -->
+  <script>
+    document.querySelectorAll('.faq-question').forEach(function(btn) {
+      btn.addEventListener('click', function() { this.closest('.faq-item').classList.toggle('open'); });
+    });
+  </script>
+<script src="/footer.js" defer></script>
+</body></html>

--- a/printables/cross-stitch-letters/index.html
+++ b/printables/cross-stitch-letters/index.html
@@ -1,0 +1,293 @@
+<!DOCTYPE html><html lang="en"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cross-Stitch Letter Generator — Free Printable Charts | UltraTextGen</title>
+  <meta name="description" content="Turn any word or name into a printable cross-stitch pattern — a charted grid with a stitch-color legend. Download PNG or print. Free, no sign-up.">
+  <link rel="canonical" href="https://ultratextgen.com/printables/cross-stitch-letters/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/cross-stitch-letters/">
+  <meta property="og:title" content="Cross-Stitch Letter Generator — Free Printable Charts | UltraTextGen">
+  <meta property="og:description" content="Turn any word or name into a printable cross-stitch pattern — a charted grid with a stitch-color legend. Download PNG or print. Free, no sign-up.">
+  <meta property="og:url" content="https://ultratextgen.com/printables/cross-stitch-letters/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/printables-cross-stitch-letters.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Cross-Stitch Letter Generator — Free Printable Charts | UltraTextGen">
+  <meta name="twitter:description" content="Turn any word or name into a printable cross-stitch pattern — a charted grid with a stitch-color legend. Download PNG or print. Free, no sign-up.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/printables-cross-stitch-letters.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ultratextgen.com/" },
+    { "@type": "ListItem", "position": 2, "name": "Printables", "item": "https://ultratextgen.com/printables/" },
+    { "@type": "ListItem", "position": 3, "name": "Cross-Stitch Letters", "item": "https://ultratextgen.com/printables/cross-stitch-letters/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "How do I chart a name for cross-stitch?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Type the name into the box and it is charted instantly on a grid — one square for every stitch. Pick a thread color and a cross (X) or filled-square style, then use Print pattern or Download PNG to take the chart to your hoop."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What grid size does this use?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "It uses a classic 5×7 stitch alphabet — each letter is 5 columns wide and 7 rows tall. That is one of the most common sizes for cross-stitch letter charts: big enough to read cleanly and small enough to fit a whole name across a band or border."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I change the stitch color?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Choose from six thread-like colors — black, red, navy, forest green, plum, and gold. The chart, the legend, the printout, and the PNG all update to match the color you pick."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I print the pattern or save it as an image?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Print pattern opens your browser's print dialog showing just the chart, its title, and the legend — choose Save as PDF there to keep a copy. Download PNG saves a crisp image you can share, reprint, or drop into pattern software."
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/">Home</a>
+  <span class="breadcrumb-separator">›</span>
+  <a href="/printables/">Printables</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Cross-Stitch Letters</span>
+</nav>
+
+  <section class="hero">
+    <div class="hero-inner" style="max-width:820px;">
+      <h1 class="hero-headline">Cross-Stitch Letter Generator — Free Printable Charts</h1>
+      <p class="hero-tagline">
+        Type any word or name and get a printable cross-stitch pattern — a charted grid with a
+        stitch-color legend. Pick your thread color and cross or filled style, then print or download a PNG.
+        Free, no sign-up.
+      </p>
+    </div>
+  </section>
+
+  <main class="container">
+
+    <!-- Generator studio -->
+    <section class="bubble-alphabet" aria-labelledby="csHeading">
+      <h2 id="csHeading">Chart a word or name</h2>
+      <p class="bubble-az-intro">Type a word, choose a <strong>stitch color</strong> and a <strong>grid style</strong>, and the chart builds live on the right — one square per stitch on a classic 5×7 alphabet. Print it, save a PDF, or download a PNG. Free, no sign-up.</p>
+
+      <div class="pt-studio">
+        <!-- Controls -->
+        <div class="pt-studio-controls">
+          <div class="pt-field">
+            <label class="pt-field-label" for="cs-input">Word or name</label>
+            <div class="input-wrapper">
+              <input type="text" class="main-input" id="cs-input" placeholder="e.g. NOAH" maxlength="20" autocomplete="off" value="HOME">
+            </div>
+          </div>
+
+          <div class="pt-field">
+            <span class="pt-field-label">Stitch color</span>
+            <div class="pt-swatches" id="cs-color-group" role="radiogroup" aria-label="Stitch color">
+              <button type="button" class="pt-swatch is-active" data-value="#2b2b2b" role="radio" aria-checked="true"><span class="pt-swatch-art"></span><span class="pt-swatch-label">Black</span></button>
+              <button type="button" class="pt-swatch" data-value="#c0392b" role="radio" aria-checked="false"><span class="pt-swatch-art"></span><span class="pt-swatch-label">Red</span></button>
+              <button type="button" class="pt-swatch" data-value="#2c3e6b" role="radio" aria-checked="false"><span class="pt-swatch-art"></span><span class="pt-swatch-label">Navy</span></button>
+              <button type="button" class="pt-swatch" data-value="#3f6b3f" role="radio" aria-checked="false"><span class="pt-swatch-art"></span><span class="pt-swatch-label">Green</span></button>
+              <button type="button" class="pt-swatch" data-value="#6b3f6b" role="radio" aria-checked="false"><span class="pt-swatch-art"></span><span class="pt-swatch-label">Plum</span></button>
+              <button type="button" class="pt-swatch" data-value="#b8860b" role="radio" aria-checked="false"><span class="pt-swatch-art"></span><span class="pt-swatch-label">Gold</span></button>
+            </div>
+          </div>
+
+          <div class="pt-field">
+            <span class="pt-field-label">Grid style</span>
+            <div class="pt-swatches" id="cs-style-group" role="radiogroup" aria-label="Grid style">
+              <button type="button" class="pt-swatch is-active" data-value="x-stitch" role="radio" aria-checked="true"><span class="pt-swatch-art"></span><span class="pt-swatch-label">Cross</span></button>
+              <button type="button" class="pt-swatch" data-value="filled" role="radio" aria-checked="false"><span class="pt-swatch-art"></span><span class="pt-swatch-label">Filled</span></button>
+            </div>
+          </div>
+        </div>
+
+        <!-- Live preview -->
+        <div class="pt-studio-preview">
+          <div class="pt-preview-head">
+            <span class="pt-preview-tag">Live chart</span>
+            <span class="pt-preview-meta">print · PNG</span>
+          </div>
+          <div class="pt-paper">
+            <div id="cs-chart"></div>
+            <div id="cs-legend" aria-live="polite"></div>
+          </div>
+          <div class="pt-preview-actions">
+            <button type="button" class="bubble-btn bubble-btn-primary" id="cs-print">Print pattern</button>
+            <button type="button" class="bubble-btn" id="cs-png">Download PNG</button>
+          </div>
+          <p class="pt-preview-note">Runs entirely in your browser — nothing is uploaded. In the print dialog, choose “Save as PDF” to keep a copy.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Editorial -->
+    <section class="editorial-section">
+      <h2>How to cross-stitch a name or word</h2>
+      <p>Each letter here is drawn on a <strong>5×7 grid</strong>, where every filled square is one
+        cross-stitch — an X made from two diagonal stitches over a single square of fabric. Type a word or
+        name and the whole chart builds live, one square per stitch, with the exact column and row count in
+        the legend so you can plan where it lands.</p>
+      <h3>Reading the chart</h3>
+      <p>Work the chart left to right, and count out from the center of your fabric so the word ends up
+        where you want it. Each square on the grid is one X stitch; the <strong>Cross</strong> style shows
+        every stitch as an ✕, while <strong>Filled</strong> shows it as a solid block for a simpler,
+        pixel-art read. Use whichever is easier to follow while you stitch — the pattern is the same either way.</p>
+      <h3>Estimating the finished size</h3>
+      <p>Cross-stitch size depends on your fabric's <em>count</em> — the number of stitches per inch. To
+        estimate how wide your word will be, divide the chart's column count by your fabric's count. On
+        14-count Aida cloth there are 14 stitches to an inch, so a chart 23 columns wide works out to about
+        23 ÷ 14 ≈ 1.6 inches across; the seven rows are half an inch tall. Lower counts like 11-count come
+        out bigger per stitch, and higher counts like 18-count come out smaller — use the same simple division
+        for your own word and cloth.</p>
+      <p>Want a flowing script name instead of blocky charted letters? Try the
+        <a href="/printables/cursive-alphabet/">cursive practice sheets</a> or the copy-paste
+        <a href="/category/cursive-fonts/">cursive text generator</a>. You can also browse every sheet in the
+        <a href="/printables/">printables library</a>.</p>
+    </section>
+
+    <div class="cta-card">
+      <h3>Prefer a name you can copy and paste?</h3>
+      <p>Type once and copy flowing Unicode script for bios, captions, tags, and signatures — no image needed.</p>
+      <a class="cta-btn" href="/category/cursive-fonts/">Open the cursive text generator →</a>
+    </div>
+
+    <!-- Cross-family Navigation -->
+    <section class="related-pages">
+      <h2>Explore More</h2>
+      <div class="related-pages-grid">
+        <a href="/printables/bubble-letters/" class="related-page-card">
+          <span class="related-page-label">Printable</span>
+          <h4>Bubble letters</h4>
+        </a>
+        <a href="/printables/name-tracing/" class="related-page-card">
+          <span class="related-page-label">Printable</span>
+          <h4>Name tracing</h4>
+        </a>
+        <a href="/category/cursive-fonts/" class="related-page-card">
+          <span class="related-page-label">Generator</span>
+          <h4>Cursive text</h4>
+        </a>
+        <a href="/printables/" class="related-page-card">
+          <span class="related-page-label">Library</span>
+          <h4>All printables</h4>
+        </a>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <h2 class="faq-category">Cross-Stitch Letters — FAQ</h2>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          How do I chart a name for cross-stitch?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Type the name into the box and it is charted instantly on a grid — one square for every stitch.
+          Pick a thread color and a cross (X) or filled-square style, then use <strong>Print pattern</strong> or
+          <strong>Download PNG</strong> to take the chart to your hoop.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          What grid size does this use?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          It uses a classic 5×7 stitch alphabet — each letter is 5 columns wide and 7 rows tall. That is one of
+          the most common sizes for cross-stitch letter charts: big enough to read cleanly and small enough to
+          fit a whole name across a band or border.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Can I change the stitch color?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Yes. Choose from six thread-like colors — black, red, navy, forest green, plum, and gold. The chart,
+          the legend, the printout, and the PNG all update to match the color you pick.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Can I print the pattern or save it as an image?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Yes. <strong>Print pattern</strong> opens your browser's print dialog showing just the chart, its
+          title, and the legend — choose Save as PDF there to keep a copy. <strong>Download PNG</strong> saves a
+          crisp image you can share, reprint, or drop into pattern software.
+        </div>
+      </div>
+
+    </div>
+  </footer>
+
+  <!-- Print surface (hidden on screen, isolated when printing) -->
+  <div id="pt-print-root" aria-hidden="true"></div>
+
+  <script src="/js/printables/crossStitchEngine.js" defer></script>
+
+  <!-- FAQ toggle -->
+  <script>
+    document.querySelectorAll('.faq-question').forEach(function(btn) {
+      btn.addEventListener('click', function() { this.closest('.faq-item').classList.toggle('open'); });
+    });
+  </script>
+<script src="/footer.js" defer></script>
+</body></html>

--- a/printables/cursive-alphabet/index.html
+++ b/printables/cursive-alphabet/index.html
@@ -153,6 +153,7 @@
           <button type="button" class="bubble-btn" id="pt-name-png">Download PNG</button>
         </div>
       </div>
+      <p class="bubble-az-intro">Or start from a ready-made word: <a href="/printables/mom-in-cursive/">Mom</a>, <a href="/printables/dad-in-cursive/">Dad</a>, <a href="/printables/love-in-cursive/">Love</a>, <a href="/printables/happy-birthday-in-cursive/">Happy Birthday</a>, <a href="/printables/best-friend-in-cursive/">Best Friend</a>, and <a href="/printables/family-in-cursive/">Family</a> in cursive.</p>
     </section>
 
     <!-- Editorial -->

--- a/printables/dad-in-cursive/index.html
+++ b/printables/dad-in-cursive/index.html
@@ -1,0 +1,204 @@
+<!DOCTYPE html><html lang="en"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dad in Cursive — Free Printable | UltraTextGen</title>
+  <meta name="description" content="See and print “Dad” in cursive — a ready-made worksheet with a model row and trace rows, or type your own word. Great for Father’s Day cards. Free, no sign-up.">
+  <link rel="canonical" href="https://ultratextgen.com/printables/dad-in-cursive/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/dad-in-cursive/">
+  <meta property="og:title" content="Dad in Cursive — Free Printable | UltraTextGen">
+  <meta property="og:description" content="See “Dad” in flowing cursive script, print a tracing worksheet, or download a PNG. A quick front door for Father’s Day cards and gifts.">
+  <meta property="og:url" content="https://ultratextgen.com/printables/dad-in-cursive/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/printables-dad-in-cursive.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Dad in Cursive — Free Printable | UltraTextGen">
+  <meta name="twitter:description" content="See “Dad” in flowing cursive script, print a tracing worksheet, or download a PNG. A quick front door for Father’s Day cards and gifts.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/printables-dad-in-cursive.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ultratextgen.com/" },
+    { "@type": "ListItem", "position": 2, "name": "Printables", "item": "https://ultratextgen.com/printables/" },
+    { "@type": "ListItem", "position": 3, "name": "Dad in Cursive", "item": "https://ultratextgen.com/printables/dad-in-cursive/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "How do I write and print \"Dad\" in cursive?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The word Dad already appears in cursive in the preview on this page. Tap Print the worksheet for a page with a model row plus faded rows to trace by hand, or Download PNG to save it as an image. It all runs in your browser, with no sign-up or watermark."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I use this for a Father's Day card or gift?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Print the worksheet so a child can trace \"Dad\" onto a homemade Father's Day card, or use the PNG on a mug, gift tag, or garage-workshop sign. Prefer \"Daddy\", \"Papa\", or \"Grandpa\"? Type it into the box and the cursive updates instantly."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I type a different word instead?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. The input box is fully editable — clear it and type any name or word (up to 40 characters) and the on-screen preview, the printable worksheet, and the PNG download all update instantly."
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/">Home</a>
+  <span class="breadcrumb-separator">›</span>
+  <a href="/printables/">Printables</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Dad in Cursive</span>
+</nav>
+
+  <section class="hero">
+    <div class="hero-inner" style="max-width:820px;">
+      <h1 class="hero-headline">Dad in Cursive</h1>
+      <p class="hero-tagline">
+        See “Dad” written in elegant cursive script — print a ready-made tracing worksheet,
+        download it as a PNG, or type a different name below.
+      </p>
+    </div>
+  </section>
+
+  <main class="container">
+
+    <section class="bubble-alphabet" aria-labelledby="ptNameHeading">
+      <h2 id="ptNameHeading">Print “Dad” in cursive</h2>
+      <p class="bubble-az-intro">A ready-made cursive worksheet for the word “Dad”, with a model row and faded rows to trace. Type a different word or name any time — the preview, print, and PNG all update instantly.</p>
+      <div class="pt-name-tool">
+        <div class="input-wrapper">
+          <input type="text" class="main-input pt-name-input" id="pt-name-input" placeholder="Type a name or word…" maxlength="40" value="Dad">
+        </div>
+        <div class="pt-name-preview" id="pt-name-preview" aria-live="polite"></div>
+        <div class="bubble-actions pt-name-actions">
+          <button type="button" class="bubble-btn bubble-btn-primary" id="pt-name-print">Print the worksheet</button>
+          <button type="button" class="bubble-btn" id="pt-name-png">Download PNG</button>
+        </div>
+      </div>
+    </section>
+
+    <section class="editorial-section">
+      <h2>Dad in cursive for Father’s Day cards and crafts</h2>
+      <p>A short word like “Dad” is a perfect first cursive project, which is why it turns up on so many homemade Father’s Day
+        cards. Print the sheet and let a child trace the faded rows until the joins flow, then write it freehand on the front
+        of the card — the model row keeps every letter consistent.</p>
+      <p>Save the PNG when you want the word as a clean graphic for a mug, a keychain, a workshop or garage sign, or a photo
+        caption. Grandpa, Papa, or Daddy work just as well: clear the box, type the version you want, and the cursive preview,
+        worksheet, and download all follow along.</p>
+      <p>Want the full alphabet, or a name worksheet with more trace rows? Open the <a href="/printables/cursive-alphabet/">Cursive Alphabet &amp; Practice Sheets</a> tool. For copy-paste cursive text you can use in an Instagram bio or caption, try the <a href="/category/cursive-fonts/">cursive text generator</a>.</p>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <h2 class="faq-category">Dad in Cursive — FAQ</h2>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          How do I write and print "Dad" in cursive?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          The word Dad already appears in cursive in the preview on this page. Tap <strong>Print the worksheet</strong> for a
+          page with a model row plus faded rows to trace by hand, or <strong>Download PNG</strong> to save it as an image. It
+          all runs in your browser, with no sign-up or watermark.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Can I use this for a Father's Day card or gift?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Yes. Print the worksheet so a child can trace “Dad” onto a homemade Father’s Day card, or use the PNG on a mug, gift
+          tag, or garage-workshop sign. Prefer “Daddy”, “Papa”, or “Grandpa”? Type it into the box and the cursive updates
+          instantly.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Can I type a different word instead?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Yes. The input box is fully editable — clear it and type any name or word (up to 40 characters) and the on-screen
+          preview, the printable worksheet, and the PNG download all update instantly.
+        </div>
+      </div>
+
+    </div>
+  </footer>
+
+  <!-- Print surface (hidden on screen, isolated when printing) -->
+  <div id="pt-print-root" aria-hidden="true"></div>
+
+  <script>
+    window.UTG_PRINTABLE = {
+      key: "dad-in-cursive",
+      render: "glyph",
+      noun: "cursive",
+      pngPrefix: "cursive-dad-in-cursive",
+      font: "'Plus Jakarta Sans', 'Segoe UI Symbol', 'Noto Sans Symbols 2', sans-serif",
+      charset: "alpha",
+      variantFamily: "cursive",
+      glyphStyle: "Ultra Script",
+      nameDemo: "Dad"
+    };
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/js/printables/printablesEngine.js" defer></script>
+
+  <!-- FAQ toggle -->
+  <script>
+    document.querySelectorAll('.faq-question').forEach(function(btn) {
+      btn.addEventListener('click', function() { this.closest('.faq-item').classList.toggle('open'); });
+    });
+  </script>
+<script src="/footer.js" defer></script>
+</body></html>

--- a/printables/family-in-cursive/index.html
+++ b/printables/family-in-cursive/index.html
@@ -1,0 +1,204 @@
+<!DOCTYPE html><html lang="en"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Family in Cursive — Free Printable | UltraTextGen</title>
+  <meta name="description" content="See and print “Family” in cursive — a ready-made worksheet to trace or download as a PNG for wall signs, family-tree crafts, and decor. Free, no sign-up.">
+  <link rel="canonical" href="https://ultratextgen.com/printables/family-in-cursive/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/family-in-cursive/">
+  <meta property="og:title" content="Family in Cursive — Free Printable | UltraTextGen">
+  <meta property="og:description" content="See “Family” in flowing cursive script, print or trace it, or download a PNG — for home decor, wall signs, and family-tree crafts.">
+  <meta property="og:url" content="https://ultratextgen.com/printables/family-in-cursive/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/printables-family-in-cursive.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Family in Cursive — Free Printable | UltraTextGen">
+  <meta name="twitter:description" content="See “Family” in flowing cursive script, print or trace it, or download a PNG — for home decor, wall signs, and family-tree crafts.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/printables-family-in-cursive.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ultratextgen.com/" },
+    { "@type": "ListItem", "position": 2, "name": "Printables", "item": "https://ultratextgen.com/printables/" },
+    { "@type": "ListItem", "position": 3, "name": "Family in Cursive", "item": "https://ultratextgen.com/printables/family-in-cursive/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "How do I write and print \"Family\" in cursive?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The word Family already appears in cursive in the preview on this page. Tap Print the worksheet for a page with a model row plus faded rows to trace, or Download PNG to save a clean image for a craft or sign. It all runs in your browser, with no sign-up."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I use cursive \"Family\" for home decor or a family-tree craft?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Download the PNG for a printable wall sign, a gallery-wall frame, or the header of a family-tree or heritage craft, or trace the word onto a card or scrapbook page. You can also type your surname, like \"The Garcia Family\", and print that instead."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I type a different word instead?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. The input box is fully editable — clear it and type any name or word (up to 40 characters) and the on-screen preview, the printable worksheet, and the PNG download all update instantly."
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/">Home</a>
+  <span class="breadcrumb-separator">›</span>
+  <a href="/printables/">Printables</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Family in Cursive</span>
+</nav>
+
+  <section class="hero">
+    <div class="hero-inner" style="max-width:820px;">
+      <h1 class="hero-headline">Family in Cursive</h1>
+      <p class="hero-tagline">
+        See “Family” written in elegant cursive script — print a ready-made tracing worksheet,
+        download it as a PNG, or type your surname below.
+      </p>
+    </div>
+  </section>
+
+  <main class="container">
+
+    <section class="bubble-alphabet" aria-labelledby="ptNameHeading">
+      <h2 id="ptNameHeading">Print “Family” in cursive</h2>
+      <p class="bubble-az-intro">A ready-made cursive worksheet for the word “Family”, with a model row and faded rows to trace. Type a surname or a different word any time — the preview, print, and PNG all update instantly.</p>
+      <div class="pt-name-tool">
+        <div class="input-wrapper">
+          <input type="text" class="main-input pt-name-input" id="pt-name-input" placeholder="Type a name or word…" maxlength="40" value="Family">
+        </div>
+        <div class="pt-name-preview" id="pt-name-preview" aria-live="polite"></div>
+        <div class="bubble-actions pt-name-actions">
+          <button type="button" class="bubble-btn bubble-btn-primary" id="pt-name-print">Print the worksheet</button>
+          <button type="button" class="bubble-btn" id="pt-name-png">Download PNG</button>
+        </div>
+      </div>
+    </section>
+
+    <section class="editorial-section">
+      <h2>Family in cursive for home decor and keepsakes</h2>
+      <p>“Family” is a staple of home decor, and a flowing script gives it the warm, hand-lettered look that suits a living-room
+        wall or a gallery frame. Download the PNG and print it as a sign, a photo-wall header, or the title of a family-tree or
+        heritage craft — the cursive joins carry the sentiment better than plain block type.</p>
+      <p>For a more personal touch, trace the model row onto a card or scrapbook page, or type your surname — “The Garcia
+        Family” — and print that instead. The preview, worksheet, and download all follow whatever you type, so one page
+        covers the word and every name.</p>
+      <p>Want the full alphabet, or a name worksheet with more trace rows? Open the <a href="/printables/cursive-alphabet/">Cursive Alphabet &amp; Practice Sheets</a> tool. For copy-paste cursive text you can use in an Instagram bio or caption, try the <a href="/category/cursive-fonts/">cursive text generator</a>.</p>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <h2 class="faq-category">Family in Cursive — FAQ</h2>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          How do I write and print "Family" in cursive?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          The word Family already appears in cursive in the preview on this page. Tap <strong>Print the worksheet</strong> for a
+          page with a model row plus faded rows to trace, or <strong>Download PNG</strong> to save a clean image for a craft or
+          sign. It all runs in your browser, with no sign-up.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Can I use cursive "Family" for home decor or a family-tree craft?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Yes. Download the PNG for a printable wall sign, a gallery-wall frame, or the header of a family-tree or heritage
+          craft, or trace the word onto a card or scrapbook page. You can also type your surname, like “The Garcia Family”, and
+          print that instead.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Can I type a different word instead?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Yes. The input box is fully editable — clear it and type any name or word (up to 40 characters) and the on-screen
+          preview, the printable worksheet, and the PNG download all update instantly.
+        </div>
+      </div>
+
+    </div>
+  </footer>
+
+  <!-- Print surface (hidden on screen, isolated when printing) -->
+  <div id="pt-print-root" aria-hidden="true"></div>
+
+  <script>
+    window.UTG_PRINTABLE = {
+      key: "family-in-cursive",
+      render: "glyph",
+      noun: "cursive",
+      pngPrefix: "cursive-family-in-cursive",
+      font: "'Plus Jakarta Sans', 'Segoe UI Symbol', 'Noto Sans Symbols 2', sans-serif",
+      charset: "alpha",
+      variantFamily: "cursive",
+      glyphStyle: "Ultra Script",
+      nameDemo: "Family"
+    };
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/js/printables/printablesEngine.js" defer></script>
+
+  <!-- FAQ toggle -->
+  <script>
+    document.querySelectorAll('.faq-question').forEach(function(btn) {
+      btn.addEventListener('click', function() { this.closest('.faq-item').classList.toggle('open'); });
+    });
+  </script>
+<script src="/footer.js" defer></script>
+</body></html>

--- a/printables/happy-birthday-in-cursive/index.html
+++ b/printables/happy-birthday-in-cursive/index.html
@@ -1,0 +1,204 @@
+<!DOCTYPE html><html lang="en"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Happy Birthday in Cursive — Free Printable | UltraTextGen</title>
+  <meta name="description" content="See and print “Happy Birthday” in cursive — a ready-made worksheet you can trace or download as a PNG for cards and banners. Type any name too. Free, no sign-up.">
+  <link rel="canonical" href="https://ultratextgen.com/printables/happy-birthday-in-cursive/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/happy-birthday-in-cursive/">
+  <meta property="og:title" content="Happy Birthday in Cursive — Free Printable | UltraTextGen">
+  <meta property="og:description" content="See “Happy Birthday” in flowing cursive script, print or trace it, or download a PNG for birthday cards, banners, and cake toppers.">
+  <meta property="og:url" content="https://ultratextgen.com/printables/happy-birthday-in-cursive/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/printables-happy-birthday-in-cursive.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Happy Birthday in Cursive — Free Printable | UltraTextGen">
+  <meta name="twitter:description" content="See “Happy Birthday” in flowing cursive script, print or trace it, or download a PNG for birthday cards, banners, and cake toppers.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/printables-happy-birthday-in-cursive.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ultratextgen.com/" },
+    { "@type": "ListItem", "position": 2, "name": "Printables", "item": "https://ultratextgen.com/printables/" },
+    { "@type": "ListItem", "position": 3, "name": "Happy Birthday in Cursive", "item": "https://ultratextgen.com/printables/happy-birthday-in-cursive/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "How do I write and print \"Happy Birthday\" in cursive?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The phrase Happy Birthday already appears in cursive in the preview on this page. Tap Print the worksheet for a page with a model row plus faded rows to trace, or Download PNG to save it as an image for a card. It runs entirely in your browser, with no sign-up."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I use this on a birthday card, banner, or cake topper?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Download the PNG and use it as a card headline, print it large for a wall banner, or scale it down for a cake topper or gift tag. To personalize it, type \"Happy Birthday Emma\" or the person's name and the cursive updates instantly before you print."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I type a different word instead?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. The input box is fully editable — clear it and type any name, greeting, or phrase (up to 40 characters) and the on-screen preview, the printable worksheet, and the PNG download all update instantly."
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/">Home</a>
+  <span class="breadcrumb-separator">›</span>
+  <a href="/printables/">Printables</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Happy Birthday in Cursive</span>
+</nav>
+
+  <section class="hero">
+    <div class="hero-inner" style="max-width:820px;">
+      <h1 class="hero-headline">Happy Birthday in Cursive</h1>
+      <p class="hero-tagline">
+        See “Happy Birthday” written in elegant cursive script — print a ready-made tracing worksheet,
+        download it as a PNG, or type a name below.
+      </p>
+    </div>
+  </section>
+
+  <main class="container">
+
+    <section class="bubble-alphabet" aria-labelledby="ptNameHeading">
+      <h2 id="ptNameHeading">Print “Happy Birthday” in cursive</h2>
+      <p class="bubble-az-intro">A ready-made cursive worksheet for the phrase “Happy Birthday”, with a model row and faded rows to trace. Type a name or a different greeting any time — the preview, print, and PNG all update instantly.</p>
+      <div class="pt-name-tool">
+        <div class="input-wrapper">
+          <input type="text" class="main-input pt-name-input" id="pt-name-input" placeholder="Type a name or greeting…" maxlength="40" value="Happy Birthday">
+        </div>
+        <div class="pt-name-preview" id="pt-name-preview" aria-live="polite"></div>
+        <div class="bubble-actions pt-name-actions">
+          <button type="button" class="bubble-btn bubble-btn-primary" id="pt-name-print">Print the worksheet</button>
+          <button type="button" class="bubble-btn" id="pt-name-png">Download PNG</button>
+        </div>
+      </div>
+    </section>
+
+    <section class="editorial-section">
+      <h2>Happy Birthday in cursive for cards and banners</h2>
+      <p>“Happy Birthday” is the phrase people most want in a pretty script, and cursive gives a homemade card that little bit
+        of polish. Trace the model row for a hand-lettered greeting inside a card, or download the PNG and set it as the big
+        headline on the front — the flowing joins read as celebratory without any clip-art.</p>
+      <p>Scaled up, the same image works as a party banner or backdrop sign; scaled down, it becomes a cake topper or a gift
+        tag. Add the birthday person’s name — type “Happy Birthday Emma” — and the whole phrase re-renders in cursive before
+        you print, so the card feels made for them.</p>
+      <p>Want the full alphabet, or a name worksheet with more trace rows? Open the <a href="/printables/cursive-alphabet/">Cursive Alphabet &amp; Practice Sheets</a> tool. For copy-paste cursive text you can use in an Instagram bio or caption, try the <a href="/category/cursive-fonts/">cursive text generator</a>.</p>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <h2 class="faq-category">Happy Birthday in Cursive — FAQ</h2>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          How do I write and print "Happy Birthday" in cursive?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          The phrase Happy Birthday already appears in cursive in the preview on this page. Tap <strong>Print the worksheet</strong>
+          for a page with a model row plus faded rows to trace, or <strong>Download PNG</strong> to save it as an image for a
+          card. It runs entirely in your browser, with no sign-up.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Can I use this on a birthday card, banner, or cake topper?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Yes. Download the PNG and use it as a card headline, print it large for a wall banner, or scale it down for a cake
+          topper or gift tag. To personalize it, type “Happy Birthday Emma” or the person’s name and the cursive updates
+          instantly before you print.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Can I type a different word instead?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Yes. The input box is fully editable — clear it and type any name, greeting, or phrase (up to 40 characters) and the
+          on-screen preview, the printable worksheet, and the PNG download all update instantly.
+        </div>
+      </div>
+
+    </div>
+  </footer>
+
+  <!-- Print surface (hidden on screen, isolated when printing) -->
+  <div id="pt-print-root" aria-hidden="true"></div>
+
+  <script>
+    window.UTG_PRINTABLE = {
+      key: "happy-birthday-in-cursive",
+      render: "glyph",
+      noun: "cursive",
+      pngPrefix: "cursive-happy-birthday-in-cursive",
+      font: "'Plus Jakarta Sans', 'Segoe UI Symbol', 'Noto Sans Symbols 2', sans-serif",
+      charset: "alpha",
+      variantFamily: "cursive",
+      glyphStyle: "Ultra Script",
+      nameDemo: "Happy Birthday"
+    };
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/js/printables/printablesEngine.js" defer></script>
+
+  <!-- FAQ toggle -->
+  <script>
+    document.querySelectorAll('.faq-question').forEach(function(btn) {
+      btn.addEventListener('click', function() { this.closest('.faq-item').classList.toggle('open'); });
+    });
+  </script>
+<script src="/footer.js" defer></script>
+</body></html>

--- a/printables/index.html
+++ b/printables/index.html
@@ -56,7 +56,9 @@
       { "@type": "ListItem", "position": 9, "name": "Sight Word Tracing Worksheets", "url": "https://ultratextgen.com/printables/sight-word-tracing/" },
       { "@type": "ListItem", "position": 10, "name": "Name Puzzle Maker", "url": "https://ultratextgen.com/printables/name-puzzle-maker/" },
       { "@type": "ListItem", "position": 11, "name": "Dot-to-Dot Alphabet", "url": "https://ultratextgen.com/printables/dot-to-dot-alphabet/" },
-      { "@type": "ListItem", "position": 12, "name": "Printable Banner Maker", "url": "https://ultratextgen.com/printables/banner-maker/" }
+      { "@type": "ListItem", "position": 12, "name": "Printable Banner Maker", "url": "https://ultratextgen.com/printables/banner-maker/" },
+      { "@type": "ListItem", "position": 13, "name": "Monogram Maker", "url": "https://ultratextgen.com/printables/monogram-maker/" },
+      { "@type": "ListItem", "position": 14, "name": "Cross-Stitch Letter Generator", "url": "https://ultratextgen.com/printables/cross-stitch-letters/" }
     ]
   }
 }
@@ -235,6 +237,20 @@
           <h3>Printable Banner Maker</h3>
           <p>Type a word or phrase to build a letter banner — one cut-out flag per letter with a dashed cut line and string holes. Long phrases paginate across sheets automatically.</p>
           <span class="printable-card-cta">Open the banner maker →</span>
+        </a>
+
+        <a class="printable-card" href="/printables/monogram-maker/">
+          <span class="printable-card-art" aria-hidden="true">J·S·L</span>
+          <h3>Monogram Maker</h3>
+          <p>Turn up to 3 initials into a printable monogram — classic three-letter, stacked, or circle-frame layouts, in solid or outline style. Download PNG or print.</p>
+          <span class="printable-card-cta">Open the monogram maker →</span>
+        </a>
+
+        <a class="printable-card" href="/printables/cross-stitch-letters/">
+          <span class="printable-card-art" aria-hidden="true">✕ ✕ ✕</span>
+          <h3>Cross-Stitch Letter Generator</h3>
+          <p>Type any word or name to chart it as a printable cross-stitch pattern — a 5×7 stitch grid with a color legend and stitch count. Download PNG or print.</p>
+          <span class="printable-card-cta">Open the cross-stitch generator →</span>
         </a>
 
       </div>

--- a/printables/love-in-cursive/index.html
+++ b/printables/love-in-cursive/index.html
@@ -1,0 +1,204 @@
+<!DOCTYPE html><html lang="en"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Love in Cursive — Free Printable | UltraTextGen</title>
+  <meta name="description" content="See and print “Love” in cursive — a ready-made worksheet with a model row and trace rows, or type your own word. Ideal for Valentine’s cards. Free, no sign-up.">
+  <link rel="canonical" href="https://ultratextgen.com/printables/love-in-cursive/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/love-in-cursive/">
+  <meta property="og:title" content="Love in Cursive — Free Printable | UltraTextGen">
+  <meta property="og:description" content="See “Love” in flowing cursive script, print a tracing worksheet, or download a PNG — for Valentine’s cards, wedding decor, and scrapbooks.">
+  <meta property="og:url" content="https://ultratextgen.com/printables/love-in-cursive/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/printables-love-in-cursive.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Love in Cursive — Free Printable | UltraTextGen">
+  <meta name="twitter:description" content="See “Love” in flowing cursive script, print a tracing worksheet, or download a PNG — for Valentine’s cards, wedding decor, and scrapbooks.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/printables-love-in-cursive.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ultratextgen.com/" },
+    { "@type": "ListItem", "position": 2, "name": "Printables", "item": "https://ultratextgen.com/printables/" },
+    { "@type": "ListItem", "position": 3, "name": "Love in Cursive", "item": "https://ultratextgen.com/printables/love-in-cursive/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "How do I write and print \"Love\" in cursive?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The word Love already appears in cursive in the preview on this page. Tap Print the worksheet for a page with a model row plus faded rows to trace, or Download PNG to save a clean image you can print or reuse. No sign-up and no watermark."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I use cursive \"Love\" for Valentine's cards or wedding decor?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. The flowing script suits romantic projects — print or trace it onto a Valentine's card, use the PNG on a wedding sign, table place card, or invitation, or add it to a scrapbook or framed print. You can also type a couple's names or \"I love you\" instead."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I type a different word instead?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. The input box is fully editable — clear it and type any name or word (up to 40 characters) and the on-screen preview, the printable worksheet, and the PNG download all update instantly."
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/">Home</a>
+  <span class="breadcrumb-separator">›</span>
+  <a href="/printables/">Printables</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Love in Cursive</span>
+</nav>
+
+  <section class="hero">
+    <div class="hero-inner" style="max-width:820px;">
+      <h1 class="hero-headline">Love in Cursive</h1>
+      <p class="hero-tagline">
+        See “Love” written in elegant cursive script — print a ready-made tracing worksheet,
+        download it as a PNG, or type a different word below.
+      </p>
+    </div>
+  </section>
+
+  <main class="container">
+
+    <section class="bubble-alphabet" aria-labelledby="ptNameHeading">
+      <h2 id="ptNameHeading">Print “Love” in cursive</h2>
+      <p class="bubble-az-intro">A ready-made cursive worksheet for the word “Love”, with a model row and faded rows to trace. Type a different word or name any time — the preview, print, and PNG all update instantly.</p>
+      <div class="pt-name-tool">
+        <div class="input-wrapper">
+          <input type="text" class="main-input pt-name-input" id="pt-name-input" placeholder="Type a name or word…" maxlength="40" value="Love">
+        </div>
+        <div class="pt-name-preview" id="pt-name-preview" aria-live="polite"></div>
+        <div class="bubble-actions pt-name-actions">
+          <button type="button" class="bubble-btn bubble-btn-primary" id="pt-name-print">Print the worksheet</button>
+          <button type="button" class="bubble-btn" id="pt-name-png">Download PNG</button>
+        </div>
+      </div>
+    </section>
+
+    <section class="editorial-section">
+      <h2>Love in cursive for Valentine’s cards and wedding decor</h2>
+      <p>Few words carry as well in script as “Love” — the long lower-case joins give it a romantic, hand-lettered feel that
+        printed block type never has. Trace the model row for a Valentine’s card or a little love note, or lift the word
+        straight from the download for a wedding welcome sign, place cards, and invitation accents.</p>
+      <p>Because the PNG is a clean, transparent-free image, it drops neatly into scrapbook layouts, framed prints, and photo
+        captions. Want a couple’s names, “I love you”, or “xoxo” instead? Type it in and the cursive preview, worksheet, and
+        download refresh right away.</p>
+      <p>Want the full alphabet, or a name worksheet with more trace rows? Open the <a href="/printables/cursive-alphabet/">Cursive Alphabet &amp; Practice Sheets</a> tool. For copy-paste cursive text you can use in an Instagram bio or caption, try the <a href="/category/cursive-fonts/">cursive text generator</a>.</p>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <h2 class="faq-category">Love in Cursive — FAQ</h2>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          How do I write and print "Love" in cursive?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          The word Love already appears in cursive in the preview on this page. Tap <strong>Print the worksheet</strong> for a
+          page with a model row plus faded rows to trace, or <strong>Download PNG</strong> to save a clean image you can print
+          or reuse. No sign-up and no watermark.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Can I use cursive "Love" for Valentine's cards or wedding decor?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Yes. The flowing script suits romantic projects — print or trace it onto a Valentine’s card, use the PNG on a wedding
+          sign, table place card, or invitation, or add it to a scrapbook or framed print. You can also type a couple’s names
+          or “I love you” instead.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Can I type a different word instead?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Yes. The input box is fully editable — clear it and type any name or word (up to 40 characters) and the on-screen
+          preview, the printable worksheet, and the PNG download all update instantly.
+        </div>
+      </div>
+
+    </div>
+  </footer>
+
+  <!-- Print surface (hidden on screen, isolated when printing) -->
+  <div id="pt-print-root" aria-hidden="true"></div>
+
+  <script>
+    window.UTG_PRINTABLE = {
+      key: "love-in-cursive",
+      render: "glyph",
+      noun: "cursive",
+      pngPrefix: "cursive-love-in-cursive",
+      font: "'Plus Jakarta Sans', 'Segoe UI Symbol', 'Noto Sans Symbols 2', sans-serif",
+      charset: "alpha",
+      variantFamily: "cursive",
+      glyphStyle: "Ultra Script",
+      nameDemo: "Love"
+    };
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/js/printables/printablesEngine.js" defer></script>
+
+  <!-- FAQ toggle -->
+  <script>
+    document.querySelectorAll('.faq-question').forEach(function(btn) {
+      btn.addEventListener('click', function() { this.closest('.faq-item').classList.toggle('open'); });
+    });
+  </script>
+<script src="/footer.js" defer></script>
+</body></html>

--- a/printables/mom-in-cursive/index.html
+++ b/printables/mom-in-cursive/index.html
@@ -1,0 +1,204 @@
+<!DOCTYPE html><html lang="en"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Mom in Cursive — Free Printable | UltraTextGen</title>
+  <meta name="description" content="See and print “Mom” in cursive — a ready-made worksheet with a model row and trace rows, or type your own word. Perfect for Mother’s Day cards. Free, no sign-up.">
+  <link rel="canonical" href="https://ultratextgen.com/printables/mom-in-cursive/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/mom-in-cursive/">
+  <meta property="og:title" content="Mom in Cursive — Free Printable | UltraTextGen">
+  <meta property="og:description" content="See “Mom” in flowing cursive script, print a tracing worksheet, or download a PNG. A quick front door for Mother’s Day cards and gifts.">
+  <meta property="og:url" content="https://ultratextgen.com/printables/mom-in-cursive/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/printables-mom-in-cursive.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Mom in Cursive — Free Printable | UltraTextGen">
+  <meta name="twitter:description" content="See “Mom” in flowing cursive script, print a tracing worksheet, or download a PNG. A quick front door for Mother’s Day cards and gifts.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/printables-mom-in-cursive.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ultratextgen.com/" },
+    { "@type": "ListItem", "position": 2, "name": "Printables", "item": "https://ultratextgen.com/printables/" },
+    { "@type": "ListItem", "position": 3, "name": "Mom in Cursive", "item": "https://ultratextgen.com/printables/mom-in-cursive/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "How do I write and print \"Mom\" in cursive?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The word Mom already appears in cursive in the preview on this page. Tap Print the worksheet for a page with a model row plus faded rows to trace by hand, or Download PNG to save it as an image you can drop into a card. Everything runs in your browser — no sign-up."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is this good for a Mother's Day card?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes — that is exactly what most people use it for. Print the worksheet so a child can trace the word neatly onto a homemade Mother's Day card, or download the PNG and add it to a gift tag, framed print, or photo caption. You can also swap in \"Mommy\", \"Mum\", or her name."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I type a different word instead?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. The input box is fully editable — clear it and type any name or word (up to 40 characters) and the on-screen preview, the printable worksheet, and the PNG download all update instantly."
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/">Home</a>
+  <span class="breadcrumb-separator">›</span>
+  <a href="/printables/">Printables</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Mom in Cursive</span>
+</nav>
+
+  <section class="hero">
+    <div class="hero-inner" style="max-width:820px;">
+      <h1 class="hero-headline">Mom in Cursive</h1>
+      <p class="hero-tagline">
+        See “Mom” written in elegant cursive script — print a ready-made tracing worksheet,
+        download it as a PNG, or type a different name below.
+      </p>
+    </div>
+  </section>
+
+  <main class="container">
+
+    <section class="bubble-alphabet" aria-labelledby="ptNameHeading">
+      <h2 id="ptNameHeading">Print “Mom” in cursive</h2>
+      <p class="bubble-az-intro">A ready-made cursive worksheet for the word “Mom”, with a model row and faded rows to trace. Type a different word or name any time — the preview, print, and PNG all update instantly.</p>
+      <div class="pt-name-tool">
+        <div class="input-wrapper">
+          <input type="text" class="main-input pt-name-input" id="pt-name-input" placeholder="Type a name or word…" maxlength="40" value="Mom">
+        </div>
+        <div class="pt-name-preview" id="pt-name-preview" aria-live="polite"></div>
+        <div class="bubble-actions pt-name-actions">
+          <button type="button" class="bubble-btn bubble-btn-primary" id="pt-name-print">Print the worksheet</button>
+          <button type="button" class="bubble-btn" id="pt-name-png">Download PNG</button>
+        </div>
+      </div>
+    </section>
+
+    <section class="editorial-section">
+      <h2>Mom in cursive for Mother’s Day cards and gifts</h2>
+      <p>“Mom” is one of the most-written words in any home craft, and it looks its warmest in a flowing script. Use the
+        model row above as a guide for a handmade Mother’s Day card, a framed keepsake, or a gift tag — a child can trace
+        the faded rows to write it neatly themselves, which turns a plain card into something she keeps.</p>
+      <p>Download the PNG when you want the word as a clean image: drop it onto a photo collage, a mug design, or the front of
+        a scrapbook page. Prefer “Mommy”, “Mum”, or her actual name? Clear the box and type it — the cursive preview,
+        worksheet, and download update on the spot.</p>
+      <p>Want the full alphabet, or a name worksheet with more trace rows? Open the <a href="/printables/cursive-alphabet/">Cursive Alphabet &amp; Practice Sheets</a> tool. For copy-paste cursive text you can use in an Instagram bio or caption, try the <a href="/category/cursive-fonts/">cursive text generator</a>.</p>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <h2 class="faq-category">Mom in Cursive — FAQ</h2>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          How do I write and print "Mom" in cursive?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          The word Mom already appears in cursive in the preview on this page. Tap <strong>Print the worksheet</strong> for a
+          page with a model row plus faded rows to trace by hand, or <strong>Download PNG</strong> to save it as an image you
+          can drop into a card. Everything runs in your browser — no sign-up.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Is this good for a Mother's Day card?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Yes — that is exactly what most people use it for. Print the worksheet so a child can trace the word neatly onto a
+          homemade Mother’s Day card, or download the PNG and add it to a gift tag, framed print, or photo caption. You can
+          also swap in “Mommy”, “Mum”, or her name.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Can I type a different word instead?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Yes. The input box is fully editable — clear it and type any name or word (up to 40 characters) and the on-screen
+          preview, the printable worksheet, and the PNG download all update instantly.
+        </div>
+      </div>
+
+    </div>
+  </footer>
+
+  <!-- Print surface (hidden on screen, isolated when printing) -->
+  <div id="pt-print-root" aria-hidden="true"></div>
+
+  <script>
+    window.UTG_PRINTABLE = {
+      key: "mom-in-cursive",
+      render: "glyph",
+      noun: "cursive",
+      pngPrefix: "cursive-mom-in-cursive",
+      font: "'Plus Jakarta Sans', 'Segoe UI Symbol', 'Noto Sans Symbols 2', sans-serif",
+      charset: "alpha",
+      variantFamily: "cursive",
+      glyphStyle: "Ultra Script",
+      nameDemo: "Mom"
+    };
+  </script>
+  <script src="/styles.js" defer></script>
+  <script src="/renderer.js" defer></script>
+  <script src="/js/printables/printablesEngine.js" defer></script>
+
+  <!-- FAQ toggle -->
+  <script>
+    document.querySelectorAll('.faq-question').forEach(function(btn) {
+      btn.addEventListener('click', function() { this.closest('.faq-item').classList.toggle('open'); });
+    });
+  </script>
+<script src="/footer.js" defer></script>
+</body></html>

--- a/printables/monogram-maker/index.html
+++ b/printables/monogram-maker/index.html
@@ -1,0 +1,289 @@
+<!DOCTYPE html><html lang="en"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Monogram Maker — Free Printable Initial Monograms | UltraTextGen</title>
+  <meta name="description" content="Turn up to 3 initials into a printable monogram — classic three-letter, stacked, or circle-frame layouts. Download PNG or print. Free, no sign-up.">
+  <link rel="canonical" href="https://ultratextgen.com/printables/monogram-maker/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/monogram-maker/">
+  <meta property="og:title" content="Monogram Maker — Free Printable Initial Monograms | UltraTextGen">
+  <meta property="og:description" content="Turn up to 3 initials into a printable monogram — classic three-letter, stacked, or circle-frame layouts. Download PNG or print. Free, no sign-up.">
+  <meta property="og:url" content="https://ultratextgen.com/printables/monogram-maker/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/printables-monogram-maker.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Monogram Maker — Free Printable Initial Monograms | UltraTextGen">
+  <meta name="twitter:description" content="Turn up to 3 initials into a printable monogram — classic, stacked, or circle-frame layouts. Download PNG or print. Free, no sign-up.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/printables-monogram-maker.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@500;700;900&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ultratextgen.com/" },
+    { "@type": "ListItem", "position": 2, "name": "Printables", "item": "https://ultratextgen.com/printables/" },
+    { "@type": "ListItem", "position": 3, "name": "Monogram Maker", "item": "https://ultratextgen.com/printables/monogram-maker/" }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Monogram Maker",
+  "url": "https://ultratextgen.com/printables/monogram-maker/",
+  "applicationCategory": "DesignApplication",
+  "operatingSystem": "Any (web browser)",
+  "browserRequirements": "Requires JavaScript",
+  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+  "featureList": [
+    "Turn up to three initials into a monogram",
+    "Classic three-letter, stacked, and circle-frame layouts",
+    "Solid or traceable outline styles",
+    "Print a full page or download a high-resolution PNG",
+    "Runs entirely in the browser — no sign-up or watermark"
+  ],
+  "description": "Free in-browser monogram maker. Type up to three initials and see them rendered live as a classic three-letter, stacked, or circle-frame monogram in a solid or traceable outline style. Print the monogram or download a 1600x1600 PNG. Everything is generated client-side as SVG and Canvas — no sign-up or watermark."
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "How do I make a printable monogram?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Type one, two, or three initials into the boxes, then pick a layout (classic three-letter, stacked, or circle frame) and a style (solid or outline). The monogram builds live in your browser as you type. Press Print monogram for a full-page print, or Download PNG to save a high-resolution image. There is no sign-up, watermark, or limit."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What's the difference between the three monogram layouts?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Classic three-letter puts a large center initial between two smaller ones on a single baseline — the traditional look for weddings, stationery, and gifts, where the center letter is usually the last-name initial. Stacked places the initials vertically at one size for a compact mark that suits stickers, labels, and small spaces. Circle frame centers the initials inside a double ring for a stamp, badge, or wax-seal look."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I print or save the monogram as an image?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Print monogram opens your browser's print dialog with just the monogram and a title on the page — choose Save as PDF there to keep a file. Download PNG saves a high-resolution 1600 by 1600 pixel PNG on a white background that you can print, share, or drop into another design."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Unicode used to render the monogram?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. Unlike the site's copy-paste font generators, the monogram maker draws the letters in a real serif typeface (Playfair Display) as native SVG and Canvas, not Unicode characters. So it is not a copy-paste string you can drop into a bio or username — it is a visual you print or download as an image. For copy-paste initials or names, use the font generators instead."
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/">Home</a>
+  <span class="breadcrumb-separator">›</span>
+  <a href="/printables/">Printables</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Monogram Maker</span>
+</nav>
+
+  <section class="hero">
+    <div class="hero-inner" style="max-width:820px;">
+      <h1 class="hero-headline">Monogram Maker — Free Printable Initials</h1>
+      <p class="hero-tagline">
+        Turn up to three initials into a monogram in seconds. Choose a classic
+        three-letter, stacked, or circle-frame layout in a solid or traceable
+        outline style, watch it build live, then print it or download a PNG.
+        Free, no sign-up.
+      </p>
+    </div>
+  </section>
+
+  <main class="container">
+
+    <!-- Monogram studio (primary tool) -->
+    <section class="bubble-alphabet" aria-labelledby="monoHeading">
+      <h2 id="monoHeading">Make your monogram</h2>
+      <p class="bubble-az-intro">Type one, two, or three initials, pick a layout and a style, and your monogram builds live on the right. Print it or download a PNG — free, no sign-up.</p>
+
+      <div class="pt-studio">
+        <!-- Controls -->
+        <div class="pt-studio-controls">
+          <div class="pt-field">
+            <span class="pt-field-label">Initials <span class="pt-field-opt">— up to three</span></span>
+            <div class="pt-field-inline">
+              <span class="pt-opt" style="flex-direction:column;align-items:center;gap:0.35rem;">
+                <label for="mono-left">Left initial</label>
+                <input type="text" id="mono-left" class="main-input pt-design-input" maxlength="1" value="J" autocomplete="off" aria-label="Left initial" style="width:80px;padding:0;text-align:center;font-size:1.5rem;">
+              </span>
+              <span class="pt-opt" style="flex-direction:column;align-items:center;gap:0.35rem;">
+                <label for="mono-center">Center initial</label>
+                <input type="text" id="mono-center" class="main-input pt-design-input" maxlength="1" value="S" autocomplete="off" aria-label="Center initial" style="width:80px;padding:0;text-align:center;font-size:1.5rem;">
+              </span>
+              <span class="pt-opt" style="flex-direction:column;align-items:center;gap:0.35rem;">
+                <label for="mono-right">Right initial</label>
+                <input type="text" id="mono-right" class="main-input pt-design-input" maxlength="1" value="L" autocomplete="off" aria-label="Right initial" style="width:80px;padding:0;text-align:center;font-size:1.5rem;">
+              </span>
+            </div>
+          </div>
+
+          <div class="pt-field">
+            <span class="pt-field-label">Layout</span>
+            <div class="pt-swatches" id="mono-layout-group" role="radiogroup" aria-label="Monogram layout">
+              <button type="button" class="pt-swatch is-active" data-value="classic" role="radio" aria-checked="true"><span class="pt-swatch-art"></span><span class="pt-swatch-label">Classic</span></button>
+              <button type="button" class="pt-swatch" data-value="stacked" role="radio" aria-checked="false"><span class="pt-swatch-art"></span><span class="pt-swatch-label">Stacked</span></button>
+              <button type="button" class="pt-swatch" data-value="circle" role="radio" aria-checked="false"><span class="pt-swatch-art"></span><span class="pt-swatch-label">Circle</span></button>
+            </div>
+          </div>
+
+          <div class="pt-field">
+            <span class="pt-field-label">Style</span>
+            <div class="pt-swatches" id="mono-style-group" role="radiogroup" aria-label="Monogram style">
+              <button type="button" class="pt-swatch is-active" data-value="solid" role="radio" aria-checked="true"><span class="pt-swatch-art"></span><span class="pt-swatch-label">Solid</span></button>
+              <button type="button" class="pt-swatch" data-value="outline" role="radio" aria-checked="false"><span class="pt-swatch-art"></span><span class="pt-swatch-label">Outline</span></button>
+            </div>
+          </div>
+        </div>
+
+        <!-- Live preview -->
+        <div class="pt-studio-preview">
+          <div class="pt-preview-head">
+            <span class="pt-preview-tag">Live preview</span>
+            <span class="pt-preview-meta">Square · print &amp; PNG</span>
+          </div>
+          <div class="pt-paper" id="mono-preview" aria-live="polite"></div>
+          <div class="pt-preview-actions">
+            <button type="button" class="bubble-btn bubble-btn-primary" id="mono-print">Print monogram</button>
+            <button type="button" class="bubble-btn" id="mono-png">Download PNG</button>
+          </div>
+          <p class="pt-preview-note">Runs entirely in your browser — nothing is uploaded. In the print dialog, choose “Save as PDF” to keep a copy.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Editorial -->
+    <section class="editorial-section">
+      <h2>How to make a printable monogram</h2>
+      <p>A monogram turns your initials into a small piece of lettering you can print, frame, or add to a card, gift tag, or label. Type up to three initials, choose a layout and a style, and the preview updates as you go — then print it or download a PNG.</p>
+      <p>The three layouts each suit a different job. <strong>Classic three-letter</strong> — a large center initial flanked by two smaller ones — is the traditional monogram for weddings, stationery, and engraved gifts; by convention the center letter is the last-name initial. <strong>Stacked</strong> keeps every initial the same size in a tight vertical column, which stays legible when the mark is small, so it works well for stickers, labels, and name badges. <strong>Circle frame</strong> sets the initials inside a double ring for a stamp, seal, or badge look.</p>
+      <p>Pick <strong>Solid</strong> for a crisp, filled monogram that reads cleanly at any size, or <strong>Outline</strong> for open, white-filled letters with a dark edge — the same traceable, colorable look as the rest of the printables, handy if you want to color the monogram in or trace it.</p>
+      <p>Want a whole name in a flowing hand instead of just initials? The <a href="/printables/cursive-alphabet/">cursive alphabet practice sheets</a> and the <a href="/category/cursive-fonts/">cursive text generator</a> turn full words into script. For handwriting practice, try the <a href="/printables/name-tracing/">name tracing worksheets</a>.</p>
+    </section>
+
+    <!-- Cross-family navigation -->
+    <section class="related-pages">
+      <h2>Explore more printables</h2>
+      <div class="related-pages-grid">
+        <a href="/printables/cursive-alphabet/" class="related-page-card">
+          <span class="related-page-label">Printable</span>
+          <h4>Cursive alphabet A–Z</h4>
+        </a>
+        <a href="/printables/bubble-letters/" class="related-page-card">
+          <span class="related-page-label">Printable</span>
+          <h4>Bubble letters</h4>
+        </a>
+        <a href="/category/cursive-fonts/" class="related-page-card">
+          <span class="related-page-label">Generator</span>
+          <h4>Cursive text</h4>
+        </a>
+        <a href="/printables/" class="related-page-card">
+          <span class="related-page-label">All</span>
+          <h4>Printables home</h4>
+        </a>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <h2 class="faq-category">Monogram Maker — FAQ</h2>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          How do I make a printable monogram?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Type one, two, or three initials into the boxes, then pick a layout (classic three-letter, stacked, or circle frame) and a style (solid or outline). The monogram builds live in your browser as you type. Press <strong>Print monogram</strong> for a full-page print, or <strong>Download PNG</strong> to save a high-resolution image. No sign-up, watermark, or limit.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          What's the difference between the three monogram layouts?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          <strong>Classic three-letter</strong> puts a large center initial between two smaller ones on a single baseline — the traditional look for weddings, stationery, and gifts, where the center letter is usually the last-name initial. <strong>Stacked</strong> places the initials vertically at one size for a compact mark that suits stickers, labels, and small spaces. <strong>Circle frame</strong> centers the initials inside a double ring for a stamp, badge, or wax-seal look.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Can I print or save the monogram as an image?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Yes. <strong>Print monogram</strong> opens your browser's print dialog with just the monogram and a title on the page — choose <strong>Save as PDF</strong> there to keep a file. <strong>Download PNG</strong> saves a high-resolution 1600&nbsp;×&nbsp;1600 pixel PNG on a white background that you can print, share, or drop into another design.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Is Unicode used to render the monogram?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          No. Unlike the site's copy-paste font generators, the monogram maker draws the letters in a real serif typeface (Playfair Display) as native SVG and Canvas, not Unicode characters. So it is not a copy-paste string you can drop into a bio or username — it is a visual you print or download as an image. For copy-paste initials or names, use the <a href="/category/">font generators</a> instead.
+        </div>
+      </div>
+
+    </div>
+  </footer>
+
+  <!-- Print surface (hidden on screen, isolated when printing) -->
+  <div id="pt-print-root" aria-hidden="true"></div>
+
+  <script src="/js/printables/monogramEngine.js" defer></script>
+  <script>
+    document.querySelectorAll('.faq-question').forEach(function(btn) {
+      btn.addEventListener('click', function() { this.closest('.faq-item').classList.toggle('open'); });
+    });
+  </script>
+<script src="/footer.js" defer></script>
+</body></html>

--- a/usecase/index.html
+++ b/usecase/index.html
@@ -133,6 +133,36 @@ o</div>
       </div>
     </section>
 
+    <!-- Fun Translators -->
+    <section class="editorial-section" id="fun-translators">
+      <h2>Fun Translators</h2>
+      <p class="section-subline">Curated word-swap translators — type once, get a whole new voice.</p>
+
+      <div class="style-card usecase-cards" style="flex-direction:column;align-items:stretch;gap:8px;">
+        <div class="style-name">
+          <span class="style-tag">🏴‍☠️</span>
+          Pirate Translator
+        </div>
+        <p class="usecase-outcome">Talk like a pirate, instantly.</p>
+        <p class="usecase-diff">Swaps everyday words and phrases for pirate slang — ye, matey, arrr and more.</p>
+        <div class="usecase-example">Hello my friend, where is the treasure?
+Ahoy me matey, where be the booty? Arrr!</div>
+        <a class="usecase-cta" href="/usecase/pirate-translator/">Try Pirate Translator →</a>
+      </div>
+
+      <div class="style-card usecase-cards" style="flex-direction:column;align-items:stretch;gap:8px;">
+        <div class="style-name">
+          <span class="style-tag">📜</span>
+          Old English Translator
+        </div>
+        <p class="usecase-outcome">Give your text a thee/thou, Shakespearean-style voice.</p>
+        <p class="usecase-diff">Swaps everyday words for mock-archaic equivalents — thou, thy, art, hath.</p>
+        <div class="usecase-example">Hello my friend, are you well today?
+Hail mine good fellow, art thou well this day?</div>
+        <a class="usecase-cta" href="/usecase/old-english-translator/">Try Old English Translator →</a>
+      </div>
+    </section>
+
     <!-- Comments & Social Posting -->
     <section class="editorial-section" id="comments-social">
       <h2>Comments &amp; Social Posting</h2>

--- a/usecase/old-english-translator/index.html
+++ b/usecase/old-english-translator/index.html
@@ -1,0 +1,299 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Old English Translator — Thee, Thou &amp; Thy Speak | UltraTextGen</title>
+  <meta name="description" content="Turn any text into old-fashioned thee/thou English — Shakespearean-style word swaps like thou, thy, art and hath. Type a sentence and get an instant translation. Free, no sign-up.">
+  <link rel="canonical" href="https://ultratextgen.com/usecase/old-english-translator/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/usecase/old-english-translator/">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/usecase-old-english-translator.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/usecase-old-english-translator.png">
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="Old English Translator — Thee, Thou &amp; Thy Speak | UltraTextGen">
+  <meta property="og:description" content="Turn any text into old-fashioned thee/thou English — Shakespearean-style word swaps like thou, thy, art and hath. Type a sentence and get an instant translation. Free, no sign-up.">
+  <meta property="og:url" content="https://ultratextgen.com/usecase/old-english-translator/">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="UltraTextGen">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Old English Translator — Thee, Thou &amp; Thy Speak | UltraTextGen">
+  <meta name="twitter:description" content="Turn any text into old-fashioned thee/thou English — Shakespearean-style word swaps like thou, thy, art and hath. Type a sentence and get an instant translation. Free, no sign-up.">
+
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "How does the Old English translator work?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "It swaps modern words for old-fashioned thee/thou equivalents using a curated dictionary — \"you\" becomes \"thou\", \"your\" becomes \"thy\", \"are\" becomes \"art\", and \"has\" becomes \"hath\". It's a fun, rule-based novelty translator, not a language model or AI, so it works best on simple everyday sentences. Words it doesn't recognise are left as they are."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is this real Old English?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No, and this is worth being clear about. Real Old English is the language of Beowulf, spoken in England roughly 1,000–1,500 years ago. It is a completely different language that a modern reader cannot understand without study. What this tool produces is better described as \"mock-archaic\" or early-modern, Shakespearean-flavoured English — the thee/thou style people associate with Shakespeare and the King James Bible, which is early modern English, not Old English at all. We use the popular name because that's what people search for, but the distinction is real."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I copy the translated text?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Press the Copy button under the output and the translated text is copied to your clipboard, ready to paste into a message, caption, story, D&D character line, or anywhere else."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does it change grammar or word order?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. This is word-and-phrase substitution only — it replaces individual words and a few short phrases but never reorders your sentence or rebuilds its grammar. That keeps the result readable and predictable, but it also means it won't perfectly match how someone actually wrote or spoke centuries ago."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is it linguistically accurate?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "It's a fun novelty tool, not a scholarly one. It captures the flavour of archaic English through familiar words like thou, thy, art, hath, prithee and hither, but it doesn't follow the full grammar (verb endings, cases, or word order) of any real historical period. Enjoy it for creative writing, games, and playful messages rather than as a reference."
+      }
+    }
+  ]
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://ultratextgen.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Use Cases",
+      "item": "https://ultratextgen.com/usecase/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Old English Translator",
+      "item": "https://ultratextgen.com/usecase/old-english-translator/"
+    }
+  ]
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Old English Translator",
+  "alternateName": ["Thee Thou Translator", "Shakespearean English Translator", "Old Fashioned English Translator"],
+  "url": "https://ultratextgen.com/usecase/old-english-translator/",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "description": "Turn any text into old-fashioned thee/thou style English. Type a sentence and get an instant translation using a curated word-and-phrase substitution dictionary. Copy-paste, free, no sign-up.",
+  "featureList": [
+    "Instant thee/thou style translation as you type",
+    "Word and phrase substitution dictionary",
+    "Deterministic — the same text always translates the same way",
+    "Free, no sign-up",
+    "Copy with one click"
+  ],
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+
+  <div id="shared-header"></div>
+  <script src="/header.js" defer></script>
+
+  <nav class="breadcrumbs" aria-label="Breadcrumb">
+    <a href="/">Home</a>
+    <span class="breadcrumb-separator">›</span>
+    <a href="/usecase/">Use Cases</a>
+    <span class="breadcrumb-separator">›</span>
+    <span class="breadcrumb-current">Old English Translator</span>
+  </nav>
+
+  <!-- Hero + tool -->
+  <section class="hero">
+    <div class="hero-inner">
+      <h1 class="hero-headline">Old English Translator</h1>
+      <p class="hero-tagline">Type any sentence and turn it into old-fashioned <em>thee / thou</em> English — thou, thy, art, hath, prithee and more. Free, instant, and ready to copy anywhere.</p>
+
+      <!-- Input -->
+      <div class="input-wrapper">
+        <textarea class="main-input" id="persona-input" aria-label="Text to translate into old-fashioned English" placeholder="Type a sentence to translate into thee/thou English…" maxlength="1000" rows="3">Hello my friend, are you well today?</textarea>
+        <div class="char-count"><span id="persona-count">36</span> / 1000</div>
+      </div>
+
+      <!-- Output -->
+      <div class="hero-card">
+        <p id="persona-output" aria-live="polite" aria-atomic="true"></p>
+        <div class="bubble-actions">
+          <button class="bubble-btn bubble-btn-primary" id="persona-copy" type="button">Copy translation</button>
+          <button class="bubble-btn" id="persona-clear" type="button">Clear</button>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Editorial -->
+  <main>
+    <section class="editorial-section">
+      <h2>What this translator does</h2>
+      <p>This tool rewrites your text in the old-fashioned <em>thee / thou</em> style people love for creative writing, fantasy games, wedding toasts, and playful messages. It works by reading your sentence and swapping familiar modern words for archaic equivalents from a hand-picked dictionary: "you" becomes "thou", "your" becomes "thy", "are you" becomes "art thou", "please" becomes "prithee", and "here" becomes "hither".</p>
+      <p>It's word-and-phrase substitution only, which keeps the output readable and predictable. It runs entirely in your browser, translates as you type, and leaves any word it doesn't recognise unchanged.</p>
+    </section>
+
+    <section class="editorial-section">
+      <h2>"Old English" vs Shakespeare vs the real thing</h2>
+      <p>Here's the honest, and genuinely interesting, part. The style this tool produces is <strong>not</strong> actual Old English. Real Old English is the language of <em>Beowulf</em> — spoken in England more than a thousand years ago — and it's so different from today's language that a modern reader simply can't understand it without studying it like a foreign tongue.</p>
+      <p>What most people mean by "old English" is really the <strong>early modern English</strong> of Shakespeare and the King James Bible: <em>thou art</em>, <em>thy heart</em>, <em>wherefore</em>, <em>hither</em>. That's the flavour this translator recreates. It's best thought of as "mock-archaic" or "ye olde" English — a fun stylistic costume, not a linguistically accurate reconstruction of any single historical period. We use the popular name because that's what people search for, but it's worth knowing the difference.</p>
+    </section>
+
+    <section class="editorial-section">
+      <h2>How to use the Old English translator</h2>
+      <p>Type or paste your text in the box above. The thee/thou version appears instantly below — no button press needed. When you like it, tap <strong>Copy translation</strong> and paste it wherever you want: a message, a caption, a Dungeons &amp; Dragons character's line, a fantasy story draft, or a toast.</p>
+      <p>Because it's pure word substitution, the same sentence always produces the same result, and only words in the dictionary change. If you want <em>visual</em> old-style lettering — blackletter and gothic fonts you can copy and paste — try the <a href="/category/old-english-fonts/">Old English fonts</a> generator instead.</p>
+    </section>
+
+    <section class="related-pages">
+      <h2>Related tools</h2>
+      <div class="related-pages-grid">
+        <a class="related-page-card" href="/usecase/pirate-translator/">
+          <span class="related-page-label">Translator</span>
+          <h4>Pirate Translator</h4>
+        </a>
+        <a class="related-page-card" href="/usecase/zalgo-text/">
+          <span class="related-page-label">Text effect</span>
+          <h4>Zalgo Glitch Text Generator</h4>
+        </a>
+        <a class="related-page-card" href="/category/old-english-fonts/">
+          <span class="related-page-label">Fonts</span>
+          <h4>Old English Fonts (Blackletter)</h4>
+        </a>
+      </div>
+    </section>
+
+    <section class="editorial-section">
+      <h2>Frequently asked questions</h2>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          How does the Old English translator work?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+          </svg>
+        </button>
+        <div class="faq-answer">
+          <p>It swaps modern words for old-fashioned thee/thou equivalents using a curated dictionary — "you" becomes "thou", "your" becomes "thy", "are" becomes "art", and "has" becomes "hath". It's a fun, rule-based novelty translator, not a language model or AI, so it works best on simple everyday sentences. Words it doesn't recognise are left as they are.</p>
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Is this real Old English?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+          </svg>
+        </button>
+        <div class="faq-answer">
+          <p>No, and this is worth being clear about. Real Old English is the language of Beowulf, spoken in England roughly 1,000–1,500 years ago. It is a completely different language that a modern reader cannot understand without study. What this tool produces is better described as "mock-archaic" or early-modern, Shakespearean-flavoured English — the thee/thou style people associate with Shakespeare and the King James Bible, which is early modern English, not Old English at all. We use the popular name because that's what people search for, but the distinction is real.</p>
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Can I copy the translated text?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+          </svg>
+        </button>
+        <div class="faq-answer">
+          <p>Yes. Press the Copy button under the output and the translated text is copied to your clipboard, ready to paste into a message, caption, story, D&amp;D character line, or anywhere else.</p>
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Does it change grammar or word order?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+          </svg>
+        </button>
+        <div class="faq-answer">
+          <p>No. This is word-and-phrase substitution only — it replaces individual words and a few short phrases but never reorders your sentence or rebuilds its grammar. That keeps the result readable and predictable, but it also means it won't perfectly match how someone actually wrote or spoke centuries ago.</p>
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Is it linguistically accurate?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+          </svg>
+        </button>
+        <div class="faq-answer">
+          <p>It's a fun novelty tool, not a scholarly one. It captures the flavour of archaic English through familiar words like thou, thy, art, hath, prithee and hither, but it doesn't follow the full grammar (verb endings, cases, or word order) of any real historical period. Enjoy it for creative writing, games, and playful messages rather than as a reference.</p>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="footer-inner"></div>
+  </footer>
+
+  <script>
+    window.UTG_PERSONA_PAGE = { key: "oldEnglish", demoText: "Hello my friend, are you well today?" };
+  </script>
+  <script src="/js/translator/personaTranslator.js" defer></script>
+  <script>
+    document.querySelectorAll('.faq-question').forEach(function (btn) {
+      btn.addEventListener('click', function () { this.closest('.faq-item').classList.toggle('open'); });
+    });
+  </script>
+  <script src="/footer.js" defer></script>
+</body>
+</html>

--- a/usecase/pirate-translator/index.html
+++ b/usecase/pirate-translator/index.html
@@ -1,0 +1,299 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Pirate Translator — Talk Like a Pirate | UltraTextGen</title>
+  <meta name="description" content="Turn any text into pirate speak — ye, matey, arrr and more. Type a sentence and get an instant pirate translation. Free, copy-paste, no sign-up.">
+  <link rel="canonical" href="https://ultratextgen.com/usecase/pirate-translator/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/usecase/pirate-translator/">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/usecase-pirate-translator.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/usecase-pirate-translator.png">
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="Pirate Translator — Talk Like a Pirate | UltraTextGen">
+  <meta property="og:description" content="Turn any text into pirate speak — ye, matey, arrr and more. Type a sentence and get an instant pirate translation. Free, copy-paste, no sign-up.">
+  <meta property="og:url" content="https://ultratextgen.com/usecase/pirate-translator/">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="UltraTextGen">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Pirate Translator — Talk Like a Pirate | UltraTextGen">
+  <meta name="twitter:description" content="Turn any text into pirate speak — ye, matey, arrr and more. Type a sentence and get an instant pirate translation. Free, copy-paste, no sign-up.">
+
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "How does the pirate translator work?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "It swaps common English words and phrases for pirate-slang equivalents using a curated dictionary — for example \"you\" becomes \"ye\", \"friend\" becomes \"matey\", and \"yes\" becomes \"aye\". It's a fun, rule-based translator, not a language model or AI, so it works best on simple, everyday sentences. Words that aren't in the dictionary are left unchanged."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is this real Pirate English?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. There is no historical \"pirate language.\" What most people picture as pirate speak is a fictionalized stage accent popularized by movie portrayals of characters like Long John Silver and by Talk Like a Pirate Day. This tool leans into that fun, pop-culture version — it is not a historical or academic dialect."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I copy the translated text?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Hit the Copy button under the output and the translated text is copied to your clipboard, ready to paste into a message, caption, comment, or bio anywhere you like."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does it work for long paragraphs?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes — you can paste in whole paragraphs and every sentence is translated in one pass. Just remember that only words in the pirate dictionary change, so a passage full of everyday words will read more piratey than one full of technical or unusual vocabulary. The translation runs instantly in your browser, so length is not a problem."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is the translation random?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. The translation is fully deterministic: the same input always produces the same output. There is no randomness in the word swaps — the only fixed touch is a friendly \"arrr!\" added to the end of the result."
+      }
+    }
+  ]
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://ultratextgen.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Use Cases",
+      "item": "https://ultratextgen.com/usecase/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Pirate Translator",
+      "item": "https://ultratextgen.com/usecase/pirate-translator/"
+    }
+  ]
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Pirate Translator",
+  "alternateName": ["Talk Like a Pirate Translator", "Pirate Speak Generator", "English to Pirate Translator"],
+  "url": "https://ultratextgen.com/usecase/pirate-translator/",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "All",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "description": "Turn any text into fun pirate speak. Type a sentence and get an instant pirate translation using a curated word-and-phrase substitution dictionary. Copy-paste, free, no sign-up.",
+  "featureList": [
+    "Instant pirate-speak translation as you type",
+    "Word and phrase substitution dictionary",
+    "Deterministic — the same text always translates the same way",
+    "Free, no sign-up",
+    "Copy with one click"
+  ],
+  "browserRequirements": "Requires JavaScript. Works in all modern browsers."
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+
+  <div id="shared-header"></div>
+  <script src="/header.js" defer></script>
+
+  <nav class="breadcrumbs" aria-label="Breadcrumb">
+    <a href="/">Home</a>
+    <span class="breadcrumb-separator">›</span>
+    <a href="/usecase/">Use Cases</a>
+    <span class="breadcrumb-separator">›</span>
+    <span class="breadcrumb-current">Pirate Translator</span>
+  </nav>
+
+  <!-- Hero + tool -->
+  <section class="hero">
+    <div class="hero-inner">
+      <h1 class="hero-headline">Pirate Translator</h1>
+      <p class="hero-tagline">Type any sentence and watch it turn into pirate speak — ahoy, ye, matey, booty, and a hearty <em>arrr!</em> Free, instant, and ready to copy anywhere.</p>
+
+      <!-- Input -->
+      <div class="input-wrapper">
+        <textarea class="main-input" id="persona-input" aria-label="Text to translate into pirate speak" placeholder="Type a sentence to translate into pirate speak…" maxlength="1000" rows="3">Hello my friend, where is the treasure?</textarea>
+        <div class="char-count"><span id="persona-count">39</span> / 1000</div>
+      </div>
+
+      <!-- Output -->
+      <div class="hero-card">
+        <p id="persona-output" aria-live="polite" aria-atomic="true"></p>
+        <div class="bubble-actions">
+          <button class="bubble-btn bubble-btn-primary" id="persona-copy" type="button">Copy translation</button>
+          <button class="bubble-btn" id="persona-clear" type="button">Clear</button>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Editorial -->
+  <main>
+    <section class="editorial-section">
+      <h2>What is pirate speak?</h2>
+      <p>"Pirate speak" is a playful, exaggerated style of English full of words like <em>ahoy</em>, <em>ye</em>, <em>matey</em>, <em>aye</em>, and of course <em>arrr</em>. This translator recreates it the simplest possible way: it reads your text and swaps everyday words and short phrases for their pirate-slang equivalents from a hand-picked dictionary. "You are" becomes "ye be", "my friend" becomes "me matey", "treasure" becomes "booty", and a cheerful <em>arrr!</em> is tacked on at the end.</p>
+      <p>It's a novelty tool, plain and simple — a fun way to jazz up a caption, a birthday message, a party invite, or a Talk Like a Pirate Day post. It runs entirely in your browser, translates as you type, and never changes the words it doesn't recognise, so the result stays readable.</p>
+    </section>
+
+    <section class="editorial-section">
+      <h2>Where pirate speak comes from</h2>
+      <p>There was never a real "pirate language." The accent and vocabulary people imagine today come mostly from pop culture — above all from film and TV portrayals of larger-than-life pirates, and the West Country English drawl that came with them. That style was cemented by classic adventure stories like <em>Treasure Island</em> and has been carried forward ever since.</p>
+      <p>It got a yearly celebration too: <strong>International Talk Like a Pirate Day</strong>, held every <strong>September 19</strong>, which turned "arrr, matey" into a running joke that shows up in games, memes, and social posts. This translator is built for exactly that kind of fun, not for historical accuracy.</p>
+    </section>
+
+    <section class="editorial-section">
+      <h2>How to use the pirate translator</h2>
+      <p>Type or paste your text in the box above. The pirate version appears instantly below it — no button press needed. When you're happy with it, tap <strong>Copy translation</strong> and paste it wherever you like: a text message, a Discord or WhatsApp chat, an Instagram caption, a game username idea, or a party invitation.</p>
+      <p>Because the translation is pure word-and-phrase substitution, the same sentence always produces the same result, and only words in the dictionary change. Keep sentences short and everyday for the most piratey effect.</p>
+    </section>
+
+    <section class="related-pages">
+      <h2>Related tools</h2>
+      <div class="related-pages-grid">
+        <a class="related-page-card" href="/usecase/old-english-translator/">
+          <span class="related-page-label">Translator</span>
+          <h4>Old English Translator</h4>
+        </a>
+        <a class="related-page-card" href="/usecase/zalgo-text/">
+          <span class="related-page-label">Text effect</span>
+          <h4>Zalgo Glitch Text Generator</h4>
+        </a>
+        <a class="related-page-card" href="/category/">
+          <span class="related-page-label">Browse</span>
+          <h4>All Font &amp; Text Styles</h4>
+        </a>
+      </div>
+    </section>
+
+    <section class="editorial-section">
+      <h2>Frequently asked questions</h2>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          How does the pirate translator work?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+          </svg>
+        </button>
+        <div class="faq-answer">
+          <p>It swaps common English words and phrases for pirate-slang equivalents using a curated dictionary — for example "you" becomes "ye", "friend" becomes "matey", and "yes" becomes "aye". It's a fun, rule-based translator, not a language model or AI, so it works best on simple, everyday sentences. Words that aren't in the dictionary are left unchanged.</p>
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Is this real Pirate English?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+          </svg>
+        </button>
+        <div class="faq-answer">
+          <p>No. There is no historical "pirate language." What most people picture as pirate speak is a fictionalized stage accent popularized by movie portrayals of characters like Long John Silver and by Talk Like a Pirate Day. This tool leans into that fun, pop-culture version — it is not a historical or academic dialect.</p>
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Can I copy the translated text?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+          </svg>
+        </button>
+        <div class="faq-answer">
+          <p>Yes. Hit the Copy button under the output and the translated text is copied to your clipboard, ready to paste into a message, caption, comment, or bio anywhere you like.</p>
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Does it work for long paragraphs?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+          </svg>
+        </button>
+        <div class="faq-answer">
+          <p>Yes — you can paste in whole paragraphs and every sentence is translated in one pass. Just remember that only words in the pirate dictionary change, so a passage full of everyday words will read more piratey than one full of technical or unusual vocabulary. The translation runs instantly in your browser, so length is not a problem.</p>
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Is the translation random?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+          </svg>
+        </button>
+        <div class="faq-answer">
+          <p>No. The translation is fully deterministic: the same input always produces the same output. There is no randomness in the word swaps — the only fixed touch is a friendly "arrr!" added to the end of the result.</p>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="footer-inner"></div>
+  </footer>
+
+  <script>
+    window.UTG_PERSONA_PAGE = { key: "pirate", demoText: "Hello my friend, where is the treasure?" };
+  </script>
+  <script src="/js/translator/personaTranslator.js" defer></script>
+  <script>
+    document.querySelectorAll('.faq-question').forEach(function (btn) {
+      btn.addEventListener('click', function () { this.closest('.faq-item').classList.toggle('open'); });
+    });
+  </script>
+  <script src="/footer.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

This PR adds three major feature categories to UltraTextGen:

1. **Persona Translators** — Two new translator pages (Pirate Speak, Old English) powered by a shared, config-driven translation engine
2. **Printable Generators** — Two new interactive printable tools (Cross-Stitch Letter Generator, Monogram Maker) with live SVG preview and PNG/print export
3. **Cursive Landing Pages** — Six new pre-made cursive printable pages for common phrases (Mom, Dad, Family, Love, Happy Birthday, Best Friend)

All features are **client-side only**, built with vanilla JavaScript, native SVG/Canvas, and no external dependencies.

## Key Changes

### New JavaScript Engines

- **`js/translator/personaTranslator.js`** — Shared translation engine for persona pages
  - Curated word/phrase dictionaries for Pirate and Old English (deterministic, no randomness)
  - Config-driven page controller that gates on DOM presence
  - Supports live input→output translation, copy-to-clipboard, character counter
  - Single fixed suffix per persona (always-on, no variation)

- **`js/printables/crossStitchEngine.js`** — Cross-stitch chart generator
  - 5×7 bitmap alphabet (A–Z, 0–9, space) rendered as SVG grid
  - Two stitch styles: X-stitch (two diagonals) or filled square
  - Live color picker, stitch counter, grid toggle
  - SVG preview + PNG download + print support
  - Responsive sizing with explicit width/height + max-width for print

- **`js/printables/monogramEngine.js`** — Monogram maker
  - Three layout modes: classic (small·BIG·small), stacked, circle frame
  - Two styles: solid ink or white-fill outline (traceable)
  - Uses Playfair Display serif font (Google Fonts, not site Unicode registry)
  - Measures glyphs to prevent collisions (wide letters like M/W)
  - SVG preview + PNG download + print support

### New Pages

**Translator Pages:**
- `usecase/pirate-translator/index.html` — Pirate Speak translator
- `usecase/old-english-translator/index.html` — Old English (thee/thou) translator

**Printable Generator Pages:**
- `printables/cross-stitch-letters/index.html` — Cross-stitch chart maker
- `printables/monogram-maker/index.html` — Monogram generator

**Pre-Made Cursive Printables:**
- `printables/best-friend-in-cursive/index.html`
- `printables/dad-in-cursive/index.html`
- `printables/family-in-cursive/index.html`
- `printables/happy-birthday-in-cursive/index.html`
- `printables/love-in-cursive/index.html`
- `printables/mom-in-cursive/index.html`

### Updated Pages

- `usecase/index.html` — Added "Fun Translators" section with links to new translator pages
- `printables/index.html` — Added new printable tools to the catalog
- `printables/cursive-alphabet/index.html` — Added intro text linking to pre-made cursive pages

## Implementation Details

- **No external dependencies** — All rendering uses native SVG/Canvas APIs
- **Gate-on-presence pattern** — DOM controllers only wire up features if their mount points exist on the page
- **Deterministic translation** — Persona translators use fixed dictionaries; same input always produces same output (no randomness, no grammar engine)
- **Print-ready SVG** — Charts and monograms sized with explicit dimensions + inline max-width for crisp printing
- **Accessibility** — All pages include proper semantic HTML, structured data (FAQPage, BreadcrumbList, WebApplication), and meta tags for social sharing
- **Theme-aware colors** — Grid lines and text colors chosen to work in both light and dark themes

https://claude.ai/code/session_019o3MVqphYTMepKLBTcXonP