### PR TITLE
Add VK status platform to character counter (26 platforms)

### DIFF
--- a/character-counter/index.html
+++ b/character-counter/index.html
@@ -11,7 +11,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Character Counter & Word Counter — Free Online Tool | UltraTextGen</title>
-  <meta name="description" content="Free character counter and word counter. Live word, character, sentence, paragraph, and reading-time stats as you type, plus a checker for 25 platform limits — X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS, and more.">
+  <meta name="description" content="Free character counter and word counter. Live word, character, sentence, paragraph, and reading-time stats as you type, plus a checker for 26 platform limits — X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS, and more.">
   <link rel="canonical" href="https://ultratextgen.com/character-counter/">
 
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/character-counter/">
@@ -28,7 +28,7 @@
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/character-counter/">
 
   <meta property="og:title" content="Character Counter & Word Counter — Free Online Tool | UltraTextGen">
-  <meta property="og:description" content="Live word, character, sentence, paragraph, and reading-time stats as you type, plus a fit checker for 25 platform character limits. Free, instant, no signup.">
+  <meta property="og:description" content="Live word, character, sentence, paragraph, and reading-time stats as you type, plus a fit checker for 26 platform character limits. Free, instant, no signup.">
   <meta property="og:url" content="https://ultratextgen.com/character-counter/">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://ultratextgen.com/assets/og/category.png">
@@ -37,7 +37,7 @@
   <meta property="og:image:type" content="image/png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Character Counter & Word Counter — Free Online Tool | UltraTextGen">
-  <meta name="twitter:description" content="Live word, character, sentence, paragraph, and reading-time stats as you type, plus a fit checker for 25 platform character limits. Free, instant, no signup.">
+  <meta name="twitter:description" content="Live word, character, sentence, paragraph, and reading-time stats as you type, plus a fit checker for 26 platform character limits. Free, instant, no signup.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=Space+Mono&display=swap" rel="stylesheet">
@@ -103,7 +103,7 @@
 
 <section class="hero"><div class="hero-inner"><div class="hero-card">
   <h1 class="hero-headline">Character Counter &amp; Word Counter</h1>
-  <p class="hero-sub">Live word, character, sentence, paragraph, and reading-time stats as you type — plus a checker for whether your text fits X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS, and 17 other platform limits.</p>
+  <p class="hero-sub">Live word, character, sentence, paragraph, and reading-time stats as you type — plus a checker for whether your text fits X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS, and 18 other platform limits.</p>
 </div></div></section>
 
 <main class="container">

--- a/de/woerter-zeichen-zaehlen/index.html
+++ b/de/woerter-zeichen-zaehlen/index.html
@@ -11,7 +11,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Wörter zählen & Zeichen zählen — Kostenloses Online-Tool | UltraTextGen</title>
-  <meta name="description" content="Kostenloser Wörter- und Zeichenzähler. Wörter, Zeichen, Sätze, Absätze und Lesezeit live beim Tippen zählen – plus ein Check für 25 Plattform-Limits: X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS und mehr.">
+  <meta name="description" content="Kostenloser Wörter- und Zeichenzähler. Wörter, Zeichen, Sätze, Absätze und Lesezeit live beim Tippen zählen – plus ein Check für 26 Plattform-Limits: X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS und mehr.">
   <link rel="canonical" href="https://ultratextgen.com/de/woerter-zeichen-zaehlen/">
 
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/character-counter/">
@@ -28,7 +28,7 @@
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/character-counter/">
 
   <meta property="og:title" content="Wörter zählen & Zeichen zählen — Kostenloses Online-Tool | UltraTextGen">
-  <meta property="og:description" content="Wörter, Zeichen, Sätze, Absätze und Lesezeit live beim Tippen zählen, plus ein Fit-Check für 25 Plattform-Zeichenlimits. Kostenlos, sofort, ohne Anmeldung.">
+  <meta property="og:description" content="Wörter, Zeichen, Sätze, Absätze und Lesezeit live beim Tippen zählen, plus ein Fit-Check für 26 Plattform-Zeichenlimits. Kostenlos, sofort, ohne Anmeldung.">
   <meta property="og:url" content="https://ultratextgen.com/de/woerter-zeichen-zaehlen/">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://ultratextgen.com/assets/og/category.png">
@@ -37,7 +37,7 @@
   <meta property="og:image:type" content="image/png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Wörter zählen & Zeichen zählen — Kostenloses Online-Tool | UltraTextGen">
-  <meta name="twitter:description" content="Wörter, Zeichen, Sätze, Absätze und Lesezeit live beim Tippen zählen, plus ein Fit-Check für 25 Plattform-Zeichenlimits. Kostenlos, sofort, ohne Anmeldung.">
+  <meta name="twitter:description" content="Wörter, Zeichen, Sätze, Absätze und Lesezeit live beim Tippen zählen, plus ein Fit-Check für 26 Plattform-Zeichenlimits. Kostenlos, sofort, ohne Anmeldung.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=Space+Mono&display=swap" rel="stylesheet">
@@ -104,7 +104,7 @@
 
 <section class="hero"><div class="hero-inner"><div class="hero-card">
   <h1 class="hero-headline">Wörter zählen &amp; Zeichen zählen</h1>
-  <p class="hero-sub">Wörter, Zeichen, Sätze, Absätze und Lesezeit live beim Tippen – plus ein Check, ob dein Text ins Limit von X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS und 17 weiteren Plattformen passt.</p>
+  <p class="hero-sub">Wörter, Zeichen, Sätze, Absätze und Lesezeit live beim Tippen – plus ein Check, ob dein Text ins Limit von X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS und 18 weiteren Plattformen passt.</p>
 </div></div></section>
 
 <main class="container">

--- a/es/contador-de-palabras-y-caracteres/index.html
+++ b/es/contador-de-palabras-y-caracteres/index.html
@@ -11,7 +11,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Contador de Palabras y Caracteres — Herramienta Online Gratis | UltraTextGen</title>
-  <meta name="description" content="Contador de palabras y contador de caracteres gratis. Estadísticas en vivo de palabras, caracteres, oraciones, párrafos y tiempo de lectura mientras escribes, más un verificador de límites para 25 plataformas — X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS y más.">
+  <meta name="description" content="Contador de palabras y contador de caracteres gratis. Estadísticas en vivo de palabras, caracteres, oraciones, párrafos y tiempo de lectura mientras escribes, más un verificador de límites para 26 plataformas — X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS y más.">
   <link rel="canonical" href="https://ultratextgen.com/es/contador-de-palabras-y-caracteres/">
 
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/character-counter/">
@@ -28,7 +28,7 @@
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/character-counter/">
 
   <meta property="og:title" content="Contador de Palabras y Caracteres — Herramienta Online Gratis | UltraTextGen">
-  <meta property="og:description" content="Estadísticas en vivo de palabras, caracteres, oraciones, párrafos y tiempo de lectura, más un verificador de ajuste para 25 límites de caracteres por plataforma. Gratis, instantáneo, sin registro.">
+  <meta property="og:description" content="Estadísticas en vivo de palabras, caracteres, oraciones, párrafos y tiempo de lectura, más un verificador de ajuste para 26 límites de caracteres por plataforma. Gratis, instantáneo, sin registro.">
   <meta property="og:url" content="https://ultratextgen.com/es/contador-de-palabras-y-caracteres/">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://ultratextgen.com/assets/og/category.png">
@@ -37,7 +37,7 @@
   <meta property="og:image:type" content="image/png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Contador de Palabras y Caracteres — Herramienta Online Gratis | UltraTextGen">
-  <meta name="twitter:description" content="Estadísticas en vivo de palabras, caracteres, oraciones, párrafos y tiempo de lectura, más un verificador de ajuste para 25 límites de caracteres por plataforma. Gratis, instantáneo, sin registro.">
+  <meta name="twitter:description" content="Estadísticas en vivo de palabras, caracteres, oraciones, párrafos y tiempo de lectura, más un verificador de ajuste para 26 límites de caracteres por plataforma. Gratis, instantáneo, sin registro.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=Space+Mono&display=swap" rel="stylesheet">
@@ -103,7 +103,7 @@
 
 <section class="hero"><div class="hero-inner"><div class="hero-card">
   <h1 class="hero-headline">Contador de Palabras y Caracteres</h1>
-  <p class="hero-sub">Estadísticas en vivo de palabras, caracteres, oraciones, párrafos y tiempo de lectura mientras escribes — más un verificador de si tu texto cabe en los límites de X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS y otras 17 plataformas.</p>
+  <p class="hero-sub">Estadísticas en vivo de palabras, caracteres, oraciones, párrafos y tiempo de lectura mientras escribes — más un verificador de si tu texto cabe en los límites de X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS y otras 18 plataformas.</p>
 </div></div></section>
 
 <main class="container">

--- a/fr/compteur-de-mots-et-de-caracteres/index.html
+++ b/fr/compteur-de-mots-et-de-caracteres/index.html
@@ -11,7 +11,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Compteur de Mots et de Caractères — Outil Gratuit en Ligne | UltraTextGen</title>
-  <meta name="description" content="Compteur de mots et de caractères gratuit. Statistiques en direct sur les mots, caractères, phrases, paragraphes et le temps de lecture pendant que tu tapes, plus un vérificateur pour 25 limites de plateforme — X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS et plus encore.">
+  <meta name="description" content="Compteur de mots et de caractères gratuit. Statistiques en direct sur les mots, caractères, phrases, paragraphes et le temps de lecture pendant que tu tapes, plus un vérificateur pour 26 limites de plateforme — X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS et plus encore.">
   <link rel="canonical" href="https://ultratextgen.com/fr/compteur-de-mots-et-de-caracteres/">
 
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/character-counter/">
@@ -28,7 +28,7 @@
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/character-counter/">
 
   <meta property="og:title" content="Compteur de Mots et de Caractères — Outil Gratuit en Ligne | UltraTextGen">
-  <meta property="og:description" content="Statistiques en direct sur les mots, caractères, phrases, paragraphes et le temps de lecture, plus un vérificateur pour 25 limites de caractères par plateforme. Gratuit, instantané, sans inscription.">
+  <meta property="og:description" content="Statistiques en direct sur les mots, caractères, phrases, paragraphes et le temps de lecture, plus un vérificateur pour 26 limites de caractères par plateforme. Gratuit, instantané, sans inscription.">
   <meta property="og:url" content="https://ultratextgen.com/fr/compteur-de-mots-et-de-caracteres/">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://ultratextgen.com/assets/og/category.png">
@@ -37,7 +37,7 @@
   <meta property="og:image:type" content="image/png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Compteur de Mots et de Caractères — Outil Gratuit en Ligne | UltraTextGen">
-  <meta name="twitter:description" content="Statistiques en direct sur les mots, caractères, phrases, paragraphes et le temps de lecture, plus un vérificateur pour 25 limites de caractères par plateforme. Gratuit, instantané, sans inscription.">
+  <meta name="twitter:description" content="Statistiques en direct sur les mots, caractères, phrases, paragraphes et le temps de lecture, plus un vérificateur pour 26 limites de caractères par plateforme. Gratuit, instantané, sans inscription.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=Space+Mono&display=swap" rel="stylesheet">
@@ -104,7 +104,7 @@
 
 <section class="hero"><div class="hero-inner"><div class="hero-card">
   <h1 class="hero-headline">Compteur de Mots et de Caractères</h1>
-  <p class="hero-sub">Statistiques en direct sur les mots, caractères, phrases, paragraphes et le temps de lecture pendant que tu tapes — plus un vérificateur pour savoir si ton texte respecte les limites de X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS et 17 autres plateformes.</p>
+  <p class="hero-sub">Statistiques en direct sur les mots, caractères, phrases, paragraphes et le temps de lecture pendant que tu tapes — plus un vérificateur pour savoir si ton texte respecte les limites de X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS et 18 autres plateformes.</p>
 </div></div></section>
 
 <main class="container">

--- a/id/penghitung-kata-dan-karakter/index.html
+++ b/id/penghitung-kata-dan-karakter/index.html
@@ -11,7 +11,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Penghitung Kata dan Karakter — Alat Online Gratis | UltraTextGen</title>
-  <meta name="description" content="Penghitung karakter dan kata gratis. Statistik langsung — kata, karakter, kalimat, paragraf, dan waktu baca — plus pengecekan batas untuk 25 platform: X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS, dan lainnya.">
+  <meta name="description" content="Penghitung karakter dan kata gratis. Statistik langsung — kata, karakter, kalimat, paragraf, dan waktu baca — plus pengecekan batas untuk 26 platform: X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS, dan lainnya.">
   <link rel="canonical" href="https://ultratextgen.com/id/penghitung-kata-dan-karakter/">
 
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/character-counter/">
@@ -28,7 +28,7 @@
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/character-counter/">
 
   <meta property="og:title" content="Penghitung Kata dan Karakter — Alat Online Gratis | UltraTextGen">
-  <meta property="og:description" content="Statistik kata, karakter, kalimat, paragraf, dan waktu baca secara langsung saat kamu mengetik, plus pengecekan apakah teks kamu muat di batas karakter 25 platform. Gratis, instan, tanpa daftar.">
+  <meta property="og:description" content="Statistik kata, karakter, kalimat, paragraf, dan waktu baca secara langsung saat kamu mengetik, plus pengecekan apakah teks kamu muat di batas karakter 26 platform. Gratis, instan, tanpa daftar.">
   <meta property="og:url" content="https://ultratextgen.com/id/penghitung-kata-dan-karakter/">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://ultratextgen.com/assets/og/category.png">
@@ -37,7 +37,7 @@
   <meta property="og:image:type" content="image/png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Penghitung Kata dan Karakter — Alat Online Gratis | UltraTextGen">
-  <meta name="twitter:description" content="Statistik kata, karakter, kalimat, paragraf, dan waktu baca secara langsung saat kamu mengetik, plus pengecekan apakah teks kamu muat di batas karakter 25 platform. Gratis, instan, tanpa daftar.">
+  <meta name="twitter:description" content="Statistik kata, karakter, kalimat, paragraf, dan waktu baca secara langsung saat kamu mengetik, plus pengecekan apakah teks kamu muat di batas karakter 26 platform. Gratis, instan, tanpa daftar.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=Space+Mono&display=swap" rel="stylesheet">
@@ -103,7 +103,7 @@
 
 <section class="hero"><div class="hero-inner"><div class="hero-card">
   <h1 class="hero-headline">Penghitung Kata dan Karakter</h1>
-  <p class="hero-sub">Statistik kata, karakter, kalimat, paragraf, dan waktu baca secara langsung saat kamu mengetik — plus pengecekan apakah teks kamu muat di batas karakter X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS, dan 17 platform lainnya.</p>
+  <p class="hero-sub">Statistik kata, karakter, kalimat, paragraf, dan waktu baca secara langsung saat kamu mengetik — plus pengecekan apakah teks kamu muat di batas karakter X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS, dan 18 platform lainnya.</p>
 </div></div></section>
 
 <main class="container">
@@ -286,6 +286,7 @@
     "li-headline": "Headline LinkedIn",
     "whatsapp-about": "Info WhatsApp",
     "telegram-bio": "Bio Telegram",
+    "vk-status": "Status VK",
     "discord-nick": "Nickname Discord",
     "tiktok-username": "Username TikTok",
     "ig-username": "Username Instagram",

--- a/it/contatore-di-parole-e-caratteri/index.html
+++ b/it/contatore-di-parole-e-caratteri/index.html
@@ -11,7 +11,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Contatore di Parole e Caratteri — Strumento Online Gratuito | UltraTextGen</title>
-  <meta name="description" content="Contatore di parole e caratteri gratuito. Statistiche in tempo reale su parole, caratteri, frasi, paragrafi e tempo di lettura mentre scrivi, più un verificatore per 25 limiti di piattaforma — X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS e altro.">
+  <meta name="description" content="Contatore di parole e caratteri gratuito. Statistiche in tempo reale su parole, caratteri, frasi, paragrafi e tempo di lettura mentre scrivi, più un verificatore per 26 limiti di piattaforma — X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS e altro.">
   <link rel="canonical" href="https://ultratextgen.com/it/contatore-di-parole-e-caratteri/">
 
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/character-counter/">
@@ -30,7 +30,7 @@
   <meta name="robots" content="index, follow">
   <meta property="og:site_name" content="UltraTextGen">
   <meta property="og:title" content="Contatore di Parole e Caratteri — Strumento Online Gratuito | UltraTextGen">
-  <meta property="og:description" content="Statistiche in tempo reale su parole, caratteri, frasi, paragrafi e tempo di lettura, più un verificatore di compatibilità per 25 limiti di caratteri per piattaforma. Gratis, istantaneo, senza registrazione.">
+  <meta property="og:description" content="Statistiche in tempo reale su parole, caratteri, frasi, paragrafi e tempo di lettura, più un verificatore di compatibilità per 26 limiti di caratteri per piattaforma. Gratis, istantaneo, senza registrazione.">
   <meta property="og:url" content="https://ultratextgen.com/it/contatore-di-parole-e-caratteri/">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://ultratextgen.com/assets/og/category.png">
@@ -39,7 +39,7 @@
   <meta property="og:image:type" content="image/png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Contatore di Parole e Caratteri — Strumento Online Gratuito | UltraTextGen">
-  <meta name="twitter:description" content="Statistiche in tempo reale su parole, caratteri, frasi, paragrafi e tempo di lettura, più un verificatore di compatibilità per 25 limiti di caratteri per piattaforma. Gratis, istantaneo, senza registrazione.">
+  <meta name="twitter:description" content="Statistiche in tempo reale su parole, caratteri, frasi, paragrafi e tempo di lettura, più un verificatore di compatibilità per 26 limiti di caratteri per piattaforma. Gratis, istantaneo, senza registrazione.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=Space+Mono&display=swap" rel="stylesheet">
@@ -107,7 +107,7 @@
 
 <section class="hero"><div class="hero-inner"><div class="hero-card">
   <h1 class="hero-headline">Contatore di Parole e Caratteri</h1>
-  <p class="hero-sub">Statistiche in tempo reale su parole, caratteri, frasi, paragrafi e tempo di lettura mentre scrivi — più un verificatore per sapere se il tuo testo rientra nei limiti di X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS e altre 17 piattaforme.</p>
+  <p class="hero-sub">Statistiche in tempo reale su parole, caratteri, frasi, paragrafi e tempo di lettura mentre scrivi — più un verificatore per sapere se il tuo testo rientra nei limiti di X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS e altre 18 piattaforme.</p>
 </div></div></section>
 
 <main class="container">
@@ -305,6 +305,7 @@
     "li-headline": "Titolo LinkedIn (headline)",
     "whatsapp-about": "Info WhatsApp",
     "telegram-bio": "Bio Telegram",
+    "vk-status": "Stato VK",
     "discord-nick": "Soprannome Discord",
     "tiktok-username": "Nome utente TikTok",
     "ig-username": "Nome utente Instagram",

--- a/js/counter/counterControllerDe.js
+++ b/js/counter/counterControllerDe.js
@@ -59,6 +59,7 @@
     "li-headline": "LinkedIn-Headline",
     "whatsapp-about": "WhatsApp-Info",
     "telegram-bio": "Telegram-Bio",
+    "vk-status": "VK-Status",
     "discord-nick": "Discord-Spitzname",
     "tiktok-username": "TikTok-Benutzername",
     "ig-username": "Instagram-Benutzername",

--- a/js/counter/counterControllerEs.js
+++ b/js/counter/counterControllerEs.js
@@ -60,6 +60,7 @@
     "li-headline": "Titular de LinkedIn",
     "whatsapp-about": "Info de WhatsApp",
     "telegram-bio": "Biografía de Telegram",
+    "vk-status": "Estado de VK",
     "discord-nick": "Apodo de Discord",
     "tiktok-username": "Nombre de usuario de TikTok",
     "ig-username": "Nombre de usuario de Instagram",

--- a/js/counter/counterControllerFr.js
+++ b/js/counter/counterControllerFr.js
@@ -60,6 +60,7 @@
     "li-headline": "Titre LinkedIn",
     "whatsapp-about": "À propos WhatsApp",
     "telegram-bio": "Bio Telegram",
+    "vk-status": "Statut VK",
     "discord-nick": "Pseudo Discord",
     "tiktok-username": "Nom d'utilisateur TikTok",
     "ig-username": "Nom d'utilisateur Instagram",

--- a/js/counter/counterControllerPl.js
+++ b/js/counter/counterControllerPl.js
@@ -59,6 +59,7 @@
     "li-headline": "Nagłówek LinkedIn",
     "whatsapp-about": "Sekcja „O mnie” WhatsApp",
     "telegram-bio": "Bio na Telegramie",
+    "vk-status": "Status na VK",
     "discord-nick": "Pseudonim na Discordzie",
     "tiktok-username": "Nazwa użytkownika TikTok",
     "ig-username": "Nazwa użytkownika Instagram",

--- a/js/counter/counterControllerVi.js
+++ b/js/counter/counterControllerVi.js
@@ -59,6 +59,7 @@
     "li-headline": "Tiêu đề LinkedIn",
     "whatsapp-about": "Giới thiệu WhatsApp",
     "telegram-bio": "Tiểu sử Telegram",
+    "vk-status": "Trạng thái VK",
     "discord-nick": "Biệt danh Discord",
     "tiktok-username": "Tên người dùng TikTok",
     "ig-username": "Tên người dùng Instagram",

--- a/js/counter/counterRules.js
+++ b/js/counter/counterRules.js
@@ -51,6 +51,7 @@
     { id: "li-headline", label: "LinkedIn headline", limit: 220, group: "bios" },
     { id: "whatsapp-about", label: "WhatsApp About", limit: 139, group: "bios" },
     { id: "telegram-bio", label: "Telegram bio", limit: 70, group: "bios" },
+    { id: "vk-status", label: "VK status", limit: 140, group: "bios" },
 
     { id: "discord-nick", label: "Discord nickname", limit: 32, group: "usernames" },
     { id: "tiktok-username", label: "TikTok username", limit: 24, group: "usernames" },

--- a/pl/licznik-slow-i-znakow/index.html
+++ b/pl/licznik-slow-i-znakow/index.html
@@ -11,7 +11,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Licznik Słów i Znaków — Darmowe Narzędzie Online | UltraTextGen</title>
-  <meta name="description" content="Darmowy licznik znaków i licznik słów. Statystyki na żywo — słowa, znaki, zdania, akapity i czas czytania — plus sprawdzian limitów dla 25 platform: X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS i inne.">
+  <meta name="description" content="Darmowy licznik znaków i licznik słów. Statystyki na żywo — słowa, znaki, zdania, akapity i czas czytania — plus sprawdzian limitów dla 26 platform: X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS i inne.">
   <link rel="canonical" href="https://ultratextgen.com/pl/licznik-slow-i-znakow/">
 
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/character-counter/">
@@ -28,7 +28,7 @@
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/character-counter/">
 
   <meta property="og:title" content="Licznik Słów i Znaków — Darmowe Narzędzie Online | UltraTextGen">
-  <meta property="og:description" content="Statystyki słów, znaków, zdań, akapitów i czasu czytania na żywo podczas pisania, plus sprawdzian dopasowania do limitów znaków 25 platform. Za darmo, natychmiast, bez rejestracji.">
+  <meta property="og:description" content="Statystyki słów, znaków, zdań, akapitów i czasu czytania na żywo podczas pisania, plus sprawdzian dopasowania do limitów znaków 26 platform. Za darmo, natychmiast, bez rejestracji.">
   <meta property="og:url" content="https://ultratextgen.com/pl/licznik-slow-i-znakow/">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://ultratextgen.com/assets/og/category.png">
@@ -37,7 +37,7 @@
   <meta property="og:image:type" content="image/png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Licznik Słów i Znaków — Darmowe Narzędzie Online | UltraTextGen">
-  <meta name="twitter:description" content="Statystyki słów, znaków, zdań, akapitów i czasu czytania na żywo podczas pisania, plus sprawdzian dopasowania do limitów znaków 25 platform. Za darmo, natychmiast, bez rejestracji.">
+  <meta name="twitter:description" content="Statystyki słów, znaków, zdań, akapitów i czasu czytania na żywo podczas pisania, plus sprawdzian dopasowania do limitów znaków 26 platform. Za darmo, natychmiast, bez rejestracji.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=Space+Mono&display=swap" rel="stylesheet">
@@ -103,7 +103,7 @@
 
 <section class="hero"><div class="hero-inner"><div class="hero-card">
   <h1 class="hero-headline">Licznik Słów i Znaków</h1>
-  <p class="hero-sub">Statystyki słów, znaków, zdań, akapitów i czasu czytania na żywo podczas pisania — plus sprawdzian, czy Twój tekst mieści się w limitach X/Twittera, Instagrama, TikToka, LinkedIn, YouTube, Discorda, Telegrama, SMS-ów i 17 innych platform.</p>
+  <p class="hero-sub">Statystyki słów, znaków, zdań, akapitów i czasu czytania na żywo podczas pisania — plus sprawdzian, czy Twój tekst mieści się w limitach X/Twittera, Instagrama, TikToka, LinkedIn, YouTube, Discorda, Telegrama, SMS-ów i 18 innych platform.</p>
 </div></div></section>
 
 <main class="container">

--- a/pt/contador-de-palavras-e-caracteres/index.html
+++ b/pt/contador-de-palavras-e-caracteres/index.html
@@ -11,7 +11,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Contador de Palavras e Caracteres — Ferramenta Online Grátis | UltraTextGen</title>
-  <meta name="description" content="Contador de caracteres e contador de palavras grátis. Contagem ao vivo de palavras, caracteres, frases, parágrafos e tempo de leitura enquanto você digita, mais um verificador de limite para 25 plataformas — X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS e mais.">
+  <meta name="description" content="Contador de caracteres e contador de palavras grátis. Contagem ao vivo de palavras, caracteres, frases, parágrafos e tempo de leitura enquanto você digita, mais um verificador de limite para 26 plataformas — X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS e mais.">
   <link rel="canonical" href="https://ultratextgen.com/pt/contador-de-palavras-e-caracteres/">
 
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/character-counter/">
@@ -28,7 +28,7 @@
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/character-counter/">
 
   <meta property="og:title" content="Contador de Palavras e Caracteres — Ferramenta Online Grátis | UltraTextGen">
-  <meta property="og:description" content="Contagem ao vivo de palavras, caracteres, frases, parágrafos e tempo de leitura, mais um verificador de limite para 25 plataformas. Grátis, instantâneo, sem cadastro.">
+  <meta property="og:description" content="Contagem ao vivo de palavras, caracteres, frases, parágrafos e tempo de leitura, mais um verificador de limite para 26 plataformas. Grátis, instantâneo, sem cadastro.">
   <meta property="og:url" content="https://ultratextgen.com/pt/contador-de-palavras-e-caracteres/">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="UltraTextGen">
@@ -38,7 +38,7 @@
   <meta property="og:image:type" content="image/png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Contador de Palavras e Caracteres — Ferramenta Online Grátis | UltraTextGen">
-  <meta name="twitter:description" content="Contagem ao vivo de palavras, caracteres, frases, parágrafos e tempo de leitura, mais um verificador de limite para 25 plataformas. Grátis, instantâneo, sem cadastro.">
+  <meta name="twitter:description" content="Contagem ao vivo de palavras, caracteres, frases, parágrafos e tempo de leitura, mais um verificador de limite para 26 plataformas. Grátis, instantâneo, sem cadastro.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=Space+Mono&display=swap" rel="stylesheet">
@@ -104,7 +104,7 @@
 
 <section class="hero"><div class="hero-inner"><div class="hero-card">
   <h1 class="hero-headline">Contador de Palavras e Caracteres</h1>
-  <p class="hero-sub">Contagem ao vivo de palavras, caracteres, frases, parágrafos e tempo de leitura enquanto você digita — mais um verificador de se o seu texto cabe nos limites de X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS e outras 17 plataformas.</p>
+  <p class="hero-sub">Contagem ao vivo de palavras, caracteres, frases, parágrafos e tempo de leitura enquanto você digita — mais um verificador de se o seu texto cabe nos limites de X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS e outras 18 plataformas.</p>
 </div></div></section>
 
 <main class="container">
@@ -278,6 +278,7 @@
     "li-headline": "Título do LinkedIn",
     "whatsapp-about": "Recado do WhatsApp",
     "telegram-bio": "Bio do Telegram",
+    "vk-status": "Status do VK",
     "discord-nick": "Apelido do Discord",
     "tiktok-username": "Nome de usuário do TikTok",
     "ig-username": "Nome de usuário do Instagram",

--- a/tr/js/counter/counterControllerTr.js
+++ b/tr/js/counter/counterControllerTr.js
@@ -61,6 +61,7 @@
     "li-headline": "LinkedIn başlığı",
     "whatsapp-about": "WhatsApp Hakkında yazısı",
     "telegram-bio": "Telegram biyografisi",
+    "vk-status": "VK durumu",
     "discord-nick": "Discord takma adı",
     "tiktok-username": "TikTok kullanıcı adı",
     "ig-username": "Instagram kullanıcı adı",

--- a/tr/karakter-sayaci/index.html
+++ b/tr/karakter-sayaci/index.html
@@ -11,7 +11,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Karakter Sayacı ve Kelime Sayacı — Ücretsiz Online Araç | UltraTextGen</title>
-  <meta name="description" content="Ücretsiz karakter sayacı ve kelime sayacı. Yazarken canlı kelime, karakter, cümle, paragraf ve okuma süresi istatistikleri, artı 25 platform sınırı için kontrol — X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS ve daha fazlası.">
+  <meta name="description" content="Ücretsiz karakter sayacı ve kelime sayacı. Yazarken canlı kelime, karakter, cümle, paragraf ve okuma süresi istatistikleri, artı 26 platform sınırı için kontrol — X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS ve daha fazlası.">
   <link rel="canonical" href="https://ultratextgen.com/tr/karakter-sayaci/">
 
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/character-counter/">
@@ -28,7 +28,7 @@
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/character-counter/">
 
   <meta property="og:title" content="Karakter Sayacı ve Kelime Sayacı — Ücretsiz Online Araç | UltraTextGen">
-  <meta property="og:description" content="Yazarken canlı kelime, karakter, cümle, paragraf ve okuma süresi istatistikleri, artı 25 platformun karakter sınırı için sığma kontrolü. Ücretsiz, anında, üyeliksiz.">
+  <meta property="og:description" content="Yazarken canlı kelime, karakter, cümle, paragraf ve okuma süresi istatistikleri, artı 26 platformun karakter sınırı için sığma kontrolü. Ücretsiz, anında, üyeliksiz.">
   <meta property="og:url" content="https://ultratextgen.com/tr/karakter-sayaci/">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://ultratextgen.com/assets/og/category.png">
@@ -37,7 +37,7 @@
   <meta property="og:image:type" content="image/png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Karakter Sayacı ve Kelime Sayacı — Ücretsiz Online Araç | UltraTextGen">
-  <meta name="twitter:description" content="Yazarken canlı kelime, karakter, cümle, paragraf ve okuma süresi istatistikleri, artı 25 platformun karakter sınırı için sığma kontrolü. Ücretsiz, anında, üyeliksiz.">
+  <meta name="twitter:description" content="Yazarken canlı kelime, karakter, cümle, paragraf ve okuma süresi istatistikleri, artı 26 platformun karakter sınırı için sığma kontrolü. Ücretsiz, anında, üyeliksiz.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=Space+Mono&display=swap" rel="stylesheet">
@@ -103,7 +103,7 @@
 
 <section class="hero"><div class="hero-inner"><div class="hero-card">
   <h1 class="hero-headline">Karakter Sayacı ve Kelime Sayacı</h1>
-  <p class="hero-sub">Yazarken canlı kelime, karakter, cümle, paragraf ve okuma süresi istatistikleri — artı metnin X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS ve 17 diğer platformun sınırına sığıp sığmadığını gösteren kontrol.</p>
+  <p class="hero-sub">Yazarken canlı kelime, karakter, cümle, paragraf ve okuma süresi istatistikleri — artı metnin X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS ve 18 diğer platformun sınırına sığıp sığmadığını gösteren kontrol.</p>
 </div></div></section>
 
 <main class="container">

--- a/vi/dem-tu-dem-ky-tu/index.html
+++ b/vi/dem-tu-dem-ky-tu/index.html
@@ -11,7 +11,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Đếm Từ &amp; Đếm Ký Tự — Công Cụ Miễn Phí Trực Tuyến | UltraTextGen</title>
-  <meta name="description" content="Công cụ đếm từ và đếm ký tự miễn phí. Xem số từ, ký tự, câu, đoạn văn và thời gian đọc cập nhật trực tiếp khi bạn gõ, kèm bộ kiểm tra giới hạn ký tự cho 25 nền tảng — Zalo, X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS và nhiều hơn nữa.">
+  <meta name="description" content="Công cụ đếm từ và đếm ký tự miễn phí. Xem số từ, ký tự, câu, đoạn văn và thời gian đọc cập nhật trực tiếp khi bạn gõ, kèm bộ kiểm tra giới hạn ký tự cho 26 nền tảng — Zalo, X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS và nhiều hơn nữa.">
   <link rel="canonical" href="https://ultratextgen.com/vi/dem-tu-dem-ky-tu/">
 
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/character-counter/">
@@ -28,7 +28,7 @@
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/character-counter/">
 
   <meta property="og:title" content="Đếm Từ &amp; Đếm Ký Tự — Công Cụ Miễn Phí Trực Tuyến | UltraTextGen">
-  <meta property="og:description" content="Xem số từ, ký tự, câu, đoạn văn và thời gian đọc cập nhật trực tiếp khi bạn gõ, kèm bộ kiểm tra giới hạn ký tự cho 25 nền tảng. Miễn phí, tức thì, không cần đăng ký.">
+  <meta property="og:description" content="Xem số từ, ký tự, câu, đoạn văn và thời gian đọc cập nhật trực tiếp khi bạn gõ, kèm bộ kiểm tra giới hạn ký tự cho 26 nền tảng. Miễn phí, tức thì, không cần đăng ký.">
   <meta property="og:url" content="https://ultratextgen.com/vi/dem-tu-dem-ky-tu/">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://ultratextgen.com/assets/og/category.png">
@@ -37,7 +37,7 @@
   <meta property="og:image:type" content="image/png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Đếm Từ &amp; Đếm Ký Tự — Công Cụ Miễn Phí Trực Tuyến | UltraTextGen">
-  <meta name="twitter:description" content="Xem số từ, ký tự, câu, đoạn văn và thời gian đọc cập nhật trực tiếp khi bạn gõ, kèm bộ kiểm tra giới hạn ký tự cho 25 nền tảng. Miễn phí, tức thì, không cần đăng ký.">
+  <meta name="twitter:description" content="Xem số từ, ký tự, câu, đoạn văn và thời gian đọc cập nhật trực tiếp khi bạn gõ, kèm bộ kiểm tra giới hạn ký tự cho 26 nền tảng. Miễn phí, tức thì, không cần đăng ký.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=Space+Mono&display=swap" rel="stylesheet">
@@ -103,7 +103,7 @@
 
 <section class="hero"><div class="hero-inner"><div class="hero-card">
   <h1 class="hero-headline">Đếm Từ &amp; Đếm Ký Tự</h1>
-  <p class="hero-sub">Số từ, ký tự, câu, đoạn văn và thời gian đọc cập nhật ngay khi bạn gõ — cùng bộ kiểm tra xem văn bản có vừa giới hạn của Zalo, X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS và 16 nền tảng khác.</p>
+  <p class="hero-sub">Số từ, ký tự, câu, đoạn văn và thời gian đọc cập nhật ngay khi bạn gõ — cùng bộ kiểm tra xem văn bản có vừa giới hạn của Zalo, X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS và 17 nền tảng khác.</p>
 </div></div></section>
 
 <main class="container">


### PR DESCRIPTION
## Summary
Added VK (VKontakte) status as a new platform limit checker to the character counter tool, bringing the total supported platforms from 25 to 26.

## Changes Made

- **Platform limit rule**: Added VK status with a 140-character limit to `js/counter/counterRules.js`
- **UI labels**: Added localized "VK status" labels across all supported languages:
  - English: "VK status"
  - German: "VK-Status"
  - Spanish: "Estado de VK"
  - French: "Statut VK"
  - Polish: "Status na VK"
  - Vietnamese: "Trạng thái VK"
  - Italian: "Stato VK"
  - Portuguese: "Status do VK"
  - Turkish: "VK durumu"
  - Indonesian: "Status VK"
- **Meta descriptions**: Updated all character counter page descriptions (10 language variants) to reflect 26 platforms instead of 25
- **Hero subtitle**: Updated hero section text on all pages to reference "18 other platforms" instead of "17" (8 explicitly named + 18 others = 26 total)

## Implementation Details

VK status follows the same pattern as other bio/profile fields (Telegram bio, WhatsApp About, LinkedIn headline) and is grouped under the "bios" category in the counter rules. The 140-character limit matches VK's actual status field constraint.

https://claude.ai/code/session_014Hf7LkKVbkNpBfaQaYiiDD