### PR TITLE
Add scrolling text generator with bio and marquee modes

### DIFF
--- a/footer.js
+++ b/footer.js
@@ -20,6 +20,7 @@
         '<a href="/usecase/comment-font/" class="footer-link">Comment Font</a>' +
         '<a href="/usecase/bio-font/" class="footer-link">Bio Font</a>' +
         '<a href="/usecase/vertical-text/" class="footer-link">Vertical Text</a>' +
+        '<a href="/usecase/scrolling-text/" class="footer-link">Scrolling Text</a>' +
         '<a href="/usecase/zalgo-text/" class="footer-link">Zalgo Text</a>' +
         '<a href="/ascii-art-generator/" class="footer-link">ASCII Art Generator</a>' +
       '</div>' +

--- a/footer.js
+++ b/footer.js
@@ -21,6 +21,7 @@
         '<a href="/usecase/bio-font/" class="footer-link">Bio Font</a>' +
         '<a href="/usecase/vertical-text/" class="footer-link">Vertical Text</a>' +
         '<a href="/usecase/scrolling-text/" class="footer-link">Scrolling Text</a>' +
+        '<a href="/usecase/repeat-text/" class="footer-link">Repeat Text</a>' +
         '<a href="/usecase/zalgo-text/" class="footer-link">Zalgo Text</a>' +
         '<a href="/ascii-art-generator/" class="footer-link">ASCII Art Generator</a>' +
       '</div>' +

--- a/js/repeat/repeatData.js
+++ b/js/repeat/repeatData.js
@@ -1,0 +1,53 @@
+/* ==========================================================================
+   UltraTextGen — repeatData.js
+   Data-only module for the repeat-text generator (/usecase/repeat-text/).
+   No DOM, no logic — just the quick-fill phrases, the quick-fill repeat
+   counts, and the page's defaults. The divider glyphs are NOT redeclared here:
+   the page reuses window.UTG_SCROLL_DATA.DIVIDERS from the scrolling-text build.
+
+   Exposes: window.UTG_REPEAT_DATA
+   ========================================================================== */
+
+(function () {
+  "use strict";
+
+  window.UTG_REPEAT_DATA = {
+
+    /* ----------------------------------------------------------------------
+       Quick-fill example phrases. Deliberately distinct from the scrolling
+       page's more general list: this page's demand is apology / love, so the
+       presets lead with the phrases people actually search to repeat
+       ("sorry 100 times", "i love you 100 times"). Short and tasteful — a
+       convenience, not a content library.
+       ---------------------------------------------------------------------- */
+    PRESET_MESSAGES: [
+      "Sorry",
+      "I'm sorry",
+      "Please forgive me",
+      "My bad",
+      "I love you",
+      "I miss you",
+      "Thank you",
+      "I appreciate you"
+    ],
+
+    /* ----------------------------------------------------------------------
+       Quick-fill repeat counts. 100 is the literal searched number
+       ("sorry 100 times"); the rest give a spread around it, up to the
+       shared 200 cap ("say it 200 times").
+       ---------------------------------------------------------------------- */
+    COUNT_PRESETS: [10, 25, 50, 100, 200],
+
+    /* ----------------------------------------------------------------------
+       First-paint defaults so there is meaningful output on load. "Sorry"
+       repeated 100 times as a plain block is the most literal answer to the
+       primary query, so that is the default arrangement.
+       ---------------------------------------------------------------------- */
+    DEFAULTS: {
+      phrase: "Sorry",
+      count: 100,
+      shape: "block",
+      columns: 5
+    }
+  };
+})();

--- a/js/repeat/repeatPageController.js
+++ b/js/repeat/repeatPageController.js
@@ -1,0 +1,471 @@
+/* ==========================================================================
+   UltraTextGen — repeatPageController.js
+   Takes over the /usecase/repeat-text/ page. Must load AFTER script.js
+   (which it suppresses via window.UTG_REPEAT_MODE). One job, one arrangement
+   picker (no mode tabs): repeat a phrase N times and arrange the copies —
+   inline, block, or a shape (pyramid, reverse pyramid, staircase, diagonal,
+   box grid).
+
+   It reuses #resultsGrid + the .style-card / .copy-btn contract (with
+   dataset.text), so script.js's document-level clipboard + toast handler does
+   the copying — never reimplemented here. It reuses the scrolling-text build:
+   window.UTG_SCROLL_DATA.DIVIDERS for the divider picker and
+   window.UTG_SCROLL_BUILDERS (via repeatShapes.js) for the repeat-and-join.
+
+   applyStylePerLine and makePlatformSafe are re-implemented locally on purpose
+   (each is tiny), keeping this module independent — same spirit as
+   verticalLayouts.js's intentionally-duplicated FLIP_MAP.
+
+   Requires (loaded before this): styles.js, renderer.js, scrollData.js,
+   scrollBuilders.js, repeatData.js, repeatShapes.js, script.js.
+   ========================================================================== */
+
+(function () {
+  "use strict";
+
+  const Render = window.UltraTextGenRender;
+  const stylesRegistry = window.textStyles || {};
+  const DATA = window.UTG_REPEAT_DATA;
+  const SCROLL_DATA = window.UTG_SCROLL_DATA;
+  const B = window.UTG_SCROLL_BUILDERS;
+  const SHAPES_API = window.UTG_REPEAT_SHAPES;
+  if (!Render || !DATA || !SCROLL_DATA || !B || !SHAPES_API) return;
+
+  const SHAPES = SHAPES_API.SHAPES;
+
+  /* Cards rendered immediately; the rest render when scrolled near. A repeated
+     block can be tall, so start with fewer and cap the total (mirrors the
+     scrolling-text controller's exact constants). */
+  const INITIAL_CARDS = 18;
+  const MAX_STYLE_CARDS = 60;
+
+  /* Invisible-but-real character (Braille Pattern Blank). Instagram/TikTok and
+     similar apps strip empty lines and leading spaces on save; indentation and
+     blank lines rebuilt from U+2800 survive (same trick as vertical text). */
+  const BRAILLE_BLANK = "⠀";
+
+  /* Sample used to draw each shape's mini preview in the picker. */
+  const SAMPLE_PHRASE = "hi";
+
+  /* ---- State ---- */
+  let currentShapeId = (DATA.DEFAULTS && DATA.DEFAULTS.shape) || "block";
+  let repeatCount = (DATA.DEFAULTS && DATA.DEFAULTS.count) || 100;
+  let columns = (DATA.DEFAULTS && DATA.DEFAULTS.columns) || SHAPES_API.DEFAULT_COLUMNS;
+  let currentDivider = pickDefaultDivider();
+  let currentDividerTab = dividerTabFor(currentDivider) || Object.keys(SCROLL_DATA.DIVIDERS)[0] || "basics";
+  let lazyObserver = null;
+  let renderTimer = null;
+
+  /* ---- Helpers ---- */
+  function $(sel, root) { return (root || document).querySelector(sel); }
+  function $$(sel, root) { return Array.from((root || document).querySelectorAll(sel)); }
+
+  function el(tag, className, text) {
+    let node = document.createElement(tag);
+    if (className) node.className = className;
+    if (text != null) node.textContent = text;
+    return node;
+  }
+
+  function charLen(str) { return B.charLen(str); }
+
+  function shapeById(id) {
+    return SHAPES.filter(function (s) { return s.id === id; })[0] || SHAPES[0];
+  }
+
+  function pickDefaultDivider() {
+    /* Default to "None" so the primary output ("sorry 100 times") is a clean
+       repeated list; users can add a divider for inline/block if they want. */
+    let basics = SCROLL_DATA.DIVIDERS.basics;
+    if (basics && basics.length) return basics[0];
+    let first = SCROLL_DATA.DIVIDERS[Object.keys(SCROLL_DATA.DIVIDERS)[0]];
+    return (first && first[0]) || { id: "none", label: "None", symbol: "" };
+  }
+
+  function dividerTabFor(divider) {
+    if (!divider) return null;
+    let keys = Object.keys(SCROLL_DATA.DIVIDERS);
+    for (let i = 0; i < keys.length; i++) {
+      let list = SCROLL_DATA.DIVIDERS[keys[i]] || [];
+      for (let j = 0; j < list.length; j++) {
+        if (list[j].id === divider.id) return keys[i];
+      }
+    }
+    return null;
+  }
+
+  function capitalize(str) {
+    return str.charAt(0).toUpperCase() + str.slice(1);
+  }
+
+  /* Style a possibly multi-line string line-by-line, so reversing/transform
+     styles never fold across newlines. Blank lines stay blank. */
+  function applyStylePerLine(text, key) {
+    let style = key ? stylesRegistry[key] : null;
+    if (!style) return text;
+    return text.split("\n").map(function (line) {
+      if (line === "") return "";
+      try { return Render.renderAny(line, style); } catch (e) { return line; }
+    }).join("\n");
+  }
+
+  /* Pad blank lines and rebuild leading indents from U+2800 so a shape's
+     centering / indentation survives apps that strip whitespace. Applied last,
+     after styling — mirrors verticalPageController.js's makePlatformSafe. */
+  function makePlatformSafe(text) {
+    return text.split("\n").map(function (line) {
+      let noTrail = line.replace(/[ \t]+$/, "");
+      if (noTrail === "") return BRAILLE_BLANK;
+      return noTrail.replace(/^ +/, function (m) {
+        return BRAILLE_BLANK.repeat(m.length);
+      });
+    }).join("\n");
+  }
+
+  /* --------------------------------------------------------------------------
+     Build the plain (unstyled) arrangement from the current controls.
+     -------------------------------------------------------------------------- */
+  function currentPhrase() {
+    let input = $("#repeatPhraseInput");
+    return input ? input.value : "";
+  }
+
+  function buildArrangement() {
+    let shape = shapeById(currentShapeId);
+    return shape.fn(currentPhrase(), repeatCount, {
+      divider: currentDivider ? currentDivider.symbol : "",
+      columns: columns
+    });
+  }
+
+  /* --------------------------------------------------------------------------
+     Output note (copies / characters / lines)
+     -------------------------------------------------------------------------- */
+  function renderNote(rawText) {
+    let note = $("#repeatNote");
+    if (!note) return;
+    note.innerHTML = "";
+    if (!rawText) return;
+    let copies = SHAPES_API.clampCount(repeatCount);
+    let lines = rawText.split("\n").length;
+    note.appendChild(el("span", "scroll-fit-count",
+      "Output: " + copies + " copies · " + charLen(rawText) + " characters · " + lines + " lines"));
+  }
+
+  /* --------------------------------------------------------------------------
+     Result cards
+     -------------------------------------------------------------------------- */
+  function buildCard(name, text) {
+    let card = el("div", "style-card scroll-style-card repeat-style-card");
+    let info = el("div", "style-info");
+    info.appendChild(el("p", "style-name", name));
+    info.appendChild(el("p", "scroll-card-meta", charLen(text) + " chars"));
+
+    let preview = el("div", "style-preview repeat-preview");
+    preview.textContent = text;
+    info.appendChild(preview);
+
+    let btn = el("button", "copy-btn");
+    btn.type = "button";
+    btn.textContent = "Copy";
+    btn.dataset.text = text;
+    btn.dataset.style = name;
+    if (!text) btn.disabled = true;
+    info.appendChild(btn);
+
+    card.appendChild(info);
+    return card;
+  }
+
+  function renderResults() {
+    let grid = $("#resultsGrid");
+    if (!grid) return;
+    if (lazyObserver) { lazyObserver.disconnect(); lazyObserver = null; }
+    grid.innerHTML = "";
+
+    let rawText = buildArrangement();
+    renderNote(rawText);
+    if (!rawText) return;
+
+    /* Compute every style's output, collapsing identical results. The plain
+       (unstyled) block is the primary want on this page ("sorry 100 times"),
+       so it leads as its own "Normal" card before the Unicode styles. */
+    let items = [];
+    let seen = {};
+
+    let plain = makePlatformSafe(rawText);
+    items.push({ name: "Normal", text: plain });
+    seen[plain] = true;
+
+    Object.keys(stylesRegistry).forEach(function (name) {
+      if (items.length >= MAX_STYLE_CARDS) return;
+      let styled = makePlatformSafe(applyStylePerLine(rawText, name));
+      if (seen[styled]) return;
+      seen[styled] = true;
+      items.push({ name: name, text: styled });
+    });
+
+    items.slice(0, INITIAL_CARDS).forEach(function (item) {
+      grid.appendChild(buildCard(item.name, item.text));
+    });
+
+    if (items.length > INITIAL_CARDS) {
+      let sentinel = el("div", "scroll-lazy-sentinel");
+      grid.appendChild(sentinel);
+      let renderRest = function () {
+        if (lazyObserver) { lazyObserver.disconnect(); lazyObserver = null; }
+        let frag = document.createDocumentFragment();
+        items.slice(INITIAL_CARDS).forEach(function (item) {
+          frag.appendChild(buildCard(item.name, item.text));
+        });
+        sentinel.replaceWith(frag);
+      };
+      if ("IntersectionObserver" in window) {
+        lazyObserver = new IntersectionObserver(function (entries) {
+          if (entries.some(function (e) { return e.isIntersecting; })) renderRest();
+        }, { rootMargin: "100000px 0px 600px 0px" });
+        lazyObserver.observe(sentinel);
+      } else {
+        renderRest();
+      }
+    }
+  }
+
+  /* --------------------------------------------------------------------------
+     Debounced render dispatch (for typing performance)
+     -------------------------------------------------------------------------- */
+  function triggerRender() {
+    if (renderTimer) clearTimeout(renderTimer);
+    renderTimer = setTimeout(renderResults, 120);
+  }
+
+  /* --------------------------------------------------------------------------
+     Phrase presets
+     -------------------------------------------------------------------------- */
+  function buildPresets() {
+    let host = $("#repeatPresets");
+    if (!host) return;
+    DATA.PRESET_MESSAGES.forEach(function (phrase) {
+      let chip = el("button", "scroll-preset-chip", phrase);
+      chip.type = "button";
+      chip.addEventListener("click", function () {
+        let input = $("#repeatPhraseInput");
+        if (!input) return;
+        input.value = phrase;
+        renderResults();
+      });
+      host.appendChild(chip);
+    });
+  }
+
+  /* --------------------------------------------------------------------------
+     Arrangement (shape) picker — visual buttons with a mini preview each,
+     mirroring verticalPageController.js's layout picker.
+     -------------------------------------------------------------------------- */
+  function shapeMini(shape) {
+    let count = shapeMiniCount(shape.id);
+    let out = shape.fn(SAMPLE_PHRASE, count, { divider: "", columns: 3 });
+    return out || SAMPLE_PHRASE;
+  }
+
+  function shapeMiniCount(id) {
+    if (id === "inline" || id === "block") return 3;
+    if (id === "staircase" || id === "diagonal") return 4;
+    return 6; // pyramids + box
+  }
+
+  function buildShapePicker() {
+    let host = $("#repeatShapePicker");
+    if (!host) return;
+    host.innerHTML = "";
+    SHAPES.forEach(function (shape) {
+      let active = shape.id === currentShapeId;
+      let btn = el("button", "repeat-shape-option" + (active ? " active" : ""));
+      btn.type = "button";
+      btn.dataset.shape = shape.id;
+      btn.title = shape.description;
+      btn.setAttribute("aria-pressed", String(active));
+
+      let mini = el("pre", "repeat-shape-mini");
+      mini.setAttribute("aria-hidden", "true");
+      mini.textContent = shapeMini(shape);
+      btn.appendChild(mini);
+      btn.appendChild(el("span", "repeat-shape-name", shape.label));
+
+      btn.addEventListener("click", function () {
+        currentShapeId = shape.id;
+        $$(".repeat-shape-option", host).forEach(function (b) {
+          let on = b.dataset.shape === currentShapeId;
+          b.classList.toggle("active", on);
+          b.setAttribute("aria-pressed", String(on));
+        });
+        syncContextControls();
+        renderResults();
+      });
+      host.appendChild(btn);
+    });
+  }
+
+  /* Show the divider block only for inline/block, the columns block only for
+     box — a divider or a column count is meaningless for the other shapes. */
+  function syncContextControls() {
+    let shape = shapeById(currentShapeId);
+    let dividerBlock = $("#repeatDividerBlock");
+    let columnsBlock = $("#repeatColumnsBlock");
+    if (dividerBlock) dividerBlock.classList.toggle("u-hidden", !shape.divider);
+    if (columnsBlock) columnsBlock.classList.toggle("u-hidden", !shape.columns);
+  }
+
+  /* --------------------------------------------------------------------------
+     Count controls — quick-fill chips + a slider bounded by MAX_REPEATS
+     -------------------------------------------------------------------------- */
+  function setCount(n) {
+    repeatCount = Math.max(1, Math.min(B.MAX_REPEATS, Math.floor(Number(n)) || 1));
+    let range = $("#repeatCountRange");
+    if (range) range.value = String(repeatCount);
+    let label = $("#repeatCountValue");
+    if (label) label.textContent = String(repeatCount);
+    syncCountChips();
+  }
+
+  function syncCountChips() {
+    $$("#repeatCountPresets .scroll-preset-chip").forEach(function (chip) {
+      chip.classList.toggle("active", parseInt(chip.dataset.count, 10) === repeatCount);
+    });
+  }
+
+  function buildCountControls() {
+    let host = $("#repeatCountPresets");
+    if (host) {
+      DATA.COUNT_PRESETS.forEach(function (n) {
+        let chip = el("button", "scroll-preset-chip", "×" + n);
+        chip.type = "button";
+        chip.dataset.count = String(n);
+        chip.addEventListener("click", function () {
+          setCount(n);
+          renderResults();
+        });
+        host.appendChild(chip);
+      });
+    }
+
+    let range = $("#repeatCountRange");
+    if (range) {
+      range.max = String(B.MAX_REPEATS);
+      range.value = String(repeatCount);
+      let label = $("#repeatCountValue");
+      if (label) label.textContent = String(repeatCount);
+      range.addEventListener("input", function () {
+        setCount(range.value);
+        renderResults();
+      });
+    }
+    syncCountChips();
+  }
+
+  /* --------------------------------------------------------------------------
+     Columns control (box grid only)
+     -------------------------------------------------------------------------- */
+  function buildColumnsControl() {
+    let range = $("#repeatColumnsRange");
+    if (!range) return;
+    range.max = String(SHAPES_API.MAX_COLUMNS || 12);
+    range.value = String(columns);
+    let label = $("#repeatColumnsValue");
+    if (label) label.textContent = String(columns);
+    range.addEventListener("input", function () {
+      columns = SHAPES_API.clampColumns(range.value);
+      if (label) label.textContent = String(columns);
+      renderResults();
+    });
+  }
+
+  /* --------------------------------------------------------------------------
+     Divider picker — reuses window.UTG_SCROLL_DATA.DIVIDERS
+     -------------------------------------------------------------------------- */
+  function buildDividerPicker() {
+    let tabsHost = $("#repeatDividerTabs");
+    let gridHost = $("#repeatDividerGrid");
+    if (!tabsHost || !gridHost) return;
+
+    Object.keys(SCROLL_DATA.DIVIDERS).forEach(function (tabKey) {
+      let tab = el("button", "scroll-tab" + (tabKey === currentDividerTab ? " active" : ""), capitalize(tabKey));
+      tab.type = "button";
+      tab.dataset.dividerTab = tabKey;
+      tab.addEventListener("click", function () {
+        currentDividerTab = tabKey;
+        $$(".scroll-tab", tabsHost).forEach(function (t) {
+          t.classList.toggle("active", t.dataset.dividerTab === currentDividerTab);
+        });
+        renderDividerGrid();
+      });
+      tabsHost.appendChild(tab);
+    });
+    renderDividerGrid();
+  }
+
+  function renderDividerGrid() {
+    let gridHost = $("#repeatDividerGrid");
+    if (!gridHost) return;
+    gridHost.innerHTML = "";
+    let list = SCROLL_DATA.DIVIDERS[currentDividerTab] || [];
+    list.forEach(function (item) {
+      let active = currentDivider && currentDivider.id === item.id;
+      let chip = el("button", "vertical-chip" + (active ? " active" : ""), item.label);
+      chip.type = "button";
+      chip.title = item.symbol ? "Divider: " + item.symbol : "No divider";
+      chip.addEventListener("click", function () {
+        currentDivider = item;
+        $$(".vertical-chip", gridHost).forEach(function (c) { c.classList.remove("active"); });
+        chip.classList.add("active");
+        renderResults();
+      });
+      gridHost.appendChild(chip);
+    });
+  }
+
+  function bindPhraseInput() {
+    let input = $("#repeatPhraseInput");
+    if (input) input.addEventListener("input", triggerRender);
+  }
+
+  /* --------------------------------------------------------------------------
+     Init
+     -------------------------------------------------------------------------- */
+  function readUrlState() {
+    try {
+      let params = new URLSearchParams(window.location.search);
+      let text = params.get("text") || params.get("q");
+      let input = $("#repeatPhraseInput");
+      if (text && input && !input.value) input.value = text;
+
+      let n = params.get("n") || params.get("count");
+      if (n != null && n !== "") repeatCount = Math.max(1, Math.min(B.MAX_REPEATS, parseInt(n, 10) || repeatCount));
+
+      let shape = params.get("shape");
+      if (shape && SHAPES.some(function (s) { return s.id === shape; })) currentShapeId = shape;
+    } catch (e) {}
+  }
+
+  function init() {
+    readUrlState();
+
+    let input = $("#repeatPhraseInput");
+    if (input && !input.value.trim()) input.value = (DATA.DEFAULTS && DATA.DEFAULTS.phrase) || "Sorry";
+
+    buildPresets();
+    buildShapePicker();
+    buildCountControls();
+    buildColumnsControl();
+    buildDividerPicker();
+    bindPhraseInput();
+    syncContextControls();
+    renderResults();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/js/repeat/repeatShapes.js
+++ b/js/repeat/repeatShapes.js
@@ -1,0 +1,231 @@
+/* ==========================================================================
+   UltraTextGen — repeatShapes.js
+   Pure logic for the repeat-text generator. No DOM calls: (phrase, count,
+   options) in, plain multi-line string out — so it can be reasoned about in
+   isolation, mirroring verticalLayouts.js's LAYOUTS shape.
+
+   The atomic "unit" being arranged is one full repeated copy of the phrase
+   (not a grapheme, like verticalLayouts.js, and not a word). The two "flat"
+   arrangements (inline / block) are thin wrappers over the shared repeat
+   engine (window.UTG_SCROLL_BUILDERS.buildBioScrollText) — that logic is not
+   reimplemented here. The remaining arrangements borrow verticalLayouts.js's
+   shape vocabulary (pyramid, reverse pyramid, staircase, diagonal, box) and
+   its centering technique: plain leading-space padding (the controller
+   converts those to a Braille blank so the indentation survives copy-paste
+   into apps that strip whitespace — same split as verticalPageController.js).
+
+   Deterministic: no Math.random / Date.now. Every arrangement is clamped to
+   the shared MAX_REPEATS cap so a shape can never run past the engine's limit.
+
+   Exposes: window.UTG_REPEAT_SHAPES
+   ========================================================================== */
+
+(function () {
+  "use strict";
+
+  const B = window.UTG_SCROLL_BUILDERS || {};
+  const MAX = B.MAX_REPEATS || 200;
+
+  const DEFAULT_COLUMNS = 5;
+  const MAX_COLUMNS = 12;
+
+  /* ---- Small helpers ---- */
+  function normPhrase(p) {
+    return (p == null ? "" : String(p)).trim();
+  }
+
+  /* Clamp a requested copy count to [1, MAX] using the SHARED cap, so no shape
+     can ever render past what the repeat engine itself allows. */
+  function clampCount(n) {
+    let r = Math.floor(Number(n));
+    if (!isFinite(r) || r < 1) return 1;
+    if (r > MAX) return MAX;
+    return r;
+  }
+
+  function clampColumns(c) {
+    let n = Math.floor(Number(c));
+    if (!isFinite(n) || n < 1) return DEFAULT_COLUMNS;
+    if (n > MAX_COLUMNS) return MAX_COLUMNS;
+    return n;
+  }
+
+  function spaces(n) {
+    return n > 0 ? " ".repeat(n) : "";
+  }
+
+  /* Join `n` copies of `phrase` with `sep` between them. */
+  function repeatJoin(phrase, n, sep) {
+    let parts = [];
+    for (let i = 0; i < n; i++) parts.push(phrase);
+    return parts.join(sep);
+  }
+
+  /* --------------------------------------------------------------------------
+     Growing row sizes: [1, 2, 3, …] until `count` copies are placed. The last
+     row may be partial (smaller than its position) when count is not a perfect
+     triangular number. e.g. count = 11 -> [1, 2, 3, 4, 1].
+     -------------------------------------------------------------------------- */
+  function growingSizes(count) {
+    let sizes = [];
+    let placed = 0;
+    let k = 1;
+    while (placed < count) {
+      let inRow = Math.min(k, count - placed);
+      sizes.push(inRow);
+      placed += inRow;
+      k += 1;
+    }
+    return sizes;
+  }
+
+  /* --------------------------------------------------------------------------
+     Turn an array of row sizes into a centered block of phrase copies. Each
+     row is `size` copies joined by a single space; rows are centered relative
+     to the widest row using leading spaces (same technique as
+     verticalLayouts.js's centered pyramid — the controller later swaps those
+     leading spaces for a Braille blank so the shape survives paste).
+     -------------------------------------------------------------------------- */
+  function centeredFromSizes(phrase, sizes) {
+    let rows = sizes.map(function (s) { return repeatJoin(phrase, s, " "); });
+    let maxWidth = rows.reduce(function (m, r) { return Math.max(m, r.length); }, 0);
+    return rows.map(function (r) {
+      let pad = Math.max(0, Math.floor((maxWidth - r.length) / 2));
+      return spaces(pad) + r;
+    }).join("\n");
+  }
+
+  /* --------------------------------------------------------------------------
+     Arrangement 1 & 2: Inline / Block — thin wrappers over the shared engine.
+     buildBioScrollText already trims, clamps and handles the divider + join
+     mode, so these do not reimplement any repeat-and-join logic.
+     -------------------------------------------------------------------------- */
+  function shapeInline(phrase, count, options) {
+    options = options || {};
+    if (typeof B.buildBioScrollText !== "function") return "";
+    return B.buildBioScrollText({
+      text: phrase,
+      divider: options.divider || "",
+      repeats: clampCount(count),
+      joinMode: "inline"
+    });
+  }
+
+  function shapeBlock(phrase, count, options) {
+    options = options || {};
+    if (typeof B.buildBioScrollText !== "function") return "";
+    return B.buildBioScrollText({
+      text: phrase,
+      divider: options.divider || "",
+      repeats: clampCount(count),
+      joinMode: "own-line"
+    });
+  }
+
+  /* --------------------------------------------------------------------------
+     Arrangement 3: Pyramid — row k holds k copies, growing until `count`
+     copies are placed (last row may be partial), centered.
+        Sorry
+      Sorry Sorry
+     Sorry Sorry Sorry
+     -------------------------------------------------------------------------- */
+  function shapePyramid(phrase, count) {
+    phrase = normPhrase(phrase);
+    if (!phrase) return "";
+    return centeredFromSizes(phrase, growingSizes(clampCount(count)));
+  }
+
+  /* --------------------------------------------------------------------------
+     Arrangement 4: Reverse Pyramid — the same row sizes as the pyramid, but
+     ordered widest-first so the block starts full and tapers down, centered.
+     -------------------------------------------------------------------------- */
+  function shapeReversePyramid(phrase, count) {
+    phrase = normPhrase(phrase);
+    if (!phrase) return "";
+    let sizes = growingSizes(clampCount(count)).slice().sort(function (a, b) { return b - a; });
+    return centeredFromSizes(phrase, sizes);
+  }
+
+  /* --------------------------------------------------------------------------
+     Arrangement 5: Staircase — one copy per row, each row indented one gentle
+     step (2 spaces) further than the last. Leading spaces only (the controller
+     Braille-pads them for paste survival).
+     -------------------------------------------------------------------------- */
+  function shapeStaircase(phrase, count) {
+    phrase = normPhrase(phrase);
+    if (!phrase) return "";
+    count = clampCount(count);
+    const STEP = 2;
+    let rows = [];
+    for (let i = 0; i < count; i++) rows.push(spaces(i * STEP) + phrase);
+    return rows.join("\n");
+  }
+
+  /* --------------------------------------------------------------------------
+     Arrangement 6: Diagonal — like verticalLayouts.js's diagonal-right, one
+     copy per row stepping right, but a steeper step (4 spaces) so it reads
+     distinctly from the staircase.
+     -------------------------------------------------------------------------- */
+  function shapeDiagonal(phrase, count) {
+    phrase = normPhrase(phrase);
+    if (!phrase) return "";
+    count = clampCount(count);
+    const STEP = 4;
+    let rows = [];
+    for (let i = 0; i < count; i++) rows.push(spaces(i * STEP) + phrase);
+    return rows.join("\n");
+  }
+
+  /* --------------------------------------------------------------------------
+     Arrangement 7: Box Grid — copies tiled left-to-right, wrapping into rows
+     at `columns` copies per row, so `count` copies form a roughly rectangular
+     block. Every cell is the identical phrase, so the columns line up without
+     any padding.
+     -------------------------------------------------------------------------- */
+  function shapeBox(phrase, count, options) {
+    phrase = normPhrase(phrase);
+    if (!phrase) return "";
+    count = clampCount(count);
+    let columns = clampColumns(options && options.columns);
+    const GAP = "  "; // two spaces between columns
+    let rows = [];
+    let placed = 0;
+    while (placed < count) {
+      let inRow = Math.min(columns, count - placed);
+      rows.push(repeatJoin(phrase, inRow, GAP));
+      placed += inRow;
+    }
+    return rows.join("\n");
+  }
+
+  /* --------------------------------------------------------------------------
+     Descriptor registry — array of { id, label, description, fn } for UI
+     iteration, mirroring verticalLayouts.js's LAYOUTS. `divider: true` marks
+     the arrangements a between-copies divider makes sense for (inline / block);
+     `columns: true` marks the one that takes a column count (box).
+     -------------------------------------------------------------------------- */
+  const SHAPES = [
+    { id: "block",           label: "Block",           description: "Each copy on its own line — the literal “say it N times” list.", fn: shapeBlock,          divider: true },
+    { id: "inline",          label: "Inline",          description: "Every copy on one long line, separated by your divider.",                  fn: shapeInline,         divider: true },
+    { id: "pyramid",         label: "Pyramid",         description: "Copies build up row by row into a centered pyramid.",                      fn: shapePyramid },
+    { id: "reverse-pyramid", label: "Reverse Pyramid", description: "Starts wide at the top and tapers down to a point.",                       fn: shapeReversePyramid },
+    { id: "staircase",       label: "Staircase",       description: "One copy per row, each stepped a little further right.",                   fn: shapeStaircase },
+    { id: "diagonal",        label: "Diagonal",        description: "One copy per row on a steeper rightward diagonal.",                        fn: shapeDiagonal },
+    { id: "box",             label: "Box Grid",        description: "Copies tiled left-to-right into a rectangular grid.",                      fn: shapeBox,            columns: true }
+  ];
+
+  window.UTG_REPEAT_SHAPES = {
+    SHAPES: SHAPES,
+    DEFAULT_COLUMNS: DEFAULT_COLUMNS,
+    MAX_COLUMNS: MAX_COLUMNS,
+    clampCount: clampCount,
+    clampColumns: clampColumns,
+    shapeInline: shapeInline,
+    shapeBlock: shapeBlock,
+    shapePyramid: shapePyramid,
+    shapeReversePyramid: shapeReversePyramid,
+    shapeStaircase: shapeStaircase,
+    shapeDiagonal: shapeDiagonal,
+    shapeBox: shapeBox
+  };
+})();

--- a/js/scroll/scrollBuilders.js
+++ b/js/scroll/scrollBuilders.js
@@ -15,8 +15,11 @@
   "use strict";
 
   /* Hard cap on repeats so a runaway control can't build megabytes of text,
-     mirroring verticalLayouts.js's maxUnits guard. */
-  const MAX_REPEATS = 40;
+     mirroring verticalLayouts.js's maxUnits guard. Shared with the repeat-text
+     generator (/usecase/repeat-text/), whose whole point is "100 times" (and
+     its "200 times" sibling), so the cap is 200 — read dynamically by both
+     pages, so raising it just gives the scrolling-text slider more headroom. */
+  const MAX_REPEATS = 200;
 
   /* Unicode-aware length (counts code points the way platforms roughly do). */
   function charLen(str) {

--- a/js/scroll/scrollBuilders.js
+++ b/js/scroll/scrollBuilders.js
@@ -1,0 +1,221 @@
+/* ==========================================================================
+   UltraTextGen — scrollBuilders.js
+   Pure logic for the scrolling-text generator. No DOM calls: options in,
+   string / plain-object out — so it can be reasoned about and tested in
+   isolation, mirroring curvedText.js's build() shape.
+
+   Exposes: window.UTG_SCROLL_BUILDERS = {
+     buildBioScrollText,   // -> string   (repeated, divider-separated block)
+     computeFillRepeats,   // -> integer  (how many repeats fit a bio limit)
+     buildMarqueeSnippet   // -> { previewHtml, embedHtml, embedCss }
+   }
+   ========================================================================== */
+
+(function () {
+  "use strict";
+
+  /* Hard cap on repeats so a runaway control can't build megabytes of text,
+     mirroring verticalLayouts.js's maxUnits guard. */
+  const MAX_REPEATS = 40;
+
+  /* Unicode-aware length (counts code points the way platforms roughly do). */
+  function charLen(str) {
+    return str ? Array.from(str).length : 0;
+  }
+
+  function clampRepeats(n) {
+    let r = Math.floor(Number(n));
+    if (!isFinite(r) || r < 1) return 1;
+    if (r > MAX_REPEATS) return MAX_REPEATS;
+    return r;
+  }
+
+  /* --------------------------------------------------------------------------
+     buildBioScrollText
+       { text, divider, repeats, joinMode } -> string
+
+     Repeats `text` `repeats` times, joined by `divider`.
+       joinMode: "own-line" — divider sits on its own line between repeats
+                              (message \n divider \n message …). This is the
+                              block people paste into a bio so it overflows.
+                 "inline"   — divider sits inline between repeats on the flow
+                              (message · divider · message …), one long line.
+     An empty divider ("None") collapses to a bare newline (own-line) or a
+     single space (inline).
+     -------------------------------------------------------------------------- */
+  function buildBioScrollText(opts) {
+    opts = opts || {};
+    let text = (opts.text == null ? "" : String(opts.text)).trim();
+    if (!text) return "";
+
+    let divider = opts.divider == null ? "" : String(opts.divider);
+    let joinMode = opts.joinMode === "inline" ? "inline" : "own-line";
+    let repeats = clampRepeats(opts.repeats);
+
+    let parts = [];
+    for (let i = 0; i < repeats; i++) parts.push(text);
+
+    if (joinMode === "inline") {
+      let inlineSep = divider ? " " + divider + " " : " ";
+      return parts.join(inlineSep);
+    }
+
+    let lineSep = divider ? "\n" + divider + "\n" : "\n";
+    return parts.join(lineSep);
+  }
+
+  /* --------------------------------------------------------------------------
+     computeFillRepeats
+       { text, dividerLength, platformLimit } -> integer
+
+     Pure arithmetic: how many repeats fit under a target field's character
+     budget. `dividerLength` is the per-join cost (in characters) the caller
+     already worked out for the chosen divider + join mode.
+
+       n repeats cost:  n * unit + (n - 1) * dividerLength  <= platformLimit
+       => n <= (platformLimit + dividerLength) / (unit + dividerLength)
+
+     Always returns at least 1 and never more than the shared MAX_REPEATS cap.
+     -------------------------------------------------------------------------- */
+  function computeFillRepeats(opts) {
+    opts = opts || {};
+    let unit = charLen((opts.text == null ? "" : String(opts.text)).trim());
+    if (unit <= 0) return 1;
+
+    let dividerLength = Math.max(0, Number(opts.dividerLength) || 0);
+    let limit = Math.max(0, Number(opts.platformLimit) || 0);
+
+    let n = Math.floor((limit + dividerLength) / (unit + dividerLength));
+    return clampRepeats(n);
+  }
+
+  /* --------------------------------------------------------------------------
+     Deterministic id from the inputs (no Math.random / Date.now), so the same
+     settings always produce the same namespace and two marquees on one page
+     never collide. djb2 hash -> base36.
+     -------------------------------------------------------------------------- */
+  function hashId(str) {
+    let h = 5381;
+    for (let i = 0; i < str.length; i++) {
+      h = ((h << 5) + h + str.charCodeAt(i)) >>> 0;
+    }
+    return h.toString(36);
+  }
+
+  const HTML_ESCAPE = { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" };
+  function esc(s) {
+    return String(s == null ? "" : s).replace(/[&<>"']/g, function (c) { return HTML_ESCAPE[c]; });
+  }
+
+  /* Keep colors / numbers safe to splice into CSS. */
+  function safeColor(v, fallback) {
+    return /^#[0-9a-fA-F]{3,8}$/.test(String(v)) ? String(v) : fallback;
+  }
+  function num(v, fallback, min, max) {
+    let n = Number(v);
+    if (!isFinite(n)) n = fallback;
+    if (min != null && n < min) n = min;
+    if (max != null && n > max) n = max;
+    return n;
+  }
+
+  /* --------------------------------------------------------------------------
+     buildMarqueeSnippet
+       { text, speed, direction, gap, textColor, bgColor, fontSize, repeatCount }
+       -> { previewHtml, embedHtml, embedCss }
+
+     A self-contained, uniquely-namespaced CSS-animation marquee built with the
+     doubled-track technique (mirrors the 404.css marquee: two identical passes,
+     translateX(-50%) loops seamlessly). embedHtml + embedCss together are a
+     portable snippet a user can paste into their own site, forum signature, or
+     OBS browser source — they lean on no UltraTextGen CSS classes. Honors
+     prefers-reduced-motion in the embeddable CSS too.
+
+     previewHtml bundles a <style> so assigning it to innerHTML animates live.
+     -------------------------------------------------------------------------- */
+  function buildMarqueeSnippet(opts) {
+    opts = opts || {};
+    let text = (opts.text == null ? "" : String(opts.text)) || "Your scrolling text";
+    let speed = num(opts.speed, 12, 1, 600);
+    let direction = opts.direction === "right" ? "right" : "left";
+    let gap = num(opts.gap, 48, 0, 400);
+    let fontSize = num(opts.fontSize, 28, 8, 200);
+    let textColor = safeColor(opts.textColor, "#8b5cf6");
+    let bgColor = safeColor(opts.bgColor, "#0f172a");
+    let repeatCount = clampRepeats(num(opts.repeatCount, 4, 1, MAX_REPEATS));
+
+    let ns = "utg-marquee-" + hashId([
+      text, speed, direction, gap, fontSize, textColor, bgColor, repeatCount
+    ].join("|"));
+
+    let trackCls = ns + "__track";
+    let itemCls = ns + "__item";
+    let kf = ns + "__scroll";
+    let gapHalf = gap / 2;
+
+    /* "right" travels the opposite way along the same doubled track. */
+    let fromX = direction === "right" ? "-50%" : "0";
+    let toX = direction === "right" ? "0" : "-50%";
+
+    let embedCss = [
+      "." + ns + " {",
+      "  overflow: hidden;",
+      "  width: 100%;",
+      "  box-sizing: border-box;",
+      "  background: " + bgColor + ";",
+      "  padding: 12px 0;",
+      "}",
+      "." + ns + " ." + trackCls + " {",
+      "  display: inline-flex;",
+      "  flex-wrap: nowrap;",
+      "  white-space: nowrap;",
+      "  width: max-content;",
+      "  will-change: transform;",
+      "  animation: " + kf + " " + speed + "s linear infinite;",
+      "}",
+      "." + ns + ":hover ." + trackCls + " {",
+      "  animation-play-state: paused;",
+      "}",
+      "." + ns + " ." + itemCls + " {",
+      "  display: inline-block;",
+      "  padding: 0 " + gapHalf + "px;",
+      "  font-size: " + fontSize + "px;",
+      "  line-height: 1.3;",
+      "  color: " + textColor + ";",
+      "  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;",
+      "}",
+      "@keyframes " + kf + " {",
+      "  from { transform: translateX(" + fromX + "); }",
+      "  to   { transform: translateX(" + toX + "); }",
+      "}",
+      "@media (prefers-reduced-motion: reduce) {",
+      "  ." + ns + " ." + trackCls + " { animation: none; }",
+      "}"
+    ].join("\n");
+
+    /* One pass of items, then the pass is duplicated for a seamless -50% loop. */
+    let onePass = "";
+    for (let i = 0; i < repeatCount; i++) {
+      onePass += '      <span class="' + itemCls + '">' + esc(text) + "</span>\n";
+    }
+    let embedHtml =
+      '<div class="' + ns + '" role="img" aria-label="' + esc(text) + '">\n' +
+      '  <div class="' + trackCls + '">\n' +
+      onePass +
+      onePass +
+      "  </div>\n" +
+      "</div>";
+
+    let previewHtml = "<style>\n" + embedCss + "\n</style>\n" + embedHtml;
+
+    return { previewHtml: previewHtml, embedHtml: embedHtml, embedCss: embedCss };
+  }
+
+  window.UTG_SCROLL_BUILDERS = {
+    MAX_REPEATS: MAX_REPEATS,
+    charLen: charLen,
+    buildBioScrollText: buildBioScrollText,
+    computeFillRepeats: computeFillRepeats,
+    buildMarqueeSnippet: buildMarqueeSnippet
+  };
+})();

--- a/js/scroll/scrollData.js
+++ b/js/scroll/scrollData.js
@@ -1,0 +1,115 @@
+/* ==========================================================================
+   UltraTextGen — scrollData.js
+   Data-only module for the scrolling-text generator (/usecase/scrolling-text/).
+   No DOM, no logic — just the divider glyphs, quick-fill preset phrases,
+   approximate platform bio limits, and the marquee defaults.
+
+   Divider glyphs are drawn from the Box Drawing (U+2500–U+257F) and General
+   Punctuation (U+2000–U+206F) blocks, grouped so the picker can show tabs.
+   Shape mirrors verticalDecoratorData.js: { id, label, symbol } per item,
+   grouped by key.
+
+   Exposes: window.UTG_SCROLL_DATA
+   ========================================================================== */
+
+(function () {
+  "use strict";
+
+  window.UTG_SCROLL_DATA = {
+
+    /* ----------------------------------------------------------------------
+       Divider glyphs, grouped for the tabbed picker. `symbol` is what goes
+       between (or on its own line between) each repeated message.
+         - The "Basics" group carries the no-divider and blank-gap options.
+         - "blank" uses U+2800 (Braille Pattern Blank) so an empty-looking
+           separator line survives Instagram/TikTok bio saving, which strips
+           truly empty lines (same trick the vertical-text tool uses).
+       ---------------------------------------------------------------------- */
+    DIVIDERS: {
+      "basics": [
+        { id: "none",  label: "None",       symbol: "" },
+        { id: "blank", label: "Blank gap",  symbol: "⠀" },
+        { id: "space", label: "· dot ·",    symbol: "·" }
+      ],
+      "lines": [
+        { id: "line-thin",   label: "─", symbol: "──────" },
+        { id: "line-heavy",  label: "━", symbol: "━━━━━━" },
+        { id: "line-double", label: "═", symbol: "══════" },
+        { id: "line-dash8",  label: "┈", symbol: "┈┈┈┈┈┈" },
+        { id: "line-dash4",  label: "┄", symbol: "┄┄┄┄┄┄" },
+        { id: "line-mixed",  label: "━╍", symbol: "━╍━╍━╍" }
+      ],
+      "dots": [
+        { id: "dot-bullet",  label: "•", symbol: "• • •" },
+        { id: "dot-mid",     label: "∙", symbol: "∙ ∙ ∙" },
+        { id: "dot-ring",    label: "◦", symbol: "◦ ◦ ◦" },
+        { id: "dot-tri",     label: "‣", symbol: "‣‣‣" },
+        { id: "dot-ellip",   label: "⋯", symbol: "⋯⋯⋯" },
+        { id: "dot-hellip",  label: "…", symbol: "…" }
+      ],
+      "stars": [
+        { id: "star-filled", label: "★", symbol: "★ ★ ★" },
+        { id: "star-spark",  label: "✦", symbol: "✦ ✦ ✦" },
+        { id: "star-open",   label: "✧", symbol: "✧ ✧ ✧" },
+        { id: "star-flor",   label: "❈", symbol: "❈ ❈ ❈" },
+        { id: "star-shadow", label: "❍", symbol: "❍ ❍ ❍" },
+        { id: "star-heart",  label: "♥", symbol: "♥ ♥ ♥" }
+      ]
+    },
+
+    /* ----------------------------------------------------------------------
+       Quick-fill example phrases. Weighted toward what real searchers want:
+       "I love you" is the confirmed high-volume variant, plus a handful of
+       similarly short romantic / cute / status-y phrases. A convenience, not
+       a content library — keep it short and tasteful.
+       ---------------------------------------------------------------------- */
+    PRESET_MESSAGES: [
+      "I love you",
+      "Miss you",
+      "Good vibes only",
+      "New phone who dis",
+      "Best day ever",
+      "Happy birthday",
+      "You're my favorite",
+      "Thinking of you",
+      "Stay golden",
+      "On repeat"
+    ],
+
+    /* ----------------------------------------------------------------------
+       Approximate bio / about character limits for the platforms this site
+       already has dedicated pages for. Platforms change these often, so the
+       UI always labels them "approx." Used to compute how many repeats fit
+       under a target field, and to flag which boxes the output overflows
+       (overflowing the fixed-height box is what makes a bio scroll).
+       ---------------------------------------------------------------------- */
+    PLATFORM_LIMITS: [
+      { id: "instagram", label: "Instagram bio", limit: 150 },
+      { id: "tiktok",    label: "TikTok bio",    limit: 80 },
+      { id: "x",         label: "X / Twitter bio", limit: 160 },
+      { id: "facebook",  label: "Facebook bio",  limit: 101 },
+      { id: "discord",   label: "Discord About Me", limit: 190 },
+      { id: "snapchat",  label: "Snapchat bio",  limit: 80 },
+      { id: "pinterest", label: "Pinterest about", limit: 160 },
+      { id: "linkedin",  label: "LinkedIn headline", limit: 220 },
+      { id: "youtube",   label: "YouTube description", limit: 1000 }
+    ],
+
+    /* ----------------------------------------------------------------------
+       Marquee mode defaults. Colors are literal on purpose: the marquee is an
+       embeddable, self-contained snippet, so it carries real values (not this
+       site's CSS tokens). Purple-on-dark matches the brand look by default.
+       `speed` is seconds per loop (lower = faster).
+       ---------------------------------------------------------------------- */
+    MARQUEE_DEFAULTS: {
+      text: "Breaking news — your scrolling text here",
+      speed: 12,
+      direction: "left",
+      gap: 48,
+      textColor: "#8b5cf6",
+      bgColor: "#0f172a",
+      fontSize: 28,
+      repeatCount: 4
+    }
+  };
+})();

--- a/js/scroll/scrollPageController.js
+++ b/js/scroll/scrollPageController.js
@@ -1,0 +1,634 @@
+/* ==========================================================================
+   UltraTextGen — scrollPageController.js
+   Takes over the /usecase/scrolling-text/ page. Must load AFTER script.js
+   (which it suppresses via window.UTG_SCROLL_MODE). Two modes, one per job:
+
+     bio      — a repeated, divider-separated block you paste into a profile
+                bio so it overflows the fixed-height box and forces a scroll.
+                Reuses #resultsGrid + the .style-card / .copy-btn contract, so
+                script.js's document-level clipboard + toast handler does the
+                copying (we never reimplement it here).
+     marquee  — a self-contained CSS-animation banner/ticker for a website,
+                forum signature, or OBS overlay, with its own live preview and
+                "Copy embed code" button (its own toast, since it isn't a card).
+
+   Mode is tab-switchable and persisted in ?mode=. Mirrors the MODES-tab +
+   URL-persisted-mode pattern of tattooPageController.js.
+
+   Requires (loaded before this): styles.js, renderer.js, scrollData.js,
+   scrollBuilders.js, script.js.
+   ========================================================================== */
+
+(function () {
+  "use strict";
+
+  const Render = window.UltraTextGenRender;
+  const stylesRegistry = window.textStyles || {};
+  const DATA = window.UTG_SCROLL_DATA;
+  const B = window.UTG_SCROLL_BUILDERS;
+  if (!Render || !DATA || !B) return;
+
+  /* Cards rendered immediately; the rest render when scrolled near. Bio cards
+     hold repeated multi-line text, so they are taller than normal style cards —
+     start with fewer and cap the total to keep the DOM bounded. */
+  const INITIAL_CARDS = 18;
+  const MAX_STYLE_CARDS = 60;
+
+  /* Curated Unicode styles that read well in a running banner. Only names that
+     exist in the registry are offered (mirrors curved-text's STYLE_CHOICES), so
+     this stays correct as the registry changes. */
+  const STYLE_CHOICES = [
+    ["", "Normal"],
+    ["Ultra Bold", "Bold"],
+    ["Ultra Italic", "Italic"],
+    ["Ultra Script", "Script"],
+    ["Ultra Gothic", "Gothic"],
+    ["Ultra Bubble", "Bubble"],
+    ["Ultra Fullwidth", "Fullwidth"],
+    ["Ultra Runic", "Runic"]
+  ];
+
+  const MODES = [
+    { id: "bio", label: "Bio Scroll Text",
+      hint: "A repeated block that overflows a bio and scrolls" },
+    { id: "marquee", label: "Marquee Banner",
+      hint: "An animated ticker to embed on a site or OBS" }
+  ];
+
+  /* ---- State ---- */
+  let mode = "bio";
+  let currentDivider = pickDefaultDivider();
+  /* Open the picker on the tab that actually holds the default divider, so its
+     active chip is visible on first paint. */
+  let currentDividerTab = dividerTabFor(currentDivider) || Object.keys(DATA.DIVIDERS)[0] || "basics";
+  let repeatMode = "count";          // 'count' | 'fill'
+  let repeatCount = 6;
+  let fillPlatformId = (DATA.PLATFORM_LIMITS[0] || {}).id || "instagram";
+  let joinMode = "own-line";         // 'own-line' | 'inline'
+  let lazyObserver = null;
+  let renderTimer = null;
+  let lastEmbedSnippet = "";
+
+  /* ---- Helpers ---- */
+  function $(sel, root) { return (root || document).querySelector(sel); }
+  function $$(sel, root) { return Array.from((root || document).querySelectorAll(sel)); }
+
+  function el(tag, className, text) {
+    let node = document.createElement(tag);
+    if (className) node.className = className;
+    if (text != null) node.textContent = text;
+    return node;
+  }
+
+  function pickDefaultDivider() {
+    let dots = DATA.DIVIDERS.dots;
+    if (dots && dots.length) return dots[0];
+    let first = DATA.DIVIDERS[Object.keys(DATA.DIVIDERS)[0]];
+    return (first && first[0]) || { id: "none", label: "None", symbol: "" };
+  }
+
+  /* Which divider-group key holds a given divider item. */
+  function dividerTabFor(divider) {
+    if (!divider) return null;
+    let keys = Object.keys(DATA.DIVIDERS);
+    for (let i = 0; i < keys.length; i++) {
+      let list = DATA.DIVIDERS[keys[i]] || [];
+      for (let j = 0; j < list.length; j++) {
+        if (list[j].id === divider.id) return keys[i];
+      }
+    }
+    return null;
+  }
+
+  function styleObj(key) {
+    return key ? stylesRegistry[key] : null;
+  }
+
+  /* Style a possibly multi-line string line-by-line, so reversing/transform
+     styles never fold across newlines. Blank lines stay blank. */
+  function applyStylePerLine(text, key) {
+    let style = styleObj(key);
+    if (!style) return text;
+    return text.split("\n").map(function (line) {
+      if (line === "") return "";
+      try { return Render.renderAny(line, style); } catch (e) { return line; }
+    }).join("\n");
+  }
+
+  /* Per-join character cost of the current divider + join mode. own-line adds
+     "\n" + divider + "\n"; inline adds " " + divider + " " — both divider+2.
+     Empty divider collapses to a single separator char. */
+  function perJoinCost() {
+    let sym = currentDivider ? currentDivider.symbol : "";
+    return sym ? B.charLen(sym) + 2 : 1;
+  }
+
+  function resolveRepeats(text) {
+    if (repeatMode === "fill") {
+      let platform = DATA.PLATFORM_LIMITS.filter(function (p) { return p.id === fillPlatformId; })[0];
+      return B.computeFillRepeats({
+        text: text,
+        dividerLength: perJoinCost(),
+        platformLimit: platform ? platform.limit : 150
+      });
+    }
+    return repeatCount;
+  }
+
+  /* --------------------------------------------------------------------------
+     BIO MODE
+     -------------------------------------------------------------------------- */
+  function currentBioText() {
+    let input = $("#scrollBioInput");
+    return input ? input.value : "";
+  }
+
+  function buildBio() {
+    let raw = currentBioText();
+    let repeats = resolveRepeats(raw);
+    return {
+      text: B.buildBioScrollText({
+        text: raw,
+        divider: currentDivider ? currentDivider.symbol : "",
+        repeats: repeats,
+        joinMode: joinMode
+      }),
+      repeats: repeats
+    };
+  }
+
+  function renderBioNote(built) {
+    let note = $("#scrollBioNote");
+    if (!note) return;
+    note.innerHTML = "";
+    if (!built.text) return;
+
+    let count = B.charLen(built.text);
+    let row = el("div", "scroll-fit-row");
+    row.appendChild(el("span", "scroll-fit-count",
+      "Output: " + count + " characters · " + built.repeats + " repeats"));
+
+    DATA.PLATFORM_LIMITS.forEach(function (p) {
+      let scrolls = count > p.limit;
+      let badge = el("span", "scroll-fit-badge" + (scrolls ? " scrolls" : ""),
+        (scrolls ? "↕ " : "· ") + p.label + " (~" + p.limit + ")");
+      badge.title = scrolls
+        ? "Longer than the " + p.label + " limit, so it overflows the box and scrolls."
+        : "Fits inside the " + p.label + " limit — add repeats to make it overflow and scroll.";
+      row.appendChild(badge);
+    });
+
+    note.appendChild(row);
+    note.appendChild(el("p", "scroll-fit-legend",
+      "↕ = longer than that field's limit, so it overflows the fixed-height box and scrolls. Counts are approximate and use the plain (unstyled) text."));
+  }
+
+  function buildBioCard(name, text) {
+    let card = el("div", "style-card scroll-style-card");
+    let info = el("div", "style-info");
+    info.appendChild(el("p", "style-name", name));
+    info.appendChild(el("p", "scroll-card-meta", B.charLen(text) + " chars"));
+
+    let preview = el("div", "style-preview scroll-preview");
+    preview.textContent = text;
+    info.appendChild(preview);
+
+    let btn = el("button", "copy-btn");
+    btn.type = "button";
+    btn.textContent = "Copy";
+    btn.dataset.text = text;
+    btn.dataset.style = name;
+    if (!text) btn.disabled = true;
+    info.appendChild(btn);
+
+    card.appendChild(info);
+    return card;
+  }
+
+  function renderBio() {
+    let grid = $("#resultsGrid");
+    if (!grid) return;
+    if (lazyObserver) { lazyObserver.disconnect(); lazyObserver = null; }
+    grid.innerHTML = "";
+
+    let built = buildBio();
+    renderBioNote(built);
+
+    if (!built.text) return;
+
+    /* Compute every style's output, collapsing identical results. */
+    let items = [];
+    let seen = {};
+    Object.keys(stylesRegistry).forEach(function (name) {
+      if (items.length >= MAX_STYLE_CARDS) return;
+      let styled = applyStylePerLine(built.text, name);
+      if (seen[styled]) return;
+      seen[styled] = true;
+      items.push({ name: name, text: styled });
+    });
+
+    items.slice(0, INITIAL_CARDS).forEach(function (item) {
+      grid.appendChild(buildBioCard(item.name, item.text));
+    });
+
+    if (items.length > INITIAL_CARDS) {
+      let sentinel = el("div", "scroll-lazy-sentinel");
+      grid.appendChild(sentinel);
+      let renderRest = function () {
+        if (lazyObserver) { lazyObserver.disconnect(); lazyObserver = null; }
+        let frag = document.createDocumentFragment();
+        items.slice(INITIAL_CARDS).forEach(function (item) {
+          frag.appendChild(buildBioCard(item.name, item.text));
+        });
+        sentinel.replaceWith(frag);
+      };
+      if ("IntersectionObserver" in window) {
+        lazyObserver = new IntersectionObserver(function (entries) {
+          if (entries.some(function (e) { return e.isIntersecting; })) renderRest();
+        }, { rootMargin: "100000px 0px 600px 0px" });
+        lazyObserver.observe(sentinel);
+      } else {
+        renderRest();
+      }
+    }
+  }
+
+  /* --------------------------------------------------------------------------
+     MARQUEE MODE
+     -------------------------------------------------------------------------- */
+  function marqueeTransform(text) {
+    let sel = $("#scrollMarqueeStyle");
+    let key = sel ? sel.value : "";
+    if (!key) return text;
+    let style = styleObj(key);
+    if (!style) return text;
+    try { return Render.renderAny(text, style); } catch (e) { return text; }
+  }
+
+  function readMarqueeControls() {
+    let d = DATA.MARQUEE_DEFAULTS;
+    function val(id, fallback) {
+      let node = $(id);
+      return node ? node.value : fallback;
+    }
+    let input = $("#scrollMarqueeInput");
+    let raw = input ? input.value : d.text;
+    return {
+      text: marqueeTransform(raw || d.text),
+      speed: val("#scrollMarqueeSpeed", d.speed),
+      direction: val("#scrollMarqueeDirection", d.direction),
+      gap: val("#scrollMarqueeGap", d.gap),
+      fontSize: val("#scrollMarqueeSize", d.fontSize),
+      textColor: val("#scrollMarqueeColor", d.textColor),
+      bgColor: val("#scrollMarqueeBg", d.bgColor),
+      repeatCount: val("#scrollMarqueeRepeat", d.repeatCount)
+    };
+  }
+
+  function syncRangeLabels(opts) {
+    setText("#scrollSpeedVal", opts.speed + "s");
+    setText("#scrollGapVal", opts.gap + "px");
+    setText("#scrollSizeVal", opts.fontSize + "px");
+    setText("#scrollRepeatVal", String(opts.repeatCount));
+  }
+
+  function setText(sel, text) {
+    let node = $(sel);
+    if (node) node.textContent = text;
+  }
+
+  function renderMarquee() {
+    let preview = $("#scrollMarqueePreview");
+    if (!preview) return;
+    let opts = readMarqueeControls();
+    let snippet = B.buildMarqueeSnippet(opts);
+
+    preview.innerHTML = snippet.previewHtml;
+    syncRangeLabels(opts);
+
+    lastEmbedSnippet = "<style>\n" + snippet.embedCss + "\n</style>\n" + snippet.embedHtml;
+    let code = $("#scrollEmbedCode");
+    if (code) code.value = lastEmbedSnippet;
+  }
+
+  function copyEmbed() {
+    if (!lastEmbedSnippet) return;
+    let done = function () { marqueeToast("Embed code copied"); };
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(lastEmbedSnippet).then(done, function () {
+        fallbackCopy(lastEmbedSnippet, done);
+      });
+    } else {
+      fallbackCopy(lastEmbedSnippet, done);
+    }
+  }
+
+  function fallbackCopy(text, done) {
+    let ta = document.createElement("textarea");
+    ta.value = text;
+    ta.setAttribute("readonly", "");
+    ta.style.position = "absolute";
+    ta.style.left = "-9999px";
+    document.body.appendChild(ta);
+    ta.select();
+    try { document.execCommand("copy"); done(); } catch (e) { /* noop */ }
+    document.body.removeChild(ta);
+  }
+
+  let marqueeToastTimer = null;
+  function marqueeToast(msg) {
+    let toast = $("#scrollToast");
+    if (!toast) return;
+    toast.textContent = msg;
+    toast.classList.add("is-visible");
+    if (marqueeToastTimer) clearTimeout(marqueeToastTimer);
+    marqueeToastTimer = setTimeout(function () {
+      toast.classList.remove("is-visible");
+    }, 1600);
+  }
+
+  /* --------------------------------------------------------------------------
+     Debounced render dispatch
+     -------------------------------------------------------------------------- */
+  function triggerRender() {
+    if (renderTimer) clearTimeout(renderTimer);
+    renderTimer = setTimeout(function () {
+      if (mode === "bio") renderBio();
+      else renderMarquee();
+    }, 120);
+  }
+
+  /* --------------------------------------------------------------------------
+     Mode tabs + panel switching
+     -------------------------------------------------------------------------- */
+  function buildModeTabs() {
+    let host = $("#scrollModeTabs");
+    if (!host) return;
+    MODES.forEach(function (m) {
+      let tab = el("button", "scroll-mode-tab" + (m.id === mode ? " active" : ""));
+      tab.type = "button";
+      tab.dataset.mode = m.id;
+      tab.appendChild(el("span", "scroll-mode-tab-label", m.label));
+      tab.appendChild(el("span", "scroll-mode-tab-hint", m.hint));
+      tab.addEventListener("click", function () { setMode(m.id); });
+      host.appendChild(tab);
+    });
+  }
+
+  function setMode(next) {
+    mode = (next === "marquee") ? "marquee" : "bio";
+    $$(".scroll-mode-tab").forEach(function (t) {
+      t.classList.toggle("active", t.dataset.mode === mode);
+    });
+    $$("[data-scroll-panel]").forEach(function (panel) {
+      panel.classList.toggle("u-hidden", panel.dataset.scrollPanel !== mode);
+    });
+    try {
+      let url = new URL(window.location.href);
+      if (mode === "bio") url.searchParams.delete("mode");
+      else url.searchParams.set("mode", mode);
+      history.replaceState(null, "", url.toString());
+    } catch (e) {}
+
+    if (mode === "bio") renderBio();
+    else renderMarquee();
+  }
+
+  /* --------------------------------------------------------------------------
+     Bio controls
+     -------------------------------------------------------------------------- */
+  function buildPresets() {
+    let host = $("#scrollPresets");
+    if (!host) return;
+    DATA.PRESET_MESSAGES.forEach(function (phrase) {
+      let chip = el("button", "scroll-preset-chip", phrase);
+      chip.type = "button";
+      chip.addEventListener("click", function () {
+        let input = $("#scrollBioInput");
+        if (!input) return;
+        input.value = phrase;
+        renderBio();
+      });
+      host.appendChild(chip);
+    });
+  }
+
+  function buildDividerPicker() {
+    let tabsHost = $("#scrollDividerTabs");
+    let gridHost = $("#scrollDividerGrid");
+    if (!tabsHost || !gridHost) return;
+
+    Object.keys(DATA.DIVIDERS).forEach(function (tabKey) {
+      let tab = el("button", "scroll-tab" + (tabKey === currentDividerTab ? " active" : ""),
+        capitalize(tabKey));
+      tab.type = "button";
+      tab.dataset.dividerTab = tabKey;
+      tab.addEventListener("click", function () {
+        currentDividerTab = tabKey;
+        $$(".scroll-tab", tabsHost).forEach(function (t) {
+          t.classList.toggle("active", t.dataset.dividerTab === currentDividerTab);
+        });
+        renderDividerGrid();
+      });
+      tabsHost.appendChild(tab);
+    });
+    renderDividerGrid();
+  }
+
+  function renderDividerGrid() {
+    let gridHost = $("#scrollDividerGrid");
+    if (!gridHost) return;
+    gridHost.innerHTML = "";
+    let list = DATA.DIVIDERS[currentDividerTab] || [];
+    list.forEach(function (item) {
+      let active = currentDivider && currentDivider.id === item.id;
+      let chip = el("button", "vertical-chip" + (active ? " active" : ""), item.label);
+      chip.type = "button";
+      chip.title = item.symbol ? "Divider: " + item.symbol : "No divider";
+      chip.addEventListener("click", function () {
+        currentDivider = item;
+        $$(".vertical-chip", gridHost).forEach(function (c) { c.classList.remove("active"); });
+        chip.classList.add("active");
+        renderBio();
+      });
+      gridHost.appendChild(chip);
+    });
+  }
+
+  function buildRepeatControls() {
+    /* Repeat-mode chips: explicit count vs. fill to a platform limit. */
+    let modeHost = $("#scrollRepeatModeTabs");
+    if (modeHost) {
+      [["count", "Set count"], ["fill", "Fill to platform"]].forEach(function (pair) {
+        let chip = el("button", "vertical-chip" + (pair[0] === repeatMode ? " active" : ""), pair[1]);
+        chip.type = "button";
+        chip.dataset.repeatMode = pair[0];
+        chip.addEventListener("click", function () {
+          repeatMode = pair[0];
+          $$(".vertical-chip", modeHost).forEach(function (c) {
+            c.classList.toggle("active", c.dataset.repeatMode === repeatMode);
+          });
+          syncRepeatRows();
+          renderBio();
+        });
+        modeHost.appendChild(chip);
+      });
+    }
+
+    let range = $("#scrollRepeatCount");
+    if (range) {
+      range.value = String(repeatCount);
+      range.max = String(B.MAX_REPEATS);
+      let label = $("#scrollRepeatValue");
+      if (label) label.textContent = String(repeatCount);
+      range.addEventListener("input", function () {
+        repeatCount = Math.max(1, Math.min(B.MAX_REPEATS, parseInt(range.value, 10) || 1));
+        if (label) label.textContent = String(repeatCount);
+        renderBio();
+      });
+    }
+
+    let select = $("#scrollPlatformSelect");
+    if (select) {
+      DATA.PLATFORM_LIMITS.forEach(function (p) {
+        let opt = document.createElement("option");
+        opt.value = p.id;
+        opt.textContent = p.label + " (~" + p.limit + ")";
+        select.appendChild(opt);
+      });
+      select.value = fillPlatformId;
+      select.addEventListener("change", function () {
+        fillPlatformId = select.value;
+        renderBio();
+      });
+    }
+    syncRepeatRows();
+  }
+
+  function syncRepeatRows() {
+    let countRow = $("#scrollCountRow");
+    let fillRow = $("#scrollFillRow");
+    if (countRow) countRow.classList.toggle("u-hidden", repeatMode !== "count");
+    if (fillRow) fillRow.classList.toggle("u-hidden", repeatMode !== "fill");
+  }
+
+  function buildJoinControls() {
+    let host = $("#scrollJoinTabs");
+    if (!host) return;
+    [["own-line", "Divider on its own line"], ["inline", "Divider inline"]].forEach(function (pair) {
+      let chip = el("button", "vertical-chip" + (pair[0] === joinMode ? " active" : ""), pair[1]);
+      chip.type = "button";
+      chip.dataset.joinMode = pair[0];
+      chip.addEventListener("click", function () {
+        joinMode = pair[0];
+        $$(".vertical-chip", host).forEach(function (c) {
+          c.classList.toggle("active", c.dataset.joinMode === joinMode);
+        });
+        renderBio();
+      });
+      host.appendChild(chip);
+    });
+  }
+
+  function bindBioInput() {
+    let input = $("#scrollBioInput");
+    if (input) input.addEventListener("input", triggerRender);
+  }
+
+  /* --------------------------------------------------------------------------
+     Marquee controls
+     -------------------------------------------------------------------------- */
+  function fillSelect(select, choices, isStyle) {
+    if (!select) return;
+    select.innerHTML = "";
+    choices.forEach(function (pair) {
+      let val = pair[0];
+      if (isStyle && val && !stylesRegistry[val]) return;
+      let opt = document.createElement("option");
+      opt.value = val;
+      opt.textContent = pair[1];
+      select.appendChild(opt);
+    });
+  }
+
+  function buildMarqueeControls() {
+    let d = DATA.MARQUEE_DEFAULTS;
+
+    fillSelect($("#scrollMarqueeStyle"), STYLE_CHOICES, true);
+    fillSelect($("#scrollMarqueeDirection"),
+      [["left", "Right → Left"], ["right", "Left → Right"]], false);
+
+    setVal("#scrollMarqueeInput", d.text);
+    setVal("#scrollMarqueeSpeed", d.speed);
+    setVal("#scrollMarqueeGap", d.gap);
+    setVal("#scrollMarqueeSize", d.fontSize);
+    setVal("#scrollMarqueeRepeat", d.repeatCount);
+    setVal("#scrollMarqueeColor", d.textColor);
+    setVal("#scrollMarqueeBg", d.bgColor);
+
+    let controls = [
+      "#scrollMarqueeInput", "#scrollMarqueeStyle", "#scrollMarqueeDirection",
+      "#scrollMarqueeSpeed", "#scrollMarqueeGap", "#scrollMarqueeSize",
+      "#scrollMarqueeColor", "#scrollMarqueeBg", "#scrollMarqueeRepeat"
+    ];
+    controls.forEach(function (sel) {
+      let node = $(sel);
+      if (!node) return;
+      let ev = (node.tagName === "SELECT") ? "change" : "input";
+      node.addEventListener(ev, renderMarquee);
+    });
+
+    let copyBtn = $("#scrollCopyEmbed");
+    if (copyBtn) copyBtn.addEventListener("click", copyEmbed);
+  }
+
+  function setVal(sel, value) {
+    let node = $(sel);
+    if (node) node.value = value;
+  }
+
+  function capitalize(str) {
+    return str.charAt(0).toUpperCase() + str.slice(1);
+  }
+
+  /* --------------------------------------------------------------------------
+     Init
+     -------------------------------------------------------------------------- */
+  function readUrlState() {
+    try {
+      let params = new URLSearchParams(window.location.search);
+      let urlMode = params.get("mode");
+      if (urlMode && MODES.some(function (m) { return m.id === urlMode; })) mode = urlMode;
+      let text = params.get("text") || params.get("q");
+      let input = $("#scrollBioInput");
+      if (text && input && !input.value) input.value = text;
+    } catch (e) {}
+  }
+
+  function init() {
+    /* URL state first, so a ?q=/?text= link fills the input before we fall
+       back to the preloaded sample. */
+    readUrlState();
+
+    let bioInput = $("#scrollBioInput");
+    /* Preload a sample so there is output on first paint (mirrors the other
+       studio pages). "I love you" is the confirmed high-intent variant. */
+    if (bioInput && !bioInput.value.trim()) bioInput.value = "I love you";
+
+    buildModeTabs();
+    buildPresets();
+    buildDividerPicker();
+    buildRepeatControls();
+    buildJoinControls();
+    bindBioInput();
+    buildMarqueeControls();
+
+    setMode(mode);
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/script.js
+++ b/script.js
@@ -925,6 +925,7 @@ const decorations = window.UTG_DECORATIONS
     if (window.UTG_ZALGO_MODE) return;
     if (window.UTG_DECORATOR_MODE) return;
     if (window.UTG_TATTOO_MODE) return;
+    if (window.UTG_SCROLL_MODE) return;
     if (window.UTG_CURSIVE_MODE) return;
     if (window.UTG_EVENT_MODE) return;
     if (!el.decorationGrid) return;
@@ -977,7 +978,7 @@ const decorations = window.UTG_DECORATIONS
   // editing each HTML file (skipped on the dedicated vertical/zalgo pages,
   // which run their own controllers).
   function ensureScopeControl() {
-    if (window.UTG_VERTICAL_MODE || window.UTG_ZALGO_MODE || window.UTG_DECORATOR_MODE || window.UTG_TATTOO_MODE || window.UTG_CURSIVE_MODE || window.UTG_EVENT_MODE) return null;
+    if (window.UTG_VERTICAL_MODE || window.UTG_ZALGO_MODE || window.UTG_DECORATOR_MODE || window.UTG_TATTOO_MODE || window.UTG_CURSIVE_MODE || window.UTG_EVENT_MODE || window.UTG_SCROLL_MODE) return null;
     if (!el.resultsGrid) return null;
 
     let control = $("#scopeControl");
@@ -1062,7 +1063,7 @@ const decorations = window.UTG_DECORATIONS
   // style is generated, so every card in the grid gains the formatting at once.
   function ensureFormatControl() {
     if (!window.UTG_FORMAT_MARKS) return null;
-    if (window.UTG_VERTICAL_MODE || window.UTG_ZALGO_MODE || window.UTG_DECORATOR_MODE || window.UTG_TATTOO_MODE || window.UTG_CURSIVE_MODE || window.UTG_EVENT_MODE) return null;
+    if (window.UTG_VERTICAL_MODE || window.UTG_ZALGO_MODE || window.UTG_DECORATOR_MODE || window.UTG_TATTOO_MODE || window.UTG_CURSIVE_MODE || window.UTG_EVENT_MODE || window.UTG_SCROLL_MODE) return null;
     if (!el.resultsGrid) return null;
 
     let control = $("#formatControl");
@@ -1193,6 +1194,7 @@ const decorations = window.UTG_DECORATIONS
     if (window.UTG_ZALGO_MODE) return;
     if (window.UTG_DECORATOR_MODE) return;
     if (window.UTG_TATTOO_MODE) return;
+    if (window.UTG_SCROLL_MODE) return;
     if (window.UTG_CURSIVE_MODE) return;
     if (window.UTG_EVENT_MODE) return;
     if (!el.resultsGrid) return;
@@ -1238,6 +1240,7 @@ const decorations = window.UTG_DECORATIONS
     if (window.UTG_ZALGO_MODE) return;
     if (window.UTG_DECORATOR_MODE) return;
     if (window.UTG_TATTOO_MODE) return;
+    if (window.UTG_SCROLL_MODE) return;
     if (window.UTG_CURSIVE_MODE) return;
     if (window.UTG_EVENT_MODE) return;
     if (!el.resultsGrid) return;

--- a/script.js
+++ b/script.js
@@ -926,6 +926,7 @@ const decorations = window.UTG_DECORATIONS
     if (window.UTG_DECORATOR_MODE) return;
     if (window.UTG_TATTOO_MODE) return;
     if (window.UTG_SCROLL_MODE) return;
+    if (window.UTG_REPEAT_MODE) return;
     if (window.UTG_CURSIVE_MODE) return;
     if (window.UTG_EVENT_MODE) return;
     if (!el.decorationGrid) return;
@@ -978,7 +979,7 @@ const decorations = window.UTG_DECORATIONS
   // editing each HTML file (skipped on the dedicated vertical/zalgo pages,
   // which run their own controllers).
   function ensureScopeControl() {
-    if (window.UTG_VERTICAL_MODE || window.UTG_ZALGO_MODE || window.UTG_DECORATOR_MODE || window.UTG_TATTOO_MODE || window.UTG_CURSIVE_MODE || window.UTG_EVENT_MODE || window.UTG_SCROLL_MODE) return null;
+    if (window.UTG_VERTICAL_MODE || window.UTG_ZALGO_MODE || window.UTG_DECORATOR_MODE || window.UTG_TATTOO_MODE || window.UTG_CURSIVE_MODE || window.UTG_EVENT_MODE || window.UTG_SCROLL_MODE || window.UTG_REPEAT_MODE) return null;
     if (!el.resultsGrid) return null;
 
     let control = $("#scopeControl");
@@ -1063,7 +1064,7 @@ const decorations = window.UTG_DECORATIONS
   // style is generated, so every card in the grid gains the formatting at once.
   function ensureFormatControl() {
     if (!window.UTG_FORMAT_MARKS) return null;
-    if (window.UTG_VERTICAL_MODE || window.UTG_ZALGO_MODE || window.UTG_DECORATOR_MODE || window.UTG_TATTOO_MODE || window.UTG_CURSIVE_MODE || window.UTG_EVENT_MODE || window.UTG_SCROLL_MODE) return null;
+    if (window.UTG_VERTICAL_MODE || window.UTG_ZALGO_MODE || window.UTG_DECORATOR_MODE || window.UTG_TATTOO_MODE || window.UTG_CURSIVE_MODE || window.UTG_EVENT_MODE || window.UTG_SCROLL_MODE || window.UTG_REPEAT_MODE) return null;
     if (!el.resultsGrid) return null;
 
     let control = $("#formatControl");
@@ -1195,6 +1196,7 @@ const decorations = window.UTG_DECORATIONS
     if (window.UTG_DECORATOR_MODE) return;
     if (window.UTG_TATTOO_MODE) return;
     if (window.UTG_SCROLL_MODE) return;
+    if (window.UTG_REPEAT_MODE) return;
     if (window.UTG_CURSIVE_MODE) return;
     if (window.UTG_EVENT_MODE) return;
     if (!el.resultsGrid) return;
@@ -1241,6 +1243,7 @@ const decorations = window.UTG_DECORATIONS
     if (window.UTG_DECORATOR_MODE) return;
     if (window.UTG_TATTOO_MODE) return;
     if (window.UTG_SCROLL_MODE) return;
+    if (window.UTG_REPEAT_MODE) return;
     if (window.UTG_CURSIVE_MODE) return;
     if (window.UTG_EVENT_MODE) return;
     if (!el.resultsGrid) return;

--- a/style.css
+++ b/style.css
@@ -7448,3 +7448,71 @@ body.dark-mode .kana-cell-empty { opacity: 0.35; }
 @media (max-width: 640px) {
   .scroll-mode-tabs { grid-template-columns: 1fr; }
 }
+
+/* ==========================================================================
+   REPEAT TEXT GENERATOR (/usecase/repeat-text/)
+   Reuses the .scroll-* field / chip / control-block / card styling; only the
+   arrangement (shape) picker and the shape-preserving preview are page-specific
+   (repeat-* prefix). Tokens only — no hardcoded colors — so dark mode adapts
+   the same way the shared .scroll-* classes do.
+   ========================================================================== */
+
+/* Arrangement picker — visual buttons with a mini preview per shape (mirrors
+   the vertical page's layout picker) */
+.repeat-shape-picker {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(96px, 1fr));
+  gap: 8px;
+}
+.repeat-shape-option {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 8px 6px;
+  border: 1px solid var(--border-light);
+  border-radius: 10px;
+  background: var(--bg-white);
+  color: var(--text-primary);
+  font: inherit;
+  cursor: pointer;
+  transition: border-color .15s, background .15s, color .15s;
+}
+.repeat-shape-option:hover {
+  border-color: var(--accent-purple);
+}
+.repeat-shape-option.active {
+  border-color: var(--accent-purple);
+  box-shadow: inset 0 0 0 1px var(--accent-purple);
+}
+.repeat-shape-mini {
+  margin: 0;
+  width: 100%;
+  height: 40px;
+  overflow: hidden;
+  font-family: monospace, monospace;
+  font-size: 0.5rem;
+  line-height: 1.15;
+  white-space: pre;
+  text-align: left;
+  color: var(--text-muted);
+  pointer-events: none;
+}
+.repeat-shape-option.active .repeat-shape-mini {
+  color: var(--accent-purple);
+}
+.repeat-shape-name {
+  font-size: 0.68rem;
+  font-weight: 600;
+  text-align: center;
+}
+
+/* Shape-preserving preview — monospace + real newlines so pyramids/box grids
+   keep their geometry; wide shapes scroll horizontally instead of wrapping. */
+.repeat-preview {
+  white-space: pre;
+  overflow: auto;
+  max-height: 240px;
+  font-family: monospace, monospace;
+  line-height: 1.4;
+}

--- a/style.css
+++ b/style.css
@@ -7143,3 +7143,308 @@ body.dark-mode .kana-cell-empty { opacity: 0.35; }
   white-space: pre;
   color: var(--text-primary);
 }
+
+/* ==========================================================================
+   SCROLLING TEXT TOOL  (/usecase/scrolling-text/)
+   Two modes under one page: "bio" (a repeated, divider-separated block that
+   overflows a bio and scrolls — rendered into #resultsGrid via the shared
+   .style-card / .copy-btn contract) and "marquee" (a portable CSS-animation
+   banner with a live preview + embed code). Tokens only; no hardcoded colors.
+   ========================================================================== */
+
+/* Mode tabs — two big pills under the headline */
+.scroll-mode-tabs {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 8px;
+  margin: 16px 0 4px;
+}
+.scroll-mode-tab {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  padding: 10px 12px;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius);
+  background: var(--bg-white);
+  color: var(--text-primary);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color .15s, box-shadow .15s;
+}
+.scroll-mode-tab:hover {
+  border-color: var(--accent-purple);
+}
+.scroll-mode-tab.active {
+  border-color: var(--accent-purple);
+  box-shadow: inset 0 0 0 1px var(--accent-purple);
+}
+.scroll-mode-tab-label {
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+.scroll-mode-tab-hint {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  line-height: 1.35;
+}
+
+/* Panels + tool card */
+.scroll-panel {
+  margin-top: 18px;
+}
+.scroll-tool {
+  background: var(--bg-white);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-lg);
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-bottom: 20px;
+}
+.scroll-tool-marquee {
+  display: grid;
+  grid-template-columns: minmax(260px, 340px) 1fr;
+  gap: 24px;
+  align-items: start;
+}
+
+/* Control blocks */
+.scroll-control-block {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.scroll-control-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: .04em;
+}
+
+/* Fields (shared by both modes) */
+.scroll-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.scroll-field > label {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+.scroll-field textarea,
+.scroll-field input[type="text"],
+.scroll-field select,
+.scroll-select {
+  width: 100%;
+  border: 1px solid var(--border-light);
+  border-radius: 8px;
+  background: var(--bg-base);
+  color: var(--text-primary);
+  font-family: inherit;
+  font-size: 0.9375rem;
+  padding: 8px 10px;
+}
+.scroll-field textarea { resize: vertical; min-height: 64px; }
+.scroll-field input[type="range"] { width: 100%; accent-color: var(--accent-purple); }
+.scroll-field input[type="color"] {
+  width: 44px; height: 32px; padding: 0;
+  border: 1px solid var(--border-light); border-radius: 8px;
+  background: var(--bg-white); cursor: pointer;
+}
+.scroll-row { display: flex; gap: 12px; }
+.scroll-row .scroll-field { flex: 1; }
+
+/* Preset quick-fill chips */
+.scroll-presets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.scroll-preset-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 5px 12px;
+  border: 1px solid var(--border-light);
+  border-radius: 20px;
+  background: var(--bg-base);
+  color: var(--text-primary);
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: border-color .15s, color .15s;
+}
+.scroll-preset-chip:hover {
+  border-color: var(--accent-purple);
+  color: var(--accent-purple);
+}
+
+/* Divider group tabs */
+.scroll-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.scroll-tab {
+  padding: 4px 12px;
+  border: 1px solid var(--border-light);
+  border-radius: 20px;
+  background: var(--bg-white);
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: border-color .15s, color .15s;
+}
+.scroll-tab:hover { border-color: var(--accent-purple); color: var(--accent-purple); }
+.scroll-tab.active {
+  border-color: var(--accent-purple);
+  color: var(--accent-purple);
+  box-shadow: inset 0 0 0 1px var(--accent-purple);
+}
+
+/* Reused chip grid (divider / repeat-mode / join chips use .vertical-chip) */
+.scroll-chip-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.scroll-inline-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.scroll-inline-label {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  font-weight: 600;
+}
+.scroll-range-value {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  min-width: 34px;
+}
+.scroll-select { max-width: 260px; cursor: pointer; }
+
+/* Output note + fit badges (bio mode) */
+.scroll-output-note {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.scroll-fit-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.75rem;
+}
+.scroll-fit-count {
+  font-weight: 600;
+  color: var(--text-secondary);
+  margin-right: 4px;
+}
+.scroll-fit-badge {
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-weight: 600;
+  border: 1px solid var(--border-light);
+  color: var(--text-muted);
+}
+.scroll-fit-badge.scrolls {
+  border-color: var(--accent-purple);
+  color: var(--accent-purple);
+}
+.scroll-fit-legend {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  line-height: 1.4;
+  margin: 0;
+}
+
+/* Bio result cards — bounded height so a long repeated block stays tidy */
+.scroll-style-card .scroll-card-meta {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  margin: 2px 0 6px;
+}
+.scroll-preview {
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 220px;
+  overflow-y: auto;
+  line-height: 1.4;
+}
+.scroll-lazy-sentinel { width: 100%; height: 1px; }
+
+/* Marquee stage */
+.scroll-stage {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.marquee-preview {
+  min-height: 120px;
+  display: flex;
+  align-items: center;
+  border: 1px solid var(--border-light);
+  border-radius: 14px;
+  overflow: hidden;
+  background: var(--bg-base);
+}
+.marquee-preview > div { width: 100%; }
+.scroll-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+}
+/* Deliberately NOT .copy-btn: that class is matched by script.js's global
+   document click delegate (keyed off dataset.text), which would immediately
+   overwrite this button's own clipboard write with an empty string. Same
+   look, own click handling (see scrollPageController.js's copyEmbed()). */
+.scroll-copy-btn {
+  padding: 8px 16px;
+  border: 1px solid var(--border-light);
+  border-radius: 8px;
+  background: var(--bg-white);
+  color: var(--text-secondary);
+  font-family: inherit;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+.scroll-copy-btn:hover {
+  background: var(--accent-purple);
+  border-color: var(--accent-purple);
+  color: white;
+}
+.scroll-embed-code {
+  width: 100%;
+  min-height: 120px;
+  border: 1px solid var(--border-light);
+  border-radius: 8px;
+  background: var(--bg-base);
+  color: var(--text-primary);
+  font-family: 'Space Mono', ui-monospace, 'Courier New', monospace;
+  font-size: 0.78rem;
+  line-height: 1.4;
+  padding: 10px 12px;
+  resize: vertical;
+}
+
+@media (max-width: 780px) {
+  .scroll-tool-marquee { grid-template-columns: 1fr; }
+}
+@media (max-width: 640px) {
+  .scroll-mode-tabs { grid-template-columns: 1fr; }
+}

--- a/usecase/index.html
+++ b/usecase/index.html
@@ -106,6 +106,17 @@ o</div>
 
       <div class="style-card usecase-cards" style="flex-direction:column;align-items:stretch;gap:8px;">
         <div class="style-name">
+          <span class="style-tag">🔁</span>
+          Scrolling Text Generator
+        </div>
+        <p class="usecase-outcome">Make a bio scroll — or embed a moving banner.</p>
+        <p class="usecase-diff">Repeat a message into a divider-separated block that overflows a bio box and forces a scroll, or build a self-contained CSS marquee to paste on a website, forum signature, or OBS overlay.</p>
+        <div class="usecase-example">I love you ────── I love you ────── I love you</div>
+        <a class="usecase-cta" href="/usecase/scrolling-text/">Generate Scrolling Text →</a>
+      </div>
+
+      <div class="style-card usecase-cards" style="flex-direction:column;align-items:stretch;gap:8px;">
+        <div class="style-name">
           <span class="style-tag">【 】</span>
           Text Decorator
         </div>

--- a/usecase/index.html
+++ b/usecase/index.html
@@ -117,6 +117,19 @@ o</div>
 
       <div class="style-card usecase-cards" style="flex-direction:column;align-items:stretch;gap:8px;">
         <div class="style-name">
+          <span class="style-tag">🔂</span>
+          Repeat Text Generator
+        </div>
+        <p class="usecase-outcome">Say it 100 times, then copy and paste.</p>
+        <p class="usecase-diff">Repeat any phrase up to 200 times — say sorry 100 times or build an I love you 100 times block — then arrange the copies inline, in a list, or into a pyramid, staircase, diagonal, or box grid.</p>
+        <div class="usecase-example">Sorry Sorry Sorry
+Sorry Sorry
+Sorry</div>
+        <a class="usecase-cta" href="/usecase/repeat-text/">Generate Repeat Text →</a>
+      </div>
+
+      <div class="style-card usecase-cards" style="flex-direction:column;align-items:stretch;gap:8px;">
+        <div class="style-name">
           <span class="style-tag">【 】</span>
           Text Decorator
         </div>

--- a/usecase/repeat-text/index.html
+++ b/usecase/repeat-text/index.html
@@ -1,0 +1,285 @@
+<!DOCTYPE html><html lang="en"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Repeat Text Generator — Say Sorry 100 Times &amp; I Love You 100 Times, Copy-Paste | UltraTextGen</title>
+  <meta name="description" content="Repeat text generator: say sorry 100 times, make an I love you 100 times copy-paste block, or repeat any phrase and arrange the copies into a pyramid, staircase, diagonal, or box grid. Free, no signup, runs in your browser.">
+  <link rel="canonical" href="https://ultratextgen.com/usecase/repeat-text/">
+  <meta name="robots" content="index, follow">
+
+  <!-- Open Graph -->
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Repeat Text Generator — Sorry 100 Times &amp; I Love You 100 Times">
+  <meta property="og:description" content="Repeat any phrase N times and copy-paste it — say sorry 100 times, build an I love you 100 times block, or arrange the copies into a pyramid, staircase, diagonal, or grid. Free.">
+  <meta property="og:url" content="https://ultratextgen.com/usecase/repeat-text/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/fancy-text-generator-preview.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Repeat Text Generator — Sorry 100 Times &amp; I Love You 100 Times">
+  <meta name="twitter:description" content="Repeat any phrase N times and copy-paste it. Say sorry 100 times, make an I love you 100 times block, or shape the copies. Free, no signup.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/fancy-text-generator-preview.png">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Repeat Text Generator",
+  "alternateName": ["Sorry 100 Times Generator", "I Love You 100 Times Generator", "Repeat Text Copy Paste", "Say It N Times Generator"],
+  "url": "https://ultratextgen.com/usecase/repeat-text/",
+  "inLanguage": "en",
+  "applicationCategory": "UtilitiesApplication",
+  "operatingSystem": "Any",
+  "description": "Repeat a phrase any number of times and copy-paste the result. Say sorry 100 times, build an I love you 100 times block, or arrange the copies into a pyramid, reverse pyramid, staircase, diagonal, or box grid — then restyle the whole block in 80+ Unicode fonts.",
+  "featureList": [
+    "Repeat any phrase up to 200 times and copy-paste the block",
+    "Quick-fill apology and love phrases plus a 100-times preset",
+    "Inline (one line) or block (one copy per line) arrangements with dividers",
+    "Shape the copies into a pyramid, reverse pyramid, staircase, diagonal, or box grid",
+    "Indentation padded with an invisible character so shapes survive pasting",
+    "Restyle the repeated block in 80+ Unicode fonts, then copy and paste"
+  ],
+  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "en",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "How do I say sorry 100 times online?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Type \"Sorry\" (or \"I'm sorry\", \"Please forgive me\") into the phrase box, set the count to 100 using the ×100 chip or the slider, and leave the arrangement on Block so each apology sits on its own line. The tool builds the whole \"sorry 100 times\" block instantly — press Copy on the Normal card and paste it wherever you need it. You can also switch to Inline for one long line, or restyle the block in any of the Unicode fonts before copying." }
+    },
+    {
+      "@type": "Question",
+      "name": "How do I make an \"I love you 100 times\" copy-paste block?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Pick the \"I love you\" quick-fill chip (or type your own phrase), set the count to 100, and choose an arrangement. Block puts one \"I love you\" per line for a classic 100-times list; Inline runs them along a single line separated by a divider; or use a shape like Pyramid or Box Grid to make it look like a card. Hit Copy and paste the block into a message, a note, a caption, or a bio." }
+    },
+    {
+      "@type": "Question",
+      "name": "What are the shape arrangements for?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Beyond a plain repeated list, you can arrange the copies visually. Pyramid builds the copies up row by row into a centered triangle; Reverse Pyramid starts wide and tapers to a point; Staircase and Diagonal step each copy further to the right; and Box Grid tiles the copies into a rectangle with a column count you choose. They turn a simple \"say it N times\" into something that reads like art — handy for a heartfelt message, a comment, or a shout-out." }
+    },
+    {
+      "@type": "Question",
+      "name": "Will the shaped text stay intact after I paste it?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Mostly, yes — with a caveat. The shapes rely on indentation, and some apps (notably Instagram and TikTok bios) strip leading spaces and blank lines when you save. To survive that, the tool rebuilds the indentation from an invisible Braille-blank character (U+2800) instead of ordinary spaces, so the shape holds in most places you paste. It is still safest to keep the phrase short, paste into a monospace-friendly field, and preview before you post. The plain Inline and Block arrangements have no indentation, so they paste cleanly everywhere." }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I repeat any text, not just apologies or love notes?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Yes. The repeat text copy paste tool works with any short phrase — a name, a word, an emoji, a catchphrase, a username, or a lyric. Type it in, choose how many times to repeat it (up to 200), pick an arrangement, and copy the result. The apology and love presets are just shortcuts for the most-searched phrases; nothing limits you to them." }
+    },
+    {
+      "@type": "Question",
+      "name": "Is the repeat text generator free?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Completely free. No sign-up, no watermark, no limits beyond the 200-copy cap that keeps the output sane. Everything runs in your browser — nothing is uploaded to a server — so you can repeat and copy as much as you like." }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ultratextgen.com/" },
+    { "@type": "ListItem", "position": 2, "name": "Use Cases", "item": "https://ultratextgen.com/usecase/" },
+    { "@type": "ListItem", "position": 3, "name": "Repeat Text Generator", "item": "https://ultratextgen.com/usecase/repeat-text/" }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/">Home</a>
+  <span class="breadcrumb-separator">›</span>
+  <a href="/usecase/">Use Cases</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Repeat Text</span>
+</nav>
+
+<section class="hero">
+  <div class="hero-inner">
+    <div class="hero-card">
+      <h1 class="hero-headline">Repeat Text Generator</h1>
+      <p class="hero-tagline">Repeat any phrase and copy-paste it in one tap. Say <strong>sorry 100 times</strong>, build an <strong>I love you 100 times</strong> block, or arrange the copies into a pyramid, staircase, diagonal, or box grid — then restyle the whole thing in 80+ Unicode fonts.</p>
+    </div>
+  </div>
+</section>
+
+<main class="container">
+
+  <!-- ===================== TOOL ===================== -->
+  <section class="scroll-panel">
+    <div class="scroll-tool">
+      <div class="scroll-field">
+        <label for="repeatPhraseInput">Your phrase</label>
+        <textarea id="repeatPhraseInput" maxlength="120" placeholder="Type a short phrase… e.g. Sorry"></textarea>
+      </div>
+
+      <div class="scroll-control-block">
+        <span class="scroll-control-label">Quick fill</span>
+        <div class="scroll-presets" id="repeatPresets"></div>
+      </div>
+
+      <div class="scroll-control-block">
+        <span class="scroll-control-label">Arrangement</span>
+        <div class="repeat-shape-picker" id="repeatShapePicker"></div>
+      </div>
+
+      <div class="scroll-control-block">
+        <span class="scroll-control-label">How many times</span>
+        <div class="scroll-presets" id="repeatCountPresets"></div>
+        <div class="scroll-inline-row">
+          <input type="range" id="repeatCountRange" min="1" max="200" value="100" aria-label="Number of copies">
+          <span class="scroll-range-value"><span id="repeatCountValue">100</span>×</span>
+        </div>
+      </div>
+
+      <div class="scroll-control-block" id="repeatDividerBlock">
+        <span class="scroll-control-label">Divider (inline &amp; block)</span>
+        <div class="scroll-tabs" id="repeatDividerTabs"></div>
+        <div class="scroll-chip-grid" id="repeatDividerGrid"></div>
+      </div>
+
+      <div class="scroll-control-block u-hidden" id="repeatColumnsBlock">
+        <span class="scroll-control-label">Columns (box grid)</span>
+        <div class="scroll-inline-row">
+          <input type="range" id="repeatColumnsRange" min="2" max="12" value="5" aria-label="Columns in the box grid">
+          <span class="scroll-range-value"><span id="repeatColumnsValue">5</span> cols</span>
+        </div>
+      </div>
+
+      <div class="scroll-output-note" id="repeatNote" aria-live="polite"></div>
+    </div>
+
+    <div class="results-grid" id="resultsGrid"></div>
+  </section>
+
+  <!-- ===================== EDITORIAL ===================== -->
+  <section class="editorial-section">
+    <h2>Repeat a phrase, then copy and paste it</h2>
+    <p class="editorial-intro">Sometimes one "sorry" is not enough. This <strong>repeat text</strong> tool takes a short phrase, repeats it as many times as you want, and hands you a block you can copy and paste anywhere. Type the phrase, set the count, and go — the most-searched jobs, <strong>sorry 100 times</strong> and <strong>I love you 100 times</strong>, are one tap each.</p>
+    <div class="block-example">
+      1. Type a phrase → 2. set how many times (the <strong>×100</strong> chip is right there) → 3. pick an arrangement → 4. copy and paste
+    </div>
+    <p>The plain <strong>Normal</strong> card is the literal repeated text — real characters and line breaks — so it pastes cleanly into a message, a note, a caption, or a comment. Every other card is the same block restyled in a Unicode font, in case you want the repetition to stand out.</p>
+  </section>
+
+  <section class="editorial-section">
+    <h2>Shape the copies — pyramid, staircase, diagonal, box</h2>
+    <p class="editorial-intro">A flat list is only the start. Switch the arrangement and the same copies rearrange themselves into a shape, so "say it a hundred times" becomes something closer to art.</p>
+    <div class="block-example">
+      — <strong>Block</strong>: one copy per line — the classic "sorry 100 times" list.<br>
+      — <strong>Inline</strong>: every copy on one long line, separated by a divider you choose.<br>
+      — <strong>Pyramid / Reverse Pyramid</strong>: the copies build up (or taper down) into a centered triangle.<br>
+      — <strong>Staircase / Diagonal</strong>: one copy per row, each stepped further to the right.<br>
+      — <strong>Box Grid</strong>: the copies tile into a rectangle with a column count you set.
+    </div>
+    <p>The shaped arrangements lean on indentation, so the tool rebuilds that indentation from an invisible character (U+2800) rather than plain spaces. That helps the shape survive apps that strip whitespace — the same trick the <a href="/usecase/vertical-text/">vertical text generator</a> uses — though it is still smart to preview before you post.</p>
+  </section>
+
+  <section class="editorial-section">
+    <h2>Say sorry 100 times — or I love you 100 times</h2>
+    <p class="editorial-intro">The two phrases people repeat most are an apology and a declaration. Both start from a quick-fill chip.</p>
+    <div class="block-example">
+      <strong>Sorry ×100</strong> → a full page of apologies, ready to paste into a chat or a note.<br>
+      <strong>I love you ×100</strong> → a heartfelt block for a message, a caption, or a card.
+    </div>
+    <p>Keep the phrase short so the block stays readable, and remember the count caps at 200 — enough for "100 times," its "200 times" sibling, and anything in between. Want a bio that physically scrolls instead of a static block? That is a different job — the <a href="/usecase/scrolling-text/">scrolling text generator</a> handles it.</p>
+  </section>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <h2 class="faq-category">Repeat text questions</h2>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">How do I say sorry 100 times online?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">Type "Sorry" (or "I'm sorry", "Please forgive me") into the phrase box, set the count to 100 using the ×100 chip or the slider, and leave the arrangement on Block so each apology sits on its own line. The tool builds the whole "sorry 100 times" block instantly — press Copy on the Normal card and paste it wherever you need it. You can also switch to Inline for one long line, or restyle the block in any of the Unicode fonts before copying.</div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">How do I make an "I love you 100 times" copy-paste block?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">Pick the "I love you" quick-fill chip (or type your own phrase), set the count to 100, and choose an arrangement. Block puts one "I love you" per line for a classic 100-times list; Inline runs them along a single line separated by a divider; or use a shape like Pyramid or Box Grid to make it look like a card. Hit Copy and paste the block into a message, a caption, or a bio.</div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">What are the shape arrangements for?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">Beyond a plain repeated list, you can arrange the copies visually. Pyramid builds the copies up row by row into a centered triangle; Reverse Pyramid starts wide and tapers to a point; Staircase and Diagonal step each copy further to the right; and Box Grid tiles the copies into a rectangle with a column count you choose. They turn a simple "say it N times" into something that reads like art — handy for a heartfelt message, a comment, or a shout-out.</div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">Will the shaped text stay intact after I paste it?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">Mostly, yes — with a caveat. The shapes rely on indentation, and some apps (notably <a href="/instagram/">Instagram</a> and <a href="/tiktok/">TikTok</a> bios) strip leading spaces and blank lines when you save. To survive that, the tool rebuilds the indentation from an invisible Braille-blank character (U+2800) instead of ordinary spaces, so the shape holds in most places you paste. It is still safest to keep the phrase short, paste into a monospace-friendly field, and preview before you post. The plain Inline and Block arrangements have no indentation, so they paste cleanly everywhere.</div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">Can I repeat any text, not just apologies or love notes?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">Yes. The repeat text copy paste tool works with any short phrase — a name, a word, an emoji, a catchphrase, a username, or a lyric. Type it in, choose how many times to repeat it (up to 200), pick an arrangement, and copy the result. The apology and love presets are just shortcuts for the most-searched phrases; nothing limits you to them.</div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">Is the repeat text generator free?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">Completely free. No sign-up, no watermark, no limits beyond the 200-copy cap that keeps the output sane. Everything runs in your browser — nothing is uploaded to a server — so you can repeat and copy as much as you like.</div>
+      </div>
+    </div>
+  </footer>
+</main>
+
+<div class="copy-toast" id="copyToast">Copied!</div>
+
+<script>window.UTG_REPEAT_MODE = true;</script>
+<script src="/styles.js" defer></script>
+<script src="/renderer.js" defer></script>
+<script src="/js/scroll/scrollData.js" defer></script>
+<script src="/js/scroll/scrollBuilders.js" defer></script>
+<script src="/js/repeat/repeatData.js" defer></script>
+<script src="/js/repeat/repeatShapes.js" defer></script>
+<script src="/script.js" defer></script>
+<script src="/js/repeat/repeatPageController.js" defer></script>
+<script src="/footer.js" defer></script>
+</body></html>

--- a/usecase/scrolling-text/index.html
+++ b/usecase/scrolling-text/index.html
@@ -1,0 +1,350 @@
+<!DOCTYPE html><html lang="en"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script data-grow-initializer="">!(function(){window.growMe||((window.growMe=function(e){window.growMe._.push(e);}),(window.growMe._=[]));var e=document.createElement("script");(e.type="text/javascript"),(e.src="https://faves.grow.me/main.js"),(e.defer=!0),e.setAttribute("data-grow-faves-site-id","U2l0ZTplMzgxNTIwYS1jYTIzLTQ4Y2EtYTA2Ni04M2M0MjBkZGRkZWE=");var t=document.getElementsByTagName("script")[0];t.parentNode.insertBefore(e,t);})();</script>
+  <script type="text/javascript" async="async" data-noptimize="1" data-cfasync="false" src="//scripts.scriptwrapper.com/tags/e381520a-ca23-48ca-a066-83c420ddddea.js"></script>
+
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Scrolling Text Generator — Copy-Paste Bio Scroll &amp; Marquee Banner | UltraTextGen</title>
+  <meta name="description" content="Scrolling text generator: copy and paste a repeated, divider-separated block that overflows an Instagram or TikTok bio and scrolls — or build a portable CSS marquee banner for a website, forum signature, or OBS overlay. Free, no signup.">
+  <link rel="canonical" href="https://ultratextgen.com/usecase/scrolling-text/">
+  <meta name="robots" content="index, follow">
+
+  <!-- Open Graph -->
+  <meta property="og:site_name" content="UltraTextGen">
+  <meta property="og:title" content="Scrolling Text Generator — Bio Scroll Trick &amp; Marquee Banner">
+  <meta property="og:description" content="Copy and paste a repeated, divider-separated block that overflows your bio and scrolls — or build a portable CSS marquee for a site or OBS overlay. Free.">
+  <meta property="og:url" content="https://ultratextgen.com/usecase/scrolling-text/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://ultratextgen.com/assets/og/fancy-text-generator-preview.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:type" content="image/png">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Scrolling Text Generator — Bio Scroll Trick &amp; Marquee Banner">
+  <meta name="twitter:description" content="Copy-paste a repeated block that overflows your bio and scrolls, or embed a portable CSS marquee banner. Free, no signup.">
+  <meta name="twitter:image" content="https://ultratextgen.com/assets/og/fancy-text-generator-preview.png">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Scrolling Text Generator",
+  "alternateName": ["Scrolling Text Copy Paste", "Bio Scroll Text Generator", "Marquee Text Generator", "Scrolling Marquee Banner Maker"],
+  "url": "https://ultratextgen.com/usecase/scrolling-text/",
+  "inLanguage": "en",
+  "applicationCategory": "UtilitiesApplication",
+  "operatingSystem": "Any",
+  "description": "Two ways to make scrolling text: a repeated, divider-separated block you copy and paste into a profile bio so it overflows the fixed-height box and forces a scroll, and a self-contained CSS-animation marquee banner you can embed on a website, forum signature, or OBS overlay.",
+  "featureList": [
+    "Repeat any message into a divider-separated bio block that overflows and scrolls",
+    "Fill-to-platform repeats using approximate Instagram, TikTok, X and other bio limits",
+    "Box Drawing and General Punctuation dividers between repeats",
+    "Style the block in 80+ Unicode fonts, then copy and paste",
+    "Build a portable CSS marquee banner with speed, direction, gap and colors",
+    "Copy a self-contained embed snippet for a website or OBS browser source"
+  ],
+  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "en",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is scrolling text?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Scrolling text means two different things, and this generator does both. The first is the bio-scroll trick: you repeat a short message many times, separated by dividers, and paste that block into a profile bio. Because the block is taller than the fixed-height bio box, the box has to scroll to show it all. The second is a moving marquee (or ticker) — text that literally slides across the screen — which is an animation, not plain characters, so this tool gives you a portable CSS snippet to embed on a website, forum signature, or OBS overlay." }
+    },
+    {
+      "@type": "Question",
+      "name": "How do I make my Instagram or TikTok bio scroll?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Use Bio Scroll Text mode. Type your message (for example \"I love you\"), pick a divider, and set the repeat count high enough that the output is longer than the bio's character limit — Instagram is about 150 characters, TikTok about 80. Use \"Fill to platform\" to have the tool pick the repeats for you. Copy the result and paste it into your bio. Because the pasted block overflows the fixed-height bio box, the box scrolls. Tip: keep the message short, and edit your bio on the desktop site, which preserves line breaks more reliably than the app." }
+    },
+    {
+      "@type": "Question",
+      "name": "How do I add a scrolling marquee or ticker to a website or OBS overlay?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Switch to Marquee Banner mode, set the text, speed, direction, gap and colors, then press \"Copy embed code\". You get one self-contained snippet — a small block of CSS plus HTML — that you paste into your own page. For a website, drop it into your HTML. For a forum signature, paste it wherever raw HTML is allowed. For OBS, save the snippet as an .html file and add it as a Browser source. The snippet uses uniquely-named classes and its own keyframes, so it will not clash with the rest of your page, and it needs no external files or fonts." }
+    },
+    {
+      "@type": "Question",
+      "name": "Does this still work like the old HTML marquee tag?",
+      "acceptedAnswer": { "@type": "Answer", "text": "It replaces it. The old <marquee> tag is deprecated and non-standard — browsers still tend to honor it, but it was never part of a modern HTML standard and can stop working at any time. This generator produces the modern, portable equivalent instead: a CSS animation that scrolls a doubled track for a seamless loop. It pauses on hover and automatically stops for visitors who have reduced-motion turned on, which the old tag never did." }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I copy scrolling text as plain characters?",
+      "acceptedAnswer": { "@type": "Answer", "text": "The bio-scroll block is plain, copy-paste text — real Unicode characters and line breaks — so it works anywhere you can paste text, and you can style it in any of the Unicode fonts on this page first. Actual motion (a marquee that slides across the screen) is an animation, not a text property, so it cannot be copied as characters. That is why marquee mode gives you an embeddable code snippet rather than copy-paste text." }
+    },
+    {
+      "@type": "Question",
+      "name": "Why does my scrolling bio collapse into one line?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Some apps strip blank lines and trailing spaces when you save a bio. If you used the plain \"None\" or \"Blank gap\" divider and the lines collapsed, switch to a visible divider (a line, dot, or star row) so every line has a real character on it and survives saving. Editing your bio on the platform's desktop website, and pasting straight from this tool rather than from a rich-text editor, also helps the line breaks stick." }
+    },
+    {
+      "@type": "Question",
+      "name": "Is the scrolling text generator free?",
+      "acceptedAnswer": { "@type": "Answer", "text": "Completely free. No sign-up, no watermark, no limits. Everything runs in your browser — nothing is uploaded to a server — whether you are copying a bio-scroll block or an embeddable marquee snippet." }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ultratextgen.com/" },
+    { "@type": "ListItem", "position": 2, "name": "Use Cases", "item": "https://ultratextgen.com/usecase/" },
+    { "@type": "ListItem", "position": 3, "name": "Scrolling Text Generator", "item": "https://ultratextgen.com/usecase/scrolling-text/" }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/">Home</a>
+  <span class="breadcrumb-separator">›</span>
+  <a href="/usecase/">Use Cases</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Scrolling Text</span>
+</nav>
+
+<section class="hero">
+  <div class="hero-inner">
+    <div class="hero-card">
+      <h1 class="hero-headline">Scrolling Text Generator</h1>
+      <p class="hero-tagline">Two ways to make text scroll. <strong>Bio Scroll Text</strong> repeats your message into a divider-separated block you copy and paste so it overflows a bio box and scrolls. <strong>Marquee Banner</strong> builds a portable, animated ticker you can embed on a website, forum signature, or OBS overlay.</p>
+      <div class="scroll-mode-tabs" id="scrollModeTabs"></div>
+    </div>
+  </div>
+</section>
+
+<main class="container">
+
+  <!-- ===================== BIO SCROLL PANEL ===================== -->
+  <section class="scroll-panel" data-scroll-panel="bio">
+    <div class="scroll-tool">
+      <div class="scroll-field">
+        <label for="scrollBioInput">Your message</label>
+        <textarea id="scrollBioInput" maxlength="200" placeholder="Type a short message… e.g. I love you"></textarea>
+      </div>
+
+      <div class="scroll-control-block">
+        <span class="scroll-control-label">Quick fill</span>
+        <div class="scroll-presets" id="scrollPresets"></div>
+      </div>
+
+      <div class="scroll-control-block">
+        <span class="scroll-control-label">Divider</span>
+        <div class="scroll-tabs" id="scrollDividerTabs"></div>
+        <div class="scroll-chip-grid" id="scrollDividerGrid"></div>
+      </div>
+
+      <div class="scroll-control-block">
+        <span class="scroll-control-label">Repeat</span>
+        <div class="scroll-chip-grid" id="scrollRepeatModeTabs"></div>
+        <div class="scroll-inline-row" id="scrollCountRow">
+          <input type="range" id="scrollRepeatCount" min="1" max="40" value="6" aria-label="Number of repeats">
+          <span class="scroll-range-value"><span id="scrollRepeatValue">6</span>×</span>
+        </div>
+        <div class="scroll-inline-row u-hidden" id="scrollFillRow">
+          <label for="scrollPlatformSelect" class="scroll-inline-label">Fill to</label>
+          <select id="scrollPlatformSelect" class="scroll-select"></select>
+        </div>
+      </div>
+
+      <div class="scroll-control-block">
+        <span class="scroll-control-label">Layout</span>
+        <div class="scroll-chip-grid" id="scrollJoinTabs"></div>
+      </div>
+
+      <div class="scroll-output-note" id="scrollBioNote" aria-live="polite"></div>
+    </div>
+
+    <div class="results-grid" id="resultsGrid"></div>
+  </section>
+
+  <!-- ===================== MARQUEE PANEL ===================== -->
+  <section class="scroll-panel u-hidden" data-scroll-panel="marquee">
+    <div class="scroll-tool scroll-tool-marquee">
+      <div class="scroll-marquee-controls">
+        <div class="scroll-field">
+          <label for="scrollMarqueeInput">Banner text</label>
+          <input type="text" id="scrollMarqueeInput" maxlength="120">
+        </div>
+        <div class="scroll-row">
+          <div class="scroll-field">
+            <label for="scrollMarqueeStyle">Font style</label>
+            <select id="scrollMarqueeStyle"></select>
+          </div>
+          <div class="scroll-field">
+            <label for="scrollMarqueeDirection">Direction</label>
+            <select id="scrollMarqueeDirection"></select>
+          </div>
+        </div>
+        <div class="scroll-field">
+          <label for="scrollMarqueeSpeed">Speed — lower is faster (<span id="scrollSpeedVal">12s</span>)</label>
+          <input type="range" id="scrollMarqueeSpeed" min="2" max="40" value="12">
+        </div>
+        <div class="scroll-field">
+          <label for="scrollMarqueeGap">Gap between copies (<span id="scrollGapVal">48px</span>)</label>
+          <input type="range" id="scrollMarqueeGap" min="0" max="160" value="48">
+        </div>
+        <div class="scroll-field">
+          <label for="scrollMarqueeSize">Text size (<span id="scrollSizeVal">28px</span>)</label>
+          <input type="range" id="scrollMarqueeSize" min="12" max="80" value="28">
+        </div>
+        <div class="scroll-field">
+          <label for="scrollMarqueeRepeat">Copies per loop (<span id="scrollRepeatVal">4</span>)</label>
+          <input type="range" id="scrollMarqueeRepeat" min="1" max="12" value="4">
+        </div>
+        <div class="scroll-row">
+          <div class="scroll-field">
+            <label for="scrollMarqueeColor">Text color</label>
+            <input type="color" id="scrollMarqueeColor" value="#8b5cf6">
+          </div>
+          <div class="scroll-field">
+            <label for="scrollMarqueeBg">Background</label>
+            <input type="color" id="scrollMarqueeBg" value="#0f172a">
+          </div>
+        </div>
+      </div>
+
+      <div class="scroll-stage">
+        <div class="marquee-preview" id="scrollMarqueePreview" aria-live="polite"></div>
+        <div class="scroll-actions">
+          <button class="scroll-copy-btn" id="scrollCopyEmbed" type="button">Copy embed code</button>
+          <span class="curved-toast" id="scrollToast" role="status"></span>
+        </div>
+        <div class="scroll-field">
+          <label for="scrollEmbedCode">Embed code (HTML + CSS)</label>
+          <textarea id="scrollEmbedCode" class="scroll-embed-code" readonly rows="6" spellcheck="false"></textarea>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ===================== EDITORIAL ===================== -->
+  <section class="editorial-section">
+    <h2>Two kinds of scrolling text — pick the one you need</h2>
+    <p class="editorial-intro">"Scrolling text" is really two jobs, and this page does both. Most people want the <strong>bio-scroll trick</strong>: a block of repeated text that overflows a profile's fixed-height bio box so the box has to scroll. A smaller group wants a literal <strong>animated marquee</strong> — a ticker that slides across a screen — for a website, a forum signature, or a stream overlay.</p>
+    <div class="block-example">
+      <strong>Bio Scroll Text</strong> → plain, copy-paste characters that overflow and scroll inside a bio.<br>
+      <strong>Marquee Banner</strong> → an embeddable CSS animation that physically moves across the screen.
+    </div>
+    <p>The tab at the top of the page switches between them. Bio mode is the front door — plain text solves the job in seconds. Reach for marquee mode only when you actually need motion on a page you control.</p>
+  </section>
+
+  <section class="editorial-section">
+    <h2>How the bio scroll trick works</h2>
+    <p class="editorial-intro">A profile bio is a box with a fixed height. If the text you paste is taller than that box, the box scrolls to reveal the rest. That is the whole trick — there is no special "scroll" character.</p>
+    <div class="block-example">
+      1. Type a short message → 2. pick a divider → 3. repeat it until the block is longer than the bio limit → 4. copy and paste it into your bio
+    </div>
+    <p>Use <strong>Fill to platform</strong> and the tool sets the repeat count to just clear a chosen field's limit (Instagram bios hold about 150 characters; TikTok about 80 — always approximate, since platforms change them). If your blank lines collapse when you save, switch to a visible divider — a line, dot, or star row — so every line carries a real character and survives. You can also restyle the whole block in any Unicode font before copying; the letters change, the divider glyphs stay.</p>
+  </section>
+
+  <section class="editorial-section">
+    <h2>Embed a scrolling marquee on a site or OBS overlay</h2>
+    <p class="editorial-intro">Marquee mode builds a self-contained snippet — a little CSS plus HTML — that you paste into a page you control. It uses uniquely-named classes and its own keyframes, so it never clashes with the rest of your page, and it bundles no external fonts or files.</p>
+    <div class="block-example">
+      — <strong>Website</strong>: paste the snippet into your HTML where you want the banner.<br>
+      — <strong>Forum signature</strong>: paste it wherever raw HTML is allowed.<br>
+      — <strong>OBS overlay</strong>: save the snippet as an <code>.html</code> file and add it as a Browser source.
+    </div>
+    <p>The animation scrolls a doubled track for a seamless loop, pauses on hover, and — unlike the old approach — automatically stops for visitors who prefer reduced motion. It is the modern replacement for the deprecated <code>&lt;marquee&gt;</code> tag: same effect, standards-based, portable.</p>
+  </section>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <h2 class="faq-category">Scrolling text questions</h2>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">What is scrolling text?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">Scrolling text means two different things, and this generator does both. The first is the bio-scroll trick: you repeat a short message many times, separated by dividers, and paste that block into a profile bio. Because the block is taller than the fixed-height bio box, the box has to scroll to show it all. The second is a moving marquee (or ticker) — text that literally slides across the screen — which is an animation, not plain characters, so this tool gives you a portable CSS snippet to embed on a website, forum signature, or OBS overlay.</div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">How do I make my Instagram or TikTok bio scroll?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">Use Bio Scroll Text mode. Type your message (for example "I love you"), pick a divider, and set the repeat count high enough that the output is longer than the bio's character limit — <a href="/instagram/">Instagram</a> is about 150 characters, <a href="/tiktok/">TikTok</a> about 80. Use "Fill to platform" to have the tool pick the repeats for you. Copy the result and paste it into your bio. Because the pasted block overflows the fixed-height bio box, the box scrolls. Tip: keep the message short, and edit your bio on the desktop site, which preserves line breaks more reliably than the app.</div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">How do I add a scrolling marquee or ticker to a website or OBS overlay?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">Switch to Marquee Banner mode, set the text, speed, direction, gap and colors, then press "Copy embed code". You get one self-contained snippet — a small block of CSS plus HTML — that you paste into your own page. For a website, drop it into your HTML. For a forum signature, paste it wherever raw HTML is allowed. For OBS, save the snippet as an .html file and add it as a Browser source. The snippet uses uniquely-named classes and its own keyframes, so it will not clash with the rest of your page, and it needs no external files or fonts.</div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">Does this still work like the old HTML &lt;marquee&gt; tag?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">It replaces it. The old <code>&lt;marquee&gt;</code> tag is deprecated and non-standard — browsers still tend to honor it, but it was never part of a modern HTML standard and can stop working at any time. This generator produces the modern, portable equivalent instead: a CSS animation that scrolls a doubled track for a seamless loop. It pauses on hover and automatically stops for visitors who have reduced-motion turned on, which the old tag never did.</div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">Can I copy scrolling text as plain characters?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">The bio-scroll block is plain, copy-paste text — real Unicode characters and line breaks — so it works anywhere you can paste text, and you can style it in any of the Unicode fonts on this page first. Actual motion (a marquee that slides across the screen) is an animation, not a text property, so it cannot be copied as characters. That is why marquee mode gives you an embeddable code snippet rather than copy-paste text.</div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">Why does my scrolling bio collapse into one line?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">Some apps strip blank lines and trailing spaces when you save a bio. If you used the plain "None" or "Blank gap" divider and the lines collapsed, switch to a visible divider (a line, dot, or star row) so every line has a real character on it and survives saving. Editing your bio on the platform's desktop website, and pasting straight from this tool rather than from a rich-text editor, also helps the line breaks stick. For more on stacking text vertically, see the <a href="/usecase/vertical-text/">vertical text generator</a>.</div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">Is the scrolling text generator free?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">Completely free. No sign-up, no watermark, no limits. Everything runs in your browser — nothing is uploaded to a server — whether you are copying a bio-scroll block or an embeddable marquee snippet.</div>
+      </div>
+    </div>
+  </footer>
+</main>
+
+<div class="copy-toast" id="copyToast">Copied!</div>
+
+<script>window.UTG_SCROLL_MODE = true;</script>
+<script src="/styles.js" defer></script>
+<script src="/renderer.js" defer></script>
+<script src="/js/scroll/scrollData.js" defer></script>
+<script src="/js/scroll/scrollBuilders.js" defer></script>
+<script src="/script.js" defer></script>
+<script src="/js/scroll/scrollPageController.js" defer></script>
+<script src="/footer.js" defer></script>
+</body></html>


### PR DESCRIPTION
## Summary

Adds a new `/usecase/scrolling-text/` page with two distinct modes for generating scrolling text: a **bio scroll** mode that creates a repeated, divider-separated block for pasting into profile bios, and a **marquee banner** mode that generates a self-contained CSS-animation snippet for embedding on websites, forums, or OBS overlays.

## Key Changes

- **New page**: `usecase/scrolling-text/index.html` — full-featured tool with mode tabs, live preview, and copy functionality
- **New controller**: `js/scroll/scrollPageController.js` — 634-line IIFE managing both modes, divider picker, repeat controls, and marquee live rendering
- **New builders**: `js/scroll/scrollBuilders.js` — pure logic layer (no DOM) for bio text composition, fill-to-platform repeat calculation, and marquee CSS/HTML generation
- **New data module**: `js/scroll/scrollData.js` — divider glyphs (Box Drawing + General Punctuation), preset phrases, platform bio limits, and marquee defaults
- **Styles**: Added ~300 lines to `style.css` covering mode tabs, control blocks, divider picker, preset chips, marquee preview, and embed code textarea
- **Integration**: Updated `script.js` to suppress its global clipboard handler when `UTG_SCROLL_MODE` is set; updated `usecase/index.html` and `footer.js` to link the new tool

## Implementation Details

- **Bio mode** reuses the existing `.style-card` / `.copy-btn` contract from `script.js`, so clipboard and toast handling work without reimplementation
- **Marquee mode** has its own toast and clipboard logic (`copyEmbed()` + `fallbackCopy()`) to avoid collision with the global delegate
- **Divider picker** uses tabbed groups (Basics, Lines, Dots, Stars) mirroring the vertical-text tool's pattern
- **Repeat modes**: explicit count (1–40) or "fill to platform" (Instagram ~150, TikTok ~80, etc.) with character-count badges showing overflow status
- **Marquee generation** uses deterministic hashing (`hashId()`) to produce unique CSS class/keyframe namespaces, so multiple marquees on one page never collide
- **Lazy rendering**: bio cards beyond the initial 18 load on scroll via `IntersectionObserver` to keep the DOM bounded
- **Debounced render**: 120ms timer prevents thrashing when controls change rapidly
- **Mode persistence**: URL `?mode=marquee` or `?mode=bio` (defaults to bio) via `history.replaceState()`
- **Reduced-motion support**: marquee CSS respects `prefers-reduced-motion` in the embeddable snippet

All three new JS modules follow the zero-framework, client-side-only philosophy: no dependencies, no server calls, pure functions where possible (builders), and DOM logic isolated in the controller.

https://claude.ai/code/session_018o66PaEC7Q1pytPnN7vqoc