### PR TITLE
Document keyword ownership check before creating new pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -358,6 +358,37 @@ To add a new text style, edit `styles.js`:
 2. Update `CATEGORY_PAGES` in `styles.js`
 3. Assign matching `familySlug` values in relevant styles
 
+### Before building a page for a keyword: check who already owns it
+
+High search volume alone is not sufficient justification for a new page. Before
+creating a page/spoke targeting a specific keyword or query cluster, check
+whether an existing page in the same locale — including that locale's own
+hub/homepage — already targets and ranks for the same term (search its title,
+H1, and meta for the exact phrase and close variants). If a hub page already
+owns the term, a new spoke competes with it instead of adding coverage, and
+search engines will consolidate onto whichever page has more authority
+(usually the hub) — leaving the new page with near-zero traffic no matter how
+deep its content is.
+
+**Case study (2026-07-06):** `vi/chu-kieu/` was created in a batch of 5 new VN
+pages, justified in the commit message purely by keyword volume — "chữ kiểu /
+tạo chữ kiểu / chữ kiểu đẹp (90.5k/mo)." But the `/vi/` homepage had already
+been deepened around this exact term 9 days earlier (2026-06-27) and was
+already ranking for it — the same commit even cited "ranking pos 4-8 on the
+chữ kiểu cluster" as part of its own rationale, evidence the term was already
+being served, without checking that the homepage was the asset doing the
+serving. The result: `vi/chu-kieu/` shipped as a strictly thinner duplicate of
+the homepage's own "chữ kiểu" section (same H1 pattern, same how-to/A-Z-table/
+diacritic-FAQ structure, none of the homepage's use-case/guide/expanded-FAQ
+depth) and earned ~1 click across a full month of GSC data, while the
+homepage absorbed effectively all of the term's traffic (840+ clicks in the
+same window). Confirmed via the query×landing-page GSC cross-tab, not
+assumed.
+
+Deepen the existing page instead of building a new one, unless the new page
+serves a genuinely different search intent (e.g. an informational/explainer
+job, not another transactional/tool page on the same term).
+
 ---
 
 ## Localization Workflow — the English-Parent Rule
@@ -488,6 +519,11 @@ Do not add a test framework unless explicitly requested.
   that has no live English parent yet, without first raising it as an
   explicit, discussed exception. See "Localization Workflow — the
   English-Parent Rule" above.
+- Do not create a new page for a high-volume keyword without first checking
+  whether an existing page in that locale (especially its own hub/homepage)
+  already targets and ranks for it. See "Before building a page for a
+  keyword: check who already owns it" above — the `vi/chu-kieu/` case study
+  is exactly this mistake.
 - Do not add npm packages that run in the browser
 - Do not introduce a JavaScript framework or bundler
 - Do not generate images server-side or with an image-processing library. Visual/printable


### PR DESCRIPTION
## Summary
Added guidance to CLAUDE.md documenting the importance of checking whether existing pages already target and rank for a keyword before creating new pages. This prevents duplicate content that competes with existing assets instead of expanding coverage.

## Changes
- **New section: "Before building a page for a keyword: check who already owns it"**
  - Explains why high search volume alone is insufficient justification for a new page
  - Describes the risk: new pages compete with existing hubs/homepages instead of adding coverage, resulting in near-zero traffic
  - Includes a detailed case study (`vi/chu-kieu/`) from 2026-07-06 demonstrating the exact failure mode:
    - Page was created based purely on keyword volume (90.5k/mo)
    - Existing `/vi/` homepage had already been deepened around the same term 9 days earlier
    - Result: new page earned ~1 click/month while homepage absorbed 840+ clicks on the same term
    - Evidence confirmed via GSC query×landing-page cross-tab, not assumption
  - Recommends deepening existing pages instead of building duplicates, unless the new page serves genuinely different search intent

- **Added enforcement rule to "Do not" section**
  - New bullet point warning against creating high-volume keyword pages without checking existing coverage
  - References the case study for concrete example of the mistake

## Context
This documentation update codifies a lesson learned from a specific SEO mistake, ensuring future contributors check for existing page ownership before justifying new pages on keyword volume alone. The case study provides concrete, measurable evidence (GSC data) of why this check matters.

https://claude.ai/code/session_01D9PfzVMQ4uj9r8Thzdq7gF