### PR TITLE
fix(updates): fix card/subline overlap, merge filter into category cards

### DIFF
--- a/style.css
+++ b/style.css
@@ -1638,6 +1638,51 @@
   line-height: 1.5;
 }
 
+.compare-card p {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+/* Interactive variant: a .compare-card that's also a filter toggle
+   (e.g. /updates/'s "What we track" cards double as its category filter). */
+button.compare-card.is-toggle {
+  all: unset;
+  box-sizing: border-box;
+  display: block;
+  width: 100%;
+  padding: 1rem;
+  border-radius: var(--radius);
+  border: 1px solid var(--border-light);
+  background: var(--bg-base);
+  cursor: pointer;
+  text-align: left;
+  font-family: inherit;
+  transition: border-color 0.15s, background 0.15s;
+}
+button.compare-card.is-toggle:hover:not(:disabled) {
+  border-color: var(--accent-purple);
+}
+button.compare-card.is-toggle.active {
+  border-color: var(--accent-purple);
+  background: rgba(139, 92, 246, 0.07);
+}
+button.compare-card.is-toggle:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+.compare-card-meta {
+  display: block;
+  margin-top: 0.6rem;
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--accent-purple);
+}
+button.compare-card.is-toggle:disabled .compare-card-meta {
+  color: var(--text-muted);
+}
+
 .compare-badge {
   display: inline-block;
   font-size: 0.65rem;

--- a/updates/index.html
+++ b/updates/index.html
@@ -70,34 +70,33 @@
 <section class="editorial-section">
   <span class="article-section-label">What we track</span>
   <h2>One Place for Every Unicode, Platform &amp; Game Rule Change</h2>
-  <div class="compare-grid">
-    <div class="compare-card variant-muted">
+  <p class="section-subline">Tap a category to jump to what's changed.</p>
+  <div class="compare-grid" id="updatesCategoryCards">
+    <button type="button" class="compare-card variant-muted is-toggle" data-category="unicode">
       <span class="compare-badge">Unicode</span>
       <p>Every new character and emoji the Unicode Consortium adds — and, just as useful, when your platform actually gets it.</p>
-    </div>
-    <div class="compare-card variant-muted">
+      <span class="compare-card-meta" data-role="meta"></span>
+    </button>
+    <button type="button" class="compare-card variant-muted is-toggle" data-category="platform">
       <span class="compare-badge">Platform rules</span>
       <p>Formatting and character-support changes on Discord, Instagram, LinkedIn, TikTok, and WhatsApp, as they roll out.</p>
-    </div>
-    <div class="compare-card variant-muted">
+      <span class="compare-card-meta" data-role="meta"></span>
+    </button>
+    <button type="button" class="compare-card variant-muted is-toggle" data-category="game">
       <span class="compare-badge">Game rules</span>
       <p>Nickname length limits and allowed-character changes after a game patch — the numbers behind our per-game name checker.</p>
-    </div>
+      <span class="compare-card-meta" data-role="meta"></span>
+    </button>
   </div>
-  <p class="section-subline">New entries go up as soon as something changes — check back whenever a name that used to work suddenly doesn't.</p>
 </section>
 
 <div class="section-divider"></div>
 
 <section class="editorial-section">
   <span class="article-section-label">Latest</span>
-  <h2>Recent Updates</h2>
-
-  <div class="lib-filter-row" id="updatesFilterRow">
-    <span class="lib-filter-label">Category</span>
-    <button class="lib-pill" type="button" data-category="unicode">Unicode <span class="pill-count"></span></button>
-    <button class="lib-pill" type="button" data-category="platform">Platform rules <span class="pill-count"></span></button>
-    <button class="lib-pill" type="button" data-category="game">Game rules <span class="pill-count"></span></button>
+  <div style="display:flex;align-items:baseline;gap:0.75rem;flex-wrap:wrap;">
+    <h2 style="margin:0;">Recent Updates</h2>
+    <span id="updatesShowing" class="compare-card-meta" hidden></span>
     <button class="lib-clear-btn" type="button" id="updatesClearFilter">✕ Clear filter</button>
   </div>
   <p class="section-subline" id="updatesEmptyState" hidden>No updates in this category yet — check back soon, or <button type="button" class="lib-clear-btn visible" id="updatesEmptyClear">see all updates</button>.</p>
@@ -115,26 +114,28 @@
 <script>
 (function () {
   "use strict";
-  var row = document.getElementById("updatesFilterRow");
-  if (!row) return;
-  var pills = Array.prototype.slice.call(row.querySelectorAll(".lib-pill"));
+  var categoryCards = Array.prototype.slice.call(document.querySelectorAll("#updatesCategoryCards .compare-card"));
+  if (!categoryCards.length) return;
   var clearBtn = document.getElementById("updatesClearFilter");
   var emptyClearBtn = document.getElementById("updatesEmptyClear");
-  var cards = Array.prototype.slice.call(document.querySelectorAll("#updatesGrid .related-card"));
+  var showing = document.getElementById("updatesShowing");
+  var entryCards = Array.prototype.slice.call(document.querySelectorAll("#updatesGrid .related-card"));
   var emptyState = document.getElementById("updatesEmptyState");
   var active = null;
 
-  // Pill counts + disabled state are derived from the actual cards in the
+  var LABELS = { unicode: "Unicode", platform: "Platform rules", game: "Game rules" };
+
+  // Counts + disabled state are derived from the actual entry cards in the
   // DOM, not hardcoded, so a category stays accurate as entries are added.
-  pills.forEach(function (pill) {
-    var count = cards.filter(function (c) { return c.dataset.category === pill.dataset.category; }).length;
-    pill.querySelector(".pill-count").textContent = "(" + count + ")";
+  categoryCards.forEach(function (card) {
+    var count = entryCards.filter(function (c) { return c.dataset.category === card.dataset.category; }).length;
+    var meta = card.querySelector('[data-role="meta"]');
+    meta.textContent = count > 0 ? (count + (count === 1 ? " update →" : " updates →")) : "Coming soon";
     if (count === 0) {
-      pill.classList.add("is-disabled");
-      pill.disabled = true;
+      card.disabled = true;
     } else {
-      pill.addEventListener("click", function () {
-        active = active === pill.dataset.category ? null : pill.dataset.category;
+      card.addEventListener("click", function () {
+        active = active === card.dataset.category ? null : card.dataset.category;
         render();
       });
     }
@@ -142,16 +143,19 @@
 
   function render() {
     var visible = 0;
-    cards.forEach(function (card) {
+    entryCards.forEach(function (card) {
       var show = !active || card.dataset.category === active;
       card.hidden = !show;
       if (show) visible++;
     });
-    pills.forEach(function (pill) {
-      pill.classList.toggle("active", pill.dataset.category === active);
-      pill.setAttribute("aria-pressed", String(pill.dataset.category === active));
+    categoryCards.forEach(function (card) {
+      var isActive = card.dataset.category === active;
+      card.classList.toggle("active", isActive);
+      card.setAttribute("aria-pressed", String(isActive));
     });
     clearBtn.classList.toggle("visible", !!active);
+    showing.hidden = !active;
+    if (active) showing.textContent = "Showing: " + LABELS[active];
     emptyState.hidden = visible > 0;
   }
   clearBtn.addEventListener("click", function () { active = null; render(); });


### PR DESCRIPTION
## Summary
This is a follow-up to #608, which merged before its second commit landed — the overlap fix below never made it into `main`. Reopening as a fresh PR per the merged-branch protocol (restarted from latest `main`, not stacked on the closed branch).

- **Root cause of the reported overlap**: `.section-subline` has `margin-top: -1rem`, designed to sit tight directly under a heading. It was placed after a 3-card grid instead — when the card text wrapped to more lines than expected, that negative margin pulled the subline up into the cards. Compounding bug: `.compare-card` had no CSS rule for a bare `<p>` (the site's existing pattern uses `<ul><li>`), so it fell back to default browser paragraph margins. Fixed both: added `.compare-card p`, and moved `.section-subline` back to directly under the heading.
- **Removes the redundant category-pill row** from "Recent Updates" — the "What we track" cards now double as the filter (click Unicode / Platform rules / Game rules to filter the list below) instead of two separate UI elements repeating the same three categories. A "Showing: X — Clear filter" indicator appears next to the heading when a filter is active.

## Test plan
- [x] Rendered `/updates/` in a headless browser (light + dark mode) — no overlap, clean spacing
- [x] Verified filter behavior via direct DOM-state assertions: clicking a disabled (0-count) category card is a no-op, clicking an enabled one filters correctly and shows the "Showing: X" indicator, "Clear filter" resets state
- [x] `python3 scripts/check-image-assets.py` — no new failures introduced
- [x] HTML parses cleanly (no parser errors)


---
_Generated by [Claude Code](https://claude.ai/code/session_0182Vfm7pDf1uHCWYjR7Rk4v)_