### PR TITLE
Validate translated pages' lane consistency with English

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,17 @@ is idempotent. Still add one entry back on `symbol/index.html` by hand.
 `library/*` and **fails on orphan spokes** (a spoke no `library/` hub links to),
 so a forgotten sync run is caught before the PR.
 
+**Translating a `library/`/`symbol/` page:** the lane is inherited from the
+English source's `page_type` — it is never re-decided per language. A
+translation of a `symbol/<slug>/` page ships to `<lang>/symbol/<slug>/`, even
+if that language has no `symbol/` pillar yet and every prior translation for
+it landed in `<lang>/library/`. `scripts/validate_library_pages.py` scans
+every `<lang>/library/*` and `<lang>/symbol/*` by default and fails on **lane
+mismatch** (a page's own directory vs. its `hreflang="en"` counterpart's
+directory) — run it over your translated batch before opening the PR. Full
+rationale and the recurring failure mode: `docs/unicode-library-workflow.md`
+§7.
+
 ---
 
 ## Core JavaScript Architecture

--- a/docs/unicode-library-workflow.md
+++ b/docs/unicode-library-workflow.md
@@ -355,21 +355,53 @@ overlap/research gap has been consciously resolved).
 Before opening the PR, lint every generated/changed page:
 
 ```bash
-# whole library
+# whole library — English root AND every translated lane (<lang>/library/,
+# <lang>/symbol/) by default
 python3 scripts/validate_library_pages.py
 
 # or just the batch
 python3 scripts/validate_library_pages.py library/<slug>/ library/<slug2>/
+python3 scripts/validate_library_pages.py id/library/<slug>/
 ```
 
 Errors (fail the run): missing title/description/canonical, not exactly one
 `<h1>`, fewer than 3 `<h2>`, single-copy page under the minimum button count,
 `.symbol-tile` buttons missing `data-symbol`/`aria-label`, missing
 `#symbolToast` or `/symbol-explorer.js`, a collections container with no
-`buildGrids` call, and duplicate titles/descriptions across pages.
+`buildGrids` call, duplicate titles/descriptions across pages, and a **lane
+mismatch** — a page under a `library/` directory whose `hreflang="en"`
+counterpart is under `/symbol/`, or vice versa (see below).
 
 Fix all errors before the PR. Warnings (e.g. missing related-links block)
 should be reviewed but don't block.
+
+### Translating a page: the lane is inherited, never re-decided
+
+`library/` vs `symbol/` (CLAUDE.md, "Content Types: Library vs Symbol") is a
+**content-type** decision made once, on the English page, via its spec's
+`page_type`. Translating that page into `<lang>/` does not reopen the
+decision — a translation of a `/symbol/<slug>/` page ships to
+`<lang>/symbol/<slug>/`, full stop, even though `<lang>/library/` is the
+lane most translation batches actually touch and may be the only lane that
+already exists for that language.
+
+This has gone wrong repeatedly in practice — not as one session's mistake,
+but because most languages simply never built a `<lang>/symbol/` pillar, so
+every subsequent translation session defaulted to the one lane that existed
+(`<lang>/library/`) for single-glyph content too. `ar/` is the only language
+that got this right end-to-end (it has its own `ar/symbol/`). Before
+starting a translation batch:
+
+- Check whether the English source page lives under `symbol/` or `library/`
+  and mirror that, not the target language's existing folder layout.
+- If the language has no `<lang>/symbol/` directory yet, create it — "no
+  precedent in this language" is not a reason to fold single-glyph content
+  into `<lang>/library/`.
+- The validator now scans every `<lang>/library/` and `<lang>/symbol/` by
+  default specifically to catch this: it reads each page's own
+  `hreflang="en"` link and flags a mismatch between the page's directory and
+  its English counterpart's directory. Run it over your translated batch,
+  not just against the English pages you touched.
 
 ---
 

--- a/scripts/validate_library_pages.py
+++ b/scripts/validate_library_pages.py
@@ -7,6 +7,11 @@ Structural / SEO linter for Unicode library pages under /library/. Run it
 over the whole directory (default) or against specific paths before opening
 a batch PR.
 
+The default scan covers the English root (`library/`, `symbol/`) **and**
+every translated lane (`<lang>/library/`, `<lang>/symbol/`) — a translated
+page is just as capable of shipping with the wrong lane as an English one,
+and it must not go unchecked just because it lives under `id/`, `pl/`, etc.
+
 Checks per page
 ---------------
   - <title> present and non-empty
@@ -20,6 +25,7 @@ Checks per page
   - a #symbolToast element exists
   - /symbol-explorer.js is referenced
   - at least one related/internal link block is present
+  - lane matches its English hreflang counterpart (see below)
 
 Cross-page checks
 -----------------
@@ -28,6 +34,18 @@ Cross-page checks
   - every /symbol/ spoke is linked from at least one /library/ hub
     (orphan spokes are only discoverable via the sitemap; fix with
     scripts/sync_symbol_spoke_links.py --write)
+
+Cross-language lane consistency
+--------------------------------
+A page's lane (`library/` vs `symbol/`) is a content-type decision, not a
+per-language one — a translation of a single-glyph `/symbol/` page must ship
+under `<lang>/symbol/`, never `<lang>/library/`, regardless of which session
+translates it. Every page in this repo carries a `hreflang="en"` alternate
+link pointing at its English counterpart, which makes this mechanically
+checkable: if a page lives under a `library/` directory but its own
+`hreflang="en"` href is under `/symbol/` (or vice versa), that is a lane
+mismatch, flagged as an ERROR. See CLAUDE.md's "Content Types: Library vs
+Symbol" section for the underlying rule.
 
 Exit status is non-zero if any ERROR-level issue is found, so the script is
 CI-friendly. WARN-level issues do not fail the run.
@@ -72,6 +90,9 @@ EXPLORER_JS_RE = re.compile(r'src=["\']/symbol-explorer\.js["\']')
 RELATED_RE = re.compile(r'Related Resources|class=["\'][^"\']*compare-card',
                         re.IGNORECASE)
 SYM_HREF_RE = re.compile(r'href="/symbol/([a-z0-9-]+)/"')
+HREFLANG_EN_RE = re.compile(
+    r'hreflang=["\']en["\']\s+href=["\']([^"\']+)["\']', re.IGNORECASE
+)
 
 
 class Issue:
@@ -187,6 +208,29 @@ def validate_page(path):
     if not RELATED_RE.search(html):
         issues.append(Issue("WARN", "no related-resources / internal link block found"))
 
+    # Cross-language lane consistency: this page's own directory (library/
+    # vs symbol/) must match the lane of its hreflang="en" counterpart. A
+    # translation session can pick the wrong lane independently of the
+    # English original; this is the only check that would catch it.
+    own_lane = path.resolve().parent.parent.name
+    if own_lane in ("library", "symbol"):
+        m_en = HREFLANG_EN_RE.search(html)
+        if m_en:
+            en_href = m_en.group(1)
+            if "/symbol/" in en_href:
+                en_lane = "symbol"
+            elif "/library/" in en_href:
+                en_lane = "library"
+            else:
+                en_lane = None
+            if en_lane and en_lane != own_lane:
+                issues.append(
+                    Issue("ERROR",
+                          f'lane mismatch: page lives under {own_lane}/ but its '
+                          f'hreflang="en" counterpart is under {en_lane}/ '
+                          f'({en_href}) — move it to the matching lane')
+                )
+
     return {
         "title_norm": normalize_text(title),
         "desc_norm": normalize_text(desc),
@@ -214,7 +258,18 @@ def gather_paths(args_paths):
             else:
                 paths.append(pp)
         return paths
-    return sorted(LIBRARY_DIR.glob("*/index.html")) + sorted(SYMBOL_DIR.glob("*/index.html"))
+    paths = sorted(LIBRARY_DIR.glob("*/index.html")) + sorted(SYMBOL_DIR.glob("*/index.html"))
+    # Every translated lane (<lang>/library/, <lang>/symbol/) gets the same
+    # scan by default — a two-letter top-level dir with no such subfolder
+    # (e.g. js/) simply contributes nothing.
+    for lang_dir in sorted(REPO.glob("??")):
+        if not lang_dir.is_dir():
+            continue
+        for lane in ("library", "symbol"):
+            lane_dir = lang_dir / lane
+            if lane_dir.is_dir():
+                paths.extend(sorted(lane_dir.glob("*/index.html")))
+    return paths
 
 
 def main(argv=None):


### PR DESCRIPTION
## Summary

Extends `validate_library_pages.py` to scan and validate every translated page (`<lang>/library/`, `<lang>/symbol/`) alongside English pages, and adds a new cross-language lane consistency check that ensures a translated page's directory (`library/` vs `symbol/`) matches its English counterpart's directory.

## Changes

- **Expanded default scan scope**: `gather_paths()` now includes all translated lanes (`<lang>/library/`, `<lang>/symbol/`) by default, not just English root pages. A two-letter language directory with no such subdirectories contributes nothing.

- **New lane consistency validation**: Added `HREFLANG_EN_RE` regex to extract a page's `hreflang="en"` alternate link. The `validate_page()` function now:
  - Extracts the English counterpart's URL from the page's own `hreflang="en"` link
  - Determines the English page's lane (`library/` or `symbol/`)
  - Compares it against the translated page's own directory
  - Flags a **lane mismatch as an ERROR** if they differ, with a clear message indicating which lane the page should move to

- **Documentation updates**:
  - `validate_library_pages.py`: Added docstring sections explaining the expanded scan scope and the lane consistency rule, with rationale for why translations must inherit the English page's lane decision
  - `docs/unicode-library-workflow.md`: Added detailed guidance on translating pages, emphasizing that lane is a content-type decision made once on the English page and never re-decided per language. Includes the recurring failure mode (languages without a `symbol/` pillar defaulting all single-glyph content to `library/`) and instructions to create missing `<lang>/symbol/` directories
  - `CLAUDE.md`: Added brief note on lane inheritance for translations and validator behavior

## Implementation Details

- The lane mismatch check only runs if the page's own directory is `library/` or `symbol/` (skips other directory structures)
- The regex is case-insensitive to handle variations in HTML formatting
- Error message includes the English counterpart's full href for debugging
- This is the only check that catches lane mismatches introduced by translation sessions working independently of the English original

https://claude.ai/code/session_01Dn8asxzCjhLruuVb16CB9q