### PR TITLE
Optimize hero image loading with fetchpriority

### DIFF
--- a/scripts/wire-site-art.py
+++ b/scripts/wire-site-art.py
@@ -52,7 +52,7 @@ def figure_block(slug):
     return (
         f'\n<figure class="page-hero-figure" data-uthero aria-hidden="true">\n'
         f'  <img src="/assets/hero/{slug}.svg" width="1200" height="340"\n'
-        f'       loading="lazy" alt="">\n'
+        f'       fetchpriority="high" alt="">\n'
         f'</figure>\n')
 
 


### PR DESCRIPTION
## Summary
Replace `loading="lazy"` with `fetchpriority="high"` on the hero image in the site art generation script to prioritize above-the-fold image delivery.

## Changes
- Updated `scripts/wire-site-art.py` to use `fetchpriority="high"` instead of `loading="lazy"` for the hero figure image
- This ensures the hero image is fetched with high priority, improving perceived performance for the critical above-the-fold visual element

## Implementation Details
The hero image (`/assets/hero/{slug}.svg`) is a key visual component displayed immediately on page load. By setting `fetchpriority="high"`, the browser will prioritize this resource in its fetch queue, resulting in faster rendering of the page's primary visual element — aligning with the project's "Fast > Fancy" philosophy.

https://claude.ai/code/session_01UnbKnb5nUnjaL3i7cTfvrP