### PR TITLE
Close the DE gap: roblox-symbols, y2k-symbols, and emoji-combos parity

### DIFF
--- a/ar/library/roblox-symbols/index.html
+++ b/ar/library/roblox-symbols/index.html
@@ -31,6 +31,7 @@
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/roblox-symbols/">
   <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/simvoly-roblox/">
   <link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/roblox-symbols/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/library/roblox-symbole/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/roblox-symbols/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/ar-library-roblox-symbols.png">
 <meta property="og:image:width" content="1200">
@@ -467,6 +468,7 @@ document.addEventListener("DOMContentLoaded", function () {
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="اختيار اللغة">
       <a class="lang-option active" href="/ar/library/roblox-symbols/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/de/library/roblox-symbole/" hreflang="de">DE</a>
       <a class="lang-option" href="/library/roblox-symbols/" hreflang="en">EN</a>
       <a class="lang-option" href="/es/library/simbolos-roblox/" hreflang="es">ES</a>
       <a class="lang-option" href="/fr/library/symboles-roblox/" hreflang="fr">FR</a>

--- a/de/emoji-kombinationen/index.html
+++ b/de/emoji-kombinationen/index.html
@@ -10,8 +10,8 @@
        crossorigin="anonymous"></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Emoji-Kombinationen zum Kopieren 🦋✨ Emoji-Combos | UltraTextGen</title>
-  <meta name="description" content="Emoji-Kombinationen zum Kopieren und Einfügen: süß, coquette, Liebe, dark und Strand. Emoji-Combos für deine Insta-Bio, deinen Status und deine Captions — kostenlos.">
+  <title>100+ Emoji-Kombinationen zum Kopieren 🦋✨ Emoji-Combos | UltraTextGen</title>
+  <meta name="description" content="Über 100 Emoji-Kombinationen zum Kopieren und Einfügen: süß, coquette, cottagecore, Y2K, kawaii, dark academia, Nachthimmel, angelcore, Liebe, dark und Strand. Emoji-Combos für deine Insta-Bio, deinen Status und deine Captions — kostenlos.">
   <link rel="canonical" href="https://ultratextgen.com/de/emoji-kombinationen/">
 
   <link rel="alternate" hreflang="ar" href="https://ultratextgen.com/ar/library/emoji-combos/">
@@ -31,8 +31,8 @@
 
   <meta name="robots" content="index, follow">
   <meta property="og:site_name" content="UltraTextGen">
-  <meta property="og:title" content="Emoji-Kombinationen zum Kopieren 🦋✨ Emoji-Combos">
-  <meta property="og:description" content="Dutzende fertige Emoji-Combos — süß, coquette, Liebe, dark, Strand — zum Einfügen in deine Insta-Bio, deinen Status und deine Captions. Antippen, schon kopiert.">
+  <meta property="og:title" content="100+ Emoji-Kombinationen zum Kopieren 🦋✨ Emoji-Combos">
+  <meta property="og:description" content="Über 100 fertige Emoji-Combos — süß, coquette, cottagecore, Y2K, kawaii, dark academia, Nachthimmel, angelcore, Liebe, dark und Strand — zum Einfügen in deine Insta-Bio, deinen Status und deine Captions. Antippen, schon kopiert.">
   <meta property="og:url" content="https://ultratextgen.com/de/emoji-kombinationen/">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://ultratextgen.com/assets/og/de-emoji-kombinationen.png">
@@ -40,8 +40,8 @@
   <meta property="og:image:height" content="630">
   <meta property="og:image:type" content="image/png">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Emoji-Kombinationen zum Kopieren 🦋✨ Emoji-Combos">
-  <meta name="twitter:description" content="Süße, coquette und dark Emoji-Combos zum Kopieren und Einfügen in deine Bio und deinen Status.">
+  <meta name="twitter:title" content="100+ Emoji-Kombinationen zum Kopieren 🦋✨ Emoji-Combos">
+  <meta name="twitter:description" content="Über 100 süße, coquette, cottagecore, Y2K, dark und ästhetische Emoji-Combos zum Kopieren und Einfügen in deine Bio und deinen Status.">
   <meta name="twitter:image" content="https://ultratextgen.com/assets/og/de-emoji-kombinationen.png">
   <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/style.css">
@@ -57,7 +57,7 @@
   "inLanguage": "de",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Any",
-  "description": "Emoji-Kombinationen zum Kopieren und Einfügen: süß, coquette, Liebe, dark und Strand. Emoji-Combos für deine Bio, deinen Status, deine Captions und deinen Nickname.",
+  "description": "Über 100 Emoji-Kombinationen zum Kopieren und Einfügen: süß, coquette, cottagecore, Y2K, kawaii, dark academia, Nachthimmel, angelcore, Liebe, dark und Strand. Emoji-Combos für deine Bio, deinen Status, deine Captions und deinen Nickname.",
   "offers": { "@type": "Offer", "price": "0", "priceCurrency": "EUR" }
 }
 </script>
@@ -133,7 +133,7 @@
   <div class="hero-inner">
     <div class="hero-card">
       <h1 class="hero-headline">Emoji-Kombinationen zum Kopieren und Einfügen</h1>
-      <p class="hero-tagline">Fertige Emoji-Combos, die deiner Bio, deinem Status und deinen Captions eine klare Stimmung geben — süß, coquette, Liebe, dark und Strand. Tipp auf einen Combo, um ihn zu kopieren, oder schreib unten deinen Namen und bau dir deinen eigenen mit einer stylischen Schrift an den Enden.</p>
+      <p class="hero-tagline">Über 100 fertige Emoji-Combos, die deiner Bio, deinem Status und deinen Captions eine klare Stimmung geben — süß, coquette, cottagecore, Y2K, kawaii, dark academia, Nachthimmel, angelcore, Liebe, dark und Strand. Tipp auf einen Combo, um ihn zu kopieren, oder schreib unten deinen Namen und bau dir deinen eigenen mit einer stylischen Schrift an den Enden.</p>
       <div class="input-wrapper">
         <textarea class="main-input" id="mainInput" placeholder="Schreib hier deinen Namen oder Text…" maxlength="500" autofocus=""></textarea>
         <span class="char-count"><span id="charCount">0</span>/500</span>
@@ -159,7 +159,7 @@
   <!-- Was ist eine Emoji-Kombination -->
   <section class="editorial-section">
     <h2>Was ist eine Emoji-Kombination?</h2>
-    <p class="editorial-intro">Eine Emoji-Kombination ist eine <strong>Folge aus Emojis</strong>, die gut zusammenpassen und eine Ästhetik ergeben — statt eines einzelnen Emojis eine kleine Reihe, die schon die Stimmung setzt (🦋✨🌸 süß, 🥀🖤⛓️ dark, 🌊🐚🤍 Strand). Genau dieses Detail lässt eine Bio oder einen Nickname durchdacht wirken. Weiter unten findest du fertige Combos nach Thema sortiert: antippen zum Kopieren und direkt in deine Bio, deinen Status oder deine Caption einfügen.</p>
+    <p class="editorial-intro">Eine Emoji-Kombination ist eine <strong>Folge aus Emojis</strong>, die gut zusammenpassen und eine Ästhetik ergeben — statt eines einzelnen Emojis eine kleine Reihe, die schon die Stimmung setzt (🦋✨🌸 süß, 🥀🖤⛓️ dark, 🌊🐚🤍 Strand). Genau dieses Detail lässt eine Bio oder einen Nickname durchdacht wirken. Weiter unten findest du <strong>über 100 fertige Combos</strong> nach Thema sortiert — süß, Liebe, dark, Strand, cottagecore, Nachthimmel, Y2K, kawaii, fairycore, dark academia, angelcore, Sonnenuntergang, Weltraum und Pflanzen: antippen zum Kopieren und direkt in deine Bio, deinen Status oder deine Caption einfügen.</p>
     <div class="block-example">
       <strong>Beispiel:</strong> Name + Combo → 🦋 𝓼𝓸𝓯𝓲𝓪 🦋 · ⋆｡°✩ 𝒹𝓊𝒹𝒶 ✩°｡⋆ · 🖤 𝕕𝕒𝕣𝕜 𝕤𝕠𝕦𝕝 🖤
     </div>
@@ -181,6 +181,118 @@
       <button class="uname-chip symbol-tile" data-symbol="🐚🤍🪸" aria-label="Combo kopieren">🐚🤍🪸</button>
       <button class="uname-chip symbol-tile" data-symbol="🍰🎀🩷" aria-label="Combo kopieren">🍰🎀🩷</button>
       <button class="uname-chip symbol-tile" data-symbol="🌙⭐🤍" aria-label="Combo kopieren">🌙⭐🤍</button>
+    </div>
+  </section>
+
+  <!-- Cottagecore Combos -->
+  <section class="editorial-section">
+    <h2>Cottagecore Emoji-Combos</h2>
+    <p class="editorial-intro">Pilze, Honig und Wiesentiere für eine gemütliche, ländliche Stimmung — perfekt für einen ruhigen Feed mit Landhaus-Charme und langsamen Nachmittagen.</p>
+    <div class="uname-grid">
+      <button class="uname-chip symbol-tile" data-symbol="🍄🌿🧺" aria-label="Combo kopieren">🍄🌿🧺</button>
+      <button class="uname-chip symbol-tile" data-symbol="🌷🐝🍯" aria-label="Combo kopieren">🌷🐝🍯</button>
+      <button class="uname-chip symbol-tile" data-symbol="🍃🐚🤎" aria-label="Combo kopieren">🍃🐚🤎</button>
+      <button class="uname-chip symbol-tile" data-symbol="🧺🍓🌼" aria-label="Combo kopieren">🧺🍓🌼</button>
+      <button class="uname-chip symbol-tile" data-symbol="🍄🐌🌧️" aria-label="Combo kopieren">🍄🐌🌧️</button>
+      <button class="uname-chip symbol-tile" data-symbol="🌾🐑☁️" aria-label="Combo kopieren">🌾🐑☁️</button>
+      <button class="uname-chip symbol-tile" data-symbol="🕯️📖🍂" aria-label="Combo kopieren">🕯️📖🍂</button>
+      <button class="uname-chip symbol-tile" data-symbol="🌻🐝🌾" aria-label="Combo kopieren">🌻🐝🌾</button>
+    </div>
+  </section>
+
+  <!-- Nachthimmel / Celestial Combos -->
+  <section class="editorial-section">
+    <h2>Emoji-Combos für Nachthimmel und Sterne</h2>
+    <p class="editorial-intro">Monde, Sterne und Wolken für eine verträumte, himmlische Ästhetik — ideal für Gute-Nacht-Captions und ruhige Bios. Für einzelne Sterne schau dir die <a href="/de/library/stern-symbole/">Stern-Symbole</a> an.</p>
+    <div class="uname-grid">
+      <button class="uname-chip symbol-tile" data-symbol="🌙⭐☁️" aria-label="Combo kopieren">🌙⭐☁️</button>
+      <button class="uname-chip symbol-tile" data-symbol="✦⋆｡˚🌙" aria-label="Combo kopieren">✦⋆｡˚🌙</button>
+      <button class="uname-chip symbol-tile" data-symbol="🌌🔭✨" aria-label="Combo kopieren">🌌🔭✨</button>
+      <button class="uname-chip symbol-tile" data-symbol="🌙🤍🌠" aria-label="Combo kopieren">🌙🤍🌠</button>
+      <button class="uname-chip symbol-tile" data-symbol="⭐🪐💫" aria-label="Combo kopieren">⭐🪐💫</button>
+      <button class="uname-chip symbol-tile" data-symbol="🌃🌙⭐" aria-label="Combo kopieren">🌃🌙⭐</button>
+      <button class="uname-chip symbol-tile" data-symbol="☾⋆⁺₊✧" aria-label="Combo kopieren">☾⋆⁺₊✧</button>
+      <button class="uname-chip symbol-tile" data-symbol="🌙🦉🕯️" aria-label="Combo kopieren">🌙🦉🕯️</button>
+    </div>
+  </section>
+
+  <!-- Y2K Combos -->
+  <section class="editorial-section">
+    <h2>Y2K Emoji-Combos</h2>
+    <p class="editorial-intro">CDs, Schmetterlinge und Disco-Glanz für einen Cyber-Look im Stil der frühen 2000er.</p>
+    <div class="uname-grid">
+      <button class="uname-chip symbol-tile" data-symbol="💿🦋⚡" aria-label="Combo kopieren">💿🦋⚡</button>
+      <button class="uname-chip symbol-tile" data-symbol="🪩💖💿" aria-label="Combo kopieren">🪩💖💿</button>
+      <button class="uname-chip symbol-tile" data-symbol="✨💗🦋" aria-label="Combo kopieren">✨💗🦋</button>
+      <button class="uname-chip symbol-tile" data-symbol="⭐🌐💜" aria-label="Combo kopieren">⭐🌐💜</button>
+      <button class="uname-chip symbol-tile" data-symbol="💋💅✨" aria-label="Combo kopieren">💋💅✨</button>
+      <button class="uname-chip symbol-tile" data-symbol="🦋🫧💿" aria-label="Combo kopieren">🦋🫧💿</button>
+      <button class="uname-chip symbol-tile" data-symbol="⚡🛹🤍" aria-label="Combo kopieren">⚡🛹🤍</button>
+      <button class="uname-chip symbol-tile" data-symbol="🌈🪩💫" aria-label="Combo kopieren">🌈🪩💫</button>
+    </div>
+  </section>
+
+  <!-- Kawaii Combos -->
+  <section class="editorial-section">
+    <h2>Kawaii Emoji-Combos</h2>
+    <p class="editorial-intro">Rund, pastellfarben und knuffig — für eine niedliche Bio im japanisch inspirierten Stil.</p>
+    <div class="uname-grid">
+      <button class="uname-chip symbol-tile" data-symbol="🍡🌸🐰" aria-label="Combo kopieren">🍡🌸🐰</button>
+      <button class="uname-chip symbol-tile" data-symbol="🧸🍓💕" aria-label="Combo kopieren">🧸🍓💕</button>
+      <button class="uname-chip symbol-tile" data-symbol="🐰🎀🍙" aria-label="Combo kopieren">🐰🎀🍙</button>
+      <button class="uname-chip symbol-tile" data-symbol="🍓🐻🤍" aria-label="Combo kopieren">🍓🐻🤍</button>
+      <button class="uname-chip symbol-tile" data-symbol="🌸🍡🐣" aria-label="Combo kopieren">🌸🍡🐣</button>
+      <button class="uname-chip symbol-tile" data-symbol="🧁🐰💗" aria-label="Combo kopieren">🧁🐰💗</button>
+      <button class="uname-chip symbol-tile" data-symbol="🍮🐱🌸" aria-label="Combo kopieren">🍮🐱🌸</button>
+      <button class="uname-chip symbol-tile" data-symbol="🐥🌼🤍" aria-label="Combo kopieren">🐥🌼🤍</button>
+    </div>
+  </section>
+
+  <!-- Fairycore Combos -->
+  <section class="editorial-section">
+    <h2>Fairycore Emoji-Combos</h2>
+    <p class="editorial-intro">Feen, Pilze und Marienkäfer für einen verwunschenen Wald-Look.</p>
+    <div class="uname-grid">
+      <button class="uname-chip symbol-tile" data-symbol="🧚🍄🌿" aria-label="Combo kopieren">🧚🍄🌿</button>
+      <button class="uname-chip symbol-tile" data-symbol="🦋🌸🍃" aria-label="Combo kopieren">🦋🌸🍃</button>
+      <button class="uname-chip symbol-tile" data-symbol="🧚‍♀️✨🌷" aria-label="Combo kopieren">🧚‍♀️✨🌷</button>
+      <button class="uname-chip symbol-tile" data-symbol="🍃🐞🌼" aria-label="Combo kopieren">🍃🐞🌼</button>
+      <button class="uname-chip symbol-tile" data-symbol="🌙🧚🍄" aria-label="Combo kopieren">🌙🧚🍄</button>
+      <button class="uname-chip symbol-tile" data-symbol="🦋🌿💫" aria-label="Combo kopieren">🦋🌿💫</button>
+      <button class="uname-chip symbol-tile" data-symbol="🐌🍄🌧️" aria-label="Combo kopieren">🐌🍄🌧️</button>
+      <button class="uname-chip symbol-tile" data-symbol="🌸🧚🤍" aria-label="Combo kopieren">🌸🧚🤍</button>
+    </div>
+  </section>
+
+  <!-- Dark Academia Combos -->
+  <section class="editorial-section">
+    <h2>Dark-Academia Emoji-Combos</h2>
+    <p class="editorial-intro">Bücher, Kerzen und Tinte für eine gelehrte, altmodische Stimmung — perfekt für Bücherwürmer und alle mit einem Faible für alte Bibliotheken.</p>
+    <div class="uname-grid">
+      <button class="uname-chip symbol-tile" data-symbol="📚🕯️🖋️" aria-label="Combo kopieren">📚🕯️🖋️</button>
+      <button class="uname-chip symbol-tile" data-symbol="🖤📖☕" aria-label="Combo kopieren">🖤📖☕</button>
+      <button class="uname-chip symbol-tile" data-symbol="🕯️📜🪶" aria-label="Combo kopieren">🕯️📜🪶</button>
+      <button class="uname-chip symbol-tile" data-symbol="🏛️📚🤎" aria-label="Combo kopieren">🏛️📚🤎</button>
+      <button class="uname-chip symbol-tile" data-symbol="☕📖🍂" aria-label="Combo kopieren">☕📖🍂</button>
+      <button class="uname-chip symbol-tile" data-symbol="🖋️📜🕯️" aria-label="Combo kopieren">🖋️📜🕯️</button>
+      <button class="uname-chip symbol-tile" data-symbol="🦉📚🌙" aria-label="Combo kopieren">🦉📚🌙</button>
+      <button class="uname-chip symbol-tile" data-symbol="🤎📖🕰️" aria-label="Combo kopieren">🤎📖🕰️</button>
+    </div>
+  </section>
+
+  <!-- Angelcore Combos -->
+  <section class="editorial-section">
+    <h2>Angelcore- und himmlische Emoji-Combos</h2>
+    <p class="editorial-intro">Flügel, Wolken und sanftes weißes Licht für eine himmlische, engelhafte Ästhetik.</p>
+    <div class="uname-grid">
+      <button class="uname-chip symbol-tile" data-symbol="👼🤍🕊️" aria-label="Combo kopieren">👼🤍🕊️</button>
+      <button class="uname-chip symbol-tile" data-symbol="🕊️☁️✨" aria-label="Combo kopieren">🕊️☁️✨</button>
+      <button class="uname-chip symbol-tile" data-symbol="🤍🪽😇" aria-label="Combo kopieren">🤍🪽😇</button>
+      <button class="uname-chip symbol-tile" data-symbol="☁️👼💫" aria-label="Combo kopieren">☁️👼💫</button>
+      <button class="uname-chip symbol-tile" data-symbol="🕯️🤍🕊️" aria-label="Combo kopieren">🕯️🤍🕊️</button>
+      <button class="uname-chip symbol-tile" data-symbol="😇☁️🌙" aria-label="Combo kopieren">😇☁️🌙</button>
+      <button class="uname-chip symbol-tile" data-symbol="🪽✨🤍" aria-label="Combo kopieren">🪽✨🤍</button>
+      <button class="uname-chip symbol-tile" data-symbol="🤍🕊️🌥️" aria-label="Combo kopieren">🤍🕊️🌥️</button>
     </div>
   </section>
 
@@ -220,7 +332,7 @@
   <!-- Strand / Sommer / Natur Combos -->
   <section class="editorial-section">
     <h2>Emoji-Combos für Strand, Sommer und Natur</h2>
-    <p class="editorial-intro">Für ein Urlaubsalbum, einen Sommer-Feed und die Bio eines Sonnenfans. Meer, Muscheln, Sonne und kleine Pflanzen.</p>
+    <p class="editorial-intro">Für ein Urlaubsalbum, einen Sommer-Feed und die Bio eines Sonnenfans. Meer, Muscheln, Delfine und kleine Pflanzen.</p>
     <div class="uname-grid">
       <button class="uname-chip symbol-tile" data-symbol="🌊🐚🤍" aria-label="Combo kopieren">🌊🐚🤍</button>
       <button class="uname-chip symbol-tile" data-symbol="🌴🥥🌊" aria-label="Combo kopieren">🌴🥥🌊</button>
@@ -230,7 +342,241 @@
       <button class="uname-chip symbol-tile" data-symbol="🌻🐝🍯" aria-label="Combo kopieren">🌻🐝🍯</button>
       <button class="uname-chip symbol-tile" data-symbol="🍉☀️🌴" aria-label="Combo kopieren">🍉☀️🌴</button>
       <button class="uname-chip symbol-tile" data-symbol="🌸🍃🦋" aria-label="Combo kopieren">🌸🍃🦋</button>
+      <button class="uname-chip symbol-tile" data-symbol="🐬🌊💙" aria-label="Combo kopieren">🐬🌊💙</button>
+      <button class="uname-chip symbol-tile" data-symbol="🏝️🌴☀️" aria-label="Combo kopieren">🏝️🌴☀️</button>
+      <button class="uname-chip symbol-tile" data-symbol="🐚🧜‍♀️💦" aria-label="Combo kopieren">🐚🧜‍♀️💦</button>
+      <button class="uname-chip symbol-tile" data-symbol="🌊⛱️🩵" aria-label="Combo kopieren">🌊⛱️🩵</button>
+      <button class="uname-chip symbol-tile" data-symbol="🦀🏖️🐚" aria-label="Combo kopieren">🦀🏖️🐚</button>
+      <button class="uname-chip symbol-tile" data-symbol="🌅🌊🤍" aria-label="Combo kopieren">🌅🌊🤍</button>
     </div>
+  </section>
+
+  <!-- Sonnenuntergang Combos -->
+  <section class="editorial-section">
+    <h2>Emoji-Combos für Sonnenuntergang und warme Töne</h2>
+    <p class="editorial-intro">Goldene Stunde, Orangetöne und warmes Braun für eine gemütliche, glühende Stimmung.</p>
+    <div class="uname-grid">
+      <button class="uname-chip symbol-tile" data-symbol="🌅🍊🧡" aria-label="Combo kopieren">🌅🍊🧡</button>
+      <button class="uname-chip symbol-tile" data-symbol="🌇🌺🤎" aria-label="Combo kopieren">🌇🌺🤎</button>
+      <button class="uname-chip symbol-tile" data-symbol="🍂🍁🤎" aria-label="Combo kopieren">🍂🍁🤎</button>
+      <button class="uname-chip symbol-tile" data-symbol="🌻☀️🧡" aria-label="Combo kopieren">🌻☀️🧡</button>
+      <button class="uname-chip symbol-tile" data-symbol="🌄🔥🧡" aria-label="Combo kopieren">🌄🔥🧡</button>
+      <button class="uname-chip symbol-tile" data-symbol="🍊🌅💛" aria-label="Combo kopieren">🍊🌅💛</button>
+      <button class="uname-chip symbol-tile" data-symbol="🌆🌴🧡" aria-label="Combo kopieren">🌆🌴🧡</button>
+      <button class="uname-chip symbol-tile" data-symbol="☀️🌾🧡" aria-label="Combo kopieren">☀️🌾🧡</button>
+    </div>
+  </section>
+
+  <!-- Kosmische Combos -->
+  <section class="editorial-section">
+    <h2>Kosmische Emoji-Combos und Weltraum</h2>
+    <p class="editorial-intro">Planeten, Raketen und Kometen für einen galaktischen Sci-Fi-Look.</p>
+    <div class="uname-grid">
+      <button class="uname-chip symbol-tile" data-symbol="🪐🌌💫" aria-label="Combo kopieren">🪐🌌💫</button>
+      <button class="uname-chip symbol-tile" data-symbol="🚀⭐🌙" aria-label="Combo kopieren">🚀⭐🌙</button>
+      <button class="uname-chip symbol-tile" data-symbol="👽🛸🌠" aria-label="Combo kopieren">👽🛸🌠</button>
+      <button class="uname-chip symbol-tile" data-symbol="🌠💜🪐" aria-label="Combo kopieren">🌠💜🪐</button>
+      <button class="uname-chip symbol-tile" data-symbol="☄️✨🌌" aria-label="Combo kopieren">☄️✨🌌</button>
+      <button class="uname-chip symbol-tile" data-symbol="🌑🌒🌓" aria-label="Combo kopieren">🌑🌒🌓</button>
+      <button class="uname-chip symbol-tile" data-symbol="🔭⭐🪐" aria-label="Combo kopieren">🔭⭐🪐</button>
+      <button class="uname-chip symbol-tile" data-symbol="🌟🌌💫" aria-label="Combo kopieren">🌟🌌💫</button>
+    </div>
+  </section>
+
+  <!-- Pflanzen Combos -->
+  <section class="editorial-section">
+    <h2>Emoji-Combos für Pflanzen und Grün</h2>
+    <p class="editorial-intro">Blätter, Sukkulenten und kleine Tiere für eine ruhige, botanische Bio.</p>
+    <div class="uname-grid">
+      <button class="uname-chip symbol-tile" data-symbol="🌿🪴🌱" aria-label="Combo kopieren">🌿🪴🌱</button>
+      <button class="uname-chip symbol-tile" data-symbol="🍀🐸🌿" aria-label="Combo kopieren">🍀🐸🌿</button>
+      <button class="uname-chip symbol-tile" data-symbol="🪴🌵☀️" aria-label="Combo kopieren">🪴🌵☀️</button>
+      <button class="uname-chip symbol-tile" data-symbol="🌱🐌🍃" aria-label="Combo kopieren">🌱🐌🍃</button>
+      <button class="uname-chip symbol-tile" data-symbol="🌿🦋🤍" aria-label="Combo kopieren">🌿🦋🤍</button>
+      <button class="uname-chip symbol-tile" data-symbol="🍃🌾🤎" aria-label="Combo kopieren">🍃🌾🤎</button>
+      <button class="uname-chip symbol-tile" data-symbol="🪴🌸🌿" aria-label="Combo kopieren">🪴🌸🌿</button>
+      <button class="uname-chip symbol-tile" data-symbol="🌵🏜️🌞" aria-label="Combo kopieren">🌵🏜️🌞</button>
+    </div>
+  </section>
+
+  <!-- Aesthetic Emoji Staples -->
+  <section class="mood-explainers" id="aesthetic-staples">
+    <span class="article-section-label">Grundausstattung</span>
+    <h2>Emoji-Staples für Ästhetik-Combos</h2>
+    <p class="u-secondary-tight">Die Kern-Emojis, die in fast jedem ästhetischen Combo auftauchen — Glitzer, Schleifen, Schmetterlinge und sanfte Himmelselemente.</p>
+    <div class="flag-rows">
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="✨" aria-label="Glitzer kopieren">✨</button>
+        <span class="flag-label">Glitzer</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="🌸" aria-label="Kirschblüte kopieren">🌸</button>
+        <span class="flag-label">Kirschblüte</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="🎀" aria-label="Schleife kopieren">🎀</button>
+        <span class="flag-label">Schleife</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="🦋" aria-label="Schmetterling kopieren">🦋</button>
+        <span class="flag-label">Schmetterling</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="☁️" aria-label="Wolke kopieren">☁️</button>
+        <span class="flag-label">Wolke</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="🌷" aria-label="Tulpe kopieren">🌷</button>
+        <span class="flag-label">Tulpe</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="💫" aria-label="Sternenglanz kopieren">💫</button>
+        <span class="flag-label">Sternenglanz</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="🍓" aria-label="Erdbeere kopieren">🍓</button>
+        <span class="flag-label">Erdbeere</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="🌙" aria-label="Mondsichel kopieren">🌙</button>
+        <span class="flag-label">Mondsichel</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="🫧" aria-label="Seifenblasen kopieren">🫧</button>
+        <span class="flag-label">Seifenblasen</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- Cute & Cozy Emojis -->
+  <section class="mood-explainers" id="cute-cozy">
+    <span class="article-section-label">Gemütlich</span>
+    <h2>Süße und gemütliche Emojis</h2>
+    <p class="u-secondary-tight">Warme, wohnliche Emojis für Cottagecore-, Lern- und Wohlfühl-Combos.</p>
+    <div class="flag-rows">
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="🧸" aria-label="Teddybär kopieren">🧸</button>
+        <span class="flag-label">Teddybär</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="🍄" aria-label="Pilz kopieren">🍄</button>
+        <span class="flag-label">Pilz</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="🐚" aria-label="Muschel kopieren">🐚</button>
+        <span class="flag-label">Muschel</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="🕯️" aria-label="Kerze kopieren">🕯️</button>
+        <span class="flag-label">Kerze</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="📖" aria-label="Aufgeschlagenes Buch kopieren">📖</button>
+        <span class="flag-label">Aufgeschlagenes Buch</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="☕" aria-label="Heißgetränk kopieren">☕</button>
+        <span class="flag-label">Heißgetränk</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="🧺" aria-label="Korb kopieren">🧺</button>
+        <span class="flag-label">Korb</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="🍯" aria-label="Honigtopf kopieren">🍯</button>
+        <span class="flag-label">Honigtopf</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- Bright & Fun Emojis -->
+  <section class="mood-explainers" id="bright-fun">
+    <span class="article-section-label">Bunt</span>
+    <h2>Bunte und fröhliche Emojis</h2>
+    <p class="u-secondary-tight">Energiegeladene Emojis für verspielte, bunte und Y2K-angehauchte Kombinationen.</p>
+    <div class="flag-rows">
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="🌈" aria-label="Regenbogen kopieren">🌈</button>
+        <span class="flag-label">Regenbogen</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="⚡" aria-label="Blitz kopieren">⚡</button>
+        <span class="flag-label">Blitz</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="🍒" aria-label="Kirschen kopieren">🍒</button>
+        <span class="flag-label">Kirschen</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="🍋" aria-label="Zitrone kopieren">🍋</button>
+        <span class="flag-label">Zitrone</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="🌻" aria-label="Sonnenblume kopieren">🌻</button>
+        <span class="flag-label">Sonnenblume</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="🪩" aria-label="Discokugel kopieren">🪩</button>
+        <span class="flag-label">Discokugel</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="💖" aria-label="Funkelndes Herz kopieren">💖</button>
+        <span class="flag-label">Funkelndes Herz</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="🎉" aria-label="Partyknaller kopieren">🎉</button>
+        <span class="flag-label">Partyknaller</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- Symbol Accents -->
+  <section class="mood-explainers" id="symbol-accents">
+    <span class="article-section-label">Akzente</span>
+    <h2>Symbol-Akzente für Combos</h2>
+    <p class="u-secondary-tight">Textsymbole, die zwischen Emojis passen und einen Combo handgemacht wirken lassen.</p>
+    <div class="flag-rows">
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="♡" aria-label="Weißes Herz (Kartenfarbe) kopieren">♡</button>
+        <span class="flag-label">Weißes Herz (Kartenfarbe)</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="☆" aria-label="Weißer Stern kopieren">☆</button>
+        <span class="flag-label">Weißer Stern</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="✧" aria-label="Vierzackig weiß kopieren">✧</button>
+        <span class="flag-label">Vierzackig weiß</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="✦" aria-label="Vierzackig kopieren">✦</button>
+        <span class="flag-label">Vierzackig</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="❀" aria-label="Weiße Blüte kopieren">❀</button>
+        <span class="flag-label">Weiße Blüte</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="✿" aria-label="Schwarze Blüte kopieren">✿</button>
+        <span class="flag-label">Schwarze Blüte</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="⋆" aria-label="Kleiner Stern kopieren">⋆</button>
+        <span class="flag-label">Kleiner Stern</span>
+      </div>
+      <div class="flag-row">
+        <button class="flag-emoji symbol-tile" data-symbol="°" aria-label="Gradzeichen kopieren">°</button>
+        <span class="flag-label">Gradzeichen</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- Ready-Made Combo Sets -->
+  <section class="mood-explainers" id="combo-sets">
+    <span class="article-section-label">Combo-Sets</span>
+    <h2>Fertige Emoji-Combo-Sets</h2>
+    <p class="u-secondary-block">Kopier ein komplettes ästhetisches Emoji-Set mit einem Klick — perfekt für Bio, Captions und Status.</p>
+    <div id="emojiCombosContainer"></div>
   </section>
 
   <!-- Wie du deinen eigenen Combo baust -->
@@ -319,5 +665,58 @@
 <script src="/renderer.js"></script>
 <script src="/script.js" defer=""></script>
 <script src="/symbol-explorer.js"></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    {
+      name: "Soft Girl",
+      flags: ["🎀", "🌸", "🩰", "🤍", "✨"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Meeresbrise",
+      flags: ["🌊", "🐚", "🐬", "⛱️", "🫧"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Cottage-Garten",
+      flags: ["🍄", "🌷", "🐝", "🍓", "🧺"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Nachthimmel",
+      flags: ["🌙", "⭐", "☁️", "💫", "🔭"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Kaffee-Date",
+      flags: ["☕", "🥐", "📖", "🍂", "🤎"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Y2K-Glitzer",
+      flags: ["💿", "🦋", "💖", "⚡", "🪩"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Niedliche Tiere",
+      flags: ["🐰", "🐻", "🍯", "🌼", "☀️"],
+      defaultFormat: "inline"
+    },
+    {
+      name: "Sonnenuntergangs-Vibes",
+      flags: ["🌅", "🍊", "🌺", "🏝️", "🧡"],
+      defaultFormat: "inline"
+    }
+  ];
+
+  ns.buildGrids("emojiCombosContainer", GROUPS);
+  if (ns.parseTwemoji) ns.parseTwemoji(document.body);
+});
+</script>
 <script src="/footer.js"></script>
 </body></html>

--- a/de/library/roblox-symbole/index.html
+++ b/de/library/roblox-symbole/index.html
@@ -1,0 +1,488 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8242324164413945"
+       crossorigin="anonymous"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Roblox-Symbole ✦ ⚡ ♡ zum Kopieren — für Anzeigenamen &amp; Bios</title>
+<meta name="description" content="Roblox-Symbole ✦ ⚡ ♡ zum Kopieren und Einfügen für Anzeigenamen, Bios und Gruppen — ästhetische Verzierungen, die den Namensfilter von Roblox bestehen und nicht blockiert werden.">
+
+<link rel="canonical" href="https://ultratextgen.com/de/library/roblox-symbole/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/roblox-symbols/">
+  <link rel="alternate" hreflang="ar" href="https://ultratextgen.com/ar/library/roblox-symbols/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/library/roblox-symbole/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/library/simbolos-roblox/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles-roblox/">
+  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-roblox/">
+  <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-roblox/">
+  <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/roblox-symbols/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/roblox-giho/">
+  <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-roblox/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-roblox/">
+  <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/simvoly-roblox/">
+  <link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/roblox-symbols/">
+  <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/roblox-sembolleri/">
+  <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/ki-tu-roblox/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/roblox-symbols/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/library-roblox-symbols.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Roblox-Symbole ✦ ⚡ ♡ zum Kopieren — für Anzeigenamen &amp; Bios">
+<meta name="twitter:description" content="Roblox-Symbole ✦ ⚡ ♡ zum Kopieren und Einfügen für Anzeigenamen, Bios und Gruppen — ästhetische Verzierungen, die den Namensfilter von Roblox bestehen und nicht blockiert werden.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/library-roblox-symbols.png">
+<meta property="og:title" content="Roblox-Symbole ✦ ⚡ ♡ zum Kopieren — für Anzeigenamen &amp; Bios">
+<meta property="og:description" content="Roblox-Symbole ✦ ⚡ ♡ zum Kopieren und Einfügen für Anzeigenamen, Bios und Gruppen — ästhetische Verzierungen, die den Namensfilter von Roblox bestehen und nicht blockiert werden.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/de/library/roblox-symbole/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "inLanguage": "de",
+  "headline": "Roblox-Symbole ✦ ⚡ ♡ zum Kopieren & Einfügen — Verzierungen für Anzeigename & Bio",
+  "alternateName": ["Roblox-Symbole kopieren und einfügen", "Symbole für Roblox", "Roblox-Namenssymbole", "Roblox-Textsymbole", "Roblox-Benutzernamen-Symbole", "Roblox-Bio-Symbole"],
+  "description": "Symbole für Roblox-Anzeigenamen, Bios und Gruppen. Ästhetische Verzierungen, die mit der Namensvalidierung von Roblox funktionieren — Zeichen zum Kopieren und Einfügen, die nicht blockiert werden.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/library-roblox-symbols.png",
+  "mainEntityOfPage": "https://ultratextgen.com/de/library/roblox-symbole/",
+  "datePublished": "2026-07-13",
+  "dateModified": "2026-07-13"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Startseite",
+      "item": "https://ultratextgen.com/de/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Roblox-Symbole",
+      "item": "https://ultratextgen.com/de/library/roblox-symbole/"
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "de",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Welche Symbole sind in Roblox-Anzeigenamen erlaubt?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Einzelzeichen-Unicode-Symbole wie ★ ♡ ✦ ❀ ⋆ ✧ sind am zuverlässigsten — sie bestehen den Namensfilter von Roblox und werden im Spiel angezeigt. Seltene Unicode-Blöcke und lange Mehrzeichen-Kombis werden eher abgelehnt. Jedes Symbol im Abschnitt „Roblox-freundliche Symbole“ dieser Seite wurde ausgewählt, weil es sich zuverlässig speichern lässt."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Warum blockiert Roblox manche Symbole?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Roblox verwendet einen automatischen Inhalts-/Namensfilter, um Namen lesbar und sicher zu halten. Er lehnt Zeichen ab, die er nicht validieren kann — viele dekorative oder seltene Unicode-Zeichen, unsichtbare Zeichen und manche Kombis. Wenn sich ein Symbol nicht in deinem Anzeigenamen speichern lässt, ersetze es durch eine einfachere Einzelzeichen-Alternative."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Wie füge ich Symbole zu meinem Roblox-Anzeigenamen hinzu?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Klicke auf ein Symbol auf dieser Seite, um es zu kopieren, und füge es dann unter Einstellungen → Kontoinformationen → Anzeigename (oder in dein Gruppen-/Bio-Feld) ein. Der Anzeigename akzeptiert Symbole; der zugrunde liegende @Benutzername nicht — dieses Feld erlaubt nur Buchstaben, Zahlen und einen einzelnen Unterstrich."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Sind diese Roblox-Symbole sicher zu verwenden?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ja. Es handelt sich um gewöhnliche Unicode-Zeichen zur Verzierung, nicht um Exploits oder Umgehungstricks — ihre Verwendung in einem Anzeigenamen oder einer Bio verstößt daher nicht gegen die Regeln von Roblox. Achte nur darauf, dass dein Name insgesamt angemessen bleibt — der Inhaltsfilter gilt weiterhin für die Wörter rund um die Symbole."
+      }
+    }
+  ]
+}
+</script>
+
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/de/">Startseite</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Roblox-Symbole</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Roblox-Symbole</h1>
+    <p class="hero-tagline">Ästhetische Symbole für Roblox-Anzeigenamen, Bios und Gruppen. Alle Zeichen wurden getestet und bestehen die Namensvalidierung von Roblox — klicke, um sofort zu kopieren.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/library-roblox-symbols.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Roblox erlaubt Unicode-Zeichen in Anzeigenamen und Bios, aber manche Symbole werden vom Inhaltsfilter blockiert. Das hier sind die zuverlässigsten ästhetischen Symbole, die in Roblox korrekt angezeigt werden — Sterne, Herzen, Blumen und süße Verzierungen, die die Namensvalidierung bestehen. Verwende sie in deinem Roblox-Anzeigenamen, deiner Gruppenbeschreibung oder deiner Bio.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 1 -->
+<section class="mood-explainers" id="roblox-friendly-marks">
+  <span class="article-section-label">Roblox-freundliche Zeichen</span>
+  <h2>Roblox-freundliche Symbole</h2>
+  <p>Diese Symbole bestehen zuverlässig die Namensvalidierung von Roblox und werden im Spiel korrekt dargestellt.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⋆" aria-label="Kopieren ⋆">⋆</button>
+      <span class="flag-label">Sechszackiger Stern-Operator</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊹" aria-label="Kopieren ⊹">⊹</button>
+      <span class="flag-label">Orthogonales Kreuz</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✦" aria-label="Kopieren ✦">✦</button>
+      <span class="flag-label">Schwarzer vierzackiger Stern</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✧" aria-label="Kopieren ✧">✧</button>
+      <span class="flag-label">Weißer vierzackiger Stern</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="★" aria-label="Kopieren ★">★</button>
+      <span class="flag-label">Schwarzer Stern</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☆" aria-label="Kopieren ☆">☆</button>
+      <span class="flag-label">Weißer Stern</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♡" aria-label="Kopieren ♡">♡</button>
+      <span class="flag-label">Weißes Herz (Kartenfarbe)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♥" aria-label="Kopieren ♥">♥</button>
+      <span class="flag-label">Schwarzes Herz (Kartenfarbe)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❀" aria-label="Kopieren ❀">❀</button>
+      <span class="flag-label">Weiße Blüte</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✿" aria-label="Kopieren ✿">✿</button>
+      <span class="flag-label">Schwarze Blüte</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❁" aria-label="Kopieren ❁">❁</button>
+      <span class="flag-label">Achtblättrige Blüte</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⌒" aria-label="Kopieren ⌒">⌒</button>
+      <span class="flag-label">Bogen</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="◌" aria-label="Kopieren ◌">◌</button>
+      <span class="flag-label">Kombinierender Ring</span>
+    </div>
+      <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚡" aria-label="Kopieren ⚡">⚡</button>
+      <span class="flag-label">Blitz</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="•" aria-label="Kopieren •">•</button>
+      <span class="flag-label">Aufzählungspunkt</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ツ" aria-label="Kopieren ツ">ツ</button>
+      <span class="flag-label">Katakana Tsu (Lächeln)</span>
+    </div>
+</div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 2 -->
+<section class="mood-explainers" id="cute-decorations-roblox">
+  <span class="article-section-label">Süße Verzierungen</span>
+  <h2>Süße Verzierungen</h2>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🎀" aria-label="Kopieren 🎀">🎀</button>
+      <span class="flag-label">Schleifen-Emoji</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="୨୧" aria-label="Kopieren ୨୧">୨୧</button>
+      <span class="flag-label">Coquette-Welle (Kombi)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ʚɞ" aria-label="Kopieren ʚɞ">ʚɞ</button>
+      <span class="flag-label">Herzflügel (Kombi)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="꒰" aria-label="Kopieren ꒰">꒰</button>
+      <span class="flag-label">Ornamentale linke Klammer</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="꒱" aria-label="Kopieren ꒱">꒱</button>
+      <span class="flag-label">Ornamentale rechte Klammer</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊹" aria-label="Kopieren ⊹">⊹</button>
+      <span class="flag-label">Orthogonales Kreuz</span>
+    </div>
+      <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="๑" aria-label="Kopieren ๑">๑</button>
+      <span class="flag-label">Thailändische Ziffer Eins</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ღ" aria-label="Kopieren ღ">ღ</button>
+      <span class="flag-label">Georgisches Ghan (Herz)</span>
+    </div>
+</div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 3 -->
+<section class="mood-explainers" id="y2k-roblox">
+  <span class="article-section-label">Y2K-Stil</span>
+  <h2>Y2K-Stil-Symbole</h2>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♱" aria-label="Kopieren ♱">♱</button>
+      <span class="flag-label">Ostsyrisches Kreuz</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✟" aria-label="Kopieren ✟">✟</button>
+      <span class="flag-label">Umrandetes lateinisches Kreuz</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✮" aria-label="Kopieren ✮">✮</button>
+      <span class="flag-label">Stern im Kreis</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓆩" aria-label="Kopieren 𓆩">𓆩</button>
+      <span class="flag-label">Ägyptische Schlange links</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓆪" aria-label="Kopieren 𓆪">𓆪</button>
+      <span class="flag-label">Ägyptische Schlange rechts</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𖥔" aria-label="Kopieren 𖥔">𖥔</button>
+      <span class="flag-label">Schrägkreuz im Kreis</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⋆˚࿔" aria-label="Kopieren ⋆˚࿔">⋆˚࿔</button>
+      <span class="flag-label">Funkel-Ring (Kombi)</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 4 -->
+<section class="mood-explainers" id="roblox-filter-note">
+  <span class="article-section-label">Über den Roblox-Filter</span>
+  <h2>Über den Roblox-Inhaltsfilter</h2>
+  <p>Roblox verwendet einen automatischen Inhaltsfilter, der manche Unicode-Zeichen in Anzeigenamen und Bios blockieren kann. Einzelzeichen-Symbole wie ★ ♡ ✦ ❀ ⋆ sind am sichersten. Mehrzeichen-Kombis und seltene Unicode-Blöcke werden eher blockiert oder entfernt. Wenn sich ein Symbol nicht in deinem Anzeigenamen speichern lässt, probiere eine einfachere Einzelzeichen-Alternative aus dem Abschnitt „Roblox-freundliche Symbole“ oben.</p>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- COLLECTIONS -->
+<section class="mood-explainers" id="roblox-collections">
+  <span class="article-section-label">Roblox-Sammlungen</span>
+  <h2>Roblox-Anzeigename- &amp; Bio-Kombis</h2>
+  <p class="u-secondary-block">Fertige Verzierungs-Zeichenketten, die du direkt in einen Roblox-Anzeigenamen, eine Bio oder eine Gruppenbeschreibung einfügen kannst — kopiere die ganze Kombi mit einem Klick.</p>
+  <div id="robloxCollectionsContainer"></div>
+</section>
+
+<div class="section-divider"></div>
+
+
+<!-- FAQ -->
+<section class="editorial-section" id="faq">
+  <span class="article-section-label">FAQ</span>
+  <h2>Roblox-Symbole, erklärt</h2>
+  <details class="faq-item">
+    <summary class="faq-question">Welche Symbole sind in Roblox-Anzeigenamen erlaubt?</summary>
+    <p class="faq-answer">Einzelzeichen-Unicode-Symbole wie ★ ♡ ✦ ❀ ⋆ ✧ sind am zuverlässigsten — sie bestehen den Namensfilter von Roblox und werden im Spiel angezeigt. Seltene Unicode-Blöcke und lange Mehrzeichen-Kombis werden eher abgelehnt. Jedes Symbol im Abschnitt „Roblox-freundliche Symbole“ oben wurde ausgewählt, weil es sich zuverlässig speichern lässt.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">Warum blockiert Roblox manche Symbole?</summary>
+    <p class="faq-answer">Roblox verwendet einen automatischen Inhalts-/Namensfilter, um Namen lesbar und sicher zu halten. Er lehnt Zeichen ab, die er nicht validieren kann — viele dekorative oder seltene Unicode-Zeichen, unsichtbare Zeichen und manche Kombis. Wenn sich ein Symbol nicht in deinem Anzeigenamen speichern lässt, ersetze es durch eine einfachere Einzelzeichen-Alternative.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">Wie füge ich Symbole zu meinem Roblox-Anzeigenamen hinzu?</summary>
+    <p class="faq-answer">Klicke auf ein Symbol auf dieser Seite, um es zu kopieren, und füge es dann unter Einstellungen → Kontoinformationen → Anzeigename (oder in dein Gruppen-/Bio-Feld) ein. Der Anzeigename akzeptiert Symbole; der zugrunde liegende @Benutzername nicht — dieses Feld erlaubt nur Buchstaben, Zahlen und einen einzelnen Unterstrich.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">Sind diese Roblox-Symbole sicher zu verwenden?</summary>
+    <p class="faq-answer">Ja. Es handelt sich um gewöhnliche Unicode-Zeichen zur Verzierung, nicht um Exploits oder Umgehungstricks — ihre Verwendung in einem Anzeigenamen oder einer Bio verstößt daher nicht gegen die Regeln von Roblox. Achte nur darauf, dass dein Name insgesamt angemessen bleibt — der Inhaltsfilter gilt weiterhin für die Wörter rund um die Symbole.</p>
+  </details>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- CTA: Generator cross-link (C2) -->
+<div class="cta-card">
+  <h3>Brauchst du einen Roblox-Benutzernamen (nicht nur Symbole)?</h3>
+  <p>Diese Symbole sind für deinen Anzeigenamen gedacht. Wenn du einen echten @Benutzernamen brauchst — die eigentliche Login-ID —, generiere verfügbare Optionen nach Vibe oder Länge.</p>
+  <a href="/roblox/name-generator/" class="cta-btn">Verfügbaren Roblox-Benutzernamen generieren →</a>
+</div>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Verwandle Text mit Unicode-Schriftarten</h3>
+  <p>Nutze UltraTextGen, um normalen Text in Fett, Kursiv, Schreibschrift und über 100 weitere Unicode-Schriftstile umzuwandeln — kostenlos und sofort.</p>
+  <a href="/de/" class="cta-btn">UltraTextGen öffnen →</a>
+</div>
+
+
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Verwandte Ressourcen</span>
+  <div class="compare-grid">
+    <a href="/roblox/name-generator/" class="compare-card variant-positive u-no-underline">
+      <h4>Roblox-Benutzernamen-Generator</h4>
+      <p>Generiere verfügbare Roblox-@Benutzernamen nach Vibe oder Länge — mit Live-Prüfung, ob sie noch frei sind.</p>
+    </a>
+    <a href="/library/aesthetic-symbols/" class="compare-card variant-muted u-no-underline">
+      <h4>Ästhetische Symbole</h4>
+      <p>Ausgewählte ästhetische Unicode-Zeichen für Bios.</p>
+    </a>
+    <a href="/de/library/herz-symbole/" class="compare-card variant-muted u-no-underline">
+      <h4>Herz-Symbole</h4>
+      <p>Herz-Emojis und Unicode-Herzzeichen.</p>
+    </a>
+    <a href="/de/library/stern-symbole/" class="compare-card variant-muted u-no-underline">
+      <h4>Stern-Symbol-Sammlung</h4>
+      <p>Sterne und Funkel-Zeichen.</p>
+    </a>
+    <a href="/library/coquette-symbols/" class="compare-card variant-muted u-no-underline">
+      <h4>Coquette-Symbole</h4>
+      <p>Weiche, feminine ästhetische Symbole.</p>
+    </a>
+    <a href="/library/y2k-symbols/" class="compare-card variant-muted u-no-underline">
+      <h4>Y2K-Symbole</h4>
+      <p>Cyber- und dunkle Y2K-ästhetische Symbole.</p>
+    </a>
+    <a href="/library/gaming-aesthetic-symbols/" class="compare-card variant-muted u-no-underline">
+      <h4>Gaming-Ästhetik-Symbole</h4>
+      <p>Rahmen für Clan-Tags, HUD-Leisten und Kampf-Icons.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    { name: "Stern-Namenskombi", flags: ["⋆","★","✦","★","⋆"], defaultFormat: "inline" },
+    { name: "Niedliche Schleifen-Namenskombi", flags: ["୨୧","♡","୨୧"], defaultFormat: "inline" },
+    { name: "Blumen-Anzeigename", flags: ["❀","✿","❁","✿","❀"], defaultFormat: "inline" },
+    { name: "Herzflügel-Kombi", flags: ["⋆","ʚɞ","⋆"], defaultFormat: "inline" },
+    { name: "Klammer-Stern-Name", flags: ["꒰","⊹","✧","⊹","꒱"], defaultFormat: "inline" },
+    { name: "Funkel-Bio-Trenner", flags: ["⋆","☆","⊹","☆","⋆"], defaultFormat: "inline" }
+  ];
+
+  ns.buildGrids("robloxCollectionsContainer", GROUPS);
+  ns.parseTwemoji(document.body);
+});
+</script>
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Sprachauswahl">
+      <a class="lang-option" href="/ar/library/roblox-symbols/" hreflang="ar">AR</a>
+      <a class="lang-option active" href="/de/library/roblox-symbole/" hreflang="de">DE</a>
+      <a class="lang-option" href="/library/roblox-symbols/" hreflang="en">EN</a>
+      <a class="lang-option" href="/es/library/simbolos-roblox/" hreflang="es">ES</a>
+      <a class="lang-option" href="/fr/library/symboles-roblox/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/id/library/simbol-roblox/" hreflang="id">ID</a>
+      <a class="lang-option" href="/it/library/simboli-roblox/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ja/library/roblox-symbols/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/roblox-giho/" hreflang="ko">KO</a>
+      <a class="lang-option" href="/pl/library/symbole-roblox/" hreflang="pl">PL</a>
+      <a class="lang-option" href="/pt/library/simbolos-roblox/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/ru/library/simvoly-roblox/" hreflang="ru">RU</a>
+      <a class="lang-option" href="/th/library/roblox-symbols/" hreflang="th">TH</a>
+      <a class="lang-option" href="/tr/library/roblox-sembolleri/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/vi/ki-tu-roblox/" hreflang="vi">VI</a>
+    </div>
+  </div>
+</footer>
+
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/de/library/y2k-symbole/index.html
+++ b/de/library/y2k-symbole/index.html
@@ -1,0 +1,831 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8242324164413945"
+       crossorigin="anonymous"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Y2K-Symbole ✦ 80+ Ästhetische Cyber-Deko zum Kopieren &amp; Einfügen</title>
+<meta name="description" content="Y2K-Symbole zum Kopieren und Einfügen — Sterne ✦, Schmetterlinge 🦋, Kreuze ♱, Funkeln und CDs 💿 für deine Bio, deinen Benutzernamen und Captions. Ein Tipp genügt zum Kopieren.">
+
+<link rel="canonical" href="https://ultratextgen.com/de/library/y2k-symbole/">
+  <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/y2k-symbols/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/library/y2k-symbole/">
+  <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/library/simbolos-y2k/">
+  <link rel="alternate" hreflang="fr" href="https://ultratextgen.com/fr/library/symboles-y2k/">
+  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-y2k/">
+  <link rel="alternate" hreflang="it" href="https://ultratextgen.com/it/library/simboli-y2k/">
+  <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/y2k-symbols/">
+  <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/y2k-giho/">
+  <link rel="alternate" hreflang="pl" href="https://ultratextgen.com/pl/library/symbole-y2k/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-y2k/">
+  <link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/y2k-symbols/">
+  <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/y2k-sembolleri/">
+  <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/ki-tu-y2k/">
+  <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/y2k-symbols/">
+<meta property="og:image" content="https://ultratextgen.com/assets/og/library-y2k-symbols.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Y2K-Symbole ✦ 80+ Ästhetische Cyber-Deko zum Kopieren &amp; Einfügen">
+<meta name="twitter:description" content="Y2K-Symbole zum Kopieren und Einfügen — Sterne ✦, Schmetterlinge 🦋, Kreuze ♱, Funkeln und CDs 💿 für deine Bio, deinen Benutzernamen und Captions. Ein Tipp genügt zum Kopieren.">
+<meta name="twitter:image" content="https://ultratextgen.com/assets/og/library-y2k-symbols.png">
+<meta property="og:title" content="Y2K-Symbole ✦ 80+ Ästhetische Cyber-Deko zum Kopieren &amp; Einfügen">
+<meta property="og:description" content="Y2K-Symbole zum Kopieren und Einfügen — Sterne ✦, Schmetterlinge 🦋, Kreuze ♱, Funkeln und CDs 💿 für deine Bio, deinen Benutzernamen und Captions. Ein Tipp genügt zum Kopieren.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/de/library/y2k-symbole/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "inLanguage": "de",
+  "headline": "Y2K-Symbole ✦ 80+ Ästhetische Cyber-Deko zum Kopieren & Einfügen",
+  "alternateName": ["Y2K Ästhetik Symbole", "Y2K Symbole Kopieren Einfügen", "2000er Ästhetik Symbole", "Cyber Y2K Zeichen", "Y2K Bio Deko", "Y2K Textsymbole", "2000er Aesthetic zum Kopieren"],
+  "description": "Y2K-Symbole zum Kopieren und Einfügen — Sterne ✦, Schmetterlinge 🦋, Kreuze ♱, Funkeln und CDs 💿 für deine Bio, deinen Benutzernamen und Captions. Ein Tipp genügt zum Kopieren.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "image": "https://ultratextgen.com/assets/og/library-y2k-symbols.png",
+  "mainEntityOfPage": "https://ultratextgen.com/de/library/y2k-symbole/",
+  "datePublished": "2026-07-13",
+  "dateModified": "2026-07-13"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Startseite",
+      "item": "https://ultratextgen.com/de/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Y2K-Symbole",
+      "item": "https://ultratextgen.com/de/library/y2k-symbole/"
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "inLanguage": "de",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Was sind Y2K-Symbole?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Y2K-Symbole sind Unicode-Zeichen, die die Cyber-Ästhetik der frühen 2000er einfangen — Funkelsterne (✦ ✮ ⋆), gotische Kreuze (♱ ✟ †), Schmetterlinge (🦋), CDs und Pager (💿 📟) sowie schimmernde Staub-Akzente. Da es sich um reinen Unicode-Text und nicht um Bilder handelt, kannst du sie direkt in jede Bio, jeden Benutzernamen oder jede Caption einfügen, ohne eine Datei hochzuladen."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Wie verwende ich Y2K-Symbole in einer Instagram-Bio?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Tippe auf ein beliebiges Symbol oder eine Kombi auf dieser Seite, um es zu kopieren, öffne dann Instagram, gehe zu „Profil bearbeiten” und füge es in dein Namens- oder Bio-Feld ein. Rahme deinen Text mit passenden Symbolen ein — zum Beispiel ♱ dein Text ♱ oder 𓆩♡𓆪 — und setze ein Funkeln (✦) oder einen Stern (✮) zwischen die Wörter. Beschränke dich auf zwei bis drei Symbole, damit die Bio lesbar bleibt."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Funktionieren Y2K-Symbole auf TikTok und Discord?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ja. Jedes Symbol hier ist Standard-Unicode und wird daher in TikTok-Benutzernamen, Captions und Kommentaren sowie in Discord-Anzeigenamen, Kanalnamen und Nachrichten dargestellt. Ein paar seltene Zeichen können auf älteren Geräten ohne die passende Schriftart als Kästchen erscheinen — teste sie deshalb vorher auf deinem Handy. Einfache Sterne, Herzen und Kreuze haben die beste Unterstützung."
+      }
+    }
+  ]
+}
+</script>
+
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/de/">Startseite</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">Y2K-Symbole</span>
+</nav>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Y2K-Symbole</h1>
+    <p class="hero-tagline">Die Y2K-Ästhetik ist pure Cyber-Nostalgie der frühen 2000er — Funkelsterne, gotische Kreuze, Schmetterlinge und CD-Glanz. Tippe auf ein Symbol unten, um es sofort zu kopieren.</p>
+  </div>
+</section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/library-y2k-symbols.svg" width="1200" height="340"
+       loading="lazy" alt="">
+</figure>
+
+
+
+<!-- QUICK COPY (above the fold) -->
+<section class="mood-explainers" id="quick-copy">
+  <span class="article-section-label">Die meistkopierten Y2K-Symbole</span>
+  <h2>Zum Kopieren tippen</h2>
+  <p>Die Y2K-Ästhetik-Symbole, die am häufigsten kopiert werden — Sterne, Kreuze, Schmetterlinge, Funkeln und CDs. Ein Tipp kopiert das Zeichen.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✦" aria-label="Kopieren ✦">✦</button>
+      <span class="flag-label">Funkelstern</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✮" aria-label="Kopieren ✮">✮</button>
+      <span class="flag-label">Y2K-Stern</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♱" aria-label="Kopieren ♱">♱</button>
+      <span class="flag-label">Kreuz</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦋" aria-label="Kopieren 🦋">🦋</button>
+      <span class="flag-label">Schmetterling</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✨" aria-label="Kopieren ✨">✨</button>
+      <span class="flag-label">Funkeln</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💿" aria-label="Kopieren 💿">💿</button>
+      <span class="flag-label">CD</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𖤐" aria-label="Kopieren 𖤐">𖤐</button>
+      <span class="flag-label">Schwarze Sonne</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓆩♡𓆪" aria-label="Kopieren 𓆩♡𓆪">𓆩♡𓆪</button>
+      <span class="flag-label">Herz-Rahmen</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Y2K-Ästhetik-Symbole schöpfen aus der Internet-Nostalgie der frühen 2000er: Schmetterlingsspangen, Klapphandys, Glitzer, gotische Kreuze und holografischer CD-Glanz. Diese Unicode-Zeichen fangen genau diese Energie ein — Funkelsterne für den Glanz, Kreuze für die härtere Kante, Schmetterlinge und Schleifen für die weiche Seite, Cyber-Glyphen für die Tech-Ära und Pfeilklammern, um deinen Text einzurahmen. Alles unten ist zum Kopieren und Einfügen: Tippe auf ein Symbol, um es zu greifen, und füge es dann in eine Instagram-Bio, eine TikTok-Caption, einen Discord-Namen oder überall dort ein, wo Unicode-Text unterstützt wird.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 1 -->
+<section class="mood-explainers" id="stars-sparkles">
+  <span class="article-section-label">Sterne &amp; Funkeln</span>
+  <h2>Sterne &amp; Funkeln</h2>
+  <p>Das Herzstück der Y2K-Ästhetik — Funkelsterne und Glitzerzeichen für Benutzernamen, Bios und Captions. Tippe auf eines, um es zu kopieren.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✦" aria-label="Kopieren ✦">✦</button>
+      <span class="flag-label">Schwarzer vierzackiger Stern</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✧" aria-label="Kopieren ✧">✧</button>
+      <span class="flag-label">Weißer vierzackiger Stern</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="★" aria-label="Kopieren ★">★</button>
+      <span class="flag-label">Schwarzer Stern</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☆" aria-label="Kopieren ☆">☆</button>
+      <span class="flag-label">Weißer Stern</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✮" aria-label="Kopieren ✮">✮</button>
+      <span class="flag-label">Fett umrandeter Stern</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✯" aria-label="Kopieren ✯">✯</button>
+      <span class="flag-label">Windrad-Stern</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✩" aria-label="Kopieren ✩">✩</button>
+      <span class="flag-label">Betont umrandeter Stern</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✪" aria-label="Kopieren ✪">✪</button>
+      <span class="flag-label">Weißer Stern im Kreis</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✫" aria-label="Kopieren ✫">✫</button>
+      <span class="flag-label">Schwarzer Stern mit offener Mitte</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✬" aria-label="Kopieren ✬">✬</button>
+      <span class="flag-label">Weißer Stern mit schwarzer Mitte</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✭" aria-label="Kopieren ✭">✭</button>
+      <span class="flag-label">Umrandeter schwarzer Stern</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✰" aria-label="Kopieren ✰">✰</button>
+      <span class="flag-label">Weißer Stern mit Schatten</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⭑" aria-label="Kopieren ⭑">⭑</button>
+      <span class="flag-label">Kleiner schwarzer Stern</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⭒" aria-label="Kopieren ⭒">⭒</button>
+      <span class="flag-label">Kleiner weißer Stern</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⋆" aria-label="Kopieren ⋆">⋆</button>
+      <span class="flag-label">Stern-Operator</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⍟" aria-label="Kopieren ⍟">⍟</button>
+      <span class="flag-label">Stern im Quadrat</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚝" aria-label="Kopieren ⚝">⚝</button>
+      <span class="flag-label">Umrandeter weißer Stern</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✨" aria-label="Kopieren ✨">✨</button>
+      <span class="flag-label">Funkeln-Emoji</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌟" aria-label="Kopieren 🌟">🌟</button>
+      <span class="flag-label">Leuchtender Stern</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💫" aria-label="Kopieren 💫">💫</button>
+      <span class="flag-label">Sternwirbel</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⭐" aria-label="Kopieren ⭐">⭐</button>
+      <span class="flag-label">Stern-Emoji</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="˚" aria-label="Kopieren ˚">˚</button>
+      <span class="flag-label">Ring oben (Staub)</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 1B -->
+<section class="mood-explainers" id="hearts-crosses">
+  <span class="article-section-label">Herzen &amp; Kreuze</span>
+  <h2>Herzen &amp; Kreuze</h2>
+  <p>Gotische Kreuze und Y2K-Herzen — die Mischung aus hart und weich im Zentrum des 2000er-Revivals.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♡" aria-label="Kopieren ♡">♡</button>
+      <span class="flag-label">Weißes Herz</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♥" aria-label="Kopieren ♥">♥</button>
+      <span class="flag-label">Schwarzes Herz</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❤" aria-label="Kopieren ❤">❤</button>
+      <span class="flag-label">Rotes Herz-Emoji</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🖤" aria-label="Kopieren 🖤">🖤</button>
+      <span class="flag-label">Schwarzes Herz-Emoji</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🤍" aria-label="Kopieren 🤍">🤍</button>
+      <span class="flag-label">Weißes Herz-Emoji</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ᥫ᭡" aria-label="Kopieren ᥫ᭡">ᥫ᭡</button>
+      <span class="flag-label">Lässiges Herz</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ʚ♡ɞ" aria-label="Kopieren ʚ♡ɞ">ʚ♡ɞ</button>
+      <span class="flag-label">Geflügeltes Herz (Kombi)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❦" aria-label="Kopieren ❦">❦</button>
+      <span class="flag-label">Blumen-Herz</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❧" aria-label="Kopieren ❧">❧</button>
+      <span class="flag-label">Gedrehtes Blumen-Herz</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♱" aria-label="Kopieren ♱">♱</button>
+      <span class="flag-label">Ostsyrisches Kreuz</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♰" aria-label="Kopieren ♰">♰</button>
+      <span class="flag-label">Westsyrisches Kreuz</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✟" aria-label="Kopieren ✟">✟</button>
+      <span class="flag-label">Umrandetes lateinisches Kreuz</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✝" aria-label="Kopieren ✝">✝</button>
+      <span class="flag-label">Lateinisches Kreuz</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="†" aria-label="Kopieren †">†</button>
+      <span class="flag-label">Kreuzzeichen</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☦" aria-label="Kopieren ☦">☦</button>
+      <span class="flag-label">Orthodoxes Kreuz</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛧" aria-label="Kopieren ⛧">⛧</button>
+      <span class="flag-label">Umgekehrtes Pentagramm</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𖤐" aria-label="Kopieren 𖤐">𖤐</button>
+      <span class="flag-label">Schwarze Sonne</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 2 -->
+<section class="mood-explainers" id="tech-cyber">
+  <span class="article-section-label">Tech &amp; Cyber</span>
+  <h2>Tech- &amp; Cyber-Symbole</h2>
+  <p>CDs, Pager und Cyber-Motive aus der digitalen Ära der frühen 2000er — die Tech-Ästhetik von Y2K in Reinform.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💿" aria-label="Kopieren 💿">💿</button>
+      <span class="flag-label">CD-Emoji</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="📀" aria-label="Kopieren 📀">📀</button>
+      <span class="flag-label">DVD-Emoji</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💾" aria-label="Kopieren 💾">💾</button>
+      <span class="flag-label">Disketten-Emoji</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="📟" aria-label="Kopieren 📟">📟</button>
+      <span class="flag-label">Pager-Emoji</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="📱" aria-label="Kopieren 📱">📱</button>
+      <span class="flag-label">Handy-Emoji</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💻" aria-label="Kopieren 💻">💻</button>
+      <span class="flag-label">Laptop-Emoji</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🖥" aria-label="Kopieren 🖥">🖥</button>
+      <span class="flag-label">Desktop-Computer</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕹" aria-label="Kopieren 🕹">🕹</button>
+      <span class="flag-label">Joystick-Emoji</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🎮" aria-label="Kopieren 🎮">🎮</button>
+      <span class="flag-label">Videospiel-Controller</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌐" aria-label="Kopieren 🌐">🌐</button>
+      <span class="flag-label">Globus mit Meridianen</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🛸" aria-label="Kopieren 🛸">🛸</button>
+      <span class="flag-label">Ufo-Emoji</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="📡" aria-label="Kopieren 📡">📡</button>
+      <span class="flag-label">Satellitenschüssel</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🔋" aria-label="Kopieren 🔋">🔋</button>
+      <span class="flag-label">Batterie-Emoji</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕸" aria-label="Kopieren 🕸">🕸</button>
+      <span class="flag-label">Spinnennetz</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦇" aria-label="Kopieren 🦇">🦇</button>
+      <span class="flag-label">Fledermaus-Emoji</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚙" aria-label="Kopieren ⚙">⚙</button>
+      <span class="flag-label">Zahnrad</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⌨" aria-label="Kopieren ⌨">⌨</button>
+      <span class="flag-label">Tastatur</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 3 -->
+<section class="mood-explainers" id="butterflies-bows">
+  <span class="article-section-label">Schmetterlinge, Schleifen &amp; Blasen</span>
+  <h2>Schmetterlinge, Schleifen &amp; Blasen</h2>
+  <p>Die weiche Seite von Y2K — Schmetterlingsspangen, Schleifenbänder und milchige Blasen-Akzente.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦋" aria-label="Kopieren 🦋">🦋</button>
+      <span class="flag-label">Schmetterling-Emoji</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🎀" aria-label="Kopieren 🎀">🎀</button>
+      <span class="flag-label">Schleifen-Emoji</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🩰" aria-label="Kopieren 🩰">🩰</button>
+      <span class="flag-label">Ballettschuhe-Emoji</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🫧" aria-label="Kopieren 🫧">🫧</button>
+      <span class="flag-label">Blasen-Emoji</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌸" aria-label="Kopieren 🌸">🌸</button>
+      <span class="flag-label">Kirschblüte</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🍓" aria-label="Kopieren 🍓">🍓</button>
+      <span class="flag-label">Erdbeere</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ꨄ" aria-label="Kopieren ꨄ">ꨄ</button>
+      <span class="flag-label">Geschwungenes Herz</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ᡣ𐭩" aria-label="Kopieren ᡣ𐭩">ᡣ𐭩</button>
+      <span class="flag-label">Kätzchen-Gesicht (Kombi)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✨" aria-label="Kopieren ✨">✨</button>
+      <span class="flag-label">Funkeln-Emoji</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 3B -->
+<section class="mood-explainers" id="arrows-brackets">
+  <span class="article-section-label">Pfeile &amp; Klammern</span>
+  <h2>Pfeile &amp; Klammern</h2>
+  <p>Rahme deinen Text im Y2K-Stil ein — Eckklammern, geschwungene Klammern und Pfeile, um deine Bio zu markieren und einzurahmen.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="「" aria-label="Kopieren 「">「</button>
+      <span class="flag-label">Linke Eckklammer</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="」" aria-label="Kopieren 」">」</button>
+      <span class="flag-label">Rechte Eckklammer</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="『" aria-label="Kopieren 『">『</button>
+      <span class="flag-label">Weiße linke Eckklammer</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="』" aria-label="Kopieren 』">』</button>
+      <span class="flag-label">Weiße rechte Eckklammer</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="꒰" aria-label="Kopieren ꒰">꒰</button>
+      <span class="flag-label">Linke geschwungene Klammer</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="꒱" aria-label="Kopieren ꒱">꒱</button>
+      <span class="flag-label">Rechte geschwungene Klammer</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⫷" aria-label="Kopieren ⫷">⫷</button>
+      <span class="flag-label">Linke Dreiecksklammer</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⫸" aria-label="Kopieren ⫸">⫸</button>
+      <span class="flag-label">Rechte Dreiecksklammer</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="➶" aria-label="Kopieren ➶">➶</button>
+      <span class="flag-label">Fetter Pfeil nach oben</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="➴" aria-label="Kopieren ➴">➴</button>
+      <span class="flag-label">Fetter Pfeil nach unten</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="↳" aria-label="Kopieren ↳">↳</button>
+      <span class="flag-label">Pfeil mit Haken</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="➤" aria-label="Kopieren ➤">➤</button>
+      <span class="flag-label">Schwarze Pfeilspitze</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☆彡" aria-label="Kopieren ☆彡">☆彡</button>
+      <span class="flag-label">Sternschnuppe (Kombi)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⌗" aria-label="Kopieren ⌗">⌗</button>
+      <span class="flag-label">Viewdata-Quadrat</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 4 -->
+<section class="mood-explainers" id="egyptian-frames">
+  <span class="article-section-label">Ägyptische Rahmen</span>
+  <h2>Ägyptische Rahmen</h2>
+  <p>Hieroglyphen-Zeichen, die als ästhetische Rahmenklammern zweckentfremdet wurden — ein Y2K-Internet-Klassiker.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓆩" aria-label="Kopieren 𓆩">𓆩</button>
+      <span class="flag-label">Ägyptische Schlange links</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓆪" aria-label="Kopieren 𓆪">𓆪</button>
+      <span class="flag-label">Ägyptische Schlange rechts</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓆝" aria-label="Kopieren 𓆝">𓆝</button>
+      <span class="flag-label">Ägyptische Schildkröte</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓍯" aria-label="Kopieren 𓍯">𓍯</button>
+      <span class="flag-label">Ägyptischer Korb</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓂃" aria-label="Kopieren 𓂃">𓂃</button>
+      <span class="flag-label">Ägyptische Feder</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓏸" aria-label="Kopieren 𓏸">𓏸</button>
+      <span class="flag-label">Ägyptisches Zeichen</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓏲" aria-label="Kopieren 𓏲">𓏲</button>
+      <span class="flag-label">Ägyptisches Zeichen 2</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓆩♱𓆪" aria-label="Kopieren 𓆩♱𓆪">𓆩♱𓆪</button>
+      <span class="flag-label">Ägyptischer Kreuz-Rahmen (Kombi)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓆩♡𓆪" aria-label="Kopieren 𓆩♡𓆪">𓆩♡𓆪</button>
+      <span class="flag-label">Ägyptischer Herz-Rahmen (Kombi)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓆩 ⛧ 𓆪" aria-label="Kopieren 𓆩 ⛧ 𓆪">𓆩 ⛧ 𓆪</button>
+      <span class="flag-label">Ägyptischer Pentagramm-Rahmen (Kombi)</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 5 -->
+<section class="mood-explainers" id="sparkle-dust">
+  <span class="article-section-label">Dekorativer Staub &amp; Funkeln</span>
+  <h2>Dekorativer Staub &amp; Funkeln</h2>
+  <p>Winzige Funkel- und Staub-Akzente zum Kombinieren in Y2K-Ästhetik-Kombis.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𖥔" aria-label="Kopieren 𖥔">𖥔</button>
+      <span class="flag-label">Andreaskreuz im Kreis</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⊹" aria-label="Kopieren ⊹">⊹</button>
+      <span class="flag-label">Orthogonales Kreuz</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="‧₊˚" aria-label="Kopieren ‧₊˚">‧₊˚</button>
+      <span class="flag-label">Tiefgestelltes Funkeln (Kombi)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="࣪" aria-label="Kopieren ࣪">࣪</button>
+      <span class="flag-label">Kombinierendes Zeichen</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="݁" aria-label="Kopieren ݁">݁</button>
+      <span class="flag-label">Kombinierender Punkt</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- SECTION 6 -->
+<section class="mood-explainers" id="y2k-combos">
+  <span class="article-section-label">Y2K-Kombis</span>
+  <h2>Y2K-Kombi-Vorlagen</h2>
+  <p>Fertige Y2K-Ästhetik-Kombis für Bios und Benutzernamen. Klicke auf eine, um sie zu kopieren.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♱*.ﾟ🎧⚝‧,₊˚🕷️✮𖤐📟🕸️,.♰" aria-label="Kopieren ♱*.ﾟ🎧⚝‧,₊˚🕷️✮𖤐📟🕸️,.♰">♱*.ﾟ🎧⚝‧,₊˚🕷️✮𖤐📟🕸️,.♰</button>
+      <span class="flag-label">Y2K-Bio-Kombi</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𓆩♱𓆪 𖥔 ᥫ᭡ ⋆" aria-label="Kopieren 𓆩♱𓆪 𖥔 ᥫ᭡ ⋆">𓆩♱𓆪 𖥔 ᥫ᭡ ⋆</button>
+      <span class="flag-label">Ägyptische Stern-Kombi</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❦.♱ʚ♡ɞ♱❦." aria-label="Kopieren ❦.♱ʚ♡ɞ♱❦.">❦.♱ʚ♡ɞ♱❦.</button>
+      <span class="flag-label">Gotische Herz-Kombi</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✮⋆˙" aria-label="Kopieren ✮⋆˙">✮⋆˙</button>
+      <span class="flag-label">Stern-Funkeln</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="𖤐 ⛧ ✟" aria-label="Kopieren 𖤐 ⛧ ✟">𖤐 ⛧ ✟</button>
+      <span class="flag-label">Dunkler Stern mit Kreuz</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+
+<!-- FAQ -->
+<section class="editorial-section" id="faq">
+  <span class="article-section-label">FAQ</span>
+  <h2>Y2K-Symbole, erklärt</h2>
+  <details class="faq-item">
+    <summary class="faq-question">Was sind Y2K-Symbole?</summary>
+    <p class="faq-answer">Y2K-Symbole sind Unicode-Zeichen, die die Cyber-Ästhetik der frühen 2000er einfangen — Funkelsterne (✦ ✮ ⋆), gotische Kreuze (♱ ✟ †), Schmetterlinge (🦋), CDs und Pager (💿 📟) sowie schimmernde Staub-Akzente. Da es sich um reinen Unicode-Text und nicht um Bilder handelt, kannst du sie direkt in jede Bio, jeden Benutzernamen oder jede Caption einfügen, ohne eine Datei hochzuladen.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">Wie verwende ich Y2K-Symbole in einer Instagram-Bio?</summary>
+    <p class="faq-answer">Tippe auf ein beliebiges Symbol oder eine Kombi auf dieser Seite, um es zu kopieren, öffne dann Instagram, gehe zu „Profil bearbeiten” und füge es in dein Namens- oder Bio-Feld ein. Rahme deinen Text mit passenden Symbolen ein — zum Beispiel ♱ dein Text ♱ oder 𓆩♡𓆪 — und setze ein Funkeln (✦) oder einen Stern (✮) zwischen die Wörter. Beschränke dich auf zwei bis drei Symbole, damit die Bio lesbar bleibt.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">Funktionieren Y2K-Symbole auf TikTok und Discord?</summary>
+    <p class="faq-answer">Ja. Jedes Symbol hier ist Standard-Unicode und wird daher in TikTok-Benutzernamen, Captions und Kommentaren sowie in Discord-Anzeigenamen, Kanalnamen und Nachrichten dargestellt. Ein paar seltene Zeichen können auf älteren Geräten ohne die passende Schriftart als Kästchen erscheinen — teste sie deshalb vorher auf deinem Handy. Einfache Sterne, Herzen und Kreuze haben die beste Unterstützung.</p>
+  </details>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- COLLECTIONS -->
+<section class="mood-explainers" id="y2k-collections">
+  <span class="article-section-label">Y2K-Sammlungen</span>
+  <h2>Y2K-Kombi-Vorlagen</h2>
+  <p class="u-secondary-block">Fertige Y2K-Zeichenketten, die du direkt in eine Bio, einen Benutzernamen oder eine Caption einfügen kannst — kopiere die ganze Kombi mit einem Klick.</p>
+  <div id="y2kCollectionsContainer"></div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- GENERATOR CTA -->
+<div class="cta-card">
+  <h3>Willst du einen Live-Y2K-Kombi-Generator?</h3>
+  <p>Gib deinen Namen oder Bio-Text in den Text-Dekorator ein, wähle den Y2K-Vibe und erhalte sofort Dutzende fertige Kombis zum Kopieren — ohne einzeln durch Kacheln zu klicken.</p>
+  <a href="https://ultratextgen.com/category/text-decorator/?vibe=y2k" class="cta-btn">Y2K-Generator ausprobieren →</a>
+</div>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Verwandle Text mit Unicode-Schriftarten</h3>
+  <p>Nutze UltraTextGen, um normalen Text in Fett, Kursiv, Schreibschrift und über 100 weitere Unicode-Schriftstile zu verwandeln — kostenlos und sofort.</p>
+  <a href="/de/" class="cta-btn">UltraTextGen öffnen →</a>
+</div>
+
+
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Verwandte Ressourcen</span>
+  <div class="compare-grid">
+    <a href="/library/aesthetic-symbols/" class="compare-card variant-muted u-no-underline">
+      <h4>Ästhetische Symbole</h4>
+      <p>Handverlesene ästhetische Unicode-Zeichen für Bios und Benutzernamen.</p>
+    </a>
+    <a href="/library/coquette-symbols/" class="compare-card variant-muted u-no-underline">
+      <h4>Coquette-Symbole</h4>
+      <p>Schleifen, Bänder und sanft-feminine Zeichen für deine Bio.</p>
+    </a>
+    <a href="/library/sparkle-symbols/" class="compare-card variant-muted u-no-underline">
+      <h4>Funkel-Symbole</h4>
+      <p>Glitzer- und Funkel-Zeichen zum Verzieren.</p>
+    </a>
+    <a href="/de/library/stern-symbole/" class="compare-card variant-muted u-no-underline">
+      <h4>Stern-Symbole</h4>
+      <p>Sterne und Funkel-Zeichen in verschiedenen Stilen.</p>
+    </a>
+    <a href="/library/egyptian-hieroglyphs/" class="compare-card variant-muted u-no-underline">
+      <h4>Ägyptische Hieroglyphen</h4>
+      <p>Alle 1.072 Unicode-Hieroglyphen-Zeichen.</p>
+    </a>
+    <a href="/library/gaming-aesthetic-symbols/" class="compare-card variant-muted u-no-underline">
+      <h4>Gaming-Ästhetik-Symbole</h4>
+      <p>Clan-Tag-Rahmen, HUD-Leisten und Kampf-Icons.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js" defer></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  "use strict";
+  var ns = window.UltraTextGen;
+  if (!ns || !ns.buildGrids) return;
+
+  var GROUPS = [
+    { name: "Cyber-Benutzername-Kombi", flags: ["✮","⋆","˚","𖤐","˚","⋆","✮"], defaultFormat: "inline" },
+    { name: "Gotische Kreuz-Bio-Kombi", flags: ["♱","✟","†","✟","♱"], defaultFormat: "inline" },
+    { name: "Ägyptischer Kreuz-Rahmen", flags: ["𓆩♱𓆪"], defaultFormat: "inline" },
+    { name: "Schmetterling-Bio-Kombi", flags: ["🦋","‧₊˚","🫧","‧₊˚","🦋"], defaultFormat: "inline" },
+    { name: "Dunkle Stern-Kombi", flags: ["𖤐","⛧","✯","⛧","𖤐"], defaultFormat: "inline" },
+    { name: "Funkel-Staub-Trenner", flags: ["𖥔","⊹","‧₊˚","⊹","𖥔"], defaultFormat: "inline" }
+  ];
+
+  ns.buildGrids("y2kCollectionsContainer", GROUPS);
+  ns.parseTwemoji(document.body);
+});
+</script>
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+    <!-- Language Switcher -->
+    <div class="lang-switcher" role="navigation" aria-label="Sprachauswahl">
+      <a class="lang-option active" href="/de/library/y2k-symbole/" hreflang="de">DE</a>
+      <a class="lang-option" href="/library/y2k-symbols/" hreflang="en">EN</a>
+      <a class="lang-option" href="/es/library/simbolos-y2k/" hreflang="es">ES</a>
+      <a class="lang-option" href="/fr/library/symboles-y2k/" hreflang="fr">FR</a>
+      <a class="lang-option" href="/id/library/simbol-y2k/" hreflang="id">ID</a>
+      <a class="lang-option" href="/it/library/simboli-y2k/" hreflang="it">IT</a>
+      <a class="lang-option" href="/ja/library/y2k-symbols/" hreflang="ja">JA</a>
+      <a class="lang-option" href="/ko/library/y2k-giho/" hreflang="ko">KO</a>
+      <a class="lang-option" href="/pl/library/symbole-y2k/" hreflang="pl">PL</a>
+      <a class="lang-option" href="/pt/library/simbolos-y2k/" hreflang="pt">PT</a>
+      <a class="lang-option" href="/th/library/y2k-symbols/" hreflang="th">TH</a>
+      <a class="lang-option" href="/tr/library/y2k-sembolleri/" hreflang="tr">TR</a>
+      <a class="lang-option" href="/vi/ki-tu-y2k/" hreflang="vi">VI</a>
+    </div>
+  </div>
+</footer>
+
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/es/library/simbolos-roblox/index.html
+++ b/es/library/simbolos-roblox/index.html
@@ -31,6 +31,7 @@
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/roblox-symbols/">
   <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/simvoly-roblox/">
   <link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/roblox-symbols/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/library/roblox-symbole/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/roblox-symbols/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/es-library-simbolos-roblox.png">
 <meta property="og:image:width" content="1200">
@@ -460,6 +461,7 @@ document.addEventListener("DOMContentLoaded", function () {
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="Selector de idioma">
       <a class="lang-option" href="/ar/library/roblox-symbols/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/de/library/roblox-symbole/" hreflang="de">DE</a>
       <a class="lang-option" href="/library/roblox-symbols/" hreflang="en">EN</a>
       <a class="lang-option active" href="/es/library/simbolos-roblox/" hreflang="es">ES</a>
       <a class="lang-option" href="/fr/library/symboles-roblox/" hreflang="fr">FR</a>

--- a/es/library/simbolos-y2k/index.html
+++ b/es/library/simbolos-y2k/index.html
@@ -29,6 +29,7 @@
   <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/ki-tu-y2k/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/y2k-symbols/">
   <link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/y2k-symbols/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/library/y2k-symbole/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/y2k-symbols/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/es-library-simbolos-y2k.png">
 <meta property="og:image:width" content="1200">
@@ -787,6 +788,7 @@ document.addEventListener("DOMContentLoaded", function () {
   <div class="footer-inner">
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="Selector de idioma">
+      <a class="lang-option" href="/de/library/y2k-symbole/" hreflang="de">DE</a>
       <a class="lang-option" href="/library/y2k-symbols/" hreflang="en">EN</a>
       <a class="lang-option active" href="/es/library/simbolos-y2k/" hreflang="es">ES</a>
       <a class="lang-option" href="/fr/library/symboles-y2k/" hreflang="fr">FR</a>

--- a/fr/library/symboles-roblox/index.html
+++ b/fr/library/symboles-roblox/index.html
@@ -31,6 +31,7 @@
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/roblox-symbols/">
   <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/simvoly-roblox/">
   <link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/roblox-symbols/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/library/roblox-symbole/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/roblox-symbols/">
 
 <meta property="og:image" content="https://ultratextgen.com/assets/og/fr-library-symboles-roblox.png">
@@ -432,6 +433,7 @@
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="Sélecteur de langue">
       <a class="lang-option" href="/ar/library/roblox-symbols/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/de/library/roblox-symbole/" hreflang="de">DE</a>
       <a class="lang-option" href="/library/roblox-symbols/" hreflang="en">EN</a>
       <a class="lang-option" href="/es/library/simbolos-roblox/" hreflang="es">ES</a>
       <a class="lang-option active" href="/fr/library/symboles-roblox/" hreflang="fr">FR</a>

--- a/fr/library/symboles-y2k/index.html
+++ b/fr/library/symboles-y2k/index.html
@@ -29,6 +29,7 @@
   <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/ki-tu-y2k/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/y2k-symbols/">
   <link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/y2k-symbols/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/library/y2k-symbole/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/y2k-symbols/">
 
 <meta property="og:image" content="https://ultratextgen.com/assets/og/fr-library-symboles-y2k.png">
@@ -769,6 +770,7 @@
   <div class="footer-inner">
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="Sélecteur de langue">
+      <a class="lang-option" href="/de/library/y2k-symbole/" hreflang="de">DE</a>
       <a class="lang-option" href="/library/y2k-symbols/" hreflang="en">EN</a>
       <a class="lang-option" href="/es/library/simbolos-y2k/" hreflang="es">ES</a>
       <a class="lang-option active" href="/fr/library/symboles-y2k/" hreflang="fr">FR</a>

--- a/id/library/simbol-roblox/index.html
+++ b/id/library/simbol-roblox/index.html
@@ -31,6 +31,7 @@
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/roblox-symbols/">
   <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/simvoly-roblox/">
   <link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/roblox-symbols/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/library/roblox-symbole/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/roblox-symbols/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/id-library-simbol-roblox.png">
 <meta property="og:image:width" content="1200">
@@ -474,6 +475,7 @@ document.addEventListener("DOMContentLoaded", function () {
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="Pemilih bahasa">
       <a class="lang-option" href="/ar/library/roblox-symbols/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/de/library/roblox-symbole/" hreflang="de">DE</a>
       <a class="lang-option" href="/library/roblox-symbols/" hreflang="en">EN</a>
       <a class="lang-option" href="/es/library/simbolos-roblox/" hreflang="es">ES</a>
       <a class="lang-option" href="/fr/library/symboles-roblox/" hreflang="fr">FR</a>

--- a/id/library/simbol-y2k/index.html
+++ b/id/library/simbol-y2k/index.html
@@ -29,6 +29,7 @@
   <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/ki-tu-y2k/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/y2k-symbols/">
   <link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/y2k-symbols/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/library/y2k-symbole/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/y2k-symbols/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/id-library-simbol-y2k.png">
 <meta property="og:image:width" content="1200">
@@ -805,6 +806,7 @@ document.addEventListener("DOMContentLoaded", function () {
   <div class="footer-inner">
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="Pemilih bahasa">
+      <a class="lang-option" href="/de/library/y2k-symbole/" hreflang="de">DE</a>
       <a class="lang-option" href="/library/y2k-symbols/" hreflang="en">EN</a>
       <a class="lang-option" href="/es/library/simbolos-y2k/" hreflang="es">ES</a>
       <a class="lang-option" href="/fr/library/symboles-y2k/" hreflang="fr">FR</a>

--- a/it/library/simboli-roblox/index.html
+++ b/it/library/simboli-roblox/index.html
@@ -31,6 +31,7 @@
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/roblox-symbols/">
   <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/simvoly-roblox/">
   <link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/roblox-symbols/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/library/roblox-symbole/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/roblox-symbols/">
 
 <meta property="og:image" content="https://ultratextgen.com/assets/og/it-library-simboli-roblox.png">
@@ -433,6 +434,7 @@
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="Selettore di lingua">
       <a class="lang-option" href="/ar/library/roblox-symbols/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/de/library/roblox-symbole/" hreflang="de">DE</a>
       <a class="lang-option" href="/library/roblox-symbols/" hreflang="en">EN</a>
       <a class="lang-option" href="/es/library/simbolos-roblox/" hreflang="es">ES</a>
       <a class="lang-option" href="/fr/library/symboles-roblox/" hreflang="fr">FR</a>

--- a/it/library/simboli-y2k/index.html
+++ b/it/library/simboli-y2k/index.html
@@ -29,6 +29,7 @@
   <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/ki-tu-y2k/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/y2k-symbols/">
   <link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/y2k-symbols/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/library/y2k-symbole/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/y2k-symbols/">
 
 <meta name="robots" content="index, follow">
@@ -746,6 +747,7 @@
   <div class="footer-inner">
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="Selettore di lingua">
+      <a class="lang-option" href="/de/library/y2k-symbole/" hreflang="de">DE</a>
       <a class="lang-option" href="/library/y2k-symbols/" hreflang="en">EN</a>
       <a class="lang-option" href="/es/library/simbolos-y2k/" hreflang="es">ES</a>
       <a class="lang-option" href="/fr/library/symboles-y2k/" hreflang="fr">FR</a>

--- a/ja/library/roblox-symbols/index.html
+++ b/ja/library/roblox-symbols/index.html
@@ -31,6 +31,7 @@
   <link rel="alternate" hreflang="ar" href="https://ultratextgen.com/ar/library/roblox-symbols/">
   <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/simvoly-roblox/">
   <link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/roblox-symbols/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/library/roblox-symbole/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/roblox-symbols/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/ja-library-roblox-symbols.png">
 <meta property="og:image:width" content="1200">
@@ -483,6 +484,7 @@ document.addEventListener("DOMContentLoaded", function () {
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="言語切り替え">
       <a class="lang-option" href="/ar/library/roblox-symbols/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/de/library/roblox-symbole/" hreflang="de">DE</a>
       <a class="lang-option" href="/library/roblox-symbols/" hreflang="en">EN</a>
       <a class="lang-option" href="/es/library/simbolos-roblox/" hreflang="es">ES</a>
       <a class="lang-option" href="/fr/library/symboles-roblox/" hreflang="fr">FR</a>

--- a/ja/library/y2k-symbols/index.html
+++ b/ja/library/y2k-symbols/index.html
@@ -29,6 +29,7 @@
   <link rel="alternate" hreflang="tr" href="https://ultratextgen.com/tr/library/y2k-sembolleri/">
   <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/ki-tu-y2k/">
   <link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/y2k-symbols/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/library/y2k-symbole/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/y2k-symbols/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/ja-library-y2k-symbols.png">
 <meta property="og:image:width" content="1200">
@@ -715,6 +716,7 @@ document.addEventListener("DOMContentLoaded", function () {
   <div class="footer-inner">
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="言語切り替え">
+      <a class="lang-option" href="/de/library/y2k-symbole/" hreflang="de">DE</a>
       <a class="lang-option" href="/library/y2k-symbols/" hreflang="en">EN</a>
       <a class="lang-option" href="/es/library/simbolos-y2k/" hreflang="es">ES</a>
       <a class="lang-option" href="/fr/library/symboles-y2k/" hreflang="fr">FR</a>

--- a/ko/library/roblox-giho/index.html
+++ b/ko/library/roblox-giho/index.html
@@ -31,6 +31,7 @@
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/roblox-symbols/">
   <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/simvoly-roblox/">
   <link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/roblox-symbols/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/library/roblox-symbole/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/roblox-symbols/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/ko-library-roblox-giho.png">
 <meta property="og:image:width" content="1200">
@@ -450,6 +451,7 @@ document.addEventListener("DOMContentLoaded", function () {
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="언어 선택">
       <a class="lang-option" href="/ar/library/roblox-symbols/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/de/library/roblox-symbole/" hreflang="de">DE</a>
       <a class="lang-option" href="/library/roblox-symbols/" hreflang="en">EN</a>
       <a class="lang-option" href="/es/library/simbolos-roblox/" hreflang="es">ES</a>
       <a class="lang-option" href="/fr/library/symboles-roblox/" hreflang="fr">FR</a>

--- a/ko/library/y2k-giho/index.html
+++ b/ko/library/y2k-giho/index.html
@@ -29,6 +29,7 @@
   <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/ki-tu-y2k/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/y2k-symbols/">
   <link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/y2k-symbols/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/library/y2k-symbole/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/y2k-symbols/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/ko-library-y2k-giho.png">
 <meta property="og:image:width" content="1200">
@@ -765,6 +766,7 @@ document.addEventListener("DOMContentLoaded", function () {
   <div class="footer-inner">
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="언어 선택">
+      <a class="lang-option" href="/de/library/y2k-symbole/" hreflang="de">DE</a>
       <a class="lang-option" href="/library/y2k-symbols/" hreflang="en">EN</a>
       <a class="lang-option" href="/es/library/simbolos-y2k/" hreflang="es">ES</a>
       <a class="lang-option" href="/fr/library/symboles-y2k/" hreflang="fr">FR</a>

--- a/library/roblox-symbols/index.html
+++ b/library/roblox-symbols/index.html
@@ -31,6 +31,7 @@
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/roblox-symbols/">
   <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/simvoly-roblox/">
   <link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/roblox-symbols/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/library/roblox-symbole/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/roblox-symbols/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/library-roblox-symbols.png">
 <meta property="og:image:width" content="1200">
@@ -462,6 +463,7 @@ document.addEventListener("DOMContentLoaded", function () {
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="Language switcher">
       <a class="lang-option" href="/ar/library/roblox-symbols/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/de/library/roblox-symbole/" hreflang="de">DE</a>
       <a class="lang-option active" href="/library/roblox-symbols/" hreflang="en">EN</a>
       <a class="lang-option" href="/es/library/simbolos-roblox/" hreflang="es">ES</a>
       <a class="lang-option" href="/fr/library/symboles-roblox/" hreflang="fr">FR</a>

--- a/library/y2k-symbols/index.html
+++ b/library/y2k-symbols/index.html
@@ -29,6 +29,7 @@
   <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/ki-tu-y2k/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/y2k-symbols/">
   <link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/y2k-symbols/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/library/y2k-symbole/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/y2k-symbols/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/library-y2k-symbols.png">
 <meta property="og:image:width" content="1200">
@@ -806,6 +807,7 @@ document.addEventListener("DOMContentLoaded", function () {
   <div class="footer-inner">
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="Language switcher">
+      <a class="lang-option" href="/de/library/y2k-symbole/" hreflang="de">DE</a>
       <a class="lang-option active" href="/library/y2k-symbols/" hreflang="en">EN</a>
       <a class="lang-option" href="/es/library/simbolos-y2k/" hreflang="es">ES</a>
       <a class="lang-option" href="/fr/library/symboles-y2k/" hreflang="fr">FR</a>

--- a/pl/library/symbole-roblox/index.html
+++ b/pl/library/symbole-roblox/index.html
@@ -31,6 +31,7 @@
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/roblox-symbols/">
   <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/simvoly-roblox/">
   <link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/roblox-symbols/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/library/roblox-symbole/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/roblox-symbols/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/pl-library-symbole-roblox.png">
 <meta property="og:image:width" content="1200">
@@ -460,6 +461,7 @@ document.addEventListener("DOMContentLoaded", function () {
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="Wybór języka">
       <a class="lang-option" href="/ar/library/roblox-symbols/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/de/library/roblox-symbole/" hreflang="de">DE</a>
       <a class="lang-option" href="/library/roblox-symbols/" hreflang="en">EN</a>
       <a class="lang-option" href="/es/library/simbolos-roblox/" hreflang="es">ES</a>
       <a class="lang-option" href="/fr/library/symboles-roblox/" hreflang="fr">FR</a>

--- a/pl/library/symbole-y2k/index.html
+++ b/pl/library/symbole-y2k/index.html
@@ -29,6 +29,7 @@
   <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/ki-tu-y2k/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/y2k-symbols/">
   <link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/y2k-symbols/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/library/y2k-symbole/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/y2k-symbols/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/pl-library-symbole-y2k.png">
 <meta property="og:image:width" content="1200">
@@ -792,6 +793,7 @@ document.addEventListener("DOMContentLoaded", function () {
   <div class="footer-inner">
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="Wybór języka">
+      <a class="lang-option" href="/de/library/y2k-symbole/" hreflang="de">DE</a>
       <a class="lang-option" href="/library/y2k-symbols/" hreflang="en">EN</a>
       <a class="lang-option" href="/es/library/simbolos-y2k/" hreflang="es">ES</a>
       <a class="lang-option" href="/fr/library/symboles-y2k/" hreflang="fr">FR</a>

--- a/pt/library/simbolos-roblox/index.html
+++ b/pt/library/simbolos-roblox/index.html
@@ -31,6 +31,7 @@
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/roblox-symbols/">
   <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/simvoly-roblox/">
   <link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/roblox-symbols/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/library/roblox-symbole/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/roblox-symbols/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/pt-library-simbolos-roblox.png">
 <meta property="og:image:width" content="1200">
@@ -458,6 +459,7 @@ document.addEventListener("DOMContentLoaded", function () {
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="Seletor de idioma">
       <a class="lang-option" href="/ar/library/roblox-symbols/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/de/library/roblox-symbole/" hreflang="de">DE</a>
       <a class="lang-option" href="/library/roblox-symbols/" hreflang="en">EN</a>
       <a class="lang-option" href="/es/library/simbolos-roblox/" hreflang="es">ES</a>
       <a class="lang-option" href="/fr/library/symboles-roblox/" hreflang="fr">FR</a>

--- a/pt/library/simbolos-y2k/index.html
+++ b/pt/library/simbolos-y2k/index.html
@@ -29,6 +29,7 @@
   <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/ki-tu-y2k/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/y2k-symbols/">
   <link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/y2k-symbols/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/library/y2k-symbole/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/y2k-symbols/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/pt-library-simbolos-y2k.png">
 <meta property="og:image:width" content="1200">
@@ -797,6 +798,7 @@ document.addEventListener("DOMContentLoaded", function () {
   <div class="footer-inner">
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="Seletor de idioma">
+      <a class="lang-option" href="/de/library/y2k-symbole/" hreflang="de">DE</a>
       <a class="lang-option" href="/library/y2k-symbols/" hreflang="en">EN</a>
       <a class="lang-option" href="/es/library/simbolos-y2k/" hreflang="es">ES</a>
       <a class="lang-option" href="/fr/library/symboles-y2k/" hreflang="fr">FR</a>

--- a/ru/library/simvoly-roblox/index.html
+++ b/ru/library/simvoly-roblox/index.html
@@ -31,6 +31,7 @@
   <link rel="alternate" hreflang="ar" href="https://ultratextgen.com/ar/library/roblox-symbols/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/roblox-symbols/">
   <link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/roblox-symbols/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/library/roblox-symbole/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/roblox-symbols/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/library-roblox-symbols.png">
 <meta property="og:image:width" content="1200">
@@ -490,6 +491,7 @@ document.addEventListener("DOMContentLoaded", function () {
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="Выбор языка">
       <a class="lang-option" href="/ar/library/roblox-symbols/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/de/library/roblox-symbole/" hreflang="de">DE</a>
       <a class="lang-option" href="/library/roblox-symbols/" hreflang="en">EN</a>
       <a class="lang-option" href="/es/library/simbolos-roblox/" hreflang="es">ES</a>
       <a class="lang-option" href="/fr/library/symboles-roblox/" hreflang="fr">FR</a>

--- a/th/library/roblox-symbols/index.html
+++ b/th/library/roblox-symbols/index.html
@@ -31,6 +31,7 @@
   <link rel="alternate" hreflang="ar" href="https://ultratextgen.com/ar/library/roblox-symbols/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/roblox-symbols/">
   <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/simvoly-roblox/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/library/roblox-symbole/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/roblox-symbols/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/library-roblox-symbols.png">
 <meta property="og:image:width" content="1200">
@@ -488,6 +489,7 @@ document.addEventListener("DOMContentLoaded", function () {
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="ตัวเลือกภาษา">
       <a class="lang-option" href="/ar/library/roblox-symbols/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/de/library/roblox-symbole/" hreflang="de">DE</a>
       <a class="lang-option" href="/library/roblox-symbols/" hreflang="en">EN</a>
       <a class="lang-option" href="/es/library/simbolos-roblox/" hreflang="es">ES</a>
       <a class="lang-option" href="/fr/library/symboles-roblox/" hreflang="fr">FR</a>

--- a/th/library/y2k-symbols/index.html
+++ b/th/library/y2k-symbols/index.html
@@ -29,6 +29,7 @@
   <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/ki-tu-y2k/">
   <link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/y2k-symbols/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/y2k-symbols/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/library/y2k-symbole/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/y2k-symbols/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/library-y2k-symbols.png">
 <meta property="og:image:width" content="1200">
@@ -784,6 +785,7 @@ document.addEventListener("DOMContentLoaded", function () {
   <div class="footer-inner">
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="ตัวเลือกภาษา">
+      <a class="lang-option" href="/de/library/y2k-symbole/" hreflang="de">DE</a>
       <a class="lang-option" href="/library/y2k-symbols/" hreflang="en">EN</a>
       <a class="lang-option" href="/es/library/simbolos-y2k/" hreflang="es">ES</a>
       <a class="lang-option" href="/fr/library/symboles-y2k/" hreflang="fr">FR</a>

--- a/tr/library/roblox-sembolleri/index.html
+++ b/tr/library/roblox-sembolleri/index.html
@@ -32,6 +32,7 @@
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/roblox-symbols/">
   <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/simvoly-roblox/">
   <link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/roblox-symbols/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/library/roblox-symbole/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/roblox-symbols/">
 
   <meta name="robots" content="index, follow">
@@ -381,6 +382,7 @@
       <div class="faq-item"><button class="faq-question" type="button">Bu Roblox sembollerini kullanmak güvenli mi?<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg></button><div class="faq-answer">Evet. Bunlar süsleme için kullanılan sıradan Unicode karakterleridir; hile veya açık değildir, bu yüzden görünen adında ya da bioda kullanmak Roblox kurallarını ihlal etmez. Yeter ki genel adın uygun olsun — içerik filtresi sembollerin etrafındaki kelimeler için hâlâ geçerlidir.</div></div>
       <div class="lang-switcher" role="navigation" aria-label="Dil seçici">
       <a class="lang-option" href="/ar/library/roblox-symbols/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/de/library/roblox-symbole/" hreflang="de">DE</a>
       <a class="lang-option" href="/library/roblox-symbols/" hreflang="en">EN</a>
       <a class="lang-option" href="/es/library/simbolos-roblox/" hreflang="es">ES</a>
       <a class="lang-option" href="/fr/library/symboles-roblox/" hreflang="fr">FR</a>

--- a/tr/library/y2k-sembolleri/index.html
+++ b/tr/library/y2k-sembolleri/index.html
@@ -29,6 +29,7 @@
   <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/ki-tu-y2k/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/y2k-symbols/">
   <link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/y2k-symbols/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/library/y2k-symbole/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/y2k-symbols/">
 
   <meta name="robots" content="index, follow">
@@ -742,6 +743,7 @@
   <footer class="footer">
     <div class="footer-inner">
       <div class="lang-switcher" role="navigation" aria-label="Dil seçici">
+      <a class="lang-option" href="/de/library/y2k-symbole/" hreflang="de">DE</a>
       <a class="lang-option" href="/library/y2k-symbols/" hreflang="en">EN</a>
       <a class="lang-option" href="/es/library/simbolos-y2k/" hreflang="es">ES</a>
       <a class="lang-option" href="/fr/library/symboles-y2k/" hreflang="fr">FR</a>

--- a/vi/ki-tu-roblox/index.html
+++ b/vi/ki-tu-roblox/index.html
@@ -31,6 +31,7 @@
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/roblox-symbols/">
   <link rel="alternate" hreflang="ru" href="https://ultratextgen.com/ru/library/simvoly-roblox/">
   <link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/roblox-symbols/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/library/roblox-symbole/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/roblox-symbols/">
 
 <meta name="robots" content="index, follow">
@@ -434,6 +435,7 @@
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="Bộ chọn ngôn ngữ">
       <a class="lang-option" href="/ar/library/roblox-symbols/" hreflang="ar">AR</a>
+      <a class="lang-option" href="/de/library/roblox-symbole/" hreflang="de">DE</a>
       <a class="lang-option" href="/library/roblox-symbols/" hreflang="en">EN</a>
       <a class="lang-option" href="/es/library/simbolos-roblox/" hreflang="es">ES</a>
       <a class="lang-option" href="/fr/library/symboles-roblox/" hreflang="fr">FR</a>

--- a/vi/ki-tu-y2k/index.html
+++ b/vi/ki-tu-y2k/index.html
@@ -25,6 +25,7 @@
   <link rel="alternate" hreflang="vi" href="https://ultratextgen.com/vi/ki-tu-y2k/">
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/library/y2k-symbols/">
   <link rel="alternate" hreflang="th" href="https://ultratextgen.com/th/library/y2k-symbols/">
+  <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/library/y2k-symbole/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/y2k-symbols/">
 
   <meta name="robots" content="index, follow">
@@ -722,6 +723,7 @@
 
     <!-- Language Switcher -->
     <div class="lang-switcher" role="navigation" aria-label="Bộ chọn ngôn ngữ">
+      <a class="lang-option" href="/de/library/y2k-symbole/" hreflang="de">DE</a>
       <a class="lang-option" href="/library/y2k-symbols/" hreflang="en">EN</a>
       <a class="lang-option" href="/es/library/simbolos-y2k/" hreflang="es">ES</a>
       <a class="lang-option" href="/fr/library/symboles-y2k/" hreflang="fr">FR</a>


### PR DESCRIPTION
## Summary

Follow-up to #537. That PR fixed cross-locale linking for the discord-symbols / roblox-symbols / y2k-symbols / emoji-combos cluster but left German (`de`) short of the other major locales: it only had `discord-symbole`, and its `emoji-kombinationen` page was far thinner than the English source. This PR closes that gap.

- **`de/library/roblox-symbole/`** (new) — full German translation of `library/roblox-symbols/`, symbol data byte-identical to English, ships with the complete 15-locale hreflang cluster + language switcher.
- **`de/library/y2k-symbole/`** (new) — same treatment for `library/y2k-symbols/`, 13-locale cluster ("Y2K" itself left untranslated, matching every other locale).
- **`de/emoji-kombinationen/`** (expanded) — grown from 8 to 23 sections and 35 to 155 tiles to match the English page's full aesthetic-category coverage (Cottagecore, Night Sky, Y2K, Kawaii, Fairycore, Dark Academia, Angelcore, Sunset, Cosmic, Plant/Green, plus the full "Ready-Made Combo Sets" collection block). hreflang/switcher on this file were already correct from #537 and are untouched here.
- Added the `de` alternate to the hreflang cluster and language switcher on all 14 existing `roblox-symbols` locale pages and all 12 existing `y2k-symbols` locale pages, so the new German pages are reciprocally linked from every sibling locale, not just discoverable via sitemap.

## Verification

- All 3 JSON-LD blocks on each new/changed `de` page parse as valid JSON.
- Unicode symbol/emoji data on the new/expanded pages diffed byte-for-byte against the English source — identical.
- `scripts/validate_library_pages.py`: 29 errors, all pre-existing and unrelated to this branch (confirmed against the same baseline pre-change).
- `scripts/sync_symbol_spoke_links.py`: 0 errors, 0 warnings.
- `sitemap.xml` untouched.
- Tag balance (div/section/footer/script/h2) verified even on all touched files.

## Test plan

- [ ] Spot-check `/de/library/roblox-symbole/`, `/de/library/y2k-symbole/`, and `/de/emoji-kombinationen/` render correctly and the language switcher on each links out to a live page in every direction.
- [ ] Confirm the `de` entry now appears in the switcher on a couple of sibling locale pages (e.g. `/library/roblox-symbols/`, `/es/library/simbolos-y2k/`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01GnF7QL9V9AwqvfwMtjubAs)_