### PR TITLE
Add class-set and difficulty-ladder batch printing to printables

### DIFF
--- a/js/printables/printablesEngine.js
+++ b/js/printables/printablesEngine.js
@@ -344,6 +344,7 @@
     bookPrint: $("#pt-book-print"),
     practicePrint: $("#pt-practice-print"),
     nameInput: $("#pt-name-input"),
+    nameRoster: $("#pt-name-roster"),
     namePrint: $("#pt-name-print"),
     namePng: $("#pt-name-png"),
     namePreview: $("#pt-name-preview"),
@@ -365,6 +366,7 @@
     genPng: $("#pt-gen-png"),
     genScript: $("#pt-gen-script"),
     genRoster: $("#pt-gen-roster"),
+    genLadder: $("#pt-gen-ladder"),
     // Coloring-sheet designer (optional; gated on its own mounts)
     designInput: $("#pt-design-input"),
     designInput2: $("#pt-design-input2"),
@@ -383,6 +385,7 @@
     designHint: $("#pt-design-hint"),
     designPreview: $("#pt-design-preview"),
     designPrint: $("#pt-design-print"),
+    designLadder: $("#pt-design-ladder"),
     designPng: $("#pt-design-png"),
     // Banner maker (optional; gated on its own mounts)
     bannerInput: $("#pt-banner-input"),
@@ -392,6 +395,7 @@
     bannerPng: $("#pt-banner-png"),
     // Name puzzle maker (optional; gated on its own mounts)
     puzzleInput: $("#pt-puzzle-input"),
+    puzzleRoster: $("#pt-puzzle-roster"),
     puzzleHeading: $("#pt-puzzle-heading"),
     puzzleBorderGroup: $("#pt-puzzle-border-group"),
     puzzleFooter: $("#pt-puzzle-footer"),
@@ -1132,8 +1136,11 @@
     }
   }
 
-  function buildNameWorksheet() {
-    const name = nameValue();
+  // The full name worksheet as a DOM node — one primitive behind the single
+  // print and the class-set print, so every sheet in a set matches the solo
+  // one. `nameOverride` lets the roster path build one sheet per child.
+  function nameSheetNode(nameOverride) {
+    const name = nameOverride != null ? String(nameOverride).slice(0, 40) : nameValue();
     const rows = document.createElement("div");
     rows.className = "pt-name-sheet";
 
@@ -1144,8 +1151,24 @@
     for (let i = 0; i < traceCount; i++) rows.appendChild(nameRow(name, "trace"));
     // Blank ruled rows for free practice.
     for (let i = 0; i < 2; i++) rows.appendChild(nameRow(name, "blank"));
+    return rows;
+  }
 
-    printWrap(name + " — tracing worksheet · ultratextgen.com", rows);
+  function buildNameWorksheet() {
+    const names = rosterNames(el.nameRoster);
+    if (names.length >= 2) {
+      const set = document.createElement("div");
+      set.className = "pt-class-set";
+      names.forEach((n) => {
+        const page = document.createElement("div");
+        page.className = "pt-sheet-page";
+        page.appendChild(nameSheetNode(n));
+        set.appendChild(page);
+      });
+      printWrap(names.length + " " + T.sheets + " — tracing worksheets · ultratextgen.com", set);
+      return;
+    }
+    printWrap(nameValue() + " — tracing worksheet · ultratextgen.com", nameSheetNode());
   }
 
   function nameRow(name, kind) {
@@ -1315,19 +1338,40 @@
 
   // A pasted class roster (one name per line) turns one print job into one
   // sheet per child — the workflow every teacher-facing worksheet generator
-  // is expected to support. Capped so a stray paste can't build 500 sheets.
+  // is expected to support. Capped so a stray paste can't build 500 sheets;
+  // 60 leaves room for the whole Dolch primer list (52 words) as one packet.
+  const ROSTER_CAP = 60;
   function rosterNames(mount) {
     if (!mount) return [];
-    return mount.value.split(/\r?\n/).map((s) => s.trim()).filter(Boolean).slice(0, 35);
+    return mount.value.split(/\r?\n/).map((s) => s.trim()).filter(Boolean).slice(0, ROSTER_CAP);
+  }
+
+  // Word-list preset buttons (page-authored, crawlable): a .pt-roster-preset
+  // carries its whole list in data-words ("word|word|…") and one click fills
+  // the roster textarea with it — the "print the whole Dolch list in one job"
+  // path. Wired against whichever roster mount the page ships.
+  function wireRosterPresets(mount, onFill) {
+    if (!mount) return;
+    $$(".pt-roster-preset").forEach((b) => {
+      b.addEventListener("click", () => {
+        const words = String(b.dataset.words || "").split("|").map((s) => s.trim()).filter(Boolean);
+        if (!words.length) return;
+        mount.value = words.join("\n");
+        const field = mount.closest("details");
+        if (field) field.open = true;
+        if (onFill) onFill();
+      });
+    });
   }
 
   // The full worksheet as a DOM node — the SINGLE primitive behind both the
   // live paper preview and the printed sheet, so what you see is what prints.
   // `wordOverride` lets the class-set print path build one sheet per roster
-  // name without touching the input field.
-  function genSheetNode(wordOverride) {
+  // name without touching the input field; `levelOverride` lets the ladder
+  // pack build one sheet per difficulty level the same way.
+  function genSheetNode(wordOverride, levelOverride) {
     const word = wordOverride != null ? applyCase(String(wordOverride).slice(0, 42)) : genValue();
-    const level = genLevel();
+    const level = levelOverride != null ? levelOverride : genLevel();
     const sheet = document.createElement("div");
     sheet.className = "pt-gen-sheet";
     // A solid model row on top so the target is always visible (unless the
@@ -1425,6 +1469,22 @@
     printWrap(genValue() + " — " + spec.label + " worksheet · ultratextgen.com", genSheetNode());
   }
 
+  // The whole difficulty ladder as one print job — one sheet per level,
+  // easiest to hardest, same word. The graded progression is the thing the
+  // level engine can batch that a static-PDF sheet never can.
+  function buildGeneratorLadder() {
+    const word = genValue();
+    const set = document.createElement("div");
+    set.className = "pt-class-set";
+    TRACE_LEVELS.forEach((spec, i) => {
+      const page = document.createElement("div");
+      page.className = "pt-sheet-page";
+      page.appendChild(genSheetNode(word, i + 1));
+      set.appendChild(page);
+    });
+    printWrap(word + " — " + TRACE_LEVELS.length + " " + T.sheets + " · ultratextgen.com", set);
+  }
+
   // Word at a level -> wide PNG (mirrors the SVG spec on Canvas).
   function genWordPNG(word, level) {
     const spec = levelSpec(level);
@@ -1520,8 +1580,10 @@
         if (rosterTimer) clearTimeout(rosterTimer);
         rosterTimer = setTimeout(updateGenUI, 150);
       });
+      wireRosterPresets(el.genRoster, updateGenUI);
     }
     if (el.genPrint) el.genPrint.addEventListener("click", buildGeneratorSheet);
+    if (el.genLadder) el.genLadder.addEventListener("click", buildGeneratorLadder);
     if (el.genPng) el.genPng.addEventListener("click", () => genWordPNG(genValue(), genLevel()));
     if (el.genSlider) genLevelState = clampLevel(parseInt(el.genSlider.value, 10));
     renderGenPreview();
@@ -2213,6 +2275,24 @@
     printWrap("", holder);
   }
 
+  // Dot-to-dot difficulty ladder as one print job — the same word at every
+  // density, easy to expert. designSheetSVG reads designState.density, so the
+  // loop swaps it per page and restores the picked value afterwards.
+  function printDesignLadder() {
+    const holder = document.createElement("div");
+    holder.className = "pt-design-print-holder pt-class-set";
+    const picked = designState.density;
+    DOT_LEVELS.forEach((lvl) => {
+      designState.density = lvl.key;
+      const page = document.createElement("div");
+      page.className = "pt-sheet-page";
+      page.appendChild(designSheetSVG());
+      holder.appendChild(page);
+    });
+    designState.density = picked;
+    printWrap("", holder);
+  }
+
   function roundRectPath(ctx, x, y, w, h, r) {
     ctx.beginPath();
     ctx.moveTo(x + r, y);
@@ -2380,6 +2460,7 @@
     }
     [el.designFill, el.designBorder, el.designFooter].forEach((c) => { if (c) c.addEventListener("change", renderDesignPreview); });
     if (el.designPrint) el.designPrint.addEventListener("click", printDesign);
+    if (el.designLadder) el.designLadder.addEventListener("click", printDesignLadder);
     if (el.designPng) el.designPng.addEventListener("click", designPNG);
     syncDesignMode();
     renderDesignPreview();
@@ -2761,8 +2842,11 @@
 
   // The whole puzzle as one DOM sheet — the single primitive behind both the
   // live preview and the printed page, so what's on screen is what prints.
-  function puzzleSheetNode() {
-    const word = puzzleValue();
+  // `wordOverride` lets the class-set print path build one puzzle per roster
+  // name; a typed heading (if any) applies to every sheet, while the default
+  // heading stays per-name.
+  function puzzleSheetNode(wordOverride) {
+    const word = wordOverride != null ? String(wordOverride).slice(0, 20) : puzzleValue();
     const heading = puzzleHeadingText();
     const strip = puzzleBorderSym().split(" ").filter(Boolean);
     const footer = puzzleFooterOn();
@@ -2804,6 +2888,18 @@
   function printPuzzle() {
     const holder = document.createElement("div");
     holder.className = "pt-puzzle-print-holder";
+    const names = rosterNames(el.puzzleRoster);
+    if (names.length >= 2) {
+      holder.classList.add("pt-class-set");
+      names.forEach((n) => {
+        const page = document.createElement("div");
+        page.className = "pt-sheet-page";
+        page.appendChild(puzzleSheetNode(n));
+        holder.appendChild(page);
+      });
+      printWrap("", holder);
+      return;
+    }
     holder.appendChild(puzzleSheetNode());
     printWrap("", holder);
   }

--- a/printables/coloring-page-maker/index.html
+++ b/printables/coloring-page-maker/index.html
@@ -127,7 +127,7 @@
       "name": "Can I print a sheet for every child in my class at once?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes. Open Class set — one sheet per name, paste your class list with one name per line (up to 35 names), and Print builds one personalized sheet per child using the style, fill and border you picked. In the print dialog choose “Save as PDF” to keep the whole set as a single PDF file."
+        "text": "Yes. Open Class set — one sheet per name, paste your class list with one name per line (up to 60 names), and Print builds one personalized sheet per child using the style, fill and border you picked. In the print dialog choose “Save as PDF” to keep the whole set as a single PDF file."
       }
     },
     {
@@ -270,7 +270,7 @@
           <details class="pt-roster-field">
             <summary>Class set — one sheet per name</summary>
             <textarea id="pt-design-roster" class="main-input" rows="5" placeholder="One name per line…&#10;Emma&#10;Noah&#10;Ava" aria-label="Class roster — one name per line"></textarea>
-            <p class="pt-roster-hint">Paste your class list (up to 35 names) and Print builds one sheet per name with the style, fill and border picked above — choose “Save as PDF” in the print dialog to get the whole set as one PDF. Download PNG saves the sheet shown in the preview.</p>
+            <p class="pt-roster-hint">Paste your class list (up to 60 names) and Print builds one sheet per name with the style, fill and border picked above — choose “Save as PDF” in the print dialog to get the whole set as one PDF. Download PNG saves the sheet shown in the preview.</p>
           </details>
         </div>
 
@@ -435,7 +435,7 @@
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
         </button>
         <div class="faq-answer">
-          Yes. Open <strong>Class set — one sheet per name</strong>, paste your class list with one name per line (up to 35 names), and <strong>Print</strong> builds one personalized sheet per child using the style, fill and border you picked. In the print dialog choose <strong>“Save as PDF”</strong> to keep the whole set as a single PDF file.
+          Yes. Open <strong>Class set — one sheet per name</strong>, paste your class list with one name per line (up to 60 names), and <strong>Print</strong> builds one personalized sheet per child using the style, fill and border you picked. In the print dialog choose <strong>“Save as PDF”</strong> to keep the whole set as a single PDF file.
         </div>
       </div>
 

--- a/printables/dot-to-dot-name/index.html
+++ b/printables/dot-to-dot-name/index.html
@@ -116,6 +116,14 @@
         "@type": "Answer",
         "text": "Completely free, with no sign-up, no account, and no watermark. Everything is generated in your browser and nothing is uploaded. Make as many puzzles as you like."
       }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I make a dot-to-dot for every child in my class at once?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Open Class set — one puzzle per name, paste your class list with one name per line (up to 60 names), and Print builds one dot-to-dot per child at the difficulty you picked. In the print dialog choose “Save as PDF” to keep the whole set as one PDF. There is also Print all 4 levels, which prints the same name at easy, medium, hard and expert difficulty in one job."
+      }
     }
   ]
 }
@@ -207,6 +215,8 @@
               <input type="checkbox" id="pt-design-hint" checked>
               Show faint guide lines
             </label>
+            <button type="button" class="bubble-btn pt-ladder-btn" id="pt-design-ladder">Print all 4 levels — easy to expert</button>
+            <p class="pt-roster-hint">One print job, four sheets of the same name — start easy, finish expert. Choose “Save as PDF” in the print dialog to keep the set as one PDF.</p>
           </div>
 
           <div class="pt-field">
@@ -227,6 +237,12 @@
               Add a name &amp; date line
             </label>
           </div>
+
+          <details class="pt-roster-field">
+            <summary>Class set — one puzzle per name</summary>
+            <textarea id="pt-design-roster" class="main-input" rows="5" placeholder="One name per line…&#10;Emma&#10;Noah&#10;Ava" aria-label="Class roster — one name per line"></textarea>
+            <p class="pt-roster-hint">Paste your class list (up to 60 names) and Print builds one dot-to-dot per name at the difficulty picked above — choose “Save as PDF” in the print dialog to get the whole set as one PDF. Download PNG saves the single name typed above.</p>
+          </details>
         </div>
 
         <!-- Live preview -->
@@ -352,6 +368,19 @@
         </button>
         <div class="faq-answer">
           Completely free, with no sign-up, no account, and no watermark. Everything is generated in your browser and nothing is uploaded. Make as many puzzles as you like.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Can I make a dot-to-dot for every child in my class at once?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Yes. Open <strong>Class set — one puzzle per name</strong>, paste your class list with one name per line (up to 60 names),
+          and <strong>Print</strong> builds one dot-to-dot per child at the difficulty you picked. In the print dialog choose
+          <strong>“Save as PDF”</strong> to keep the whole set as one PDF. There is also <strong>Print all 4 levels</strong>,
+          which prints the same name at easy, medium, hard and expert difficulty in one job.
         </div>
       </div>
 

--- a/printables/handwriting-worksheet-generator/index.html
+++ b/printables/handwriting-worksheet-generator/index.html
@@ -94,7 +94,7 @@
       "name": "Can I make a worksheet for every student in my class at once?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes. Open Class set — one sheet per name, paste your class list with one name per line (up to 35 names), and Print builds one personalized worksheet per student at the difficulty you picked. In the print dialog choose “Save as PDF” to keep the whole set as a single PDF file."
+        "text": "Yes. Open Class set — one sheet per name, paste your class list with one name per line (up to 60 names), and Print builds one personalized worksheet per student at the difficulty you picked. In the print dialog choose “Save as PDF” to keep the whole set as a single PDF file."
       }
     },
     {
@@ -247,7 +247,7 @@
           <details class="pt-roster-field">
             <summary>Class set — one sheet per name</summary>
             <textarea id="pt-gen-roster" class="main-input" rows="5" placeholder="One name per line…&#10;Emma&#10;Noah&#10;Ava" aria-label="Class roster — one name per line"></textarea>
-            <p class="pt-roster-hint">Paste your class list (up to 35 names) and Print builds one worksheet per name at the difficulty picked above — choose “Save as PDF” in the print dialog to get the whole set as one PDF. Download PNG saves the single name typed above.</p>
+            <p class="pt-roster-hint">Paste your class list (up to 60 names) and Print builds one worksheet per name at the difficulty picked above — choose “Save as PDF” in the print dialog to get the whole set as one PDF. Download PNG saves the single name typed above.</p>
           </details>
         </div>
 
@@ -260,6 +260,7 @@
           <div class="pt-paper" id="pt-gen-preview" aria-live="polite"></div>
           <div class="pt-preview-actions">
             <button type="button" class="bubble-btn bubble-btn-primary" id="pt-gen-print">Print worksheet</button>
+            <button type="button" class="bubble-btn" id="pt-gen-ladder">Print all 7 levels</button>
             <button type="button" class="bubble-btn" id="pt-gen-png">Download PNG</button>
           </div>
           <p class="pt-preview-note">Runs entirely in your browser — nothing is uploaded. In the print dialog, choose “Save as PDF” to keep a copy.</p>
@@ -348,7 +349,7 @@
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
         </button>
         <div class="faq-answer">
-          Yes. Open <strong>Class set — one sheet per name</strong>, paste your class list with one name per line (up to 35 names), and <strong>Print</strong> builds one personalized worksheet per student at the difficulty you picked. In the print dialog choose <strong>“Save as PDF”</strong> to keep the whole set as a single PDF file.
+          Yes. Open <strong>Class set — one sheet per name</strong>, paste your class list with one name per line (up to 60 names), and <strong>Print</strong> builds one personalized worksheet per student at the difficulty you picked. In the print dialog choose <strong>“Save as PDF”</strong> to keep the whole set as a single PDF file.
         </div>
       </div>
 

--- a/printables/name-puzzle-maker/index.html
+++ b/printables/name-puzzle-maker/index.html
@@ -101,6 +101,14 @@
         "@type": "Answer",
         "text": "Regular paper works, but cardstock holds up much better once the pieces are cut apart, handled, and stored. Laminating the sheet before cutting makes the pieces reusable for many practice sessions."
       }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I make a name puzzle for every child in my class at once?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Open Class set — one puzzle per name, paste your class list with one name per line (up to 60 names), and Print builds one cut-apart puzzle per child with the border you picked. In the print dialog choose “Save as PDF” to keep the whole set as a single PDF file."
+      }
     }
   ]
 }
@@ -179,6 +187,12 @@
               Add a name &amp; date line
             </label>
           </div>
+
+          <details class="pt-roster-field">
+            <summary>Class set — one puzzle per name</summary>
+            <textarea id="pt-puzzle-roster" class="main-input" rows="5" placeholder="One name per line…&#10;Emma&#10;Noah&#10;Ava" aria-label="Class roster — one name per line"></textarea>
+            <p class="pt-roster-hint">Paste your class list (up to 60 names) and Print builds one name puzzle per name with the border picked above — choose “Save as PDF” in the print dialog to get the whole set as one PDF. Download PNG saves the single name typed above.</p>
+          </details>
         </div>
 
         <!-- Live preview -->
@@ -287,6 +301,18 @@
         </button>
         <div class="faq-answer">
           Regular paper works, but cardstock holds up much better once the pieces are cut apart, handled, and stored. Laminating the sheet before cutting makes the pieces reusable for many practice sessions.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Can I make a name puzzle for every child in my class at once?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Yes. Open <strong>Class set — one puzzle per name</strong>, paste your class list with one name per line (up to 60 names),
+          and <strong>Print</strong> builds one cut-apart puzzle per child with the border you picked. In the print dialog choose
+          <strong>“Save as PDF”</strong> to keep the whole set as a single PDF file.
         </div>
       </div>
 

--- a/printables/name-tracing/index.html
+++ b/printables/name-tracing/index.html
@@ -86,6 +86,14 @@
         "@type": "Answer",
         "text": "Name tracing suits preschool and kindergarten learners building letter formation and fine-motor control, and anyone practicing neat handwriting. Print several copies and keep sessions short and frequent for the best results."
       }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I print a tracing worksheet for my whole class at once?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Open Class set — one worksheet per name, paste your class list with one name per line (up to 60 names), and Print builds one personalized tracing worksheet per student. In the print dialog choose “Save as PDF” to keep the whole set as a single PDF file — free, with no email required."
+      }
     }
   ]
 }
@@ -151,6 +159,11 @@
             <option value="6">6</option>
           </select>
         </div>
+        <details class="pt-roster-field">
+          <summary>Class set — one worksheet per name</summary>
+          <textarea id="pt-name-roster" class="main-input" rows="5" placeholder="One name per line…&#10;Emma&#10;Noah&#10;Ava" aria-label="Class roster — one name per line"></textarea>
+          <p class="pt-roster-hint">Paste your class list (up to 60 names) and Print builds one tracing worksheet per name with the trace rows picked above — choose “Save as PDF” in the print dialog to get the whole set as one PDF. Download PNG saves the single name typed above.</p>
+        </details>
         <div class="pt-name-preview" id="pt-name-preview" aria-live="polite"></div>
         <div class="bubble-actions pt-name-actions">
           <button type="button" class="bubble-btn bubble-btn-primary" id="pt-name-print">Print the worksheet</button>
@@ -240,6 +253,18 @@
         <div class="faq-answer">
           Name tracing suits preschool and kindergarten learners building letter formation and fine-motor control, and anyone
           practicing neat handwriting. Print several copies and keep sessions short and frequent for the best results.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Can I print a tracing worksheet for my whole class at once?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Yes. Open <strong>Class set — one worksheet per name</strong>, paste your class list with one name per line (up to 60 names),
+          and <strong>Print</strong> builds one personalized tracing worksheet per student. In the print dialog choose
+          <strong>“Save as PDF”</strong> to keep the whole set as a single PDF file — free, with no email required.
         </div>
       </div>
 

--- a/printables/sight-word-tracing/index.html
+++ b/printables/sight-word-tracing/index.html
@@ -92,6 +92,14 @@
         "@type": "Answer",
         "text": "Yes — completely free, with no sign-up, watermark, or limit. Everything is generated in your browser, so you can make as many sight word worksheets as you like."
       }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I print the whole Dolch or Fry list at once?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Open Whole list — one sheet per word and tap a preset to load the complete Dolch pre-primer list (40 words), Dolch primer list (52 words), or the first 50 Fry words — or paste your own list. Print builds one worksheet per word at your chosen difficulty; choose “Save as PDF” in the print dialog to keep the whole packet as one PDF, free, with no email required."
+      }
     }
   ]
 }
@@ -244,6 +252,17 @@
               Solid model row on top
             </label>
           </div>
+
+          <details class="pt-roster-field">
+            <summary>Whole list — one sheet per word</summary>
+            <div class="pt-roster-presets" role="group" aria-label="Load a whole sight-word list">
+              <button type="button" class="pt-roster-preset" data-words="a|and|away|big|blue|can|come|down|find|for|funny|go|help|here|I|in|is|it|jump|little|look|make|me|my|not|one|play|red|run|said|see|the|three|to|two|up|we|where|yellow|you">Dolch pre-primer · 40 words</button>
+              <button type="button" class="pt-roster-preset" data-words="all|am|are|at|ate|be|black|brown|but|came|did|do|eat|four|get|good|have|he|into|like|must|new|no|now|on|our|out|please|pretty|ran|ride|saw|say|she|so|soon|that|there|they|this|too|under|want|was|well|went|what|white|who|will|with|yes">Dolch primer · 52 words</button>
+              <button type="button" class="pt-roster-preset" data-words="the|of|and|a|to|in|is|you|that|it|he|was|for|on|are|as|with|his|they|I|at|be|this|have|from|or|one|had|by|word|but|not|what|all|were|we|when|your|can|said|there|use|an|each|which|she|do|how|their|if">Fry first 50</button>
+            </div>
+            <textarea id="pt-gen-roster" class="main-input" rows="5" placeholder="One word per line…&#10;the&#10;and&#10;see" aria-label="Word list — one word per line"></textarea>
+            <p class="pt-roster-hint">Load a full Dolch or Fry list with one tap — or paste your own list or class roster (up to 60 lines). Print builds one worksheet per word at the difficulty picked above; choose “Save as PDF” in the print dialog to get the whole packet as one PDF. Download PNG saves the single word typed above.</p>
+          </details>
         </div>
 
         <!-- Live preview -->
@@ -255,6 +274,7 @@
           <div class="pt-paper" id="pt-gen-preview" aria-live="polite"></div>
           <div class="pt-preview-actions">
             <button type="button" class="bubble-btn bubble-btn-primary" id="pt-gen-print">Print worksheet</button>
+            <button type="button" class="bubble-btn" id="pt-gen-ladder">Print all 7 levels</button>
             <button type="button" class="bubble-btn" id="pt-gen-png">Download PNG</button>
           </div>
           <p class="pt-preview-note">Runs entirely in your browser — nothing is uploaded. In the print dialog, choose “Save as PDF” to keep a copy.</p>
@@ -334,6 +354,19 @@
         <div class="faq-answer">
           Yes — completely free, with no sign-up, watermark, or limit. Everything is generated in your
           browser, so you can make as many sight word worksheets as you like.
+        </div>
+      </div>
+
+      <div class="faq-item">
+        <button class="faq-question" type="button">
+          Can I print the whole Dolch or Fry list at once?
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+        </button>
+        <div class="faq-answer">
+          Yes. Open <strong>Whole list — one sheet per word</strong> and tap a preset to load the complete Dolch pre-primer list
+          (40 words), Dolch primer list (52 words), or the first 50 Fry words — or paste your own list. <strong>Print</strong> builds
+          one worksheet per word at your chosen difficulty; choose <strong>“Save as PDF”</strong> in the print dialog to keep the
+          whole packet as one PDF, free, with no email required.
         </div>
       </div>
 

--- a/style.css
+++ b/style.css
@@ -7899,6 +7899,36 @@ body.dark-mode .kana-cell-empty { opacity: 0.35; }
   color: var(--text-secondary);
   margin: 0.35rem 0 0;
 }
+/* One-tap word-list presets inside a roster field (Dolch / Fry lists). */
+.pt-roster-presets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-top: 0.55rem;
+}
+.pt-roster-preset {
+  font: inherit;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  background: var(--bg-base);
+  border: 1px solid var(--border-light);
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+.pt-roster-preset:hover {
+  border-color: var(--accent-purple);
+  background: var(--bg-white);
+}
+/* Difficulty-ladder pack button when it sits inside a control field
+   (preview-action instances inherit .pt-preview-actions sizing). */
+.pt-ladder-btn {
+  margin-top: 0.7rem;
+  padding: 0.6rem 0.95rem;
+  font-size: 0.88rem;
+}
 .pt-step-title {
   font-size: 0.72rem;
   font-weight: 700;


### PR DESCRIPTION
## Summary

Extends the printables engine with two new batch-printing workflows that teachers commonly need:

1. **Class-set printing**: paste a roster (one name/word per line, up to 60 items) to generate one personalized worksheet per child in a single print job
2. **Difficulty-ladder printing**: generate the same word/name at every difficulty level in one job, enabling graded progression practice

Both workflows output multi-page PDFs via the browser's print dialog, with no server upload or email required.

## Key Changes

**Engine (`printablesEngine.js`)**
- Refactored sheet-building functions to accept overrides, enabling per-item customization:
  - `nameSheetNode(nameOverride)` — extracted from `buildNameWorksheet()` to support per-name sheets
  - `genSheetNode(wordOverride, levelOverride)` — added `levelOverride` parameter for ladder printing
  - `puzzleSheetNode(wordOverride)` — added override support for class-set puzzles
- Added `buildGeneratorLadder()` — prints one sheet per difficulty level (7 levels for sight words)
- Added `printDesignLadder()` — prints one dot-to-dot per density level (4 levels)
- Refactored `buildNameWorksheet()` and `printPuzzle()` to detect roster input and build multi-page sets
- Added `rosterNames(mount)` helper — parses textarea input, caps at 60 lines (up from 35)
- Added `wireRosterPresets(mount, onFill)` — wires one-tap preset buttons (Dolch/Fry lists) to fill roster textareas
- Added `ROSTER_CAP = 60` constant with comment explaining the 52-word Dolch primer use case
- Wired event listeners for new buttons (`#pt-gen-ladder`, `#pt-design-ladder`) and preset buttons

**HTML (all printable pages)**
- Added roster textarea fields with `pt-roster-field` collapsible sections:
  - `name-tracing/index.html`: `#pt-name-roster`
  - `sight-word-tracing/index.html`: `#pt-gen-roster` (with Dolch/Fry preset buttons)
  - `dot-to-dot-name/index.html`: `#pt-design-roster`
  - `name-puzzle-maker/index.html`: `#pt-puzzle-roster`
- Added ladder-print buttons:
  - `sight-word-tracing/index.html`: "Print all 7 levels" button
  - `dot-to-dot-name/index.html`: "Print all 4 levels — easy to expert" button
- Added preset button group in sight-word-tracing with three one-tap lists:
  - Dolch pre-primer (40 words)
  - Dolch primer (52 words)
  - Fry first 50
- Updated FAQ sections across all pages with new Q&A entries explaining class-set and ladder workflows
- Updated roster-cap references in FAQ from 35 to 60 names

**Styles (`style.css`)**
- Added `.pt-roster-presets` — flex layout for one-tap preset buttons
- Added `.pt-roster-preset` — styled pill buttons with hover state
- Added `.pt-ladder-btn` — spacing/sizing for ladder buttons inside control fields

## Implementation Details

- **Multi-page output**: Uses `.pt-class-set` and `.pt-sheet-page` wrapper divs to structure multi-page PDFs; users save via browser print dialog as PDF
- **Roster parsing**: Splits on `\r?\n`, trims whitespace, filters empty lines, caps at 60 items
- **Preset data**: Word lists stored in `data-words` attribute as pipe-separated strings; click handler splits, fills textarea, opens collapsible section
- **Ladder generation**: Loops `TRACE_LEVELS` or `DOT_LEVELS` array, swaps state per page, restores original after render
- **Backward compatible**: Single-item workflows (no roster or roster with <2 items) fall back to original single

https://claude.ai/code/session_01JCgczJNcmR6AfztJLwhRwp