### PR TITLE
Add locale-aware header and footer navigation

### DIFF
--- a/footer.js
+++ b/footer.js
@@ -9,6 +9,290 @@
   var path = (window.location && window.location.pathname) || "";
   var isPrintablesContext = path.indexOf("/printables/") === 0 || path.indexOf("/learn/") === 0;
 
+  // Locale-aware footer — same Tier-1 locale set and same no-hub fallback
+  // rule as header.js (see that file's NAV comment + the roadmap doc in the
+  // private lab repo for why Category/Use Cases/Answers/Events still point
+  // at the English hub for every locale today). "tools" and "categories"
+  // link to real, on-disk native-slug pages verified 2026-07-20 — not
+  // translated guesses. "company" labels are translated but the About/
+  // Privacy/Terms/Contact pages themselves have no locale versions yet, so
+  // those hrefs stay English (same pattern yaytext.com uses for its own
+  // untranslated Privacy Policy link, verified live 2026-07-20).
+  var FOOTER = {
+    pt: {
+      home: { label: "Início", href: "/pt/" },
+      explore: [
+        { label: "Guias", href: "/pt/guide/" },
+        { label: "Respostas", href: "/answers/" },
+        { label: "Usos", href: "/usecase/" },
+        { label: "Categorias", href: "/category/" },
+        { label: "Biblioteca", href: "/pt/library/" },
+        { label: "Imprimíveis", href: "/pt/imprimiveis/" },
+        { label: "Eventos", href: "/events/" }
+      ],
+      tools: [
+        { label: "Fontes para Bio", href: "/pt/usecase/fontes-para-bio/" },
+        { label: "Letras para Tatuagem", href: "/pt/usecase/letras-para-tatuagem/" },
+        { label: "Tradutor de Emojis", href: "/pt/usecase/tradutor-de-emojis/" },
+        { label: "Texto Vertical", href: "/pt/usecase/vertical-text/" }
+      ],
+      categories: [
+        { label: "Letras Negrito", href: "/pt/letras-negrito/" },
+        { label: "Letra Cursiva", href: "/pt/letra-cursiva/" },
+        { label: "Fonte Gótica", href: "/pt/fonte-gotica/" },
+        { label: "Letras Pequenas", href: "/pt/letras-pequenas/" },
+        { label: "Letra Tachada", href: "/pt/letra-tachada/" }
+      ],
+      company: [
+        { label: "Sobre", href: "/about/" },
+        { label: "Política de Privacidade", href: "/privacy/" },
+        { label: "Termos de Serviço", href: "/terms/" },
+        { label: "Contato", href: "/contact/" }
+      ],
+      colTitles: { explore: "Explorar", tools: "Ferramentas Populares", categories: "Categorias Populares", company: "Empresa" },
+      copyright: "© 2026 UltraTextGen. Letras diferentes pra usar em qualquer canto da internet."
+    },
+    fr: {
+      home: { label: "Accueil", href: "/fr/" },
+      explore: [
+        { label: "Guides", href: "/fr/guide/" },
+        { label: "Réponses", href: "/answers/" },
+        { label: "Usages", href: "/usecase/" },
+        { label: "Catégories", href: "/category/" },
+        { label: "Bibliothèque", href: "/fr/library/" },
+        { label: "Imprimables", href: "/fr/imprimables/" },
+        { label: "Événements", href: "/events/" }
+      ],
+      tools: [
+        { label: "Écriture pour Bio", href: "/fr/usecase/ecriture-bio/" },
+        { label: "Écriture Tatouage", href: "/fr/usecase/ecriture-tatouage/" },
+        { label: "Traducteur Emoji", href: "/fr/usecase/traducteur-emoji/" },
+        { label: "Texte Vertical", href: "/fr/usecase/vertical-text/" }
+      ],
+      categories: [
+        { label: "Texte en Gras", href: "/fr/texte-en-gras/" },
+        { label: "Écriture Cursive", href: "/fr/ecriture-cursive/" },
+        { label: "Écriture Gothique", href: "/fr/ecriture-gothique/" },
+        { label: "Petite Écriture", href: "/fr/petite-ecriture/" },
+        { label: "Écriture Aesthetic", href: "/fr/ecriture-aesthetic/" }
+      ],
+      company: [
+        { label: "À Propos", href: "/about/" },
+        { label: "Politique de Confidentialité", href: "/privacy/" },
+        { label: "Conditions d'Utilisation", href: "/terms/" },
+        { label: "Contact", href: "/contact/" }
+      ],
+      colTitles: { explore: "Explorer", tools: "Outils Populaires", categories: "Catégories Populaires", company: "Entreprise" },
+      copyright: "© 2026 UltraTextGen. Une écriture stylée qui marche partout."
+    },
+    de: {
+      home: { label: "Startseite", href: "/de/" },
+      explore: [
+        { label: "Ratgeber", href: "/de/guide/" },
+        { label: "Antworten", href: "/answers/" },
+        { label: "Anwendungen", href: "/usecase/" },
+        { label: "Kategorien", href: "/category/" },
+        { label: "Bibliothek", href: "/de/library/" },
+        { label: "Zum Ausdrucken", href: "/de/zum-ausdrucken/" },
+        { label: "Anlässe", href: "/events/" }
+      ],
+      tools: [
+        { label: "Bio-Schriftart", href: "/de/usecase/bio-schriftart/" },
+        { label: "Tattoo-Schrift", href: "/de/usecase/tattoo-schrift/" },
+        { label: "Emoji-Übersetzer", href: "/de/usecase/emoji-uebersetzer/" },
+        { label: "Vertikaler Text", href: "/de/usecase/vertical-text/" }
+      ],
+      categories: [
+        { label: "Fette Schrift", href: "/de/fette-schrift/" },
+        { label: "Schreibschrift", href: "/de/schreibschrift/" },
+        { label: "Gotische Schrift", href: "/de/gotische-schrift/" },
+        { label: "Kleine Schrift", href: "/de/kleine-schrift/" },
+        { label: "Durchgestrichener Text", href: "/de/durchgestrichener-text/" }
+      ],
+      company: [
+        { label: "Über Uns", href: "/about/" },
+        { label: "Datenschutzerklärung", href: "/privacy/" },
+        { label: "Nutzungsbedingungen", href: "/terms/" },
+        { label: "Kontakt", href: "/contact/" }
+      ],
+      colTitles: { explore: "Entdecken", tools: "Beliebte Tools", categories: "Beliebte Kategorien", company: "Unternehmen" },
+      copyright: "© 2026 UltraTextGen. Schnelle Schriftarten, die überall funktionieren."
+    },
+    it: {
+      home: { label: "Home", href: "/it/" },
+      explore: [
+        { label: "Guide", href: "/it/guide/" },
+        { label: "Risposte", href: "/answers/" },
+        { label: "Usi", href: "/usecase/" },
+        { label: "Categorie", href: "/category/" },
+        { label: "Libreria", href: "/it/library/" },
+        { label: "Da Stampare", href: "/it/da-stampare/" },
+        { label: "Eventi", href: "/events/" }
+      ],
+      tools: [
+        { label: "Font per Bio", href: "/it/usecase/font-per-bio/" },
+        { label: "Font per Tatuaggi", href: "/it/usecase/font-tatuaggi/" },
+        { label: "Traduttore Emoji", href: "/it/usecase/traduttore-emoji/" },
+        { label: "Testo Verticale", href: "/it/usecase/vertical-text/" }
+      ],
+      categories: [
+        { label: "Grassetto", href: "/it/grassetto/" },
+        { label: "Corsivo", href: "/it/lettere-in-corsivo/" },
+        { label: "Gotico", href: "/it/gotico/" },
+        { label: "Testo Piccolo", href: "/it/testo-piccolo/" },
+        { label: "Testo Barrato", href: "/it/testo-barrato/" }
+      ],
+      company: [
+        { label: "Chi Siamo", href: "/about/" },
+        { label: "Informativa sulla Privacy", href: "/privacy/" },
+        { label: "Termini di Servizio", href: "/terms/" },
+        { label: "Contatti", href: "/contact/" }
+      ],
+      colTitles: { explore: "Esplora", tools: "Strumenti Popolari", categories: "Categorie Popolari", company: "Azienda" },
+      copyright: "© 2026 UltraTextGen. Scritte stilizzate che reggono ovunque le incolli."
+    },
+    tr: {
+      home: { label: "Ana Sayfa", href: "/tr/" },
+      explore: [
+        { label: "Rehberler", href: "/tr/guide/" },
+        { label: "Yanıtlar", href: "/answers/" },
+        { label: "Kullanımlar", href: "/usecase/" },
+        { label: "Kategoriler", href: "/category/" },
+        { label: "Kütüphane", href: "/tr/library/" },
+        { label: "Baskılar", href: "/printables/" },
+        { label: "Etkinlikler", href: "/events/" }
+      ],
+      tools: [
+        { label: "Biyografi Yazı Tipi", href: "/tr/usecase/biyografi-yazi-tipi/" },
+        { label: "Dövme Yazı Fontları", href: "/tr/usecase/dovme-yazi-fontlari/" },
+        { label: "Emoji Çevirici", href: "/tr/usecase/emoji-ceviri/" },
+        { label: "Dikey Yazı", href: "/tr/usecase/vertical-text/" }
+      ],
+      categories: [
+        { label: "Kalın Yazı", href: "/tr/kalin-yazi/" },
+        { label: "El Yazısı Fontu", href: "/tr/el-yazisi-fontu/" },
+        { label: "İtalik Yazı", href: "/tr/italik-yazi/" },
+        { label: "Küçük Yazı", href: "/tr/kucuk-yazi/" },
+        { label: "Üstü Çizili Yazı", href: "/tr/ustu-cizili-yazi/" }
+      ],
+      company: [
+        { label: "Hakkımızda", href: "/about/" },
+        { label: "Gizlilik Politikası", href: "/privacy/" },
+        { label: "Kullanım Şartları", href: "/terms/" },
+        { label: "İletişim", href: "/contact/" }
+      ],
+      colTitles: { explore: "Keşfet", tools: "Popüler Araçlar", categories: "Popüler Kategoriler", company: "Şirket" },
+      copyright: "© 2026 UltraTextGen. Her yerde aynı görünen şekilli yazı."
+    },
+    es: {
+      home: { label: "Inicio", href: "/es/" },
+      explore: [
+        { label: "Guías", href: "/es/guide/" },
+        { label: "Respuestas", href: "/answers/" },
+        { label: "Usos", href: "/usecase/" },
+        { label: "Categorías", href: "/category/" },
+        { label: "Biblioteca", href: "/es/library/" },
+        { label: "Imprimibles", href: "/es/imprimibles/" },
+        { label: "Eventos", href: "/events/" }
+      ],
+      tools: [
+        { label: "Letras para Bio", href: "/es/usecase/letras-para-bio/" },
+        { label: "Letras para Tatuajes", href: "/es/usecase/letras-para-tatuajes/" },
+        { label: "Traductor de Emojis", href: "/es/usecase/traductor-de-emojis/" },
+        { label: "Texto Vertical", href: "/es/usecase/vertical-text/" }
+      ],
+      categories: [
+        { label: "Letras Negritas", href: "/es/letras-negritas/" },
+        { label: "Letra Cursiva", href: "/es/letra-cursiva/" },
+        { label: "Letras Góticas", href: "/es/letras-goticas/" },
+        { label: "Texto Pequeño", href: "/es/texto-pequeno/" },
+        { label: "Letra Tachada", href: "/es/letra-tachada/" }
+      ],
+      company: [
+        { label: "Sobre Nosotros", href: "/about/" },
+        { label: "Política de Privacidad", href: "/privacy/" },
+        { label: "Términos de Servicio", href: "/terms/" },
+        { label: "Contacto", href: "/contact/" }
+      ],
+      colTitles: { explore: "Explorar", tools: "Herramientas Populares", categories: "Categorías Populares", company: "Empresa" },
+      copyright: "© 2026 UltraTextGen. Letras bonitas que funcionan en todas partes."
+    },
+    id: {
+      home: { label: "Beranda", href: "/id/" },
+      explore: [
+        { label: "Panduan", href: "/id/guide/" },
+        { label: "Jawaban", href: "/answers/" },
+        { label: "Kegunaan", href: "/usecase/" },
+        { label: "Kategori", href: "/category/" },
+        { label: "Perpustakaan", href: "/id/library/" },
+        { label: "Cetak", href: "/printables/" },
+        { label: "Acara", href: "/events/" }
+      ],
+      tools: [
+        { label: "Bio Aesthetic", href: "/id/usecase/bio-ig-aesthetic/" },
+        { label: "Font Tato", href: "/id/usecase/font-tato/" },
+        { label: "Penerjemah Emoji", href: "/id/usecase/penerjemah-emoji/" },
+        { label: "Teks Vertikal", href: "/id/usecase/vertical-text/" }
+      ],
+      categories: [
+        { label: "Tulisan Tebal", href: "/id/tulisan-tebal/" },
+        { label: "Tulisan Sambung", href: "/id/tulisan-sambung/" },
+        { label: "Tulisan Gotik", href: "/id/tulisan-gotik/" },
+        { label: "Tulisan Kecil", href: "/id/tulisan-kecil/" },
+        { label: "Tulisan Coret", href: "/id/tulisan-coret/" }
+      ],
+      company: [
+        { label: "Tentang Kami", href: "/about/" },
+        { label: "Kebijakan Privasi", href: "/privacy/" },
+        { label: "Syarat Layanan", href: "/terms/" },
+        { label: "Kontak", href: "/contact/" }
+      ],
+      colTitles: { explore: "Jelajahi", tools: "Alat Populer", categories: "Kategori Populer", company: "Perusahaan" },
+      copyright: "© 2026 UltraTextGen. Tulisan aesthetic & font keren yang nempel ke mana pun."
+    }
+  };
+
+  function detectLocale() {
+    var m = path.match(/^\/([a-z]{2})\//);
+    return m && FOOTER[m[1]] ? m[1] : "en";
+  }
+
+  function linksHTML(items) {
+    return items.map(function (item) {
+      return '<a href="' + item.href + '" class="footer-link">' + item.label + '</a>';
+    }).join('');
+  }
+
+  function buildLocaleFooterHTML(locale) {
+    var f = FOOTER[locale];
+    return '<div class="footer-columns">' +
+        '<div class="footer-col">' +
+          '<span class="footer-col-title">' + f.colTitles.explore + '</span>' +
+          '<a href="' + f.home.href + '" class="footer-link">' + f.home.label + '</a>' +
+          linksHTML(f.explore) +
+        '</div>' +
+        '<div class="footer-col">' +
+          '<span class="footer-col-title">' + f.colTitles.tools + '</span>' +
+          linksHTML(f.tools) +
+        '</div>' +
+        '<div class="footer-col">' +
+          '<span class="footer-col-title">' + f.colTitles.categories + '</span>' +
+          linksHTML(f.categories) +
+        '</div>' +
+        '<div class="footer-col">' +
+          '<span class="footer-col-title">' + f.colTitles.company + '</span>' +
+          linksHTML(f.company) +
+        '</div>' +
+      '</div>' +
+      '<div class="footer-social-links">' +
+        '<a href="https://www.youtube.com/@UltraTextGen" class="footer-link" target="_blank" rel="noopener noreferrer">YouTube</a>' +
+        '<a href="https://www.facebook.com/profile.php?id=61588587387596" class="footer-link" target="_blank" rel="noopener noreferrer">Facebook</a>' +
+        '<a href="https://www.linkedin.com/company/71290348/" class="footer-link" target="_blank" rel="noopener noreferrer">LinkedIn</a>' +
+        '<a href="https://x.com/UltraTextGen" class="footer-link" target="_blank" rel="noopener noreferrer">X</a>' +
+      '</div>' +
+      '<div class="footer-bottom">' + f.copyright + '</div>';
+  }
+
   var printablesLinksHTML =
     '<div class="footer-columns">' +
       '<div class="footer-col">' +
@@ -96,11 +380,15 @@
       '<a href="https://x.com/UltraTextGen" class="footer-link" target="_blank" rel="noopener noreferrer">X</a>' +
     '</div>' +
     '<div class="footer-bottom">' +
-      '\u00a9 2026 UltraTextGen. Fast text styles that work everywhere.' +
+      '© 2026 UltraTextGen. Fast text styles that work everywhere.' +
     '</div>';
+
+  var locale = detectLocale();
 
   if (isPrintablesContext) {
     footerLinksHTML = printablesLinksHTML;
+  } else if (locale !== "en") {
+    footerLinksHTML = buildLocaleFooterHTML(locale);
   }
 
   // Idempotency guard — do nothing if footer-bottom already exists

--- a/header.js
+++ b/header.js
@@ -25,9 +25,146 @@
         'data-ad-slot="5968968934"></ins>' +
     '</aside>';
 
+  // Locale-aware nav — Tier-1 locales only (real guide/library hubs + native
+  // category/usecase pages to point at). Everyone else falls through to EN.
+  // Where a locale has no hub page at all yet (category/usecase/answers/events
+  // hubs exist in zero locales; printables only in 5/7), the label is still
+  // translated but the href falls back to the English hub — same pattern
+  // yaytext.com uses for its own untranslated pages (verified live 2026-07-20).
+  // See ultratextgen-lab-/docs/locale-depth-roadmap-2026-07-20.md for the plan
+  // to close these fallbacks as each locale's hub pages get built.
+  const NAV = {
+    pt: {
+      home: "/pt/",
+      guide: { label: "Guias", href: "/pt/guide/" },
+      answers: { label: "Respostas", href: "/answers/" },
+      category: { label: "Categorias", href: "/category/" },
+      usecase: { label: "Usos", href: "/usecase/" },
+      library: { label: "Biblioteca", href: "/pt/library/" },
+      printables: { label: "Imprimíveis", href: "/pt/imprimiveis/" },
+      events: { label: "Eventos", href: "/events/" },
+      search: "Buscar estilos de fonte…",
+      darkMode: "Alternar modo escuro"
+    },
+    fr: {
+      home: "/fr/",
+      guide: { label: "Guides", href: "/fr/guide/" },
+      answers: { label: "Réponses", href: "/answers/" },
+      category: { label: "Catégories", href: "/category/" },
+      usecase: { label: "Usages", href: "/usecase/" },
+      library: { label: "Bibliothèque", href: "/fr/library/" },
+      printables: { label: "Imprimables", href: "/fr/imprimables/" },
+      events: { label: "Événements", href: "/events/" },
+      search: "Rechercher un style d'écriture…",
+      darkMode: "Basculer le mode sombre"
+    },
+    de: {
+      home: "/de/",
+      guide: { label: "Ratgeber", href: "/de/guide/" },
+      answers: { label: "Antworten", href: "/answers/" },
+      category: { label: "Kategorien", href: "/category/" },
+      usecase: { label: "Anwendungen", href: "/usecase/" },
+      library: { label: "Bibliothek", href: "/de/library/" },
+      printables: { label: "Zum Ausdrucken", href: "/de/zum-ausdrucken/" },
+      events: { label: "Anlässe", href: "/events/" },
+      search: "Schriftstile suchen…",
+      darkMode: "Dunkelmodus umschalten"
+    },
+    it: {
+      home: "/it/",
+      guide: { label: "Guide", href: "/it/guide/" },
+      answers: { label: "Risposte", href: "/answers/" },
+      category: { label: "Categorie", href: "/category/" },
+      usecase: { label: "Usi", href: "/usecase/" },
+      library: { label: "Libreria", href: "/it/library/" },
+      printables: { label: "Da Stampare", href: "/it/da-stampare/" },
+      events: { label: "Eventi", href: "/events/" },
+      search: "Cerca stili di carattere…",
+      darkMode: "Attiva/disattiva modalità scura"
+    },
+    tr: {
+      home: "/tr/",
+      guide: { label: "Rehberler", href: "/tr/guide/" },
+      answers: { label: "Yanıtlar", href: "/answers/" },
+      category: { label: "Kategoriler", href: "/category/" },
+      usecase: { label: "Kullanımlar", href: "/usecase/" },
+      library: { label: "Kütüphane", href: "/tr/library/" },
+      printables: { label: "Baskılar", href: "/printables/" },
+      events: { label: "Etkinlikler", href: "/events/" },
+      search: "Yazı stili ara…",
+      darkMode: "Karanlık modu değiştir"
+    },
+    es: {
+      home: "/es/",
+      guide: { label: "Guías", href: "/es/guide/" },
+      answers: { label: "Respuestas", href: "/answers/" },
+      category: { label: "Categorías", href: "/category/" },
+      usecase: { label: "Usos", href: "/usecase/" },
+      library: { label: "Biblioteca", href: "/es/library/" },
+      printables: { label: "Imprimibles", href: "/es/imprimibles/" },
+      events: { label: "Eventos", href: "/events/" },
+      search: "Buscar estilos de fuente…",
+      darkMode: "Alternar modo oscuro"
+    },
+    id: {
+      home: "/id/",
+      guide: { label: "Panduan", href: "/id/guide/" },
+      answers: { label: "Jawaban", href: "/answers/" },
+      category: { label: "Kategori", href: "/category/" },
+      usecase: { label: "Kegunaan", href: "/usecase/" },
+      library: { label: "Perpustakaan", href: "/id/library/" },
+      printables: { label: "Cetak", href: "/printables/" },
+      events: { label: "Acara", href: "/events/" },
+      search: "Cari gaya font…",
+      darkMode: "Alihkan mode gelap"
+    }
+  };
+
+  const EN = {
+    home: "/",
+    guide: { label: "Guide", href: "/guide/" },
+    answers: { label: "Answers", href: "/answers/" },
+    category: { label: "Category", href: "/category/" },
+    usecase: { label: "Use cases", href: "/usecase/" },
+    library: { label: "Library", href: "/library/" },
+    printables: { label: "Printables", href: "/printables/" },
+    events: { label: "Events", href: "/events/" },
+    search: "Search font styles…",
+    darkMode: "Toggle dark mode"
+  };
+
+  function detectLocale() {
+    const path = (window.location && window.location.pathname) || "";
+    const m = path.match(/^\/([a-z]{2})\//);
+    return m && NAV[m[1]] ? m[1] : "en";
+  }
+
+  const nav = NAV[detectLocale()] || EN;
+
+  // Fixed icon set — only the label/href per nav item change per locale.
+  const NAV_ITEMS = [
+    { key: "guide", icon: '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 19l7-7 3 3-7 7-3-3zM18 13l-6-6-8 8v6h6l8-8z" />' },
+    { key: "answers", icon: '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-4l-4 4v-4z" />' },
+    { key: "category", icon: '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7h6v6H3V7zm12 0h6v6h-6V7zM3 17h6v4H3v-4zm12 0h6v4h-6v-4z"></path>' },
+    { key: "usecase", icon: '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />' },
+    { key: "library", icon: '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />' },
+    { key: "printables", icon: '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 9V2h12v7M6 18H4a2 2 0 01-2-2v-5a2 2 0 012-2h16a2 2 0 012 2v5a2 2 0 01-2 2h-2M6 14h12v8H6v-8z" />' },
+    { key: "events", icon: '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />' }
+  ];
+
+  var navButtonsHTML = NAV_ITEMS.map(function (item) {
+    var entry = nav[item.key];
+    return '<a class="header-btn" href="' + entry.href + '" aria-label="' + entry.label + '">' +
+        '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">' +
+          item.icon +
+        '</svg>' +
+        '<span>' + entry.label + '</span>' +
+      '</a>';
+  }).join('');
+
   var headerHTML = '<header class="header">' +
     '<div class="header-inner">' +
-      '<a href="/" class="logo">' +
+      '<a href="' + nav.home + '" class="logo">' +
         '<span class="logo-icon">U</span>' +
         '<span>UltraTextGen</span>' +
       '</a>' +
@@ -35,52 +172,11 @@
         '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">' +
           '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>' +
         '</svg>' +
-        '<input type="search" id="searchInput" placeholder="Search font styles…" aria-label="Search font styles">' +
+        '<input type="search" id="searchInput" placeholder="' + nav.search + '" aria-label="' + nav.search + '">' +
       '</div>' +
       '<div class="header-actions">' +
-        '<a class="header-btn" href="/guide/" aria-label="Guide">' +
-          '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">' +
-            '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 19l7-7 3 3-7 7-3-3zM18 13l-6-6-8 8v6h6l8-8z" />' +
-          '</svg>' +
-          '<span>Guide</span>' +
-        '</a>' +
-        '<a class="header-btn" href="/answers/" aria-label="Answers">' +
-          '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">' +
-            '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-4l-4 4v-4z" />' +
-          '</svg>' +
-          '<span>Answers</span>' +
-        '</a>' +
-        '<a class="header-btn" href="/category/" aria-label="Category">' +
-          '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">' +
-            '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7h6v6H3V7zm12 0h6v6h-6V7zM3 17h6v4H3v-4zm12 0h6v4h-6v-4z"></path>' +
-          '</svg>' +
-          '<span>Category</span>' +
-        '</a>' +
-        '<a class="header-btn" href="/usecase/" aria-label="Use cases">' +
-          '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">' +
-            '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />' +
-          '</svg>' +
-          '<span>Use cases</span>' +
-        '</a>' +
-        '<a class="header-btn" href="/library/" aria-label="Library">' +
-          '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">' +
-            '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />' +
-          '</svg>' +
-          '<span>Library</span>' +
-        '</a>' +
-        '<a class="header-btn" href="/printables/" aria-label="Printables">' +
-          '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">' +
-            '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 9V2h12v7M6 18H4a2 2 0 01-2-2v-5a2 2 0 012-2h16a2 2 0 012 2v5a2 2 0 01-2 2h-2M6 14h12v8H6v-8z" />' +
-          '</svg>' +
-          '<span>Printables</span>' +
-        '</a>' +
-        '<a class="header-btn" href="/events/" aria-label="Events">' +
-          '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">' +
-            '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />' +
-          '</svg>' +
-          '<span>Events</span>' +
-        '</a>' +
-        '<button class="header-btn" id="darkModeBtn" aria-label="Toggle dark mode" type="button">' +
+        navButtonsHTML +
+        '<button class="header-btn" id="darkModeBtn" aria-label="' + nav.darkMode + '" type="button">' +
           '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">' +
             '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"></path>' +
           '</svg>' +


### PR DESCRIPTION
## Summary

Implement locale-aware navigation and footer for 7 Tier-1 locales (Portuguese, French, German, Italian, Turkish, Spanish, Indonesian) with fallback to English. Navigation items, labels, and footer links are now translated and point to locale-specific hub pages where they exist, with graceful fallback to English hubs for pages not yet localized.

## Key Changes

**header.js:**
- Added `NAV` object with locale-specific navigation configuration for pt, fr, de, it, tr, es, id
- Added `EN` fallback configuration for English navigation
- Implemented `detectLocale()` function to extract locale from URL path (`/[a-z]{2}/`)
- Refactored hardcoded nav buttons into dynamic `NAV_ITEMS` array with icon definitions
- Generated nav buttons from locale-aware `nav` object, making labels, hrefs, and placeholders locale-specific
- Updated logo link and dark mode button label to use locale-aware `nav` object
- Added detailed comment explaining Tier-1 locale strategy and hub page fallback pattern

**footer.js:**
- Added `FOOTER` object with complete locale-specific footer configuration for all 7 locales
- Implemented `detectLocale()` function matching header.js pattern
- Added `linksHTML()` helper to generate footer link HTML from item arrays
- Added `buildLocaleFooterHTML()` function to construct full locale-aware footer with columns, social links, and copyright
- Integrated locale detection into footer rendering logic: uses locale-specific footer if detected, otherwise falls back to English
- Updated copyright symbol from HTML entity (`\u00a9`) to literal `©` for consistency
- Added comprehensive comment documenting locale strategy, verified native-slug pages, and untranslated page fallback pattern

## Implementation Details

- **Locale detection:** Both files use identical URL pattern matching (`/^\/([a-z]{2})\//`) to extract 2-letter locale codes
- **Hub page strategy:** Tier-1 locales have real guide/library hubs and native category/usecase pages. Pages without locale versions (answers, events, category, usecase hubs) still show translated labels but link to English hubs — same pattern as yaytext.com
- **Verified pages:** "tools" and "categories" links point to real, on-disk native-slug pages verified 2026-07-20; "company" pages (About/Privacy/Terms/Contact) remain English-only as no locale versions exist yet
- **Printables context:** Footer continues to use printables-specific layout when `isPrintablesContext` is true, unaffected by locale changes
- **Fallback behavior:** Non-Tier-1 locales and unrecognized paths default to English navigation and footer

https://claude.ai/code/session_01Y6Vy7ovEB8JPFJz9MBHBP9