### PR TITLE
fix(updates): reposition copy, add category filter to /updates/

### DIFF
--- a/style.css
+++ b/style.css
@@ -7945,3 +7945,82 @@ body.dark-mode .kana-cell-empty { opacity: 0.35; }
   margin: 1.4rem 0 0.6rem;
 }
 .footer-bridge .footer-link { display: inline; }
+
+/* ── Filter pills (shared component — same pattern as library/index.html's
+   inline copy; kept here so new pages can reuse it without inline <style>) ── */
+.lib-filter-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+}
+.lib-filter-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+  margin-right: 0.25rem;
+  white-space: nowrap;
+}
+.lib-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.28rem 0.7rem;
+  border-radius: 999px;
+  border: 1px solid var(--border-light);
+  background: var(--bg-white);
+  color: var(--text-secondary);
+  font-family: inherit;
+  font-size: 0.8rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.12s, border-color 0.12s, color 0.12s;
+  white-space: nowrap;
+  user-select: none;
+}
+.lib-pill:hover {
+  border-color: var(--accent-purple);
+  color: var(--accent-purple);
+}
+.lib-pill.active {
+  background: var(--accent-purple);
+  border-color: var(--accent-purple);
+  color: #fff;
+}
+.lib-pill .pill-count {
+  opacity: 0.75;
+  font-size: 0.72rem;
+}
+.lib-pill.active .pill-count {
+  opacity: 0.9;
+}
+.lib-pill.is-disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.lib-pill.is-disabled:hover {
+  border-color: var(--border-light);
+  color: var(--text-secondary);
+}
+.lib-clear-btn {
+  display: none;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.28rem 0.7rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-muted);
+  font-family: inherit;
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: color 0.12s;
+}
+.lib-clear-btn:hover {
+  color: var(--text-primary);
+}
+.lib-clear-btn.visible {
+  display: inline-flex;
+}

--- a/updates/index.html
+++ b/updates/index.html
@@ -59,7 +59,7 @@
 <section class="hero">
   <div class="hero-inner">
     <h1 class="hero-headline">Updates</h1>
-    <p class="hero-tagline">What changed, and why it matters for your text. New Unicode symbols, platform formatting rules, and game nickname rules — tracked as they happen, because they're the same events that can make our own Check tools go stale.</p>
+    <p class="hero-tagline">Your source for what's new in Unicode, on the platforms you post to, and in the games you play — tracked here as it happens.</p>
   </div>
 </section>
 <figure class="page-hero-figure" data-uthero aria-hidden="true">
@@ -69,22 +69,22 @@
 
 <section class="editorial-section">
   <span class="article-section-label">What we track</span>
-  <h2>Three Things That Can Break a Working Name Overnight</h2>
+  <h2>One Place for Every Unicode, Platform &amp; Game Rule Change</h2>
   <div class="compare-grid">
     <div class="compare-card variant-muted">
       <span class="compare-badge">Unicode</span>
-      <p>New characters and emoji the Unicode Consortium adds each version — and, just as important, when your platform actually gets them.</p>
+      <p>Every new character and emoji the Unicode Consortium adds — and, just as useful, when your platform actually gets it.</p>
     </div>
     <div class="compare-card variant-muted">
       <span class="compare-badge">Platform rules</span>
-      <p>Formatting and character-support changes on Discord, Instagram, LinkedIn, TikTok, and WhatsApp — the kind that quietly turn a working name into boxes.</p>
+      <p>Formatting and character-support changes on Discord, Instagram, LinkedIn, TikTok, and WhatsApp, as they roll out.</p>
     </div>
     <div class="compare-card variant-muted">
       <span class="compare-badge">Game rules</span>
-      <p>Nickname length limits and allowed-character changes after a game patch — the exact numbers our per-game name checker relies on.</p>
+      <p>Nickname length limits and allowed-character changes after a game patch — the numbers behind our per-game name checker.</p>
     </div>
   </div>
-  <p class="section-subline">Every entry here exists because something on this list changed, and it's the reason to double-check a name you already thought was safe.</p>
+  <p class="section-subline">New entries go up as soon as something changes — check back whenever a name that used to work suddenly doesn't.</p>
 </section>
 
 <div class="section-divider"></div>
@@ -92,9 +92,19 @@
 <section class="editorial-section">
   <span class="article-section-label">Latest</span>
   <h2>Recent Updates</h2>
-  <div class="related-grid">
-    <a class="related-card" href="/updates/unicode-17-new-emoji-rollout/">
-      <span class="related-tag">🗞</span>
+
+  <div class="lib-filter-row" id="updatesFilterRow">
+    <span class="lib-filter-label">Category</span>
+    <button class="lib-pill" type="button" data-category="unicode">Unicode <span class="pill-count"></span></button>
+    <button class="lib-pill" type="button" data-category="platform">Platform rules <span class="pill-count"></span></button>
+    <button class="lib-pill" type="button" data-category="game">Game rules <span class="pill-count"></span></button>
+    <button class="lib-clear-btn" type="button" id="updatesClearFilter">✕ Clear filter</button>
+  </div>
+  <p class="section-subline" id="updatesEmptyState" hidden>No updates in this category yet — check back soon, or <button type="button" class="lib-clear-btn visible" id="updatesEmptyClear">see all updates</button>.</p>
+
+  <div class="related-grid" id="updatesGrid">
+    <a class="related-card" href="/updates/unicode-17-new-emoji-rollout/" data-category="unicode">
+      <span class="related-tag">🔤</span>
       <span class="related-title">Jul 20, 2026 — Unicode 17.0's New Emoji: Rollout Tracker</span>
       <span class="related-desc">8 new emoji, tracked platform by platform — live on Apple devices, still rolling out on Android, Windows, Samsung and WhatsApp.</span>
     </a>
@@ -102,5 +112,55 @@
 </section>
 
 <footer class="footer"><div class="footer-inner"></div></footer>
+<script>
+(function () {
+  "use strict";
+  var row = document.getElementById("updatesFilterRow");
+  if (!row) return;
+  var pills = Array.prototype.slice.call(row.querySelectorAll(".lib-pill"));
+  var clearBtn = document.getElementById("updatesClearFilter");
+  var emptyClearBtn = document.getElementById("updatesEmptyClear");
+  var cards = Array.prototype.slice.call(document.querySelectorAll("#updatesGrid .related-card"));
+  var emptyState = document.getElementById("updatesEmptyState");
+  var active = null;
+
+  // Pill counts + disabled state are derived from the actual cards in the
+  // DOM, not hardcoded, so a category stays accurate as entries are added.
+  pills.forEach(function (pill) {
+    var count = cards.filter(function (c) { return c.dataset.category === pill.dataset.category; }).length;
+    pill.querySelector(".pill-count").textContent = "(" + count + ")";
+    if (count === 0) {
+      pill.classList.add("is-disabled");
+      pill.disabled = true;
+    } else {
+      pill.addEventListener("click", function () {
+        active = active === pill.dataset.category ? null : pill.dataset.category;
+        render();
+      });
+    }
+  });
+
+  function render() {
+    var visible = 0;
+    cards.forEach(function (card) {
+      var show = !active || card.dataset.category === active;
+      card.hidden = !show;
+      if (show) visible++;
+    });
+    pills.forEach(function (pill) {
+      pill.classList.toggle("active", pill.dataset.category === active);
+      pill.setAttribute("aria-pressed", String(pill.dataset.category === active));
+    });
+    clearBtn.classList.toggle("visible", !!active);
+    emptyState.hidden = visible > 0;
+  }
+  clearBtn.addEventListener("click", function () { active = null; render(); });
+  if (emptyClearBtn) {
+    emptyClearBtn.addEventListener("click", function () { active = null; render(); });
+  }
+
+  render();
+})();
+</script>
 <script src="/footer.js" defer></script>
 </body></html>


### PR DESCRIPTION
## Summary
- Rewrites `/updates/`'s "What we track" copy from a warning/threat frame ("Three Things That Can Break a Working Name Overnight") to a positioning frame ("One Place for Every Unicode, Platform & Game Rule Change") — the section reads as UltraTextGen's source for this, not a scare list. Hero tagline and the subline under the cards got the same treatment.
- Adds a Unicode / Platform rules / Game rules category filter to the hub, borrowed from `library/index.html`'s pill-filter pattern — promoted into `style.css` as a shared component instead of copy-pasting into another inline `<style>` block. Pill counts and the disabled state on empty categories are derived from the actual cards in the DOM, not hardcoded, so they stay correct as entries are added.
- Investigated the reported layout bug via an isolated headless render (light + dark) — it didn't reproduce; the colored underlines in the report look like a browser extension overlay, not a page bug.

## Test plan
- [x] Rendered `/updates/` in a headless browser (light + dark mode) — layout is clean, no overlap or spacing issues
- [x] Verified filter behavior via direct DOM-state assertions (not just screenshots): clicking an enabled pill hides non-matching cards, toggling off restores all, clicking a disabled (0-count) pill is a no-op, "Clear filter" resets state
- [x] Confirmed pill counts and disabled state are computed from live DOM card count, not hardcoded
- [x] `python3 scripts/check-image-assets.py` — no new failures introduced
- [x] HTML parses cleanly (balanced tags, no parser errors)


---
_Generated by [Claude Code](https://claude.ai/code/session_0182Vfm7pDf1uHCWYjR7Rk4v)_