### PR TITLE
Add 8 new emoji combo aesthetics + Discord formatting answer pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,6 +192,87 @@ rationale and the recurring failure mode: `docs/unicode-library-workflow.md`
 
 ---
 
+## Hub vs Spoke: preventing self-cannibalization
+
+A **hub** owns a broad head term and a *browse-or-tool* intent (`/discord/` = the
+"discord fonts" generator; `/library/emoji-combos/` = the "emoji combos" browse
+grid). A **spoke** is a page that owns ONE narrower query with a *different* SERP
+intent (a how-to, an answer, a single item, a single aesthetic). Hubs and spokes
+are how the site scales coverage — but when a hub and its own spoke both try to
+rank for the *same* query, they **cannibalize**: Google ranks only one of your
+URLs well, picks the higher-authority hub (often the *worse* answer, so it ranks
+badly), and starves the spoke that would have ranked. This is the same failure as
+"check who already owns it" below, turned inward — the hub eating its own spokes.
+
+**This is distinct from, and stricter than, "check who already owns it."** That
+rule guards a *new* page against an *existing* page. This one governs the standing
+relationship between a hub and the spokes beneath it, in *both* directions.
+
+The rule has four parts. Apply all four — the Discord case below failed only on
+Rule 3, and that was enough to strand five real pages.
+
+1. **One query, one target.** Every query cluster has exactly ONE page designated
+   to rank for it. Name that exact query *before* building anything. Before adding
+   a hub section, confirm no spoke owns the query. Before creating a spoke, confirm
+   the hub is not already page-1 for it.
+
+2. **The spoke test — when to split out vs. keep as a hub section.** Make it a
+   spoke only if **all three** hold:
+   - **(a) Distinct SERP intent** — the query's SERP is a *different type* than the
+     hub's (how-to article + PAA + forums, vs. a tool/collection). If the two SERPs
+     look the same, it is **not** a spoke.
+   - **(b) Self-contained** — fully answerable on its own page, without the hub's
+     tool/collection as the payload.
+   - **(c) Standalone demand** — real independent volume (GSC impressions or
+     Semrush), not a fragment of the hub's head term.
+
+   If **any** fail → it is a **section on the hub**, not a spoke.
+
+3. **De-confliction (the part most often skipped, and the one that bites).** The
+   moment a spoke exists, the hub must **de-target** that query: strip the competing
+   prose down to a one-line pointer link ("to format messages, see the guide"). The
+   hub keeps its head term; the spoke gets a clean run at its query. Symmetric — a
+   spoke must not chase the hub's head term (don't stuff "discord fonts" into a
+   formatting guide). A spoke that exists while the hub still targets its query is a
+   cannibal, not coverage.
+
+4. **Link direction.** Hub → spoke (a contextual link inside the relevant hub
+   section) and spoke → hub (breadcrumb + one back-link). No orphan spokes (no hub
+   links in), no un-pointed hub sections (a section whose spoke it never links to).
+
+**Diagnosing an existing cannibalization:** pull GSC query×page. The signature is a
+spoke sitting at **position 5–8 with thousands of impressions and ~zero clicks**
+(the hub on the same SERP takes the click), or a spoke with **~zero impressions**
+for its target query while the hub ranks that query poorly (the hub is intercepting
+it). Both mean Rule 3 was never applied — fix the hub, don't rebuild the spoke.
+
+**Worked application:**
+- *Emoji aesthetics (baddie, emo, scene, weirdcore, …)* → **hub sections**, not
+  spokes. "baddie emoji combos" has the **same** SERP intent as "emoji combos"
+  (copy-paste collection lists) → fails the spoke test on (a). Building 11 spokes
+  would create 11 cannibals against the hub that already ranks page-2 for the head
+  term. Promotion path: if one aesthetic later shows large standalone volume **and**
+  a distinct SERP, promote it to a spoke **and** de-target it from the hub (Rule 3).
+- *Discord native formatting (bold, underline, big text, color)* → correctly
+  **spokes** (distinct how-to/PAA/forum SERP), which already exist as
+  `guide/discord-text-formatting-explained`, `guide/discord-colored-text-guide`,
+  `answers/how-to-make-bold-text-in-discord`, etc. — but Rule 3 was never applied,
+  so the `/discord/` generator hub still carries the formatting how-to prose and
+  intercepts every "how to X in discord" query. Fix is de-targeting the hub, **not**
+  another page.
+
+**Case study (2026-07-18):** a GSC query×page pull (last 3 months, queries
+containing "discord") showed `/discord/` at 1,247 clicks / 89,848 impressions while
+`/answers/discord-allowed-characters/` had **0 clicks on 3,656 impressions** (pos
+7.85), `/answers/do-you-need-nitro-for-discord-fonts/` **0 clicks on 3,567**
+(7.45), and `/guide/discord-text-formatting-explained/` **0 clicks on 452** at
+position 6.06 — all indexed, all on-SERP, all starved by the hub above them.
+`answers/how-to-make-bold-text-in-discord` drew essentially no impressions because
+the hub intercepts "how to bold" and then ranks ~80 for it. Five purpose-built
+pages, near-zero traffic, because Rule 3 was never applied to the hub.
+
+---
+
 ## Core JavaScript Architecture
 
 Scripts are loaded in a strict order in every HTML page:

--- a/answers/how-to-make-big-text-in-discord/index.html
+++ b/answers/how-to-make-big-text-in-discord/index.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html><html lang="en"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8242324164413945"
+       crossorigin="anonymous"></script>
+
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <title>How to Make Big Text in Discord (Headers + Subtext) | UltraTextGen</title>
+  <meta name="description" content="Start a message line with # and a space for a big header, ## for medium, ### for smaller, and -# for subtext. Headers only work in messages — for a name that stands out where big text can't reach, paste a Unicode font instead.">
+  <link rel="canonical" href="https://ultratextgen.com/answers/how-to-make-big-text-in-discord/">
+  <meta property="og:title" content="How to Make Big Text in Discord (Headers + Subtext)">
+  <meta property="og:description" content="Start a line with # and a space for a big header, ## medium, ### smaller, -# subtext. Only in messages — for a standout name, paste a Unicode font.">
+  <meta property="og:url" content="https://ultratextgen.com/answers/how-to-make-big-text-in-discord/">
+  <meta property="og:type" content="article">
+  <meta property="og:image" content="https://ultratextgen.com/logo.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="How to Make Big Text in Discord (Headers + Subtext)">
+  <meta name="twitter:description" content="# and a space makes a big header; ## medium; ### smaller; -# subtext. Only in messages — for a standout name, paste a Unicode font.">
+  <meta name="twitter:image" content="https://ultratextgen.com/logo.png">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "How do I make big text in a Discord message?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Start a new line with a hash and a space, then your text. # Text is the biggest header, ## Text is medium, and ### Text is a smaller header. The space after the hash is required, and it only works at the start of a line. This is built-in markdown, free, no Nitro, and works on desktop, web, and mobile."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What does -# do in Discord?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "A dash, a hash, and a space at the start of a line — -# Text — makes subtext, which renders smaller and greyer than normal text. It is the opposite of a header and is useful for captions or fine print under a big title."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I make my Discord username or a channel name bigger?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. Headers are markdown and only work inside messages. Usernames, display names, channel names, and status render at a fixed size, and markdown does nothing there. To make a name stand out where you cannot make it bigger, paste a Unicode font — bold or fancy characters that look distinct even though they are the same size."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Do Discord headers work on mobile?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Type the hash and a space at the start of a line in the mobile app exactly as on desktop. The header renders the same way. There is no separate button for it, so type the markdown manually."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Do I need Nitro to make big text in Discord?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. Headers and subtext are free built-in markdown. Unicode fonts for a standout name are just characters you paste, so they also work without Nitro. Nitro is unrelated to text size or formatting."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ultratextgen.com/" },
+    { "@type": "ListItem", "position": 2, "name": "Answers", "item": "https://ultratextgen.com/answers/" },
+    { "@type": "ListItem", "position": 3, "name": "How to Make Big Text in Discord", "item": "https://ultratextgen.com/answers/how-to-make-big-text-in-discord/" }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/">Home</a>
+  <span class="breadcrumb-separator">›</span>
+  <a href="/answers/">Answers</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">How to Make Big Text in Discord</span>
+</nav>
+
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">How to Make Big Text in Discord</h1>
+    <p class="hero-tagline">Start a message line with <code>#</code> and a space for a big header, <code>##</code> for medium, <code>###</code> for smaller, and <code>-#</code> for subtext. That's for messages — a username can't be made bigger, so for a name that stands out, paste a Unicode font instead.</p>
+  </div>
+</section>
+
+<section class="editorial-section">
+  <span class="article-section-label">Short answer</span>
+  <div class="editorial-block">
+    <p>To make big text in a <strong>message</strong>, start a new line with a <strong>hash and a space</strong>: <code># Big</code> is the largest header, <code>## Medium</code> is smaller, and <code>### Small</code> is smaller still. Add <code>-# </code> before a line for <strong>subtext</strong> (smaller and greyer). The space after the hash is required, and it only works at the start of a line. This is built-in markdown — free, no Nitro, desktop, web, and mobile. Headers only work <strong>inside messages</strong>, though: a <strong>username, display name, or channel</strong> renders at a fixed size and can't be enlarged, so to make a name stand out you paste a <strong>Unicode font</strong> instead.</p>
+  </div>
+  <div class="block-example">
+    <strong>In one line:</strong> messages → <code># Header</code>, <code>## </code>, <code>### </code>, <code>-# subtext</code> · a standout name → paste a Unicode font.
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="editorial-section">
+  <span class="article-section-label">In messages</span>
+  <h2>Headers and subtext with the hash</h2>
+  <div class="editorial-block">
+    <p>Discord's markdown added true headers. Put the marker at the very start of a line, always followed by a space:</p>
+    <ul>
+      <li><code># Heading</code> → the biggest header (H1)</li>
+      <li><code>## Heading</code> → medium header (H2)</li>
+      <li><code>### Heading</code> → smaller header (H3)</li>
+      <li><code>-# Subtext</code> → smaller, greyer subtext</li>
+    </ul>
+    <p>Because a header takes a whole line, you can stack a big title over small print — a <code># </code> header on one line and a <code>-# </code> caption on the next gives a clean title-and-description layout for announcements. A few gotchas: the space after the hash is mandatory (<code>#Heading</code> stays plain text), headers only work at line start (not mid-sentence), and they render identically on desktop, web, and mobile with no Nitro. Bold and other inline styles still work inside a header line.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="editorial-section">
+  <span class="article-section-label">Where big text can't reach</span>
+  <h2>Names and channels: use a Unicode font to stand out</h2>
+  <div class="editorial-block">
+    <p>People often search for "big text" because they want a <strong>name</strong> that pops — a display name, a channel, a server title. Headers can't do that: markdown is message-only, and Discord renders every name and channel at a <strong>fixed size</strong>, so there's no way to make the letters literally bigger. What you <em>can</em> do is make them <strong>look distinct</strong> with a <strong>Unicode font</strong>:</p>
+    <ul>
+      <li>Bold characters — <strong>𝗕𝗼𝗹𝗱 𝗡𝗮𝗺𝗲</strong> — heavier than the default</li>
+      <li>Fancy and outlined styles that catch the eye in a member list</li>
+      <li>These are real characters, so they paste into any plain-text field — username, nickname, channel, status</li>
+    </ul>
+    <p>They're the same point size as normal text, but the extra weight and unusual shapes make a name stand out far more than plain letters — and, unlike headers, they work in the exact fields where markdown does nothing. No Nitro required; it's just text you copy and paste.</p>
+  </div>
+</section>
+
+<div class="cta-card">
+  <h3>Make a standout Discord name to paste anywhere</h3>
+  <p>Type your text, copy a bold or fancy version, and paste it into your display name, a channel, or your status — free, no sign-up, no Nitro.</p>
+  <a href="/discord/" class="cta-btn">Open the Discord Font Generator →</a>
+</div>
+
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Related: for the full set of Discord markdown (bold, underline, colored text, spoilers, lists) see <a href="/guide/discord-text-formatting-explained/">Discord text formatting explained</a>. Also handy: <a href="/answers/how-to-make-bold-text-in-discord/">how to make bold text in Discord</a> and <a href="/answers/how-to-underline-in-discord/">how to underline in Discord</a>. Wondering if you have to pay? See <a href="/answers/do-you-need-nitro-for-discord-fonts/">do you need Nitro for Discord fonts</a>. To build a standout name, use the <a href="/discord/">Discord Fonts generator</a>.</p>
+  </div>
+</section>
+
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/answers/how-to-underline-in-discord/index.html
+++ b/answers/how-to-underline-in-discord/index.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html><html lang="en"><head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8242324164413945"
+       crossorigin="anonymous"></script>
+
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <title>How to Underline in Discord (Markdown + Unicode Underline) | UltraTextGen</title>
+  <meta name="description" content="Wrap text in double underscores — __like this__ — to underline a Discord message, or press Ctrl/Cmd+U. For usernames, display names, and channels where markdown does nothing, paste Unicode underline instead. Here's both.">
+  <link rel="canonical" href="https://ultratextgen.com/answers/how-to-underline-in-discord/">
+  <meta property="og:title" content="How to Underline in Discord (Markdown + Unicode Underline)">
+  <meta property="og:description" content="Two underscores each side — __like this__ — underline a message. For names and channels where markdown fails, paste Unicode underline instead.">
+  <meta property="og:url" content="https://ultratextgen.com/answers/how-to-underline-in-discord/">
+  <meta property="og:type" content="article">
+  <meta property="og:image" content="https://ultratextgen.com/logo.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="How to Underline in Discord (Markdown + Unicode Underline)">
+  <meta name="twitter:description" content="Two underscores each side underline a message. For names and channels markdown can't reach, paste Unicode underline instead.">
+  <meta name="twitter:image" content="https://ultratextgen.com/logo.png">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/style.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "How do I underline text in a Discord message?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Wrap the text in two underscores on each side. Typing __hello__ sends the word hello underlined. On desktop and web you can also highlight the text and press Ctrl+U (Cmd+U on Mac). This is Discord's built-in markdown, it's free, no Nitro is needed, and the underscores disappear once the message posts."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Why don't the underscores underline my Discord username or channel name?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Markdown only renders inside message and post bodies. Usernames, display names, server nicknames, channel and category names, custom status, and role names are plain-text fields, so Discord shows the literal underscores there instead of underlining. To get an underlined look in those places you paste Unicode underlined characters, which carry a combining underline on each character and survive being pasted anywhere."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the difference between one underscore and two in Discord?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "One underscore on each side, _like this_, renders italic. Two underscores, __like this__, render underline. They stack with other markdown: __*text*__ is underlined italic and __**text**__ is underlined bold. Make sure there is no space between the underscores and the text."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I underline text on the Discord mobile app?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. There is no Ctrl+U shortcut on mobile, but you can type two underscores before and after the text manually, or select the text and tap the U in the formatting bar that appears above the keyboard. Underscores are usually behind the symbols key on a phone keyboard."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Do I need Nitro to underline text in Discord?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. Markdown underline with double underscores is free and built in. Unicode underline is just characters you paste, so it also works without Nitro anywhere text can be typed. Nitro is unrelated to text formatting."
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://ultratextgen.com/" },
+    { "@type": "ListItem", "position": 2, "name": "Answers", "item": "https://ultratextgen.com/answers/" },
+    { "@type": "ListItem", "position": 3, "name": "How to Underline in Discord", "item": "https://ultratextgen.com/answers/how-to-underline-in-discord/" }
+  ]
+}
+</script>
+</head>
+<body>
+  <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+  <div id="shared-header"></div>
+<script src="/header.js" defer></script>
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="/">Home</a>
+  <span class="breadcrumb-separator">›</span>
+  <a href="/answers/">Answers</a>
+  <span class="breadcrumb-separator">›</span>
+  <span class="breadcrumb-current">How to Underline in Discord</span>
+</nav>
+
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">How to Underline in Discord</h1>
+    <p class="hero-tagline">In a message, wrap your text in double underscores — or press Ctrl/Cmd+U. In a username, display name, or channel — where markdown does nothing — paste Unicode underline instead. Here's both, and when to use each.</p>
+  </div>
+</section>
+
+<section class="editorial-section">
+  <span class="article-section-label">Short answer</span>
+  <div class="editorial-block">
+    <p>To underline a <strong>message</strong>, wrap the text in <strong>two underscores</strong> on each side: type <code>__underline__</code> and it sends as underlined. On desktop and web you can instead highlight the text and press <strong>Ctrl+U</strong> (⌘+U on Mac). This is Discord's built-in markdown — free, no Nitro, works on desktop, web, and mobile. But markdown only styles the inside of messages. For a <strong>username, display name, nickname, channel name, or status</strong>, Discord ignores the underscores and prints them literally, so you paste <strong>Unicode underline</strong> characters instead — the line is baked into each character, so it stays underlined anywhere.</p>
+  </div>
+  <div class="block-example">
+    <strong>In one line:</strong> messages → <code>__double underscores__</code> (or Ctrl/Cmd+U) · names, channels, status → paste Unicode underline.
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="editorial-section">
+  <span class="article-section-label">In messages</span>
+  <h2>Markdown underline with double underscores</h2>
+  <div class="editorial-block">
+    <p>Discord uses a lightweight Markdown in every message box. Underline is <strong>two underscores</strong> on each side of the text — and unlike some editors, a single underscore does something different.</p>
+    <ul>
+      <li><code>__underline__</code> → underlined (two underscores)</li>
+      <li><code>_italic_</code> → <em>italic</em> (one underscore — the common mix-up)</li>
+      <li><code>__*underline italic*__</code> → underlined italic</li>
+      <li><code>__**underline bold**__</code> → underlined bold</li>
+      <li><code>__***all three***__</code> → underlined, bold, and italic</li>
+    </ul>
+    <p>On the desktop and web apps you can skip the syntax: select the text and press <strong>Ctrl+U</strong> (<strong>⌘+U</strong> on Mac). If the shortcut does nothing, just type the underscores manually — that always works. The underscores vanish once the message posts; readers only see the line. Keep the text tight against the underscores — <code>__ spaced __</code> won't render — and note that underline inside a code block (between backticks) is shown verbatim, not styled.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="editorial-section">
+  <span class="article-section-label">Where markdown fails</span>
+  <h2>Usernames, channels, and status need Unicode underline</h2>
+  <div class="editorial-block">
+    <p>Markdown is only interpreted inside message and post content. Everywhere else Discord treats the field as plain text and prints your underscores exactly as typed — so <code>__general__</code> as a channel name literally shows the underscores. The fields where markdown does <strong>nothing</strong> include:</p>
+    <ul>
+      <li>Your username and display name</li>
+      <li>Per-server nicknames</li>
+      <li>Channel names and category names</li>
+      <li>Custom status ("what are you up to")</li>
+      <li>Role names and the server name</li>
+    </ul>
+    <p>To get an underlined look in any of these, use <strong>Unicode underline</strong>: ordinary letters with a combining underline mark on each character, so the underline lives in the text itself rather than in markup. Because it isn't markdown, it survives being pasted into a plain-text field. Generate it, copy it, and paste it as the name or status — no Nitro, it's just characters. The same trick gives you a bold, italic, or fancy name where <code>**</code> and <code>__</code> can't reach.</p>
+  </div>
+</section>
+
+<div class="cta-card">
+  <h3>Make an underlined Discord name to paste anywhere</h3>
+  <p>Type your text, copy an underlined or styled version, and paste it into your display name, a channel, or your status — free, no sign-up, no Nitro.</p>
+  <a href="/discord/" class="cta-btn">Open the Discord Font Generator →</a>
+</div>
+
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>Related: for the full set of Discord markdown (bold, headers, colored text, spoilers, lists) see <a href="/guide/discord-text-formatting-explained/">Discord text formatting explained</a>. Also handy: <a href="/answers/how-to-make-bold-text-in-discord/">how to make bold text in Discord</a> and <a href="/answers/how-to-make-big-text-in-discord/">how to make big text in Discord</a>. Wondering if you have to pay? See <a href="/answers/do-you-need-nitro-for-discord-fonts/">do you need Nitro for Discord fonts</a>. To build underlined and styled names, use the <a href="/discord/">Discord Fonts generator</a>.</p>
+  </div>
+</section>
+
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<script src="/footer.js" defer></script>
+</body>
+</html>

--- a/discord/index.html
+++ b/discord/index.html
@@ -545,7 +545,7 @@
 
   <div class="editorial-block">
     <h3>Make Big Text on Discord</h3>
-    <p>In chat messages, use Discord's header markdown: type <code>#</code> followed by a space for the largest heading, <code>##</code> for medium, or <code>###</code> for small. Headers work at the start of a new line. Outside of chat (display names, bios), there's no way to increase font size.</p>
+    <p>There's no font-size control for display names or bios. In chat messages you can use header markdown — the full steps are in <a href="/answers/how-to-make-big-text-in-discord/">how to make big text in Discord</a>. To make a <em>name</em> stand out instead, pick a bold or fancy style from the generator above.</p>
   </div>
 
   <div class="editorial-block">
@@ -567,34 +567,15 @@
 
 
 <section class="editorial-section">
-  <h2>Discord Text Formatting Commands</h2>
+  <h2>Formatting Messages vs. Styling Names</h2>
 
   <div class="editorial-block">
-    <p>Discord uses Markdown syntax for basic text formatting in chat. These are built-in commands — separate from the Unicode font styles above.</p>
-
-    <div class="data-table-wrap">
-      <table class="data-table">
-        <thead>
-          <tr>
-            <th>Format</th>
-            <th>Syntax</th>
-            <th>Result</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr><td>Bold</td><td><code>**text**</code></td><td><strong>text</strong></td></tr>
-          <tr><td>Italic</td><td><code>*text*</code></td><td><em>text</em></td></tr>
-          <tr><td>Underline</td><td><code>__text__</code></td><td><u>text</u></td></tr>
-          <tr><td>Strikethrough</td><td><code>~~text~~</code></td><td><s>text</s></td></tr>
-          <tr><td>Spoiler</td><td><code>||text||</code></td><td>█████</td></tr>
-          <tr><td>Inline Code</td><td><code>`text`</code></td><td><code>text</code></td></tr>
-          <tr><td>Big Header</td><td><code># text</code></td><td>Heading 1</td></tr>
-          <tr><td>Block Quote</td><td><code>&gt; text</code></td><td>Quoted text</td></tr>
-          <tr><td>Bulleted List</td><td><code>- text</code></td><td>List item</td></tr>
-          <tr><td>Masked Link</td><td><code>[label](url)</code></td><td>Clickable link</td></tr>
-        </tbody>
-      </table>
-    </div>
+    <p>The styles on this page are <strong>Unicode fonts</strong> — the right tool for <strong>display names, nicknames, channels, bios, and status</strong>, the fields where Discord's own formatting does nothing. Formatting <strong>inside chat messages</strong> is a separate system: Discord's built-in <strong>Markdown</strong> (bold, italic, underline, strikethrough, spoilers, headers, colored text). For the full message-formatting reference and step-by-steps, use these:</p>
+    <ul>
+      <li><a href="/guide/discord-text-formatting-explained/">Discord text formatting explained</a> — the complete Markdown reference</li>
+      <li>Quick how-tos: <a href="/answers/how-to-make-bold-text-in-discord/">bold</a>, <a href="/answers/how-to-underline-in-discord/">underline</a>, and <a href="/answers/how-to-make-big-text-in-discord/">big text</a></li>
+      <li><a href="/guide/discord-colored-text-guide/">Colored text</a> — ANSI code blocks (desktop only)</li>
+    </ul>
   </div>
 </section>
 

--- a/guide/discord-text-formatting-explained/index.html
+++ b/guide/discord-text-formatting-explained/index.html
@@ -366,6 +366,16 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <span class="related-title">Personal Branding Through Typography</span>
       <span class="related-desc">Make your name a signature people recognize.</span>
     </a>
+    <a class="related-card" href="/answers/how-to-underline-in-discord/">
+      <span class="related-tag">＿</span>
+      <span class="related-title">How to Underline in Discord</span>
+      <span class="related-desc">Double underscores in messages; Unicode for names.</span>
+    </a>
+    <a class="related-card" href="/answers/how-to-make-big-text-in-discord/">
+      <span class="related-tag">🔠</span>
+      <span class="related-title">How to Make Big Text in Discord</span>
+      <span class="related-desc">Headers and subtext, and why names can't scale.</span>
+    </a>
   </div>
 </section>
 

--- a/library/emoji-combos/index.html
+++ b/library/emoji-combos/index.html
@@ -179,7 +179,7 @@
 <section class="editorial-section" id="combos-by-aesthetic">
   <span class="article-section-label">Browse by vibe</span>
   <h2>Emoji Combos by Aesthetic</h2>
-  <p class="u-secondary-block">112 ready-made emoji combos grouped by aesthetic — tap any combo to copy the whole string, then paste it into your bio, caption, username, or status. Jump to <a href="#combo-soft-girl">soft girl</a>, <a href="#combo-cottagecore">cottagecore</a>, <a href="#combo-night-sky">night sky</a>, <a href="#combo-y2k">Y2K</a>, <a href="#combo-grunge">grunge</a>, or <a href="#combo-kawaii">kawaii</a>.</p>
+  <p class="u-secondary-block">200 ready-made emoji combos grouped by aesthetic — tap any combo to copy the whole string, then paste it into your bio, caption, username, or status. Jump to <a href="#combo-soft-girl">soft girl</a>, <a href="#combo-cottagecore">cottagecore</a>, <a href="#combo-night-sky">night sky</a>, <a href="#combo-y2k">Y2K</a>, <a href="#combo-grunge">grunge</a>, <a href="#combo-kawaii">kawaii</a>, <a href="#combo-baddie">baddie</a>, or <a href="#combo-emo">emo</a>.</p>
 </section>
 
 <div class="section-divider"></div>
@@ -766,6 +766,468 @@
     <div class="flag-row">
       <button class="flag-emoji symbol-tile" data-symbol="🌵🏜️🌞" aria-label="Copy Cactus sun emoji combo">🌵🏜️🌞</button>
       <span class="flag-label">Cactus sun</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="combo-baddie">
+  <span class="article-section-label">Baddie</span>
+  <h2>Baddie Combos</h2>
+  <p class="u-secondary-tight">Fierce, glam, and unbothered — chains, cherries, and boss energy for a confident bio or username.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💅😈🔥" aria-label="Copy Bad energy emoji combo">💅😈🔥</button>
+      <span class="flag-label">Bad energy</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🖤⛓️💋" aria-label="Copy Chain kiss emoji combo">🖤⛓️💋</button>
+      <span class="flag-label">Chain kiss</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💸👑🥂" aria-label="Copy Boss emoji combo">💸👑🥂</button>
+      <span class="flag-label">Boss</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌹🥊💯" aria-label="Copy Knockout emoji combo">🌹🥊💯</button>
+      <span class="flag-label">Knockout</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="😎🍒🖤" aria-label="Copy Cool cherry emoji combo">😎🍒🖤</button>
+      <span class="flag-label">Cool cherry</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💄🛍️✨" aria-label="Copy Glam haul emoji combo">💄🛍️✨</button>
+      <span class="flag-label">Glam haul</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦋💅🏽💿" aria-label="Copy Y2K baddie emoji combo">🦋💅🏽💿</button>
+      <span class="flag-label">Y2K baddie</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🔥💋🎯" aria-label="Copy On target emoji combo">🔥💋🎯</button>
+      <span class="flag-label">On target</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="combo-emo">
+  <span class="article-section-label">Emo</span>
+  <h2>Emo Combos</h2>
+  <p class="u-secondary-tight">Black hearts, wilted roses, and chains — 2000s emo mood for edgy bios and playlists.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🖤🥀🎧" aria-label="Copy Heartbreak emoji combo">🖤🥀🎧</button>
+      <span class="flag-label">Heartbreak</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛓️🖤😔" aria-label="Copy Chained emoji combo">⛓️🖤😔</button>
+      <span class="flag-label">Chained</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🩹🖤⛓️" aria-label="Copy Patched up emoji combo">🩹🖤⛓️</button>
+      <span class="flag-label">Patched up</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💔🖤🥀" aria-label="Copy Broken emoji combo">💔🖤🥀</button>
+      <span class="flag-label">Broken</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🖤🎸⛓️" aria-label="Copy Band tee emoji combo">🖤🎸⛓️</button>
+      <span class="flag-label">Band tee</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦇🖤🕯️" aria-label="Copy Nightfall emoji combo">🦇🖤🕯️</button>
+      <span class="flag-label">Nightfall</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="😭🖤🥀" aria-label="Copy Tears emoji combo">😭🖤🥀</button>
+      <span class="flag-label">Tears</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⛓️🩸🖤" aria-label="Copy Bleeding emoji combo">⛓️🩸🖤</button>
+      <span class="flag-label">Bleeding</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="combo-scene">
+  <span class="article-section-label">Scene</span>
+  <h2>Scene Combos</h2>
+  <p class="u-secondary-tight">Loud rainbow-on-black with leopard, unicorns, and bows — myspace-era scene kid energy.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌈💀🎀" aria-label="Copy Rawr emoji combo">🌈💀🎀</button>
+      <span class="flag-label">Rawr</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦄⚡🖤" aria-label="Copy Neon unicorn emoji combo">🦄⚡🖤</button>
+      <span class="flag-label">Neon unicorn</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐆🌈💚" aria-label="Copy Wild print emoji combo">🐆🌈💚</button>
+      <span class="flag-label">Wild print</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🎀💚🦴" aria-label="Copy Bones emoji combo">🎀💚🦴</button>
+      <span class="flag-label">Bones</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⭐🖤🌈" aria-label="Copy Star scene emoji combo">⭐🖤🌈</button>
+      <span class="flag-label">Star scene</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🦓🌈💀" aria-label="Copy Zebra emoji combo">🦓🌈💀</button>
+      <span class="flag-label">Zebra</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💚🖤🎧" aria-label="Copy Coontails emoji combo">💚🖤🎧</button>
+      <span class="flag-label">Coontails</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌈🦋⚡" aria-label="Copy Electric emoji combo">🌈🦋⚡</button>
+      <span class="flag-label">Electric</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="combo-weirdcore">
+  <span class="article-section-label">Weirdcore</span>
+  <h2>Weirdcore Combos</h2>
+  <p class="u-secondary-tight">Eyes, spirals, and liminal clouds — the unsettling dream-logic look of weirdcore.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="👁️🌀🍄" aria-label="Copy Eye spiral emoji combo">👁️🌀🍄</button>
+      <span class="flag-label">Eye spiral</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☁️🚪👁️" aria-label="Copy Liminal door emoji combo">☁️🚪👁️</button>
+      <span class="flag-label">Liminal door</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌈👁️😵" aria-label="Copy Dizzy emoji combo">🌈👁️😵</button>
+      <span class="flag-label">Dizzy</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🍄🌀⭐" aria-label="Copy Mushroom swirl emoji combo">🍄🌀⭐</button>
+      <span class="flag-label">Mushroom swirl</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="👁️💿🌫️" aria-label="Copy Static emoji combo">👁️💿🌫️</button>
+      <span class="flag-label">Static</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🚪🌈👁️" aria-label="Copy Exit emoji combo">🚪🌈👁️</button>
+      <span class="flag-label">Exit</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="😵‍💫🌀🍭" aria-label="Copy Sugar daze emoji combo">😵‍💫🌀🍭</button>
+      <span class="flag-label">Sugar daze</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⭐👁️☁️" aria-label="Copy Dream eye emoji combo">⭐👁️☁️</button>
+      <span class="flag-label">Dream eye</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="combo-dreamcore">
+  <span class="article-section-label">Dreamcore</span>
+  <h2>Dreamcore Combos</h2>
+  <p class="u-secondary-tight">Carousels, soft clouds, and moons — the nostalgic, hazy calm of dreamcore.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="☁️🌙🎠" aria-label="Copy Carousel emoji combo">☁️🌙🎠</button>
+      <span class="flag-label">Carousel</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌈☁️🚪" aria-label="Copy Soft exit emoji combo">🌈☁️🚪</button>
+      <span class="flag-label">Soft exit</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🎠☁️💫" aria-label="Copy Merry-go emoji combo">🎠☁️💫</button>
+      <span class="flag-label">Merry-go</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌙☁️🫧" aria-label="Copy Bubble moon emoji combo">🌙☁️🫧</button>
+      <span class="flag-label">Bubble moon</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🕰️☁️🌀" aria-label="Copy Timeless emoji combo">🕰️☁️🌀</button>
+      <span class="flag-label">Timeless</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💤☁️🌙" aria-label="Copy Sleepy emoji combo">💤☁️🌙</button>
+      <span class="flag-label">Sleepy</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🎡☁️✨" aria-label="Copy Ferris emoji combo">🎡☁️✨</button>
+      <span class="flag-label">Ferris</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌫️🌙🎠" aria-label="Copy Foggy fair emoji combo">🌫️🌙🎠</button>
+      <span class="flag-label">Foggy fair</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="combo-cybercore">
+  <span class="article-section-label">Cybercore</span>
+  <h2>Cybercore Combos</h2>
+  <p class="u-secondary-tight">Robots, matrix green, and neon screens — a tech-forward cyber aesthetic.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💿🛸🤖" aria-label="Copy Cyber disc emoji combo">💿🛸🤖</button>
+      <span class="flag-label">Cyber disc</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚡🌐💾" aria-label="Copy Datastream emoji combo">⚡🌐💾</button>
+      <span class="flag-label">Datastream</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🖥️💜⚡" aria-label="Copy Neon screen emoji combo">🖥️💜⚡</button>
+      <span class="flag-label">Neon screen</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🤖💿🔩" aria-label="Copy Android emoji combo">🤖💿🔩</button>
+      <span class="flag-label">Android</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌐👾💚" aria-label="Copy Matrix emoji combo">🌐👾💚</button>
+      <span class="flag-label">Matrix</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⚙️💿🛸" aria-label="Copy Machine emoji combo">⚙️💿🛸</button>
+      <span class="flag-label">Machine</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="📡⚡🖤" aria-label="Copy Signal emoji combo">📡⚡🖤</button>
+      <span class="flag-label">Signal</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="👾🌐💜" aria-label="Copy Glitch emoji combo">👾🌐💜</button>
+      <span class="flag-label">Glitch</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="combo-mermaidcore">
+  <span class="article-section-label">Mermaidcore</span>
+  <h2>Mermaidcore Combos</h2>
+  <p class="u-secondary-tight">Shells, pearls, and jellyfish — oceanic fantasy for a dreamy sea-witch vibe.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐚🌊🧜‍♀️" aria-label="Copy Mermaid emoji combo">🐚🌊🧜‍♀️</button>
+      <span class="flag-label">Mermaid</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🪼🐚✨" aria-label="Copy Jelly shine emoji combo">🪼🐚✨</button>
+      <span class="flag-label">Jelly shine</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌊🐠🫧" aria-label="Copy Reef emoji combo">🌊🐠🫧</button>
+      <span class="flag-label">Reef</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧜‍♀️🐚💎" aria-label="Copy Pearl emoji combo">🧜‍♀️🐚💎</button>
+      <span class="flag-label">Pearl</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🪸🌊🐚" aria-label="Copy Coral emoji combo">🪸🌊🐚</button>
+      <span class="flag-label">Coral</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✨🐚🌙" aria-label="Copy Moon tide emoji combo">✨🐚🌙</button>
+      <span class="flag-label">Moon tide</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🫧🪼🌊" aria-label="Copy Bubbles emoji combo">🫧🪼🌊</button>
+      <span class="flag-label">Bubbles</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐚💙🌊" aria-label="Copy Seafoam emoji combo">🐚💙🌊</button>
+      <span class="flag-label">Seafoam</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="combo-kidcore">
+  <span class="article-section-label">Kidcore</span>
+  <h2>Kidcore Combos</h2>
+  <p class="u-secondary-tight">Crayons, toys, and primary-color fun — bright, nostalgic 90s-kid energy.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌈🖍️⭐" aria-label="Copy Crayon emoji combo">🌈🖍️⭐</button>
+      <span class="flag-label">Crayon</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🍭🎈🌈" aria-label="Copy Candy fun emoji combo">🍭🎈🌈</button>
+      <span class="flag-label">Candy fun</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="⭐🧸🍄" aria-label="Copy Toybox emoji combo">⭐🧸🍄</button>
+      <span class="flag-label">Toybox</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🎨🌈🖍️" aria-label="Copy Art class emoji combo">🎨🌈🖍️</button>
+      <span class="flag-label">Art class</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🍬🎈⚽" aria-label="Copy Playground emoji combo">🍬🎈⚽</button>
+      <span class="flag-label">Playground</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌈🧩🌟" aria-label="Copy Puzzle emoji combo">🌈🧩🌟</button>
+      <span class="flag-label">Puzzle</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐛🌈🍭" aria-label="Copy Bug day emoji combo">🐛🌈🍭</button>
+      <span class="flag-label">Bug day</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🎠🎈🌈" aria-label="Copy Fairground emoji combo">🎠🎈🌈</button>
+      <span class="flag-label">Fairground</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="combo-clowncore">
+  <span class="article-section-label">Clowncore</span>
+  <h2>Clowncore Combos</h2>
+  <p class="u-secondary-tight">Big-top color, balloons, and confetti — playful circus maximalism.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🤡🎪🎈" aria-label="Copy Big top emoji combo">🤡🎪🎈</button>
+      <span class="flag-label">Big top</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🎪🍭🤡" aria-label="Copy Sweet circus emoji combo">🎪🍭🤡</button>
+      <span class="flag-label">Sweet circus</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🎈🌈🤹" aria-label="Copy Juggle emoji combo">🎈🌈🤹</button>
+      <span class="flag-label">Juggle</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🤡🎠🎪" aria-label="Copy Carnival emoji combo">🤡🎠🎪</button>
+      <span class="flag-label">Carnival</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🎪🎭🎈" aria-label="Copy Show emoji combo">🎪🎭🎈</button>
+      <span class="flag-label">Show</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🍭🤡🎡" aria-label="Copy Funfair emoji combo">🍭🤡🎡</button>
+      <span class="flag-label">Funfair</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🎈🤹🌈" aria-label="Copy Balloons emoji combo">🎈🤹🌈</button>
+      <span class="flag-label">Balloons</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🎪✨🤡" aria-label="Copy Spotlight emoji combo">🎪✨🤡</button>
+      <span class="flag-label">Spotlight</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="combo-goblincore">
+  <span class="article-section-label">Goblincore</span>
+  <h2>Goblincore Combos</h2>
+  <p class="u-secondary-tight">Mushrooms, frogs, snails, and moss — cozy, earthy forest-floor charm.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🍄🐸🌿" aria-label="Copy Toadstool emoji combo">🍄🐸🌿</button>
+      <span class="flag-label">Toadstool</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐌🍄🍂" aria-label="Copy Forest floor emoji combo">🐌🍄🍂</button>
+      <span class="flag-label">Forest floor</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🌿🐸🪨" aria-label="Copy Mossy emoji combo">🌿🐸🪨</button>
+      <span class="flag-label">Mossy</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🍄🌰🐛" aria-label="Copy Acorn emoji combo">🍄🌰🐛</button>
+      <span class="flag-label">Acorn</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐸🍄🕯️" aria-label="Copy Swamp cottage emoji combo">🐸🍄🕯️</button>
+      <span class="flag-label">Swamp cottage</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🪵🍄🌿" aria-label="Copy Log emoji combo">🪵🍄🌿</button>
+      <span class="flag-label">Log</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🐌🌿🍄" aria-label="Copy Snail trail emoji combo">🐌🌿🍄</button>
+      <span class="flag-label">Snail trail</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🍂🐸🍄" aria-label="Copy Autumn emoji combo">🍂🐸🍄</button>
+      <span class="flag-label">Autumn</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="combo-lovecore">
+  <span class="article-section-label">Lovecore</span>
+  <h2>Lovecore Combos</h2>
+  <p class="u-secondary-tight">Cupids, love letters, and ribboned hearts — retro-valentine romance.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❤️💌🎀" aria-label="Copy Love note emoji combo">❤️💌🎀</button>
+      <span class="flag-label">Love note</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💘💝🕯️" aria-label="Copy Cupid emoji combo">💘💝🕯️</button>
+      <span class="flag-label">Cupid</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❤️🏹💌" aria-label="Copy Arrow emoji combo">❤️🏹💌</button>
+      <span class="flag-label">Arrow</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💗🎀💘" aria-label="Copy Sweetheart emoji combo">💗🎀💘</button>
+      <span class="flag-label">Sweetheart</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💌❤️🌹" aria-label="Copy Valentine emoji combo">💌❤️🌹</button>
+      <span class="flag-label">Valentine</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="💝😇❤️" aria-label="Copy Cherub emoji combo">💝😇❤️</button>
+      <span class="flag-label">Cherub</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="❤️💋💌" aria-label="Copy Kiss letter emoji combo">❤️💋💌</button>
+      <span class="flag-label">Kiss letter</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🏹💗❤️" aria-label="Copy Struck emoji combo">🏹💗❤️</button>
+      <span class="flag-label">Struck</span>
     </div>
   </div>
 </section>

--- a/scripts/generate-site-art.py
+++ b/scripts/generate-site-art.py
@@ -2200,6 +2200,8 @@ PAGES.update({
 "answers-how-to-change-discord-username": ("Change Your Discord Username", "Unique name vs display name, explained", m_qa, K_ANS),
 "answers-how-to-change-instagram-username": ("Change Your Instagram Username", "The rules, the 14-day limit, and fancy fonts", m_qa, K_ANS),
 "answers-how-to-make-bold-text-in-discord": ("Bold Text in Discord", "Markdown for messages, Unicode for names", m_qa, K_ANS),
+"answers-how-to-underline-in-discord": ("Underline in Discord", "Markdown for messages, Unicode for names", m_qa, K_ANS),
+"answers-how-to-make-big-text-in-discord": ("Big Text in Discord", "Headers for messages, a font for names", m_qa, K_ANS),
 "answers-how-to-remove-zalgo-text": ("How to Remove Zalgo Text", "Strip combining marks and recover the original", m_zalgo, K_ANS),
 "answers-how-to-uncover-redacted-text": ("Can You Uncover Redacted Text?", "Unicode blocks are permanent, images sometimes aren't", m_qa, K_ANS),
 "answers-is-fancy-text-bad-for-accessibility": ("Is Fancy Text Bad for Accessibility?", "How screen readers handle styled Unicode", m_qa, K_ANS),


### PR DESCRIPTION
## Summary
Expanded emoji combo library from 112 to 200 combos by adding 8 new aesthetic categories (baddie, emo, scene, weirdcore, dreamcore, cybercore, mermaidcore, kidcore, clowncore, goblincore, lovecore). Created two new answer pages for Discord text formatting how-tos. Updated hub navigation and de-conflicted existing guide content per hub/spoke rules.

## Key Changes

**Emoji Combos Library (`library/emoji-combos/index.html`)**
- Updated intro copy: 112 → 200 ready-made combos
- Added navigation links to 2 new aesthetics (baddie, emo) in the jump menu
- Added 11 new `<section>` blocks with 8 emoji combos each:
  - Baddie (fierce, glam, boss energy)
  - Emo (black hearts, wilted roses, chains)
  - Scene (rainbow-on-black, leopard, unicorns)
  - Weirdcore (eyes, spirals, liminal clouds)
  - Dreamcore (carousels, soft clouds, moons)
  - Cybercore (robots, matrix green, neon screens)
  - Mermaidcore (shells, pearls, jellyfish)
  - Kidcore (crayons, toys, primary colors)
  - Clowncore (big-top, balloons, confetti)
  - Goblincore (mushrooms, frogs, snails, moss)
  - Lovecore (cupids, love letters, ribboned hearts)

**New Answer Pages**
- `answers/how-to-underline-in-discord/index.html` — markdown double-underscore syntax + Unicode underline for names/channels (183 lines)
- `answers/how-to-make-big-text-in-discord/index.html` — header markdown (#, ##, ###, -#) + Unicode fonts for standout names (180 lines)
- Both include FAQ schema, breadcrumbs, and link back to the Discord hub

**Discord Hub De-confliction (`discord/index.html`)**
- Replaced verbose "Discord Text Formatting Commands" table with a brief pointer: "The full steps are in [how to make big text in Discord](/answers/how-to-make-big-text-in-discord/)"
- Removed redundant formatting table (bold, italic, underline, strikethrough) to avoid cannibalizing the new answer pages
- Kept the Unicode font generator as the primary feature; formatting how-tos now live on spokes

**Guide Cross-Link (`guide/discord-text-formatting-explained/index.html`)**
- Added related card linking to the new underline answer page

**Build Metadata (`scripts/generate-site-art.py`)**
- Registered two new answer pages in the site art generator for Pinterest/social pin generation

## Implementation Notes

- All 11 new emoji combo sections follow the existing `mood-explainers` template with 8 combos per aesthetic
- Each combo has a `data-symbol` attribute for copy-to-clipboard functionality and an `aria-label` for accessibility
- Answer pages use FAQ schema (`FAQPage`) for zero-click SERP snippets and breadcrumb schema for navigation
- Hub/spoke de-confliction applied per CLAUDE.md Rule 3: hub no longer targets the spoke queries (underline, big text), spoke links back to hub
- No changes to core rendering logic, styles, or Unicode font registry

https://claude.ai/code/session_01C7ZXNqPjhsbbcGrHykSEjp