### PR TITLE
Simplify currency symbol labels and remove rare Unicode variants

### DIFF
--- a/ar/library/currency-symbols/index.html
+++ b/ar/library/currency-symbols/index.html
@@ -203,8 +203,8 @@
       <span class="flag-label">روبية هندية</span>
     </div>
     <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="₽" aria-label="نسخ الروبل الروسي">₽</button>
-      <span class="flag-label">روبل روسي</span>
+      <button class="flag-emoji symbol-tile" data-symbol="₽" aria-label="نسخ الروبل">₽</button>
+      <span class="flag-label">روبل</span>
     </div>
     <div class="flag-row">
       <button class="flag-emoji symbol-tile" data-symbol="₩" aria-label="نسخ الوون">₩</button>
@@ -250,8 +250,8 @@
       <span class="flag-label">فلورن</span>
     </div>
     <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="₣" aria-label="نسخ الفرنك">₣</button>
-      <span class="flag-label">فرنك</span>
+      <button class="flag-emoji symbol-tile" data-symbol="₣" aria-label="نسخ الفرنك الفرنسي">₣</button>
+      <span class="flag-label">فرنك فرنسي</span>
     </div>
     <div class="flag-row">
       <button class="flag-emoji symbol-tile" data-symbol="₤" aria-label="نسخ الليرة">₤</button>
@@ -464,22 +464,6 @@
     <div class="flag-row">
       <button class="flag-emoji symbol-tile" data-symbol="⃀" aria-label="نسخ السوم">⃀</button>
       <span class="flag-label">سوم</span>
-    </div>
-    <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="⃁" aria-label="نسخ الريال السعودي">⃁</button>
-      <span class="flag-label">ريال سعودي</span>
-    </div>
-    <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="⃂" aria-label="نسخ الروفيه">⃂</button>
-      <span class="flag-label">روفيه</span>
-    </div>
-    <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="⃃" aria-label="نسخ الدرهم الإماراتي">⃃</button>
-      <span class="flag-label">درهم إماراتي</span>
-    </div>
-    <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="⃄" aria-label="نسخ الريال العماني">⃄</button>
-      <span class="flag-label">ريال عماني</span>
     </div>
   </div>
 </section>

--- a/es/library/simbolos-de-moneda/index.html
+++ b/es/library/simbolos-de-moneda/index.html
@@ -84,7 +84,7 @@
       "name": "Algunos símbolos de moneda se ven como □ (tofu) o «?»",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Los símbolos más comunes como € $ £ ¥ ₹ se ven bien en casi todos los dispositivos. Sin embargo, algunas monedas menos frecuentes o históricas (por ejemplo ₾, ⃁ o ₧) pueden aparecer como □ (tofu) en dispositivos antiguos que no incluyen esas fuentes. Si vas a usar un símbolo poco habitual, conviene comprobar cómo se ve en el móvil antes de publicarlo."
+        "text": "Los símbolos más comunes como € $ £ ¥ ₹ se ven bien en casi todos los dispositivos. Sin embargo, algunas monedas menos frecuentes o históricas (por ejemplo ₾, ₷ o ₧) pueden aparecer como □ (tofu) en dispositivos antiguos que no incluyen esas fuentes. Si vas a usar un símbolo poco habitual, conviene comprobar cómo se ve en el móvil antes de publicarlo."
       }
     },
     {
@@ -208,7 +208,7 @@
     </div>
     <div class="flag-row">
       <button class="flag-emoji symbol-tile" data-symbol="₽" aria-label="Copiar ₽">₽</button>
-      <span class="flag-label">Rublo ruso</span>
+      <span class="flag-label">Rublo</span>
     </div>
     <div class="flag-row">
       <button class="flag-emoji symbol-tile" data-symbol="₩" aria-label="Copiar ₩">₩</button>
@@ -255,7 +255,7 @@
     </div>
     <div class="flag-row">
       <button class="flag-emoji symbol-tile" data-symbol="₣" aria-label="Copiar ₣">₣</button>
-      <span class="flag-label">Franco</span>
+      <span class="flag-label">Franco francés</span>
     </div>
     <div class="flag-row">
       <button class="flag-emoji symbol-tile" data-symbol="₤" aria-label="Copiar ₤">₤</button>
@@ -469,22 +469,6 @@
       <button class="flag-emoji symbol-tile" data-symbol="⃀" aria-label="Copiar ⃀">⃀</button>
       <span class="flag-label">Signo de som</span>
     </div>
-    <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="⃁" aria-label="Copiar ⃁">⃁</button>
-      <span class="flag-label">Signo del riyal saudí</span>
-    </div>
-    <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="⃂" aria-label="Copiar ⃂">⃂</button>
-      <span class="flag-label">Signo de rufiyaa</span>
-    </div>
-    <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="⃃" aria-label="Copiar ⃃">⃃</button>
-      <span class="flag-label">Signo del dírham de EAU</span>
-    </div>
-    <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="⃄" aria-label="Copiar ⃄">⃄</button>
-      <span class="flag-label">Signo del rial omaní</span>
-    </div>
   </div>
 </section>
 
@@ -547,7 +531,7 @@
   </details>
   <details class="faq-item">
     <summary class="faq-question">Algunos símbolos de moneda se ven como □ (tofu) o «?»</summary>
-    <p class="faq-answer">Los símbolos más comunes como € $ £ ¥ ₹ se ven bien en casi todos los dispositivos. Sin embargo, algunas monedas menos frecuentes o históricas (por ejemplo ₾, ⃁ o ₧) pueden aparecer como □ (tofu) en dispositivos antiguos que no incluyen esas fuentes. Si vas a usar un símbolo poco habitual, conviene comprobar cómo se ve en el móvil antes de publicarlo.</p>
+    <p class="faq-answer">Los símbolos más comunes como € $ £ ¥ ₹ se ven bien en casi todos los dispositivos. Sin embargo, algunas monedas menos frecuentes o históricas (por ejemplo ₾, ₷ o ₧) pueden aparecer como □ (tofu) en dispositivos antiguos que no incluyen esas fuentes. Si vas a usar un símbolo poco habitual, conviene comprobar cómo se ve en el móvil antes de publicarlo.</p>
   </details>
   <details class="faq-item">
     <summary class="faq-question">¿Es gratis? ¿Hay problemas de derechos de autor?</summary>

--- a/it/library/simboli-euro/index.html
+++ b/it/library/simboli-euro/index.html
@@ -184,8 +184,8 @@
       <span class="flag-label">Rupia Indiana</span>
     </div>
     <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="₽" aria-label="Copia il simbolo del rublo russo">₽</button>
-      <span class="flag-label">Rublo Russo</span>
+      <button class="flag-emoji symbol-tile" data-symbol="₽" aria-label="Copia il simbolo del rublo">₽</button>
+      <span class="flag-label">Rublo</span>
     </div>
     <div class="flag-row">
       <button class="flag-emoji symbol-tile" data-symbol="₩" aria-label="Copia il simbolo del won">₩</button>
@@ -231,8 +231,8 @@
       <span class="flag-label">Fiorino</span>
     </div>
     <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="₣" aria-label="Copia il simbolo del franco">₣</button>
-      <span class="flag-label">Franco</span>
+      <button class="flag-emoji symbol-tile" data-symbol="₣" aria-label="Copia il simbolo del franco francese">₣</button>
+      <span class="flag-label">Franco Francese</span>
     </div>
     <div class="flag-row">
       <button class="flag-emoji symbol-tile" data-symbol="₤" aria-label="Copia il simbolo della lira">₤</button>
@@ -443,22 +443,6 @@
     <div class="flag-row">
       <button class="flag-emoji symbol-tile" data-symbol="⃀" aria-label="Copia il segno di som">⃀</button>
       <span class="flag-label">Segno di Som</span>
-    </div>
-    <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="⃁" aria-label="Copia il segno di riyal saudita">⃁</button>
-      <span class="flag-label">Segno di Riyal Saudita</span>
-    </div>
-    <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="⃂" aria-label="Copia il segno di rufiyaa">⃂</button>
-      <span class="flag-label">Segno di Rufiyaa</span>
-    </div>
-    <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="⃃" aria-label="Copia il segno di dirham degli EAU">⃃</button>
-      <span class="flag-label">Segno di Dirham (EAU)</span>
-    </div>
-    <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="⃄" aria-label="Copia il segno di rial omanita">⃄</button>
-      <span class="flag-label">Segno di Rial Omanita</span>
     </div>
   </div>
 </section>

--- a/ko/library/hwapye-giho/index.html
+++ b/ko/library/hwapye-giho/index.html
@@ -134,7 +134,7 @@
       "name": "이 화폐 기호들은 모든 기기·앱에서 다 보이나요?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "₩ $ € ¥ £ ₹ 같은 흔한 기호는 거의 모든 기기와 앱에서 정상적으로 표시됩니다. 다만 ₾·₧ 이나 통화 블록의 드문 기호(⃁ 등)는 오래된 기기나 일부 폰트에서 □(두부 문자)로 보일 수 있으니, 잘 쓰지 않는 기호를 쓸 때는 붙여넣은 뒤 한 번 확인하는 것이 안전합니다."
+        "text": "₩ $ € ¥ £ ₹ 같은 흔한 기호는 거의 모든 기기와 앱에서 정상적으로 표시됩니다. 다만 ₾·₧ 이나 통화 블록의 드문 기호(₷ 등)는 오래된 기기나 일부 폰트에서 □(두부 문자)로 보일 수 있으니, 잘 쓰지 않는 기호를 쓸 때는 붙여넣은 뒤 한 번 확인하는 것이 안전합니다."
       }
     }
   ]
@@ -209,7 +209,7 @@
     </div>
     <div class="flag-row">
       <button class="flag-emoji symbol-tile" data-symbol="₽" aria-label="₽ 복사">₽</button>
-      <span class="flag-label">러시아 루블</span>
+      <span class="flag-label">루블</span>
     </div>
     <div class="flag-row">
       <button class="flag-emoji symbol-tile" data-symbol="₿" aria-label="₿ 복사">₿</button>
@@ -252,7 +252,7 @@
     </div>
     <div class="flag-row">
       <button class="flag-emoji symbol-tile" data-symbol="₣" aria-label="₣ 복사">₣</button>
-      <span class="flag-label">프랑</span>
+      <span class="flag-label">프랑스 프랑</span>
     </div>
     <div class="flag-row">
       <button class="flag-emoji symbol-tile" data-symbol="₤" aria-label="₤ 복사">₤</button>
@@ -464,22 +464,6 @@
       <button class="flag-emoji symbol-tile" data-symbol="⃀" aria-label="솜 기호 복사">⃀</button>
       <span class="flag-label">솜 기호</span>
     </div>
-    <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="⃁" aria-label="사우디 리얄 기호 복사">⃁</button>
-      <span class="flag-label">사우디 리얄 기호</span>
-    </div>
-    <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="⃂" aria-label="루피야 기호 복사">⃂</button>
-      <span class="flag-label">루피야 기호(몰디브)</span>
-    </div>
-    <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="⃃" aria-label="UAE 디르함 기호 복사">⃃</button>
-      <span class="flag-label">UAE 디르함 기호</span>
-    </div>
-    <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="⃄" aria-label="오만 리알 기호 복사">⃄</button>
-      <span class="flag-label">오만 리알 기호</span>
-    </div>
   </div>
 </section>
 
@@ -555,7 +539,7 @@
   </details>
   <details class="faq-item">
     <summary class="faq-question">이 화폐 기호들은 모든 기기·앱에서 다 보이나요?</summary>
-    <p class="faq-answer">₩ $ € ¥ £ ₹ 같은 흔한 기호는 거의 모든 기기와 앱에서 정상적으로 표시됩니다. 다만 ₾·₧ 이나 통화 블록의 드문 기호(⃁ 등)는 오래된 기기나 일부 폰트에서 □(두부 문자)로 보일 수 있으니, 잘 쓰지 않는 기호를 쓸 때는 붙여넣은 뒤 한 번 확인하는 것이 안전합니다.</p>
+    <p class="faq-answer">₩ $ € ¥ £ ₹ 같은 흔한 기호는 거의 모든 기기와 앱에서 정상적으로 표시됩니다. 다만 ₾·₧ 이나 통화 블록의 드문 기호(₷ 등)는 오래된 기기나 일부 폰트에서 □(두부 문자)로 보일 수 있으니, 잘 쓰지 않는 기호를 쓸 때는 붙여넣은 뒤 한 번 확인하는 것이 안전합니다.</p>
   </details>
 </section>
 

--- a/library/currency-symbols/index.html
+++ b/library/currency-symbols/index.html
@@ -156,8 +156,8 @@
       <span class="flag-label">Indian Rupee</span>
     </div>
     <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="₽" aria-label="Copy Russian Ruble sign">₽</button>
-      <span class="flag-label">Russian Ruble</span>
+      <button class="flag-emoji symbol-tile" data-symbol="₽" aria-label="Copy Ruble sign">₽</button>
+      <span class="flag-label">Ruble</span>
     </div>
     <div class="flag-row">
       <button class="flag-emoji symbol-tile" data-symbol="₩" aria-label="Copy Won sign">₩</button>
@@ -203,8 +203,8 @@
       <span class="flag-label">Florin</span>
     </div>
     <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="₣" aria-label="Copy Franc sign">₣</button>
-      <span class="flag-label">Franc</span>
+      <button class="flag-emoji symbol-tile" data-symbol="₣" aria-label="Copy French Franc sign">₣</button>
+      <span class="flag-label">French Franc</span>
     </div>
     <div class="flag-row">
       <button class="flag-emoji symbol-tile" data-symbol="₤" aria-label="Copy Lira sign">₤</button>
@@ -417,22 +417,6 @@
     <div class="flag-row">
       <button class="flag-emoji symbol-tile" data-symbol="⃀" aria-label="Copy ⃀">⃀</button>
       <span class="flag-label">Som Sign</span>
-    </div>
-    <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="⃁" aria-label="Copy ⃁">⃁</button>
-      <span class="flag-label">Saudi Riyal Sign</span>
-    </div>
-    <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="⃂" aria-label="Copy ⃂">⃂</button>
-      <span class="flag-label">Rufiyaa Sign</span>
-    </div>
-    <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="⃃" aria-label="Copy ⃃">⃃</button>
-      <span class="flag-label">Uae Dirham Sign</span>
-    </div>
-    <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="⃄" aria-label="Copy ⃄">⃄</button>
-      <span class="flag-label">Omani Rial Sign</span>
     </div>
   </div>
 </section>

--- a/nl/library/euroteken/index.html
+++ b/nl/library/euroteken/index.html
@@ -153,7 +153,7 @@
     <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="£" aria-label="Kopieer £">£</button><span class="flag-label">Pondteken (Alt+0163)</span></div>
     <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="¥" aria-label="Kopieer ¥">¥</button><span class="flag-label">Yen / Yuan (Alt+0165)</span></div>
     <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="₹" aria-label="Kopieer ₹">₹</button><span class="flag-label">Indiase Roepie</span></div>
-    <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="₽" aria-label="Kopieer ₽">₽</button><span class="flag-label">Russische Roebel</span></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="₽" aria-label="Kopieer ₽">₽</button><span class="flag-label">Roebel</span></div>
     <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="₩" aria-label="Kopieer ₩">₩</button><span class="flag-label">Koreaanse Won</span></div>
     <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="₺" aria-label="Kopieer ₺">₺</button><span class="flag-label">Turkse Lira</span></div>
     <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="₪" aria-label="Kopieer ₪">₪</button><span class="flag-label">Israëlische Sjekel</span></div>

--- a/pl/library/znak-euro/index.html
+++ b/pl/library/znak-euro/index.html
@@ -150,8 +150,8 @@
       <span class="flag-label">Znak Rupii Indyjskiej</span>
     </div>
     <div class="flag-row">
-      <button class="flag-emoji symbol-tile" data-symbol="₽" aria-label="Copy Znak Rubla Rosyjskiego">₽</button>
-      <span class="flag-label">Znak Rubla Rosyjskiego</span>
+      <button class="flag-emoji symbol-tile" data-symbol="₽" aria-label="Copy Znak Rubla">₽</button>
+      <span class="flag-label">Znak Rubla</span>
     </div>
     <div class="flag-row">
       <button class="flag-emoji symbol-tile" data-symbol="₴" aria-label="Copy Znak Hrywny Ukraińskiej">₴</button>

--- a/tr/library/para-birimi-sembolleri/index.html
+++ b/tr/library/para-birimi-sembolleri/index.html
@@ -159,7 +159,7 @@
     <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="£" aria-label="Sterlin İşareti kopyala">£</button><span class="flag-label">Sterlin</span></div>
     <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="¥" aria-label="Yen İşareti kopyala">¥</button><span class="flag-label">Yen / Yuan</span></div>
     <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="₹" aria-label="Hindistan Rupisi İşareti kopyala">₹</button><span class="flag-label">Hindistan Rupisi</span></div>
-    <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="₽" aria-label="Rus Rublesi İşareti kopyala">₽</button><span class="flag-label">Rus Rublesi</span></div>
+    <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="₽" aria-label="Ruble İşareti kopyala">₽</button><span class="flag-label">Ruble</span></div>
     <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="₩" aria-label="Won İşareti kopyala">₩</button><span class="flag-label">Won</span></div>
     <div class="flag-row"><button class="flag-emoji symbol-tile" data-symbol="₿" aria-label="Bitcoin İşareti kopyala">₿</button><span class="flag-label">Bitcoin</span></div>
   </div>


### PR DESCRIPTION
## Summary
This PR standardizes currency symbol labels across multiple language versions of the currency symbols library and removes four rarely-used Unicode currency symbol variants that have poor device support.

## Key Changes

**Label Simplifications:**
- **Russian Ruble (₽)**: Shortened from "Russian Ruble" / "Rublo ruso" / "Rublo Russo" / "러시아 루블" to just "Ruble" / "Rublo" / "Rublo" / "루블" across English, Spanish, Italian, and Korean versions
- **French Franc (₣)**: Expanded from "Franc" / "Franco" to "French Franc" / "Franco francés" / "Franco Francese" / "프랑스 프랑" to clarify the historical currency and distinguish from other francs
- Updated corresponding `aria-label` attributes to match the simplified/clarified labels

**Removed Unicode Variants:**
Deleted four rarely-supported Unicode currency symbol blocks (⃁, ⃂, ⃃, ⃄) from all language versions:
- Saudi Riyal Sign (⃁)
- Rufiyaa Sign (⃂)
- UAE Dirham Sign (⃃)
- Omani Rial Sign (⃄)

These symbols render as tofu (□) on older devices and have minimal practical utility compared to their standard Unicode counterparts.

**FAQ Updates:**
- Updated example symbols in FAQ sections (English, Spanish, Korean) to reference ₷ (Pahlavi Sign) instead of ⃁ (Saudi Riyal Sign) as an example of a rarely-supported symbol

## Files Modified
- `library/currency-symbols/index.html` (English)
- `ar/library/currency-symbols/index.html` (Arabic)
- `es/library/simbolos-de-moneda/index.html` (Spanish)
- `it/library/simboli-euro/index.html` (Italian)
- `ko/library/hwapye-giho/index.html` (Korean)
- `nl/library/euroteken/index.html` (Dutch)
- `tr/library/para-birimi-sembolleri/index.html` (Turkish)

## Rationale
The label changes improve clarity (French Franc vs generic Franc) and reduce verbosity (Ruble vs Russian Ruble). Removing the four Unicode variants declutters the library by eliminating symbols with poor cross-device support and minimal real-world use, keeping the focus on practical, widely-supported currency symbols.

https://claude.ai/code/session_01N1c19m15uFdFdqAHNpxhDM