### PR TITLE
Add language switcher to footer across all locales

### DIFF
--- a/de/library/alt-codes/index.html
+++ b/de/library/alt-codes/index.html
@@ -529,6 +529,14 @@
 <!-- FOOTER -->
 <footer class="footer">
   <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Sprachauswahl">
+      <a class="lang-option" href="/library/alt-codes/" hreflang="en">EN</a>
+      <a class="lang-option" href="/fr/library/codes-alt/" hreflang="fr">FR</a>
+      <a class="lang-option active" href="/de/library/alt-codes/" hreflang="de">DE</a>
+      <a class="lang-option" href="/it/library/codici-alt/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ru/library/alt-kody/" hreflang="ru">RU</a>
+    </div>
   </div>
 </footer>
 

--- a/it/library/codici-alt/index.html
+++ b/it/library/codici-alt/index.html
@@ -537,7 +537,9 @@
     <div class="lang-switcher" role="navigation" aria-label="Selettore di lingua">
       <a class="lang-option" href="/library/alt-codes/" hreflang="en">EN</a>
       <a class="lang-option" href="/fr/library/codes-alt/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/de/library/alt-codes/" hreflang="de">DE</a>
       <a class="lang-option active" href="/it/library/codici-alt/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ru/library/alt-kody/" hreflang="ru">RU</a>
     </div>
   </div>
 </footer>

--- a/library/alt-codes/index.html
+++ b/library/alt-codes/index.html
@@ -456,6 +456,14 @@
 <!-- FOOTER -->
 <footer class="footer">
   <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Language switcher">
+      <a class="lang-option active" href="/library/alt-codes/" hreflang="en">EN</a>
+      <a class="lang-option" href="/fr/library/codes-alt/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/de/library/alt-codes/" hreflang="de">DE</a>
+      <a class="lang-option" href="/it/library/codici-alt/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ru/library/alt-kody/" hreflang="ru">RU</a>
+    </div>
   </div>
 </footer>
 

--- a/ru/library/alt-kody/index.html
+++ b/ru/library/alt-kody/index.html
@@ -604,6 +604,14 @@
 <!-- FOOTER -->
 <footer class="footer">
   <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Переключатель языка">
+      <a class="lang-option" href="/library/alt-codes/" hreflang="en">EN</a>
+      <a class="lang-option" href="/fr/library/codes-alt/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/de/library/alt-codes/" hreflang="de">DE</a>
+      <a class="lang-option" href="/it/library/codici-alt/" hreflang="it">IT</a>
+      <a class="lang-option active" href="/ru/library/alt-kody/" hreflang="ru">RU</a>
+    </div>
   </div>
 </footer>
 


### PR DESCRIPTION
## Summary
Adds a language switcher component to the footer of the alt-codes library pages across all supported language variants (English, French, German, Italian, and Russian).

## Changes
- **English (`library/alt-codes/index.html`)**: Added language switcher with EN marked as active
- **German (`de/library/alt-codes/index.html`)**: Added language switcher with DE marked as active
- **Russian (`ru/library/alt-kody/index.html`)**: Added language switcher with RU marked as active
- **Italian (`it/library/codici-alt/index.html`)**: Updated existing language switcher to include missing DE and RU language options

## Implementation Details
- Language switcher is implemented as a semantic `<div>` with `role="navigation"` and localized `aria-label` attributes for accessibility
- Each language option is a link with appropriate `hreflang` attributes for SEO
- The "active" class marks the current page's language
- All links point to the correct locale-specific paths (`/library/alt-codes/`, `/fr/library/codes-alt/`, `/de/library/alt-codes/`, `/it/library/codici-alt/`, `/ru/library/alt-kody/`)
- Consistent structure and styling across all locale variants

https://claude.ai/code/session_016Zrwn6Kknq7cD4q5kqmecN