### PR TITLE
Fix accent placement in wrap styles & reclassify Regional Indicator

### DIFF
--- a/data/accent-support.json
+++ b/data/accent-support.json
@@ -8,8 +8,8 @@
     }
   },
   "counts": {
-    "full": 77,
-    "partial": 21,
+    "full": 76,
+    "partial": 22,
     "na": 8,
     "none": 6
   },
@@ -151,8 +151,8 @@
       "category": "bubble",
       "groupSlug": "bracket",
       "bucket": "full",
-      "example_es": "⦅S⦆⦅e⦆⦅n⦆̃⦅o⦆⦅r⦆",
-      "example_vi": "⦅V⦆⦅i⦆⦅e⦆̣̂⦅t⦆"
+      "example_es": "⦅S⦆⦅e⦆⦅ñ⦆⦅o⦆⦅r⦆",
+      "example_vi": "⦅V⦆⦅i⦆⦅ệ⦆⦅t⦆"
     },
     {
       "name": "Ultra Bubble Angle Spaced",
@@ -161,8 +161,8 @@
       "category": "bubble",
       "groupSlug": "spaced",
       "bucket": "full",
-      "example_es": "⦅S⦆ ⦅e⦆ ⦅n⦆̃ ⦅o⦆ ⦅r⦆",
-      "example_vi": "⦅V⦆ ⦅i⦆ ⦅e⦆̣̂ ⦅t⦆"
+      "example_es": "⦅S⦆ ⦅e⦆ ⦅ñ⦆ ⦅o⦆ ⦅r⦆",
+      "example_vi": "⦅V⦆ ⦅i⦆ ⦅ệ⦆ ⦅t⦆"
     },
     {
       "name": "Ultra Bubble Curly",
@@ -171,8 +171,8 @@
       "category": "bubble",
       "groupSlug": "bracket",
       "bucket": "full",
-      "example_es": "❨S❩❨e❩❨n❩̃❨o❩❨r❩",
-      "example_vi": "❨V❩❨i❩❨e❩̣̂❨t❩"
+      "example_es": "❨S❩❨e❩❨ñ❩❨o❩❨r❩",
+      "example_vi": "❨V❩❨i❩❨ệ❩❨t❩"
     },
     {
       "name": "Ultra Bubble Curly Spaced",
@@ -181,8 +181,8 @@
       "category": "bubble",
       "groupSlug": "spaced",
       "bucket": "full",
-      "example_es": "❨S❩ ❨e❩ ❨n❩̃ ❨o❩ ❨r❩",
-      "example_vi": "❨V❩ ❨i❩ ❨e❩̣̂ ❨t❩"
+      "example_es": "❨S❩ ❨e❩ ❨ñ❩ ❨o❩ ❨r❩",
+      "example_vi": "❨V❩ ❨i❩ ❨ệ❩ ❨t❩"
     },
     {
       "name": "Ultra Bubble Filled",
@@ -211,8 +211,8 @@
       "category": "bubble",
       "groupSlug": "bracket",
       "bucket": "full",
-      "example_es": "( S )( e )( n )̃( o )( r )",
-      "example_vi": "( V )( i )( e )̣̂( t )"
+      "example_es": "( S )( e )( ñ )( o )( r )",
+      "example_vi": "( V )( i )( ệ )( t )"
     },
     {
       "name": "Ultra Cherokee",
@@ -473,16 +473,6 @@
       "bucket": "full",
       "example_es": "S̅e̅ñ̅o̅r̅",
       "example_vi": "V̅i̅ệ̅t̅"
-    },
-    {
-      "name": "Ultra Regional Indicator",
-      "slug": "ultra-regional-indicator",
-      "type": "map",
-      "category": "emoji-letters",
-      "groupSlug": "emoji-letters",
-      "bucket": "full",
-      "example_es": "🇸⁠🇪⁠🇳⁠̃🇴⁠🇷⁠",
-      "example_vi": "🇻⁠🇮⁠🇪⁠̣̂🇹⁠"
     },
     {
       "name": "Ultra Script",
@@ -963,6 +953,16 @@
       "bucket": "partial",
       "example_es": "サエñオラ",
       "example_vi": "ヴイệタ"
+    },
+    {
+      "name": "Ultra Regional Indicator",
+      "slug": "ultra-regional-indicator",
+      "type": "map",
+      "category": "emoji-letters",
+      "groupSlug": "emoji-letters",
+      "bucket": "partial",
+      "example_es": "🇸⁠🇪⁠ñ🇴⁠🇷⁠",
+      "example_vi": "🇻⁠🇮⁠ệ🇹⁠"
     },
     {
       "name": "Ultra Runic",

--- a/renderer.js
+++ b/renderer.js
@@ -297,6 +297,24 @@ function resolveBaseAndMarks(char) {
   return { base: char, marks: '' };
 }
 
+// Reattaches a combining mark right after the base letter inside its mapped
+// token, rather than at the very end of the token. Most styles map a letter
+// to a single styled glyph (e.g. bold 'c' -> "𝗰"), where "end of token" and
+// "right after the letter" are the same position. But the bracket/paren
+// "wrap" styles (Ultra Bubble Curly/Angle/Parentheses, etc.) map a letter to
+// a multi-character token like "❨c❩" — appending a mark at the end used to
+// land the accent on the closing bracket instead of the letter (e.g. Turkish
+// ç coming out as "❨c❩̧" instead of "❨ç❩"). Locating the base letter inside
+// the token and inserting there fixes those styles; for single-glyph tokens
+// the base letter never appears literally (bold's "𝗰" isn't the string "c"),
+// so this falls through to the original append-at-the-end behaviour.
+function attachMarks(token, base, marks) {
+  if (!marks) return token;
+  const idx = token.indexOf(base);
+  if (idx === -1) return token + marks;
+  return token.slice(0, idx + base.length) + marks + token.slice(idx + base.length);
+}
+
 // Shared per-character lookup used by both renderMap branches below.
 // `accentSafe` gates ONLY the combining-mark-carrying path: a handful of
 // styles substitute into Unicode blocks (Enclosed Alphanumerics, Fullwidth,
@@ -320,10 +338,10 @@ function mapChar(ch, normalUpper, normalLower, normalNums, upperArr, lowerArr, n
   const { base, marks } = resolveBaseAndMarks(ch);
   if (base !== ch && (accentSafe || !marks)) {
     const bu = normalUpper.indexOf(base);
-    if (bu !== -1) return (upperArr[bu] || base) + marks;
+    if (bu !== -1) return attachMarks(upperArr[bu] || base, base, marks);
 
     const bl = normalLower.indexOf(base);
-    if (bl !== -1) return (lowerArr[bl] || base) + marks;
+    if (bl !== -1) return attachMarks(lowerArr[bl] || base, base, marks);
   }
 
   return ch;

--- a/styles.js
+++ b/styles.js
@@ -1462,6 +1462,12 @@ const textStyles = {
     familySlug: ['emoji-letters'],
     groupSlug: 'emoji-letters',
     slug: 'ultra-regional-indicator',
+    // Each token is a flag/regional-indicator emoji + word-joiner, not a
+    // literal base letter, so a reattached combining accent has nowhere
+    // correct to land — it ends up floating off the letterform's dashed
+    // fallback box instead of sitting on the letter. Same silent-mangle
+    // risk as Ultra Bubble Tiles/Ultra Squared (verified in Chromium).
+    accentSafe: false,
     platforms: ["all","instagram","x","discord"]
   },
 


### PR DESCRIPTION
## Summary
Fixes combining accent marks landing on closing brackets/parens instead of letters in wrap-style text transforms (Ultra Bubble Curly/Angle/Parentheses, etc.), and reclassifies Ultra Regional Indicator from full to partial accent support due to inherent Unicode limitations.

## Key Changes

- **Accent reattachment logic** (`renderer.js`): Added `attachMarks()` function that inserts combining marks immediately after the base letter *inside* its mapped token, rather than appending at the end. This fixes styles that wrap letters in multi-character tokens (e.g., `❨c❩` → `❨ç❩` instead of `❨c❩̧`). Single-glyph tokens (bold, italic, etc.) fall through to append-at-end behavior unchanged.

- **Ultra Regional Indicator reclassification** (`styles.js`, `data/accent-support.json`):
  - Moved from `"bucket": "full"` to `"bucket": "partial"` — regional indicator emoji + word-joiner tokens have no literal base letter, so reattached accents float off the dashed fallback box instead of landing on the letter.
  - Added `accentSafe: false` flag to prevent the reattachment logic from running on this style.
  - Updated example strings to reflect actual output (e.g., `🇸⁠🇪⁠ñ🇴⁠🇷⁠` instead of `🇸⁠🇪⁠🇳⁠̃🇴⁠🇷⁠`).

- **Support counts** (`data/accent-support.json`): Decremented `"full"` from 77 → 76, incremented `"partial"` from 21 → 22.

- **Example string corrections**: Updated Spanish/Vietnamese examples across four wrap styles (Ultra Bubble Angle, Ultra Bubble Angle Spaced, Ultra Bubble Curly, Ultra Bubble Curly Spaced, Ultra Parentheses) to use precomposed characters (ñ, ệ) instead of base + combining mark sequences, matching the actual rendered output.

## Implementation Details

The `attachMarks()` function searches for the base letter inside the mapped token and inserts marks there if found; if the base doesn't appear literally (as in bold/italic), it appends at the end as before. This preserves backward compatibility while fixing the bracket/paren styles where the base *does* appear as a literal character.

https://claude.ai/code/session_01FsbYfeib1baHKdJceJtqo1