### PR TITLE
feat: real German school-cursive printable (Grundschrift/SAS/VA)

### DIFF
--- a/de/zum-ausdrucken/index.html
+++ b/de/zum-ausdrucken/index.html
@@ -53,7 +53,8 @@
     "itemListElement": [
       { "@type": "ListItem", "position": 1, "name": "Namen nachspuren", "url": "https://ultratextgen.com/de/zum-ausdrucken/namen-schreiben/" },
       { "@type": "ListItem", "position": 2, "name": "Schreibübungen-Generator", "url": "https://ultratextgen.com/de/zum-ausdrucken/schreibuebungen/" },
-      { "@type": "ListItem", "position": 3, "name": "Name-Ausmalbild", "url": "https://ultratextgen.com/de/zum-ausdrucken/name-ausmalen/" }
+      { "@type": "ListItem", "position": 3, "name": "Name-Ausmalbild", "url": "https://ultratextgen.com/de/zum-ausdrucken/name-ausmalen/" },
+      { "@type": "ListItem", "position": 4, "name": "Schreibschrift-Generator", "url": "https://ultratextgen.com/de/zum-ausdrucken/schreibschrift/" }
     ]
   }
 }
@@ -156,6 +157,13 @@
           <h3>Name-Ausmalbild</h3>
           <p>Verwandle einen Namen, ein Wort oder einen Buchstaben in ein Ausmalbild mit Live-Vorschau — wähle eine Füllung und einen hübschen Rahmen, füge eine Überschrift und eine Name-und-Datum-Zeile hinzu, dann drucken oder als PDF/PNG speichern.</p>
           <span class="printable-card-cta">Ausmalbild-Generator öffnen →</span>
+        </a>
+
+        <a class="printable-card" href="/de/zum-ausdrucken/schreibschrift/">
+          <span class="printable-card-art" aria-hidden="true">✎ 𝓼</span>
+          <h3>Schreibschrift-Generator</h3>
+          <p>Wähle die echte Schulschrift deines Kindes — Grundschrift, Schulausgangsschrift (SAS) oder Vereinfachte Ausgangsschrift (VA) — und erstelle ein Nachspur-Arbeitsblatt in genau dieser Schrift. Keine generische Kursivschrift.</p>
+          <span class="printable-card-cta">Schreibschrift-Generator öffnen →</span>
         </a>
 
       </div>

--- a/de/zum-ausdrucken/namen-schreiben/index.html
+++ b/de/zum-ausdrucken/namen-schreiben/index.html
@@ -188,7 +188,9 @@
       <p>Bereit, die Schwierigkeit mit dem Fortschritt zu steigern? Mit dem
         <a href="/de/zum-ausdrucken/schreibuebungen/">Schreibübungen-Generator</a> stellst du die Schwierigkeit von kräftig
         gepunkteten Buchstaben bis zu einer zarten Hilfslinie oder leeren Linie ein. Oder verwandle den Namen in ein
-        <a href="/de/zum-ausdrucken/name-ausmalen/">Ausmalbild</a> zum Verzieren.</p>
+        <a href="/de/zum-ausdrucken/name-ausmalen/">Ausmalbild</a> zum Verzieren. Lernt dein Kind schon eine verbundene
+        Schreibschrift? Der <a href="/de/zum-ausdrucken/schreibschrift/">Schreibschrift-Generator</a> spurt Namen in
+        echter Grundschrift, SAS oder VA nach — nicht nur in Druckschrift.</p>
     </section>
   </main>
 

--- a/de/zum-ausdrucken/schreibschrift/index.html
+++ b/de/zum-ausdrucken/schreibschrift/index.html
@@ -10,29 +10,25 @@
   <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Schreibübungen-Generator — verstellbares gepunktetes Nachspuren | UltraTextGen</title>
-  <meta name="description" content="Erstelle dein eigenes Schreibblatt: Gib einen Namen oder Wörter ein und stelle die Schwierigkeit von kräftig gepunkteten Buchstaben über blasse Schrift bis zur leeren Linie ein. Altersvorgaben von Vorschule bis 2. Klasse. Kostenlos, ohne Anmeldung — drucken oder als PNG herunterladen.">
-  <link rel="canonical" href="https://ultratextgen.com/de/zum-ausdrucken/schreibuebungen/">
+  <title>Schreibschrift-Generator — Grundschrift, SAS &amp; VA zum Nachspuren | UltraTextGen</title>
+  <meta name="description" content="Erstelle ein Schreibschrift-Arbeitsblatt mit echten deutschen Schulausgangsschriften: Grundschrift, Schulausgangsschrift (SAS) oder Vereinfachte Ausgangsschrift (VA). Name oder Wörter eingeben, Schrift wählen, Schwierigkeit einstellen — kostenlos, ohne Anmeldung.">
+  <link rel="canonical" href="https://ultratextgen.com/de/zum-ausdrucken/schreibschrift/">
 
-  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/printables/handwriting-worksheet-generator/">
-  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/zum-ausdrucken/schreibuebungen/">
-  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/handwriting-worksheet-generator/">
-
-  <meta property="og:title" content="Schreibübungen-Generator — verstellbares gepunktetes Nachspuren | UltraTextGen">
-  <meta property="og:description" content="Erstelle ein individuelles Schreibblatt und stelle die Schwierigkeit ein, während das Kind Fortschritte macht — kräftig gepunktet, fein gepunktet, gestrichelt, blass oder leer. Mit Altersvorgaben. Kostenlos, drucken oder PNG.">
-  <meta property="og:url" content="https://ultratextgen.com/de/zum-ausdrucken/schreibuebungen/">
+  <meta property="og:title" content="Schreibschrift-Generator — Grundschrift, SAS &amp; VA zum Nachspuren | UltraTextGen">
+  <meta property="og:description" content="Wähle die echte Schulschrift deines Kindes — Grundschrift, Schulausgangsschrift oder Vereinfachte Ausgangsschrift — und erstelle ein individuelles Nachspur-Arbeitsblatt. Kostenlos, drucken oder PNG.">
+  <meta property="og:url" content="https://ultratextgen.com/de/zum-ausdrucken/schreibschrift/">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://ultratextgen.com/assets/og/category.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
   <meta property="og:image:type" content="image/png">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Schreibübungen-Generator — verstellbares gepunktetes Nachspuren | UltraTextGen">
-  <meta name="twitter:description" content="Erstelle dein eigenes Schreibblatt und steigere die Schwierigkeit, während das Kind Fortschritte macht — von kräftig gepunkteten Buchstaben bis zur leeren Linie.">
+  <meta name="twitter:title" content="Schreibschrift-Generator — Grundschrift, SAS &amp; VA zum Nachspuren | UltraTextGen">
+  <meta name="twitter:description" content="Die echte Schulschrift deines Kindes als Nachspur-Arbeitsblatt — Grundschrift, SAS oder VA. Kostenlos, ohne Anmeldung.">
   <meta name="twitter:image" content="https://ultratextgen.com/assets/og/category.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;family=Quicksand:wght@500;600;700&amp;display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;family=Quicksand:wght@500;600;700&amp;family=Playwrite+DE+Grund&amp;family=Playwrite+DE+SAS&amp;family=Playwrite+DE+VA&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/style.css">
 
 <script type="application/ld+json">
@@ -42,7 +38,7 @@
   "itemListElement": [
     { "@type": "ListItem", "position": 1, "name": "Startseite", "item": "https://ultratextgen.com/de/" },
     { "@type": "ListItem", "position": 2, "name": "Zum Ausdrucken", "item": "https://ultratextgen.com/de/zum-ausdrucken/" },
-    { "@type": "ListItem", "position": 3, "name": "Schreibübungen-Generator", "item": "https://ultratextgen.com/de/zum-ausdrucken/schreibuebungen/" }
+    { "@type": "ListItem", "position": 3, "name": "Schreibschrift-Generator", "item": "https://ultratextgen.com/de/zum-ausdrucken/schreibschrift/" }
   ]
 }
 </script>
@@ -51,13 +47,13 @@
 {
   "@context": "https://schema.org",
   "@type": "WebApplication",
-  "name": "Schreibübungen-Generator",
-  "url": "https://ultratextgen.com/de/zum-ausdrucken/schreibuebungen/",
+  "name": "Schreibschrift-Generator",
+  "url": "https://ultratextgen.com/de/zum-ausdrucken/schreibschrift/",
   "applicationCategory": "EducationalApplication",
   "operatingSystem": "Any",
   "browserRequirements": "Benötigt JavaScript. Läuft vollständig im Browser.",
   "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
-  "description": "Erstelle aus einem beliebigen Namen oder Wörtern ein individuelles Schreibblatt und stelle die Schwierigkeit ein — volle Vorlage, kräftig gepunktet, fein gepunktet, gestrichelt, blass, zart oder leer — mit Altersvorgaben von Vorschule bis 2. Klasse. Zum Drucken oder als PNG, im Browser erzeugt. Alle Buchstaben in Druckschrift."
+  "description": "Erstelle aus einem beliebigen Namen oder Wörtern ein Schreibschrift-Arbeitsblatt in einer echten deutschen Schulausgangsschrift — Grundschrift, Schulausgangsschrift (SAS) oder Vereinfachte Ausgangsschrift (VA) — mit sieben Schwierigkeitsstufen von voller Vorlage bis zur leeren Linie. Zum Drucken oder als PNG, im Browser erzeugt."
 }
 </script>
 
@@ -68,10 +64,18 @@
   "mainEntity": [
     {
       "@type": "Question",
-      "name": "Wie erstelle ich mein eigenes Schreibblatt?",
+      "name": "Welche Schreibschrift soll ich wählen — Grundschrift, SAS oder VA?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Gib einen Namen oder ein paar Wörter ein, tippe eine Altersvorgabe oder eine Schwierigkeitsstufe an und klicke dann auf Arbeitsblatt drucken. Das Blatt enthält eine volle Vorlagenzeile, mehrere Zeilen in der gewählten Schwierigkeit zum Nachspuren und leere Linien zum freien Üben. Du kannst es auch als PNG herunterladen."
+        "text": "Das hängt vom Bundesland und von der Schule deines Kindes ab — es gibt in Deutschland keine bundesweit einheitliche Schreibschrift. Am sichersten ist es, in der Schule oder beim Lehrer nachzufragen, welche Ausgangsschrift verwendet wird, und dann genau diese Stufe hier auszuwählen. Grundschrift ist eine druckschriftbasierte Schrift mit optionalen Verbindungen und wird in immer mehr Schulen als erste Schrift eingeführt. Schulausgangsschrift (SAS) und Vereinfachte Ausgangsschrift (VA) sind beides verbundene Schreibschriften, unterscheiden sich aber in einzelnen Buchstabenformen, etwa bei s, t und z."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Sind das echte Schulschriften oder nur ein kursiver Font?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Echte Schulschriften. Der Generator nutzt Playwrite DE Grund, Playwrite DE SAS und Playwrite DE VA — eigens für den deutschen Grundschulunterricht entwickelte, freie Schriften von Google Fonts, keine generische Schreibschrift. Die Buchstabenformen orientieren sich an den tatsächlichen Ausgangsschriften, nicht an einer beliebigen kursiven Optik."
       }
     },
     {
@@ -79,23 +83,15 @@
       "name": "Wie funktionieren die Schwierigkeitsstufen?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Die sieben Stufen werden allmählich schwerer: volle Vorlage, kräftig gepunktet, fein gepunktet, gestrichelt, blasse Schrift, zarte Hilfslinie und leere Linie. Jede Stufe kombiniert drei Dinge, an die eine Lehrkraft denkt — die Strichstärke, den Abstand der Punkte und wie dunkel die Buchstaben sind — sodass ein Regler die Herausforderung sauber erhöht oder senkt."
+        "text": "Genau wie beim Schreibübungen-Generator: sieben Stufen von voller Vorlage über kräftig gepunktet, fein gepunktet, gestrichelt, blasse Schrift und zarte Hilfslinie bis zur leeren Linie. Wähle zuerst die Schrift, dann die Stufe — beides lässt sich jederzeit ändern, die Vorschau aktualisiert sich sofort."
       }
     },
     {
       "@type": "Question",
-      "name": "Welche Schwierigkeit passt zum Alter meines Kindes?",
+      "name": "Ist der Schreibschrift-Generator kostenlos?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Als Ausgangspunkt: Die Vorschule kommt gut mit kräftig gepunkteten Buchstaben zurecht, die 1. Klasse mit fein gepunkteten, die 2. Klasse mit gestrichelten, und ab der 3. Klasse mit einer zarten Hilfslinie, bevor frei geschrieben wird. Nutze die Altersvorgaben, um zu einer sinnvollen Stufe zu springen, und erhöhe dann eine Stufe, wenn das Kind sicherer wird."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Ist der Schreibübungen-Generator kostenlos?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Ja — vollständig kostenlos, ohne Anmeldung, ohne Wasserzeichen und ohne Limit. Alles wird in deinem Browser erzeugt, sodass du so viele Blätter erstellen kannst, wie du möchtest, für jeden Namen, jedes Wort und jede Schwierigkeit."
+        "text": "Ja — vollständig kostenlos, ohne Anmeldung, ohne Wasserzeichen und ohne Limit. Alles wird in deinem Browser erzeugt, sodass du so viele Blätter erstellen kannst, wie du möchtest, für jeden Namen, jedes Wort und jede Schrift."
       }
     }
   ]
@@ -116,17 +112,17 @@
   <span class="breadcrumb-separator">›</span>
   <a href="/de/zum-ausdrucken/">Zum Ausdrucken</a>
   <span class="breadcrumb-separator">›</span>
-  <span class="breadcrumb-current">Schreibübungen-Generator</span>
+  <span class="breadcrumb-current">Schreibschrift-Generator</span>
 </nav>
 
   <section class="hero">
     <div class="hero-inner" style="max-width:820px;">
-      <h1 class="hero-headline">Schreibübungen-Generator</h1>
+      <h1 class="hero-headline">Schreibschrift-Generator</h1>
       <p class="hero-tagline">
-        Erstelle in Sekunden dein eigenes Schreibblatt. Gib einen Namen oder Wörter ein, tippe eine
-        Schwierigkeitsstufe von kräftig gepunkteten Buchstaben bis zur leeren Linie an, und das Blatt
-        entsteht live. Ideal für Vorschule bis 2. Klasse — auch für Erwachsene. Alle Buchstaben in
-        Druckschrift. Kostenlos, ohne Anmeldung, drucken oder als PDF/PNG speichern.
+        Gib einen Namen oder Wörter ein, wähle die echte Schulschrift deines Kindes — Grundschrift,
+        Schulausgangsschrift (SAS) oder Vereinfachte Ausgangsschrift (VA) — und stelle die Schwierigkeit
+        von voller Vorlage bis zur leeren Linie ein. Keine generische Kursivschrift, sondern echte
+        deutsche Ausgangsschriften. Kostenlos, ohne Anmeldung, drucken oder als PNG speichern.
       </p>
     </div>
   </section>
@@ -135,8 +131,8 @@
 
     <!-- Generator studio (primary) -->
     <section class="bubble-alphabet" aria-labelledby="ptGenHeading">
-      <h2 id="ptGenHeading">Erstelle dein Arbeitsblatt</h2>
-      <p class="bubble-az-intro">Gib einen Namen oder Wörter ein, tippe eine Schwierigkeitsstufe an, und das Blatt entsteht live auf der rechten Seite. Drucke es, speichere ein PDF oder lade ein PNG herunter — kostenlos, ohne Anmeldung.</p>
+      <h2 id="ptGenHeading">Erstelle dein Schreibschrift-Arbeitsblatt</h2>
+      <p class="bubble-az-intro">Wähle zuerst die Schrift, dann die Schwierigkeitsstufe — die Vorschau rechts aktualisiert sich sofort. Drucke das Blatt oder lade es als PNG herunter.</p>
 
       <div class="pt-studio">
         <!-- Controls -->
@@ -149,13 +145,13 @@
           </div>
 
           <div class="pt-field">
-            <span class="pt-field-label">Nach Alter starten <span class="pt-field-opt">— optionale Abkürzung</span></span>
-            <div class="pt-segment" id="pt-gen-presets" role="group" aria-label="Altersvorgabe">
-              <button type="button" class="pt-gen-preset" data-level="2" aria-pressed="false">Vorschule <small>kräftig gepunktet</small></button>
-              <button type="button" class="pt-gen-preset" data-level="3" aria-pressed="false">1. Klasse <small>fein gepunktet</small></button>
-              <button type="button" class="pt-gen-preset" data-level="4" aria-pressed="false">2. Klasse <small>gestrichelt</small></button>
-              <button type="button" class="pt-gen-preset" data-level="6" aria-pressed="false">3.–4. Klasse <small>zarte Hilfslinie</small></button>
+            <span class="pt-field-label">Schrift wählen <span class="pt-field-opt">— welche lernt dein Kind in der Schule?</span></span>
+            <div class="pt-segment" id="pt-gen-script" role="radiogroup" aria-label="Schreibschrift-Standard">
+              <button type="button" class="pt-gen-preset pt-gen-script-opt" data-script="grund" aria-pressed="false">Grundschrift <small>druckschriftbasiert, optional verbunden</small></button>
+              <button type="button" class="pt-gen-preset pt-gen-script-opt" data-script="sas" aria-pressed="false">Schulausgangsschrift <small>verbundene Schreibschrift</small></button>
+              <button type="button" class="pt-gen-preset pt-gen-script-opt" data-script="va" aria-pressed="false">Vereinfachte Ausgangsschrift <small>verbundene Schreibschrift</small></button>
             </div>
+            <p class="pt-level-readout"><span id="pt-gen-script-hint"></span></p>
           </div>
 
           <div class="pt-field">
@@ -225,12 +221,7 @@
               <input type="checkbox" id="pt-gen-model" checked>
               Volle Vorlagenzeile oben
             </label>
-            <label class="pt-check" for="pt-stroke-toggle">
-              <input type="checkbox" id="pt-stroke-toggle">
-              Schreibrichtung anzeigen
-            </label>
           </div>
-          <p class="pt-stroke-toggle-hint">Die Schreibrichtung fügt jedem Buchstaben einen nummerierten Startpunkt und Pfeile hinzu, die zeigen, in welche Richtung man ihn schreibt.</p>
         </div>
 
         <!-- Live preview -->
@@ -249,43 +240,69 @@
       </div>
     </section>
 
-    <!-- How difficulty works (crawlable explainer; the ladder above is interactive) -->
-    <section class="editorial-section" aria-labelledby="ptLadderHeading">
-      <h2 id="ptLadderHeading">Wie die Schwierigkeit funktioniert</h2>
-      <p>Jede Schwierigkeitsstufe kombiniert drei Dinge, an die eine Lehrkraft denkt — wie <strong>dick</strong>
-        die Hilfe ist, wie <strong>eng</strong> die Punkte sitzen und wie <strong>dunkel</strong> die Buchstaben
-        sind — sodass ein Tippen die Herausforderung sauber erhöht oder senkt. Die sieben Stufen reichen von einer
-        <strong>vollen Vorlage</strong> zum Nachspuren über <strong>kräftig gepunktet</strong>,
-        <strong>fein gepunktet</strong>, <strong>gestrichelt</strong>, <strong>blasse Schrift</strong> und
-        <strong>zarte Hilfslinie</strong> bis hin zu einer <strong>leeren Lineatur</strong> zum Schreiben aus dem
-        Gedächtnis. Fang leicht an und rücke jeweils eine Stufe weiter, wenn die Kontrolle des Kindes besser wird.</p>
-      <p>Nicht sicher, wo du starten sollst? Als Faustregel kommt die <strong>Vorschule</strong> gut mit kräftig
-        gepunktet zurecht, die <strong>1. Klasse</strong> mit fein gepunktet, die <strong>2. Klasse</strong> mit
-        gestrichelt und ab der <strong>3. Klasse</strong> mit einer zarten Hilfslinie, bevor frei geschrieben wird.
-        Erwachsene, die ihre Handschrift auffrischen, starten oft bei blasser Schrift und wechseln zur leeren Linie.
-        Die Alters-Buttons springen zu einer sinnvollen Stufe — feinjustiere dann mit der Leiter.</p>
-      <p>Lieber ein fertiges Blatt statt selbst gebaut? Hol dir ein
-        <a href="/de/zum-ausdrucken/namen-schreiben/">Schreibblatt zum Namen-Nachspuren</a>, verwandle einen Namen in
-        ein <a href="/de/zum-ausdrucken/name-ausmalen/">Ausmalbild</a>, oder sieh dir alle
-        <a href="/de/zum-ausdrucken/">Schreibvorlagen zum Ausdrucken</a> an. Übt dein Kind eine verbundene
-        Schreibschrift wie SAS oder VA? Der <a href="/de/zum-ausdrucken/schreibschrift/">Schreibschrift-Generator</a>
-        erstellt Nachspur-Blätter in der echten Schulschrift statt in Druckschrift.</p>
+    <!-- Which script explainer (crawlable, genuine differentiator) -->
+    <section class="editorial-section" aria-labelledby="ptScriptHeading">
+      <h2 id="ptScriptHeading">Grundschrift, SAS oder VA — was ist der Unterschied?</h2>
+      <p>In Deutschland gibt es keine bundesweit einheitliche Schreibschrift — welche Ausgangsschrift ein
+        Kind lernt, hängt vom Bundesland und oft von der einzelnen Schule ab. Dieser Generator bietet
+        deshalb drei echte Schulschriften zur Auswahl, nicht eine generische Kursivschrift:</p>
+      <ul class="compat-list">
+        <li><span class="ts-pill-safe">Grundschrift</span> Eine druckschriftbasierte Schrift mit
+          optionalen Verbindungen zwischen den Buchstaben — kein vollständig verbundenes Schreibschrift-Bild.
+          Wird in immer mehr Grundschulen als erste (und oft einzige) Schrift eingeführt.</li>
+        <li><span class="ts-pill-safe">Schulausgangsschrift (SAS)</span> Eine vollständig verbundene
+          Schreibschrift. In mehreren Bundesländern verbreitet und in der Diskussion um eine mögliche
+          bundesweite Vereinheitlichung oft als Ausgangspunkt genannt.</li>
+        <li><span class="ts-pill-safe">Vereinfachte Ausgangsschrift (VA)</span> Ebenfalls vollständig
+          verbunden, die am weitesten verbreitete Schreibschrift in deutschen Schulen. Buchstaben
+          unterscheiden sich in Details von der SAS, etwa beim Ansatzpunkt einzelner Buchstaben.</li>
+      </ul>
+      <p>Am sichersten: <strong>frag in der Schule nach</strong>, welche Schrift dort unterrichtet wird,
+        und wähle oben genau diese aus — ein Kind, das eine andere Buchstabenform übt als die Lehrkraft
+        vorgibt, lernt zwei widersprüchliche Bewegungsabläufe statt einem. Alle drei Schriften hier sind
+        <strong>Playwrite DE</strong>-Schriften von Google Fonts — eigens für den deutschen
+        Grundschulunterricht entwickelt, nicht irgendeine kursive Optik.</p>
+      <p>Suchst du stattdessen Druckschrift zum Nachspuren? Nutze den
+        <a href="/de/zum-ausdrucken/schreibuebungen/">Schreibübungen-Generator</a> oder das
+        <a href="/de/zum-ausdrucken/namen-schreiben/">Namen-Nachspuren</a>. Alle Vorlagen findest du unter
+        <a href="/de/zum-ausdrucken/">Schreibvorlagen zum Ausdrucken</a>. Suchst du dagegen kursive
+        <strong>Unicode-Schrift zum Kopieren</strong> für Instagram-Bio oder WhatsApp-Status statt ein
+        Arbeitsblatt zum Ausdrucken, ist der <a href="/de/schreibschrift/">Schreibschrift-Generator zum
+        Kopieren</a> die richtige Seite.</p>
     </section>
   </main>
 
   <footer class="footer">
     <div class="footer-inner">
-      <h2 class="faq-category">Schreibübungen-Generator — FAQ</h2>
+      <h2 class="faq-category">Schreibschrift-Generator — FAQ</h2>
 
       <div class="faq-item">
         <button class="faq-question" type="button">
-          Wie erstelle ich mein eigenes Schreibblatt?
+          Welche Schreibschrift soll ich wählen — Grundschrift, SAS oder VA?
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
         </button>
         <div class="faq-answer">
-          Gib einen Namen oder ein paar Wörter ein, tippe eine Altersvorgabe oder eine Schwierigkeitsstufe an und klicke
-          dann auf <strong>Arbeitsblatt drucken</strong>. Das Blatt enthält eine volle Vorlagenzeile, mehrere Zeilen in
-          der gewählten Schwierigkeit zum Nachspuren und leere Linien zum freien Üben. Du kannst es auch als PNG herunterladen.
+          Das hängt vom Bundesland und von der Schule deines Kindes ab — es gibt in Deutschland keine
+          bundesweit einheitliche Schreibschrift. Am sichersten ist es, in der Schule oder beim Lehrer
+          nachzufragen, welche Ausgangsschrift verwendet wird, und dann genau diese Stufe hier auszuwählen.
+          Grundschrift ist eine druckschriftbasierte Schrift mit optionalen Verbindungen und wird in immer
+          mehr Schulen als erste Schrift eingeführt. Schulausgangsschrift (SAS) und Vereinfachte
+          Ausgangsschrift (VA) sind beides verbundene Schreibschriften, unterscheiden sich aber in
+          einzelnen Buchstabenformen, etwa bei s, t und z.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Sind das echte Schulschriften oder nur ein kursiver Font?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Echte Schulschriften. Der Generator nutzt <strong>Playwrite DE Grund</strong>,
+          <strong>Playwrite DE SAS</strong> und <strong>Playwrite DE VA</strong> — eigens für den
+          deutschen Grundschulunterricht entwickelte, freie Schriften von Google Fonts, keine generische
+          Schreibschrift. Die Buchstabenformen orientieren sich an den tatsächlichen Ausgangsschriften,
+          nicht an einer beliebigen kursiven Optik.
         </div>
       </div>
 
@@ -295,35 +312,22 @@
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
         </button>
         <div class="faq-answer">
-          Die sieben Stufen werden allmählich schwerer: volle Vorlage, kräftig gepunktet, fein gepunktet,
-          gestrichelt, blasse Schrift, zarte Hilfslinie und leere Linie. Jede Stufe kombiniert drei Dinge, an die eine
-          Lehrkraft denkt — die Strichstärke, den Abstand der Punkte und wie dunkel die Buchstaben sind — sodass ein
-          Regler die Herausforderung sauber erhöht oder senkt.
+          Genau wie beim Schreibübungen-Generator: sieben Stufen von voller Vorlage über kräftig
+          gepunktet, fein gepunktet, gestrichelt, blasse Schrift und zarte Hilfslinie bis zur leeren
+          Linie. Wähle zuerst die Schrift, dann die Stufe — beides lässt sich jederzeit ändern, die
+          Vorschau aktualisiert sich sofort.
         </div>
       </div>
 
       <div class="faq-item">
         <button class="faq-question" type="button">
-          Welche Schwierigkeit passt zum Alter meines Kindes?
+          Ist der Schreibschrift-Generator kostenlos?
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
         </button>
         <div class="faq-answer">
-          Als Ausgangspunkt: Die Vorschule kommt gut mit kräftig gepunkteten Buchstaben zurecht, die 1. Klasse mit fein
-          gepunkteten, die 2. Klasse mit gestrichelten, und ab der 3. Klasse mit einer zarten Hilfslinie, bevor frei
-          geschrieben wird. Nutze die Altersvorgaben, um zu einer sinnvollen Stufe zu springen, und erhöhe dann eine
-          Stufe, wenn das Kind sicherer wird.
-        </div>
-      </div>
-
-      <div class="faq-item">
-        <button class="faq-question" type="button">
-          Ist der Schreibübungen-Generator kostenlos?
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
-        </button>
-        <div class="faq-answer">
-          Ja — vollständig kostenlos, ohne Anmeldung, ohne Wasserzeichen und ohne Limit. Alles wird in deinem Browser
-          erzeugt, sodass du so viele Blätter erstellen kannst, wie du möchtest, für jeden Namen, jedes Wort und jede
-          Schwierigkeit.
+          Ja — vollständig kostenlos, ohne Anmeldung, ohne Wasserzeichen und ohne Limit. Alles wird in
+          deinem Browser erzeugt, sodass du so viele Blätter erstellen kannst, wie du möchtest, für jeden
+          Namen, jedes Wort und jede Schrift.
         </div>
       </div>
 
@@ -336,13 +340,33 @@
   <script>
     window.UTG_PRINTABLE = {
       lang: "de",
-      key: "handwriting-worksheet-generator",
+      key: "schreibschrift-generator",
       render: "outline",
-      noun: "Schreibübung",
-      pngPrefix: "schreibuebung",
-      font: "Quicksand, 'Plus Jakarta Sans', sans-serif",
+      noun: "Schreibschrift",
+      pngPrefix: "schreibschrift",
+      font: "'Playwrite DE Grund', 'Playwrite DE SAS', cursive",
       charset: "alnum",
-      genDemo: "Emma"
+      genDemo: "Emma",
+      scriptOptions: [
+        {
+          key: "grund",
+          label: "Grundschrift",
+          font: "'Playwrite DE Grund', 'Playwrite DE SAS', cursive",
+          hint: "Druckschriftbasiert mit optionalen Verbindungen — Grundschrift, wie sie in immer mehr Bundesländern als erste Schrift unterrichtet wird."
+        },
+        {
+          key: "sas",
+          label: "Schulausgangsschrift",
+          font: "'Playwrite DE SAS', 'Playwrite DE Grund', cursive",
+          hint: "Vollständig verbundene Schreibschrift — Schulausgangsschrift (SAS)."
+        },
+        {
+          key: "va",
+          label: "Vereinfachte Ausgangsschrift",
+          font: "'Playwrite DE VA', 'Playwrite DE SAS', cursive",
+          hint: "Vollständig verbundene Schreibschrift — die am weitesten verbreitete Ausgangsschrift in deutschen Schulen."
+        }
+      ]
     };
   </script>
   <script src="/styles.js" defer></script>

--- a/js/printables/printablesEngine.js
+++ b/js/printables/printablesEngine.js
@@ -256,7 +256,18 @@
   const CHARS = (CFG.charset === "alnum") ? LETTERS.concat(DIGITS) : LETTERS.slice();
 
   const RENDER = CFG.render || "outline";           // "outline" | "glyph"
-  const FONT = CFG.font || "'Plus Jakarta Sans', 'Segoe UI Symbol', sans-serif";
+  // Mutable (not const): pages that set CFG.scriptOptions let the visitor
+  // switch the active font at runtime (e.g. choosing which German school
+  // handwriting standard to practice). Every render function below reads
+  // FONT fresh on each call, so reassigning it here is enough to repaint
+  // every surface (preview, print sheet, PNG) in the new script — no other
+  // function needs to change. Pages that don't set scriptOptions never call
+  // setGenScript(), so FONT stays exactly as constant as it always was.
+  let FONT = CFG.font || "'Plus Jakarta Sans', 'Segoe UI Symbol', sans-serif";
+  const SCRIPT_OPTIONS = Array.isArray(CFG.scriptOptions) && CFG.scriptOptions.length
+    ? CFG.scriptOptions
+    : null;
+  let genScriptKey = SCRIPT_OPTIONS ? SCRIPT_OPTIONS[0].key : null;
   const STROKE = CFG.strokeWidth || 9;
   const NOUN = CFG.noun || "letter";                // "bubble letter", "block letter"…
   // Extra space between letters in multi-letter (word/name) output, expressed
@@ -295,6 +306,7 @@
     genModel: $("#pt-gen-model"),
     genPrint: $("#pt-gen-print"),
     genPng: $("#pt-gen-png"),
+    genScript: $("#pt-gen-script"),
     // Coloring-sheet designer (optional; gated on its own mounts)
     designInput: $("#pt-design-input"),
     designHeading: $("#pt-design-heading"),
@@ -1174,6 +1186,24 @@
   }
   function genModelOn() { return !el.genModel || el.genModel.checked; }
 
+  // Script picker (CFG.scriptOptions only, e.g. choosing between real German
+  // school handwriting standards). Reassigns the shared FONT so every render
+  // path — live preview, print sheet, PNG — repaints in the new script.
+  function setGenScript(key) {
+    if (!SCRIPT_OPTIONS) return;
+    const opt = SCRIPT_OPTIONS.find((o) => o.key === key) || SCRIPT_OPTIONS[0];
+    genScriptKey = opt.key;
+    FONT = opt.font;
+    if (el.genScript) {
+      $$(".pt-gen-script-opt", el.genScript).forEach((b) => {
+        const on = b.dataset.script === genScriptKey;
+        b.classList.toggle("is-active", on);
+        b.setAttribute("aria-pressed", on ? "true" : "false");
+      });
+    }
+    withFont(renderGenPreview);
+  }
+
   // The full worksheet as a DOM node — the SINGLE primitive behind both the
   // live paper preview and the printed sheet, so what you see is what prints.
   function genSheetNode() {
@@ -1241,6 +1271,11 @@
       parts.push(genRowCount() + " trace");
       if (level !== TRACE_LEVELS.length) parts.push("2 blank");
       el.genPreviewMeta.textContent = parts.join(" · ") + " · US Letter";
+    }
+    if (SCRIPT_OPTIONS) {
+      const active = SCRIPT_OPTIONS.find((o) => o.key === genScriptKey) || SCRIPT_OPTIONS[0];
+      const hintEl = $("#pt-gen-script-hint");
+      if (hintEl) hintEl.textContent = active.hint || "";
     }
   }
 
@@ -1325,6 +1360,12 @@
     if (el.genCase) el.genCase.addEventListener("change", renderGenPreview);
     if (el.genRows) el.genRows.addEventListener("change", renderGenPreview);
     if (el.genModel) el.genModel.addEventListener("change", renderGenPreview);
+    if (el.genScript && SCRIPT_OPTIONS) {
+      $$(".pt-gen-script-opt", el.genScript).forEach((b) => {
+        b.addEventListener("click", () => setGenScript(b.dataset.script));
+      });
+      setGenScript(genScriptKey);
+    }
     // Level ladder — buttons authored in HTML (crawlable); wire + add samples.
     if (el.genLevels) {
       $$(".pt-level", el.genLevels).forEach((b) => {


### PR DESCRIPTION
## Summary

- Closer look at the "handletteringlernen.de printables angle" turned up a correction: its "Handlettering-Generator" is a lettering-*art* design canvas (Fontilo), not a tracing-worksheet competitor.
- The real head-to-head is `kostenlose-ausmalbilder.de` — feature-complete but hard-codes one cursive standard per page, has no stroke-order arrows, and has no Grundschrift generator at all.
- New: `de/zum-ausdrucken/schreibschrift/` — a worksheet generator that lets the user pick their child's actual school standard (**Grundschrift**, **Schulausgangsschrift**, or **Vereinfachte Ausgangsschrift**) in one tool, switchable live — something no free competitor offers.
- Uses **Playwrite DE Grund/SAS/VA** — Google Fonts' 2024 region-correct German school-handwriting family — loaded the same client-side way as the site's existing fonts (`fonts.googleapis.com` link), no bundled font binaries.
- Reuses the proven 7-level difficulty ladder from `schreibuebungen` unchanged.

## Engine change

`js/printables/printablesEngine.js`: `FONT` changed from `const` to `let`, gated behind a new optional `CFG.scriptOptions` config (font-family per named script + a small picker UI). Purely additive — every other printables page keeps its existing single static font untouched; nothing else in the shared engine changes behavior unless a page opts in.

Intentionally **not** included: stroke-direction arrows for cursive mode. The site's existing arrows are hand-authored for a different (print) typeface's letterforms — porting them without matching Playwrite's actual strokes would ship something quietly wrong, so the toggle is simply omitted on this page rather than faked.

## Test plan

- [x] `node -c js/printables/printablesEngine.js` — syntax clean
- [x] Downloaded the real Playwrite DE Grund/SAS/VA `.ttf` files and rendered them locally to confirm genuine, distinct, correctly-joined letterforms per standard
- [x] Drove the live page end-to-end with Playwright (network-mocked fonts, since the sandbox can't reach Google's CDN directly): script picker correctly reassigns the active font, live preview/print/PNG all repaint, dotted-trace effect correctly follows the joined cursive strokes
- [x] Regression-checked 5 existing printables pages after the engine change (`schreibuebungen`, `namen-schreiben`, EN `handwriting-worksheet-generator`, `cursive-alphabet`, `bubble-letters`) — zero console errors, unchanged rendering
- [x] Cross-linked from `de/zum-ausdrucken/` (hub card + `ItemList`), `schreibuebungen`, and `namen-schreiben`, plus a disambiguation link to the unrelated decorative `/de/schreibschrift/` (Unicode copy-paste cursive) page
- [ ] Manual review of German copy and letterform accuracy by a native speaker/educator (recommended given the curriculum-correctness claims on this page)


---
_Generated by [Claude Code](https://claude.ai/code/session_01AFNe42bvUWvP9DE5uMpc8N)_