### PR TITLE
Fix emoji and symbol representations in library pages

### DIFF
--- a/library/di-maria-emoji-combos/index.html
+++ b/library/di-maria-emoji-combos/index.html
@@ -138,7 +138,7 @@
       <span class="flag-label">Angel (Ángel)</span>
     </div>
     <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="🔟" aria-label="Copy Number 11">🔟</button>
+      <button class="flag-emoji symbol-tile" data-symbol="1️⃣1️⃣" aria-label="Copy Number 11">1️⃣1️⃣</button>
       <span class="flag-label">Number 11</span>
     </div>
     <div class="flag-row">

--- a/library/electrical-circuit-symbols/index.html
+++ b/library/electrical-circuit-symbols/index.html
@@ -271,7 +271,7 @@
   <p class="u-secondary-tight">The ohm sign plus single-character squared units for volts, amps, watts, hertz, and farads.</p>
   <div class="flag-rows">
     <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="Ω" aria-label="Copy Ohm Sign">Ω</button>
+      <button class="flag-emoji symbol-tile" data-symbol="Ω" aria-label="Copy Ohm Sign">Ω</button>
       <span class="flag-label">Ohm Sign</span>
     </div>
     <div class="flag-row">

--- a/library/france-emoji-combos/index.html
+++ b/library/france-emoji-combos/index.html
@@ -180,8 +180,8 @@
       <span class="flag-label">Rooster</span>
     </div>
     <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="🗼" aria-label="Copy Eiffel Tower">🗼</button>
-      <span class="flag-label">Eiffel Tower</span>
+      <button class="flag-emoji symbol-tile" data-symbol="⚜️" aria-label="Copy Fleur-de-lis">⚜️</button>
+      <span class="flag-label">Fleur-de-lis</span>
     </div>
     <div class="flag-row">
       <button class="flag-emoji symbol-tile" data-symbol="🏆" aria-label="Copy Trophy">🏆</button>

--- a/library/nkunku-emoji-combos/index.html
+++ b/library/nkunku-emoji-combos/index.html
@@ -138,7 +138,7 @@
       <span class="flag-label">Gem (Flair)</span>
     </div>
     <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="🔟" aria-label="Copy Number 18">🔟</button>
+      <button class="flag-emoji symbol-tile" data-symbol="1️⃣8️⃣" aria-label="Copy Number 18">1️⃣8️⃣</button>
       <span class="flag-label">Number 18</span>
     </div>
     <div class="flag-row">

--- a/library/rodrygo-emoji-combos/index.html
+++ b/library/rodrygo-emoji-combos/index.html
@@ -138,7 +138,7 @@
       <span class="flag-label">Sparkles (Magic)</span>
     </div>
     <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="🔟" aria-label="Copy Number 11">🔟</button>
+      <button class="flag-emoji symbol-tile" data-symbol="1️⃣1️⃣" aria-label="Copy Number 11">1️⃣1️⃣</button>
       <span class="flag-label">Number 11</span>
     </div>
     <div class="flag-row">

--- a/library/unit-measurement-symbols/index.html
+++ b/library/unit-measurement-symbols/index.html
@@ -128,7 +128,7 @@
   <p class="u-secondary-tight">Dedicated single-character signs for resistance, conductance, and atomic-scale measurement.</p>
   <div class="flag-rows">
     <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="Ω" aria-label="Copy Ohm Sign">Ω</button>
+      <button class="flag-emoji symbol-tile" data-symbol="Ω" aria-label="Copy Ohm Sign">Ω</button>
       <span class="flag-label">Ohm Sign</span>
     </div>
     <div class="flag-row">

--- a/symbol/celsius-symbol/index.html
+++ b/symbol/celsius-symbol/index.html
@@ -212,7 +212,7 @@
       <span class="flag-label">Micro Sign (U+00B5)</span>
     </div>
     <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="Ω" aria-label="Copy Ohm Sign (U+2126)">Ω</button>
+      <button class="flag-emoji symbol-tile" data-symbol="Ω" aria-label="Copy Ohm Sign (U+2126)">Ω</button>
       <span class="flag-label">Ohm Sign (U+2126)</span>
     </div>
   </div>

--- a/symbol/fahrenheit-symbol/index.html
+++ b/symbol/fahrenheit-symbol/index.html
@@ -212,7 +212,7 @@
       <span class="flag-label">Micro Sign (U+00B5)</span>
     </div>
     <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="Ω" aria-label="Copy Ohm Sign (U+2126)">Ω</button>
+      <button class="flag-emoji symbol-tile" data-symbol="Ω" aria-label="Copy Ohm Sign (U+2126)">Ω</button>
       <span class="flag-label">Ohm Sign (U+2126)</span>
     </div>
   </div>

--- a/symbol/micro-sign/index.html
+++ b/symbol/micro-sign/index.html
@@ -191,7 +191,7 @@
   <p class="u-secondary-tight">Other measurement and scientific-notation marks that show up alongside µ in technical text.</p>
   <div class="flag-rows">
     <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="Ω" aria-label="Copy Ohm Sign">Ω</button>
+      <button class="flag-emoji symbol-tile" data-symbol="Ω" aria-label="Copy Ohm Sign">Ω</button>
       <span class="flag-label">Ohm Sign</span>
     </div>
     <div class="flag-row">


### PR DESCRIPTION
## Summary
Corrected emoji and symbol displays across multiple library pages to use more accurate and visually appropriate representations for the intended concepts.

## Changes Made

- **France Pride Emojis**: Replaced Eiffel Tower (🗼) with Fleur-de-lis (⚜️) as a more iconic French national symbol
- **Di Maria, Nkuku, and Rodrygo Emoji Combos**: Updated jersey number representations from generic "🔟" to properly composed keycap sequences:
  - Di Maria: `1️⃣1️⃣` (Number 11)
  - Nkunku: `1️⃣8️⃣` (Number 18)
  - Rodrygo: `1️⃣1️⃣` (Number 11)
- **Electrical & Physics Unit Symbols**: Standardized Ohm Sign (Ω) display across multiple pages (electrical-circuit-symbols, unit-measurement-symbols, celsius-symbol, fahrenheit-symbol, micro-sign)

## Implementation Details

The changes maintain consistency with the existing symbol-tile button structure and aria-labels. The keycap emoji sequences use the proper combining format (individual digit + variation selector) for better cross-platform rendering of multi-digit numbers. All data-symbol attributes and display text are kept in sync.

https://claude.ai/code/session_01UkXBFPLQRcqzrk3Dbw97Wt