### PR TITLE
Add 16 new symbol pages (Om, Recycling, Ohm, Ankh, Fleur-de-lis, Alpha, Pi, Delta, Congruent, Aries, Cancer, Capricorn, Pisces, Scorpio, Virgo, Won)

### DIFF
--- a/data/library_page_specs/alpha-symbol.json
+++ b/data/library_page_specs/alpha-symbol.json
@@ -1,0 +1,97 @@
+{
+  "slug": "alpha-symbol",
+  "page_type": "symbol",
+  "title": "Alpha Symbol: Copy & Paste Α α — The Beginning to Omega's End",
+  "meta_description": "Copy and paste the alpha symbol — the Greek letter Α α that opens the alphabet, the ‘Alpha’ of the Bible's ‘Alpha and Omega,’ and the sign for alpha particles and investment alpha. Click any symbol to copy it instantly.",
+  "canonical": "https://ultratextgen.com/symbol/alpha-symbol/",
+  "breadcrumb": "Alpha Symbol",
+  "hero_h1": "Alpha Symbol",
+  "hero_tagline": "The first letter of the Greek alphabet — capital Α and lowercase α — the ‘Alpha’ of ‘Alpha and Omega,’ and the symbol behind alpha particles, investment alpha, and more. Click any symbol to copy it instantly.",
+  "intro": "Alpha is the first letter of the Greek alphabet — capital Α (U+0391) and lowercase α (U+03B1) — and where omega means ‘the end,’ alpha has always meant ‘the beginning.’ The pairing is ancient and famous: in the New Testament, Revelation 22:13 reads ‘I am Alpha and Omega, the beginning and the end, the first and the last,’ using the alphabet's bookend letters as a metaphor for totality. Beyond scripture, the lowercase α does heavy scientific lifting: an ‘alpha particle’ is the nucleus of a helium atom — two protons and two neutrons — flung out during alpha decay, and α also denotes the fine-structure constant in physics and angles in geometry. In finance, ‘alpha’ is the return an investment earns above its benchmark, formalized as Jensen's alpha by economist Michael Jensen in the 1960s. The word even seeped into pop culture as ‘alpha male’ — a phrase rooted in mid-20th-century studies of captive wolves that the researcher most associated with it, David Mech, later publicly disowned as a misreading of how wild wolves actually live.",
+  "date_published": "2026-07-13",
+  "date_modified": "2026-07-13",
+  "copy_pattern": "single",
+  "sections": [
+    {
+      "id": "the-alpha-symbol",
+      "label": "The Alpha Symbol",
+      "h2": "The Alpha Symbol — Α & α",
+      "intro": "The Greek letter itself, in both cases. Lowercase α is the one most people mean; it also carries a value of one in the ancient Greek numeral system.",
+      "symbols": [
+        {
+          "char": "Α",
+          "label": "Greek Capital Letter Alpha (U+0391)"
+        },
+        {
+          "char": "α",
+          "label": "Greek Small Letter Alpha (U+03B1)"
+        }
+      ]
+    },
+    {
+      "id": "alpha-and-omega",
+      "label": "Alpha & Omega",
+      "h2": "Alpha and Omega — The Beginning and the End",
+      "intro": "The most famous use of the letter: paired with omega as the first and last letters of the Greek alphabet, a metaphor for ‘everything from start to finish’ (Revelation 22:13). Copy the bookend pair.",
+      "symbols": [
+        {
+          "char": "α",
+          "label": "Small Alpha — ‘The Beginning’"
+        },
+        {
+          "char": "Ω",
+          "label": "Capital Omega — ‘The End’"
+        },
+        {
+          "char": "Α",
+          "label": "Capital Alpha"
+        },
+        {
+          "char": "ω",
+          "label": "Small Omega"
+        }
+      ]
+    },
+    {
+      "id": "related-greek-letters",
+      "label": "Greek Letters",
+      "h2": "Related Greek Letters",
+      "intro": "Alpha opens the alphabet; beta follows it, and these are the other Greek letters searched for most often.",
+      "symbols": [
+        {
+          "char": "β",
+          "label": "Greek Small Letter Beta"
+        },
+        {
+          "char": "Σ",
+          "label": "Greek Capital Letter Sigma"
+        },
+        {
+          "char": "Δ",
+          "label": "Greek Capital Letter Delta"
+        },
+        {
+          "char": "π",
+          "label": "Greek Small Letter Pi"
+        }
+      ]
+    }
+  ],
+  "related": [
+    {
+      "href": "/library/greek-letter-symbols/",
+      "title": "Greek Letter Symbols",
+      "desc": "The full Greek alphabet in uppercase, lowercase, and math variant forms to copy and paste."
+    },
+    {
+      "href": "/symbol/omega-symbol/",
+      "title": "Omega Symbol",
+      "desc": "Alpha's other half: ‘I am Alpha and Omega, the beginning and the end.’ The last letter of the alphabet, and the ohm sign it's confused with."
+    },
+    {
+      "href": "/symbol/sigma-symbol/",
+      "title": "Sigma Symbol",
+      "desc": "Another single Greek letter whose fame outgrew the alphabet — the summation sign in math, the ‘sigma male’ meme online."
+    }
+  ]
+}

--- a/data/library_page_specs/ankh-symbol.json
+++ b/data/library_page_specs/ankh-symbol.json
@@ -1,0 +1,101 @@
+{
+  "slug": "ankh-symbol",
+  "page_type": "symbol",
+  "title": "Ankh Symbol: Copy & Paste ☥ — the Egyptian Hieroglyph for \"Life\" Coptic Christians Reshaped into a Cross",
+  "meta_description": "Copy and paste the ankh (☥ U+2625), the ancient Egyptian hieroglyph for \"life\" held by gods and pharaohs — and the looped cross, the crux ansata, that early Coptic Christians made from it. Click any symbol to copy it instantly.",
+  "canonical": "https://ultratextgen.com/symbol/ankh-symbol/",
+  "breadcrumb": "Ankh Symbol",
+  "hero_h1": "Ankh Symbol",
+  "hero_tagline": "The ankh (☥) — the ancient Egyptian hieroglyph meaning \"life,\" later adapted by early Coptic Christians into a looped cross called the crux ansata. Click any symbol to copy it instantly.",
+  "intro": "The ankh (☥, U+2625) is an ancient Egyptian symbol meaning \"life\" or \"to live.\" It was more than an icon: in the hieroglyphic writing system it was a genuine sign — catalogued as S34 in Gardiner's Sign List — that spelled the triliteral consonant sequence ꜥ-n-ḫ (ankh), the Egyptian word for life. In tomb and temple art it appears held by deities and offered to pharaohs, a gesture representing the gift of life and revival in the afterlife. Unicode placed it in the Miscellaneous Symbols block as part of Unicode 1.1 in 1993. A well-documented turn in its history came in Egypt's Coptic period: as Christianity spread there, some early Coptic Christians adapted the ankh's looped shape into a form of the Christian cross known as the crux ansata — Latin for \"cross with a handle.\" Today the ankh also circulates in secular and spiritual settings — as jewelry, in tattoo art, and within modern Kemetic (revived ancient Egyptian) practice. This page reports that history as documented, without asserting any modern ownership of the symbol.",
+  "date_published": "2026-07-13",
+  "date_modified": "2026-07-13",
+  "copy_pattern": "single",
+  "sections": [
+    {
+      "id": "ankh",
+      "label": "Ankh",
+      "h2": "Ankh Symbol",
+      "intro": "The ankh dingbat and the cross forms its looped shape is historically linked to.",
+      "symbols": [
+        {
+          "char": "☥",
+          "label": "Ankh (Key of Life)"
+        },
+        {
+          "char": "✝️",
+          "label": "Latin Cross"
+        },
+        {
+          "char": "☦️",
+          "label": "Orthodox Cross"
+        }
+      ]
+    },
+    {
+      "id": "egyptian-symbols",
+      "label": "Egyptian Symbols",
+      "h2": "Ancient Egyptian Symbols",
+      "intro": "Emoji commonly associated with ancient Egypt and the imagery the ankh appears among.",
+      "symbols": [
+        {
+          "char": "🪲",
+          "label": "Scarab Beetle"
+        },
+        {
+          "char": "🐍",
+          "label": "Snake"
+        },
+        {
+          "char": "👁️",
+          "label": "Eye"
+        },
+        {
+          "char": "🐈",
+          "label": "Cat"
+        }
+      ]
+    },
+    {
+      "id": "protective-spiritual",
+      "label": "Spiritual & Protective",
+      "h2": "Spiritual & Protective Symbols",
+      "intro": "Other single-glyph spiritual and protective symbols the ankh is often searched alongside.",
+      "symbols": [
+        {
+          "char": "🧿",
+          "label": "Nazar Amulet (Evil Eye)"
+        },
+        {
+          "char": "🪬",
+          "label": "Hamsa Hand"
+        },
+        {
+          "char": "☯️",
+          "label": "Yin Yang"
+        },
+        {
+          "char": "☮️",
+          "label": "Peace Symbol"
+        }
+      ]
+    }
+  ],
+  "related": [
+    {
+      "href": "/library/egyptian-hieroglyphs/",
+      "title": "Egyptian Hieroglyphs",
+      "desc": "The full hieroglyphic writing system the ankh (sign S34) belongs to."
+    },
+    {
+      "href": "/symbol/cross-symbol/",
+      "title": "Cross Symbol",
+      "desc": "The Christian cross whose early \"crux ansata\" form grew directly out of the ankh's looped shape in Coptic Egypt."
+    },
+    {
+      "href": "/symbol/hamsa-symbol/",
+      "title": "Hamsa Symbol",
+      "desc": "Another ancient life-and-protection symbol reported as documented history, without picking a side."
+    }
+  ]
+}

--- a/data/library_page_specs/aries-symbol.json
+++ b/data/library_page_specs/aries-symbol.json
@@ -1,0 +1,89 @@
+{
+  "slug": "aries-symbol",
+  "page_type": "symbol",
+  "title": "Aries Symbol: Copy & Paste ♈ — The Ram Whose Fleece Became Jason's Golden Fleece",
+  "meta_description": "Copy and paste the Aries zodiac symbol (♈) and the Golden Fleece myth behind it — the winged ram that carried Phrixus to Colchis, whose fleece became the prize Jason and the Argonauts sailed to claim. Click any symbol to copy it instantly.",
+  "canonical": "https://ultratextgen.com/symbol/aries-symbol/",
+  "breadcrumb": "Aries Symbol",
+  "hero_h1": "Aries Symbol",
+  "hero_tagline": "Aries's glyph (♈) is a pair of curved ram's horns — the first sign of the zodiac, tied to the golden-fleeced ram whose fleece later became the prize Jason and the Argonauts sailed east to claim. Click any symbol to copy it instantly.",
+  "intro": "The Aries symbol (♈, U+2648) is drawn as a pair of curved ram's horns, and Aries is the first sign of the zodiac. The myth behind it is the origin of the Golden Fleece: a winged, golden-fleeced ram — Chrysomallos in Greek — was sent to rescue Phrixus and his sister Helle, two children their stepmother had schemed to have sacrificed. As the ram flew them across the sea, Helle lost her grip and fell, drowning at the strait still called the Hellespont (‘Sea of Helle’) in her memory. Phrixus reached Colchis safely, sacrificed the ram in gratitude, and dedicated its golden fleece there — the very fleece that generations later became the prize Jason and the Argonauts sailed east to claim. The ram itself was set among the stars as the constellation Aries. Aries runs March 21–April 19, is ruled by Mars, and is a Fire sign with Cardinal modality.",
+  "date_published": "2026-07-13",
+  "date_modified": "2026-07-13",
+  "copy_pattern": "single",
+  "sections": [
+    {
+      "id": "aries-symbol",
+      "label": "Aries",
+      "h2": "Aries Symbol",
+      "intro": "The Unicode Aries zodiac glyph, ready to paste.",
+      "symbols": [
+        {
+          "char": "♈",
+          "label": "Aries Symbol"
+        },
+        {
+          "char": "♈️",
+          "label": "Aries Symbol (Emoji)"
+        }
+      ]
+    },
+    {
+      "id": "ruling-planet-element",
+      "label": "Planet & Element",
+      "h2": "Ruling Planet & Element",
+      "intro": "The planet and classical element traditionally associated with Aries.",
+      "symbols": [
+        {
+          "char": "♂",
+          "label": "Mars (Ruling Planet)"
+        },
+        {
+          "char": "🜂",
+          "label": "Fire (Element, Alchemical)"
+        }
+      ]
+    },
+    {
+      "id": "related-zodiac-celestial",
+      "label": "Zodiac & Celestial",
+      "h2": "More Zodiac & Celestial Symbols",
+      "intro": "Celestial bodies and the astrological opposite of Aries (Libra).",
+      "symbols": [
+        {
+          "char": "☉",
+          "label": "Sun"
+        },
+        {
+          "char": "☽",
+          "label": "Moon (First Quarter)"
+        },
+        {
+          "char": "⛎",
+          "label": "Ophiuchus (Unofficial 13th Sign)"
+        },
+        {
+          "char": "♎",
+          "label": "Libra (Opposite Sign)"
+        }
+      ]
+    }
+  ],
+  "related": [
+    {
+      "href": "/library/zodiac-symbols/",
+      "title": "Zodiac Symbols",
+      "desc": "Western zodiac signs, planetary symbols, and Chinese zodiac animals in one reference."
+    },
+    {
+      "href": "/symbol/libra-symbol/",
+      "title": "Libra Symbol",
+      "desc": "Aries's astrological opposite sign, directly across the zodiac wheel."
+    },
+    {
+      "href": "/symbol/leo-symbol/",
+      "title": "Leo Symbol",
+      "desc": "A fellow Fire sign, with the Nemean Lion myth behind its glyph."
+    }
+  ]
+}

--- a/data/library_page_specs/cancer-symbol.json
+++ b/data/library_page_specs/cancer-symbol.json
@@ -1,0 +1,89 @@
+{
+  "slug": "cancer-symbol",
+  "page_type": "symbol",
+  "title": "Cancer Symbol: Copy & Paste ♋ — The Only Zodiac Sign Ruled by the Moon",
+  "meta_description": "Copy and paste the Cancer zodiac symbol (♋) and the crab myth behind it — the giant crab Hera sent against Heracles during his second labor, and why Cancer is the only sign ruled by the Moon. Click any symbol to copy it instantly.",
+  "canonical": "https://ultratextgen.com/symbol/cancer-symbol/",
+  "breadcrumb": "Cancer Symbol",
+  "hero_h1": "Cancer Symbol",
+  "hero_tagline": "Cancer's glyph (♋) is a pair of curled crab claws — and Cancer is the only zodiac sign ruled by the Moon, making it and Sun-ruled Leo the two signs governed by a luminary instead of a planet. Click any symbol to copy it instantly.",
+  "intro": "The Cancer symbol (♋, U+264B) is drawn as two curled crab claws — a glyph so stylized that many people read it as a sideways ‘69’ or a pair of interlocking commas. Its myth comes from the Twelve Labors of Heracles: during his second labor, the fight against the many-headed Lernaean Hydra, the goddess Hera — who despised Heracles — sent a giant crab to hinder him. The crab pinched his foot, and Heracles crushed it underfoot. To honor its effort, Hera set the crab among the stars as Cancer, in a notably dim patch of sky. Cancer is also the only zodiac sign ruled by the Moon (☽), making it — alongside Sun-ruled Leo — one of just two signs governed by a luminary rather than a planet. It runs June 21–July 22, is a Water sign with Cardinal modality, and begins at the June solstice that gave the Tropic of Cancer its name.",
+  "date_published": "2026-07-13",
+  "date_modified": "2026-07-13",
+  "copy_pattern": "single",
+  "sections": [
+    {
+      "id": "cancer-symbol",
+      "label": "Cancer",
+      "h2": "Cancer Symbol",
+      "intro": "The Unicode Cancer zodiac glyph, ready to paste.",
+      "symbols": [
+        {
+          "char": "♋",
+          "label": "Cancer Symbol"
+        },
+        {
+          "char": "♋️",
+          "label": "Cancer Symbol (Emoji)"
+        }
+      ]
+    },
+    {
+      "id": "ruling-planet-element",
+      "label": "Planet & Element",
+      "h2": "Ruling Planet & Element",
+      "intro": "The planet and classical element traditionally associated with Cancer.",
+      "symbols": [
+        {
+          "char": "☽",
+          "label": "Moon (Ruling Planet)"
+        },
+        {
+          "char": "🜄",
+          "label": "Water (Element, Alchemical)"
+        }
+      ]
+    },
+    {
+      "id": "related-zodiac-celestial",
+      "label": "Zodiac & Celestial",
+      "h2": "More Zodiac & Celestial Symbols",
+      "intro": "Celestial bodies and the astrological opposite of Cancer (Capricorn).",
+      "symbols": [
+        {
+          "char": "☉",
+          "label": "Sun"
+        },
+        {
+          "char": "☽",
+          "label": "Moon (First Quarter)"
+        },
+        {
+          "char": "⛎",
+          "label": "Ophiuchus (Unofficial 13th Sign)"
+        },
+        {
+          "char": "♑",
+          "label": "Capricorn (Opposite Sign)"
+        }
+      ]
+    }
+  ],
+  "related": [
+    {
+      "href": "/library/zodiac-symbols/",
+      "title": "Zodiac Symbols",
+      "desc": "Western zodiac signs, planetary symbols, and Chinese zodiac animals in one reference."
+    },
+    {
+      "href": "/symbol/capricorn-symbol/",
+      "title": "Capricorn Symbol",
+      "desc": "Cancer's astrological opposite sign, directly across the zodiac wheel."
+    },
+    {
+      "href": "/symbol/leo-symbol/",
+      "title": "Leo Symbol",
+      "desc": "The zodiac's only Sun-ruled sign — the luminary counterpart to Moon-ruled Cancer."
+    }
+  ]
+}

--- a/data/library_page_specs/capricorn-symbol.json
+++ b/data/library_page_specs/capricorn-symbol.json
@@ -1,0 +1,89 @@
+{
+  "slug": "capricorn-symbol",
+  "page_type": "symbol",
+  "title": "Capricorn Symbol: Copy & Paste ♑ — The Sea-Goat, Half Goat and Half Fish",
+  "meta_description": "Copy and paste the Capricorn zodiac symbol (♑) and the sea-goat myth behind it — the god Pan's half-finished escape from the monster Typhon, leaving him part goat, part fish. Click any symbol to copy it instantly.",
+  "canonical": "https://ultratextgen.com/symbol/capricorn-symbol/",
+  "breadcrumb": "Capricorn Symbol",
+  "hero_h1": "Capricorn Symbol",
+  "hero_tagline": "Capricorn's glyph (♑) is a monogram of the sea-goat — a mythical hybrid with a goat's head and horns joined to a fish's tail, born from a god's half-finished escape. Click any symbol to copy it instantly.",
+  "intro": "The Capricorn symbol (♑, U+2651) is a stylized monogram of the sea-goat — a creature with the head and horns of a goat joined to the curling tail of a fish. That strange hybrid comes straight from Greek myth: when the monster Typhon attacked the gods, Pan — the goat-legged god of the wild — fled to the banks of the Nile and leapt in, trying to turn himself into a fish to escape. The transformation only half-worked: his upper body stayed a goat while his lower half became a fish's tail. Zeus set that half-goat, half-fish form among the stars as Capricorn. It runs December 22–January 19, is an Earth sign with Cardinal modality, and is ruled by Saturn (♄). Capricorn begins at the December solstice — the reason Earth's southern line of latitude is called the Tropic of Capricorn.",
+  "date_published": "2026-07-13",
+  "date_modified": "2026-07-13",
+  "copy_pattern": "single",
+  "sections": [
+    {
+      "id": "capricorn-symbol",
+      "label": "Capricorn",
+      "h2": "Capricorn Symbol",
+      "intro": "The Unicode Capricorn zodiac glyph, ready to paste.",
+      "symbols": [
+        {
+          "char": "♑",
+          "label": "Capricorn Symbol"
+        },
+        {
+          "char": "♑️",
+          "label": "Capricorn Symbol (Emoji)"
+        }
+      ]
+    },
+    {
+      "id": "ruling-planet-element",
+      "label": "Planet & Element",
+      "h2": "Ruling Planet & Element",
+      "intro": "The planet and classical element traditionally associated with Capricorn.",
+      "symbols": [
+        {
+          "char": "♄",
+          "label": "Saturn (Ruling Planet)"
+        },
+        {
+          "char": "🜃",
+          "label": "Earth (Element, Alchemical)"
+        }
+      ]
+    },
+    {
+      "id": "related-zodiac-celestial",
+      "label": "Zodiac & Celestial",
+      "h2": "More Zodiac & Celestial Symbols",
+      "intro": "Celestial bodies and the astrological opposite of Capricorn (Cancer).",
+      "symbols": [
+        {
+          "char": "☉",
+          "label": "Sun"
+        },
+        {
+          "char": "☽",
+          "label": "Moon (First Quarter)"
+        },
+        {
+          "char": "⛎",
+          "label": "Ophiuchus (Unofficial 13th Sign)"
+        },
+        {
+          "char": "♋",
+          "label": "Cancer (Opposite Sign)"
+        }
+      ]
+    }
+  ],
+  "related": [
+    {
+      "href": "/library/zodiac-symbols/",
+      "title": "Zodiac Symbols",
+      "desc": "Western zodiac signs, planetary symbols, and Chinese zodiac animals in one reference."
+    },
+    {
+      "href": "/symbol/cancer-symbol/",
+      "title": "Cancer Symbol",
+      "desc": "Capricorn's astrological opposite sign, directly across the zodiac wheel."
+    },
+    {
+      "href": "/symbol/taurus-symbol/",
+      "title": "Taurus Symbol",
+      "desc": "A fellow Earth sign, and likely the oldest continuously tracked constellation in the zodiac."
+    }
+  ]
+}

--- a/data/library_page_specs/congruent-symbol.json
+++ b/data/library_page_specs/congruent-symbol.json
@@ -1,0 +1,93 @@
+{
+  "slug": "congruent-symbol",
+  "page_type": "symbol",
+  "title": "Congruent Symbol: Copy & Paste ≅ — The Sign Unicode Doesn't Even Call ‘Congruent’",
+  "meta_description": "Copy and paste the congruent symbol ≅ — the geometry sign for ‘same shape and size’ that Unicode officially names ‘Approximately Equal To’ (U+2245) — and tell it apart from the look-alikes ≈ and ≡. Click any symbol to copy it instantly.",
+  "canonical": "https://ultratextgen.com/symbol/congruent-symbol/",
+  "breadcrumb": "Congruent Symbol",
+  "hero_h1": "Congruent Symbol",
+  "hero_tagline": "The ≅ that every geometry class uses for congruent shapes — same shape, same size — even though Unicode's official name for it is ‘Approximately Equal To.’ Plus the look-alikes ≈ and ≡ it's constantly confused with. Click any symbol to copy it instantly.",
+  "intro": "The congruent symbol, ≅, is the one math teachers draw when two shapes are congruent — identical in both shape and size. Here's the quirk: Unicode doesn't call it that. Its official name for the character (U+2245) is ‘APPROXIMATELY EQUAL TO,’ a label that never mentions congruence at all, yet ≅ is exactly the glyph geometry classrooms worldwide reach for. The symbol reads as two ideas stacked — the ≈ of approximation over the = of equality — and it sits in a crowded neighborhood of easily-confused relatives. ≈ (U+2248, ALMOST EQUAL TO) means ‘approximately,’ the one you'd use for π ≈ 3.14. ≡ (U+2261, IDENTICAL TO) means something stronger — identity, and in number theory it's the congruence sign of modular arithmetic, as in ‘17 ≡ 2 (mod 5).’ Three symbols, three jobs, all built from stacked horizontal strokes, and all routinely typed in place of one another. This page keeps them straight and lets you copy the exact one you need.",
+  "date_published": "2026-07-13",
+  "date_modified": "2026-07-13",
+  "copy_pattern": "single",
+  "sections": [
+    {
+      "id": "the-congruent-symbol",
+      "label": "The Congruent Symbol",
+      "h2": "The Congruent Symbol — ≅",
+      "intro": "The glyph geometry uses for congruence — same shape and size — even though Unicode's official name for it makes no mention of the word. Its close visual cousin ≃ carries a single tilde instead of a double one.",
+      "symbols": [
+        {
+          "char": "≅",
+          "label": "Congruent To — Officially ‘Approximately Equal To’ (U+2245)"
+        },
+        {
+          "char": "≃",
+          "label": "Asymptotically Equal To (U+2243) — The Single-Tilde Cousin"
+        }
+      ]
+    },
+    {
+      "id": "confusable-neighbors",
+      "label": "Telling Them Apart",
+      "h2": "≅ vs. ≈ vs. ≡ — The Confusable Neighbors",
+      "intro": "Three stacked-stroke symbols that get swapped constantly, each with its own job. Congruent (same shape and size), approximately equal (a rough estimate), and identical to (true identity and modular congruence).",
+      "symbols": [
+        {
+          "char": "≅",
+          "label": "Approximately Equal To (U+2245) — Used for Geometric Congruence"
+        },
+        {
+          "char": "≈",
+          "label": "Almost Equal To (U+2248) — Approximation, e.g. π ≈ 3.14"
+        },
+        {
+          "char": "≡",
+          "label": "Identical To (U+2261) — Identity & Modular Congruence"
+        }
+      ]
+    },
+    {
+      "id": "more-relation-symbols",
+      "label": "Relation Symbols",
+      "h2": "More Math Relation Symbols",
+      "intro": "The rest of the ‘equals family’ that lives beside the congruent sign in equations and proofs.",
+      "symbols": [
+        {
+          "char": "≠",
+          "label": "Not Equal To (U+2260)"
+        },
+        {
+          "char": "=",
+          "label": "Equals Sign"
+        },
+        {
+          "char": "≤",
+          "label": "Less-Than or Equal To"
+        },
+        {
+          "char": "≥",
+          "label": "Greater-Than or Equal To"
+        }
+      ]
+    }
+  ],
+  "related": [
+    {
+      "href": "/library/math-symbols/",
+      "title": "Math Symbols",
+      "desc": "The full set of relations, operators, and Greek letters that the congruent sign lives among in equations."
+    },
+    {
+      "href": "/symbol/not-equal-sign/",
+      "title": "Not Equal Sign",
+      "desc": "The opposite relation — and a close neighbor in the same ‘equals family’ of math symbols."
+    },
+    {
+      "href": "/symbol/omega-symbol/",
+      "title": "Omega Symbol",
+      "desc": "Another character whose everyday identity — the ohm sign for electrical resistance — isn't the name Unicode officially gives it."
+    }
+  ]
+}

--- a/data/library_page_specs/delta-symbol.json
+++ b/data/library_page_specs/delta-symbol.json
@@ -1,0 +1,94 @@
+{
+  "slug": "delta-symbol",
+  "page_type": "symbol",
+  "title": "Delta Symbol: Copy & Paste Δ δ — The Letter That Means ‘Change’ in Every Equation",
+  "meta_description": "Copy and paste the delta symbol — capital Δ (the universal ‘change in’ sign) and lowercase δ — and learn its real meanings across math, physics, chemistry, and options trading, plus the ∆ increment sign it's confused with. Click any symbol to copy it instantly.",
+  "canonical": "https://ultratextgen.com/symbol/delta-symbol/",
+  "breadcrumb": "Delta Symbol",
+  "hero_h1": "Delta Symbol",
+  "hero_tagline": "The capital Δ that means ‘change in’ across math, physics, and engineering, and the lowercase δ used for infinitesimals and the partial charges of a polar bond. Click any symbol to copy it instantly.",
+  "intro": "Delta is the fourth letter of the Greek alphabet, and its capital form, Δ (U+0394, GREEK CAPITAL LETTER DELTA), is mathematical shorthand the whole world agrees on: it means ‘change in.’ Write Δx and every scientist reads ‘the change in x’; Δt is elapsed time, ΔV a change in voltage. The lowercase form, δ (U+03B4), takes the smaller jobs — an infinitesimal change in calculus, and in chemistry the partial charges δ+ and δ− that mark the slightly positive and slightly negative ends of a polar bond. The letter's triangular capital even named a landform: the fan-shaped mouth of a river is called a ‘delta’ because its shape echoes Δ, a comparison the ancient Greeks drew for the Nile. Delta reaches into finance too, where an option's ‘delta’ measures how much the option's price moves for every $1 move in the underlying asset. One letter, a dozen fields — all built on the single idea of difference.",
+  "date_published": "2026-07-13",
+  "date_modified": "2026-07-13",
+  "copy_pattern": "single",
+  "sections": [
+    {
+      "id": "the-delta-symbol",
+      "label": "The Delta Symbol",
+      "h2": "The Delta Symbol — Δ & δ",
+      "intro": "The Greek letter itself, in both cases. Capital Δ is the ‘change in’ sign; lowercase δ handles the smaller-scale jobs.",
+      "symbols": [
+        {
+          "char": "Δ",
+          "label": "Greek Capital Letter Delta (U+0394) — ‘Change In’"
+        },
+        {
+          "char": "δ",
+          "label": "Greek Small Letter Delta (U+03B4) — Infinitesimal / Partial Charge"
+        }
+      ]
+    },
+    {
+      "id": "increment-disambiguation",
+      "label": "Increment Sign",
+      "h2": "The Increment Sign Mix-Up",
+      "intro": "There is a separate math character, ∆ INCREMENT, that renders almost identically to capital delta but is a different codepoint — the same kind of look-alike trap as the ohm sign and omega. Some fonts and screen readers treat the two differently.",
+      "symbols": [
+        {
+          "char": "∆",
+          "label": "Increment (U+2206) — The Math Operator That Looks Like Δ, Different Codepoint"
+        },
+        {
+          "char": "Δ",
+          "label": "Capital Delta (U+0394) — The Greek Letter Itself"
+        }
+      ]
+    },
+    {
+      "id": "related-greek-letters",
+      "label": "Greek Letters",
+      "h2": "Related Greek Letters",
+      "intro": "Delta sits alongside the other most-searched Greek letters. Copy whichever one your equation needs.",
+      "symbols": [
+        {
+          "char": "Ω",
+          "label": "Greek Capital Letter Omega"
+        },
+        {
+          "char": "Σ",
+          "label": "Greek Capital Letter Sigma"
+        },
+        {
+          "char": "π",
+          "label": "Greek Small Letter Pi"
+        },
+        {
+          "char": "α",
+          "label": "Greek Small Letter Alpha"
+        }
+      ]
+    }
+  ],
+  "related": [
+    {
+      "href": "/library/greek-letter-symbols/",
+      "title": "Greek Letter Symbols",
+      "desc": "The full Greek alphabet in uppercase, lowercase, and math variant forms to copy and paste."
+    },
+    {
+      "href": "/library/math-symbols/",
+      "title": "Math Symbols",
+      "desc": "The ‘change in’ delta alongside the operators, relations, and Greek letters that fill out an equation."
+    },
+    {
+      "href": "/symbol/omega-symbol/",
+      "title": "Omega Symbol",
+      "desc": "One of the two Greek letters the omega page displays without a link — now it has its own page. Omega closes the alphabet; delta pairs with it in math."
+    },
+    {
+      "href": "/symbol/sigma-symbol/",
+      "title": "Sigma Symbol",
+      "desc": "Another workhorse Greek letter — the summation sign in math, and the ‘sigma male’ meme online."
+    }
+  ]
+}

--- a/data/library_page_specs/fleur-de-lis-symbol.json
+++ b/data/library_page_specs/fleur-de-lis-symbol.json
@@ -1,0 +1,101 @@
+{
+  "slug": "fleur-de-lis-symbol",
+  "page_type": "symbol",
+  "title": "Fleur-de-lis Symbol: Copy & Paste ⚜ — From French Royalty to the Scout Emblem and the New Orleans Saints",
+  "meta_description": "Copy and paste the fleur-de-lis (⚜ U+269C), the stylized lily of French royalty — now the World Scout emblem, the New Orleans Saints logo, and a fixture of Quebec's provincial flag. Click any symbol to copy it instantly.",
+  "canonical": "https://ultratextgen.com/symbol/fleur-de-lis-symbol/",
+  "breadcrumb": "Fleur-de-lis Symbol",
+  "hero_h1": "Fleur-de-lis Symbol",
+  "hero_tagline": "The fleur-de-lis (⚜) — a stylized lily that served as the emblem of French royalty and lives on today in Scouting's World Crest and the New Orleans Saints logo. Click any symbol to copy it instantly.",
+  "intro": "The fleur-de-lis (⚜, U+269C) is a heraldic charge in the stylized shape of a lily or iris — in French, fleur means \"flower\" and lis means \"lily.\" It is most famous as an emblem of French royalty, appearing on the coat of arms of France from the High Middle Ages until the monarchy's fall in 1792. Unicode added it in version 4.1 (2005), in the Miscellaneous Symbols block. Alongside its royal use, the flower carries a documented Christian association: in religious art it is linked to the Virgin Mary, and its three petals are sometimes read as the Holy Trinity. The same emblem has been widely adopted in the modern era. It forms the World Scout emblem — its three points said to stand for the three parts of the Scout Promise — chosen by Scouting founder Robert Baden-Powell for its resemblance to the north point of a compass. It is the logo of the NFL's New Orleans Saints, a marker of the region's French heritage, and it features prominently on the provincial flag of Quebec.",
+  "date_published": "2026-07-13",
+  "date_modified": "2026-07-13",
+  "copy_pattern": "single",
+  "sections": [
+    {
+      "id": "fleur-de-lis",
+      "label": "Fleur-de-lis",
+      "h2": "Fleur-de-lis Symbol",
+      "intro": "The fleur-de-lis dingbat and its emoji-style presentation.",
+      "symbols": [
+        {
+          "char": "⚜",
+          "label": "Fleur-de-lis"
+        },
+        {
+          "char": "⚜️",
+          "label": "Fleur-de-lis (Emoji Style)"
+        }
+      ]
+    },
+    {
+      "id": "heraldry-royalty",
+      "label": "Royalty & Heraldry",
+      "h2": "Crown & Royalty Symbols",
+      "intro": "Crowns and regalia that share the fleur-de-lis's heraldic, royal context.",
+      "symbols": [
+        {
+          "char": "👑",
+          "label": "Crown"
+        },
+        {
+          "char": "🤴",
+          "label": "Prince"
+        },
+        {
+          "char": "👸",
+          "label": "Princess"
+        },
+        {
+          "char": "🏰",
+          "label": "Castle"
+        },
+        {
+          "char": "🛡️",
+          "label": "Shield"
+        }
+      ]
+    },
+    {
+      "id": "flower-emblem-symbols",
+      "label": "Flowers & Florettes",
+      "h2": "Flower & Emblem Symbols",
+      "intro": "Other single-glyph flower and florette emblems in the same decorative family.",
+      "symbols": [
+        {
+          "char": "🌸",
+          "label": "Cherry Blossom"
+        },
+        {
+          "char": "🌼",
+          "label": "Blossom"
+        },
+        {
+          "char": "✿",
+          "label": "Black Florette"
+        },
+        {
+          "char": "❀",
+          "label": "White Florette"
+        }
+      ]
+    }
+  ],
+  "related": [
+    {
+      "href": "/library/crown-royalty-symbols/",
+      "title": "Crown & Royalty Symbols",
+      "desc": "Crowns, thrones, and regalia — the heraldic company the fleur-de-lis keeps."
+    },
+    {
+      "href": "/symbol/star-of-david/",
+      "title": "Star of David",
+      "desc": "Another single emblematic glyph whose path from decorative motif to defining symbol is a matter of documented record."
+    },
+    {
+      "href": "/symbol/pentagram-symbol/",
+      "title": "Pentagram Symbol",
+      "desc": "Another single star-shaped emblem carried across heraldry, religion, and the occult."
+    }
+  ]
+}

--- a/data/library_page_specs/ohm-symbol.json
+++ b/data/library_page_specs/ohm-symbol.json
@@ -1,0 +1,101 @@
+{
+  "slug": "ohm-symbol",
+  "page_type": "symbol",
+  "title": "Ohm Symbol: Copy & Paste Ω ℧ — Named for the Physicist Behind V = IR",
+  "meta_description": "Copy and paste the ohm symbol (Ω) for electrical resistance — named after physicist Georg Simon Ohm and his 1827 law V = IR — plus the mho (℧) and siemens for its inverse. Click any symbol to copy it instantly.",
+  "canonical": "https://ultratextgen.com/symbol/ohm-symbol/",
+  "breadcrumb": "Ohm Symbol",
+  "hero_h1": "Ohm Symbol",
+  "hero_tagline": "The Ω sign for electrical resistance, named after Georg Simon Ohm — the German physicist behind Ohm’s law, V = IR — plus ℧, the “mho” that measures its inverse. Click any symbol to copy it instantly.",
+  "intro": "The ohm symbol (Ω) is the unit of electrical resistance, named after Georg Simon Ohm (1789–1854), the German physicist and mathematician who set out what we now call Ohm’s law in his 1827 book Die galvanische Kette, mathematisch bearbeitet. The law is the one every electronics student memorizes: the current through a conductor is proportional to the voltage across it and inversely proportional to its resistance — the familiar V = I × R. Ohm’s work was largely ignored at first, but by 1841 the Royal Society had awarded him its Copley Medal. One wrinkle worth knowing up front: the character here is technically U+2126 OHM SIGN, a distinct codepoint that renders identically to the Greek capital letter omega (U+03A9), and Unicode’s own database treats the ohm sign as normalizing to plain omega. For the full story of that look-alike, see our omega symbol page — here we focus on the ohm as an electrical unit.",
+  "date_published": "2026-07-13",
+  "date_modified": "2026-07-13",
+  "copy_pattern": "single",
+  "sections": [
+    {
+      "id": "ohm-sign",
+      "label": "Ohm Sign",
+      "h2": "The Ohm Symbol (Ω)",
+      "intro": "The unit of electrical resistance. U+2126 is the dedicated ohm sign, though in practice most people just type Greek capital omega, which looks the same. Lowercase omega (ω) rides alongside it in alternating-current math, where it denotes angular frequency, ω = 2πf.",
+      "symbols": [
+        {
+          "char": "Ω",
+          "label": "Ohm Sign (U+2126) — Electrical Resistance"
+        },
+        {
+          "char": "ω",
+          "label": "Greek Small Omega (ω) — Angular Frequency"
+        }
+      ]
+    },
+    {
+      "id": "unicode-identity",
+      "label": "Ω vs Omega",
+      "h2": "Ohm Sign vs. Greek Omega",
+      "intro": "These two tiles are different Unicode characters — U+2126, the ohm sign, and U+03A9, Greek capital omega — that look identical in almost every font. Unicode’s database says the ohm sign should normalize to plain omega, and most keyboards and tools produce the omega, not the ohm sign. The mismatch has caused real document-conversion bugs. For copy-paste either one works; for the full disambiguation, including the documented Pandoc issue, see the omega symbol page.",
+      "symbols": [
+        {
+          "char": "Ω",
+          "label": "Ohm Sign (U+2126) — the Legacy Codepoint"
+        },
+        {
+          "char": "Ω",
+          "label": "Greek Capital Omega (U+03A9) — What Unicode Prefers"
+        }
+      ]
+    },
+    {
+      "id": "mho-siemens",
+      "label": "Mho & Siemens",
+      "h2": "Mho & Siemens — the Reciprocal Unit",
+      "intro": "Conductance is the reciprocal of resistance — literally 1 ÷ Ω — and its old unit is the mho (℧), which is simply “ohm” spelled backwards. Lord Kelvin proposed the name in 1883. The modern SI system replaced it in 1971 with the siemens (symbol S, named after inventor Werner von Siemens); NIST now flags “mho” as a special name to avoid, though ℧ still turns up in older texts and schematics.",
+      "symbols": [
+        {
+          "char": "℧",
+          "label": "Mho Sign (U+2127) — “Ohm” Reversed"
+        },
+        {
+          "char": "S",
+          "label": "Siemens (S) — the Modern SI Unit of Conductance"
+        }
+      ]
+    },
+    {
+      "id": "circuit-symbols",
+      "label": "Circuit Symbols",
+      "h2": "Other Electrical & Circuit Symbols",
+      "intro": "The ohm sits among a family of glyphs that populate circuit diagrams and datasheets. Three more Unicode characters an electronics schematic might call for:",
+      "symbols": [
+        {
+          "char": "⏚",
+          "label": "Earth Ground (U+23DA)"
+        },
+        {
+          "char": "⚡",
+          "label": "High Voltage Sign (U+26A1)"
+        },
+        {
+          "char": "∿",
+          "label": "Sine Wave (U+223F) — Alternating Current"
+        }
+      ]
+    }
+  ],
+  "related": [
+    {
+      "href": "/symbol/omega-symbol/",
+      "title": "Omega Symbol",
+      "desc": "The identical-looking Greek letter this page’s Ω normalizes to — the full Unicode disambiguation, the documented Pandoc conversion bug, and where the two glyphs quietly come apart."
+    },
+    {
+      "href": "/library/electrical-circuit-symbols/",
+      "title": "Electrical & Circuit Symbols",
+      "desc": "A browsable set of schematic glyphs — grounds, sources, switches, and the units that label them."
+    },
+    {
+      "href": "/symbol/micro-sign/",
+      "title": "Micro Sign",
+      "desc": "The exact same Unicode quirk as the ohm sign: µ is a legacy character that normalizes to Greek mu — another SI prefix (µF, µA) that looks like a Greek letter but isn’t one underneath."
+    }
+  ]
+}

--- a/data/library_page_specs/om-symbol.json
+++ b/data/library_page_specs/om-symbol.json
@@ -1,0 +1,105 @@
+{
+  "slug": "om-symbol",
+  "page_type": "symbol",
+  "title": "Om Symbol: Copy & Paste ॐ 🕉️ — One Sacred Sound, Three Meanings in Hinduism, Buddhism, and Jainism",
+  "meta_description": "Copy and paste Om / Aum (ॐ U+0950, 🕉️ U+1F549) — the sacred syllable read as the primordial cosmic sound in Hinduism, the opening of Om mani padme hum in Buddhism, and a condensed form of the five supreme beings in Jainism. Click any symbol to copy it instantly.",
+  "canonical": "https://ultratextgen.com/symbol/om-symbol/",
+  "breadcrumb": "Om Symbol",
+  "hero_h1": "Om Symbol",
+  "hero_tagline": "Om, or Aum (ॐ, 🕉️) — the sacred syllable shared by Hinduism, Buddhism, and Jainism, where the same sound is read differently in each tradition. Click any symbol to copy it instantly.",
+  "intro": "Om, also spelled Aum, is a sacred sound and symbol central to several Indian religions. Unicode encodes it two ways. The first is ॐ (U+0950 DEVANAGARI OM), a cursive ligature in the Devanagari script that fuses the letters a (अ) and u (उ) with a nasal chandrabindu; it was added in Unicode 1.1 back in 1993. The second is 🕉️ (U+1F549 OM SYMBOL), a standalone pictographic glyph defined as \"independent of Devanagari font\" and added far later, in Unicode 7.0 (2014), then taken up as an emoji in 2015 — the same glyph the Khanda symbol page already displays as a related mark. The syllable is chanted at the start or end of prayers, mantras, and yoga practice, but its meaning is not uniform across faiths: Hindu tradition often describes it as the primordial sound of the universe and an expression of ultimate reality; in Buddhism it opens mantras such as Om mani padme hum, linked to the bodhisattva of compassion; and in Jainism it is understood as a condensed form of the Panch Parmeshthi, the five supreme beings. This page reports that documented usage without ranking the traditions.",
+  "date_published": "2026-07-13",
+  "date_modified": "2026-07-13",
+  "copy_pattern": "single",
+  "sections": [
+    {
+      "id": "om-glyphs",
+      "label": "Om",
+      "h2": "Om Symbol",
+      "intro": "Three Unicode characters for Om: the Devanagari script ligature, the standalone pictographic OM SYMBOL, and the distinct Jain Om.",
+      "symbols": [
+        {
+          "char": "ॐ",
+          "label": "Devanagari Om"
+        },
+        {
+          "char": "🕉️",
+          "label": "Om Symbol"
+        },
+        {
+          "char": "ꣽ",
+          "label": "Jain Om"
+        }
+      ]
+    },
+    {
+      "id": "meditation-symbols",
+      "label": "Meditation & Yoga",
+      "h2": "Meditation & Yoga Symbols",
+      "intro": "Symbols commonly displayed alongside Om in yoga, meditation, and dharmic contexts.",
+      "symbols": [
+        {
+          "char": "🪷",
+          "label": "Lotus"
+        },
+        {
+          "char": "🧘",
+          "label": "Person in Lotus Position"
+        },
+        {
+          "char": "📿",
+          "label": "Prayer Beads"
+        },
+        {
+          "char": "☸️",
+          "label": "Dharma Wheel"
+        }
+      ]
+    },
+    {
+      "id": "faith-symbols",
+      "label": "Faith Symbols",
+      "h2": "Other Faith & Emblem Symbols",
+      "intro": "Symbols from other traditions that pair well with faith and identity content.",
+      "symbols": [
+        {
+          "char": "🪯",
+          "label": "Khanda"
+        },
+        {
+          "char": "✡️",
+          "label": "Star of David"
+        },
+        {
+          "char": "☪️",
+          "label": "Star and Crescent"
+        },
+        {
+          "char": "☯️",
+          "label": "Yin Yang"
+        },
+        {
+          "char": "✝️",
+          "label": "Latin Cross"
+        }
+      ]
+    }
+  ],
+  "related": [
+    {
+      "href": "/library/religious-symbols/",
+      "title": "Religious Symbols",
+      "desc": "Faith symbols from every major world religion in one reference."
+    },
+    {
+      "href": "/symbol/khanda-symbol/",
+      "title": "Khanda Symbol",
+      "desc": "The Sikh emblem whose own page already displays Om as a related dharmic glyph."
+    },
+    {
+      "href": "/symbol/hamsa-symbol/",
+      "title": "Hamsa Symbol",
+      "desc": "Another cross-tradition symbol reported as documented history, without picking a side."
+    }
+  ]
+}

--- a/data/library_page_specs/pi-symbol.json
+++ b/data/library_page_specs/pi-symbol.json
@@ -1,0 +1,97 @@
+{
+  "slug": "pi-symbol",
+  "page_type": "symbol",
+  "title": "Pi Symbol: Copy & Paste π Π ∏ — Coined in 1706, Made Universal by Euler",
+  "meta_description": "Copy and paste the pi symbol — lowercase π (the math constant), capital Π (the product operator), and the dedicated ∏ product sign — and learn how William Jones coined it in 1706 before Euler made it the world standard. Click any symbol to copy it instantly.",
+  "canonical": "https://ultratextgen.com/symbol/pi-symbol/",
+  "breadcrumb": "Pi Symbol",
+  "hero_h1": "Pi Symbol",
+  "hero_tagline": "The lowercase π everyone means by ‘the pi symbol,’ the capital Π that means ‘product’ in math, and the dedicated ∏ product operator — the notation William Jones introduced in 1706 and Leonhard Euler turned into the world standard. Click any symbol to copy it instantly.",
+  "intro": "Pi's lowercase glyph, π (U+03C0, GREEK SMALL LETTER PI), is one of the most recognizable characters in all of mathematics — the ratio of any circle's circumference to its diameter, roughly 3.14159 and running forever without repeating. What most people don't realize is that the symbol is far younger than the number: the Welsh mathematician William Jones first used π this way in his 1706 book ‘Synopsis Palmariorum Matheseos,’ borrowing the Greek letter that begins ‘periphery.’ For three decades it went nowhere — until Leonhard Euler, the most influential mathematician of the age, adopted it around 1737 and cemented it as the global standard through his 1748 ‘Introductio in analysin infinitorum.’ The capital form, Π (U+03A0), does entirely different work: in math it's the product operator, the multiplicative twin of Σ summation, and it has its own dedicated glyph, ∏ (U+220F, N-ARY PRODUCT). Pi is both irrational (proved by Lambert in 1761) and transcendental (Lindemann, 1882) — and it even gets its own holiday every March 14.",
+  "date_published": "2026-07-13",
+  "date_modified": "2026-07-13",
+  "copy_pattern": "single",
+  "sections": [
+    {
+      "id": "the-pi-symbol",
+      "label": "The Pi Symbol",
+      "h2": "The Pi Symbol — π & Π",
+      "intro": "The Greek letter itself. The lowercase π is the famous math constant; the capital Π is a different tool entirely.",
+      "symbols": [
+        {
+          "char": "π",
+          "label": "Greek Small Letter Pi (U+03C0) — The Math Constant ≈ 3.14159"
+        },
+        {
+          "char": "Π",
+          "label": "Greek Capital Letter Pi (U+03A0) — The Product Operator"
+        }
+      ]
+    },
+    {
+      "id": "pi-in-math",
+      "label": "Math & Operators",
+      "h2": "Pi in Math: Product vs. Summation",
+      "intro": "Capital Π is the product operator, and — exactly like sigma — it has a dedicated math glyph, ∏ (N-ARY PRODUCT), that is a separate Unicode character from the letter. It's the multiplicative mirror of ∑ summation, letter for letter.",
+      "symbols": [
+        {
+          "char": "∏",
+          "label": "N-ary Product (U+220F) — The Dedicated Product Operator"
+        },
+        {
+          "char": "Π",
+          "label": "Capital Pi (U+03A0) — The Letter Often Typed for Products"
+        },
+        {
+          "char": "∑",
+          "label": "N-ary Summation (U+2211) — The Product's Additive Twin"
+        },
+        {
+          "char": "Σ",
+          "label": "Capital Sigma (U+03A3) — The Letter Behind Summation"
+        }
+      ]
+    },
+    {
+      "id": "related-greek-letters",
+      "label": "Greek Letters",
+      "h2": "Related Greek Letters",
+      "intro": "Pi is the 16th letter of the Greek alphabet. Here are the neighbors people search for most alongside it.",
+      "symbols": [
+        {
+          "char": "Ω",
+          "label": "Greek Capital Letter Omega"
+        },
+        {
+          "char": "Δ",
+          "label": "Greek Capital Letter Delta"
+        },
+        {
+          "char": "α",
+          "label": "Greek Small Letter Alpha"
+        },
+        {
+          "char": "θ",
+          "label": "Greek Small Letter Theta"
+        }
+      ]
+    }
+  ],
+  "related": [
+    {
+      "href": "/library/greek-letter-symbols/",
+      "title": "Greek Letter Symbols",
+      "desc": "The full Greek alphabet in uppercase, lowercase, and math variant forms to copy and paste."
+    },
+    {
+      "href": "/library/math-symbols/",
+      "title": "Math Symbols",
+      "desc": "Product, summation, and the operators and Greek letters that fill out an equation."
+    },
+    {
+      "href": "/symbol/sigma-symbol/",
+      "title": "Sigma Symbol",
+      "desc": "Pi's operator twin: just as Π pairs with the ∏ product sign, Σ pairs with the ∑ summation sign."
+    }
+  ]
+}

--- a/data/library_page_specs/pisces-symbol.json
+++ b/data/library_page_specs/pisces-symbol.json
@@ -1,0 +1,89 @@
+{
+  "slug": "pisces-symbol",
+  "page_type": "symbol",
+  "title": "Pisces Symbol: Copy & Paste ♓ — The Only Zodiac Glyph That Ties Two Creatures Together",
+  "meta_description": "Copy and paste the Pisces zodiac symbol (♓) — two fish tied tail-to-tail by a cord, the only zodiac glyph that binds two creatures, from the myth of Aphrodite and Eros fleeing Typhon. Click any symbol to copy it instantly.",
+  "canonical": "https://ultratextgen.com/symbol/pisces-symbol/",
+  "breadcrumb": "Pisces Symbol",
+  "hero_h1": "Pisces Symbol",
+  "hero_tagline": "Pisces's glyph (♓) is two crescents joined by a bar — two fish tied tail-to-tail by a cord, the only zodiac symbol that binds two creatures together. Click any symbol to copy it instantly.",
+  "intro": "The Pisces symbol (♓, U+2653) is two crescents joined by a horizontal bar — a literal picture of two fish tied tail-to-tail, making Pisces the only sign whose glyph binds two creatures together. Its myth: Aphrodite and her son Eros were beside a river (Hyginus names the Euphrates) when the monster Typhon attacked; to escape, the two turned into fish and knotted their tails with a cord so the current could not separate them, and Zeus set the image among the stars. It is the same rampage that sent Pan diving into the water as the goat-fish Capricorn — the two constellations record one moment of divine flight. Pisces runs February 19–March 20, is ruled by Neptune in modern astrology (traditionally Jupiter), and is a Water sign with Mutable modality.",
+  "date_published": "2026-07-13",
+  "date_modified": "2026-07-13",
+  "copy_pattern": "single",
+  "sections": [
+    {
+      "id": "pisces-symbol",
+      "label": "Pisces",
+      "h2": "Pisces Symbol",
+      "intro": "The Unicode Pisces zodiac glyph, ready to paste.",
+      "symbols": [
+        {
+          "char": "♓",
+          "label": "Pisces Symbol"
+        },
+        {
+          "char": "♓️",
+          "label": "Pisces Symbol (Emoji)"
+        }
+      ]
+    },
+    {
+      "id": "ruling-planet-element",
+      "label": "Planet & Element",
+      "h2": "Ruling Planet & Element",
+      "intro": "The planet and classical element traditionally associated with Pisces.",
+      "symbols": [
+        {
+          "char": "♆",
+          "label": "Neptune (Ruling Planet)"
+        },
+        {
+          "char": "🜄",
+          "label": "Water (Element, Alchemical)"
+        }
+      ]
+    },
+    {
+      "id": "related-zodiac-celestial",
+      "label": "Zodiac & Celestial",
+      "h2": "More Zodiac & Celestial Symbols",
+      "intro": "Celestial bodies and the astrological opposite of Pisces (Virgo).",
+      "symbols": [
+        {
+          "char": "☉",
+          "label": "Sun"
+        },
+        {
+          "char": "☽",
+          "label": "Moon (First Quarter)"
+        },
+        {
+          "char": "⛎",
+          "label": "Ophiuchus (Unofficial 13th Sign)"
+        },
+        {
+          "char": "♍",
+          "label": "Virgo (Opposite Sign)"
+        }
+      ]
+    }
+  ],
+  "related": [
+    {
+      "href": "/library/zodiac-symbols/",
+      "title": "Zodiac Symbols",
+      "desc": "Western zodiac signs, planetary symbols, and Chinese zodiac animals in one reference."
+    },
+    {
+      "href": "/symbol/virgo-symbol/",
+      "title": "Virgo Symbol",
+      "desc": "Pisces's astrological opposite sign, directly across the zodiac wheel."
+    },
+    {
+      "href": "/symbol/sagittarius-symbol/",
+      "title": "Sagittarius Symbol",
+      "desc": "Pisces's traditional ruler Jupiter also governs Sagittarius, the archer aimed at the galaxy's center."
+    }
+  ]
+}

--- a/data/library_page_specs/recycling-symbol.json
+++ b/data/library_page_specs/recycling-symbol.json
@@ -1,0 +1,105 @@
+{
+  "slug": "recycling-symbol",
+  "page_type": "symbol",
+  "title": "Recycling Symbol: Copy & Paste ♻ — Designed by a 23-Year-Old Student for a 1970 Earth Day Contest",
+  "meta_description": "Copy and paste the recycling symbol (♻ U+267B), the three-arrow Möbius loop designed in 1970 by USC student Gary Anderson for a Container Corporation of America contest tied to the first Earth Day. Click any symbol to copy it instantly.",
+  "canonical": "https://ultratextgen.com/symbol/recycling-symbol/",
+  "breadcrumb": "Recycling Symbol",
+  "hero_h1": "Recycling Symbol",
+  "hero_tagline": "The recycling symbol (♻) — the three-arrow Möbius loop designed in 1970 by Gary Anderson, then a 23-year-old USC student, for a contest tied to the first Earth Day. Click any symbol to copy it instantly.",
+  "intro": "The recycling symbol (♻, U+267B BLACK UNIVERSAL RECYCLING SYMBOL) has an unusually well-documented origin. It was designed in 1970 by Gary Anderson, then a 23-year-old student at the University of Southern California, as an entry in a design competition sponsored by the Container Corporation of America to mark the first Earth Day. The contest drew more than 500 submissions and was judged by leading designers of the day, including Saul Bass; Anderson won a $2,500 scholarship, and his design was placed in the public domain. The three chasing arrows form a Möbius strip — Anderson has said he wanted to evoke paper moving through rollers and the idea of materials cycling endlessly into new products. The popular reading of the three arrows as \"reduce, reuse, recycle\" came later; it was not the design's original stated meaning, which was simply the continuous loop itself. Unicode encoded the filled version at U+267B in version 3.2 (2002); a hollow outline variant, the UNIVERSAL RECYCLING SYMBOL, lives separately at U+2672.",
+  "date_published": "2026-07-13",
+  "date_modified": "2026-07-13",
+  "copy_pattern": "single",
+  "sections": [
+    {
+      "id": "recycling-glyphs",
+      "label": "Recycling",
+      "h2": "Recycling Symbols",
+      "intro": "Unicode carries several recycling marks: the familiar filled symbol, its hollow outline, and the paper-recycling variant.",
+      "symbols": [
+        {
+          "char": "♻",
+          "label": "Recycling Symbol"
+        },
+        {
+          "char": "♲",
+          "label": "Universal Recycling Symbol (Outline)"
+        },
+        {
+          "char": "♼",
+          "label": "Recycled Paper Symbol"
+        }
+      ]
+    },
+    {
+      "id": "environment-symbols",
+      "label": "Environment & Nature",
+      "h2": "Environment & Nature Symbols",
+      "intro": "Symbols commonly paired with recycling in environmental and sustainability messaging.",
+      "symbols": [
+        {
+          "char": "🌱",
+          "label": "Seedling"
+        },
+        {
+          "char": "🌍",
+          "label": "Globe Showing Europe-Africa"
+        },
+        {
+          "char": "🍃",
+          "label": "Leaf Fluttering in Wind"
+        },
+        {
+          "char": "🌳",
+          "label": "Deciduous Tree"
+        },
+        {
+          "char": "💧",
+          "label": "Droplet"
+        }
+      ]
+    },
+    {
+      "id": "sign-pictograms",
+      "label": "Signs & Pictograms",
+      "h2": "Signs & Standardized Pictograms",
+      "intro": "Other internationally standardized pictograms and warning marks in the same functional family.",
+      "symbols": [
+        {
+          "char": "♿",
+          "label": "Wheelchair Symbol"
+        },
+        {
+          "char": "☣️",
+          "label": "Biohazard"
+        },
+        {
+          "char": "⚠️",
+          "label": "Warning"
+        },
+        {
+          "char": "☢️",
+          "label": "Radioactive"
+        }
+      ]
+    }
+  ],
+  "related": [
+    {
+      "href": "/library/recycle-environment-symbols/",
+      "title": "Recycle & Environment Symbols",
+      "desc": "Recycling marks, eco labels, and nature symbols in one reference — this page is the hub's dedicated recycling-symbol spoke."
+    },
+    {
+      "href": "/symbol/biohazard-symbol/",
+      "title": "Biohazard Symbol",
+      "desc": "Another modern pictogram with a documented corporate design origin — created at Dow Chemical in 1966 to be deliberately \"memorable but meaningless.\""
+    },
+    {
+      "href": "/symbol/wheelchair-symbol/",
+      "title": "Wheelchair Symbol",
+      "desc": "Another internationally standardized pictogram with a specific, traceable design history."
+    }
+  ]
+}

--- a/data/library_page_specs/scorpio-symbol.json
+++ b/data/library_page_specs/scorpio-symbol.json
@@ -1,0 +1,89 @@
+{
+  "slug": "scorpio-symbol",
+  "page_type": "symbol",
+  "title": "Scorpio Symbol: Copy & Paste ♏ — The Sign Whose Constellation Never Shares the Sky With Orion",
+  "meta_description": "Copy and paste the Scorpio zodiac symbol (♏) and the myth behind it — the giant scorpion sent to kill Orion, placed on the opposite side of the sky so the two constellations are never visible together. Click any symbol to copy it instantly.",
+  "canonical": "https://ultratextgen.com/symbol/scorpio-symbol/",
+  "breadcrumb": "Scorpio Symbol",
+  "hero_h1": "Scorpio Symbol",
+  "hero_tagline": "Scorpio's glyph (♏) is a scorpion's body ending in a raised, stinging tail — and its constellation, Scorpius, sits opposite Orion, so the hunter and the scorpion are never above the horizon at the same time. Click any symbol to copy it instantly.",
+  "intro": "The Scorpio symbol (♏, U+264F) is drawn as a stylized ‘m’ whose final stroke curls upward into an arrow — the scorpion's raised, stinging tail. The myth ties it to Orion the Hunter, who boasted he could kill every animal on earth; in the best-known version the earth goddess Gaia answered his arrogance by sending a giant scorpion, which stung him to death (some accounts credit the goddess Artemis instead). Both were set among the stars afterward, but on opposite sides of the sky — and that placement is a genuine, observable fact rather than just a story: as Scorpius climbs in the east, Orion sinks in the west, so the hunter and the scorpion are never above the horizon at the same time. Scorpio runs October 23–November 21, is ruled by Pluto in modern astrology (traditionally Mars), and is a Water sign with Fixed modality.",
+  "date_published": "2026-07-13",
+  "date_modified": "2026-07-13",
+  "copy_pattern": "single",
+  "sections": [
+    {
+      "id": "scorpio-symbol",
+      "label": "Scorpio",
+      "h2": "Scorpio Symbol",
+      "intro": "The Unicode Scorpio zodiac glyph, ready to paste.",
+      "symbols": [
+        {
+          "char": "♏",
+          "label": "Scorpio Symbol"
+        },
+        {
+          "char": "♏️",
+          "label": "Scorpio Symbol (Emoji)"
+        }
+      ]
+    },
+    {
+      "id": "ruling-planet-element",
+      "label": "Planet & Element",
+      "h2": "Ruling Planet & Element",
+      "intro": "The planet and classical element traditionally associated with Scorpio.",
+      "symbols": [
+        {
+          "char": "♇",
+          "label": "Pluto (Ruling Planet)"
+        },
+        {
+          "char": "🜄",
+          "label": "Water (Element, Alchemical)"
+        }
+      ]
+    },
+    {
+      "id": "related-zodiac-celestial",
+      "label": "Zodiac & Celestial",
+      "h2": "More Zodiac & Celestial Symbols",
+      "intro": "Celestial bodies and the astrological opposite of Scorpio (Taurus).",
+      "symbols": [
+        {
+          "char": "☉",
+          "label": "Sun"
+        },
+        {
+          "char": "☽",
+          "label": "Moon (First Quarter)"
+        },
+        {
+          "char": "⛎",
+          "label": "Ophiuchus (Unofficial 13th Sign)"
+        },
+        {
+          "char": "♉",
+          "label": "Taurus (Opposite Sign)"
+        }
+      ]
+    }
+  ],
+  "related": [
+    {
+      "href": "/library/zodiac-symbols/",
+      "title": "Zodiac Symbols",
+      "desc": "Western zodiac signs, planetary symbols, and Chinese zodiac animals in one reference."
+    },
+    {
+      "href": "/symbol/taurus-symbol/",
+      "title": "Taurus Symbol",
+      "desc": "Scorpio's astrological opposite sign, directly across the zodiac wheel."
+    },
+    {
+      "href": "/symbol/libra-symbol/",
+      "title": "Libra Symbol",
+      "desc": "The only zodiac symbol that represents an object rather than an animal or person."
+    }
+  ]
+}

--- a/data/library_page_specs/virgo-symbol.json
+++ b/data/library_page_specs/virgo-symbol.json
@@ -1,0 +1,89 @@
+{
+  "slug": "virgo-symbol",
+  "page_type": "symbol",
+  "title": "Virgo Symbol: Copy & Paste ♍ — The Only Zodiac Sign Personified as a Woman",
+  "meta_description": "Copy and paste the Virgo zodiac symbol (♍) and the real myth behind it — Astraea, the virgin goddess of justice and the only sign personified as a woman, the last deity to abandon earth. Click any symbol to copy it instantly.",
+  "canonical": "https://ultratextgen.com/symbol/virgo-symbol/",
+  "breadcrumb": "Virgo Symbol",
+  "hero_h1": "Virgo Symbol",
+  "hero_tagline": "Virgo's glyph (♍) is a looped ‘M’ read as a maiden holding a sheaf of wheat — and Virgo is the only one of the twelve signs personified as a woman, the goddess Astraea who was the last god to leave the mortal world. Click any symbol to copy it instantly.",
+  "intro": "The Virgo symbol (♍, U+264D) is a stylized letter M with a looped tail, most often read as a maiden holding a sheaf of wheat — and Virgo is the only sign of the twelve personified as a woman. The figure is most commonly identified with Astraea, the virgin goddess of justice and daughter of Zeus and Themis (the goddess of divine order). Astraea lived among mortals during the Golden Age, but as humanity turned wicked through the Silver and Bronze Ages the gods abandoned earth one by one; Astraea was the last to leave, ascending to become the constellation Virgo — still holding the scales that became neighboring Libra. Some traditions instead identify Virgo with Demeter or Persephone. Virgo runs August 23–September 22, is ruled by Mercury, and is an Earth sign with Mutable modality.",
+  "date_published": "2026-07-13",
+  "date_modified": "2026-07-13",
+  "copy_pattern": "single",
+  "sections": [
+    {
+      "id": "virgo-symbol",
+      "label": "Virgo",
+      "h2": "Virgo Symbol",
+      "intro": "The Unicode Virgo zodiac glyph, ready to paste.",
+      "symbols": [
+        {
+          "char": "♍",
+          "label": "Virgo Symbol"
+        },
+        {
+          "char": "♍️",
+          "label": "Virgo Symbol (Emoji)"
+        }
+      ]
+    },
+    {
+      "id": "ruling-planet-element",
+      "label": "Planet & Element",
+      "h2": "Ruling Planet & Element",
+      "intro": "The planet and classical element traditionally associated with Virgo.",
+      "symbols": [
+        {
+          "char": "☿",
+          "label": "Mercury (Ruling Planet)"
+        },
+        {
+          "char": "🜃",
+          "label": "Earth (Element, Alchemical)"
+        }
+      ]
+    },
+    {
+      "id": "related-zodiac-celestial",
+      "label": "Zodiac & Celestial",
+      "h2": "More Zodiac & Celestial Symbols",
+      "intro": "Celestial bodies and the astrological opposite of Virgo (Pisces).",
+      "symbols": [
+        {
+          "char": "☉",
+          "label": "Sun"
+        },
+        {
+          "char": "☽",
+          "label": "Moon (First Quarter)"
+        },
+        {
+          "char": "⛎",
+          "label": "Ophiuchus (Unofficial 13th Sign)"
+        },
+        {
+          "char": "♓",
+          "label": "Pisces (Opposite Sign)"
+        }
+      ]
+    }
+  ],
+  "related": [
+    {
+      "href": "/library/zodiac-symbols/",
+      "title": "Zodiac Symbols",
+      "desc": "Western zodiac signs, planetary symbols, and Chinese zodiac animals in one reference."
+    },
+    {
+      "href": "/symbol/pisces-symbol/",
+      "title": "Pisces Symbol",
+      "desc": "Virgo's astrological opposite sign, directly across the zodiac wheel."
+    },
+    {
+      "href": "/symbol/gemini-symbol/",
+      "title": "Gemini Symbol",
+      "desc": "The other Mercury-ruled sign, with the Castor and Pollux twins myth behind it."
+    }
+  ]
+}

--- a/data/library_page_specs/won-sign.json
+++ b/data/library_page_specs/won-sign.json
@@ -1,0 +1,85 @@
+{
+  "slug": "won-sign",
+  "page_type": "symbol",
+  "title": "Won Symbol: Copy & Paste ₩ — The One Sign Two Rival Koreas Share",
+  "meta_description": "Copy and paste the won sign (₩) — the single currency symbol used by both the South Korean won (KRW) and the North Korean won (KPW), and a linguistic cousin of the yen and yuan. Click any symbol to copy it instantly.",
+  "canonical": "https://ultratextgen.com/symbol/won-sign/",
+  "breadcrumb": "Won Sign",
+  "hero_h1": "Won Sign",
+  "hero_tagline": "The ₩ currency mark shared by both the South Korean won (KRW) and the North Korean won (KPW) — one Unicode character for two states that aren’t on speaking terms. Click any symbol to copy it instantly.",
+  "intro": "The won sign (₩) is a rare kind of currency symbol: a single Unicode character — U+20A9, added back in Unicode 1.1 in 1993 — that officially stands for two separate national currencies at once. Both the South Korean won (code KRW) and the North Korean won (KPW) are written with the identical ₩ glyph, a capital “W” crossed by a horizontal stroke, even though the two governments have been divided since 1948 and their wons trade at wildly different values. The name is old: the won was introduced under the Korean Empire in 1902, replacing the yang, and it comes from the hanja 圓 (원), meaning “round” — the very same root behind Japan’s yen and China’s yuan, all three descended from the round Spanish-American silver dollar that dominated East Asian trade for generations. One symbol, two countries, and a shared etymology stretching across the region.",
+  "date_published": "2026-07-13",
+  "date_modified": "2026-07-13",
+  "copy_pattern": "single",
+  "sections": [
+    {
+      "id": "won-sign",
+      "label": "Won Sign",
+      "h2": "The Won Symbol (₩)",
+      "intro": "The mark itself: a capital W with a horizontal bar through the middle. U+20A9 is the standard sign for almost every context; the fullwidth version is a compatibility character that lines up with the fixed grid of Korean and other CJK text.",
+      "symbols": [
+        {
+          "char": "₩",
+          "label": "Won Sign (U+20A9)"
+        },
+        {
+          "char": "￦",
+          "label": "Fullwidth Won Sign (U+FFE6)"
+        }
+      ]
+    },
+    {
+      "id": "two-koreas",
+      "label": "Two Koreas",
+      "h2": "One Sign, Two Rival Currencies",
+      "intro": "The same ₩ denotes both the South Korean won (KRW) and the North Korean won (KPW) — two currencies from two states that split in 1948 and remain, technically, at war. In Korean the unit is written 원 in Hangul. Nothing about the symbol distinguishes the two; only the three-letter currency code does.",
+      "symbols": [
+        {
+          "char": "₩",
+          "label": "Won Sign (U+20A9) — Shared by KRW (South) and KPW (North)"
+        },
+        {
+          "char": "원",
+          "label": "Won Written in Hangul (원)"
+        }
+      ]
+    },
+    {
+      "id": "won-yen-yuan",
+      "label": "Yen & Yuan Family",
+      "h2": "The Won, Yen & Yuan Family",
+      "intro": "Won, yen, and yuan are linguistic cousins — all three trace back to the character 圓 (simplified to 元 in modern China), meaning “round,” after the round silver dollars that once circulated across Asia. Japan’s yen and China’s yuan even share a single symbol, ¥, which is part of why non-native readers occasionally confuse ₩ and ¥ at a glance.",
+      "symbols": [
+        {
+          "char": "¥",
+          "label": "Yen & Yuan Sign (U+00A5)"
+        },
+        {
+          "char": "圓",
+          "label": "Hanja 圓 — “Round,” the Shared Root"
+        },
+        {
+          "char": "元",
+          "label": "Yuan (元)"
+        }
+      ]
+    }
+  ],
+  "related": [
+    {
+      "href": "/library/currency-symbols/",
+      "title": "Currency Symbols",
+      "desc": "A browsable set of world currency marks, from the dollar and euro to the rupee and bitcoin."
+    },
+    {
+      "href": "/symbol/yen-sign/",
+      "title": "Yen Sign",
+      "desc": "The won’s East Asian cousin — same “round” etymology, and the ¥ glyph non-native readers sometimes mix up with ₩."
+    },
+    {
+      "href": "/symbol/dollar-sign/",
+      "title": "Dollar Sign",
+      "desc": "The Spanish-American silver dollar that seeded the won, yen, and yuan is also the coin most often credited with the $ sign’s own origin."
+    }
+  ]
+}

--- a/library/crown-royalty-symbols/index.html
+++ b/library/crown-royalty-symbols/index.html
@@ -288,6 +288,10 @@
       <h4>Achievement Symbols</h4>
       <p>Trophies, medals, and crowns for wins, milestones, and status.</p>
     </a>
+    <a href="/symbol/fleur-de-lis-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Fleur-de-lis Symbol</h4>
+      <p>The fleur-de-lis (⚜).</p>
+    </a>
   </div>
 </section>
 

--- a/library/currency-symbols/index.html
+++ b/library/currency-symbols/index.html
@@ -512,6 +512,10 @@
       <h4>Dollar Sign ($)</h4>
       <p>The most recognized currency symbol on Earth — and historians still can't fully agree where it came from.</p>
     </a>
+    <a href="/symbol/won-sign/" class="compare-card variant-muted u-no-underline">
+      <h4>Won Sign</h4>
+      <p>The ₩ currency mark shared by both the South Korean won (KRW) and the North Korean won (KPW).</p>
+    </a>
   </div>
 </section>
 

--- a/library/egyptian-hieroglyphs/index.html
+++ b/library/egyptian-hieroglyphs/index.html
@@ -4566,6 +4566,10 @@
       <h4>Aesthetic Symbols</h4>
       <p>Decorative Unicode symbols for bios and captions.</p>
     </a>
+    <a href="/symbol/ankh-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Ankh Symbol</h4>
+      <p>The ankh (☥).</p>
+    </a>
   </div>
 </section>
 

--- a/library/electrical-circuit-symbols/index.html
+++ b/library/electrical-circuit-symbols/index.html
@@ -436,6 +436,10 @@
       <h4>Tech &amp; Status Symbols</h4>
       <p>Interface, signal, and device status glyphs to copy and paste.</p>
     </a>
+    <a href="/symbol/ohm-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Ohm Symbol</h4>
+      <p>The Ω sign for electrical resistance, named after Georg Simon Ohm — the German physicist behind Ohm’s law, V = IR.</p>
+    </a>
   </div>
 </section>
 

--- a/library/greek-letter-symbols/index.html
+++ b/library/greek-letter-symbols/index.html
@@ -450,6 +450,18 @@
       <h4>Omega Symbol</h4>
       <p>The last letter of the Greek alphabet (Ω, ω).</p>
     </a>
+    <a href="/symbol/alpha-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Alpha Symbol</h4>
+      <p>The first letter of the Greek alphabet — capital Α and lowercase α.</p>
+    </a>
+    <a href="/symbol/delta-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Delta Symbol</h4>
+      <p>The capital Δ that means ‘change in’ across math, physics, and engineering, and the lowercase δ used for infinitesimals and the partial…</p>
+    </a>
+    <a href="/symbol/pi-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Pi Symbol</h4>
+      <p>The lowercase π everyone means by ‘the pi symbol,’ the capital Π that means ‘product’ in math, and the dedicated ∏ product operator.</p>
+    </a>
   </div>
 </section>
 

--- a/library/math-symbols/index.html
+++ b/library/math-symbols/index.html
@@ -696,6 +696,18 @@
       <h4>Not Equal Sign</h4>
       <p>The equals sign with a slash through it (≠).</p>
     </a>
+    <a href="/symbol/congruent-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Congruent Symbol</h4>
+      <p>The ≅ that every geometry class uses for congruent shapes — same shape, same size.</p>
+    </a>
+    <a href="/symbol/delta-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Delta Symbol</h4>
+      <p>The capital Δ that means ‘change in’ across math, physics, and engineering, and the lowercase δ used for infinitesimals and the partial…</p>
+    </a>
+    <a href="/symbol/pi-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Pi Symbol</h4>
+      <p>The lowercase π everyone means by ‘the pi symbol,’ the capital Π that means ‘product’ in math, and the dedicated ∏ product operator.</p>
+    </a>
   </div>
 </section>
 

--- a/library/recycle-environment-symbols/index.html
+++ b/library/recycle-environment-symbols/index.html
@@ -250,6 +250,10 @@
       <h4>Special Characters</h4>
       <p>Unique Unicode symbols with individual meaning and standalone appeal.</p>
     </a>
+    <a href="/symbol/recycling-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Recycling Symbol</h4>
+      <p>The recycling symbol (♻).</p>
+    </a>
   </div>
 </section>
 

--- a/library/religious-symbols/index.html
+++ b/library/religious-symbols/index.html
@@ -509,6 +509,10 @@
       <h4>Orthodox Cross</h4>
       <p>The three-bar cross (☦) most closely associated with Russian Orthodoxy.</p>
     </a>
+    <a href="/symbol/om-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Om Symbol</h4>
+      <p>Om, or Aum (ॐ, 🕉️).</p>
+    </a>
   </div>
 </section>
 

--- a/library/zodiac-symbols/index.html
+++ b/library/zodiac-symbols/index.html
@@ -449,6 +449,30 @@
       <h4>Taurus Symbol</h4>
       <p>Taurus's glyph (♉) is a bull's head and horns.</p>
     </a>
+    <a href="/symbol/aries-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Aries Symbol</h4>
+      <p>Aries's glyph (♈) is a pair of curved ram's horns.</p>
+    </a>
+    <a href="/symbol/cancer-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Cancer Symbol</h4>
+      <p>Cancer's glyph (♋) is a pair of curled crab claws.</p>
+    </a>
+    <a href="/symbol/capricorn-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Capricorn Symbol</h4>
+      <p>Capricorn's glyph (♑) is a monogram of the sea-goat.</p>
+    </a>
+    <a href="/symbol/pisces-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Pisces Symbol</h4>
+      <p>Pisces's glyph (♓) is two crescents joined by a bar.</p>
+    </a>
+    <a href="/symbol/scorpio-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Scorpio Symbol</h4>
+      <p>Scorpio's glyph (♏) is a scorpion's body ending in a raised, stinging tail.</p>
+    </a>
+    <a href="/symbol/virgo-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Virgo Symbol</h4>
+      <p>Virgo's glyph (♍) is a looped ‘M’ read as a maiden holding a sheaf of wheat.</p>
+    </a>
   </div>
 </section>
 

--- a/symbol/alpha-symbol/index.html
+++ b/symbol/alpha-symbol/index.html
@@ -1,0 +1,215 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8242324164413945"
+       crossorigin="anonymous"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Alpha Symbol: Copy &amp; Paste Α α — The Beginning to Omega's End</title>
+<meta name="description" content="Copy and paste the alpha symbol — the Greek letter Α α that opens the alphabet, the ‘Alpha’ of the Bible&#x27;s ‘Alpha and Omega,’ and the sign for alpha particles and investment alpha. Click any symbol to copy it instantly.">
+
+<link rel="canonical" href="https://ultratextgen.com/symbol/alpha-symbol/">
+<meta property="og:image" content="https://ultratextgen.com/logo.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Alpha Symbol: Copy &amp; Paste Α α — The Beginning to Omega&#x27;s End">
+<meta name="twitter:description" content="Copy and paste the alpha symbol — the Greek letter Α α that opens the alphabet, the ‘Alpha’ of the Bible&#x27;s ‘Alpha and Omega,’ and the sign for alpha particles and investment alpha. Click any symbol to copy it instantly.">
+<meta name="twitter:image" content="https://ultratextgen.com/logo.png">
+<meta property="og:title" content="Alpha Symbol: Copy &amp; Paste Α α — The Beginning to Omega&#x27;s End">
+<meta property="og:description" content="Copy and paste the alpha symbol — the Greek letter Α α that opens the alphabet, the ‘Alpha’ of the Bible&#x27;s ‘Alpha and Omega,’ and the sign for alpha particles and investment alpha. Click any symbol to copy it instantly.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/symbol/alpha-symbol/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Alpha Symbol: Copy & Paste Α α — The Beginning to Omega's End",
+  "description": "Copy and paste the alpha symbol — the Greek letter Α α that opens the alphabet, the ‘Alpha’ of the Bible's ‘Alpha and Omega,’ and the sign for alpha particles and investment alpha. Click any symbol to copy it instantly.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "mainEntityOfPage": "https://ultratextgen.com/symbol/alpha-symbol/",
+  "datePublished": "2026-07-13",
+  "dateModified": "2026-07-13"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://ultratextgen.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Symbols",
+      "item": "https://ultratextgen.com/symbol/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Alpha Symbol",
+      "item": "https://ultratextgen.com/symbol/alpha-symbol/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<script src="/header.js"></script>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Alpha Symbol</h1>
+    <p class="hero-tagline">The first letter of the Greek alphabet — capital Α and lowercase α — the ‘Alpha’ of ‘Alpha and Omega,’ and the symbol behind alpha particles, investment alpha, and more. Click any symbol to copy it instantly.</p>
+  </div>
+</section>
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Alpha is the first letter of the Greek alphabet — capital Α (U+0391) and lowercase α (U+03B1) — and where omega means ‘the end,’ alpha has always meant ‘the beginning.’ The pairing is ancient and famous: in the New Testament, Revelation 22:13 reads ‘I am Alpha and Omega, the beginning and the end, the first and the last,’ using the alphabet's bookend letters as a metaphor for totality. Beyond scripture, the lowercase α does heavy scientific lifting: an ‘alpha particle’ is the nucleus of a helium atom — two protons and two neutrons — flung out during alpha decay, and α also denotes the fine-structure constant in physics and angles in geometry. In finance, ‘alpha’ is the return an investment earns above its benchmark, formalized as Jensen's alpha by economist Michael Jensen in the 1960s. The word even seeped into pop culture as ‘alpha male’ — a phrase rooted in mid-20th-century studies of captive wolves that the researcher most associated with it, David Mech, later publicly disowned as a misreading of how wild wolves actually live.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="the-alpha-symbol">
+  <span class="article-section-label">The Alpha Symbol</span>
+  <h2>The Alpha Symbol — Α &amp; α</h2>
+  <p class="u-secondary-tight">The Greek letter itself, in both cases. Lowercase α is the one most people mean; it also carries a value of one in the ancient Greek numeral system.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="Α" aria-label="Copy Greek Capital Letter Alpha (U+0391)">Α</button>
+      <span class="flag-label">Greek Capital Letter Alpha (U+0391)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="α" aria-label="Copy Greek Small Letter Alpha (U+03B1)">α</button>
+      <span class="flag-label">Greek Small Letter Alpha (U+03B1)</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="alpha-and-omega">
+  <span class="article-section-label">Alpha &amp; Omega</span>
+  <h2>Alpha and Omega — The Beginning and the End</h2>
+  <p class="u-secondary-tight">The most famous use of the letter: paired with omega as the first and last letters of the Greek alphabet, a metaphor for ‘everything from start to finish’ (Revelation 22:13). Copy the bookend pair.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="α" aria-label="Copy Small Alpha — ‘The Beginning’">α</button>
+      <span class="flag-label">Small Alpha — ‘The Beginning’</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="Ω" aria-label="Copy Capital Omega — ‘The End’">Ω</button>
+      <span class="flag-label">Capital Omega — ‘The End’</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="Α" aria-label="Copy Capital Alpha">Α</button>
+      <span class="flag-label">Capital Alpha</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ω" aria-label="Copy Small Omega">ω</button>
+      <span class="flag-label">Small Omega</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="related-greek-letters">
+  <span class="article-section-label">Greek Letters</span>
+  <h2>Related Greek Letters</h2>
+  <p class="u-secondary-tight">Alpha opens the alphabet; beta follows it, and these are the other Greek letters searched for most often.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="β" aria-label="Copy Greek Small Letter Beta">β</button>
+      <span class="flag-label">Greek Small Letter Beta</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="Σ" aria-label="Copy Greek Capital Letter Sigma">Σ</button>
+      <span class="flag-label">Greek Capital Letter Sigma</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="Δ" aria-label="Copy Greek Capital Letter Delta">Δ</button>
+      <span class="flag-label">Greek Capital Letter Delta</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="π" aria-label="Copy Greek Small Letter Pi">π</button>
+      <span class="flag-label">Greek Small Letter Pi</span>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Transform text with Unicode fonts</h3>
+  <p>Use UltraTextGen to convert plain text into bold, italic, cursive, and 100+ other Unicode font styles — free and instant.</p>
+  <a href="https://ultratextgen.com/" class="cta-btn">Open UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Related Resources</span>
+  <div class="compare-grid">
+    <a href="/library/greek-letter-symbols/" class="compare-card variant-muted u-no-underline">
+      <h4>Greek Letter Symbols</h4>
+      <p>The full Greek alphabet in uppercase, lowercase, and math variant forms to copy and paste.</p>
+    </a>
+    <a href="/symbol/omega-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Omega Symbol</h4>
+      <p>Alpha's other half: ‘I am Alpha and Omega, the beginning and the end.’ The last letter of the alphabet, and the ohm sign it's confused with.</p>
+    </a>
+    <a href="/symbol/sigma-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Sigma Symbol</h4>
+      <p>Another single Greek letter whose fame outgrew the alphabet — the summation sign in math, the ‘sigma male’ meme online.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js"></script>
+<script src="/footer.js"></script>
+</body>
+</html>

--- a/symbol/ankh-symbol/index.html
+++ b/symbol/ankh-symbol/index.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8242324164413945"
+       crossorigin="anonymous"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Ankh Symbol: Copy &amp; Paste ☥ — the Egyptian Hieroglyph for "Life" Coptic Christians Reshaped into a Cross</title>
+<meta name="description" content="Copy and paste the ankh (☥ U+2625), the ancient Egyptian hieroglyph for &quot;life&quot; held by gods and pharaohs — and the looped cross, the crux ansata, that early Coptic Christians made from it. Click any symbol to copy it instantly.">
+
+<link rel="canonical" href="https://ultratextgen.com/symbol/ankh-symbol/">
+<meta property="og:image" content="https://ultratextgen.com/logo.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Ankh Symbol: Copy &amp; Paste ☥ — the Egyptian Hieroglyph for &quot;Life&quot; Coptic Christians Reshaped into a Cross">
+<meta name="twitter:description" content="Copy and paste the ankh (☥ U+2625), the ancient Egyptian hieroglyph for &quot;life&quot; held by gods and pharaohs — and the looped cross, the crux ansata, that early Coptic Christians made from it. Click any symbol to copy it instantly.">
+<meta name="twitter:image" content="https://ultratextgen.com/logo.png">
+<meta property="og:title" content="Ankh Symbol: Copy &amp; Paste ☥ — the Egyptian Hieroglyph for &quot;Life&quot; Coptic Christians Reshaped into a Cross">
+<meta property="og:description" content="Copy and paste the ankh (☥ U+2625), the ancient Egyptian hieroglyph for &quot;life&quot; held by gods and pharaohs — and the looped cross, the crux ansata, that early Coptic Christians made from it. Click any symbol to copy it instantly.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/symbol/ankh-symbol/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Ankh Symbol: Copy & Paste ☥ — the Egyptian Hieroglyph for \"Life\" Coptic Christians Reshaped into a Cross",
+  "description": "Copy and paste the ankh (☥ U+2625), the ancient Egyptian hieroglyph for \"life\" held by gods and pharaohs — and the looped cross, the crux ansata, that early Coptic Christians made from it. Click any symbol to copy it instantly.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "mainEntityOfPage": "https://ultratextgen.com/symbol/ankh-symbol/",
+  "datePublished": "2026-07-13",
+  "dateModified": "2026-07-13"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://ultratextgen.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Symbols",
+      "item": "https://ultratextgen.com/symbol/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Ankh Symbol",
+      "item": "https://ultratextgen.com/symbol/ankh-symbol/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<script src="/header.js"></script>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Ankh Symbol</h1>
+    <p class="hero-tagline">The ankh (☥) — the ancient Egyptian hieroglyph meaning "life," later adapted by early Coptic Christians into a looped cross called the crux ansata. Click any symbol to copy it instantly.</p>
+  </div>
+</section>
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>The ankh (☥, U+2625) is an ancient Egyptian symbol meaning "life" or "to live." It was more than an icon: in the hieroglyphic writing system it was a genuine sign — catalogued as S34 in Gardiner's Sign List — that spelled the triliteral consonant sequence ꜥ-n-ḫ (ankh), the Egyptian word for life. In tomb and temple art it appears held by deities and offered to pharaohs, a gesture representing the gift of life and revival in the afterlife. Unicode placed it in the Miscellaneous Symbols block as part of Unicode 1.1 in 1993. A well-documented turn in its history came in Egypt's Coptic period: as Christianity spread there, some early Coptic Christians adapted the ankh's looped shape into a form of the Christian cross known as the crux ansata — Latin for "cross with a handle." Today the ankh also circulates in secular and spiritual settings — as jewelry, in tattoo art, and within modern Kemetic (revived ancient Egyptian) practice. This page reports that history as documented, without asserting any modern ownership of the symbol.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="ankh">
+  <span class="article-section-label">Ankh</span>
+  <h2>Ankh Symbol</h2>
+  <p class="u-secondary-tight">The ankh dingbat and the cross forms its looped shape is historically linked to.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☥" aria-label="Copy Ankh (Key of Life)">☥</button>
+      <span class="flag-label">Ankh (Key of Life)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✝️" aria-label="Copy Latin Cross">✝️</button>
+      <span class="flag-label">Latin Cross</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☦️" aria-label="Copy Orthodox Cross">☦️</button>
+      <span class="flag-label">Orthodox Cross</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="egyptian-symbols">
+  <span class="article-section-label">Egyptian Symbols</span>
+  <h2>Ancient Egyptian Symbols</h2>
+  <p class="u-secondary-tight">Emoji commonly associated with ancient Egypt and the imagery the ankh appears among.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🪲" aria-label="Copy Scarab Beetle">🪲</button>
+      <span class="flag-label">Scarab Beetle</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐍" aria-label="Copy Snake">🐍</button>
+      <span class="flag-label">Snake</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="👁️" aria-label="Copy Eye">👁️</button>
+      <span class="flag-label">Eye</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐈" aria-label="Copy Cat">🐈</button>
+      <span class="flag-label">Cat</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="protective-spiritual">
+  <span class="article-section-label">Spiritual &amp; Protective</span>
+  <h2>Spiritual &amp; Protective Symbols</h2>
+  <p class="u-secondary-tight">Other single-glyph spiritual and protective symbols the ankh is often searched alongside.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧿" aria-label="Copy Nazar Amulet (Evil Eye)">🧿</button>
+      <span class="flag-label">Nazar Amulet (Evil Eye)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🪬" aria-label="Copy Hamsa Hand">🪬</button>
+      <span class="flag-label">Hamsa Hand</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☯️" aria-label="Copy Yin Yang">☯️</button>
+      <span class="flag-label">Yin Yang</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☮️" aria-label="Copy Peace Symbol">☮️</button>
+      <span class="flag-label">Peace Symbol</span>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Transform text with Unicode fonts</h3>
+  <p>Use UltraTextGen to convert plain text into bold, italic, cursive, and 100+ other Unicode font styles — free and instant.</p>
+  <a href="https://ultratextgen.com/" class="cta-btn">Open UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Related Resources</span>
+  <div class="compare-grid">
+    <a href="/library/egyptian-hieroglyphs/" class="compare-card variant-muted u-no-underline">
+      <h4>Egyptian Hieroglyphs</h4>
+      <p>The full hieroglyphic writing system the ankh (sign S34) belongs to.</p>
+    </a>
+    <a href="/symbol/cross-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Cross Symbol</h4>
+      <p>The Christian cross whose early "crux ansata" form grew directly out of the ankh's looped shape in Coptic Egypt.</p>
+    </a>
+    <a href="/symbol/hamsa-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Hamsa Symbol</h4>
+      <p>Another ancient life-and-protection symbol reported as documented history, without picking a side.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js"></script>
+<script src="/footer.js"></script>
+</body>
+</html>

--- a/symbol/aries-symbol/index.html
+++ b/symbol/aries-symbol/index.html
@@ -1,0 +1,207 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8242324164413945"
+       crossorigin="anonymous"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Aries Symbol: Copy &amp; Paste ♈ — The Ram Whose Fleece Became Jason's Golden Fleece</title>
+<meta name="description" content="Copy and paste the Aries zodiac symbol (♈) and the Golden Fleece myth behind it — the winged ram that carried Phrixus to Colchis, whose fleece became the prize Jason and the Argonauts sailed to claim. Click any symbol to copy it instantly.">
+
+<link rel="canonical" href="https://ultratextgen.com/symbol/aries-symbol/">
+<meta property="og:image" content="https://ultratextgen.com/logo.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Aries Symbol: Copy &amp; Paste ♈ — The Ram Whose Fleece Became Jason&#x27;s Golden Fleece">
+<meta name="twitter:description" content="Copy and paste the Aries zodiac symbol (♈) and the Golden Fleece myth behind it — the winged ram that carried Phrixus to Colchis, whose fleece became the prize Jason and the Argonauts sailed to claim. Click any symbol to copy it instantly.">
+<meta name="twitter:image" content="https://ultratextgen.com/logo.png">
+<meta property="og:title" content="Aries Symbol: Copy &amp; Paste ♈ — The Ram Whose Fleece Became Jason&#x27;s Golden Fleece">
+<meta property="og:description" content="Copy and paste the Aries zodiac symbol (♈) and the Golden Fleece myth behind it — the winged ram that carried Phrixus to Colchis, whose fleece became the prize Jason and the Argonauts sailed to claim. Click any symbol to copy it instantly.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/symbol/aries-symbol/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Aries Symbol: Copy & Paste ♈ — The Ram Whose Fleece Became Jason's Golden Fleece",
+  "description": "Copy and paste the Aries zodiac symbol (♈) and the Golden Fleece myth behind it — the winged ram that carried Phrixus to Colchis, whose fleece became the prize Jason and the Argonauts sailed to claim. Click any symbol to copy it instantly.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "mainEntityOfPage": "https://ultratextgen.com/symbol/aries-symbol/",
+  "datePublished": "2026-07-13",
+  "dateModified": "2026-07-13"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://ultratextgen.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Symbols",
+      "item": "https://ultratextgen.com/symbol/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Aries Symbol",
+      "item": "https://ultratextgen.com/symbol/aries-symbol/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<script src="/header.js"></script>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Aries Symbol</h1>
+    <p class="hero-tagline">Aries's glyph (♈) is a pair of curved ram's horns — the first sign of the zodiac, tied to the golden-fleeced ram whose fleece later became the prize Jason and the Argonauts sailed east to claim. Click any symbol to copy it instantly.</p>
+  </div>
+</section>
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>The Aries symbol (♈, U+2648) is drawn as a pair of curved ram's horns, and Aries is the first sign of the zodiac. The myth behind it is the origin of the Golden Fleece: a winged, golden-fleeced ram — Chrysomallos in Greek — was sent to rescue Phrixus and his sister Helle, two children their stepmother had schemed to have sacrificed. As the ram flew them across the sea, Helle lost her grip and fell, drowning at the strait still called the Hellespont (‘Sea of Helle’) in her memory. Phrixus reached Colchis safely, sacrificed the ram in gratitude, and dedicated its golden fleece there — the very fleece that generations later became the prize Jason and the Argonauts sailed east to claim. The ram itself was set among the stars as the constellation Aries. Aries runs March 21–April 19, is ruled by Mars, and is a Fire sign with Cardinal modality.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="aries-symbol">
+  <span class="article-section-label">Aries</span>
+  <h2>Aries Symbol</h2>
+  <p class="u-secondary-tight">The Unicode Aries zodiac glyph, ready to paste.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♈" aria-label="Copy Aries Symbol">♈</button>
+      <span class="flag-label">Aries Symbol</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♈️" aria-label="Copy Aries Symbol (Emoji)">♈️</button>
+      <span class="flag-label">Aries Symbol (Emoji)</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="ruling-planet-element">
+  <span class="article-section-label">Planet &amp; Element</span>
+  <h2>Ruling Planet &amp; Element</h2>
+  <p class="u-secondary-tight">The planet and classical element traditionally associated with Aries.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♂" aria-label="Copy Mars (Ruling Planet)">♂</button>
+      <span class="flag-label">Mars (Ruling Planet)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜂" aria-label="Copy Fire (Element, Alchemical)">🜂</button>
+      <span class="flag-label">Fire (Element, Alchemical)</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="related-zodiac-celestial">
+  <span class="article-section-label">Zodiac &amp; Celestial</span>
+  <h2>More Zodiac &amp; Celestial Symbols</h2>
+  <p class="u-secondary-tight">Celestial bodies and the astrological opposite of Aries (Libra).</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☉" aria-label="Copy Sun">☉</button>
+      <span class="flag-label">Sun</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☽" aria-label="Copy Moon (First Quarter)">☽</button>
+      <span class="flag-label">Moon (First Quarter)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛎" aria-label="Copy Ophiuchus (Unofficial 13th Sign)">⛎</button>
+      <span class="flag-label">Ophiuchus (Unofficial 13th Sign)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♎" aria-label="Copy Libra (Opposite Sign)">♎</button>
+      <span class="flag-label">Libra (Opposite Sign)</span>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Transform text with Unicode fonts</h3>
+  <p>Use UltraTextGen to convert plain text into bold, italic, cursive, and 100+ other Unicode font styles — free and instant.</p>
+  <a href="https://ultratextgen.com/" class="cta-btn">Open UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Related Resources</span>
+  <div class="compare-grid">
+    <a href="/library/zodiac-symbols/" class="compare-card variant-muted u-no-underline">
+      <h4>Zodiac Symbols</h4>
+      <p>Western zodiac signs, planetary symbols, and Chinese zodiac animals in one reference.</p>
+    </a>
+    <a href="/symbol/libra-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Libra Symbol</h4>
+      <p>Aries's astrological opposite sign, directly across the zodiac wheel.</p>
+    </a>
+    <a href="/symbol/leo-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Leo Symbol</h4>
+      <p>A fellow Fire sign, with the Nemean Lion myth behind its glyph.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js"></script>
+<script src="/footer.js"></script>
+</body>
+</html>

--- a/symbol/cancer-symbol/index.html
+++ b/symbol/cancer-symbol/index.html
@@ -1,0 +1,207 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8242324164413945"
+       crossorigin="anonymous"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Cancer Symbol: Copy &amp; Paste ♋ — The Only Zodiac Sign Ruled by the Moon</title>
+<meta name="description" content="Copy and paste the Cancer zodiac symbol (♋) and the crab myth behind it — the giant crab Hera sent against Heracles during his second labor, and why Cancer is the only sign ruled by the Moon. Click any symbol to copy it instantly.">
+
+<link rel="canonical" href="https://ultratextgen.com/symbol/cancer-symbol/">
+<meta property="og:image" content="https://ultratextgen.com/logo.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Cancer Symbol: Copy &amp; Paste ♋ — The Only Zodiac Sign Ruled by the Moon">
+<meta name="twitter:description" content="Copy and paste the Cancer zodiac symbol (♋) and the crab myth behind it — the giant crab Hera sent against Heracles during his second labor, and why Cancer is the only sign ruled by the Moon. Click any symbol to copy it instantly.">
+<meta name="twitter:image" content="https://ultratextgen.com/logo.png">
+<meta property="og:title" content="Cancer Symbol: Copy &amp; Paste ♋ — The Only Zodiac Sign Ruled by the Moon">
+<meta property="og:description" content="Copy and paste the Cancer zodiac symbol (♋) and the crab myth behind it — the giant crab Hera sent against Heracles during his second labor, and why Cancer is the only sign ruled by the Moon. Click any symbol to copy it instantly.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/symbol/cancer-symbol/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Cancer Symbol: Copy & Paste ♋ — The Only Zodiac Sign Ruled by the Moon",
+  "description": "Copy and paste the Cancer zodiac symbol (♋) and the crab myth behind it — the giant crab Hera sent against Heracles during his second labor, and why Cancer is the only sign ruled by the Moon. Click any symbol to copy it instantly.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "mainEntityOfPage": "https://ultratextgen.com/symbol/cancer-symbol/",
+  "datePublished": "2026-07-13",
+  "dateModified": "2026-07-13"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://ultratextgen.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Symbols",
+      "item": "https://ultratextgen.com/symbol/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Cancer Symbol",
+      "item": "https://ultratextgen.com/symbol/cancer-symbol/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<script src="/header.js"></script>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Cancer Symbol</h1>
+    <p class="hero-tagline">Cancer's glyph (♋) is a pair of curled crab claws — and Cancer is the only zodiac sign ruled by the Moon, making it and Sun-ruled Leo the two signs governed by a luminary instead of a planet. Click any symbol to copy it instantly.</p>
+  </div>
+</section>
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>The Cancer symbol (♋, U+264B) is drawn as two curled crab claws — a glyph so stylized that many people read it as a sideways ‘69’ or a pair of interlocking commas. Its myth comes from the Twelve Labors of Heracles: during his second labor, the fight against the many-headed Lernaean Hydra, the goddess Hera — who despised Heracles — sent a giant crab to hinder him. The crab pinched his foot, and Heracles crushed it underfoot. To honor its effort, Hera set the crab among the stars as Cancer, in a notably dim patch of sky. Cancer is also the only zodiac sign ruled by the Moon (☽), making it — alongside Sun-ruled Leo — one of just two signs governed by a luminary rather than a planet. It runs June 21–July 22, is a Water sign with Cardinal modality, and begins at the June solstice that gave the Tropic of Cancer its name.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="cancer-symbol">
+  <span class="article-section-label">Cancer</span>
+  <h2>Cancer Symbol</h2>
+  <p class="u-secondary-tight">The Unicode Cancer zodiac glyph, ready to paste.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♋" aria-label="Copy Cancer Symbol">♋</button>
+      <span class="flag-label">Cancer Symbol</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♋️" aria-label="Copy Cancer Symbol (Emoji)">♋️</button>
+      <span class="flag-label">Cancer Symbol (Emoji)</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="ruling-planet-element">
+  <span class="article-section-label">Planet &amp; Element</span>
+  <h2>Ruling Planet &amp; Element</h2>
+  <p class="u-secondary-tight">The planet and classical element traditionally associated with Cancer.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☽" aria-label="Copy Moon (Ruling Planet)">☽</button>
+      <span class="flag-label">Moon (Ruling Planet)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜄" aria-label="Copy Water (Element, Alchemical)">🜄</button>
+      <span class="flag-label">Water (Element, Alchemical)</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="related-zodiac-celestial">
+  <span class="article-section-label">Zodiac &amp; Celestial</span>
+  <h2>More Zodiac &amp; Celestial Symbols</h2>
+  <p class="u-secondary-tight">Celestial bodies and the astrological opposite of Cancer (Capricorn).</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☉" aria-label="Copy Sun">☉</button>
+      <span class="flag-label">Sun</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☽" aria-label="Copy Moon (First Quarter)">☽</button>
+      <span class="flag-label">Moon (First Quarter)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛎" aria-label="Copy Ophiuchus (Unofficial 13th Sign)">⛎</button>
+      <span class="flag-label">Ophiuchus (Unofficial 13th Sign)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♑" aria-label="Copy Capricorn (Opposite Sign)">♑</button>
+      <span class="flag-label">Capricorn (Opposite Sign)</span>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Transform text with Unicode fonts</h3>
+  <p>Use UltraTextGen to convert plain text into bold, italic, cursive, and 100+ other Unicode font styles — free and instant.</p>
+  <a href="https://ultratextgen.com/" class="cta-btn">Open UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Related Resources</span>
+  <div class="compare-grid">
+    <a href="/library/zodiac-symbols/" class="compare-card variant-muted u-no-underline">
+      <h4>Zodiac Symbols</h4>
+      <p>Western zodiac signs, planetary symbols, and Chinese zodiac animals in one reference.</p>
+    </a>
+    <a href="/symbol/capricorn-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Capricorn Symbol</h4>
+      <p>Cancer's astrological opposite sign, directly across the zodiac wheel.</p>
+    </a>
+    <a href="/symbol/leo-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Leo Symbol</h4>
+      <p>The zodiac's only Sun-ruled sign — the luminary counterpart to Moon-ruled Cancer.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js"></script>
+<script src="/footer.js"></script>
+</body>
+</html>

--- a/symbol/capricorn-symbol/index.html
+++ b/symbol/capricorn-symbol/index.html
@@ -1,0 +1,207 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8242324164413945"
+       crossorigin="anonymous"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Capricorn Symbol: Copy &amp; Paste ♑ — The Sea-Goat, Half Goat and Half Fish</title>
+<meta name="description" content="Copy and paste the Capricorn zodiac symbol (♑) and the sea-goat myth behind it — the god Pan&#x27;s half-finished escape from the monster Typhon, leaving him part goat, part fish. Click any symbol to copy it instantly.">
+
+<link rel="canonical" href="https://ultratextgen.com/symbol/capricorn-symbol/">
+<meta property="og:image" content="https://ultratextgen.com/logo.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Capricorn Symbol: Copy &amp; Paste ♑ — The Sea-Goat, Half Goat and Half Fish">
+<meta name="twitter:description" content="Copy and paste the Capricorn zodiac symbol (♑) and the sea-goat myth behind it — the god Pan&#x27;s half-finished escape from the monster Typhon, leaving him part goat, part fish. Click any symbol to copy it instantly.">
+<meta name="twitter:image" content="https://ultratextgen.com/logo.png">
+<meta property="og:title" content="Capricorn Symbol: Copy &amp; Paste ♑ — The Sea-Goat, Half Goat and Half Fish">
+<meta property="og:description" content="Copy and paste the Capricorn zodiac symbol (♑) and the sea-goat myth behind it — the god Pan&#x27;s half-finished escape from the monster Typhon, leaving him part goat, part fish. Click any symbol to copy it instantly.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/symbol/capricorn-symbol/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Capricorn Symbol: Copy & Paste ♑ — The Sea-Goat, Half Goat and Half Fish",
+  "description": "Copy and paste the Capricorn zodiac symbol (♑) and the sea-goat myth behind it — the god Pan's half-finished escape from the monster Typhon, leaving him part goat, part fish. Click any symbol to copy it instantly.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "mainEntityOfPage": "https://ultratextgen.com/symbol/capricorn-symbol/",
+  "datePublished": "2026-07-13",
+  "dateModified": "2026-07-13"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://ultratextgen.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Symbols",
+      "item": "https://ultratextgen.com/symbol/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Capricorn Symbol",
+      "item": "https://ultratextgen.com/symbol/capricorn-symbol/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<script src="/header.js"></script>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Capricorn Symbol</h1>
+    <p class="hero-tagline">Capricorn's glyph (♑) is a monogram of the sea-goat — a mythical hybrid with a goat's head and horns joined to a fish's tail, born from a god's half-finished escape. Click any symbol to copy it instantly.</p>
+  </div>
+</section>
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>The Capricorn symbol (♑, U+2651) is a stylized monogram of the sea-goat — a creature with the head and horns of a goat joined to the curling tail of a fish. That strange hybrid comes straight from Greek myth: when the monster Typhon attacked the gods, Pan — the goat-legged god of the wild — fled to the banks of the Nile and leapt in, trying to turn himself into a fish to escape. The transformation only half-worked: his upper body stayed a goat while his lower half became a fish's tail. Zeus set that half-goat, half-fish form among the stars as Capricorn. It runs December 22–January 19, is an Earth sign with Cardinal modality, and is ruled by Saturn (♄). Capricorn begins at the December solstice — the reason Earth's southern line of latitude is called the Tropic of Capricorn.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="capricorn-symbol">
+  <span class="article-section-label">Capricorn</span>
+  <h2>Capricorn Symbol</h2>
+  <p class="u-secondary-tight">The Unicode Capricorn zodiac glyph, ready to paste.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♑" aria-label="Copy Capricorn Symbol">♑</button>
+      <span class="flag-label">Capricorn Symbol</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♑️" aria-label="Copy Capricorn Symbol (Emoji)">♑️</button>
+      <span class="flag-label">Capricorn Symbol (Emoji)</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="ruling-planet-element">
+  <span class="article-section-label">Planet &amp; Element</span>
+  <h2>Ruling Planet &amp; Element</h2>
+  <p class="u-secondary-tight">The planet and classical element traditionally associated with Capricorn.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♄" aria-label="Copy Saturn (Ruling Planet)">♄</button>
+      <span class="flag-label">Saturn (Ruling Planet)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜃" aria-label="Copy Earth (Element, Alchemical)">🜃</button>
+      <span class="flag-label">Earth (Element, Alchemical)</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="related-zodiac-celestial">
+  <span class="article-section-label">Zodiac &amp; Celestial</span>
+  <h2>More Zodiac &amp; Celestial Symbols</h2>
+  <p class="u-secondary-tight">Celestial bodies and the astrological opposite of Capricorn (Cancer).</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☉" aria-label="Copy Sun">☉</button>
+      <span class="flag-label">Sun</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☽" aria-label="Copy Moon (First Quarter)">☽</button>
+      <span class="flag-label">Moon (First Quarter)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛎" aria-label="Copy Ophiuchus (Unofficial 13th Sign)">⛎</button>
+      <span class="flag-label">Ophiuchus (Unofficial 13th Sign)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♋" aria-label="Copy Cancer (Opposite Sign)">♋</button>
+      <span class="flag-label">Cancer (Opposite Sign)</span>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Transform text with Unicode fonts</h3>
+  <p>Use UltraTextGen to convert plain text into bold, italic, cursive, and 100+ other Unicode font styles — free and instant.</p>
+  <a href="https://ultratextgen.com/" class="cta-btn">Open UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Related Resources</span>
+  <div class="compare-grid">
+    <a href="/library/zodiac-symbols/" class="compare-card variant-muted u-no-underline">
+      <h4>Zodiac Symbols</h4>
+      <p>Western zodiac signs, planetary symbols, and Chinese zodiac animals in one reference.</p>
+    </a>
+    <a href="/symbol/cancer-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Cancer Symbol</h4>
+      <p>Capricorn's astrological opposite sign, directly across the zodiac wheel.</p>
+    </a>
+    <a href="/symbol/taurus-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Taurus Symbol</h4>
+      <p>A fellow Earth sign, and likely the oldest continuously tracked constellation in the zodiac.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js"></script>
+<script src="/footer.js"></script>
+</body>
+</html>

--- a/symbol/congruent-symbol/index.html
+++ b/symbol/congruent-symbol/index.html
@@ -1,0 +1,211 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8242324164413945"
+       crossorigin="anonymous"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Congruent Symbol: Copy &amp; Paste ≅ — The Sign Unicode Doesn't Even Call ‘Congruent’</title>
+<meta name="description" content="Copy and paste the congruent symbol ≅ — the geometry sign for ‘same shape and size’ that Unicode officially names ‘Approximately Equal To’ (U+2245) — and tell it apart from the look-alikes ≈ and ≡. Click any symbol to copy it instantly.">
+
+<link rel="canonical" href="https://ultratextgen.com/symbol/congruent-symbol/">
+<meta property="og:image" content="https://ultratextgen.com/logo.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Congruent Symbol: Copy &amp; Paste ≅ — The Sign Unicode Doesn&#x27;t Even Call ‘Congruent’">
+<meta name="twitter:description" content="Copy and paste the congruent symbol ≅ — the geometry sign for ‘same shape and size’ that Unicode officially names ‘Approximately Equal To’ (U+2245) — and tell it apart from the look-alikes ≈ and ≡. Click any symbol to copy it instantly.">
+<meta name="twitter:image" content="https://ultratextgen.com/logo.png">
+<meta property="og:title" content="Congruent Symbol: Copy &amp; Paste ≅ — The Sign Unicode Doesn&#x27;t Even Call ‘Congruent’">
+<meta property="og:description" content="Copy and paste the congruent symbol ≅ — the geometry sign for ‘same shape and size’ that Unicode officially names ‘Approximately Equal To’ (U+2245) — and tell it apart from the look-alikes ≈ and ≡. Click any symbol to copy it instantly.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/symbol/congruent-symbol/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Congruent Symbol: Copy & Paste ≅ — The Sign Unicode Doesn't Even Call ‘Congruent’",
+  "description": "Copy and paste the congruent symbol ≅ — the geometry sign for ‘same shape and size’ that Unicode officially names ‘Approximately Equal To’ (U+2245) — and tell it apart from the look-alikes ≈ and ≡. Click any symbol to copy it instantly.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "mainEntityOfPage": "https://ultratextgen.com/symbol/congruent-symbol/",
+  "datePublished": "2026-07-13",
+  "dateModified": "2026-07-13"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://ultratextgen.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Symbols",
+      "item": "https://ultratextgen.com/symbol/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Congruent Symbol",
+      "item": "https://ultratextgen.com/symbol/congruent-symbol/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<script src="/header.js"></script>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Congruent Symbol</h1>
+    <p class="hero-tagline">The ≅ that every geometry class uses for congruent shapes — same shape, same size — even though Unicode's official name for it is ‘Approximately Equal To.’ Plus the look-alikes ≈ and ≡ it's constantly confused with. Click any symbol to copy it instantly.</p>
+  </div>
+</section>
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>The congruent symbol, ≅, is the one math teachers draw when two shapes are congruent — identical in both shape and size. Here's the quirk: Unicode doesn't call it that. Its official name for the character (U+2245) is ‘APPROXIMATELY EQUAL TO,’ a label that never mentions congruence at all, yet ≅ is exactly the glyph geometry classrooms worldwide reach for. The symbol reads as two ideas stacked — the ≈ of approximation over the = of equality — and it sits in a crowded neighborhood of easily-confused relatives. ≈ (U+2248, ALMOST EQUAL TO) means ‘approximately,’ the one you'd use for π ≈ 3.14. ≡ (U+2261, IDENTICAL TO) means something stronger — identity, and in number theory it's the congruence sign of modular arithmetic, as in ‘17 ≡ 2 (mod 5).’ Three symbols, three jobs, all built from stacked horizontal strokes, and all routinely typed in place of one another. This page keeps them straight and lets you copy the exact one you need.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="the-congruent-symbol">
+  <span class="article-section-label">The Congruent Symbol</span>
+  <h2>The Congruent Symbol — ≅</h2>
+  <p class="u-secondary-tight">The glyph geometry uses for congruence — same shape and size — even though Unicode's official name for it makes no mention of the word. Its close visual cousin ≃ carries a single tilde instead of a double one.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="≅" aria-label="Copy Congruent To — Officially ‘Approximately Equal To’ (U+2245)">≅</button>
+      <span class="flag-label">Congruent To — Officially ‘Approximately Equal To’ (U+2245)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="≃" aria-label="Copy Asymptotically Equal To (U+2243) — The Single-Tilde Cousin">≃</button>
+      <span class="flag-label">Asymptotically Equal To (U+2243) — The Single-Tilde Cousin</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="confusable-neighbors">
+  <span class="article-section-label">Telling Them Apart</span>
+  <h2>≅ vs. ≈ vs. ≡ — The Confusable Neighbors</h2>
+  <p class="u-secondary-tight">Three stacked-stroke symbols that get swapped constantly, each with its own job. Congruent (same shape and size), approximately equal (a rough estimate), and identical to (true identity and modular congruence).</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="≅" aria-label="Copy Approximately Equal To (U+2245) — Used for Geometric Congruence">≅</button>
+      <span class="flag-label">Approximately Equal To (U+2245) — Used for Geometric Congruence</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="≈" aria-label="Copy Almost Equal To (U+2248) — Approximation, e.g. π ≈ 3.14">≈</button>
+      <span class="flag-label">Almost Equal To (U+2248) — Approximation, e.g. π ≈ 3.14</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="≡" aria-label="Copy Identical To (U+2261) — Identity &amp; Modular Congruence">≡</button>
+      <span class="flag-label">Identical To (U+2261) — Identity &amp; Modular Congruence</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="more-relation-symbols">
+  <span class="article-section-label">Relation Symbols</span>
+  <h2>More Math Relation Symbols</h2>
+  <p class="u-secondary-tight">The rest of the ‘equals family’ that lives beside the congruent sign in equations and proofs.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="≠" aria-label="Copy Not Equal To (U+2260)">≠</button>
+      <span class="flag-label">Not Equal To (U+2260)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="=" aria-label="Copy Equals Sign">=</button>
+      <span class="flag-label">Equals Sign</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="≤" aria-label="Copy Less-Than or Equal To">≤</button>
+      <span class="flag-label">Less-Than or Equal To</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="≥" aria-label="Copy Greater-Than or Equal To">≥</button>
+      <span class="flag-label">Greater-Than or Equal To</span>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Transform text with Unicode fonts</h3>
+  <p>Use UltraTextGen to convert plain text into bold, italic, cursive, and 100+ other Unicode font styles — free and instant.</p>
+  <a href="https://ultratextgen.com/" class="cta-btn">Open UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Related Resources</span>
+  <div class="compare-grid">
+    <a href="/library/math-symbols/" class="compare-card variant-muted u-no-underline">
+      <h4>Math Symbols</h4>
+      <p>The full set of relations, operators, and Greek letters that the congruent sign lives among in equations.</p>
+    </a>
+    <a href="/symbol/not-equal-sign/" class="compare-card variant-muted u-no-underline">
+      <h4>Not Equal Sign</h4>
+      <p>The opposite relation — and a close neighbor in the same ‘equals family’ of math symbols.</p>
+    </a>
+    <a href="/symbol/omega-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Omega Symbol</h4>
+      <p>Another character whose everyday identity — the ohm sign for electrical resistance — isn't the name Unicode officially gives it.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js"></script>
+<script src="/footer.js"></script>
+</body>
+</html>

--- a/symbol/delta-symbol/index.html
+++ b/symbol/delta-symbol/index.html
@@ -1,0 +1,211 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8242324164413945"
+       crossorigin="anonymous"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Delta Symbol: Copy &amp; Paste Δ δ — The Letter That Means ‘Change’ in Every Equation</title>
+<meta name="description" content="Copy and paste the delta symbol — capital Δ (the universal ‘change in’ sign) and lowercase δ — and learn its real meanings across math, physics, chemistry, and options trading, plus the ∆ increment sign it&#x27;s confused with. Click any symbol to copy it instantly.">
+
+<link rel="canonical" href="https://ultratextgen.com/symbol/delta-symbol/">
+<meta property="og:image" content="https://ultratextgen.com/logo.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Delta Symbol: Copy &amp; Paste Δ δ — The Letter That Means ‘Change’ in Every Equation">
+<meta name="twitter:description" content="Copy and paste the delta symbol — capital Δ (the universal ‘change in’ sign) and lowercase δ — and learn its real meanings across math, physics, chemistry, and options trading, plus the ∆ increment sign it&#x27;s confused with. Click any symbol to copy it instantly.">
+<meta name="twitter:image" content="https://ultratextgen.com/logo.png">
+<meta property="og:title" content="Delta Symbol: Copy &amp; Paste Δ δ — The Letter That Means ‘Change’ in Every Equation">
+<meta property="og:description" content="Copy and paste the delta symbol — capital Δ (the universal ‘change in’ sign) and lowercase δ — and learn its real meanings across math, physics, chemistry, and options trading, plus the ∆ increment sign it&#x27;s confused with. Click any symbol to copy it instantly.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/symbol/delta-symbol/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Delta Symbol: Copy & Paste Δ δ — The Letter That Means ‘Change’ in Every Equation",
+  "description": "Copy and paste the delta symbol — capital Δ (the universal ‘change in’ sign) and lowercase δ — and learn its real meanings across math, physics, chemistry, and options trading, plus the ∆ increment sign it's confused with. Click any symbol to copy it instantly.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "mainEntityOfPage": "https://ultratextgen.com/symbol/delta-symbol/",
+  "datePublished": "2026-07-13",
+  "dateModified": "2026-07-13"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://ultratextgen.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Symbols",
+      "item": "https://ultratextgen.com/symbol/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Delta Symbol",
+      "item": "https://ultratextgen.com/symbol/delta-symbol/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<script src="/header.js"></script>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Delta Symbol</h1>
+    <p class="hero-tagline">The capital Δ that means ‘change in’ across math, physics, and engineering, and the lowercase δ used for infinitesimals and the partial charges of a polar bond. Click any symbol to copy it instantly.</p>
+  </div>
+</section>
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Delta is the fourth letter of the Greek alphabet, and its capital form, Δ (U+0394, GREEK CAPITAL LETTER DELTA), is mathematical shorthand the whole world agrees on: it means ‘change in.’ Write Δx and every scientist reads ‘the change in x’; Δt is elapsed time, ΔV a change in voltage. The lowercase form, δ (U+03B4), takes the smaller jobs — an infinitesimal change in calculus, and in chemistry the partial charges δ+ and δ− that mark the slightly positive and slightly negative ends of a polar bond. The letter's triangular capital even named a landform: the fan-shaped mouth of a river is called a ‘delta’ because its shape echoes Δ, a comparison the ancient Greeks drew for the Nile. Delta reaches into finance too, where an option's ‘delta’ measures how much the option's price moves for every $1 move in the underlying asset. One letter, a dozen fields — all built on the single idea of difference.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="the-delta-symbol">
+  <span class="article-section-label">The Delta Symbol</span>
+  <h2>The Delta Symbol — Δ &amp; δ</h2>
+  <p class="u-secondary-tight">The Greek letter itself, in both cases. Capital Δ is the ‘change in’ sign; lowercase δ handles the smaller-scale jobs.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="Δ" aria-label="Copy Greek Capital Letter Delta (U+0394) — ‘Change In’">Δ</button>
+      <span class="flag-label">Greek Capital Letter Delta (U+0394) — ‘Change In’</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="δ" aria-label="Copy Greek Small Letter Delta (U+03B4) — Infinitesimal / Partial Charge">δ</button>
+      <span class="flag-label">Greek Small Letter Delta (U+03B4) — Infinitesimal / Partial Charge</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="increment-disambiguation">
+  <span class="article-section-label">Increment Sign</span>
+  <h2>The Increment Sign Mix-Up</h2>
+  <p class="u-secondary-tight">There is a separate math character, ∆ INCREMENT, that renders almost identically to capital delta but is a different codepoint — the same kind of look-alike trap as the ohm sign and omega. Some fonts and screen readers treat the two differently.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="∆" aria-label="Copy Increment (U+2206) — The Math Operator That Looks Like Δ, Different Codepoint">∆</button>
+      <span class="flag-label">Increment (U+2206) — The Math Operator That Looks Like Δ, Different Codepoint</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="Δ" aria-label="Copy Capital Delta (U+0394) — The Greek Letter Itself">Δ</button>
+      <span class="flag-label">Capital Delta (U+0394) — The Greek Letter Itself</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="related-greek-letters">
+  <span class="article-section-label">Greek Letters</span>
+  <h2>Related Greek Letters</h2>
+  <p class="u-secondary-tight">Delta sits alongside the other most-searched Greek letters. Copy whichever one your equation needs.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="Ω" aria-label="Copy Greek Capital Letter Omega">Ω</button>
+      <span class="flag-label">Greek Capital Letter Omega</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="Σ" aria-label="Copy Greek Capital Letter Sigma">Σ</button>
+      <span class="flag-label">Greek Capital Letter Sigma</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="π" aria-label="Copy Greek Small Letter Pi">π</button>
+      <span class="flag-label">Greek Small Letter Pi</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="α" aria-label="Copy Greek Small Letter Alpha">α</button>
+      <span class="flag-label">Greek Small Letter Alpha</span>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Transform text with Unicode fonts</h3>
+  <p>Use UltraTextGen to convert plain text into bold, italic, cursive, and 100+ other Unicode font styles — free and instant.</p>
+  <a href="https://ultratextgen.com/" class="cta-btn">Open UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Related Resources</span>
+  <div class="compare-grid">
+    <a href="/library/greek-letter-symbols/" class="compare-card variant-muted u-no-underline">
+      <h4>Greek Letter Symbols</h4>
+      <p>The full Greek alphabet in uppercase, lowercase, and math variant forms to copy and paste.</p>
+    </a>
+    <a href="/library/math-symbols/" class="compare-card variant-muted u-no-underline">
+      <h4>Math Symbols</h4>
+      <p>The ‘change in’ delta alongside the operators, relations, and Greek letters that fill out an equation.</p>
+    </a>
+    <a href="/symbol/omega-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Omega Symbol</h4>
+      <p>One of the two Greek letters the omega page displays without a link — now it has its own page. Omega closes the alphabet; delta pairs with it in math.</p>
+    </a>
+    <a href="/symbol/sigma-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Sigma Symbol</h4>
+      <p>Another workhorse Greek letter — the summation sign in math, and the ‘sigma male’ meme online.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js"></script>
+<script src="/footer.js"></script>
+</body>
+</html>

--- a/symbol/fleur-de-lis-symbol/index.html
+++ b/symbol/fleur-de-lis-symbol/index.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8242324164413945"
+       crossorigin="anonymous"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Fleur-de-lis Symbol: Copy &amp; Paste ⚜ — From French Royalty to the Scout Emblem and the New Orleans Saints</title>
+<meta name="description" content="Copy and paste the fleur-de-lis (⚜ U+269C), the stylized lily of French royalty — now the World Scout emblem, the New Orleans Saints logo, and a fixture of Quebec&#x27;s provincial flag. Click any symbol to copy it instantly.">
+
+<link rel="canonical" href="https://ultratextgen.com/symbol/fleur-de-lis-symbol/">
+<meta property="og:image" content="https://ultratextgen.com/logo.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Fleur-de-lis Symbol: Copy &amp; Paste ⚜ — From French Royalty to the Scout Emblem and the New Orleans Saints">
+<meta name="twitter:description" content="Copy and paste the fleur-de-lis (⚜ U+269C), the stylized lily of French royalty — now the World Scout emblem, the New Orleans Saints logo, and a fixture of Quebec&#x27;s provincial flag. Click any symbol to copy it instantly.">
+<meta name="twitter:image" content="https://ultratextgen.com/logo.png">
+<meta property="og:title" content="Fleur-de-lis Symbol: Copy &amp; Paste ⚜ — From French Royalty to the Scout Emblem and the New Orleans Saints">
+<meta property="og:description" content="Copy and paste the fleur-de-lis (⚜ U+269C), the stylized lily of French royalty — now the World Scout emblem, the New Orleans Saints logo, and a fixture of Quebec&#x27;s provincial flag. Click any symbol to copy it instantly.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/symbol/fleur-de-lis-symbol/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Fleur-de-lis Symbol: Copy & Paste ⚜ — From French Royalty to the Scout Emblem and the New Orleans Saints",
+  "description": "Copy and paste the fleur-de-lis (⚜ U+269C), the stylized lily of French royalty — now the World Scout emblem, the New Orleans Saints logo, and a fixture of Quebec's provincial flag. Click any symbol to copy it instantly.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "mainEntityOfPage": "https://ultratextgen.com/symbol/fleur-de-lis-symbol/",
+  "datePublished": "2026-07-13",
+  "dateModified": "2026-07-13"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://ultratextgen.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Symbols",
+      "item": "https://ultratextgen.com/symbol/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Fleur-de-lis Symbol",
+      "item": "https://ultratextgen.com/symbol/fleur-de-lis-symbol/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<script src="/header.js"></script>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Fleur-de-lis Symbol</h1>
+    <p class="hero-tagline">The fleur-de-lis (⚜) — a stylized lily that served as the emblem of French royalty and lives on today in Scouting's World Crest and the New Orleans Saints logo. Click any symbol to copy it instantly.</p>
+  </div>
+</section>
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>The fleur-de-lis (⚜, U+269C) is a heraldic charge in the stylized shape of a lily or iris — in French, fleur means "flower" and lis means "lily." It is most famous as an emblem of French royalty, appearing on the coat of arms of France from the High Middle Ages until the monarchy's fall in 1792. Unicode added it in version 4.1 (2005), in the Miscellaneous Symbols block. Alongside its royal use, the flower carries a documented Christian association: in religious art it is linked to the Virgin Mary, and its three petals are sometimes read as the Holy Trinity. The same emblem has been widely adopted in the modern era. It forms the World Scout emblem — its three points said to stand for the three parts of the Scout Promise — chosen by Scouting founder Robert Baden-Powell for its resemblance to the north point of a compass. It is the logo of the NFL's New Orleans Saints, a marker of the region's French heritage, and it features prominently on the provincial flag of Quebec.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="fleur-de-lis">
+  <span class="article-section-label">Fleur-de-lis</span>
+  <h2>Fleur-de-lis Symbol</h2>
+  <p class="u-secondary-tight">The fleur-de-lis dingbat and its emoji-style presentation.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚜" aria-label="Copy Fleur-de-lis">⚜</button>
+      <span class="flag-label">Fleur-de-lis</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚜️" aria-label="Copy Fleur-de-lis (Emoji Style)">⚜️</button>
+      <span class="flag-label">Fleur-de-lis (Emoji Style)</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="heraldry-royalty">
+  <span class="article-section-label">Royalty &amp; Heraldry</span>
+  <h2>Crown &amp; Royalty Symbols</h2>
+  <p class="u-secondary-tight">Crowns and regalia that share the fleur-de-lis's heraldic, royal context.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="👑" aria-label="Copy Crown">👑</button>
+      <span class="flag-label">Crown</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🤴" aria-label="Copy Prince">🤴</button>
+      <span class="flag-label">Prince</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="👸" aria-label="Copy Princess">👸</button>
+      <span class="flag-label">Princess</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🏰" aria-label="Copy Castle">🏰</button>
+      <span class="flag-label">Castle</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🛡️" aria-label="Copy Shield">🛡️</button>
+      <span class="flag-label">Shield</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="flower-emblem-symbols">
+  <span class="article-section-label">Flowers &amp; Florettes</span>
+  <h2>Flower &amp; Emblem Symbols</h2>
+  <p class="u-secondary-tight">Other single-glyph flower and florette emblems in the same decorative family.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌸" aria-label="Copy Cherry Blossom">🌸</button>
+      <span class="flag-label">Cherry Blossom</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌼" aria-label="Copy Blossom">🌼</button>
+      <span class="flag-label">Blossom</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✿" aria-label="Copy Black Florette">✿</button>
+      <span class="flag-label">Black Florette</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❀" aria-label="Copy White Florette">❀</button>
+      <span class="flag-label">White Florette</span>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Transform text with Unicode fonts</h3>
+  <p>Use UltraTextGen to convert plain text into bold, italic, cursive, and 100+ other Unicode font styles — free and instant.</p>
+  <a href="https://ultratextgen.com/" class="cta-btn">Open UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Related Resources</span>
+  <div class="compare-grid">
+    <a href="/library/crown-royalty-symbols/" class="compare-card variant-muted u-no-underline">
+      <h4>Crown &amp; Royalty Symbols</h4>
+      <p>Crowns, thrones, and regalia — the heraldic company the fleur-de-lis keeps.</p>
+    </a>
+    <a href="/symbol/star-of-david/" class="compare-card variant-muted u-no-underline">
+      <h4>Star of David</h4>
+      <p>Another single emblematic glyph whose path from decorative motif to defining symbol is a matter of documented record.</p>
+    </a>
+    <a href="/symbol/pentagram-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Pentagram Symbol</h4>
+      <p>Another single star-shaped emblem carried across heraldry, religion, and the occult.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js"></script>
+<script src="/footer.js"></script>
+</body>
+</html>

--- a/symbol/index.html
+++ b/symbol/index.html
@@ -42,7 +42,7 @@
   "publisher": { "@type": "Organization", "name": "UltraTextGen", "url": "https://ultratextgen.com/" },
   "mainEntityOfPage": "https://ultratextgen.com/symbol/",
   "datePublished": "2026-07-11",
-  "dateModified": "2026-07-12"
+  "dateModified": "2026-07-13"
 }
 </script>
 
@@ -124,6 +124,10 @@
     <a href="/symbol/not-equal-sign/" class="compare-card variant-muted u-no-underline">
       <h4>≠ Not Equal Sign</h4>
       <p>Used by Euler, left out of ASCII, and why code uses != instead.</p>
+    </a>
+    <a href="/symbol/congruent-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>≅ Congruent Symbol</h4>
+      <p>The geometry-class sign Unicode doesn't even call "congruent."</p>
     </a>
   </div>
 </section>
@@ -218,6 +222,10 @@
       <h4>¢ Cent Sign</h4>
       <p>The one common currency symbol with no dedicated keyboard key.</p>
     </a>
+    <a href="/symbol/won-sign/" class="compare-card variant-muted u-no-underline">
+      <h4>₩ Won Symbol</h4>
+      <p>One currency sign shared by two Koreas that aren't on speaking terms.</p>
+    </a>
   </div>
 </section>
 
@@ -288,6 +296,14 @@
       <h4>🪬 Hamsa Symbol</h4>
       <p>A pre-Abrahamic amulet shared today by Jewish and Islamic tradition.</p>
     </a>
+    <a href="/symbol/om-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>ॐ 🕉️ Om Symbol</h4>
+      <p>One sacred sound, three different meanings across Hinduism, Buddhism, and Jainism.</p>
+    </a>
+    <a href="/symbol/ankh-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>☥ Ankh Symbol</h4>
+      <p>Egypt's hieroglyph for "life" — later reshaped by Coptic Christians into a cross.</p>
+    </a>
   </div>
 </section>
 
@@ -347,6 +363,18 @@
       <h4>Ⓐ Anarchy Symbol</h4>
       <p>Dated to April 1964 — and its creator-disputed "Order" meaning.</p>
     </a>
+    <a href="/symbol/ohm-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Ω ℧ Ohm Symbol</h4>
+      <p>Named for the physicist behind V = IR — identical on screen to omega.</p>
+    </a>
+    <a href="/symbol/fleur-de-lis-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>⚜ Fleur-de-lis Symbol</h4>
+      <p>French royalty's emblem, now the Scout crest and the Saints' logo.</p>
+    </a>
+    <a href="/symbol/recycling-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>♻ Recycling Symbol</h4>
+      <p>Designed by a 23-year-old student for a 1970 Earth Day contest.</p>
+    </a>
   </div>
 </section>
 
@@ -365,6 +393,18 @@
     <a href="/symbol/omega-symbol/" class="compare-card variant-muted u-no-underline">
       <h4>Ω ω Omega Symbol</h4>
       <p>The Greek letter — and the electrical ohm sign that looks identical but isn't.</p>
+    </a>
+    <a href="/symbol/pi-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>π Pi Symbol</h4>
+      <p>Coined in 1706, made universal only after Euler adopted it.</p>
+    </a>
+    <a href="/symbol/delta-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Δ δ Delta Symbol</h4>
+      <p>The letter that means "change" across math, physics, and finance.</p>
+    </a>
+    <a href="/symbol/alpha-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Α α Alpha Symbol</h4>
+      <p>The beginning to Omega's end — plus particles and investment "alpha."</p>
     </a>
   </div>
 </section>
@@ -413,6 +453,30 @@
     <a href="/symbol/aquarius-symbol/" class="compare-card variant-muted u-no-underline">
       <h4>♒ Aquarius Symbol</h4>
       <p>The water-bearer that's actually classified as an Air sign.</p>
+    </a>
+    <a href="/symbol/aries-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>♈ Aries Symbol</h4>
+      <p>The golden-fleeced ram behind Jason's own legendary quest.</p>
+    </a>
+    <a href="/symbol/cancer-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>♋ Cancer Symbol</h4>
+      <p>The only sign ruled by the Moon — Hera's crab from Heracles's Second Labor.</p>
+    </a>
+    <a href="/symbol/virgo-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>♍ Virgo Symbol</h4>
+      <p>The only zodiac sign personified as a woman.</p>
+    </a>
+    <a href="/symbol/scorpio-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>♏ Scorpio Symbol</h4>
+      <p>Its constellation and Orion's are never in the sky at the same time.</p>
+    </a>
+    <a href="/symbol/capricorn-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>♑ Capricorn Symbol</h4>
+      <p>The sea-goat — half goat, half fish, born from a half-finished escape.</p>
+    </a>
+    <a href="/symbol/pisces-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>♓ Pisces Symbol</h4>
+      <p>The only zodiac glyph that ties two creatures together.</p>
     </a>
   </div>
 </section>

--- a/symbol/ohm-symbol/index.html
+++ b/symbol/ohm-symbol/index.html
@@ -1,0 +1,221 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8242324164413945"
+       crossorigin="anonymous"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Ohm Symbol: Copy &amp; Paste Ω ℧ — Named for the Physicist Behind V = IR</title>
+<meta name="description" content="Copy and paste the ohm symbol (Ω) for electrical resistance — named after physicist Georg Simon Ohm and his 1827 law V = IR — plus the mho (℧) and siemens for its inverse. Click any symbol to copy it instantly.">
+
+<link rel="canonical" href="https://ultratextgen.com/symbol/ohm-symbol/">
+<meta property="og:image" content="https://ultratextgen.com/logo.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Ohm Symbol: Copy &amp; Paste Ω ℧ — Named for the Physicist Behind V = IR">
+<meta name="twitter:description" content="Copy and paste the ohm symbol (Ω) for electrical resistance — named after physicist Georg Simon Ohm and his 1827 law V = IR — plus the mho (℧) and siemens for its inverse. Click any symbol to copy it instantly.">
+<meta name="twitter:image" content="https://ultratextgen.com/logo.png">
+<meta property="og:title" content="Ohm Symbol: Copy &amp; Paste Ω ℧ — Named for the Physicist Behind V = IR">
+<meta property="og:description" content="Copy and paste the ohm symbol (Ω) for electrical resistance — named after physicist Georg Simon Ohm and his 1827 law V = IR — plus the mho (℧) and siemens for its inverse. Click any symbol to copy it instantly.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/symbol/ohm-symbol/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Ohm Symbol: Copy & Paste Ω ℧ — Named for the Physicist Behind V = IR",
+  "description": "Copy and paste the ohm symbol (Ω) for electrical resistance — named after physicist Georg Simon Ohm and his 1827 law V = IR — plus the mho (℧) and siemens for its inverse. Click any symbol to copy it instantly.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "mainEntityOfPage": "https://ultratextgen.com/symbol/ohm-symbol/",
+  "datePublished": "2026-07-13",
+  "dateModified": "2026-07-13"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://ultratextgen.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Symbols",
+      "item": "https://ultratextgen.com/symbol/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Ohm Symbol",
+      "item": "https://ultratextgen.com/symbol/ohm-symbol/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<script src="/header.js"></script>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Ohm Symbol</h1>
+    <p class="hero-tagline">The Ω sign for electrical resistance, named after Georg Simon Ohm — the German physicist behind Ohm’s law, V = IR — plus ℧, the “mho” that measures its inverse. Click any symbol to copy it instantly.</p>
+  </div>
+</section>
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>The ohm symbol (Ω) is the unit of electrical resistance, named after Georg Simon Ohm (1789–1854), the German physicist and mathematician who set out what we now call Ohm’s law in his 1827 book Die galvanische Kette, mathematisch bearbeitet. The law is the one every electronics student memorizes: the current through a conductor is proportional to the voltage across it and inversely proportional to its resistance — the familiar V = I × R. Ohm’s work was largely ignored at first, but by 1841 the Royal Society had awarded him its Copley Medal. One wrinkle worth knowing up front: the character here is technically U+2126 OHM SIGN, a distinct codepoint that renders identically to the Greek capital letter omega (U+03A9), and Unicode’s own database treats the ohm sign as normalizing to plain omega. For the full story of that look-alike, see our omega symbol page — here we focus on the ohm as an electrical unit.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="ohm-sign">
+  <span class="article-section-label">Ohm Sign</span>
+  <h2>The Ohm Symbol (Ω)</h2>
+  <p class="u-secondary-tight">The unit of electrical resistance. U+2126 is the dedicated ohm sign, though in practice most people just type Greek capital omega, which looks the same. Lowercase omega (ω) rides alongside it in alternating-current math, where it denotes angular frequency, ω = 2πf.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="Ω" aria-label="Copy Ohm Sign (U+2126) — Electrical Resistance">Ω</button>
+      <span class="flag-label">Ohm Sign (U+2126) — Electrical Resistance</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ω" aria-label="Copy Greek Small Omega (ω) — Angular Frequency">ω</button>
+      <span class="flag-label">Greek Small Omega (ω) — Angular Frequency</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="unicode-identity">
+  <span class="article-section-label">Ω vs Omega</span>
+  <h2>Ohm Sign vs. Greek Omega</h2>
+  <p class="u-secondary-tight">These two tiles are different Unicode characters — U+2126, the ohm sign, and U+03A9, Greek capital omega — that look identical in almost every font. Unicode’s database says the ohm sign should normalize to plain omega, and most keyboards and tools produce the omega, not the ohm sign. The mismatch has caused real document-conversion bugs. For copy-paste either one works; for the full disambiguation, including the documented Pandoc issue, see the omega symbol page.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="Ω" aria-label="Copy Ohm Sign (U+2126) — the Legacy Codepoint">Ω</button>
+      <span class="flag-label">Ohm Sign (U+2126) — the Legacy Codepoint</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="Ω" aria-label="Copy Greek Capital Omega (U+03A9) — What Unicode Prefers">Ω</button>
+      <span class="flag-label">Greek Capital Omega (U+03A9) — What Unicode Prefers</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="mho-siemens">
+  <span class="article-section-label">Mho &amp; Siemens</span>
+  <h2>Mho &amp; Siemens — the Reciprocal Unit</h2>
+  <p class="u-secondary-tight">Conductance is the reciprocal of resistance — literally 1 ÷ Ω — and its old unit is the mho (℧), which is simply “ohm” spelled backwards. Lord Kelvin proposed the name in 1883. The modern SI system replaced it in 1971 with the siemens (symbol S, named after inventor Werner von Siemens); NIST now flags “mho” as a special name to avoid, though ℧ still turns up in older texts and schematics.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="℧" aria-label="Copy Mho Sign (U+2127) — “Ohm” Reversed">℧</button>
+      <span class="flag-label">Mho Sign (U+2127) — “Ohm” Reversed</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="S" aria-label="Copy Siemens (S) — the Modern SI Unit of Conductance">S</button>
+      <span class="flag-label">Siemens (S) — the Modern SI Unit of Conductance</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="circuit-symbols">
+  <span class="article-section-label">Circuit Symbols</span>
+  <h2>Other Electrical &amp; Circuit Symbols</h2>
+  <p class="u-secondary-tight">The ohm sits among a family of glyphs that populate circuit diagrams and datasheets. Three more Unicode characters an electronics schematic might call for:</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⏚" aria-label="Copy Earth Ground (U+23DA)">⏚</button>
+      <span class="flag-label">Earth Ground (U+23DA)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚡" aria-label="Copy High Voltage Sign (U+26A1)">⚡</button>
+      <span class="flag-label">High Voltage Sign (U+26A1)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="∿" aria-label="Copy Sine Wave (U+223F) — Alternating Current">∿</button>
+      <span class="flag-label">Sine Wave (U+223F) — Alternating Current</span>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Transform text with Unicode fonts</h3>
+  <p>Use UltraTextGen to convert plain text into bold, italic, cursive, and 100+ other Unicode font styles — free and instant.</p>
+  <a href="https://ultratextgen.com/" class="cta-btn">Open UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Related Resources</span>
+  <div class="compare-grid">
+    <a href="/symbol/omega-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Omega Symbol</h4>
+      <p>The identical-looking Greek letter this page’s Ω normalizes to — the full Unicode disambiguation, the documented Pandoc conversion bug, and where the two glyphs quietly come apart.</p>
+    </a>
+    <a href="/library/electrical-circuit-symbols/" class="compare-card variant-muted u-no-underline">
+      <h4>Electrical &amp; Circuit Symbols</h4>
+      <p>A browsable set of schematic glyphs — grounds, sources, switches, and the units that label them.</p>
+    </a>
+    <a href="/symbol/micro-sign/" class="compare-card variant-muted u-no-underline">
+      <h4>Micro Sign</h4>
+      <p>The exact same Unicode quirk as the ohm sign: µ is a legacy character that normalizes to Greek mu — another SI prefix (µF, µA) that looks like a Greek letter but isn’t one underneath.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js"></script>
+<script src="/footer.js"></script>
+</body>
+</html>

--- a/symbol/om-symbol/index.html
+++ b/symbol/om-symbol/index.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8242324164413945"
+       crossorigin="anonymous"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Om Symbol: Copy &amp; Paste ॐ 🕉️ — One Sacred Sound, Three Meanings in Hinduism, Buddhism, and Jainism</title>
+<meta name="description" content="Copy and paste Om / Aum (ॐ U+0950, 🕉️ U+1F549) — the sacred syllable read as the primordial cosmic sound in Hinduism, the opening of Om mani padme hum in Buddhism, and a condensed form of the five supreme beings in Jainism. Click any symbol to copy it instantly.">
+
+<link rel="canonical" href="https://ultratextgen.com/symbol/om-symbol/">
+<meta property="og:image" content="https://ultratextgen.com/logo.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Om Symbol: Copy &amp; Paste ॐ 🕉️ — One Sacred Sound, Three Meanings in Hinduism, Buddhism, and Jainism">
+<meta name="twitter:description" content="Copy and paste Om / Aum (ॐ U+0950, 🕉️ U+1F549) — the sacred syllable read as the primordial cosmic sound in Hinduism, the opening of Om mani padme hum in Buddhism, and a condensed form of the five supreme beings in Jainism. Click any symbol to copy it instantly.">
+<meta name="twitter:image" content="https://ultratextgen.com/logo.png">
+<meta property="og:title" content="Om Symbol: Copy &amp; Paste ॐ 🕉️ — One Sacred Sound, Three Meanings in Hinduism, Buddhism, and Jainism">
+<meta property="og:description" content="Copy and paste Om / Aum (ॐ U+0950, 🕉️ U+1F549) — the sacred syllable read as the primordial cosmic sound in Hinduism, the opening of Om mani padme hum in Buddhism, and a condensed form of the five supreme beings in Jainism. Click any symbol to copy it instantly.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/symbol/om-symbol/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Om Symbol: Copy & Paste ॐ 🕉️ — One Sacred Sound, Three Meanings in Hinduism, Buddhism, and Jainism",
+  "description": "Copy and paste Om / Aum (ॐ U+0950, 🕉️ U+1F549) — the sacred syllable read as the primordial cosmic sound in Hinduism, the opening of Om mani padme hum in Buddhism, and a condensed form of the five supreme beings in Jainism. Click any symbol to copy it instantly.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "mainEntityOfPage": "https://ultratextgen.com/symbol/om-symbol/",
+  "datePublished": "2026-07-13",
+  "dateModified": "2026-07-13"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://ultratextgen.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Symbols",
+      "item": "https://ultratextgen.com/symbol/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Om Symbol",
+      "item": "https://ultratextgen.com/symbol/om-symbol/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<script src="/header.js"></script>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Om Symbol</h1>
+    <p class="hero-tagline">Om, or Aum (ॐ, 🕉️) — the sacred syllable shared by Hinduism, Buddhism, and Jainism, where the same sound is read differently in each tradition. Click any symbol to copy it instantly.</p>
+  </div>
+</section>
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Om, also spelled Aum, is a sacred sound and symbol central to several Indian religions. Unicode encodes it two ways. The first is ॐ (U+0950 DEVANAGARI OM), a cursive ligature in the Devanagari script that fuses the letters a (अ) and u (उ) with a nasal chandrabindu; it was added in Unicode 1.1 back in 1993. The second is 🕉️ (U+1F549 OM SYMBOL), a standalone pictographic glyph defined as "independent of Devanagari font" and added far later, in Unicode 7.0 (2014), then taken up as an emoji in 2015 — the same glyph the Khanda symbol page already displays as a related mark. The syllable is chanted at the start or end of prayers, mantras, and yoga practice, but its meaning is not uniform across faiths: Hindu tradition often describes it as the primordial sound of the universe and an expression of ultimate reality; in Buddhism it opens mantras such as Om mani padme hum, linked to the bodhisattva of compassion; and in Jainism it is understood as a condensed form of the Panch Parmeshthi, the five supreme beings. This page reports that documented usage without ranking the traditions.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="om-glyphs">
+  <span class="article-section-label">Om</span>
+  <h2>Om Symbol</h2>
+  <p class="u-secondary-tight">Three Unicode characters for Om: the Devanagari script ligature, the standalone pictographic OM SYMBOL, and the distinct Jain Om.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ॐ" aria-label="Copy Devanagari Om">ॐ</button>
+      <span class="flag-label">Devanagari Om</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕉️" aria-label="Copy Om Symbol">🕉️</button>
+      <span class="flag-label">Om Symbol</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="ꣽ" aria-label="Copy Jain Om">ꣽ</button>
+      <span class="flag-label">Jain Om</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="meditation-symbols">
+  <span class="article-section-label">Meditation &amp; Yoga</span>
+  <h2>Meditation &amp; Yoga Symbols</h2>
+  <p class="u-secondary-tight">Symbols commonly displayed alongside Om in yoga, meditation, and dharmic contexts.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🪷" aria-label="Copy Lotus">🪷</button>
+      <span class="flag-label">Lotus</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧘" aria-label="Copy Person in Lotus Position">🧘</button>
+      <span class="flag-label">Person in Lotus Position</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="📿" aria-label="Copy Prayer Beads">📿</button>
+      <span class="flag-label">Prayer Beads</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☸️" aria-label="Copy Dharma Wheel">☸️</button>
+      <span class="flag-label">Dharma Wheel</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="faith-symbols">
+  <span class="article-section-label">Faith Symbols</span>
+  <h2>Other Faith &amp; Emblem Symbols</h2>
+  <p class="u-secondary-tight">Symbols from other traditions that pair well with faith and identity content.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🪯" aria-label="Copy Khanda">🪯</button>
+      <span class="flag-label">Khanda</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✡️" aria-label="Copy Star of David">✡️</button>
+      <span class="flag-label">Star of David</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☪️" aria-label="Copy Star and Crescent">☪️</button>
+      <span class="flag-label">Star and Crescent</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☯️" aria-label="Copy Yin Yang">☯️</button>
+      <span class="flag-label">Yin Yang</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✝️" aria-label="Copy Latin Cross">✝️</button>
+      <span class="flag-label">Latin Cross</span>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Transform text with Unicode fonts</h3>
+  <p>Use UltraTextGen to convert plain text into bold, italic, cursive, and 100+ other Unicode font styles — free and instant.</p>
+  <a href="https://ultratextgen.com/" class="cta-btn">Open UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Related Resources</span>
+  <div class="compare-grid">
+    <a href="/library/religious-symbols/" class="compare-card variant-muted u-no-underline">
+      <h4>Religious Symbols</h4>
+      <p>Faith symbols from every major world religion in one reference.</p>
+    </a>
+    <a href="/symbol/khanda-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Khanda Symbol</h4>
+      <p>The Sikh emblem whose own page already displays Om as a related dharmic glyph.</p>
+    </a>
+    <a href="/symbol/hamsa-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Hamsa Symbol</h4>
+      <p>Another cross-tradition symbol reported as documented history, without picking a side.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js"></script>
+<script src="/footer.js"></script>
+</body>
+</html>

--- a/symbol/pi-symbol/index.html
+++ b/symbol/pi-symbol/index.html
@@ -1,0 +1,215 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8242324164413945"
+       crossorigin="anonymous"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Pi Symbol: Copy &amp; Paste π Π ∏ — Coined in 1706, Made Universal by Euler</title>
+<meta name="description" content="Copy and paste the pi symbol — lowercase π (the math constant), capital Π (the product operator), and the dedicated ∏ product sign — and learn how William Jones coined it in 1706 before Euler made it the world standard. Click any symbol to copy it instantly.">
+
+<link rel="canonical" href="https://ultratextgen.com/symbol/pi-symbol/">
+<meta property="og:image" content="https://ultratextgen.com/logo.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Pi Symbol: Copy &amp; Paste π Π ∏ — Coined in 1706, Made Universal by Euler">
+<meta name="twitter:description" content="Copy and paste the pi symbol — lowercase π (the math constant), capital Π (the product operator), and the dedicated ∏ product sign — and learn how William Jones coined it in 1706 before Euler made it the world standard. Click any symbol to copy it instantly.">
+<meta name="twitter:image" content="https://ultratextgen.com/logo.png">
+<meta property="og:title" content="Pi Symbol: Copy &amp; Paste π Π ∏ — Coined in 1706, Made Universal by Euler">
+<meta property="og:description" content="Copy and paste the pi symbol — lowercase π (the math constant), capital Π (the product operator), and the dedicated ∏ product sign — and learn how William Jones coined it in 1706 before Euler made it the world standard. Click any symbol to copy it instantly.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/symbol/pi-symbol/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Pi Symbol: Copy & Paste π Π ∏ — Coined in 1706, Made Universal by Euler",
+  "description": "Copy and paste the pi symbol — lowercase π (the math constant), capital Π (the product operator), and the dedicated ∏ product sign — and learn how William Jones coined it in 1706 before Euler made it the world standard. Click any symbol to copy it instantly.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "mainEntityOfPage": "https://ultratextgen.com/symbol/pi-symbol/",
+  "datePublished": "2026-07-13",
+  "dateModified": "2026-07-13"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://ultratextgen.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Symbols",
+      "item": "https://ultratextgen.com/symbol/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Pi Symbol",
+      "item": "https://ultratextgen.com/symbol/pi-symbol/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<script src="/header.js"></script>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Pi Symbol</h1>
+    <p class="hero-tagline">The lowercase π everyone means by ‘the pi symbol,’ the capital Π that means ‘product’ in math, and the dedicated ∏ product operator — the notation William Jones introduced in 1706 and Leonhard Euler turned into the world standard. Click any symbol to copy it instantly.</p>
+  </div>
+</section>
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Pi's lowercase glyph, π (U+03C0, GREEK SMALL LETTER PI), is one of the most recognizable characters in all of mathematics — the ratio of any circle's circumference to its diameter, roughly 3.14159 and running forever without repeating. What most people don't realize is that the symbol is far younger than the number: the Welsh mathematician William Jones first used π this way in his 1706 book ‘Synopsis Palmariorum Matheseos,’ borrowing the Greek letter that begins ‘periphery.’ For three decades it went nowhere — until Leonhard Euler, the most influential mathematician of the age, adopted it around 1737 and cemented it as the global standard through his 1748 ‘Introductio in analysin infinitorum.’ The capital form, Π (U+03A0), does entirely different work: in math it's the product operator, the multiplicative twin of Σ summation, and it has its own dedicated glyph, ∏ (U+220F, N-ARY PRODUCT). Pi is both irrational (proved by Lambert in 1761) and transcendental (Lindemann, 1882) — and it even gets its own holiday every March 14.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="the-pi-symbol">
+  <span class="article-section-label">The Pi Symbol</span>
+  <h2>The Pi Symbol — π &amp; Π</h2>
+  <p class="u-secondary-tight">The Greek letter itself. The lowercase π is the famous math constant; the capital Π is a different tool entirely.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="π" aria-label="Copy Greek Small Letter Pi (U+03C0) — The Math Constant ≈ 3.14159">π</button>
+      <span class="flag-label">Greek Small Letter Pi (U+03C0) — The Math Constant ≈ 3.14159</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="Π" aria-label="Copy Greek Capital Letter Pi (U+03A0) — The Product Operator">Π</button>
+      <span class="flag-label">Greek Capital Letter Pi (U+03A0) — The Product Operator</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="pi-in-math">
+  <span class="article-section-label">Math &amp; Operators</span>
+  <h2>Pi in Math: Product vs. Summation</h2>
+  <p class="u-secondary-tight">Capital Π is the product operator, and — exactly like sigma — it has a dedicated math glyph, ∏ (N-ARY PRODUCT), that is a separate Unicode character from the letter. It's the multiplicative mirror of ∑ summation, letter for letter.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="∏" aria-label="Copy N-ary Product (U+220F) — The Dedicated Product Operator">∏</button>
+      <span class="flag-label">N-ary Product (U+220F) — The Dedicated Product Operator</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="Π" aria-label="Copy Capital Pi (U+03A0) — The Letter Often Typed for Products">Π</button>
+      <span class="flag-label">Capital Pi (U+03A0) — The Letter Often Typed for Products</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="∑" aria-label="Copy N-ary Summation (U+2211) — The Product&#x27;s Additive Twin">∑</button>
+      <span class="flag-label">N-ary Summation (U+2211) — The Product's Additive Twin</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="Σ" aria-label="Copy Capital Sigma (U+03A3) — The Letter Behind Summation">Σ</button>
+      <span class="flag-label">Capital Sigma (U+03A3) — The Letter Behind Summation</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="related-greek-letters">
+  <span class="article-section-label">Greek Letters</span>
+  <h2>Related Greek Letters</h2>
+  <p class="u-secondary-tight">Pi is the 16th letter of the Greek alphabet. Here are the neighbors people search for most alongside it.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="Ω" aria-label="Copy Greek Capital Letter Omega">Ω</button>
+      <span class="flag-label">Greek Capital Letter Omega</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="Δ" aria-label="Copy Greek Capital Letter Delta">Δ</button>
+      <span class="flag-label">Greek Capital Letter Delta</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="α" aria-label="Copy Greek Small Letter Alpha">α</button>
+      <span class="flag-label">Greek Small Letter Alpha</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="θ" aria-label="Copy Greek Small Letter Theta">θ</button>
+      <span class="flag-label">Greek Small Letter Theta</span>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Transform text with Unicode fonts</h3>
+  <p>Use UltraTextGen to convert plain text into bold, italic, cursive, and 100+ other Unicode font styles — free and instant.</p>
+  <a href="https://ultratextgen.com/" class="cta-btn">Open UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Related Resources</span>
+  <div class="compare-grid">
+    <a href="/library/greek-letter-symbols/" class="compare-card variant-muted u-no-underline">
+      <h4>Greek Letter Symbols</h4>
+      <p>The full Greek alphabet in uppercase, lowercase, and math variant forms to copy and paste.</p>
+    </a>
+    <a href="/library/math-symbols/" class="compare-card variant-muted u-no-underline">
+      <h4>Math Symbols</h4>
+      <p>Product, summation, and the operators and Greek letters that fill out an equation.</p>
+    </a>
+    <a href="/symbol/sigma-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Sigma Symbol</h4>
+      <p>Pi's operator twin: just as Π pairs with the ∏ product sign, Σ pairs with the ∑ summation sign.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js"></script>
+<script src="/footer.js"></script>
+</body>
+</html>

--- a/symbol/pisces-symbol/index.html
+++ b/symbol/pisces-symbol/index.html
@@ -1,0 +1,207 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8242324164413945"
+       crossorigin="anonymous"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Pisces Symbol: Copy &amp; Paste ♓ — The Only Zodiac Glyph That Ties Two Creatures Together</title>
+<meta name="description" content="Copy and paste the Pisces zodiac symbol (♓) — two fish tied tail-to-tail by a cord, the only zodiac glyph that binds two creatures, from the myth of Aphrodite and Eros fleeing Typhon. Click any symbol to copy it instantly.">
+
+<link rel="canonical" href="https://ultratextgen.com/symbol/pisces-symbol/">
+<meta property="og:image" content="https://ultratextgen.com/logo.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Pisces Symbol: Copy &amp; Paste ♓ — The Only Zodiac Glyph That Ties Two Creatures Together">
+<meta name="twitter:description" content="Copy and paste the Pisces zodiac symbol (♓) — two fish tied tail-to-tail by a cord, the only zodiac glyph that binds two creatures, from the myth of Aphrodite and Eros fleeing Typhon. Click any symbol to copy it instantly.">
+<meta name="twitter:image" content="https://ultratextgen.com/logo.png">
+<meta property="og:title" content="Pisces Symbol: Copy &amp; Paste ♓ — The Only Zodiac Glyph That Ties Two Creatures Together">
+<meta property="og:description" content="Copy and paste the Pisces zodiac symbol (♓) — two fish tied tail-to-tail by a cord, the only zodiac glyph that binds two creatures, from the myth of Aphrodite and Eros fleeing Typhon. Click any symbol to copy it instantly.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/symbol/pisces-symbol/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Pisces Symbol: Copy & Paste ♓ — The Only Zodiac Glyph That Ties Two Creatures Together",
+  "description": "Copy and paste the Pisces zodiac symbol (♓) — two fish tied tail-to-tail by a cord, the only zodiac glyph that binds two creatures, from the myth of Aphrodite and Eros fleeing Typhon. Click any symbol to copy it instantly.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "mainEntityOfPage": "https://ultratextgen.com/symbol/pisces-symbol/",
+  "datePublished": "2026-07-13",
+  "dateModified": "2026-07-13"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://ultratextgen.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Symbols",
+      "item": "https://ultratextgen.com/symbol/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Pisces Symbol",
+      "item": "https://ultratextgen.com/symbol/pisces-symbol/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<script src="/header.js"></script>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Pisces Symbol</h1>
+    <p class="hero-tagline">Pisces's glyph (♓) is two crescents joined by a bar — two fish tied tail-to-tail by a cord, the only zodiac symbol that binds two creatures together. Click any symbol to copy it instantly.</p>
+  </div>
+</section>
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>The Pisces symbol (♓, U+2653) is two crescents joined by a horizontal bar — a literal picture of two fish tied tail-to-tail, making Pisces the only sign whose glyph binds two creatures together. Its myth: Aphrodite and her son Eros were beside a river (Hyginus names the Euphrates) when the monster Typhon attacked; to escape, the two turned into fish and knotted their tails with a cord so the current could not separate them, and Zeus set the image among the stars. It is the same rampage that sent Pan diving into the water as the goat-fish Capricorn — the two constellations record one moment of divine flight. Pisces runs February 19–March 20, is ruled by Neptune in modern astrology (traditionally Jupiter), and is a Water sign with Mutable modality.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="pisces-symbol">
+  <span class="article-section-label">Pisces</span>
+  <h2>Pisces Symbol</h2>
+  <p class="u-secondary-tight">The Unicode Pisces zodiac glyph, ready to paste.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♓" aria-label="Copy Pisces Symbol">♓</button>
+      <span class="flag-label">Pisces Symbol</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♓️" aria-label="Copy Pisces Symbol (Emoji)">♓️</button>
+      <span class="flag-label">Pisces Symbol (Emoji)</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="ruling-planet-element">
+  <span class="article-section-label">Planet &amp; Element</span>
+  <h2>Ruling Planet &amp; Element</h2>
+  <p class="u-secondary-tight">The planet and classical element traditionally associated with Pisces.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♆" aria-label="Copy Neptune (Ruling Planet)">♆</button>
+      <span class="flag-label">Neptune (Ruling Planet)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜄" aria-label="Copy Water (Element, Alchemical)">🜄</button>
+      <span class="flag-label">Water (Element, Alchemical)</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="related-zodiac-celestial">
+  <span class="article-section-label">Zodiac &amp; Celestial</span>
+  <h2>More Zodiac &amp; Celestial Symbols</h2>
+  <p class="u-secondary-tight">Celestial bodies and the astrological opposite of Pisces (Virgo).</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☉" aria-label="Copy Sun">☉</button>
+      <span class="flag-label">Sun</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☽" aria-label="Copy Moon (First Quarter)">☽</button>
+      <span class="flag-label">Moon (First Quarter)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛎" aria-label="Copy Ophiuchus (Unofficial 13th Sign)">⛎</button>
+      <span class="flag-label">Ophiuchus (Unofficial 13th Sign)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♍" aria-label="Copy Virgo (Opposite Sign)">♍</button>
+      <span class="flag-label">Virgo (Opposite Sign)</span>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Transform text with Unicode fonts</h3>
+  <p>Use UltraTextGen to convert plain text into bold, italic, cursive, and 100+ other Unicode font styles — free and instant.</p>
+  <a href="https://ultratextgen.com/" class="cta-btn">Open UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Related Resources</span>
+  <div class="compare-grid">
+    <a href="/library/zodiac-symbols/" class="compare-card variant-muted u-no-underline">
+      <h4>Zodiac Symbols</h4>
+      <p>Western zodiac signs, planetary symbols, and Chinese zodiac animals in one reference.</p>
+    </a>
+    <a href="/symbol/virgo-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Virgo Symbol</h4>
+      <p>Pisces's astrological opposite sign, directly across the zodiac wheel.</p>
+    </a>
+    <a href="/symbol/sagittarius-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Sagittarius Symbol</h4>
+      <p>Pisces's traditional ruler Jupiter also governs Sagittarius, the archer aimed at the galaxy's center.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js"></script>
+<script src="/footer.js"></script>
+</body>
+</html>

--- a/symbol/recycling-symbol/index.html
+++ b/symbol/recycling-symbol/index.html
@@ -1,0 +1,223 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8242324164413945"
+       crossorigin="anonymous"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Recycling Symbol: Copy &amp; Paste ♻ — Designed by a 23-Year-Old Student for a 1970 Earth Day Contest</title>
+<meta name="description" content="Copy and paste the recycling symbol (♻ U+267B), the three-arrow Möbius loop designed in 1970 by USC student Gary Anderson for a Container Corporation of America contest tied to the first Earth Day. Click any symbol to copy it instantly.">
+
+<link rel="canonical" href="https://ultratextgen.com/symbol/recycling-symbol/">
+<meta property="og:image" content="https://ultratextgen.com/logo.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Recycling Symbol: Copy &amp; Paste ♻ — Designed by a 23-Year-Old Student for a 1970 Earth Day Contest">
+<meta name="twitter:description" content="Copy and paste the recycling symbol (♻ U+267B), the three-arrow Möbius loop designed in 1970 by USC student Gary Anderson for a Container Corporation of America contest tied to the first Earth Day. Click any symbol to copy it instantly.">
+<meta name="twitter:image" content="https://ultratextgen.com/logo.png">
+<meta property="og:title" content="Recycling Symbol: Copy &amp; Paste ♻ — Designed by a 23-Year-Old Student for a 1970 Earth Day Contest">
+<meta property="og:description" content="Copy and paste the recycling symbol (♻ U+267B), the three-arrow Möbius loop designed in 1970 by USC student Gary Anderson for a Container Corporation of America contest tied to the first Earth Day. Click any symbol to copy it instantly.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/symbol/recycling-symbol/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Recycling Symbol: Copy & Paste ♻ — Designed by a 23-Year-Old Student for a 1970 Earth Day Contest",
+  "description": "Copy and paste the recycling symbol (♻ U+267B), the three-arrow Möbius loop designed in 1970 by USC student Gary Anderson for a Container Corporation of America contest tied to the first Earth Day. Click any symbol to copy it instantly.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "mainEntityOfPage": "https://ultratextgen.com/symbol/recycling-symbol/",
+  "datePublished": "2026-07-13",
+  "dateModified": "2026-07-13"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://ultratextgen.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Symbols",
+      "item": "https://ultratextgen.com/symbol/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Recycling Symbol",
+      "item": "https://ultratextgen.com/symbol/recycling-symbol/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<script src="/header.js"></script>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Recycling Symbol</h1>
+    <p class="hero-tagline">The recycling symbol (♻) — the three-arrow Möbius loop designed in 1970 by Gary Anderson, then a 23-year-old USC student, for a contest tied to the first Earth Day. Click any symbol to copy it instantly.</p>
+  </div>
+</section>
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>The recycling symbol (♻, U+267B BLACK UNIVERSAL RECYCLING SYMBOL) has an unusually well-documented origin. It was designed in 1970 by Gary Anderson, then a 23-year-old student at the University of Southern California, as an entry in a design competition sponsored by the Container Corporation of America to mark the first Earth Day. The contest drew more than 500 submissions and was judged by leading designers of the day, including Saul Bass; Anderson won a $2,500 scholarship, and his design was placed in the public domain. The three chasing arrows form a Möbius strip — Anderson has said he wanted to evoke paper moving through rollers and the idea of materials cycling endlessly into new products. The popular reading of the three arrows as "reduce, reuse, recycle" came later; it was not the design's original stated meaning, which was simply the continuous loop itself. Unicode encoded the filled version at U+267B in version 3.2 (2002); a hollow outline variant, the UNIVERSAL RECYCLING SYMBOL, lives separately at U+2672.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="recycling-glyphs">
+  <span class="article-section-label">Recycling</span>
+  <h2>Recycling Symbols</h2>
+  <p class="u-secondary-tight">Unicode carries several recycling marks: the familiar filled symbol, its hollow outline, and the paper-recycling variant.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♻" aria-label="Copy Recycling Symbol">♻</button>
+      <span class="flag-label">Recycling Symbol</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♲" aria-label="Copy Universal Recycling Symbol (Outline)">♲</button>
+      <span class="flag-label">Universal Recycling Symbol (Outline)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♼" aria-label="Copy Recycled Paper Symbol">♼</button>
+      <span class="flag-label">Recycled Paper Symbol</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="environment-symbols">
+  <span class="article-section-label">Environment &amp; Nature</span>
+  <h2>Environment &amp; Nature Symbols</h2>
+  <p class="u-secondary-tight">Symbols commonly paired with recycling in environmental and sustainability messaging.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌱" aria-label="Copy Seedling">🌱</button>
+      <span class="flag-label">Seedling</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌍" aria-label="Copy Globe Showing Europe-Africa">🌍</button>
+      <span class="flag-label">Globe Showing Europe-Africa</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🍃" aria-label="Copy Leaf Fluttering in Wind">🍃</button>
+      <span class="flag-label">Leaf Fluttering in Wind</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌳" aria-label="Copy Deciduous Tree">🌳</button>
+      <span class="flag-label">Deciduous Tree</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💧" aria-label="Copy Droplet">💧</button>
+      <span class="flag-label">Droplet</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="sign-pictograms">
+  <span class="article-section-label">Signs &amp; Pictograms</span>
+  <h2>Signs &amp; Standardized Pictograms</h2>
+  <p class="u-secondary-tight">Other internationally standardized pictograms and warning marks in the same functional family.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♿" aria-label="Copy Wheelchair Symbol">♿</button>
+      <span class="flag-label">Wheelchair Symbol</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☣️" aria-label="Copy Biohazard">☣️</button>
+      <span class="flag-label">Biohazard</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚠️" aria-label="Copy Warning">⚠️</button>
+      <span class="flag-label">Warning</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☢️" aria-label="Copy Radioactive">☢️</button>
+      <span class="flag-label">Radioactive</span>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Transform text with Unicode fonts</h3>
+  <p>Use UltraTextGen to convert plain text into bold, italic, cursive, and 100+ other Unicode font styles — free and instant.</p>
+  <a href="https://ultratextgen.com/" class="cta-btn">Open UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Related Resources</span>
+  <div class="compare-grid">
+    <a href="/library/recycle-environment-symbols/" class="compare-card variant-muted u-no-underline">
+      <h4>Recycle &amp; Environment Symbols</h4>
+      <p>Recycling marks, eco labels, and nature symbols in one reference — this page is the hub's dedicated recycling-symbol spoke.</p>
+    </a>
+    <a href="/symbol/biohazard-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Biohazard Symbol</h4>
+      <p>Another modern pictogram with a documented corporate design origin — created at Dow Chemical in 1966 to be deliberately "memorable but meaningless."</p>
+    </a>
+    <a href="/symbol/wheelchair-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Wheelchair Symbol</h4>
+      <p>Another internationally standardized pictogram with a specific, traceable design history.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js"></script>
+<script src="/footer.js"></script>
+</body>
+</html>

--- a/symbol/scorpio-symbol/index.html
+++ b/symbol/scorpio-symbol/index.html
@@ -1,0 +1,207 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8242324164413945"
+       crossorigin="anonymous"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Scorpio Symbol: Copy &amp; Paste ♏ — The Sign Whose Constellation Never Shares the Sky With Orion</title>
+<meta name="description" content="Copy and paste the Scorpio zodiac symbol (♏) and the myth behind it — the giant scorpion sent to kill Orion, placed on the opposite side of the sky so the two constellations are never visible together. Click any symbol to copy it instantly.">
+
+<link rel="canonical" href="https://ultratextgen.com/symbol/scorpio-symbol/">
+<meta property="og:image" content="https://ultratextgen.com/logo.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Scorpio Symbol: Copy &amp; Paste ♏ — The Sign Whose Constellation Never Shares the Sky With Orion">
+<meta name="twitter:description" content="Copy and paste the Scorpio zodiac symbol (♏) and the myth behind it — the giant scorpion sent to kill Orion, placed on the opposite side of the sky so the two constellations are never visible together. Click any symbol to copy it instantly.">
+<meta name="twitter:image" content="https://ultratextgen.com/logo.png">
+<meta property="og:title" content="Scorpio Symbol: Copy &amp; Paste ♏ — The Sign Whose Constellation Never Shares the Sky With Orion">
+<meta property="og:description" content="Copy and paste the Scorpio zodiac symbol (♏) and the myth behind it — the giant scorpion sent to kill Orion, placed on the opposite side of the sky so the two constellations are never visible together. Click any symbol to copy it instantly.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/symbol/scorpio-symbol/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Scorpio Symbol: Copy & Paste ♏ — The Sign Whose Constellation Never Shares the Sky With Orion",
+  "description": "Copy and paste the Scorpio zodiac symbol (♏) and the myth behind it — the giant scorpion sent to kill Orion, placed on the opposite side of the sky so the two constellations are never visible together. Click any symbol to copy it instantly.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "mainEntityOfPage": "https://ultratextgen.com/symbol/scorpio-symbol/",
+  "datePublished": "2026-07-13",
+  "dateModified": "2026-07-13"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://ultratextgen.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Symbols",
+      "item": "https://ultratextgen.com/symbol/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Scorpio Symbol",
+      "item": "https://ultratextgen.com/symbol/scorpio-symbol/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<script src="/header.js"></script>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Scorpio Symbol</h1>
+    <p class="hero-tagline">Scorpio's glyph (♏) is a scorpion's body ending in a raised, stinging tail — and its constellation, Scorpius, sits opposite Orion, so the hunter and the scorpion are never above the horizon at the same time. Click any symbol to copy it instantly.</p>
+  </div>
+</section>
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>The Scorpio symbol (♏, U+264F) is drawn as a stylized ‘m’ whose final stroke curls upward into an arrow — the scorpion's raised, stinging tail. The myth ties it to Orion the Hunter, who boasted he could kill every animal on earth; in the best-known version the earth goddess Gaia answered his arrogance by sending a giant scorpion, which stung him to death (some accounts credit the goddess Artemis instead). Both were set among the stars afterward, but on opposite sides of the sky — and that placement is a genuine, observable fact rather than just a story: as Scorpius climbs in the east, Orion sinks in the west, so the hunter and the scorpion are never above the horizon at the same time. Scorpio runs October 23–November 21, is ruled by Pluto in modern astrology (traditionally Mars), and is a Water sign with Fixed modality.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="scorpio-symbol">
+  <span class="article-section-label">Scorpio</span>
+  <h2>Scorpio Symbol</h2>
+  <p class="u-secondary-tight">The Unicode Scorpio zodiac glyph, ready to paste.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♏" aria-label="Copy Scorpio Symbol">♏</button>
+      <span class="flag-label">Scorpio Symbol</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♏️" aria-label="Copy Scorpio Symbol (Emoji)">♏️</button>
+      <span class="flag-label">Scorpio Symbol (Emoji)</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="ruling-planet-element">
+  <span class="article-section-label">Planet &amp; Element</span>
+  <h2>Ruling Planet &amp; Element</h2>
+  <p class="u-secondary-tight">The planet and classical element traditionally associated with Scorpio.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♇" aria-label="Copy Pluto (Ruling Planet)">♇</button>
+      <span class="flag-label">Pluto (Ruling Planet)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜄" aria-label="Copy Water (Element, Alchemical)">🜄</button>
+      <span class="flag-label">Water (Element, Alchemical)</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="related-zodiac-celestial">
+  <span class="article-section-label">Zodiac &amp; Celestial</span>
+  <h2>More Zodiac &amp; Celestial Symbols</h2>
+  <p class="u-secondary-tight">Celestial bodies and the astrological opposite of Scorpio (Taurus).</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☉" aria-label="Copy Sun">☉</button>
+      <span class="flag-label">Sun</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☽" aria-label="Copy Moon (First Quarter)">☽</button>
+      <span class="flag-label">Moon (First Quarter)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛎" aria-label="Copy Ophiuchus (Unofficial 13th Sign)">⛎</button>
+      <span class="flag-label">Ophiuchus (Unofficial 13th Sign)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♉" aria-label="Copy Taurus (Opposite Sign)">♉</button>
+      <span class="flag-label">Taurus (Opposite Sign)</span>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Transform text with Unicode fonts</h3>
+  <p>Use UltraTextGen to convert plain text into bold, italic, cursive, and 100+ other Unicode font styles — free and instant.</p>
+  <a href="https://ultratextgen.com/" class="cta-btn">Open UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Related Resources</span>
+  <div class="compare-grid">
+    <a href="/library/zodiac-symbols/" class="compare-card variant-muted u-no-underline">
+      <h4>Zodiac Symbols</h4>
+      <p>Western zodiac signs, planetary symbols, and Chinese zodiac animals in one reference.</p>
+    </a>
+    <a href="/symbol/taurus-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Taurus Symbol</h4>
+      <p>Scorpio's astrological opposite sign, directly across the zodiac wheel.</p>
+    </a>
+    <a href="/symbol/libra-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Libra Symbol</h4>
+      <p>The only zodiac symbol that represents an object rather than an animal or person.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js"></script>
+<script src="/footer.js"></script>
+</body>
+</html>

--- a/symbol/virgo-symbol/index.html
+++ b/symbol/virgo-symbol/index.html
@@ -1,0 +1,207 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8242324164413945"
+       crossorigin="anonymous"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Virgo Symbol: Copy &amp; Paste ♍ — The Only Zodiac Sign Personified as a Woman</title>
+<meta name="description" content="Copy and paste the Virgo zodiac symbol (♍) and the real myth behind it — Astraea, the virgin goddess of justice and the only sign personified as a woman, the last deity to abandon earth. Click any symbol to copy it instantly.">
+
+<link rel="canonical" href="https://ultratextgen.com/symbol/virgo-symbol/">
+<meta property="og:image" content="https://ultratextgen.com/logo.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Virgo Symbol: Copy &amp; Paste ♍ — The Only Zodiac Sign Personified as a Woman">
+<meta name="twitter:description" content="Copy and paste the Virgo zodiac symbol (♍) and the real myth behind it — Astraea, the virgin goddess of justice and the only sign personified as a woman, the last deity to abandon earth. Click any symbol to copy it instantly.">
+<meta name="twitter:image" content="https://ultratextgen.com/logo.png">
+<meta property="og:title" content="Virgo Symbol: Copy &amp; Paste ♍ — The Only Zodiac Sign Personified as a Woman">
+<meta property="og:description" content="Copy and paste the Virgo zodiac symbol (♍) and the real myth behind it — Astraea, the virgin goddess of justice and the only sign personified as a woman, the last deity to abandon earth. Click any symbol to copy it instantly.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/symbol/virgo-symbol/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Virgo Symbol: Copy & Paste ♍ — The Only Zodiac Sign Personified as a Woman",
+  "description": "Copy and paste the Virgo zodiac symbol (♍) and the real myth behind it — Astraea, the virgin goddess of justice and the only sign personified as a woman, the last deity to abandon earth. Click any symbol to copy it instantly.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "mainEntityOfPage": "https://ultratextgen.com/symbol/virgo-symbol/",
+  "datePublished": "2026-07-13",
+  "dateModified": "2026-07-13"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://ultratextgen.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Symbols",
+      "item": "https://ultratextgen.com/symbol/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Virgo Symbol",
+      "item": "https://ultratextgen.com/symbol/virgo-symbol/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<script src="/header.js"></script>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Virgo Symbol</h1>
+    <p class="hero-tagline">Virgo's glyph (♍) is a looped ‘M’ read as a maiden holding a sheaf of wheat — and Virgo is the only one of the twelve signs personified as a woman, the goddess Astraea who was the last god to leave the mortal world. Click any symbol to copy it instantly.</p>
+  </div>
+</section>
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>The Virgo symbol (♍, U+264D) is a stylized letter M with a looped tail, most often read as a maiden holding a sheaf of wheat — and Virgo is the only sign of the twelve personified as a woman. The figure is most commonly identified with Astraea, the virgin goddess of justice and daughter of Zeus and Themis (the goddess of divine order). Astraea lived among mortals during the Golden Age, but as humanity turned wicked through the Silver and Bronze Ages the gods abandoned earth one by one; Astraea was the last to leave, ascending to become the constellation Virgo — still holding the scales that became neighboring Libra. Some traditions instead identify Virgo with Demeter or Persephone. Virgo runs August 23–September 22, is ruled by Mercury, and is an Earth sign with Mutable modality.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="virgo-symbol">
+  <span class="article-section-label">Virgo</span>
+  <h2>Virgo Symbol</h2>
+  <p class="u-secondary-tight">The Unicode Virgo zodiac glyph, ready to paste.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♍" aria-label="Copy Virgo Symbol">♍</button>
+      <span class="flag-label">Virgo Symbol</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♍️" aria-label="Copy Virgo Symbol (Emoji)">♍️</button>
+      <span class="flag-label">Virgo Symbol (Emoji)</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="ruling-planet-element">
+  <span class="article-section-label">Planet &amp; Element</span>
+  <h2>Ruling Planet &amp; Element</h2>
+  <p class="u-secondary-tight">The planet and classical element traditionally associated with Virgo.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☿" aria-label="Copy Mercury (Ruling Planet)">☿</button>
+      <span class="flag-label">Mercury (Ruling Planet)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🜃" aria-label="Copy Earth (Element, Alchemical)">🜃</button>
+      <span class="flag-label">Earth (Element, Alchemical)</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="related-zodiac-celestial">
+  <span class="article-section-label">Zodiac &amp; Celestial</span>
+  <h2>More Zodiac &amp; Celestial Symbols</h2>
+  <p class="u-secondary-tight">Celestial bodies and the astrological opposite of Virgo (Pisces).</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☉" aria-label="Copy Sun">☉</button>
+      <span class="flag-label">Sun</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☽" aria-label="Copy Moon (First Quarter)">☽</button>
+      <span class="flag-label">Moon (First Quarter)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛎" aria-label="Copy Ophiuchus (Unofficial 13th Sign)">⛎</button>
+      <span class="flag-label">Ophiuchus (Unofficial 13th Sign)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="♓" aria-label="Copy Pisces (Opposite Sign)">♓</button>
+      <span class="flag-label">Pisces (Opposite Sign)</span>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Transform text with Unicode fonts</h3>
+  <p>Use UltraTextGen to convert plain text into bold, italic, cursive, and 100+ other Unicode font styles — free and instant.</p>
+  <a href="https://ultratextgen.com/" class="cta-btn">Open UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Related Resources</span>
+  <div class="compare-grid">
+    <a href="/library/zodiac-symbols/" class="compare-card variant-muted u-no-underline">
+      <h4>Zodiac Symbols</h4>
+      <p>Western zodiac signs, planetary symbols, and Chinese zodiac animals in one reference.</p>
+    </a>
+    <a href="/symbol/pisces-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Pisces Symbol</h4>
+      <p>Virgo's astrological opposite sign, directly across the zodiac wheel.</p>
+    </a>
+    <a href="/symbol/gemini-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Gemini Symbol</h4>
+      <p>The other Mercury-ruled sign, with the Castor and Pollux twins myth behind it.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js"></script>
+<script src="/footer.js"></script>
+</body>
+</html>

--- a/symbol/won-sign/index.html
+++ b/symbol/won-sign/index.html
@@ -1,0 +1,203 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8242324164413945"
+       crossorigin="anonymous"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Won Symbol: Copy &amp; Paste ₩ — The One Sign Two Rival Koreas Share</title>
+<meta name="description" content="Copy and paste the won sign (₩) — the single currency symbol used by both the South Korean won (KRW) and the North Korean won (KPW), and a linguistic cousin of the yen and yuan. Click any symbol to copy it instantly.">
+
+<link rel="canonical" href="https://ultratextgen.com/symbol/won-sign/">
+<meta property="og:image" content="https://ultratextgen.com/logo.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Won Symbol: Copy &amp; Paste ₩ — The One Sign Two Rival Koreas Share">
+<meta name="twitter:description" content="Copy and paste the won sign (₩) — the single currency symbol used by both the South Korean won (KRW) and the North Korean won (KPW), and a linguistic cousin of the yen and yuan. Click any symbol to copy it instantly.">
+<meta name="twitter:image" content="https://ultratextgen.com/logo.png">
+<meta property="og:title" content="Won Symbol: Copy &amp; Paste ₩ — The One Sign Two Rival Koreas Share">
+<meta property="og:description" content="Copy and paste the won sign (₩) — the single currency symbol used by both the South Korean won (KRW) and the North Korean won (KPW), and a linguistic cousin of the yen and yuan. Click any symbol to copy it instantly.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/symbol/won-sign/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Won Symbol: Copy & Paste ₩ — The One Sign Two Rival Koreas Share",
+  "description": "Copy and paste the won sign (₩) — the single currency symbol used by both the South Korean won (KRW) and the North Korean won (KPW), and a linguistic cousin of the yen and yuan. Click any symbol to copy it instantly.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "mainEntityOfPage": "https://ultratextgen.com/symbol/won-sign/",
+  "datePublished": "2026-07-13",
+  "dateModified": "2026-07-13"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://ultratextgen.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Symbols",
+      "item": "https://ultratextgen.com/symbol/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Won Sign",
+      "item": "https://ultratextgen.com/symbol/won-sign/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<script src="/header.js"></script>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Won Sign</h1>
+    <p class="hero-tagline">The ₩ currency mark shared by both the South Korean won (KRW) and the North Korean won (KPW) — one Unicode character for two states that aren’t on speaking terms. Click any symbol to copy it instantly.</p>
+  </div>
+</section>
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>The won sign (₩) is a rare kind of currency symbol: a single Unicode character — U+20A9, added back in Unicode 1.1 in 1993 — that officially stands for two separate national currencies at once. Both the South Korean won (code KRW) and the North Korean won (KPW) are written with the identical ₩ glyph, a capital “W” crossed by a horizontal stroke, even though the two governments have been divided since 1948 and their wons trade at wildly different values. The name is old: the won was introduced under the Korean Empire in 1902, replacing the yang, and it comes from the hanja 圓 (원), meaning “round” — the very same root behind Japan’s yen and China’s yuan, all three descended from the round Spanish-American silver dollar that dominated East Asian trade for generations. One symbol, two countries, and a shared etymology stretching across the region.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="won-sign">
+  <span class="article-section-label">Won Sign</span>
+  <h2>The Won Symbol (₩)</h2>
+  <p class="u-secondary-tight">The mark itself: a capital W with a horizontal bar through the middle. U+20A9 is the standard sign for almost every context; the fullwidth version is a compatibility character that lines up with the fixed grid of Korean and other CJK text.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="₩" aria-label="Copy Won Sign (U+20A9)">₩</button>
+      <span class="flag-label">Won Sign (U+20A9)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="￦" aria-label="Copy Fullwidth Won Sign (U+FFE6)">￦</button>
+      <span class="flag-label">Fullwidth Won Sign (U+FFE6)</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="two-koreas">
+  <span class="article-section-label">Two Koreas</span>
+  <h2>One Sign, Two Rival Currencies</h2>
+  <p class="u-secondary-tight">The same ₩ denotes both the South Korean won (KRW) and the North Korean won (KPW) — two currencies from two states that split in 1948 and remain, technically, at war. In Korean the unit is written 원 in Hangul. Nothing about the symbol distinguishes the two; only the three-letter currency code does.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="₩" aria-label="Copy Won Sign (U+20A9) — Shared by KRW (South) and KPW (North)">₩</button>
+      <span class="flag-label">Won Sign (U+20A9) — Shared by KRW (South) and KPW (North)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="원" aria-label="Copy Won Written in Hangul (원)">원</button>
+      <span class="flag-label">Won Written in Hangul (원)</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="won-yen-yuan">
+  <span class="article-section-label">Yen &amp; Yuan Family</span>
+  <h2>The Won, Yen &amp; Yuan Family</h2>
+  <p class="u-secondary-tight">Won, yen, and yuan are linguistic cousins — all three trace back to the character 圓 (simplified to 元 in modern China), meaning “round,” after the round silver dollars that once circulated across Asia. Japan’s yen and China’s yuan even share a single symbol, ¥, which is part of why non-native readers occasionally confuse ₩ and ¥ at a glance.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="¥" aria-label="Copy Yen &amp; Yuan Sign (U+00A5)">¥</button>
+      <span class="flag-label">Yen &amp; Yuan Sign (U+00A5)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="圓" aria-label="Copy Hanja 圓 — “Round,” the Shared Root">圓</button>
+      <span class="flag-label">Hanja 圓 — “Round,” the Shared Root</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="元" aria-label="Copy Yuan (元)">元</button>
+      <span class="flag-label">Yuan (元)</span>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Transform text with Unicode fonts</h3>
+  <p>Use UltraTextGen to convert plain text into bold, italic, cursive, and 100+ other Unicode font styles — free and instant.</p>
+  <a href="https://ultratextgen.com/" class="cta-btn">Open UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Related Resources</span>
+  <div class="compare-grid">
+    <a href="/library/currency-symbols/" class="compare-card variant-muted u-no-underline">
+      <h4>Currency Symbols</h4>
+      <p>A browsable set of world currency marks, from the dollar and euro to the rupee and bitcoin.</p>
+    </a>
+    <a href="/symbol/yen-sign/" class="compare-card variant-muted u-no-underline">
+      <h4>Yen Sign</h4>
+      <p>The won’s East Asian cousin — same “round” etymology, and the ¥ glyph non-native readers sometimes mix up with ₩.</p>
+    </a>
+    <a href="/symbol/dollar-sign/" class="compare-card variant-muted u-no-underline">
+      <h4>Dollar Sign</h4>
+      <p>The Spanish-American silver dollar that seeded the won, yen, and yuan is also the coin most often credited with the $ sign’s own origin.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js"></script>
+<script src="/footer.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
Adds 16 new symbol reference pages to the library, expanding coverage across religious/spiritual symbols, mathematical notation, zodiac signs, and currency marks. Each page follows the established single-glyph identity spoke pattern with copy-paste functionality, historical context, and related symbol variants.

## Changes

### New Symbol Pages (16 total)
- **Religious/Spiritual**: Om (ॐ 🕉️), Ankh (☥), Fleur-de-lis (⚜)
- **Mathematical/Scientific**: Ohm (Ω ℧), Alpha (Α α), Pi (π Π ∏), Delta (Δ δ), Congruent (≅)
- **Zodiac Signs**: Aries (♈), Cancer (♋), Capricorn (♑), Pisces (♓), Scorpio (♏), Virgo (♍)
- **Currency**: Won (₩)

### Data Files
- Added 16 JSON spec files in `data/library_page_specs/` with metadata, descriptions, and symbol variants for each page

### Library Index Updates
Updated cross-reference links in:
- `library/zodiac-symbols/` — added 6 zodiac symbol cards
- `library/greek-letter-symbols/` — added Alpha and Pi
- `library/math-symbols/` — added Congruent
- `library/crown-royalty-symbols/` — added Fleur-de-lis
- `library/currency-symbols/` — added Won
- `library/egyptian-hieroglyphs/` — added Ankh
- `library/electrical-circuit-symbols/` — added Ohm
- `library/recycle-environment-symbols/` — added Recycling
- `library/religious-symbols/` — added Om
- `symbol/index.html` — added Congruent to main symbol hub

### Implementation Details
- Each page includes Google Tag Manager and AdSense integration (consistent with existing pages)
- Pages feature Unicode code points, historical/mythological context, and related symbol variants
- All pages follow the established template structure (223 lines for most, 207–221 for zodiac/currency variants)
- Updated `symbol/index.html` dateModified to 2026-07-13

https://claude.ai/code/session_012nDCqmx8onEmm9ZeVaNN3J