### PR TITLE
fix: gate right rail ad request behind its viewport breakpoint

### DIFF
--- a/header.js
+++ b/header.js
@@ -123,8 +123,14 @@
     if (window.adsbygoogle === undefined) {
       window.adsbygoogle = [];
     }
+    // Top banner always requests — it's visible at every viewport width.
     window.adsbygoogle.push({});
-    window.adsbygoogle.push({});
+    // Right rail is CSS-hidden below 1600px (see .ad-rail-right in style.css);
+    // only request it when it'll actually be seen, so narrow viewports don't
+    // burn an impression on a slot nobody can view.
+    if (window.matchMedia("(min-width: 1600px)").matches) {
+      window.adsbygoogle.push({});
+    }
 
     // Dark mode: apply saved preference immediately (before paint)
     if (localStorage.getItem("darkMode") === "true") {


### PR DESCRIPTION
## Summary
- The dedicated Right Rail ad unit is CSS-hidden below 1600px viewport width (`.ad-rail-right` in `style.css`), but `header.js` fired its `adsbygoogle.push({})` request unconditionally on every page load regardless of viewport.
- Since most traffic is mobile/narrow-viewport, this meant a large share of "Manual" placement impressions were being counted for a slot nobody could ever see — dragging Manual's Active View Viewable and RPM well below the Auto ads baseline (~17% vs ~55% viewability in AdSense reporting).
- `header.js` now checks `window.matchMedia("(min-width: 1600px)")` before requesting the right rail, so narrow viewports only request the Top Banner (which is visible at every width) and skip the rail request entirely.

## Test plan
- [x] Verified via headless browser: at 1920px, `adsbygoogle` receives 2 push calls (banner + rail); at 1400px and below, only 1 (banner only), matching the CSS breakpoint.
- [ ] Confirm in AdSense reporting (Placement method breakdown) that Manual's Active View Viewable and RPM rise toward the Auto ads baseline over the next full reporting day.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DksB2qYgXMCJejnTrVXX3L)_