### PR TITLE
fix: repoint homepage cannibalization links to locale-native pages

### DIFF
--- a/fr/index.html
+++ b/fr/index.html
@@ -422,7 +422,7 @@
     <div class="block-example">
       <strong>Exemple :</strong> «aesthetic» → 𝒶𝑒𝓈𝓉𝒽𝑒𝓉𝒾𝒸 (cursive), 𝔞𝔢𝔰𝔱𝔥𝔢𝔱𝔦𝔠 (gothique), ⓐⓔⓢⓣⓗⓔⓣⓘⓒ (bubble), ａｅｓｔｈｅｔｉｃ (large), ᴀᴇsᴛʜᴇᴛɪᴄ (small caps)
     </div>
-    <p>Tu veux te concentrer sur un seul style ? File sur les pages dédiées : <a href="/category/aesthetic-fonts/">écriture aesthetic</a>, <a href="/category/cursive-fonts/">écriture cursive</a>, <a href="/category/gothic-fonts/">écriture gothique</a> ou <a href="/category/bold-fonts/">écriture en gras</a>. Sinon, laisse le générateur du haut tout afficher d'un coup et choisis ce qui colle à ton vibe.</p>
+    <p>Tu veux te concentrer sur un seul style ? File sur les pages dédiées : <a href="/fr/ecriture-aesthetic/">écriture aesthetic</a>, <a href="/fr/ecriture-cursive/">écriture cursive</a>, <a href="/fr/ecriture-gothique/">écriture gothique</a> ou <a href="/fr/texte-en-gras/">écriture en gras</a>. Sinon, laisse le générateur du haut tout afficher d'un coup et choisis ce qui colle à ton vibe.</p>
   </section>
 
   <!-- Alphabet aesthetic A–Z -->
@@ -793,7 +793,7 @@
     — des ornements discrets (✧, ✿, ⋆, ࿐, ❀);<br>
     — des écritures cursives ou gothiques douces.
     <br><br>
-    Tape ton mot dans le générateur du haut et tu auras toutes ces variantes d'un coup.</div>
+    Tape ton mot dans le générateur du haut et tu auras toutes ces variantes d'un coup. Pour rester sur ce seul style, la page <a href="/fr/ecriture-aesthetic/">écriture aesthetic</a> regroupe tout ça au même endroit.</div>
 </div>
 
 <div class="faq-item">
@@ -805,7 +805,7 @@
   </button>
   <div class="faq-answer">«Écritures stylées», «écriture stylée», «police d'écriture aesthetic», «lettres spéciales» : ce sont toutes des façons de dire la même chose — des lettres qui sortent du clavier normal et qui restent stylées une fois collées.
     <br><br>
-    Techniquement, ce sont des caractères Unicode déjà dessinés en gras, cursive, gothique, etc. Tu n'installes rien : tu tapes, tu copies, tu colles. Le rendu suit ton texte sur Insta, TikTok, Snap, WhatsApp ou Discord.</div>
+    Techniquement, ce sont des caractères Unicode déjà dessinés en gras, cursive, gothique, etc. Tu n'installes rien : tu tapes, tu copies, tu colles. Le rendu suit ton texte sur Insta, TikTok, Snap, WhatsApp ou Discord. La page <a href="/fr/ecriture-style/">écriture stylé</a> réunit 60+ de ces styles au même endroit.</div>
 </div>
 
 <div class="faq-item">

--- a/id/index.html
+++ b/id/index.html
@@ -624,6 +624,7 @@ O</pre>
   <section class="editorial-section glyph-section">
     <h2>Huruf Aesthetic A–Z</h2>
     <p class="editorial-intro">Pengen huruf aesthetic dari A sampai Z? Ini abjad lengkapnya dalam beberapa gaya paling populer. Klik satu baris buat nyalin seluruh alfabetnya sekaligus.</p>
+    <p>Mau eksplor per huruf satu-satu — 8 gaya sekaligus, plus versi gede yang bisa di-print atau di-download jadi PNG buat logo/ikon? Ada halaman khusus <a href="/id/huruf-keren-a-sampai-z/">huruf keren A sampai Z</a>.</p>
     <div class="alpha-list">
       <div class="alpha-row">
         <span class="alpha-label">Bold</span>

--- a/it/index.html
+++ b/it/index.html
@@ -415,6 +415,7 @@
     <h2>Scritta stilizzata e scritte aesthetic: come funzionano</h2>
     <p>"Scritta stilizzata" e "scritte aesthetic" indicano quasi sempre la stessa cosa: lettere con un look diverso da quello della tastiera, pronte da copiare e incollare in bio, caption, nickname o stato. La differenza è solo nel nome che usi tu — il risultato è identico.</p>
     <p>Funziona perché ogni lettera non viene messa in "grassetto" come in Word, ma sostituita con un carattere Unicode che ha già quella forma. Per questo quando fai <strong>copia e incolla</strong> su Instagram, TikTok o WhatsApp lo stile non sparisce: non è formattazione, sono proprio caratteri diversi. Ti basta scrivere la parola o la frase nel generatore qui sopra e tutte le versioni stilizzate compaiono subito.</p>
+    <p>Vuoi una pagina tutta dedicata al copia e incolla, senza il resto del sito intorno? C'è <a href="/it/font-copia-e-incolla/">font copia e incolla</a>.</p>
     <div class="block-example">
       <strong>Esempio:</strong> "sogno" → 𝓼𝓸𝓰𝓷𝓸 (corsivo), 𝔰𝔬𝔤𝔫𝔬 (gotico), ⓢⓞⓖⓝⓞ (bubble), ꜱᴏɢɴᴏ (maiuscoletto)
     </div>


### PR DESCRIPTION
GSC data showed the id/, fr/, and it/ homepages outranking their own dedicated sub-pages for exact-match queries (huruf keren a sampai z, écriture aesthetic/stylé, font copia e incolla) — each homepage covers the same topic in depth but either never links onward to the spoke page, or (fr/) links to the wrong page entirely.

- fr/index.html: "want just one style?" CTA was linking "écriture aesthetic/cursive/gothique/gras" to the English /category/ hubs instead of the existing French-native pages; repointed to fr/ecriture-aesthetic, fr/ecriture-cursive, fr/ecriture-gothique, fr/texte-en-gras. Added matching links in the two related FAQ answers (ecriture-aesthetic, ecriture-style).
- id/index.html: "Huruf Aesthetic A-Z" section had no forward link at all to the richer per-letter explorer (8 styles, PNG download) — added one.
- it/index.html: "Scritta stilizzata e scritte aesthetic" section had no forward link to font-copia-e-incolla — added one.


Claude-Session: https://claude.ai/code/session_017ApEPoHkpG68bvR6fktScq