### PR TITLE
feat: de-cannibalize Discord 'allowed characters' cluster (competitor…

### DIFF
--- a/guide/discord-safe-name-styling/index.html
+++ b/guide/discord-safe-name-styling/index.html
@@ -174,7 +174,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <span class="article-section-label">The Core Idea</span>
     <h2>"Works" and "Safe" Are Different Questions</h2>
     <div class="editorial-block">
-      <p><a href="/guide/discord-text-formatting-explained/">Discord's Unicode names work almost everywhere a name appears</a> — display name, server nickname, roles, channels. That's the "does it render" question, and for a styled name the answer is nearly always yes.</p>
+      <p><a href="/guide/discord-text-formatting-explained/">Discord's Unicode names work almost everywhere a name appears</a> — display name, server nickname, roles, channels. That's the "does it render" question, and for a styled name the answer is nearly always yes. For the exact per-field rules on which characters each field allows, see <a href="/answers/discord-allowed-characters/">Discord allowed characters</a>.</p>
       <p>"Is it safe to use" is a separate question, and it doesn't have a single yes-or-no answer — it depends on whether the specific name you picked still does the three jobs a Discord name has to do: stay readable in a crowded list, stay findable when someone wants to mention you, and stay clearly, uniquely <em>you</em> rather than an accidental (or deliberate) copy of someone else.</p>
     </div>
   </section>

--- a/guide/discord-text-formatting-explained/index.html
+++ b/guide/discord-text-formatting-explained/index.html
@@ -233,6 +233,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <div class="mood-explainer">
         <div class="mood-example"><strong>The @username rejects it.</strong> Your unique handle (the lowercase one after the @) allows only a–z, 0–9, <code>_</code> and <code>.</code> — for mentions, search and routing. Paste a fancy font there and Discord refuses to save it. Style your <em>display name</em> instead.</div>
       </div>
+      <p>For the exact per-field rules — which characters and limits each field (username, display name, nickname, server, channel, role, bio) actually allows — see <a href="/answers/discord-allowed-characters/">Discord allowed characters</a>.</p>
       <p>Two honest caveats, both covered in depth elsewhere: Unicode names can <a href="/guide/why-fonts-show-as-boxes/">show as boxes</a> on some devices (especially older Android), and they're <a href="/guide/fancy-fonts-accessibility-guide/">hard for screen readers</a>. Pick a safe style (bold, italic, small caps) and keep it tasteful — many large servers moderate hard-to-read or zalgo names.</p>
     </div>
   </section>


### PR DESCRIPTION
… pointers)

Consolidate the ~18k-vol 'allowed unicode characters in Discord names' cluster onto its owner /answers/discord-allowed-characters/ (already the strongest, most complete per-field page). Point the two guides that ranked incidentally for the cluster (formatting-explained, safe-name-styling) to the owner for the exact per-field rules, so Google consolidates the intent on one URL (Rule 3/4).

Owner page left unchanged — it already has the per-field table, generator/paste CTAs, and full schema. bio-font/discord and library/discord-symbols already link the owner. /discord/ hub de-target pending review (separate).