### PR TITLE
Add footer with language switcher to library and emoji pages

### DIFF
--- a/ar/library/discord-symbols/index.html
+++ b/ar/library/discord-symbols/index.html
@@ -676,6 +676,29 @@ document.addEventListener("DOMContentLoaded", function () {
   ns.parseTwemoji(document.body);
 });
 </script>
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="اختيار اللغة">
+      <a class="lang-option active" href="/ar/library/discord-symbols/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/de/library/discord-symbole/" hreflang="de">DE</a>
+      <a class="lang-option" href="/library/discord-symbols/" hreflang="en">EN</a>
+      <a class="lang-option" href="/es/library/simbolos-discord/" hreflang="es">ES</a>
+      <a class="lang-option" href="/fr/library/symboles-discord/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/id/library/simbol-discord/" hreflang="id">ID</a>
+      <a class="lang-option" href="/it/library/simboli-discord/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ja/library/discord-symbols/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/discord-giho/" hreflang="ko">KO</a>
+      <a class="lang-option" href="/pl/library/symbole-discord/" hreflang="pl">PL</a>
+      <a class="lang-option" href="/pt/library/simbolos-discord/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/ru/library/simvoly-discord/" hreflang="ru">RU</a>
+      <a class="lang-option" href="/tr/library/discord-sembolleri/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/vi/ki-tu-discord/" hreflang="vi">VI</a>
+    </div>
+  </div>
+</footer>
+
 <script src="/footer.js" defer></script>
 </body>
 </html>

--- a/ar/library/emoji-combos/index.html
+++ b/ar/library/emoji-combos/index.html
@@ -29,6 +29,7 @@
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/kombinasi-emoji/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/combos-de-emoji/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/emoji-kombinasyonlari/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/emoji-kombinationen/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/emoji-combos/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/ar-library-emoji-combos.png">
 <meta property="og:image:width" content="1200">
@@ -552,6 +553,28 @@ document.addEventListener("DOMContentLoaded", function () {
   ns.parseTwemoji(document.body);
 });
 </script>
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="اختيار اللغة">
+      <a class="lang-option active" href="/ar/library/emoji-combos/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/de/emoji-kombinationen/" hreflang="de">DE</a>
+      <a class="lang-option" href="/library/emoji-combos/" hreflang="en">EN</a>
+      <a class="lang-option" href="/es/combinaciones-de-emojis/" hreflang="es">ES</a>
+      <a class="lang-option" href="/fr/combos-emoji/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/id/kombinasi-emoji/" hreflang="id">ID</a>
+      <a class="lang-option" href="/ja/library/emoji-combos/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/imoji-johap/" hreflang="ko">KO</a>
+      <a class="lang-option" href="/pl/kombinacje-emoji/" hreflang="pl">PL</a>
+      <a class="lang-option" href="/pt/combos-de-emoji/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/ru/library/emoji-combos/" hreflang="ru">RU</a>
+      <a class="lang-option" href="/th/library/emoji-combos/" hreflang="th">TH</a>
+      <a class="lang-option" href="/tr/emoji-kombinasyonlari/" hreflang="tr">TR</a>
+    </div>
+  </div>
+</footer>
+
 <script src="/footer.js" defer></script>
 </body>
 </html>

--- a/ar/library/roblox-symbols/index.html
+++ b/ar/library/roblox-symbols/index.html
@@ -461,6 +461,29 @@ document.addEventListener("DOMContentLoaded", function () {
   ns.parseTwemoji(document.body);
 });
 </script>
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="اختيار اللغة">
+      <a class="lang-option active" href="/ar/library/roblox-symbols/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/library/roblox-symbols/" hreflang="en">EN</a>
+      <a class="lang-option" href="/es/library/simbolos-roblox/" hreflang="es">ES</a>
+      <a class="lang-option" href="/fr/library/symboles-roblox/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/id/library/simbol-roblox/" hreflang="id">ID</a>
+      <a class="lang-option" href="/it/library/simboli-roblox/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ja/library/roblox-symbols/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/roblox-giho/" hreflang="ko">KO</a>
+      <a class="lang-option" href="/pl/library/symbole-roblox/" hreflang="pl">PL</a>
+      <a class="lang-option" href="/pt/library/simbolos-roblox/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/ru/library/simvoly-roblox/" hreflang="ru">RU</a>
+      <a class="lang-option" href="/th/library/roblox-symbols/" hreflang="th">TH</a>
+      <a class="lang-option" href="/tr/library/roblox-sembolleri/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/vi/ki-tu-roblox/" hreflang="vi">VI</a>
+    </div>
+  </div>
+</footer>
+
 <script src="/footer.js" defer></script>
 </body>
 </html>

--- a/de/emoji-kombinationen/index.html
+++ b/de/emoji-kombinationen/index.html
@@ -14,8 +14,20 @@
   <meta name="description" content="Emoji-Kombinationen zum Kopieren und Einfügen: süß, coquette, Liebe, dark und Strand. Emoji-Combos für deine Insta-Bio, deinen Status und deine Captions — kostenlos.">
   <link rel="canonical" href="https://ultratextgen.com/de/emoji-kombinationen/">
 
+  <link rel="alternate" hreflang="ar" href="https://ultratextgen.com/ar/library/emoji-combos/">
   <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/emoji-kombinationen/">
-  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/de/emoji-kombinationen/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/emoji-combos/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/combinaciones-de-emojis/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/combos-emoji/">
+  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/kombinasi-emoji/">
+  <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/emoji-combos/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/imoji-johap/">
+  <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/kombinacje-emoji/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/combos-de-emoji/">
+  <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/emoji-combos/">
+  <link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/emoji-combos/">
+  <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/emoji-kombinasyonlari/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/emoji-combos/">
 
   <meta name="robots" content="index, follow">
   <meta property="og:site_name" content="UltraTextGen">
@@ -283,7 +295,19 @@
 
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="Sprachauswahl">
+      <a class="lang-option" href="/ar/library/emoji-combos/" hreflang="ar">AR</a>
       <a class="lang-option active" href="/de/emoji-kombinationen/" hreflang="de">DE</a>
+      <a class="lang-option" href="/library/emoji-combos/" hreflang="en">EN</a>
+      <a class="lang-option" href="/es/combinaciones-de-emojis/" hreflang="es">ES</a>
+      <a class="lang-option" href="/fr/combos-emoji/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/id/kombinasi-emoji/" hreflang="id">ID</a>
+      <a class="lang-option" href="/ja/library/emoji-combos/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/imoji-johap/" hreflang="ko">KO</a>
+      <a class="lang-option" href="/pl/kombinacje-emoji/" hreflang="pl">PL</a>
+      <a class="lang-option" href="/pt/combos-de-emoji/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/ru/library/emoji-combos/" hreflang="ru">RU</a>
+      <a class="lang-option" href="/th/library/emoji-combos/" hreflang="th">TH</a>
+      <a class="lang-option" href="/tr/emoji-kombinasyonlari/" hreflang="tr">TR</a>
     </div>
   </div>
 </footer>

--- a/de/library/discord-symbole/index.html
+++ b/de/library/discord-symbole/index.html
@@ -668,6 +668,29 @@ document.addEventListener("DOMContentLoaded", function () {
   ns.parseTwemoji(document.body);
 });
 </script>
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Sprachauswahl">
+      <a class="lang-option" href="/ar/library/discord-symbols/" hreflang="ar">AR</a>
+      <a class="lang-option active" href="/de/library/discord-symbole/" hreflang="de">DE</a>
+      <a class="lang-option" href="/library/discord-symbols/" hreflang="en">EN</a>
+      <a class="lang-option" href="/es/library/simbolos-discord/" hreflang="es">ES</a>
+      <a class="lang-option" href="/fr/library/symboles-discord/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/id/library/simbol-discord/" hreflang="id">ID</a>
+      <a class="lang-option" href="/it/library/simboli-discord/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ja/library/discord-symbols/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/discord-giho/" hreflang="ko">KO</a>
+      <a class="lang-option" href="/pl/library/symbole-discord/" hreflang="pl">PL</a>
+      <a class="lang-option" href="/pt/library/simbolos-discord/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/ru/library/simvoly-discord/" hreflang="ru">RU</a>
+      <a class="lang-option" href="/tr/library/discord-sembolleri/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/vi/ki-tu-discord/" hreflang="vi">VI</a>
+    </div>
+  </div>
+</footer>
+
 <script src="/footer.js" defer></script>
 </body>
 </html>

--- a/es/combinaciones-de-emojis/index.html
+++ b/es/combinaciones-de-emojis/index.html
@@ -26,6 +26,7 @@
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/kombinasi-emoji/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/combos-de-emoji/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/emoji-kombinasyonlari/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/emoji-kombinationen/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/emoji-combos/">
 
   <meta name="robots" content="index, follow">
@@ -455,7 +456,19 @@
 
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="Selector de idioma">
+      <a class="lang-option" href="/ar/library/emoji-combos/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/de/emoji-kombinationen/" hreflang="de">DE</a>
+      <a class="lang-option" href="/library/emoji-combos/" hreflang="en">EN</a>
       <a class="lang-option active" href="/es/combinaciones-de-emojis/" hreflang="es">ES</a>
+      <a class="lang-option" href="/fr/combos-emoji/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/id/kombinasi-emoji/" hreflang="id">ID</a>
+      <a class="lang-option" href="/ja/library/emoji-combos/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/imoji-johap/" hreflang="ko">KO</a>
+      <a class="lang-option" href="/pl/kombinacje-emoji/" hreflang="pl">PL</a>
+      <a class="lang-option" href="/pt/combos-de-emoji/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/ru/library/emoji-combos/" hreflang="ru">RU</a>
+      <a class="lang-option" href="/th/library/emoji-combos/" hreflang="th">TH</a>
+      <a class="lang-option" href="/tr/emoji-kombinasyonlari/" hreflang="tr">TR</a>
     </div>
   </div>
 </footer>

--- a/es/library/simbolos-discord/index.html
+++ b/es/library/simbolos-discord/index.html
@@ -662,6 +662,29 @@ document.addEventListener("DOMContentLoaded", function () {
   ns.parseTwemoji(document.body);
 });
 </script>
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Selector de idioma">
+      <a class="lang-option" href="/ar/library/discord-symbols/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/de/library/discord-symbole/" hreflang="de">DE</a>
+      <a class="lang-option" href="/library/discord-symbols/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/es/library/simbolos-discord/" hreflang="es">ES</a>
+      <a class="lang-option" href="/fr/library/symboles-discord/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/id/library/simbol-discord/" hreflang="id">ID</a>
+      <a class="lang-option" href="/it/library/simboli-discord/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ja/library/discord-symbols/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/discord-giho/" hreflang="ko">KO</a>
+      <a class="lang-option" href="/pl/library/symbole-discord/" hreflang="pl">PL</a>
+      <a class="lang-option" href="/pt/library/simbolos-discord/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/ru/library/simvoly-discord/" hreflang="ru">RU</a>
+      <a class="lang-option" href="/tr/library/discord-sembolleri/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/vi/ki-tu-discord/" hreflang="vi">VI</a>
+    </div>
+  </div>
+</footer>
+
 <script src="/footer.js" defer></script>
 </body>
 </html>

--- a/es/library/simbolos-roblox/index.html
+++ b/es/library/simbolos-roblox/index.html
@@ -454,6 +454,29 @@ document.addEventListener("DOMContentLoaded", function () {
   ns.parseTwemoji(document.body);
 });
 </script>
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Selector de idioma">
+      <a class="lang-option" href="/ar/library/roblox-symbols/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/library/roblox-symbols/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/es/library/simbolos-roblox/" hreflang="es">ES</a>
+      <a class="lang-option" href="/fr/library/symboles-roblox/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/id/library/simbol-roblox/" hreflang="id">ID</a>
+      <a class="lang-option" href="/it/library/simboli-roblox/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ja/library/roblox-symbols/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/roblox-giho/" hreflang="ko">KO</a>
+      <a class="lang-option" href="/pl/library/symbole-roblox/" hreflang="pl">PL</a>
+      <a class="lang-option" href="/pt/library/simbolos-roblox/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/ru/library/simvoly-roblox/" hreflang="ru">RU</a>
+      <a class="lang-option" href="/th/library/roblox-symbols/" hreflang="th">TH</a>
+      <a class="lang-option" href="/tr/library/roblox-sembolleri/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/vi/ki-tu-roblox/" hreflang="vi">VI</a>
+    </div>
+  </div>
+</footer>
+
 <script src="/footer.js" defer></script>
 </body>
 </html>

--- a/es/library/simbolos-y2k/index.html
+++ b/es/library/simbolos-y2k/index.html
@@ -782,6 +782,27 @@ document.addEventListener("DOMContentLoaded", function () {
   ns.parseTwemoji(document.body);
 });
 </script>
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Selector de idioma">
+      <a class="lang-option" href="/library/y2k-symbols/" hreflang="en">EN</a>
+      <a class="lang-option active" href="/es/library/simbolos-y2k/" hreflang="es">ES</a>
+      <a class="lang-option" href="/fr/library/symboles-y2k/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/id/library/simbol-y2k/" hreflang="id">ID</a>
+      <a class="lang-option" href="/it/library/simboli-y2k/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ja/library/y2k-symbols/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/y2k-giho/" hreflang="ko">KO</a>
+      <a class="lang-option" href="/pl/library/symbole-y2k/" hreflang="pl">PL</a>
+      <a class="lang-option" href="/pt/library/simbolos-y2k/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/th/library/y2k-symbols/" hreflang="th">TH</a>
+      <a class="lang-option" href="/tr/library/y2k-sembolleri/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/vi/ki-tu-y2k/" hreflang="vi">VI</a>
+    </div>
+  </div>
+</footer>
+
 <script src="/footer.js" defer></script>
 </body>
 </html>

--- a/fr/combos-emoji/index.html
+++ b/fr/combos-emoji/index.html
@@ -26,6 +26,7 @@
   <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/kombinacje-emoji/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/combos-de-emoji/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/emoji-kombinasyonlari/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/emoji-kombinationen/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/emoji-combos/">
 
   <meta name="robots" content="index, follow">
@@ -294,13 +295,19 @@
 
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="Sélecteur de langue">
-      <a class="lang-option" href="/library/emoji-combos/" hreflang="en">EN</a>
       <a class="lang-option" href="/ar/library/emoji-combos/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/de/emoji-kombinationen/" hreflang="de">DE</a>
+      <a class="lang-option" href="/library/emoji-combos/" hreflang="en">EN</a>
+      <a class="lang-option" href="/es/combinaciones-de-emojis/" hreflang="es">ES</a>
       <a class="lang-option active" href="/fr/combos-emoji/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/id/kombinasi-emoji/" hreflang="id">ID</a>
       <a class="lang-option" href="/ja/library/emoji-combos/" hreflang="ja">JA</a>
       <a class="lang-option" href="/ko/library/imoji-johap/" hreflang="ko">KO</a>
+      <a class="lang-option" href="/pl/kombinacje-emoji/" hreflang="pl">PL</a>
+      <a class="lang-option" href="/pt/combos-de-emoji/" hreflang="pt">PT</a>
       <a class="lang-option" href="/ru/library/emoji-combos/" hreflang="ru">RU</a>
       <a class="lang-option" href="/th/library/emoji-combos/" hreflang="th">TH</a>
+      <a class="lang-option" href="/tr/emoji-kombinasyonlari/" hreflang="tr">TR</a>
     </div>
   </div>
 </footer>

--- a/fr/library/symboles-discord/index.html
+++ b/fr/library/symboles-discord/index.html
@@ -641,14 +641,18 @@
   <div class="footer-inner">
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="Sélecteur de langue">
+      <a class="lang-option" href="/ar/library/discord-symbols/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/de/library/discord-symbole/" hreflang="de">DE</a>
       <a class="lang-option" href="/library/discord-symbols/" hreflang="en">EN</a>
       <a class="lang-option" href="/es/library/simbolos-discord/" hreflang="es">ES</a>
       <a class="lang-option active" href="/fr/library/symboles-discord/" hreflang="fr">FR</a>
       <a class="lang-option" href="/id/library/simbol-discord/" hreflang="id">ID</a>
       <a class="lang-option" href="/it/library/simboli-discord/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ja/library/discord-symbols/" hreflang="ja">JA</a>
       <a class="lang-option" href="/ko/library/discord-giho/" hreflang="ko">KO</a>
       <a class="lang-option" href="/pl/library/symbole-discord/" hreflang="pl">PL</a>
       <a class="lang-option" href="/pt/library/simbolos-discord/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/ru/library/simvoly-discord/" hreflang="ru">RU</a>
       <a class="lang-option" href="/tr/library/discord-sembolleri/" hreflang="tr">TR</a>
       <a class="lang-option" href="/vi/ki-tu-discord/" hreflang="vi">VI</a>
     </div>

--- a/fr/library/symboles-roblox/index.html
+++ b/fr/library/symboles-roblox/index.html
@@ -431,14 +431,18 @@
   <div class="footer-inner">
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="Sélecteur de langue">
+      <a class="lang-option" href="/ar/library/roblox-symbols/" hreflang="ar">AR</a>
       <a class="lang-option" href="/library/roblox-symbols/" hreflang="en">EN</a>
       <a class="lang-option" href="/es/library/simbolos-roblox/" hreflang="es">ES</a>
       <a class="lang-option active" href="/fr/library/symboles-roblox/" hreflang="fr">FR</a>
       <a class="lang-option" href="/id/library/simbol-roblox/" hreflang="id">ID</a>
       <a class="lang-option" href="/it/library/simboli-roblox/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ja/library/roblox-symbols/" hreflang="ja">JA</a>
       <a class="lang-option" href="/ko/library/roblox-giho/" hreflang="ko">KO</a>
       <a class="lang-option" href="/pl/library/symbole-roblox/" hreflang="pl">PL</a>
       <a class="lang-option" href="/pt/library/simbolos-roblox/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/ru/library/simvoly-roblox/" hreflang="ru">RU</a>
+      <a class="lang-option" href="/th/library/roblox-symbols/" hreflang="th">TH</a>
       <a class="lang-option" href="/tr/library/roblox-sembolleri/" hreflang="tr">TR</a>
       <a class="lang-option" href="/vi/ki-tu-roblox/" hreflang="vi">VI</a>
     </div>

--- a/fr/library/symboles-y2k/index.html
+++ b/fr/library/symboles-y2k/index.html
@@ -774,9 +774,11 @@
       <a class="lang-option active" href="/fr/library/symboles-y2k/" hreflang="fr">FR</a>
       <a class="lang-option" href="/id/library/simbol-y2k/" hreflang="id">ID</a>
       <a class="lang-option" href="/it/library/simboli-y2k/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ja/library/y2k-symbols/" hreflang="ja">JA</a>
       <a class="lang-option" href="/ko/library/y2k-giho/" hreflang="ko">KO</a>
       <a class="lang-option" href="/pl/library/symbole-y2k/" hreflang="pl">PL</a>
       <a class="lang-option" href="/pt/library/simbolos-y2k/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/th/library/y2k-symbols/" hreflang="th">TH</a>
       <a class="lang-option" href="/tr/library/y2k-sembolleri/" hreflang="tr">TR</a>
       <a class="lang-option" href="/vi/ki-tu-y2k/" hreflang="vi">VI</a>
     </div>

--- a/id/kombinasi-emoji/index.html
+++ b/id/kombinasi-emoji/index.html
@@ -26,6 +26,7 @@
   <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/combinaciones-de-emojis/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/combos-de-emoji/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/emoji-kombinasyonlari/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/emoji-kombinationen/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/emoji-combos/">
 
   <meta name="robots" content="index, follow">
@@ -454,7 +455,19 @@
 
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="Pemilih bahasa">
+      <a class="lang-option" href="/ar/library/emoji-combos/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/de/emoji-kombinationen/" hreflang="de">DE</a>
+      <a class="lang-option" href="/library/emoji-combos/" hreflang="en">EN</a>
+      <a class="lang-option" href="/es/combinaciones-de-emojis/" hreflang="es">ES</a>
+      <a class="lang-option" href="/fr/combos-emoji/" hreflang="fr">FR</a>
       <a class="lang-option active" href="/id/kombinasi-emoji/" hreflang="id">ID</a>
+      <a class="lang-option" href="/ja/library/emoji-combos/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/imoji-johap/" hreflang="ko">KO</a>
+      <a class="lang-option" href="/pl/kombinacje-emoji/" hreflang="pl">PL</a>
+      <a class="lang-option" href="/pt/combos-de-emoji/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/ru/library/emoji-combos/" hreflang="ru">RU</a>
+      <a class="lang-option" href="/th/library/emoji-combos/" hreflang="th">TH</a>
+      <a class="lang-option" href="/tr/emoji-kombinasyonlari/" hreflang="tr">TR</a>
     </div>
   </div>
 </footer>

--- a/id/library/simbol-discord/index.html
+++ b/id/library/simbol-discord/index.html
@@ -676,6 +676,29 @@ document.addEventListener("DOMContentLoaded", function () {
   ns.parseTwemoji(document.body);
 });
 </script>
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Pemilih bahasa">
+      <a class="lang-option" href="/ar/library/discord-symbols/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/de/library/discord-symbole/" hreflang="de">DE</a>
+      <a class="lang-option" href="/library/discord-symbols/" hreflang="en">EN</a>
+      <a class="lang-option" href="/es/library/simbolos-discord/" hreflang="es">ES</a>
+      <a class="lang-option" href="/fr/library/symboles-discord/" hreflang="fr">FR</a>
+      <a class="lang-option active" href="/id/library/simbol-discord/" hreflang="id">ID</a>
+      <a class="lang-option" href="/it/library/simboli-discord/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ja/library/discord-symbols/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/discord-giho/" hreflang="ko">KO</a>
+      <a class="lang-option" href="/pl/library/symbole-discord/" hreflang="pl">PL</a>
+      <a class="lang-option" href="/pt/library/simbolos-discord/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/ru/library/simvoly-discord/" hreflang="ru">RU</a>
+      <a class="lang-option" href="/tr/library/discord-sembolleri/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/vi/ki-tu-discord/" hreflang="vi">VI</a>
+    </div>
+  </div>
+</footer>
+
 <script src="/footer.js" defer></script>
 </body>
 </html>

--- a/id/library/simbol-roblox/index.html
+++ b/id/library/simbol-roblox/index.html
@@ -468,6 +468,29 @@ document.addEventListener("DOMContentLoaded", function () {
   ns.parseTwemoji(document.body);
 });
 </script>
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Pemilih bahasa">
+      <a class="lang-option" href="/ar/library/roblox-symbols/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/library/roblox-symbols/" hreflang="en">EN</a>
+      <a class="lang-option" href="/es/library/simbolos-roblox/" hreflang="es">ES</a>
+      <a class="lang-option" href="/fr/library/symboles-roblox/" hreflang="fr">FR</a>
+      <a class="lang-option active" href="/id/library/simbol-roblox/" hreflang="id">ID</a>
+      <a class="lang-option" href="/it/library/simboli-roblox/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ja/library/roblox-symbols/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/roblox-giho/" hreflang="ko">KO</a>
+      <a class="lang-option" href="/pl/library/symbole-roblox/" hreflang="pl">PL</a>
+      <a class="lang-option" href="/pt/library/simbolos-roblox/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/ru/library/simvoly-roblox/" hreflang="ru">RU</a>
+      <a class="lang-option" href="/th/library/roblox-symbols/" hreflang="th">TH</a>
+      <a class="lang-option" href="/tr/library/roblox-sembolleri/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/vi/ki-tu-roblox/" hreflang="vi">VI</a>
+    </div>
+  </div>
+</footer>
+
 <script src="/footer.js" defer></script>
 </body>
 </html>

--- a/id/library/simbol-y2k/index.html
+++ b/id/library/simbol-y2k/index.html
@@ -800,6 +800,27 @@ document.addEventListener("DOMContentLoaded", function () {
   ns.parseTwemoji(document.body);
 });
 </script>
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Pemilih bahasa">
+      <a class="lang-option" href="/library/y2k-symbols/" hreflang="en">EN</a>
+      <a class="lang-option" href="/es/library/simbolos-y2k/" hreflang="es">ES</a>
+      <a class="lang-option" href="/fr/library/symboles-y2k/" hreflang="fr">FR</a>
+      <a class="lang-option active" href="/id/library/simbol-y2k/" hreflang="id">ID</a>
+      <a class="lang-option" href="/it/library/simboli-y2k/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ja/library/y2k-symbols/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/y2k-giho/" hreflang="ko">KO</a>
+      <a class="lang-option" href="/pl/library/symbole-y2k/" hreflang="pl">PL</a>
+      <a class="lang-option" href="/pt/library/simbolos-y2k/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/th/library/y2k-symbols/" hreflang="th">TH</a>
+      <a class="lang-option" href="/tr/library/y2k-sembolleri/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/vi/ki-tu-y2k/" hreflang="vi">VI</a>
+    </div>
+  </div>
+</footer>
+
 <script src="/footer.js" defer></script>
 </body>
 </html>

--- a/it/library/simboli-discord/index.html
+++ b/it/library/simboli-discord/index.html
@@ -646,14 +646,18 @@
   <div class="footer-inner">
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="Selettore di lingua">
+      <a class="lang-option" href="/ar/library/discord-symbols/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/de/library/discord-symbole/" hreflang="de">DE</a>
       <a class="lang-option" href="/library/discord-symbols/" hreflang="en">EN</a>
       <a class="lang-option" href="/es/library/simbolos-discord/" hreflang="es">ES</a>
       <a class="lang-option" href="/fr/library/symboles-discord/" hreflang="fr">FR</a>
       <a class="lang-option" href="/id/library/simbol-discord/" hreflang="id">ID</a>
       <a class="lang-option active" href="/it/library/simboli-discord/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ja/library/discord-symbols/" hreflang="ja">JA</a>
       <a class="lang-option" href="/ko/library/discord-giho/" hreflang="ko">KO</a>
       <a class="lang-option" href="/pl/library/symbole-discord/" hreflang="pl">PL</a>
       <a class="lang-option" href="/pt/library/simbolos-discord/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/ru/library/simvoly-discord/" hreflang="ru">RU</a>
       <a class="lang-option" href="/tr/library/discord-sembolleri/" hreflang="tr">TR</a>
       <a class="lang-option" href="/vi/ki-tu-discord/" hreflang="vi">VI</a>
     </div>

--- a/it/library/simboli-roblox/index.html
+++ b/it/library/simboli-roblox/index.html
@@ -432,14 +432,18 @@
   <div class="footer-inner">
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="Selettore di lingua">
+      <a class="lang-option" href="/ar/library/roblox-symbols/" hreflang="ar">AR</a>
       <a class="lang-option" href="/library/roblox-symbols/" hreflang="en">EN</a>
       <a class="lang-option" href="/es/library/simbolos-roblox/" hreflang="es">ES</a>
       <a class="lang-option" href="/fr/library/symboles-roblox/" hreflang="fr">FR</a>
       <a class="lang-option" href="/id/library/simbol-roblox/" hreflang="id">ID</a>
       <a class="lang-option active" href="/it/library/simboli-roblox/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ja/library/roblox-symbols/" hreflang="ja">JA</a>
       <a class="lang-option" href="/ko/library/roblox-giho/" hreflang="ko">KO</a>
       <a class="lang-option" href="/pl/library/symbole-roblox/" hreflang="pl">PL</a>
       <a class="lang-option" href="/pt/library/simbolos-roblox/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/ru/library/simvoly-roblox/" hreflang="ru">RU</a>
+      <a class="lang-option" href="/th/library/roblox-symbols/" hreflang="th">TH</a>
       <a class="lang-option" href="/tr/library/roblox-sembolleri/" hreflang="tr">TR</a>
       <a class="lang-option" href="/vi/ki-tu-roblox/" hreflang="vi">VI</a>
     </div>

--- a/it/library/simboli-y2k/index.html
+++ b/it/library/simboli-y2k/index.html
@@ -751,9 +751,11 @@
       <a class="lang-option" href="/fr/library/symboles-y2k/" hreflang="fr">FR</a>
       <a class="lang-option" href="/id/library/simbol-y2k/" hreflang="id">ID</a>
       <a class="lang-option active" href="/it/library/simboli-y2k/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ja/library/y2k-symbols/" hreflang="ja">JA</a>
       <a class="lang-option" href="/ko/library/y2k-giho/" hreflang="ko">KO</a>
       <a class="lang-option" href="/pl/library/symbole-y2k/" hreflang="pl">PL</a>
       <a class="lang-option" href="/pt/library/simbolos-y2k/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/th/library/y2k-symbols/" hreflang="th">TH</a>
       <a class="lang-option" href="/tr/library/y2k-sembolleri/" hreflang="tr">TR</a>
       <a class="lang-option" href="/vi/ki-tu-y2k/" hreflang="vi">VI</a>
     </div>

--- a/ja/library/discord-symbols/index.html
+++ b/ja/library/discord-symbols/index.html
@@ -668,6 +668,29 @@ document.addEventListener("DOMContentLoaded", function () {
   ns.parseTwemoji(document.body);
 });
 </script>
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="言語切り替え">
+      <a class="lang-option" href="/ar/library/discord-symbols/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/de/library/discord-symbole/" hreflang="de">DE</a>
+      <a class="lang-option" href="/library/discord-symbols/" hreflang="en">EN</a>
+      <a class="lang-option" href="/es/library/simbolos-discord/" hreflang="es">ES</a>
+      <a class="lang-option" href="/fr/library/symboles-discord/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/id/library/simbol-discord/" hreflang="id">ID</a>
+      <a class="lang-option" href="/it/library/simboli-discord/" hreflang="it">IT</a>
+      <a class="lang-option active" href="/ja/library/discord-symbols/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/discord-giho/" hreflang="ko">KO</a>
+      <a class="lang-option" href="/pl/library/symbole-discord/" hreflang="pl">PL</a>
+      <a class="lang-option" href="/pt/library/simbolos-discord/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/ru/library/simvoly-discord/" hreflang="ru">RU</a>
+      <a class="lang-option" href="/tr/library/discord-sembolleri/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/vi/ki-tu-discord/" hreflang="vi">VI</a>
+    </div>
+  </div>
+</footer>
+
 <script src="/footer.js" defer></script>
 </body>
 </html>

--- a/ja/library/emoji-combos/index.html
+++ b/ja/library/emoji-combos/index.html
@@ -29,6 +29,7 @@
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/kombinasi-emoji/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/combos-de-emoji/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/emoji-kombinasyonlari/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/emoji-kombinationen/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/emoji-combos/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/ja-library-emoji-combos.png">
 <meta property="og:image:width" content="1200">
@@ -520,6 +521,28 @@ document.addEventListener("DOMContentLoaded", function () {
   ns.parseTwemoji(document.body);
 });
 </script>
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="言語切り替え">
+      <a class="lang-option" href="/ar/library/emoji-combos/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/de/emoji-kombinationen/" hreflang="de">DE</a>
+      <a class="lang-option" href="/library/emoji-combos/" hreflang="en">EN</a>
+      <a class="lang-option" href="/es/combinaciones-de-emojis/" hreflang="es">ES</a>
+      <a class="lang-option" href="/fr/combos-emoji/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/id/kombinasi-emoji/" hreflang="id">ID</a>
+      <a class="lang-option active" href="/ja/library/emoji-combos/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/imoji-johap/" hreflang="ko">KO</a>
+      <a class="lang-option" href="/pl/kombinacje-emoji/" hreflang="pl">PL</a>
+      <a class="lang-option" href="/pt/combos-de-emoji/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/ru/library/emoji-combos/" hreflang="ru">RU</a>
+      <a class="lang-option" href="/th/library/emoji-combos/" hreflang="th">TH</a>
+      <a class="lang-option" href="/tr/emoji-kombinasyonlari/" hreflang="tr">TR</a>
+    </div>
+  </div>
+</footer>
+
 <script src="/footer.js" defer></script>
 </body>
 </html>

--- a/ja/library/roblox-symbols/index.html
+++ b/ja/library/roblox-symbols/index.html
@@ -477,6 +477,29 @@ document.addEventListener("DOMContentLoaded", function () {
   ns.parseTwemoji(document.body);
 });
 </script>
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="言語切り替え">
+      <a class="lang-option" href="/ar/library/roblox-symbols/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/library/roblox-symbols/" hreflang="en">EN</a>
+      <a class="lang-option" href="/es/library/simbolos-roblox/" hreflang="es">ES</a>
+      <a class="lang-option" href="/fr/library/symboles-roblox/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/id/library/simbol-roblox/" hreflang="id">ID</a>
+      <a class="lang-option" href="/it/library/simboli-roblox/" hreflang="it">IT</a>
+      <a class="lang-option active" href="/ja/library/roblox-symbols/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/roblox-giho/" hreflang="ko">KO</a>
+      <a class="lang-option" href="/pl/library/symbole-roblox/" hreflang="pl">PL</a>
+      <a class="lang-option" href="/pt/library/simbolos-roblox/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/ru/library/simvoly-roblox/" hreflang="ru">RU</a>
+      <a class="lang-option" href="/th/library/roblox-symbols/" hreflang="th">TH</a>
+      <a class="lang-option" href="/tr/library/roblox-sembolleri/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/vi/ki-tu-roblox/" hreflang="vi">VI</a>
+    </div>
+  </div>
+</footer>
+
 <script src="/footer.js" defer></script>
 </body>
 </html>

--- a/ja/library/y2k-symbols/index.html
+++ b/ja/library/y2k-symbols/index.html
@@ -710,6 +710,27 @@ document.addEventListener("DOMContentLoaded", function () {
   ns.parseTwemoji(document.body);
 });
 </script>
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="言語切り替え">
+      <a class="lang-option" href="/library/y2k-symbols/" hreflang="en">EN</a>
+      <a class="lang-option" href="/es/library/simbolos-y2k/" hreflang="es">ES</a>
+      <a class="lang-option" href="/fr/library/symboles-y2k/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/id/library/simbol-y2k/" hreflang="id">ID</a>
+      <a class="lang-option" href="/it/library/simboli-y2k/" hreflang="it">IT</a>
+      <a class="lang-option active" href="/ja/library/y2k-symbols/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/y2k-giho/" hreflang="ko">KO</a>
+      <a class="lang-option" href="/pl/library/symbole-y2k/" hreflang="pl">PL</a>
+      <a class="lang-option" href="/pt/library/simbolos-y2k/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/th/library/y2k-symbols/" hreflang="th">TH</a>
+      <a class="lang-option" href="/tr/library/y2k-sembolleri/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/vi/ki-tu-y2k/" hreflang="vi">VI</a>
+    </div>
+  </div>
+</footer>
+
 <script src="/footer.js" defer></script>
 </body>
 </html>

--- a/ko/library/discord-giho/index.html
+++ b/ko/library/discord-giho/index.html
@@ -655,6 +655,29 @@ document.addEventListener("DOMContentLoaded", function () {
   ns.parseTwemoji(document.body);
 });
 </script>
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="언어 선택">
+      <a class="lang-option" href="/ar/library/discord-symbols/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/de/library/discord-symbole/" hreflang="de">DE</a>
+      <a class="lang-option" href="/library/discord-symbols/" hreflang="en">EN</a>
+      <a class="lang-option" href="/es/library/simbolos-discord/" hreflang="es">ES</a>
+      <a class="lang-option" href="/fr/library/symboles-discord/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/id/library/simbol-discord/" hreflang="id">ID</a>
+      <a class="lang-option" href="/it/library/simboli-discord/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ja/library/discord-symbols/" hreflang="ja">JA</a>
+      <a class="lang-option active" href="/ko/library/discord-giho/" hreflang="ko">KO</a>
+      <a class="lang-option" href="/pl/library/symbole-discord/" hreflang="pl">PL</a>
+      <a class="lang-option" href="/pt/library/simbolos-discord/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/ru/library/simvoly-discord/" hreflang="ru">RU</a>
+      <a class="lang-option" href="/tr/library/discord-sembolleri/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/vi/ki-tu-discord/" hreflang="vi">VI</a>
+    </div>
+  </div>
+</footer>
+
 <script src="/footer.js" defer></script>
 </body>
 </html>

--- a/ko/library/imoji-johap/index.html
+++ b/ko/library/imoji-johap/index.html
@@ -29,6 +29,7 @@
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/kombinasi-emoji/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/combos-de-emoji/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/emoji-kombinasyonlari/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/emoji-kombinationen/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/emoji-combos/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/ko-library-imoji-johap.png">
 <meta property="og:image:width" content="1200">
@@ -765,6 +766,28 @@ document.addEventListener("DOMContentLoaded", function () {
   if (ns && ns.parseTwemoji) ns.parseTwemoji(document.body);
 });
 </script>
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="언어 선택">
+      <a class="lang-option" href="/ar/library/emoji-combos/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/de/emoji-kombinationen/" hreflang="de">DE</a>
+      <a class="lang-option" href="/library/emoji-combos/" hreflang="en">EN</a>
+      <a class="lang-option" href="/es/combinaciones-de-emojis/" hreflang="es">ES</a>
+      <a class="lang-option" href="/fr/combos-emoji/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/id/kombinasi-emoji/" hreflang="id">ID</a>
+      <a class="lang-option" href="/ja/library/emoji-combos/" hreflang="ja">JA</a>
+      <a class="lang-option active" href="/ko/library/imoji-johap/" hreflang="ko">KO</a>
+      <a class="lang-option" href="/pl/kombinacje-emoji/" hreflang="pl">PL</a>
+      <a class="lang-option" href="/pt/combos-de-emoji/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/ru/library/emoji-combos/" hreflang="ru">RU</a>
+      <a class="lang-option" href="/th/library/emoji-combos/" hreflang="th">TH</a>
+      <a class="lang-option" href="/tr/emoji-kombinasyonlari/" hreflang="tr">TR</a>
+    </div>
+  </div>
+</footer>
+
 <script src="/footer.js" defer></script>
 </body>
 </html>

--- a/ko/library/roblox-giho/index.html
+++ b/ko/library/roblox-giho/index.html
@@ -444,6 +444,29 @@ document.addEventListener("DOMContentLoaded", function () {
   ns.parseTwemoji(document.body);
 });
 </script>
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="언어 선택">
+      <a class="lang-option" href="/ar/library/roblox-symbols/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/library/roblox-symbols/" hreflang="en">EN</a>
+      <a class="lang-option" href="/es/library/simbolos-roblox/" hreflang="es">ES</a>
+      <a class="lang-option" href="/fr/library/symboles-roblox/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/id/library/simbol-roblox/" hreflang="id">ID</a>
+      <a class="lang-option" href="/it/library/simboli-roblox/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ja/library/roblox-symbols/" hreflang="ja">JA</a>
+      <a class="lang-option active" href="/ko/library/roblox-giho/" hreflang="ko">KO</a>
+      <a class="lang-option" href="/pl/library/symbole-roblox/" hreflang="pl">PL</a>
+      <a class="lang-option" href="/pt/library/simbolos-roblox/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/ru/library/simvoly-roblox/" hreflang="ru">RU</a>
+      <a class="lang-option" href="/th/library/roblox-symbols/" hreflang="th">TH</a>
+      <a class="lang-option" href="/tr/library/roblox-sembolleri/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/vi/ki-tu-roblox/" hreflang="vi">VI</a>
+    </div>
+  </div>
+</footer>
+
 <script src="/footer.js" defer></script>
 </body>
 </html>

--- a/ko/library/y2k-giho/index.html
+++ b/ko/library/y2k-giho/index.html
@@ -760,6 +760,27 @@ document.addEventListener("DOMContentLoaded", function () {
   ns.parseTwemoji(document.body);
 });
 </script>
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="언어 선택">
+      <a class="lang-option" href="/library/y2k-symbols/" hreflang="en">EN</a>
+      <a class="lang-option" href="/es/library/simbolos-y2k/" hreflang="es">ES</a>
+      <a class="lang-option" href="/fr/library/symboles-y2k/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/id/library/simbol-y2k/" hreflang="id">ID</a>
+      <a class="lang-option" href="/it/library/simboli-y2k/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ja/library/y2k-symbols/" hreflang="ja">JA</a>
+      <a class="lang-option active" href="/ko/library/y2k-giho/" hreflang="ko">KO</a>
+      <a class="lang-option" href="/pl/library/symbole-y2k/" hreflang="pl">PL</a>
+      <a class="lang-option" href="/pt/library/simbolos-y2k/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/th/library/y2k-symbols/" hreflang="th">TH</a>
+      <a class="lang-option" href="/tr/library/y2k-sembolleri/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/vi/ki-tu-y2k/" hreflang="vi">VI</a>
+    </div>
+  </div>
+</footer>
+
 <script src="/footer.js" defer></script>
 </body>
 </html>

--- a/library/discord-symbols/index.html
+++ b/library/discord-symbols/index.html
@@ -666,6 +666,29 @@ document.addEventListener("DOMContentLoaded", function () {
   ns.parseTwemoji(document.body);
 });
 </script>
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Language switcher">
+      <a class="lang-option" href="/ar/library/discord-symbols/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/de/library/discord-symbole/" hreflang="de">DE</a>
+      <a class="lang-option active" href="/library/discord-symbols/" hreflang="en">EN</a>
+      <a class="lang-option" href="/es/library/simbolos-discord/" hreflang="es">ES</a>
+      <a class="lang-option" href="/fr/library/symboles-discord/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/id/library/simbol-discord/" hreflang="id">ID</a>
+      <a class="lang-option" href="/it/library/simboli-discord/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ja/library/discord-symbols/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/discord-giho/" hreflang="ko">KO</a>
+      <a class="lang-option" href="/pl/library/symbole-discord/" hreflang="pl">PL</a>
+      <a class="lang-option" href="/pt/library/simbolos-discord/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/ru/library/simvoly-discord/" hreflang="ru">RU</a>
+      <a class="lang-option" href="/tr/library/discord-sembolleri/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/vi/ki-tu-discord/" hreflang="vi">VI</a>
+    </div>
+  </div>
+</footer>
+
 <script src="/footer.js" defer></script>
 </body>
 </html>

--- a/library/emoji-combos/index.html
+++ b/library/emoji-combos/index.html
@@ -29,6 +29,7 @@
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/kombinasi-emoji/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/combos-de-emoji/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/emoji-kombinasyonlari/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/emoji-kombinationen/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/emoji-combos/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/library-emoji-combos.png">
 <meta property="og:image:width" content="1200">
@@ -1070,6 +1071,28 @@ document.addEventListener("DOMContentLoaded", function () {
   if (ns.parseTwemoji) ns.parseTwemoji(document.body);
 });
 </script>
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Language switcher">
+      <a class="lang-option" href="/ar/library/emoji-combos/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/de/emoji-kombinationen/" hreflang="de">DE</a>
+      <a class="lang-option active" href="/library/emoji-combos/" hreflang="en">EN</a>
+      <a class="lang-option" href="/es/combinaciones-de-emojis/" hreflang="es">ES</a>
+      <a class="lang-option" href="/fr/combos-emoji/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/id/kombinasi-emoji/" hreflang="id">ID</a>
+      <a class="lang-option" href="/ja/library/emoji-combos/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/imoji-johap/" hreflang="ko">KO</a>
+      <a class="lang-option" href="/pl/kombinacje-emoji/" hreflang="pl">PL</a>
+      <a class="lang-option" href="/pt/combos-de-emoji/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/ru/library/emoji-combos/" hreflang="ru">RU</a>
+      <a class="lang-option" href="/th/library/emoji-combos/" hreflang="th">TH</a>
+      <a class="lang-option" href="/tr/emoji-kombinasyonlari/" hreflang="tr">TR</a>
+    </div>
+  </div>
+</footer>
+
 <script src="/footer.js" defer></script>
 </body>
 </html>

--- a/library/roblox-symbols/index.html
+++ b/library/roblox-symbols/index.html
@@ -456,6 +456,29 @@ document.addEventListener("DOMContentLoaded", function () {
   ns.parseTwemoji(document.body);
 });
 </script>
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Language switcher">
+      <a class="lang-option" href="/ar/library/roblox-symbols/" hreflang="ar">AR</a>
+      <a class="lang-option active" href="/library/roblox-symbols/" hreflang="en">EN</a>
+      <a class="lang-option" href="/es/library/simbolos-roblox/" hreflang="es">ES</a>
+      <a class="lang-option" href="/fr/library/symboles-roblox/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/id/library/simbol-roblox/" hreflang="id">ID</a>
+      <a class="lang-option" href="/it/library/simboli-roblox/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ja/library/roblox-symbols/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/roblox-giho/" hreflang="ko">KO</a>
+      <a class="lang-option" href="/pl/library/symbole-roblox/" hreflang="pl">PL</a>
+      <a class="lang-option" href="/pt/library/simbolos-roblox/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/ru/library/simvoly-roblox/" hreflang="ru">RU</a>
+      <a class="lang-option" href="/th/library/roblox-symbols/" hreflang="th">TH</a>
+      <a class="lang-option" href="/tr/library/roblox-sembolleri/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/vi/ki-tu-roblox/" hreflang="vi">VI</a>
+    </div>
+  </div>
+</footer>
+
 <script src="/footer.js" defer></script>
 </body>
 </html>

--- a/library/y2k-symbols/index.html
+++ b/library/y2k-symbols/index.html
@@ -801,6 +801,27 @@ document.addEventListener("DOMContentLoaded", function () {
   ns.parseTwemoji(document.body);
 });
 </script>
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Language switcher">
+      <a class="lang-option active" href="/library/y2k-symbols/" hreflang="en">EN</a>
+      <a class="lang-option" href="/es/library/simbolos-y2k/" hreflang="es">ES</a>
+      <a class="lang-option" href="/fr/library/symboles-y2k/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/id/library/simbol-y2k/" hreflang="id">ID</a>
+      <a class="lang-option" href="/it/library/simboli-y2k/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ja/library/y2k-symbols/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/y2k-giho/" hreflang="ko">KO</a>
+      <a class="lang-option" href="/pl/library/symbole-y2k/" hreflang="pl">PL</a>
+      <a class="lang-option" href="/pt/library/simbolos-y2k/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/th/library/y2k-symbols/" hreflang="th">TH</a>
+      <a class="lang-option" href="/tr/library/y2k-sembolleri/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/vi/ki-tu-y2k/" hreflang="vi">VI</a>
+    </div>
+  </div>
+</footer>
+
 <script src="/footer.js" defer></script>
 </body>
 </html>

--- a/pl/kombinacje-emoji/index.html
+++ b/pl/kombinacje-emoji/index.html
@@ -26,6 +26,7 @@
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/kombinasi-emoji/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/combos-de-emoji/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/emoji-kombinasyonlari/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/emoji-kombinationen/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/emoji-combos/">
 
   <meta name="robots" content="index, follow">
@@ -454,7 +455,19 @@
 
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="Wybór języka">
+      <a class="lang-option" href="/ar/library/emoji-combos/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/de/emoji-kombinationen/" hreflang="de">DE</a>
+      <a class="lang-option" href="/library/emoji-combos/" hreflang="en">EN</a>
+      <a class="lang-option" href="/es/combinaciones-de-emojis/" hreflang="es">ES</a>
+      <a class="lang-option" href="/fr/combos-emoji/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/id/kombinasi-emoji/" hreflang="id">ID</a>
+      <a class="lang-option" href="/ja/library/emoji-combos/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/imoji-johap/" hreflang="ko">KO</a>
       <a class="lang-option active" href="/pl/kombinacje-emoji/" hreflang="pl">PL</a>
+      <a class="lang-option" href="/pt/combos-de-emoji/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/ru/library/emoji-combos/" hreflang="ru">RU</a>
+      <a class="lang-option" href="/th/library/emoji-combos/" hreflang="th">TH</a>
+      <a class="lang-option" href="/tr/emoji-kombinasyonlari/" hreflang="tr">TR</a>
     </div>
   </div>
 </footer>

--- a/pl/library/symbole-discord/index.html
+++ b/pl/library/symbole-discord/index.html
@@ -662,6 +662,29 @@ document.addEventListener("DOMContentLoaded", function () {
   ns.parseTwemoji(document.body);
 });
 </script>
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Wybór języka">
+      <a class="lang-option" href="/ar/library/discord-symbols/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/de/library/discord-symbole/" hreflang="de">DE</a>
+      <a class="lang-option" href="/library/discord-symbols/" hreflang="en">EN</a>
+      <a class="lang-option" href="/es/library/simbolos-discord/" hreflang="es">ES</a>
+      <a class="lang-option" href="/fr/library/symboles-discord/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/id/library/simbol-discord/" hreflang="id">ID</a>
+      <a class="lang-option" href="/it/library/simboli-discord/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ja/library/discord-symbols/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/discord-giho/" hreflang="ko">KO</a>
+      <a class="lang-option active" href="/pl/library/symbole-discord/" hreflang="pl">PL</a>
+      <a class="lang-option" href="/pt/library/simbolos-discord/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/ru/library/simvoly-discord/" hreflang="ru">RU</a>
+      <a class="lang-option" href="/tr/library/discord-sembolleri/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/vi/ki-tu-discord/" hreflang="vi">VI</a>
+    </div>
+  </div>
+</footer>
+
 <script src="/footer.js" defer></script>
 </body>
 </html>

--- a/pl/library/symbole-roblox/index.html
+++ b/pl/library/symbole-roblox/index.html
@@ -454,6 +454,29 @@ document.addEventListener("DOMContentLoaded", function () {
   ns.parseTwemoji(document.body);
 });
 </script>
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Wybór języka">
+      <a class="lang-option" href="/ar/library/roblox-symbols/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/library/roblox-symbols/" hreflang="en">EN</a>
+      <a class="lang-option" href="/es/library/simbolos-roblox/" hreflang="es">ES</a>
+      <a class="lang-option" href="/fr/library/symboles-roblox/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/id/library/simbol-roblox/" hreflang="id">ID</a>
+      <a class="lang-option" href="/it/library/simboli-roblox/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ja/library/roblox-symbols/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/roblox-giho/" hreflang="ko">KO</a>
+      <a class="lang-option active" href="/pl/library/symbole-roblox/" hreflang="pl">PL</a>
+      <a class="lang-option" href="/pt/library/simbolos-roblox/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/ru/library/simvoly-roblox/" hreflang="ru">RU</a>
+      <a class="lang-option" href="/th/library/roblox-symbols/" hreflang="th">TH</a>
+      <a class="lang-option" href="/tr/library/roblox-sembolleri/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/vi/ki-tu-roblox/" hreflang="vi">VI</a>
+    </div>
+  </div>
+</footer>
+
 <script src="/footer.js" defer></script>
 </body>
 </html>

--- a/pl/library/symbole-y2k/index.html
+++ b/pl/library/symbole-y2k/index.html
@@ -787,6 +787,27 @@ document.addEventListener("DOMContentLoaded", function () {
   ns.parseTwemoji(document.body);
 });
 </script>
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Wybór języka">
+      <a class="lang-option" href="/library/y2k-symbols/" hreflang="en">EN</a>
+      <a class="lang-option" href="/es/library/simbolos-y2k/" hreflang="es">ES</a>
+      <a class="lang-option" href="/fr/library/symboles-y2k/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/id/library/simbol-y2k/" hreflang="id">ID</a>
+      <a class="lang-option" href="/it/library/simboli-y2k/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ja/library/y2k-symbols/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/y2k-giho/" hreflang="ko">KO</a>
+      <a class="lang-option active" href="/pl/library/symbole-y2k/" hreflang="pl">PL</a>
+      <a class="lang-option" href="/pt/library/simbolos-y2k/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/th/library/y2k-symbols/" hreflang="th">TH</a>
+      <a class="lang-option" href="/tr/library/y2k-sembolleri/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/vi/ki-tu-y2k/" hreflang="vi">VI</a>
+    </div>
+  </div>
+</footer>
+
 <script src="/footer.js" defer></script>
 </body>
 </html>

--- a/pt/combos-de-emoji/index.html
+++ b/pt/combos-de-emoji/index.html
@@ -26,6 +26,7 @@
   <link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/emoji-combos/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/emoji-kombinasyonlari/">
   <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/combinaciones-de-emojis/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/emoji-kombinationen/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/emoji-combos/">
 
   <meta name="robots" content="index, follow">
@@ -475,7 +476,19 @@
 
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="Seletor de idioma">
+      <a class="lang-option" href="/ar/library/emoji-combos/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/de/emoji-kombinationen/" hreflang="de">DE</a>
+      <a class="lang-option" href="/library/emoji-combos/" hreflang="en">EN</a>
+      <a class="lang-option" href="/es/combinaciones-de-emojis/" hreflang="es">ES</a>
+      <a class="lang-option" href="/fr/combos-emoji/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/id/kombinasi-emoji/" hreflang="id">ID</a>
+      <a class="lang-option" href="/ja/library/emoji-combos/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/imoji-johap/" hreflang="ko">KO</a>
+      <a class="lang-option" href="/pl/kombinacje-emoji/" hreflang="pl">PL</a>
       <a class="lang-option active" href="/pt/combos-de-emoji/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/ru/library/emoji-combos/" hreflang="ru">RU</a>
+      <a class="lang-option" href="/th/library/emoji-combos/" hreflang="th">TH</a>
+      <a class="lang-option" href="/tr/emoji-kombinasyonlari/" hreflang="tr">TR</a>
     </div>
   </div>
 </footer>

--- a/pt/library/simbolos-discord/index.html
+++ b/pt/library/simbolos-discord/index.html
@@ -668,6 +668,29 @@ document.addEventListener("DOMContentLoaded", function () {
   ns.parseTwemoji(document.body);
 });
 </script>
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Seletor de idioma">
+      <a class="lang-option" href="/ar/library/discord-symbols/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/de/library/discord-symbole/" hreflang="de">DE</a>
+      <a class="lang-option" href="/library/discord-symbols/" hreflang="en">EN</a>
+      <a class="lang-option" href="/es/library/simbolos-discord/" hreflang="es">ES</a>
+      <a class="lang-option" href="/fr/library/symboles-discord/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/id/library/simbol-discord/" hreflang="id">ID</a>
+      <a class="lang-option" href="/it/library/simboli-discord/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ja/library/discord-symbols/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/discord-giho/" hreflang="ko">KO</a>
+      <a class="lang-option" href="/pl/library/symbole-discord/" hreflang="pl">PL</a>
+      <a class="lang-option active" href="/pt/library/simbolos-discord/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/ru/library/simvoly-discord/" hreflang="ru">RU</a>
+      <a class="lang-option" href="/tr/library/discord-sembolleri/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/vi/ki-tu-discord/" hreflang="vi">VI</a>
+    </div>
+  </div>
+</footer>
+
 <script src="/footer.js" defer></script>
 </body>
 </html>

--- a/pt/library/simbolos-roblox/index.html
+++ b/pt/library/simbolos-roblox/index.html
@@ -452,6 +452,29 @@ document.addEventListener("DOMContentLoaded", function () {
   ns.parseTwemoji(document.body);
 });
 </script>
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Seletor de idioma">
+      <a class="lang-option" href="/ar/library/roblox-symbols/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/library/roblox-symbols/" hreflang="en">EN</a>
+      <a class="lang-option" href="/es/library/simbolos-roblox/" hreflang="es">ES</a>
+      <a class="lang-option" href="/fr/library/symboles-roblox/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/id/library/simbol-roblox/" hreflang="id">ID</a>
+      <a class="lang-option" href="/it/library/simboli-roblox/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ja/library/roblox-symbols/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/roblox-giho/" hreflang="ko">KO</a>
+      <a class="lang-option" href="/pl/library/symbole-roblox/" hreflang="pl">PL</a>
+      <a class="lang-option active" href="/pt/library/simbolos-roblox/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/ru/library/simvoly-roblox/" hreflang="ru">RU</a>
+      <a class="lang-option" href="/th/library/roblox-symbols/" hreflang="th">TH</a>
+      <a class="lang-option" href="/tr/library/roblox-sembolleri/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/vi/ki-tu-roblox/" hreflang="vi">VI</a>
+    </div>
+  </div>
+</footer>
+
 <script src="/footer.js" defer></script>
 </body>
 </html>

--- a/pt/library/simbolos-y2k/index.html
+++ b/pt/library/simbolos-y2k/index.html
@@ -792,6 +792,27 @@ document.addEventListener("DOMContentLoaded", function () {
   ns.parseTwemoji(document.body);
 });
 </script>
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Seletor de idioma">
+      <a class="lang-option" href="/library/y2k-symbols/" hreflang="en">EN</a>
+      <a class="lang-option" href="/es/library/simbolos-y2k/" hreflang="es">ES</a>
+      <a class="lang-option" href="/fr/library/symboles-y2k/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/id/library/simbol-y2k/" hreflang="id">ID</a>
+      <a class="lang-option" href="/it/library/simboli-y2k/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ja/library/y2k-symbols/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/y2k-giho/" hreflang="ko">KO</a>
+      <a class="lang-option" href="/pl/library/symbole-y2k/" hreflang="pl">PL</a>
+      <a class="lang-option active" href="/pt/library/simbolos-y2k/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/th/library/y2k-symbols/" hreflang="th">TH</a>
+      <a class="lang-option" href="/tr/library/y2k-sembolleri/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/vi/ki-tu-y2k/" hreflang="vi">VI</a>
+    </div>
+  </div>
+</footer>
+
 <script src="/footer.js" defer></script>
 </body>
 </html>

--- a/ru/library/emoji-combos/index.html
+++ b/ru/library/emoji-combos/index.html
@@ -29,6 +29,7 @@
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/kombinasi-emoji/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/combos-de-emoji/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/emoji-kombinasyonlari/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/emoji-kombinationen/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/emoji-combos/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/ru-library-emoji-combos.png">
 <meta property="og:image:width" content="1200">
@@ -520,6 +521,28 @@ document.addEventListener("DOMContentLoaded", function () {
   ns.parseTwemoji(document.body);
 });
 </script>
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Выбор языка">
+      <a class="lang-option" href="/ar/library/emoji-combos/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/de/emoji-kombinationen/" hreflang="de">DE</a>
+      <a class="lang-option" href="/library/emoji-combos/" hreflang="en">EN</a>
+      <a class="lang-option" href="/es/combinaciones-de-emojis/" hreflang="es">ES</a>
+      <a class="lang-option" href="/fr/combos-emoji/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/id/kombinasi-emoji/" hreflang="id">ID</a>
+      <a class="lang-option" href="/ja/library/emoji-combos/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/imoji-johap/" hreflang="ko">KO</a>
+      <a class="lang-option" href="/pl/kombinacje-emoji/" hreflang="pl">PL</a>
+      <a class="lang-option" href="/pt/combos-de-emoji/" hreflang="pt">PT</a>
+      <a class="lang-option active" href="/ru/library/emoji-combos/" hreflang="ru">RU</a>
+      <a class="lang-option" href="/th/library/emoji-combos/" hreflang="th">TH</a>
+      <a class="lang-option" href="/tr/emoji-kombinasyonlari/" hreflang="tr">TR</a>
+    </div>
+  </div>
+</footer>
+
 <script src="/footer.js" defer></script>
 </body>
 </html>

--- a/ru/library/simvoly-discord/index.html
+++ b/ru/library/simvoly-discord/index.html
@@ -632,6 +632,29 @@ document.addEventListener("DOMContentLoaded", function () {
   ns.parseTwemoji(document.body);
 });
 </script>
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Выбор языка">
+      <a class="lang-option" href="/ar/library/discord-symbols/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/de/library/discord-symbole/" hreflang="de">DE</a>
+      <a class="lang-option" href="/library/discord-symbols/" hreflang="en">EN</a>
+      <a class="lang-option" href="/es/library/simbolos-discord/" hreflang="es">ES</a>
+      <a class="lang-option" href="/fr/library/symboles-discord/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/id/library/simbol-discord/" hreflang="id">ID</a>
+      <a class="lang-option" href="/it/library/simboli-discord/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ja/library/discord-symbols/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/discord-giho/" hreflang="ko">KO</a>
+      <a class="lang-option" href="/pl/library/symbole-discord/" hreflang="pl">PL</a>
+      <a class="lang-option" href="/pt/library/simbolos-discord/" hreflang="pt">PT</a>
+      <a class="lang-option active" href="/ru/library/simvoly-discord/" hreflang="ru">RU</a>
+      <a class="lang-option" href="/tr/library/discord-sembolleri/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/vi/ki-tu-discord/" hreflang="vi">VI</a>
+    </div>
+  </div>
+</footer>
+
 <script src="/footer.js" defer></script>
 </body>
 </html>

--- a/ru/library/simvoly-roblox/index.html
+++ b/ru/library/simvoly-roblox/index.html
@@ -484,6 +484,29 @@ document.addEventListener("DOMContentLoaded", function () {
   ns.parseTwemoji(document.body);
 });
 </script>
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Выбор языка">
+      <a class="lang-option" href="/ar/library/roblox-symbols/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/library/roblox-symbols/" hreflang="en">EN</a>
+      <a class="lang-option" href="/es/library/simbolos-roblox/" hreflang="es">ES</a>
+      <a class="lang-option" href="/fr/library/symboles-roblox/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/id/library/simbol-roblox/" hreflang="id">ID</a>
+      <a class="lang-option" href="/it/library/simboli-roblox/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ja/library/roblox-symbols/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/roblox-giho/" hreflang="ko">KO</a>
+      <a class="lang-option" href="/pl/library/symbole-roblox/" hreflang="pl">PL</a>
+      <a class="lang-option" href="/pt/library/simbolos-roblox/" hreflang="pt">PT</a>
+      <a class="lang-option active" href="/ru/library/simvoly-roblox/" hreflang="ru">RU</a>
+      <a class="lang-option" href="/th/library/roblox-symbols/" hreflang="th">TH</a>
+      <a class="lang-option" href="/tr/library/roblox-sembolleri/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/vi/ki-tu-roblox/" hreflang="vi">VI</a>
+    </div>
+  </div>
+</footer>
+
 <script src="/footer.js" defer></script>
 </body>
 </html>

--- a/th/library/emoji-combos/index.html
+++ b/th/library/emoji-combos/index.html
@@ -29,6 +29,7 @@
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/kombinasi-emoji/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/combos-de-emoji/">
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/emoji-kombinasyonlari/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/emoji-kombinationen/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/emoji-combos/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/th-library-emoji-combos.png">
 <meta property="og:image:width" content="1200">
@@ -516,6 +517,28 @@ document.addEventListener("DOMContentLoaded", function () {
   ns.parseTwemoji(document.body);
 });
 </script>
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="ตัวเลือกภาษา">
+      <a class="lang-option" href="/ar/library/emoji-combos/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/de/emoji-kombinationen/" hreflang="de">DE</a>
+      <a class="lang-option" href="/library/emoji-combos/" hreflang="en">EN</a>
+      <a class="lang-option" href="/es/combinaciones-de-emojis/" hreflang="es">ES</a>
+      <a class="lang-option" href="/fr/combos-emoji/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/id/kombinasi-emoji/" hreflang="id">ID</a>
+      <a class="lang-option" href="/ja/library/emoji-combos/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/imoji-johap/" hreflang="ko">KO</a>
+      <a class="lang-option" href="/pl/kombinacje-emoji/" hreflang="pl">PL</a>
+      <a class="lang-option" href="/pt/combos-de-emoji/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/ru/library/emoji-combos/" hreflang="ru">RU</a>
+      <a class="lang-option active" href="/th/library/emoji-combos/" hreflang="th">TH</a>
+      <a class="lang-option" href="/tr/emoji-kombinasyonlari/" hreflang="tr">TR</a>
+    </div>
+  </div>
+</footer>
+
 <script src="/footer.js" defer></script>
 </body>
 </html>

--- a/th/library/roblox-symbols/index.html
+++ b/th/library/roblox-symbols/index.html
@@ -482,6 +482,29 @@ document.addEventListener("DOMContentLoaded", function () {
   ns.parseTwemoji(document.body);
 });
 </script>
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="ตัวเลือกภาษา">
+      <a class="lang-option" href="/ar/library/roblox-symbols/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/library/roblox-symbols/" hreflang="en">EN</a>
+      <a class="lang-option" href="/es/library/simbolos-roblox/" hreflang="es">ES</a>
+      <a class="lang-option" href="/fr/library/symboles-roblox/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/id/library/simbol-roblox/" hreflang="id">ID</a>
+      <a class="lang-option" href="/it/library/simboli-roblox/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ja/library/roblox-symbols/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/roblox-giho/" hreflang="ko">KO</a>
+      <a class="lang-option" href="/pl/library/symbole-roblox/" hreflang="pl">PL</a>
+      <a class="lang-option" href="/pt/library/simbolos-roblox/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/ru/library/simvoly-roblox/" hreflang="ru">RU</a>
+      <a class="lang-option active" href="/th/library/roblox-symbols/" hreflang="th">TH</a>
+      <a class="lang-option" href="/tr/library/roblox-sembolleri/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/vi/ki-tu-roblox/" hreflang="vi">VI</a>
+    </div>
+  </div>
+</footer>
+
 <script src="/footer.js" defer></script>
 </body>
 </html>

--- a/th/library/y2k-symbols/index.html
+++ b/th/library/y2k-symbols/index.html
@@ -779,6 +779,27 @@ document.addEventListener("DOMContentLoaded", function () {
   ns.parseTwemoji(document.body);
 });
 </script>
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="ตัวเลือกภาษา">
+      <a class="lang-option" href="/library/y2k-symbols/" hreflang="en">EN</a>
+      <a class="lang-option" href="/es/library/simbolos-y2k/" hreflang="es">ES</a>
+      <a class="lang-option" href="/fr/library/symboles-y2k/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/id/library/simbol-y2k/" hreflang="id">ID</a>
+      <a class="lang-option" href="/it/library/simboli-y2k/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ja/library/y2k-symbols/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/y2k-giho/" hreflang="ko">KO</a>
+      <a class="lang-option" href="/pl/library/symbole-y2k/" hreflang="pl">PL</a>
+      <a class="lang-option" href="/pt/library/simbolos-y2k/" hreflang="pt">PT</a>
+      <a class="lang-option active" href="/th/library/y2k-symbols/" hreflang="th">TH</a>
+      <a class="lang-option" href="/tr/library/y2k-sembolleri/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/vi/ki-tu-y2k/" hreflang="vi">VI</a>
+    </div>
+  </div>
+</footer>
+
 <script src="/footer.js" defer></script>
 </body>
 </html>

--- a/tr/emoji-kombinasyonlari/index.html
+++ b/tr/emoji-kombinasyonlari/index.html
@@ -26,6 +26,7 @@
   <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/combinaciones-de-emojis/">
   <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/kombinasi-emoji/">
   <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/combos-de-emoji/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/emoji-kombinationen/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/emoji-combos/">
 
   <meta name="robots" content="index, follow">
@@ -498,6 +499,18 @@
 
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="Dil seçici">
+      <a class="lang-option" href="/ar/library/emoji-combos/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/de/emoji-kombinationen/" hreflang="de">DE</a>
+      <a class="lang-option" href="/library/emoji-combos/" hreflang="en">EN</a>
+      <a class="lang-option" href="/es/combinaciones-de-emojis/" hreflang="es">ES</a>
+      <a class="lang-option" href="/fr/combos-emoji/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/id/kombinasi-emoji/" hreflang="id">ID</a>
+      <a class="lang-option" href="/ja/library/emoji-combos/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/imoji-johap/" hreflang="ko">KO</a>
+      <a class="lang-option" href="/pl/kombinacje-emoji/" hreflang="pl">PL</a>
+      <a class="lang-option" href="/pt/combos-de-emoji/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/ru/library/emoji-combos/" hreflang="ru">RU</a>
+      <a class="lang-option" href="/th/library/emoji-combos/" hreflang="th">TH</a>
       <a class="lang-option active" href="/tr/emoji-kombinasyonlari/" hreflang="tr">TR</a>
     </div>
   </div>

--- a/tr/library/discord-sembolleri/index.html
+++ b/tr/library/discord-sembolleri/index.html
@@ -595,15 +595,19 @@
       <div class="faq-item"><button class="faq-question" type="button">Discord adıma veya bio'ma sembol nasıl eklerim?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Sayfadaki herhangi bir sembole dokunup kopyala, sonra Discord görünen adına, Hakkımda bölümüne, sunucu takma adına, sunucu adına veya bir mesaja yapıştır. Giriş kullanıcı adı alanının yalnızca küçük harf, rakam, alt çizgi ve nokta kabul ettiğini unutma — semboller kullanıcı adına değil, görünen ada girer.</div></div>
       <div class="faq-item"><button class="faq-question" type="button">Discord kanal adlarında sembol kullanabilir miyim?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Evet, kısmen. Kanal adları küçük harfe çevrilir ve boşluklar tireye dönüşür ama birçok Unicode sembol ve ayraç (örneğin ⊹, ➤, │ ve ⌗) sunucunun kanal listesini ve kategorilerini düzenlemek için ön ek veya ayırıcı olarak çalışır. Destek değişebildiği için hem masaüstünde hem mobilde test et.</div></div>
       <div class="faq-item"><button class="faq-question" type="button">Bazı Discord sembolleri neden boş kutu olarak görünüyor?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Boş kutu, karşıdaki cihazın veya uygulama sürümünün o karakter için bir glife sahip olmadığı anlamına gelir. Yaygın desteklenen semboller (yıldızlar, kalpler, noktalar, kutu çizgisi ayraçları) hemen her yerde görünür; daha nadir karakterler görünmeyebilir. Bir sembol başkalarında bozuk görünüyorsa daha yaygın bir alternatifle değiştir.</div></div>
-      <div class="lang-switcher" role="navigation" aria-label="Language switcher">
+      <div class="lang-switcher" role="navigation" aria-label="Dil seçici">
+      <a class="lang-option" href="/ar/library/discord-symbols/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/de/library/discord-symbole/" hreflang="de">DE</a>
       <a class="lang-option" href="/library/discord-symbols/" hreflang="en">EN</a>
       <a class="lang-option" href="/es/library/simbolos-discord/" hreflang="es">ES</a>
       <a class="lang-option" href="/fr/library/symboles-discord/" hreflang="fr">FR</a>
       <a class="lang-option" href="/id/library/simbol-discord/" hreflang="id">ID</a>
       <a class="lang-option" href="/it/library/simboli-discord/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ja/library/discord-symbols/" hreflang="ja">JA</a>
       <a class="lang-option" href="/ko/library/discord-giho/" hreflang="ko">KO</a>
       <a class="lang-option" href="/pl/library/symbole-discord/" hreflang="pl">PL</a>
       <a class="lang-option" href="/pt/library/simbolos-discord/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/ru/library/simvoly-discord/" hreflang="ru">RU</a>
       <a class="lang-option active" href="/tr/library/discord-sembolleri/" hreflang="tr">TR</a>
       <a class="lang-option" href="/vi/ki-tu-discord/" hreflang="vi">VI</a>
     </div>

--- a/tr/library/roblox-sembolleri/index.html
+++ b/tr/library/roblox-sembolleri/index.html
@@ -379,15 +379,19 @@
       <div class="faq-item"><button class="faq-question" type="button">Roblox neden bazı sembolleri engelliyor?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Roblox, isimleri okunur ve güvenli tutmak için otomatik bir içerik/isim filtresi çalıştırır. Doğrulayamadığı karakterleri reddeder — birçok süsleme veya nadir Unicode karakteri, görünmez karakterler ve bazı kombolar. Bir sembol görünen adına kaydolmuyorsa, daha basit tek karakterli bir alternatifle değiştir.</div></div>
       <div class="faq-item"><button class="faq-question" type="button">Roblox görünen adıma sembol nasıl eklerim?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Bu sayfadaki bir sembole dokunup kopyala, ardından Ayarlar → Hesap Bilgileri → Görünen Ad (veya grup/bio alanı) içine yapıştır. Görünen ad sembol kabul eder; alttaki @kullanıcı adı kabul etmez — o alan yalnızca harf, rakam ve tek bir alt çizgi içerir.</div></div>
       <div class="faq-item"><button class="faq-question" type="button">Bu Roblox sembollerini kullanmak güvenli mi?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Evet. Bunlar süsleme için kullanılan sıradan Unicode karakterleridir; hile veya açık değildir, bu yüzden görünen adında ya da bioda kullanmak Roblox kurallarını ihlal etmez. Yeter ki genel adın uygun olsun — içerik filtresi sembollerin etrafındaki kelimeler için hâlâ geçerlidir.</div></div>
-      <div class="lang-switcher" role="navigation" aria-label="Language switcher">
+      <div class="lang-switcher" role="navigation" aria-label="Dil seçici">
+      <a class="lang-option" href="/ar/library/roblox-symbols/" hreflang="ar">AR</a>
       <a class="lang-option" href="/library/roblox-symbols/" hreflang="en">EN</a>
       <a class="lang-option" href="/es/library/simbolos-roblox/" hreflang="es">ES</a>
       <a class="lang-option" href="/fr/library/symboles-roblox/" hreflang="fr">FR</a>
       <a class="lang-option" href="/id/library/simbol-roblox/" hreflang="id">ID</a>
       <a class="lang-option" href="/it/library/simboli-roblox/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ja/library/roblox-symbols/" hreflang="ja">JA</a>
       <a class="lang-option" href="/ko/library/roblox-giho/" hreflang="ko">KO</a>
       <a class="lang-option" href="/pl/library/symbole-roblox/" hreflang="pl">PL</a>
       <a class="lang-option" href="/pt/library/simbolos-roblox/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/ru/library/simvoly-roblox/" hreflang="ru">RU</a>
+      <a class="lang-option" href="/th/library/roblox-symbols/" hreflang="th">TH</a>
       <a class="lang-option active" href="/tr/library/roblox-sembolleri/" hreflang="tr">TR</a>
       <a class="lang-option" href="/vi/ki-tu-roblox/" hreflang="vi">VI</a>
     </div>

--- a/tr/library/y2k-sembolleri/index.html
+++ b/tr/library/y2k-sembolleri/index.html
@@ -741,15 +741,17 @@
   <!-- FOOTER -->
   <footer class="footer">
     <div class="footer-inner">
-      <div class="lang-switcher" role="navigation" aria-label="Language switcher">
+      <div class="lang-switcher" role="navigation" aria-label="Dil seçici">
       <a class="lang-option" href="/library/y2k-symbols/" hreflang="en">EN</a>
       <a class="lang-option" href="/es/library/simbolos-y2k/" hreflang="es">ES</a>
       <a class="lang-option" href="/fr/library/symboles-y2k/" hreflang="fr">FR</a>
       <a class="lang-option" href="/id/library/simbol-y2k/" hreflang="id">ID</a>
       <a class="lang-option" href="/it/library/simboli-y2k/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ja/library/y2k-symbols/" hreflang="ja">JA</a>
       <a class="lang-option" href="/ko/library/y2k-giho/" hreflang="ko">KO</a>
       <a class="lang-option" href="/pl/library/symbole-y2k/" hreflang="pl">PL</a>
       <a class="lang-option" href="/pt/library/simbolos-y2k/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/th/library/y2k-symbols/" hreflang="th">TH</a>
       <a class="lang-option active" href="/tr/library/y2k-sembolleri/" hreflang="tr">TR</a>
       <a class="lang-option" href="/vi/ki-tu-y2k/" hreflang="vi">VI</a>
     </div>

--- a/vi/ki-tu-discord/index.html
+++ b/vi/ki-tu-discord/index.html
@@ -612,15 +612,19 @@
 <footer class="footer">
   <div class="footer-inner">
     <!-- Language Switcher -->
-    <div class="lang-switcher" role="navigation" aria-label="Language switcher">
+    <div class="lang-switcher" role="navigation" aria-label="Bộ chọn ngôn ngữ">
+      <a class="lang-option" href="/ar/library/discord-symbols/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/de/library/discord-symbole/" hreflang="de">DE</a>
       <a class="lang-option" href="/library/discord-symbols/" hreflang="en">EN</a>
       <a class="lang-option" href="/es/library/simbolos-discord/" hreflang="es">ES</a>
       <a class="lang-option" href="/fr/library/symboles-discord/" hreflang="fr">FR</a>
       <a class="lang-option" href="/id/library/simbol-discord/" hreflang="id">ID</a>
       <a class="lang-option" href="/it/library/simboli-discord/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ja/library/discord-symbols/" hreflang="ja">JA</a>
       <a class="lang-option" href="/ko/library/discord-giho/" hreflang="ko">KO</a>
       <a class="lang-option" href="/pl/library/symbole-discord/" hreflang="pl">PL</a>
       <a class="lang-option" href="/pt/library/simbolos-discord/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/ru/library/simvoly-discord/" hreflang="ru">RU</a>
       <a class="lang-option" href="/tr/library/discord-sembolleri/" hreflang="tr">TR</a>
       <a class="lang-option active" href="/vi/ki-tu-discord/" hreflang="vi">VI</a>
     </div>

--- a/vi/ki-tu-roblox/index.html
+++ b/vi/ki-tu-roblox/index.html
@@ -432,15 +432,19 @@
 <footer class="footer">
   <div class="footer-inner">
     <!-- Language Switcher -->
-    <div class="lang-switcher" role="navigation" aria-label="Language switcher">
+    <div class="lang-switcher" role="navigation" aria-label="Bộ chọn ngôn ngữ">
+      <a class="lang-option" href="/ar/library/roblox-symbols/" hreflang="ar">AR</a>
       <a class="lang-option" href="/library/roblox-symbols/" hreflang="en">EN</a>
       <a class="lang-option" href="/es/library/simbolos-roblox/" hreflang="es">ES</a>
       <a class="lang-option" href="/fr/library/symboles-roblox/" hreflang="fr">FR</a>
       <a class="lang-option" href="/id/library/simbol-roblox/" hreflang="id">ID</a>
       <a class="lang-option" href="/it/library/simboli-roblox/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ja/library/roblox-symbols/" hreflang="ja">JA</a>
       <a class="lang-option" href="/ko/library/roblox-giho/" hreflang="ko">KO</a>
       <a class="lang-option" href="/pl/library/symbole-roblox/" hreflang="pl">PL</a>
       <a class="lang-option" href="/pt/library/simbolos-roblox/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/ru/library/simvoly-roblox/" hreflang="ru">RU</a>
+      <a class="lang-option" href="/th/library/roblox-symbols/" hreflang="th">TH</a>
       <a class="lang-option" href="/tr/library/roblox-sembolleri/" hreflang="tr">TR</a>
       <a class="lang-option active" href="/vi/ki-tu-roblox/" hreflang="vi">VI</a>
     </div>

--- a/vi/ki-tu-y2k/index.html
+++ b/vi/ki-tu-y2k/index.html
@@ -721,15 +721,17 @@
     <div class="faq-item"><button class="faq-question" type="button">Vì sao có máy hiện ô vuông thay vì kí tự Y2K?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Ô vuông (□) nghĩa là thiết bị đó chưa có font chứa kí tự bạn dán. Các kí hiệu cơ bản như ★ ☆ ✦ ♡ ♱ hiển thị tốt gần như mọi nơi, còn vài glyph hiếm ở nhóm khung Ai Cập hay chấm bụi sao có thể lỗi trên máy cũ. Nếu người xem báo thấy ô vuông, cứ đổi sang kí hiệu phổ thông hơn — tất cả ở đây đều là Unicode chuẩn, hoàn toàn an toàn.</div></div>
 
     <!-- Language Switcher -->
-    <div class="lang-switcher" role="navigation" aria-label="Language switcher">
+    <div class="lang-switcher" role="navigation" aria-label="Bộ chọn ngôn ngữ">
       <a class="lang-option" href="/library/y2k-symbols/" hreflang="en">EN</a>
       <a class="lang-option" href="/es/library/simbolos-y2k/" hreflang="es">ES</a>
       <a class="lang-option" href="/fr/library/symboles-y2k/" hreflang="fr">FR</a>
       <a class="lang-option" href="/id/library/simbol-y2k/" hreflang="id">ID</a>
       <a class="lang-option" href="/it/library/simboli-y2k/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ja/library/y2k-symbols/" hreflang="ja">JA</a>
       <a class="lang-option" href="/ko/library/y2k-giho/" hreflang="ko">KO</a>
       <a class="lang-option" href="/pl/library/symbole-y2k/" hreflang="pl">PL</a>
       <a class="lang-option" href="/pt/library/simbolos-y2k/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/th/library/y2k-symbols/" hreflang="th">TH</a>
       <a class="lang-option" href="/tr/library/y2k-sembolleri/" hreflang="tr">TR</a>
       <a class="lang-option active" href="/vi/ki-tu-y2k/" hreflang="vi">VI</a>
     </div>


### PR DESCRIPTION
## Summary
This PR adds a consistent footer component with a language switcher to multiple pages across the site, improving navigation between localized versions of content.

## Changes Made

- **Footer component added** to 30+ pages across multiple language versions and content types:
  - Library pages: `discord-symbols`, `emoji-combos`, `roblox-symbols`, `y2k-symbols`
  - Emoji combination pages in multiple languages (German, Spanish, Indonesian, Japanese, Korean, Portuguese, Thai, Turkish, French)
  - Symbol library pages in multiple languages

- **Language switcher implementation**:
  - Displays all available language versions of the current page
  - Marks the active language with the `active` class
  - Uses proper `hreflang` attributes for SEO
  - Includes localized `aria-label` for accessibility in each language

- **Hreflang link updates**:
  - Added missing German (`de`) hreflang links to emoji combo pages across multiple language versions
  - Ensures proper cross-language linking for search engines

- **Consistent footer structure**:
  - All footers follow the same HTML pattern: `<footer class="footer">` → `<div class="footer-inner">` → `<div class="lang-switcher">`
  - Language options are presented as links with appropriate locale codes (AR, DE, EN, ES, FR, ID, IT, JA, KO, PL, PT, RU, TH, TR, VI)
  - Each page's footer correctly identifies and marks its own language as active

## Implementation Details

- Footer markup is inserted before the closing `

https://claude.ai/code/session_01GnF7QL9V9AwqvfwMtjubAs