### PR TITLE
Reorganize alphabet section: move print button into picker

### DIFF
--- a/de/zum-ausdrucken/name-ausmalen/index.html
+++ b/de/zum-ausdrucken/name-ausmalen/index.html
@@ -261,17 +261,12 @@
       <p class="bubble-az-intro">Tippe auf einen Buchstaben A–Z oder eine Zahl 0–9 für einen großen Ausmal-Umriss eines einzelnen Zeichens, den du einzeln drucken oder herunterladen kannst.</p>
       <div class="bubble-strip" id="pt-strip" role="tablist" aria-label="Buchstaben oder Zahl zum Ausmalen wählen"></div>
       <div class="bubble-letter-panel" id="pt-panel" aria-live="polite"></div>
-    </section>
-
-    <!-- Whole alphabet -->
-    <section class="bubble-alphabet" aria-labelledby="ptAlphaHeading">
-      <div class="bubble-alphabet-head">
-        <h2 id="ptAlphaHeading">Alphabet &amp; Zahlen zum Ausdrucken</h2>
+      <p class="bubble-az-intro">Du möchtest das komplette Alphabet? Drucke alle A–Z- und 0–9-Ausmal-Umrisse auf einmal — als ein Blatt oder als Heft mit einer Seite pro Buchstabe.</p>
+      <div class="bubble-actions pt-batch-actions">
         <button class="bubble-btn bubble-btn-primary" type="button" id="pt-alphabet-print">Alphabet drucken</button>
       </div>
-      <p class="bubble-az-intro">Das komplette A–Z und 0–9 als saubere Ausmal-Umrisse. Drucke das ganze Blatt oder tippe auf ein Zeichen, um seine Druck- und Download-Optionen zu öffnen.</p>
-      <div class="bubble-alphabet-grid" id="pt-alphabet-grid"></div>
     </section>
+
 
     <!-- Editorial -->
     <section class="editorial-section">

--- a/de/zum-ausdrucken/namen-schreiben/index.html
+++ b/de/zum-ausdrucken/namen-schreiben/index.html
@@ -170,8 +170,7 @@
         <h2 id="ptAlphaHeading">A–Z- und 0–9-Blätter zum Nachspuren zum Ausdrucken</h2>
         <button class="bubble-btn bubble-btn-primary" type="button" id="pt-practice-print">Übungsblatt drucken</button>
       </div>
-      <p class="bubble-az-intro">Drucke ein liniertes A–Z- und 0–9-Blatt — mit Vorlage und Platz zum Nachspuren in jeder Zeile — oder drucke das Umriss-Alphabet unten, um ganze Buchstaben nachzuspuren.</p>
-      <div class="bubble-alphabet-grid" id="pt-alphabet-grid"></div>
+      <p class="bubble-az-intro">Drucke ein liniertes A–Z- und 0–9-Blatt — mit Vorlage und Platz zum Nachspuren in jeder Zeile — oder drucke das Umriss-Alphabet, um ganze Buchstaben nachzuspuren.</p>
       <div class="pt-alpha-print-row">
         <button class="bubble-btn" type="button" id="pt-alphabet-print">Umriss-Alphabet drucken</button>
       </div>

--- a/es/imprimibles/abecedario-para-colorear/index.html
+++ b/es/imprimibles/abecedario-para-colorear/index.html
@@ -127,17 +127,12 @@
       <p class="bubble-az-intro">Toca cualquier letra A–Z para ver su gran contorno para colorear, imprimirlo o descargar un PNG.</p>
       <div class="bubble-strip" id="pt-strip" role="tablist" aria-label="Elegir una letra para colorear"></div>
       <div class="bubble-letter-panel" id="pt-panel" aria-live="polite"></div>
-    </section>
-
-    <!-- Full printable alphabet -->
-    <section class="bubble-alphabet" aria-labelledby="ptAlphaHeading">
-      <div class="bubble-alphabet-head">
-        <h2 id="ptAlphaHeading">Alfabeto para imprimir</h2>
+      <p class="bubble-az-intro">¿Quieres el alfabeto completo? Imprime los 26 contornos para colorear de una vez — en una sola hoja, o como libro con una página por letra.</p>
+      <div class="bubble-actions pt-batch-actions">
         <button class="bubble-btn bubble-btn-primary" type="button" id="pt-alphabet-print">Imprimir el alfabeto</button>
       </div>
-      <p class="bubble-az-intro">El alfabeto A–Z completo en contornos nítidos para colorear. Imprime toda la hoja para colorear, o toca cualquier letra para abrir sus opciones de impresión y descarga.</p>
-      <div class="bubble-alphabet-grid" id="pt-alphabet-grid"></div>
     </section>
+
 
     <!-- Editorial -->
     <section class="editorial-section">

--- a/es/imprimibles/letras-burbuja/index.html
+++ b/es/imprimibles/letras-burbuja/index.html
@@ -142,6 +142,10 @@
       <p class="bubble-az-intro">Toca una letra (A–Z) o un número (0–9) para ver su gran contorno de burbuja, imprimirlo, descargar un PNG o copiar los estilos burbuja Unicode correspondientes.</p>
       <div class="bubble-strip" id="pt-strip" role="tablist" aria-label="Elegir una letra o un número burbuja"></div>
       <div class="bubble-letter-panel" id="pt-panel" aria-live="polite"></div>
+      <p class="bubble-az-intro">¿Quieres el alfabeto burbuja completo para imprimir? Imprime las letras A–Z y los números 0–9 de una vez — en una sola hoja, o como libro con una página por letra (elige “Guardar como PDF” en el diálogo de impresión).</p>
+      <div class="bubble-actions pt-batch-actions">
+        <button class="bubble-btn bubble-btn-primary" type="button" id="pt-alphabet-print">Imprimir el alfabeto</button>
+      </div>
     </section>
 
     <!-- Name / word worksheet -->
@@ -160,15 +164,6 @@
       </div>
     </section>
 
-    <!-- Full printable alphabet -->
-    <section class="bubble-alphabet" aria-labelledby="ptAlphaHeading">
-      <div class="bubble-alphabet-head">
-        <h2 id="ptAlphaHeading">Alfabeto burbuja para imprimir</h2>
-        <button class="bubble-btn bubble-btn-primary" type="button" id="pt-alphabet-print">Imprimir el alfabeto</button>
-      </div>
-      <p class="bubble-az-intro">El alfabeto burbuja A–Z y 0–9 completo en contornos. Imprime toda la hoja para trazar o colorear, o toca cualquier letra para abrir sus opciones de impresión y descarga.</p>
-      <div class="bubble-alphabet-grid" id="pt-alphabet-grid"></div>
-    </section>
 
     <!-- Editorial -->
     <section class="editorial-section">

--- a/es/imprimibles/nombre-para-trazar/index.html
+++ b/es/imprimibles/nombre-para-trazar/index.html
@@ -173,8 +173,7 @@
         <h2 id="ptAlphaHeading">Fichas para trazar A–Z &amp; 0–9 para imprimir</h2>
         <button class="bubble-btn bubble-btn-primary" type="button" id="pt-practice-print">Imprimir la hoja de práctica</button>
       </div>
-      <p class="bubble-az-intro">Imprime una ficha pautada A–Z y 0–9 — un modelo más un espacio para repasar en cada línea — o imprime el alfabeto en contorno de abajo para trazar las letras enteras.</p>
-      <div class="bubble-alphabet-grid" id="pt-alphabet-grid"></div>
+      <p class="bubble-az-intro">Imprime una ficha pautada A–Z y 0–9 — un modelo más un espacio para repasar en cada línea — o imprime el alfabeto en contorno para trazar las letras enteras.</p>
       <div class="pt-alpha-print-row">
         <button class="bubble-btn" type="button" id="pt-alphabet-print">Imprimir el alfabeto en contorno</button>
       </div>

--- a/fr/imprimables/coloriage-alphabet/index.html
+++ b/fr/imprimables/coloriage-alphabet/index.html
@@ -127,17 +127,12 @@
       <p class="bubble-az-intro">Touchez n'importe quelle lettre A–Z pour voir son grand contour de coloriage, l'imprimer ou télécharger un PNG.</p>
       <div class="bubble-strip" id="pt-strip" role="tablist" aria-label="Choisir une lettre à colorier"></div>
       <div class="bubble-letter-panel" id="pt-panel" aria-live="polite"></div>
-    </section>
-
-    <!-- Full printable alphabet -->
-    <section class="bubble-alphabet" aria-labelledby="ptAlphaHeading">
-      <div class="bubble-alphabet-head">
-        <h2 id="ptAlphaHeading">Alphabet à imprimer</h2>
+      <p class="bubble-az-intro">Envie de l'alphabet complet ? Imprimez les 26 contours de coloriage d'un coup — sur une seule feuille, ou en livret avec une page par lettre.</p>
+      <div class="bubble-actions pt-batch-actions">
         <button class="bubble-btn bubble-btn-primary" type="button" id="pt-alphabet-print">Imprimer l'alphabet</button>
       </div>
-      <p class="bubble-az-intro">L'alphabet A–Z complet en contours de coloriage nets. Imprimez toute la feuille à colorier, ou touchez n'importe quelle lettre pour ouvrir ses options d'impression et de téléchargement.</p>
-      <div class="bubble-alphabet-grid" id="pt-alphabet-grid"></div>
     </section>
+
 
     <!-- Editorial -->
     <section class="editorial-section">

--- a/fr/imprimables/lettres-bulles/index.html
+++ b/fr/imprimables/lettres-bulles/index.html
@@ -142,6 +142,10 @@
       <p class="bubble-az-intro">Touchez une lettre (A–Z) ou un chiffre (0–9) pour voir son grand contour de bulle, l'imprimer, télécharger un PNG ou copier les styles bulles Unicode correspondants.</p>
       <div class="bubble-strip" id="pt-strip" role="tablist" aria-label="Choisir une lettre ou un chiffre bulle"></div>
       <div class="bubble-letter-panel" id="pt-panel" aria-live="polite"></div>
+      <p class="bubble-az-intro">Envie de l'alphabet bulle complet à imprimer ? Imprimez toutes les lettres A–Z et les chiffres 0–9 d'un coup — sur une seule feuille, ou en livret avec une page par lettre (choisissez « Enregistrer au format PDF » dans la boîte d'impression).</p>
+      <div class="bubble-actions pt-batch-actions">
+        <button class="bubble-btn bubble-btn-primary" type="button" id="pt-alphabet-print">Imprimer l'alphabet</button>
+      </div>
     </section>
 
     <!-- Name / word worksheet -->
@@ -160,15 +164,6 @@
       </div>
     </section>
 
-    <!-- Full printable alphabet -->
-    <section class="bubble-alphabet" aria-labelledby="ptAlphaHeading">
-      <div class="bubble-alphabet-head">
-        <h2 id="ptAlphaHeading">Alphabet bulle à imprimer</h2>
-        <button class="bubble-btn bubble-btn-primary" type="button" id="pt-alphabet-print">Imprimer l'alphabet</button>
-      </div>
-      <p class="bubble-az-intro">L'alphabet bulle A–Z et 0–9 complet en contours. Imprimez toute la feuille à tracer ou à colorier, ou touchez n'importe quelle lettre pour ouvrir ses options d'impression et de téléchargement.</p>
-      <div class="bubble-alphabet-grid" id="pt-alphabet-grid"></div>
-    </section>
 
     <!-- Editorial -->
     <section class="editorial-section">

--- a/fr/imprimables/prenom-a-tracer/index.html
+++ b/fr/imprimables/prenom-a-tracer/index.html
@@ -173,8 +173,7 @@
         <h2 id="ptAlphaHeading">Fiches à tracer A–Z &amp; 0–9 à imprimer</h2>
         <button class="bubble-btn bubble-btn-primary" type="button" id="pt-practice-print">Imprimer la fiche d'entraînement</button>
       </div>
-      <p class="bubble-az-intro">Imprimez une fiche réglée A–Z et 0–9 — un modèle plus un espace à repasser sur chaque ligne — ou imprimez l'alphabet en contour ci-dessous pour tracer les lettres entières.</p>
-      <div class="bubble-alphabet-grid" id="pt-alphabet-grid"></div>
+      <p class="bubble-az-intro">Imprimez une fiche réglée A–Z et 0–9 — un modèle plus un espace à repasser sur chaque ligne — ou imprimez l'alphabet en contour pour tracer les lettres entières.</p>
       <div class="pt-alpha-print-row">
         <button class="bubble-btn" type="button" id="pt-alphabet-print">Imprimer l'alphabet en contour</button>
       </div>

--- a/it/da-stampare/nome-da-colorare/index.html
+++ b/it/da-stampare/nome-da-colorare/index.html
@@ -261,17 +261,12 @@
       <p class="bubble-az-intro">Tocca una lettera A–Z o un numero 0–9 per un grande contorno da colorare con un solo carattere, da stampare o scaricare da solo.</p>
       <div class="bubble-strip" id="pt-strip" role="tablist" aria-label="Scegli una lettera o un numero da colorare"></div>
       <div class="bubble-letter-panel" id="pt-panel" aria-live="polite"></div>
-    </section>
-
-    <!-- Whole alphabet -->
-    <section class="bubble-alphabet" aria-labelledby="ptAlphaHeading">
-      <div class="bubble-alphabet-head">
-        <h2 id="ptAlphaHeading">Alfabeto e numeri da stampare</h2>
+      <p class="bubble-az-intro">Vuoi l'alfabeto completo? Stampa tutti i contorni da colorare A–Z e 0–9 in una volta — su un solo foglio, oppure come libretto con una pagina per lettera.</p>
+      <div class="bubble-actions pt-batch-actions">
         <button class="bubble-btn bubble-btn-primary" type="button" id="pt-alphabet-print">Stampa l'alfabeto</button>
       </div>
-      <p class="bubble-az-intro">L'intero A–Z e 0–9 come puliti contorni da colorare. Stampa il foglio intero, oppure tocca un carattere per aprire le opzioni di stampa e download.</p>
-      <div class="bubble-alphabet-grid" id="pt-alphabet-grid"></div>
     </section>
+
 
     <!-- Editorial -->
     <section class="editorial-section">

--- a/it/da-stampare/tracciare-il-nome/index.html
+++ b/it/da-stampare/tracciare-il-nome/index.html
@@ -170,8 +170,7 @@
         <h2 id="ptAlphaHeading">Schede da tracciare A–Z e 0–9 da stampare</h2>
         <button class="bubble-btn bubble-btn-primary" type="button" id="pt-practice-print">Stampa la scheda di esercizio</button>
       </div>
-      <p class="bubble-az-intro">Stampa una scheda a righe A–Z e 0–9 — un modello e lo spazio per ripassare su ogni riga — oppure stampa l'alfabeto a contorno qui sotto per tracciare lettere intere.</p>
-      <div class="bubble-alphabet-grid" id="pt-alphabet-grid"></div>
+      <p class="bubble-az-intro">Stampa una scheda a righe A–Z e 0–9 — un modello e lo spazio per ripassare su ogni riga — oppure stampa l'alfabeto a contorno per tracciare lettere intere.</p>
       <div class="pt-alpha-print-row">
         <button class="bubble-btn" type="button" id="pt-alphabet-print">Stampa l'alfabeto a contorno</button>
       </div>

--- a/js/printables/printablesEngine.js
+++ b/js/printables/printablesEngine.js
@@ -32,9 +32,12 @@
  * any print action):
  *   #pt-strip            character picker
  *   #pt-panel            selected-character detail
- *   #pt-alphabet-grid    printable alphabet grid   (+ button #pt-alphabet-print;
- *                        CFG.alphabetPrint: "book" prints one character per page
- *                        instead of the compact sheet — see printAlphabetBook)
+ *   #pt-alphabet-grid    printable alphabet grid
+ *   #pt-alphabet-print   button: print the full alphabet (works with or without
+ *                        the grid; CFG.alphabetPrint: "book" prints one character
+ *                        per page instead of the compact sheet — see
+ *                        printAlphabetBook. Sheet-mode pages get an auto-added
+ *                        secondary book button beside it)
  *   #pt-book-print       optional extra button (e.g. on a promo card) that
  *                        prints the one-page-per-character alphabet book
  *   #pt-practice-print   button: print ruled practice sheet
@@ -1037,6 +1040,18 @@
 
   function buildAlphabetGrid() {
     if (el.bookPrint) el.bookPrint.addEventListener("click", printAlphabetBook);
+    if (el.alphaPrint) {
+      const bookMode = CFG.alphabetPrint === "book";
+      el.alphaPrint.addEventListener("click", bookMode ? printAlphabetBook : printAlphabetSheet);
+      if (!bookMode) {
+        const bookBtn = document.createElement("button");
+        bookBtn.type = "button";
+        bookBtn.className = "bubble-btn";
+        bookBtn.textContent = T.printBook;
+        bookBtn.addEventListener("click", printAlphabetBook);
+        el.alphaPrint.insertAdjacentElement("afterend", bookBtn);
+      }
+    }
     if (!el.alphaGrid) return;
     CHARS.forEach((ch) => {
       const cell = document.createElement("button");
@@ -1050,18 +1065,6 @@
       });
       el.alphaGrid.appendChild(cell);
     });
-    if (el.alphaPrint) {
-      const bookMode = CFG.alphabetPrint === "book";
-      el.alphaPrint.addEventListener("click", bookMode ? printAlphabetBook : printAlphabetSheet);
-      if (!bookMode) {
-        const bookBtn = document.createElement("button");
-        bookBtn.type = "button";
-        bookBtn.className = "bubble-btn";
-        bookBtn.textContent = T.printBook;
-        bookBtn.addEventListener("click", printAlphabetBook);
-        el.alphaPrint.insertAdjacentElement("afterend", bookBtn);
-      }
-    }
   }
 
   function smallGlyphCell(ch) {

--- a/pl/do-druku/pisanie-imienia/index.html
+++ b/pl/do-druku/pisanie-imienia/index.html
@@ -170,8 +170,7 @@
         <h2 id="ptAlphaHeading">Karty do obrysowania A–Ż i 0–9 do druku</h2>
         <button class="bubble-btn bubble-btn-primary" type="button" id="pt-practice-print">Drukuj kartę ćwiczeniową</button>
       </div>
-      <p class="bubble-az-intro">Wydrukuj kartę w liniaturze A–Ż i 0–9 — wzór plus miejsce do obrysowania w każdym wierszu — albo wydrukuj alfabet konturowy poniżej, aby obrysowywać całe litery.</p>
-      <div class="bubble-alphabet-grid" id="pt-alphabet-grid"></div>
+      <p class="bubble-az-intro">Wydrukuj kartę w liniaturze A–Ż i 0–9 — wzór plus miejsce do obrysowania w każdym wierszu — albo wydrukuj alfabet konturowy, aby obrysowywać całe litery.</p>
       <div class="pt-alpha-print-row">
         <button class="bubble-btn" type="button" id="pt-alphabet-print">Drukuj alfabet konturowy</button>
       </div>

--- a/pl/do-druku/pokoloruj-imie/index.html
+++ b/pl/do-druku/pokoloruj-imie/index.html
@@ -261,17 +261,12 @@
       <p class="bubble-az-intro">Dotknij dowolnej litery A–Ż lub cyfry 0–9, aby uzyskać duży kontur pojedynczego znaku do pokolorowania, który wydrukujesz lub pobierzesz osobno.</p>
       <div class="bubble-strip" id="pt-strip" role="tablist" aria-label="Wybierz literę lub cyfrę do pokolorowania"></div>
       <div class="bubble-letter-panel" id="pt-panel" aria-live="polite"></div>
-    </section>
-
-    <!-- Whole alphabet -->
-    <section class="bubble-alphabet" aria-labelledby="ptAlphaHeading">
-      <div class="bubble-alphabet-head">
-        <h2 id="ptAlphaHeading">Alfabet i cyfry do druku</h2>
+      <p class="bubble-az-intro">Chcesz cały alfabet? Wydrukuj wszystkie kontury A–Ż i 0–9 naraz — na jednej karcie albo jako książeczkę z jedną stroną na literę.</p>
+      <div class="bubble-actions pt-batch-actions">
         <button class="bubble-btn bubble-btn-primary" type="button" id="pt-alphabet-print">Drukuj alfabet</button>
       </div>
-      <p class="bubble-az-intro">Pełne A–Ż i 0–9 jako czyste kontury do kolorowania. Wydrukuj całą kartę albo dotknij dowolnego znaku, aby otworzyć opcje druku i pobierania.</p>
-      <div class="bubble-alphabet-grid" id="pt-alphabet-grid"></div>
     </section>
+
 
     <!-- Editorial -->
     <section class="editorial-section">

--- a/printables/alphabet-coloring-pages/index.html
+++ b/printables/alphabet-coloring-pages/index.html
@@ -313,17 +313,12 @@
       <p class="bubble-az-intro">Tap any letter A–Z to see its big coloring outline, print it, or download a PNG. Want the letter's own page with an example word? Open it from the A–Z list below.</p>
       <div class="bubble-strip" id="pt-strip" role="tablist" aria-label="Choose a letter to color"></div>
       <div class="bubble-letter-panel" id="pt-panel" aria-live="polite"></div>
-    </section>
-
-    <!-- Full printable alphabet -->
-    <section class="bubble-alphabet" aria-labelledby="ptAlphaHeading">
-      <div class="bubble-alphabet-head">
-        <h2 id="ptAlphaHeading">Printable alphabet</h2>
+      <p class="bubble-az-intro">Want the whole alphabet? Print all 26 coloring outlines at once — as one sheet, or as a book with one letter per page (choose “Save as PDF” in the print dialog to make a workbook).</p>
+      <div class="bubble-actions pt-batch-actions">
         <button class="bubble-btn bubble-btn-primary" type="button" id="pt-alphabet-print">Print the alphabet</button>
       </div>
-      <p class="bubble-az-intro">The full A–Z alphabet as clean coloring outlines. Print the whole sheet to color, or tap any letter to open its print and download options.</p>
-      <div class="bubble-alphabet-grid" id="pt-alphabet-grid"></div>
     </section>
+
 
     <!-- Real, crawlable per-letter links -->
     <section class="editorial-section" aria-labelledby="ptListHeading">

--- a/printables/block-letters/index.html
+++ b/printables/block-letters/index.html
@@ -146,6 +146,10 @@
       <p class="bubble-az-intro">Tap a letter (A–Z) or number (0–9) to see its large hollow block outline, print it, or download a PNG to scale and reuse.</p>
       <div class="bubble-strip" id="pt-strip" role="tablist" aria-label="Choose a block letter or number"></div>
       <div class="bubble-letter-panel" id="pt-panel" aria-live="polite"></div>
+      <p class="bubble-az-intro">Want the whole set? Print the full A–Z and 0–9 block alphabet — a complete set of alphabet and number stencils — as one sheet, or as a book with one letter per page (choose “Save as PDF” in the print dialog to make a workbook).</p>
+      <div class="bubble-actions pt-batch-actions">
+        <button class="bubble-btn bubble-btn-primary" type="button" id="pt-alphabet-print">Print the alphabet</button>
+      </div>
     </section>
 
     <!-- Name / word worksheet -->
@@ -164,15 +168,6 @@
       </div>
     </section>
 
-    <!-- Full printable alphabet -->
-    <section class="bubble-alphabet" aria-labelledby="ptAlphaHeading">
-      <div class="bubble-alphabet-head">
-        <h2 id="ptAlphaHeading">Printable alphabet &amp; number stencils</h2>
-        <button class="bubble-btn bubble-btn-primary" type="button" id="pt-alphabet-print">Print the alphabet</button>
-      </div>
-      <p class="bubble-az-intro">The full A–Z and 0–9 block alphabet as hollow outlines — a complete set of alphabet stencils and number stencils. Print the whole sheet, or tap any letter to open its print and download options.</p>
-      <div class="bubble-alphabet-grid" id="pt-alphabet-grid"></div>
-    </section>
 
     <!-- Editorial -->
     <section class="editorial-section">

--- a/printables/bubble-letters/index.html
+++ b/printables/bubble-letters/index.html
@@ -201,6 +201,10 @@
       <p class="bubble-az-intro">Tap a letter (A–Z) or number (0–9) to see its large bubble outline, print it, download a PNG, or copy the matching Unicode bubble styles.</p>
       <div class="bubble-strip" id="pt-strip" role="tablist" aria-label="Choose a bubble letter or number"></div>
       <div class="bubble-letter-panel" id="pt-panel" aria-live="polite"></div>
+      <p class="bubble-az-intro">Want the full printable bubble alphabet instead? Print every letter and number at once — as one compact sheet, or as a book with one big outline per page (choose “Save as PDF” in the print dialog to make a workbook).</p>
+      <div class="bubble-actions pt-batch-actions">
+        <button class="bubble-btn bubble-btn-primary" type="button" id="pt-alphabet-print">Print the alphabet</button>
+      </div>
     </section>
 
     <!-- Name / word worksheet -->
@@ -219,20 +223,10 @@
       </div>
     </section>
 
-    <!-- Full printable alphabet -->
-    <section class="bubble-alphabet" aria-labelledby="ptAlphaHeading">
-      <div class="bubble-alphabet-head">
-        <h2 id="ptAlphaHeading">Printable bubble alphabet</h2>
-        <button class="bubble-btn bubble-btn-primary" type="button" id="pt-alphabet-print">Print the alphabet</button>
-      </div>
-      <p class="bubble-az-intro">The full A–Z and 0–9 bubble alphabet as outlines. Print the whole sheet to trace or color, or tap any letter to open its print and download options.</p>
-      <div class="bubble-alphabet-grid" id="pt-alphabet-grid"></div>
-    </section>
-
-    <!-- Real, crawlable per-letter links -->
+    <!-- Real, crawlable per-letter and per-number links -->
     <section class="editorial-section" aria-labelledby="ptListHeading">
-      <h2 id="ptListHeading">A–Z bubble letter pages</h2>
-      <p class="bubble-az-intro">Every letter has its own printable bubble page with a big puffy outline to trace, color, print, or download — great when you searched for one exact letter.</p>
+      <h2 id="ptListHeading">A–Z &amp; 0–9 bubble letter pages</h2>
+      <p class="bubble-az-intro">Every letter and number has its own printable bubble page with a big puffy outline to trace, color, print, or download — great when you searched for one exact letter, a birthday age, a house number, or a jersey number.</p>
       <div class="pt-az-links">
         <a class="pt-az-link" href="/printables/bubble-letters/letter-a/">
           <span class="pt-az-link-letter">Aa</span>
@@ -338,14 +332,6 @@
           <span class="pt-az-link-letter">Zz</span>
           <span class="pt-az-link-word">Bubble letter Z</span>
         </a>
-      </div>
-    </section>
-
-    <!-- Real, crawlable per-number links -->
-    <section class="editorial-section" aria-labelledby="ptNumListHeading">
-      <h2 id="ptNumListHeading">0–9 bubble number pages</h2>
-      <p class="bubble-az-intro">Every digit has its own printable bubble page too — big puffy outlines for birthday ages, house numbers, jersey numbers, and countdown signs.</p>
-      <div class="pt-az-links">
         <a class="pt-az-link" href="/printables/bubble-letters/number-0/">
           <span class="pt-az-link-letter">0</span>
           <span class="pt-az-link-word">Bubble number 0</span>
@@ -397,15 +383,11 @@
         <li><span class="ts-pill-safe">Color</span> The white fill is ready for markers, crayons, or paint — great for kids and classrooms.</li>
         <li><span class="ts-pill-safe">Craft</span> Cut out letters for banners, door signs, birthday cards, scrapbooks, and bullet journals.</li>
       </ul>
-      <h3>Prefer to copy-paste instead of print?</h3>
-      <p>These outlines are for paper. If you want bubble text you can paste into an Instagram bio, a TikTok caption,
-        or a Discord name, use the <a href="/category/bubble-fonts/">bubble fonts generator</a> — it turns your text
-        into copy-paste Unicode bubble letters that keep their look anywhere.</p>
     </section>
 
     <div class="cta-card">
-      <h3>Want bubble text for your bio or caption?</h3>
-      <p>Type once and copy playful Unicode bubble letters that paste anywhere — no image needed.</p>
+      <h3>Prefer to copy-paste instead of print?</h3>
+      <p>These outlines are for paper. For bubble text you can paste into an Instagram bio, a TikTok caption, or a Discord name, type once and copy playful Unicode bubble letters that keep their look anywhere — no image needed.</p>
       <a class="cta-btn" href="/category/bubble-fonts/">Open the bubble fonts generator →</a>
     </div>
   </main>

--- a/printables/coloring-page-maker/index.html
+++ b/printables/coloring-page-maker/index.html
@@ -296,17 +296,12 @@
       <p class="bubble-az-intro">Tap any letter A–Z or number 0–9 for a big single-character coloring outline you can print or download on its own.</p>
       <div class="bubble-strip" id="pt-strip" role="tablist" aria-label="Choose a letter or number to color"></div>
       <div class="bubble-letter-panel" id="pt-panel" aria-live="polite"></div>
-    </section>
-
-    <!-- Whole alphabet -->
-    <section class="bubble-alphabet" aria-labelledby="ptAlphaHeading">
-      <div class="bubble-alphabet-head">
-        <h2 id="ptAlphaHeading">Printable alphabet &amp; numbers</h2>
+      <p class="bubble-az-intro">Want the whole set? Print the full A–Z and 0–9 as clean coloring outlines — one sheet, or a book with one character per page (choose “Save as PDF” in the print dialog to make a workbook).</p>
+      <div class="bubble-actions pt-batch-actions">
         <button class="bubble-btn bubble-btn-primary" type="button" id="pt-alphabet-print">Print the alphabet</button>
       </div>
-      <p class="bubble-az-intro">The full A–Z and 0–9 as clean coloring outlines. Print the whole sheet, or tap any character to open its print and download options.</p>
-      <div class="bubble-alphabet-grid" id="pt-alphabet-grid"></div>
     </section>
+
 
     <!-- Editorial -->
     <section class="editorial-section">

--- a/printables/dot-to-dot-alphabet/index.html
+++ b/printables/dot-to-dot-alphabet/index.html
@@ -318,15 +318,6 @@
       <div class="bubble-letter-panel" id="pt-panel" aria-live="polite"></div>
     </section>
 
-    <!-- Full printable alphabet -->
-    <section class="bubble-alphabet" aria-labelledby="ptAlphaHeading">
-      <div class="bubble-alphabet-head">
-        <h2 id="ptAlphaHeading">Printable alphabet</h2>
-        <button class="bubble-btn bubble-btn-primary" type="button" id="pt-alphabet-print">Print the alphabet book</button>
-      </div>
-      <p class="bubble-az-intro">The full alphabet — A–Z plus 0–9 — as numbered dot-to-dot puzzles. Print it as a book with every letter and number on its own full page (choose “Save as PDF” in the print dialog to download it), or tap any character to open its print and download options.</p>
-      <div class="bubble-alphabet-grid" id="pt-alphabet-grid"></div>
-    </section>
 
     <!-- Alphabet book — the whole set as a one-page-per-character printable -->
     <div class="cta-card" id="alphabet-book">

--- a/printables/name-tracing/index.html
+++ b/printables/name-tracing/index.html
@@ -173,8 +173,7 @@
         <h2 id="ptAlphaHeading">Printable A–Z &amp; 0–9 tracing sheets</h2>
         <button class="bubble-btn bubble-btn-primary" type="button" id="pt-practice-print">Print practice sheet</button>
       </div>
-      <p class="bubble-az-intro">Print a ruled A–Z and 0–9 sheet — a model plus trace space on every row — or print the outline alphabet below to trace whole letters.</p>
-      <div class="bubble-alphabet-grid" id="pt-alphabet-grid"></div>
+      <p class="bubble-az-intro">Print a ruled A–Z and 0–9 sheet — a model plus trace space on every row — or print the outline alphabet to trace whole letters.</p>
       <div class="pt-alpha-print-row">
         <button class="bubble-btn" type="button" id="pt-alphabet-print">Print the outline alphabet</button>
       </div>

--- a/pt/imprimiveis/alfabeto-para-colorir/index.html
+++ b/pt/imprimiveis/alfabeto-para-colorir/index.html
@@ -127,17 +127,12 @@
       <p class="bubble-az-intro">Toque em qualquer letra A–Z para ver seu grande contorno para colorir, imprimi-lo ou baixar um PNG.</p>
       <div class="bubble-strip" id="pt-strip" role="tablist" aria-label="Escolher uma letra para colorir"></div>
       <div class="bubble-letter-panel" id="pt-panel" aria-live="polite"></div>
-    </section>
-
-    <!-- Full printable alphabet -->
-    <section class="bubble-alphabet" aria-labelledby="ptAlphaHeading">
-      <div class="bubble-alphabet-head">
-        <h2 id="ptAlphaHeading">Alfabeto para imprimir</h2>
+      <p class="bubble-az-intro">Quer o alfabeto completo? Imprima os 26 contornos para colorir de uma vez — em uma única folha, ou como livro com uma página por letra.</p>
+      <div class="bubble-actions pt-batch-actions">
         <button class="bubble-btn bubble-btn-primary" type="button" id="pt-alphabet-print">Imprimir o alfabeto</button>
       </div>
-      <p class="bubble-az-intro">O alfabeto A–Z completo em contornos nítidos para colorir. Imprima toda a folha para colorir, ou toque em qualquer letra para abrir suas opções de impressão e download.</p>
-      <div class="bubble-alphabet-grid" id="pt-alphabet-grid"></div>
     </section>
+
 
     <!-- Editorial -->
     <section class="editorial-section">

--- a/pt/imprimiveis/letras-bolha/index.html
+++ b/pt/imprimiveis/letras-bolha/index.html
@@ -142,6 +142,10 @@
       <p class="bubble-az-intro">Toque em uma letra (A–Z) ou número (0–9) para ver seu grande contorno de bolha, imprimi-lo, baixar um PNG ou copiar os estilos bolha Unicode correspondentes.</p>
       <div class="bubble-strip" id="pt-strip" role="tablist" aria-label="Escolher uma letra ou número bolha"></div>
       <div class="bubble-letter-panel" id="pt-panel" aria-live="polite"></div>
+      <p class="bubble-az-intro">Quer o alfabeto bolha completo para imprimir? Imprima as letras A–Z e os números 0–9 de uma vez — em uma única folha, ou como livro com uma página por letra (escolha “Salvar como PDF” na caixa de impressão).</p>
+      <div class="bubble-actions pt-batch-actions">
+        <button class="bubble-btn bubble-btn-primary" type="button" id="pt-alphabet-print">Imprimir o alfabeto</button>
+      </div>
     </section>
 
     <!-- Name / word worksheet -->
@@ -160,15 +164,6 @@
       </div>
     </section>
 
-    <!-- Full printable alphabet -->
-    <section class="bubble-alphabet" aria-labelledby="ptAlphaHeading">
-      <div class="bubble-alphabet-head">
-        <h2 id="ptAlphaHeading">Alfabeto bolha para imprimir</h2>
-        <button class="bubble-btn bubble-btn-primary" type="button" id="pt-alphabet-print">Imprimir o alfabeto</button>
-      </div>
-      <p class="bubble-az-intro">O alfabeto bolha A–Z e 0–9 completo em contornos. Imprima toda a folha para traçar ou colorir, ou toque em qualquer letra para abrir suas opções de impressão e download.</p>
-      <div class="bubble-alphabet-grid" id="pt-alphabet-grid"></div>
-    </section>
 
     <!-- Editorial -->
     <section class="editorial-section">

--- a/pt/imprimiveis/nome-para-tracar/index.html
+++ b/pt/imprimiveis/nome-para-tracar/index.html
@@ -173,8 +173,7 @@
         <h2 id="ptAlphaHeading">Fichas para traçar A–Z &amp; 0–9 para imprimir</h2>
         <button class="bubble-btn bubble-btn-primary" type="button" id="pt-practice-print">Imprimir a folha de treino</button>
       </div>
-      <p class="bubble-az-intro">Imprima uma ficha pautada A–Z e 0–9 — um modelo mais um espaço para cobrir em cada linha — ou imprima o alfabeto em contorno abaixo para traçar as letras inteiras.</p>
-      <div class="bubble-alphabet-grid" id="pt-alphabet-grid"></div>
+      <p class="bubble-az-intro">Imprima uma ficha pautada A–Z e 0–9 — um modelo mais um espaço para cobrir em cada linha — ou imprima o alfabeto em contorno para traçar as letras inteiras.</p>
       <div class="pt-alpha-print-row">
         <button class="bubble-btn" type="button" id="pt-alphabet-print">Imprimir o alfabeto em contorno</button>
       </div>


### PR DESCRIPTION
## Summary
Consolidates the printable bubble alphabet feature by moving the "Print the alphabet" button from a dedicated section into the character picker area, eliminating a separate full-page section while maintaining all functionality.

## Changes

**HTML Structure (`index.html`)**
- Moved the "Print the alphabet" button and supporting text from the dedicated "Printable bubble alphabet" section into the "Pick a bubble letter" section
- Removed the entire `bubble-alphabet` section (heading, grid container, and descriptive text)
- Merged the A–Z and 0–9 per-letter/per-number link sections into a single unified section with updated heading and description
- Updated section headings and descriptions to reflect the consolidated structure and clarify that both letters and numbers are available

**JavaScript Logic (`printablesEngine.js`)**
- Reordered `buildAlphabetGrid()` to initialize the alphabet print button *before* populating the grid
- This ensures the button event listeners are attached and the secondary "book mode" button is created before the grid is built, improving initialization order and clarity
- Updated code comments to reflect that the alphabet print button now works independently of the grid presence

## Implementation Details
- The print button functionality remains unchanged: it still supports both "sheet" (compact) and "book" (one-per-page) modes via `CFG.alphabetPrint`
- When not in book mode, a secondary button for book printing is dynamically created and inserted after the primary button
- The grid is now optional; the button works whether or not `#pt-alphabet-grid` exists on the page
- All user-facing functionality is preserved; this is a UX/layout reorganization

https://claude.ai/code/session_014zTaQUehHiH9MBGESr1vQw