### PR TITLE
Add translation parity audit and enforcement tooling

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,14 +1,16 @@
 name: Validate Site
 
 # Required, blocking checks for structural correctness that must never merge
-# broken: hreflang reciprocity, /library/ and /symbol/ page structure, and
-# per-page social/Pinterest image assets. Each validator already exits
-# non-zero on failure (see scripts/audit-hreflang.js,
-# scripts/validate_library_pages.py, scripts/check-image-assets.py) — this
-# workflow is what actually wires that into CI so a PR can't merge broken
-# pages.
+# broken: hreflang reciprocity, /library/ and /symbol/ page structure,
+# per-page social/Pinterest image assets, and (new) translation parity —
+# an EN <-> locale content change introduced by this PR without its
+# sibling being updated. Each validator already exits non-zero on failure
+# (see scripts/audit-hreflang.js, scripts/validate_library_pages.py,
+# scripts/check-image-assets.py, scripts/check-translation-parity.js) —
+# this workflow is what actually wires that into CI so a PR can't merge
+# broken pages.
 #
-# All three run every time (continue-on-error on each step) so a single PR
+# All four run every time (continue-on-error on each step) so a single PR
 # shows every problem at once instead of stopping at the first failure; the
 # final step fails the job if any validator reported an error.
 
@@ -25,6 +27,11 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+        with:
+          # check-translation-parity.js diffs this PR against its base branch,
+          # which needs real history — a shallow (depth-1) checkout has no
+          # merge-base to diff against.
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -54,6 +61,11 @@ jobs:
         continue-on-error: true
         run: npm run check:images | tee image-assets.log
 
+      - name: Run translation parity check
+        id: parity
+        continue-on-error: true
+        run: npm run check:translation-parity -- --base origin/${{ github.event.pull_request.base.ref || 'main' }} | tee translation-parity.log
+
       - name: Build step summary
         if: always()
         run: |
@@ -74,10 +86,15 @@ jobs:
             echo '```'
             cat image-assets.log
             echo '```'
+            echo ""
+            echo "### Translation parity check — \`${{ steps.parity.outcome }}\`"
+            echo '```'
+            cat translation-parity.log
+            echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Fail the job if any validator reported problems
-        if: steps.hreflang.outcome == 'failure' || steps.library.outcome == 'failure' || steps.images.outcome == 'failure'
+        if: steps.hreflang.outcome == 'failure' || steps.library.outcome == 'failure' || steps.images.outcome == 'failure' || steps.parity.outcome == 'failure'
         run: |
           echo "One or more validators failed — see the Summary tab above for details."
           exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -681,6 +681,76 @@ other locale homepages) for the same failure mode while you're in there.
 
 ---
 
+## Translation Parity — keeping EN and locale pages in sync after creation
+
+The English-Parent Rule above governs *creation*: does a live EN parent exist
+before a locale page gets built. It says nothing about what happens *after*
+both exist — when the EN page (or a locale page) gets edited later and its
+sibling doesn't. That gap is real and has already shipped drift: a batch of
+Gulf currency `symbol/` pages (`dirham-sign`, `omani-rial-sign`,
+`saudi-riyal-sign`) was added to `library/currency-symbols/` across two PRs
+(2026-07-22) with zero of its 9 locale siblings (including `ar/` — arguably
+the highest-value locale for Gulf currencies) touched in either PR. Nobody
+was watching for it because nothing was watching for it.
+
+**The rule:** when you edit a page that has an hreflang cluster (an EN page
+with locale translations, or a locale page with an EN parent), check whether
+the edit is structural — a new internal link, a new FAQ item, a new section,
+a new symbol tile — not just wording. If it is, either update the sibling(s)
+in the same change, or record why they're allowed to diverge. This runs
+**both directions** — EN changed without the locale catching up, or a locale
+changed without EN (or its other locale siblings) catching up — the tooling
+below does not care which side moved first.
+
+**EN and a locale page are allowed to differ** — translators make real
+editorial calls (a different related-links set, a regionally relevant FAQ)
+and not every EN addition needs a translation the day it ships. But per the
+user's standing requirement, that divergence must be an **explicit, agreed
+decision**, not silence. Record it in
+`data/translation_parity_exceptions.json` (reason + date) rather than just
+leaving the sibling stale — see that file's own `_readme` field for the
+entry shape.
+
+### Tooling
+
+- **`node scripts/audit-translation-parity.js`** (`npm run
+  audit:translation-parity`) — point-in-time sweep of every hreflang cluster
+  site-wide. Diffs a language-independent "structural fingerprint" (internal
+  content links — resolved through the hreflang map so a locale-native link
+  and its EN equivalent count as a match, not a diff — plus FAQ/`<h2>`/
+  `.symbol-tile` counts) between EN and each locale sibling. Default output
+  leads with the highest-signal view: recent EN `feat:` commits whose locale
+  siblings weren't touched afterward — the shape of the currency-symbols
+  case above. Pass `--full` for the complete per-pair dump, `--json <path>`
+  for raw data, `--report <path>.md` to save a snapshot. This is a discovery
+  tool for triage, not a blocking check — the existing site has a real
+  backlog of drift and this will not (and should not) go to zero in one
+  pass.
+- **`node scripts/check-translation-parity.js`** (`npm run
+  check:translation-parity`) — the enforcing half, wired into
+  `.github/workflows/validate.yml` as a required CI check on every PR (same
+  continue-on-error-then-fail pattern as the hreflang/library/image
+  validators). Diffs the PR branch against its base, and for every changed
+  HTML page whose structural fingerprint actually moved, requires at least
+  one sibling in its hreflang cluster to have been touched in the same PR —
+  unless the pair is listed in `data/translation_parity_exceptions.json`.
+  Fails the PR otherwise, with the exact EN/locale file pair and the fix (sync
+  the sibling, or add a ledger entry). Byte-level edits that don't change
+  the fingerprint (typos, meta-description tweaks) never trigger it.
+- Both scripts share `scripts/lib/translation-clusters.js` (hreflang cluster
+  discovery) and `scripts/lib/content-fingerprint.js` (the fingerprint/diff
+  logic) — the audit and the enforcement gate must never define "changed" or
+  "cluster" differently, so that shared logic lives in one place.
+
+**Do not add an entry to `data/translation_parity_exceptions.json`
+unilaterally.** Every entry there is supposed to represent a real,
+discussed decision between you and the user — the same bar the English-
+Parent Rule sets for locale-first exceptions above. If `check-translation-
+parity.js` flags a pair, either sync it or raise the divergence with the
+user before recording it as intentional.
+
+---
+
 ## Build & Development
 
 ### Running locally
@@ -770,6 +840,12 @@ Do not add a test framework unless explicitly requested.
   explicit, discussed exception. See "Answer pages live under `answers/` only"
   above — the `tiktok/`/`youtube/` "what font does X use" case study is exactly
   this mistake, and it cannibalized both pairs.
+- Do not edit a page that's part of an hreflang cluster (EN + locale
+  translations) without checking whether the edit is structural and, if so,
+  syncing the sibling(s) or recording an explicit exception in
+  `data/translation_parity_exceptions.json`. See "Translation Parity" above
+  — this runs both directions (EN changed without locale catching up, or
+  vice versa) and `scripts/check-translation-parity.js` enforces it in CI.
 - Do not add npm packages that run in the browser
 - Do not introduce a JavaScript framework or bundler
 - Do not generate images server-side or with an image-processing library. Visual/printable

--- a/data/translation_parity_audit_2026-07-23.md
+++ b/data/translation_parity_audit_2026-07-23.md
@@ -1,0 +1,67 @@
+# Translation Parity Audit
+
+Generated 2026-07-23. Run `node scripts/audit-translation-parity.js` to regenerate.
+
+```
+Translation Parity Audit
+  hreflang clusters with an EN anchor:     218
+  locale pairs compared:                   1400
+  actionable drift (likely a missed sync): 1061
+  bulk/coverage-gap pairs (score > 12):     320
+  pairs fully excused by ledger:           0
+
+Showing actionable drift only. Bulk coverage-gap pairs are summarized below (pass --show-bulk for full detail, --threshold N to change the cutoff).
+
+── High-confidence: EN feat commits with un-synced locale siblings (12) ──
+
+2026-07-22  32270475 feat: add PUBG/BGMI and Steam name symbol library pages
+  pages:            library/index.html
+  un-synced locales (14): ar, da, de, it, ja, ko, nl, no, pl, pt, ru, sv, th, vi
+
+2026-07-22  c3025608 feat: add live Riot ID checker for Valorant name generator
+  pages:            usecase/index.html, usecase/nickname-generator/index.html, usecase/free-fire-name-generator/index.html
+  un-synced locales (12): ar, de, es, fr, hi, id, it, pt, th, tr, vi, zh-TW
+
+2026-07-22  79a6291a feat: add Omani rial and Saudi riyal symbol pages, fix dirham factual error
+  pages:            library/currency-symbols/index.html
+  un-synced locales (9): ar, da, de, es, it, ko, nl, sv, tr
+
+2026-07-22  10f4659a feat: add bulletin-board size/tiling option to bubble-letters alphabet print
+  pages:            printables/bubble-letters/index.html
+  un-synced locales (3): es, fr, pt
+
+2026-07-22  91a54ac3 feat: add symbol/ identity pages for Meteor, Monarch Butterfly, and Thumb Sign
+  pages:            library/animal-emojis/index.html
+  un-synced locales (2): ar, th
+
+2026-07-22  c6794de1 feat: add symbol/ identity pages for Cracking Face, Pickle, and dirham sign
+  pages:            library/food-drink-emojis/index.html
+  un-synced locales (1): th
+
+2026-07-20  6d318dc1 feat: TikTok compatibility checker, Taiwan Arena of Valor page, safe mode + platform-router features
+  pages:            category/small-text/index.html, category/superscript/index.html
+  un-synced locales (15): bs, cs, de, es, fr, hr, id, nl, pl, pt, ro, ru, sk, sr, tr
+
+2026-07-19  4cf2b9c6 feat: de-cannibalize Discord 'allowed characters' cluster (competitor pointers)
+  pages:            guide/discord-text-formatting-explained/index.html, guide/discord-safe-name-styling/index.html
+  un-synced locales (27): ar, bs, cs, da, de, es, fr, hi, hr, id, it, ja, ko, nl, no, pl, pt, ro, ru, sk, sr, sv, th, tl, tr, vi, zh-TW
+
+2026-07-18  ae026725 feat: fix internal-linking dead-ends, faucets, and orphans
+  pages:            library/text-faces-kaomoji/index.html, category/gothic-fonts/index.html, category/italic-fonts/index.html, category/text-decorator/index.html, category/bold-fonts/index.html, category/aesthetic-fonts/index.html, category/strikethrough-text/index.html, category/cursive-fonts/index.html, category/upside-down-text/index.html, usecase/bio-font/index.html, usecase/text-to-emoji/index.html, category/cute-fonts/index.html, usecase/vertical-text/index.html, category/underline-text/index.html, category/bubble-fonts/index.html, category/case-converter/index.html, library/sad-kaomoji/index.html, category/subscript/index.html
+  un-synced locales (25): ar, bs, cs, de, es, fr, hi, hr, id, it, ja, ko, nl, no, pl, pt, ro, ru, sk, sr, th, tl, tr, vi, zh-TW
+
+2026-07-18  baffd648 feat: ship 16 new symbol/ pages for Tier A/B pending English backlog
+  pages:            library/greek-letter-symbols/index.html, library/religious-symbols/index.html, library/punctuation-symbols/index.html, library/crown-royalty-symbols/index.html, library/keyboard-symbols/index.html
+  un-synced locales (15): ar, da, de, es, fr, id, it, ja, ko, nl, no, pl, pt, sv, tr
+
+2026-07-18  57702e5e feat: /learn/ education pillar, cursive hub treatment, bridge strips, cursive spoke art
+  pages:            printables/cursive-alphabet/index.html
+  un-synced locales (4): es, fr, it, pt
+
+2026-07-16  8bd0fb2f feat(roblox): add old Roblox font generator hub at /roblox/old-roblox-font/
+  pages:            roblox/index.html
+  un-synced locales (3): es, pl, vi
+
+(1061 smaller-diff pairs and 320 bulk/coverage-gap pairs omitted — pass --full to print every pair, or --json <path> for the raw data.)
+
+```

--- a/data/translation_parity_exceptions.json
+++ b/data/translation_parity_exceptions.json
@@ -1,0 +1,4 @@
+{
+  "_readme": "Ledger of EN <-> locale content differences that were explicitly discussed and agreed as intentional, rather than accidental drift. Read/written by scripts/audit-translation-parity.js and scripts/check-translation-parity.js. Do NOT add an entry here unilaterally — every entry must reflect a real discussion with the user (see CLAUDE.md, 'Translation Parity'). Entry shape: { enUrl, localeUrl (both full canonical https URLs, trailing slash), reason (why they're allowed to differ), agreed (YYYY-MM-DD), suppress (optional; omit for a full pair exception, or scope it: { onlyInEN: [...normalized hrefs to ignore], onlyInLocale: [...], h2Delta: true, faqDelta: true, symbolTilesDelta: true }) }.",
+  "exceptions": []
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "check:gtm": "node scripts/check-gtm.js",
     "check:ads": "node scripts/check-ads.js",
     "check:hreflang": "node scripts/audit-hreflang.js",
-    "check:images": "python3 scripts/check-image-assets.py"
+    "check:images": "python3 scripts/check-image-assets.py",
+    "audit:translation-parity": "node scripts/audit-translation-parity.js",
+    "check:translation-parity": "node scripts/check-translation-parity.js"
   },
   "dependencies": {
     "cheerio": "^1.2.0",

--- a/scripts/audit-translation-parity.js
+++ b/scripts/audit-translation-parity.js
@@ -1,0 +1,291 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * audit-translation-parity.js
+ *
+ * Point-in-time audit: for every EN <-> locale hreflang cluster, diff a
+ * language-independent "structural fingerprint" (internal content links,
+ * FAQ question count, <h2> count, .symbol-tile count) between the EN page
+ * and each of its locale siblings. A non-empty diff means one side gained
+ * or lost content after the translation was made and the other side was
+ * never caught up — the failure mode this script exists to surface.
+ *
+ * This is NOT a hreflang correctness check (see audit-hreflang.js) — a
+ * cluster can be perfectly reciprocal and still have drifted content.
+ *
+ * Usage:
+ *   node scripts/audit-translation-parity.js            # full report to stdout
+ *   node scripts/audit-translation-parity.js --report out.md   # also write markdown
+ *   node scripts/audit-translation-parity.js --json out.json   # also write raw JSON
+ *
+ * Known, agreed-upon divergences are suppressed via
+ * data/translation_parity_exceptions.json — see that file's own comment
+ * for the entry shape. Nothing is auto-added to it; every entry there
+ * represents an explicit decision made with the user (see CLAUDE.md,
+ * "Translation Parity" section).
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+const { discoverClusters } = require('./lib/translation-clusters');
+const { createFingerprinter } = require('./lib/content-fingerprint');
+
+const ROOT = path.resolve(__dirname, '..');
+const EXCEPTIONS_PATH = path.join(ROOT, 'data', 'translation_parity_exceptions.json');
+
+const args = process.argv.slice(2);
+const reportIdx = args.indexOf('--report');
+const jsonIdx = args.indexOf('--json');
+const reportPath = reportIdx !== -1 ? args[reportIdx + 1] : null;
+const jsonPath = jsonIdx !== -1 ? args[jsonIdx + 1] : null;
+
+// ─── Discover every page + its declared hreflang cluster ──────────────────
+
+const { byUrl, clusters, localeCodes } = discoverClusters(ROOT);
+
+// ─── Fingerprinting ─────────────────────────────────────────────────────
+
+const { fingerprint: fingerprintHtml, diff: diffFingerprints, score: scoreDiff } = createFingerprinter(
+  byUrl,
+  localeCodes
+);
+const fingerprint = (rec) => fingerprintHtml(rec.html);
+
+function lastCommit(rel) {
+  try {
+    const out = execFileSync(
+      'git',
+      ['log', '-1', '--format=%h|%ad|%s', '--date=short', '--', rel],
+      { cwd: ROOT, encoding: 'utf8' }
+    ).trim();
+    if (!out) return null;
+    const [hash, date, ...rest] = out.split('|');
+    return { hash, date, subject: rest.join('|') };
+  } catch {
+    return null;
+  }
+}
+
+// ─── Exceptions ledger ──────────────────────────────────────────────────
+
+let exceptions = [];
+if (fs.existsSync(EXCEPTIONS_PATH)) {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(EXCEPTIONS_PATH, 'utf8'));
+    exceptions = Array.isArray(parsed) ? parsed : parsed.exceptions || [];
+  } catch (e) {
+    console.error(`WARNING: could not parse ${path.relative(ROOT, EXCEPTIONS_PATH)}: ${e.message}`);
+  }
+}
+
+function findException(enUrl, localeUrl) {
+  return exceptions.find((ex) => ex.enUrl === enUrl && ex.localeUrl === localeUrl) || null;
+}
+
+function applySuppression(ex, diff) {
+  if (!ex) return diff;
+  const sup = ex.suppress || null;
+  if (!sup) {
+    // blanket exception: whole pair excused
+    return { onlyInEN: [], onlyInLocale: [], h2Delta: 0, faqDelta: 0, symbolTilesDelta: 0, suppressedAll: true };
+  }
+  const onlyInEN = diff.onlyInEN.filter((h) => !(sup.onlyInEN || []).includes(h));
+  const onlyInLocale = diff.onlyInLocale.filter((h) => !(sup.onlyInLocale || []).includes(h));
+  return {
+    onlyInEN,
+    onlyInLocale,
+    h2Delta: sup.h2Delta ? 0 : diff.h2Delta,
+    faqDelta: sup.faqDelta ? 0 : diff.faqDelta,
+    symbolTilesDelta: sup.symbolTilesDelta ? 0 : diff.symbolTilesDelta,
+    suppressedAll: false,
+  };
+}
+
+// ─── Diff every cluster ────────────────────────────────────────────────
+
+const results = [];
+
+for (const [enUrl, members] of clusters) {
+  const enRec = byUrl.get(enUrl);
+  if (!enRec) continue; // broken anchor — audit-hreflang.js already reports this
+  const enFp = fingerprint(enRec);
+  const enCommit = lastCommit(enRec.rel);
+
+  for (const memberUrl of members) {
+    if (memberUrl === enUrl) continue;
+    const rec = byUrl.get(memberUrl);
+    if (!rec) continue; // broken/headless target — audit-hreflang.js's job
+    if (rec.ownLang === 'en' || !rec.ownLang) continue; // not a real locale member
+
+    const fp = fingerprint(rec);
+    const rawDiff = diffFingerprints(enFp, fp);
+
+    const ex = findException(enUrl, memberUrl);
+    const diff = applySuppression(ex, rawDiff);
+    const score = scoreDiff(diff);
+
+    if (score === 0 && !ex) continue; // clean pair, nothing to report
+
+    results.push({
+      enUrl,
+      enRel: enRec.rel,
+      localeUrl: memberUrl,
+      localeRel: rec.rel,
+      lang: rec.ownLang,
+      diff,
+      rawScore: scoreDiff(rawDiff),
+      score,
+      exception: ex,
+      enCommit,
+      localeCommit: lastCommit(rec.rel),
+    });
+  }
+}
+
+results.sort((a, b) => b.score - a.score || b.rawScore - a.rawScore);
+
+// ─── Report ─────────────────────────────────────────────────────────────
+
+const flagged = results.filter((r) => r.score > 0);
+const excusedOnly = results.filter((r) => r.score === 0 && r.exception);
+
+// A big diff (dozens of links) almost always means "this locale's translation
+// coverage just hasn't caught up to the whole site yet" — a known, tracked,
+// separate backlog (see CLAUDE.md's grandfathered-exception / gradual-rollout
+// language) — not "someone edited one side and forgot the other," which is
+// what this tool exists to catch. Bucket by size so the small, actionable
+// drift (the currency-symbols-style case) isn't buried under hub pages that
+// legitimately link to hundreds of not-yet-translated spokes.
+const thresholdIdx = args.indexOf('--threshold');
+const BULK_THRESHOLD = thresholdIdx !== -1 ? parseInt(args[thresholdIdx + 1], 10) : 12;
+const showBulk = args.includes('--show-bulk');
+
+const actionable = flagged.filter((r) => r.score <= BULK_THRESHOLD).sort((a, b) => b.score - a.score);
+const bulk = flagged.filter((r) => r.score > BULK_THRESHOLD).sort((a, b) => b.score - a.score);
+
+const lines = [];
+const log = (s = '') => {
+  lines.push(s);
+  console.log(s);
+};
+
+log('Translation Parity Audit');
+log(`  hreflang clusters with an EN anchor:     ${clusters.size}`);
+log(`  locale pairs compared:                   ${[...clusters.values()].reduce((n, s) => n + s.size - 1, 0)}`);
+log(`  actionable drift (likely a missed sync): ${actionable.length}`);
+log(`  bulk/coverage-gap pairs (score > ${BULK_THRESHOLD}):     ${bulk.length}`);
+log(`  pairs fully excused by ledger:           ${excusedOnly.length}`);
+log('');
+log(`Showing actionable drift only. Bulk coverage-gap pairs are summarized below${showBulk ? '' : ' (pass --show-bulk for full detail, --threshold N to change the cutoff)'}.`);
+log('');
+
+// ─── Highest-signal view: group by the EN commit that likely caused it ────
+//
+// A raw per-pair diff can't tell "accidental drift" apart from "the locale
+// page was always written with different editorial choices." A commit
+// whose subject is a feat: commit that touched the EN page, landed strictly
+// after the locale sibling's own last commit, is the sharpest available
+// proxy for "EN gained content and the translation was never caught up" —
+// which is exactly the failure mode this audit exists to catch. This is
+// necessarily a heuristic (not every un-synced feat commit is a real miss,
+// and some real misses use other commit-message verbs), but grouping by
+// root commit turns a flat list of ~1000+ noisy pairs into a short list of
+// specific, reviewable changes.
+const FEAT_RE = /^feat(\(|:)/;
+const rootCauseCandidates = flagged.filter(
+  (r) => r.enCommit && FEAT_RE.test(r.enCommit.subject) && (!r.localeCommit || r.localeCommit.date < r.enCommit.date)
+);
+const byCommit = new Map();
+for (const r of rootCauseCandidates) {
+  const key = `${r.enCommit.hash} ${r.enCommit.subject}`;
+  if (!byCommit.has(key)) byCommit.set(key, { date: r.enCommit.date, pages: new Set(), langs: new Set(), pairs: [] });
+  const g = byCommit.get(key);
+  g.pages.add(r.enRel);
+  g.langs.add(r.lang);
+  g.pairs.push(r);
+}
+const commitRows = [...byCommit.entries()].sort((a, b) => b[1].date.localeCompare(a[1].date) || b[1].langs.size - a[1].langs.size);
+
+log(`── High-confidence: EN feat commits with un-synced locale siblings (${commitRows.length}) ──`);
+log('');
+for (const [key, g] of commitRows) {
+  log(`${g.date}  ${key}`);
+  log(`  pages:            ${[...g.pages].join(', ')}`);
+  log(`  un-synced locales (${g.langs.size}): ${[...g.langs].sort().join(', ')}`);
+  log('');
+}
+
+function printPair(r) {
+  log(`✗ [${r.lang}] ${r.enRel}  <->  ${r.localeRel}  (score ${r.score})`);
+  if (r.enCommit) log(`    EN last touched:     ${r.enCommit.date}  ${r.enCommit.hash}  ${r.enCommit.subject}`);
+  if (r.localeCommit)
+    log(`    ${r.lang} last touched:    ${r.localeCommit.date}  ${r.localeCommit.hash}  ${r.localeCommit.subject}`);
+  if (r.diff.onlyInEN.length) {
+    log(`    EN has, ${r.lang} missing (${r.diff.onlyInEN.length}):`);
+    for (const h of r.diff.onlyInEN) log(`      - ${h}`);
+  }
+  if (r.diff.onlyInLocale.length) {
+    log(`    ${r.lang} has, EN missing (${r.diff.onlyInLocale.length}):`);
+    for (const h of r.diff.onlyInLocale) log(`      - ${h}`);
+  }
+  if (r.diff.h2Delta !== 0) log(`    <h2> section count delta (EN - ${r.lang}): ${r.diff.h2Delta}`);
+  if (r.diff.faqDelta !== 0) log(`    FAQ question count delta (EN - ${r.lang}): ${r.diff.faqDelta}`);
+  if (r.diff.symbolTilesDelta !== 0)
+    log(`    .symbol-tile count delta (EN - ${r.lang}): ${r.diff.symbolTilesDelta}`);
+  if (r.exception) log(`    (partial exception on file, reason: "${r.exception.reason}")`);
+  log('');
+}
+
+// The full per-pair dump is mostly editorial variance across ~1000+ pairs,
+// not accidental drift — the commit-grouped section above is the actual
+// signal. Keep the raw dump available (it's the ground truth the heuristic
+// above was built from) but opt-in only, so a plain run stays readable.
+const showFull = args.includes('--full');
+if (showFull) {
+  log(`── Actionable drift (score <= ${BULK_THRESHOLD}) ──`);
+  log('');
+  for (const r of actionable) printPair(r);
+
+  log(`── Bulk / translation-coverage-gap pairs (score > ${BULK_THRESHOLD}) ──`);
+  log('');
+  if (showBulk) {
+    for (const r of bulk) printPair(r);
+  } else {
+    for (const r of bulk) log(`  ${r.score.toString().padStart(4)}  [${r.lang}] ${r.enRel}  <->  ${r.localeRel}`);
+    log('');
+  }
+} else {
+  log(`(${actionable.length} smaller-diff pairs and ${bulk.length} bulk/coverage-gap pairs omitted — pass --full to print every pair, or --json <path> for the raw data.)`);
+  log('');
+}
+
+if (excusedOnly.length) {
+  log('Pairs with a recorded, agreed exception (no unresolved drift):');
+  for (const r of excusedOnly) {
+    log(`  ✓ [${r.lang}] ${r.enRel} <-> ${r.localeRel} — ${r.exception.reason} (agreed ${r.exception.agreed})`);
+  }
+  log('');
+}
+
+if (reportPath) {
+  const md = [
+    `# Translation Parity Audit`,
+    ``,
+    `Generated ${new Date().toISOString().slice(0, 10)}. Run \`node scripts/audit-translation-parity.js\` to regenerate.`,
+    ``,
+    '```',
+    ...lines,
+    '```',
+  ].join('\n');
+  fs.writeFileSync(path.resolve(ROOT, reportPath), md, 'utf8');
+  console.log(`\nMarkdown report written to ${reportPath}`);
+}
+
+if (jsonPath) {
+  fs.writeFileSync(path.resolve(ROOT, jsonPath), JSON.stringify(results, null, 2), 'utf8');
+  console.log(`JSON written to ${jsonPath}`);
+}
+
+process.exit(flagged.length > 0 ? 0 : 0); // informational by default; see check-translation-parity.js for the enforcing check

--- a/scripts/check-translation-parity.js
+++ b/scripts/check-translation-parity.js
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * check-translation-parity.js
+ *
+ * Per-PR gate: for every HTML file changed in this branch, if the page is
+ * part of an EN <-> locale hreflang cluster AND its structural content
+ * fingerprint actually changed (a link/FAQ/section/symbol-tile added or
+ * removed — not just a wording tweak), require that at least one sibling in
+ * the same cluster (the EN parent, if a locale page changed; any locale
+ * child, if the EN parent changed) was ALSO touched in this branch.
+ *
+ * This is the enforcement half of scripts/audit-translation-parity.js: the
+ * audit finds existing drift across the whole site; this stops NEW drift
+ * from being introduced, going both directions (EN -> locale and locale ->
+ * EN), per CLAUDE.md's "Translation Parity" section.
+ *
+ * A flagged pair is not necessarily wrong — EN and a locale page are
+ * allowed to diverge when there's an explicit, agreed reason. Record that
+ * reason in data/translation_parity_exceptions.json (see its own comment
+ * for the entry shape) rather than silencing this check by leaving the
+ * sibling stale.
+ *
+ * Usage:
+ *   node scripts/check-translation-parity.js                 # diff against origin/main
+ *   node scripts/check-translation-parity.js --base main      # diff against a different ref
+ *
+ * Exit code 0 = clean (or nothing to check), 1 = unresolved drift found.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+const { discoverClusters } = require('./lib/translation-clusters');
+const { createFingerprinter } = require('./lib/content-fingerprint');
+
+const ROOT = path.resolve(__dirname, '..');
+const EXCEPTIONS_PATH = path.join(ROOT, 'data', 'translation_parity_exceptions.json');
+
+const args = process.argv.slice(2);
+const baseIdx = args.indexOf('--base');
+const requestedBase = baseIdx !== -1 ? args[baseIdx + 1] : 'origin/main';
+
+function git(cmdArgs, opts = {}) {
+  return execFileSync('git', cmdArgs, { cwd: ROOT, encoding: 'utf8', ...opts });
+}
+
+function resolveBase(base) {
+  try {
+    git(['rev-parse', '--verify', base], { stdio: 'ignore' });
+    return base;
+  } catch {
+    // Shallow CI checkouts often don't have the base branch locally at all.
+    const branch = base.replace(/^origin\//, '');
+    try {
+      git(['fetch', '--depth=200', 'origin', branch], { stdio: 'ignore' });
+      const candidate = `origin/${branch}`;
+      git(['rev-parse', '--verify', candidate], { stdio: 'ignore' });
+      return candidate;
+    } catch (e) {
+      console.error(`Could not resolve or fetch base ref "${base}": ${e.message}`);
+      process.exit(2);
+    }
+  }
+  return base;
+}
+
+const base = resolveBase(requestedBase);
+
+let mergeBase;
+try {
+  mergeBase = git(['merge-base', base, 'HEAD']).trim();
+} catch (e) {
+  console.error(`Could not compute merge-base of ${base} and HEAD: ${e.message}`);
+  process.exit(2);
+}
+
+const changedFiles = git(['diff', '--name-only', '--diff-filter=ACMR', `${mergeBase}`, 'HEAD', '--', '*.html'])
+  .split('\n')
+  .map((l) => l.trim())
+  .filter(Boolean);
+
+if (changedFiles.length === 0) {
+  console.log('Translation Parity Check: no changed HTML files — nothing to check.');
+  process.exit(0);
+}
+
+function oldContent(rel) {
+  try {
+    return git(['show', `${mergeBase}:${rel}`]);
+  } catch {
+    return null; // new file — no "before" to diff against
+  }
+}
+
+// ─── Current site state (HEAD / working tree) ──────────────────────────────
+
+const { byUrl, clusters, localeCodes } = discoverClusters(ROOT);
+const { fingerprint, diff, score } = createFingerprinter(byUrl, localeCodes);
+
+const changedSet = new Set(changedFiles);
+
+// enUrl -> Set of member urls, for quick "which cluster is this page in" lookups
+const clusterOf = new Map(); // canonical url -> en anchor url
+for (const [enUrl, members] of clusters) {
+  for (const m of members) clusterOf.set(m, enUrl);
+}
+
+// ─── Exceptions ledger ──────────────────────────────────────────────────
+
+let exceptions = [];
+if (fs.existsSync(EXCEPTIONS_PATH)) {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(EXCEPTIONS_PATH, 'utf8'));
+    exceptions = Array.isArray(parsed) ? parsed : parsed.exceptions || [];
+  } catch (e) {
+    console.error(`WARNING: could not parse ${path.relative(ROOT, EXCEPTIONS_PATH)}: ${e.message}`);
+  }
+}
+
+function hasException(enUrl, localeUrl) {
+  return exceptions.some((ex) => ex.enUrl === enUrl && ex.localeUrl === localeUrl);
+}
+
+// ─── Check every changed page that belongs to a cluster ────────────────────
+
+const flagged = []; // { enUrl, localeUrl, changedRel, unsyncedSiblingRels: [] }
+const checkedPairs = new Set(); // dedupe: "enUrl|localeUrl"
+
+for (const rel of changedFiles) {
+  const filePath = path.join(ROOT, rel);
+  if (!fs.existsSync(filePath)) continue; // deleted file
+  const newHtml = fs.readFileSync(filePath, 'utf8');
+
+  const rec = [...byUrl.values()].find((r) => r.rel === rel);
+  if (!rec) continue; // not part of any hreflang-bearing page at all
+
+  const enAnchor = clusterOf.get(rec.canonical);
+  if (!enAnchor) continue; // no cluster info — not this check's job (see audit-hreflang.js)
+
+  const before = oldContent(rel);
+  const changedFingerprint = before === null || score(diff(fingerprint(before), fingerprint(newHtml))) > 0;
+  if (!changedFingerprint) continue; // byte-level edit only (typo, meta tweak) — nothing structural moved
+
+  const members = [...clusters.get(enAnchor)].filter((u) => u !== rec.canonical);
+  for (const siblingUrl of members) {
+    const siblingRec = byUrl.get(siblingUrl);
+    if (!siblingRec) continue; // headless/broken — audit-hreflang.js's job
+
+    const enUrl = rec.canonical === enAnchor ? rec.canonical : enAnchor;
+    const localeUrl = rec.canonical === enAnchor ? siblingUrl : rec.canonical;
+    const pairKey = `${enUrl}|${localeUrl}`;
+    if (checkedPairs.has(pairKey)) continue;
+    checkedPairs.add(pairKey);
+
+    if (hasException(enUrl, localeUrl)) continue;
+
+    const enRel = enUrl === rec.canonical ? rec.rel : siblingRec.rel;
+    const localeRel = enUrl === rec.canonical ? siblingRec.rel : rec.rel;
+
+    if (changedSet.has(enRel) && changedSet.has(localeRel)) continue; // both sides touched — presumed synced
+
+    flagged.push({ enUrl, localeUrl, enRel, localeRel, changedRel: rel });
+  }
+}
+
+// ─── Report ─────────────────────────────────────────────────────────────
+
+console.log('Translation Parity Check');
+console.log(`  base:                    ${base} (merge-base ${mergeBase.slice(0, 8)})`);
+console.log(`  changed HTML files:      ${changedFiles.length}`);
+console.log(`  pairs with unsynced content change: ${flagged.length}`);
+console.log('');
+
+if (flagged.length) {
+  for (const f of flagged) {
+    console.log(`✗ ${f.changedRel} changed content, but its translation sibling was not updated in this branch:`);
+    console.log(`    EN:     ${f.enRel}`);
+    console.log(`    locale: ${f.localeRel}`);
+    console.log(
+      `    Fix: update the sibling in this PR, or add an entry to data/translation_parity_exceptions.json` +
+        ` documenting why they're allowed to diverge (see CLAUDE.md, "Translation Parity").`
+    );
+    console.log('');
+  }
+  process.exit(1);
+} else {
+  console.log('No unresolved translation-parity drift introduced by this branch.');
+  process.exit(0);
+}

--- a/scripts/lib/content-fingerprint.js
+++ b/scripts/lib/content-fingerprint.js
@@ -1,0 +1,125 @@
+'use strict';
+
+/**
+ * content-fingerprint.js
+ *
+ * Language-independent "structural fingerprint" of a page: which content
+ * pages it links to (resolved through the hreflang cluster map so a
+ * locale-native link and its EN equivalent count as the same target — see
+ * "Locale-native internal linking" in CLAUDE.md), plus FAQ/h2/symbol-tile
+ * counts. Shared by audit-translation-parity.js (point-in-time site sweep)
+ * and check-translation-parity.js (per-PR diff gate) so "did this page's
+ * content actually change" means the same thing in both places.
+ */
+
+const cheerio = require('cheerio');
+const { normalizeUrl } = require('./translation-clusters');
+
+const CONTENT_LINK_RE = /^\/(category|library|symbol|guide|answers|usecase|updates)\//;
+
+/**
+ * @param {Map} byUrl - from discoverClusters(): normalized canonical -> record
+ * @param {Set} localeCodes - from discoverClusters(): known locale hreflang codes
+ */
+function createFingerprinter(byUrl, localeCodes) {
+  const localeCodesSorted = [...localeCodes].sort((a, b) => b.length - a.length); // longest first (zh-tw before zh)
+
+  function stripLocalePrefix(pathname) {
+    for (const code of localeCodesSorted) {
+      const prefix = `/${code}/`;
+      if (pathname.toLowerCase().startsWith(prefix)) {
+        return pathname.slice(prefix.length - 1); // keep leading slash
+      }
+    }
+    return pathname;
+  }
+
+  // A raw href diff produces false positives from *correct* locale-native
+  // linking (a locale page linking its own translated sibling instead of the
+  // EN slug). Resolve every link through the cluster map to its EN-canonical
+  // identity before comparing; fall back to locale-prefix stripping only when
+  // the target isn't part of any known cluster.
+  function identityHref(absUrl) {
+    const rec = byUrl.get(absUrl);
+    if (rec) {
+      if (rec.ownLang === 'en') return rec.canonical;
+      const enAlt = rec.alternates.find((a) => a.hreflang === 'en');
+      if (enAlt) return enAlt.href;
+    }
+    return absUrl;
+  }
+
+  function normalizeContentHref(href) {
+    try {
+      const u = href.startsWith('http') ? new URL(href) : new URL(href, 'https://ultratextgen.com/');
+      const full = normalizeUrl(u.origin + u.pathname);
+      const resolved = identityHref(full);
+      let p = new URL(resolved).pathname.replace(/\/+$/, '/') || '/';
+      p = stripLocalePrefix(p);
+      return p;
+    } catch {
+      return null;
+    }
+  }
+
+  function countJsonLdQuestions(html) {
+    const scriptRe = /<script[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
+    let m;
+    let count = 0;
+    const walk = (node) => {
+      if (!node || typeof node !== 'object') return;
+      if (Array.isArray(node)) return node.forEach(walk);
+      if (node['@type'] === 'Question') count++;
+      for (const k of Object.keys(node)) walk(node[k]);
+    };
+    while ((m = scriptRe.exec(html))) {
+      try {
+        walk(JSON.parse(m[1]));
+      } catch {
+        // malformed JSON-LD is a separate problem, not this tool's job
+      }
+    }
+    return count;
+  }
+
+  function fingerprint(html) {
+    const $ = cheerio.load(html);
+    const links = new Set();
+    $('a[href]').each((_, el) => {
+      const href = $(el).attr('href');
+      if (!href) return;
+      const norm = normalizeContentHref(href);
+      if (norm && CONTENT_LINK_RE.test(norm)) links.add(norm);
+    });
+    return {
+      links,
+      h2Count: $('h2').length,
+      faqCount: countJsonLdQuestions(html),
+      symbolTileCount: $('.symbol-tile').length,
+    };
+  }
+
+  function diff(enFp, fp) {
+    return {
+      onlyInEN: [...enFp.links].filter((l) => !fp.links.has(l)).sort(),
+      onlyInLocale: [...fp.links].filter((l) => !enFp.links.has(l)).sort(),
+      h2Delta: enFp.h2Count - fp.h2Count,
+      faqDelta: enFp.faqCount - fp.faqCount,
+      symbolTilesDelta: enFp.symbolTileCount - fp.symbolTileCount,
+    };
+  }
+
+  function score(d) {
+    return (
+      d.onlyInEN.length +
+      d.onlyInLocale.length +
+      (d.h2Delta !== 0 ? 1 : 0) +
+      (d.faqDelta !== 0 ? 1 : 0) +
+      (d.symbolTilesDelta !== 0 ? 1 : 0)
+    );
+  }
+
+  return { fingerprint, diff, score, normalizeContentHref };
+}
+
+module.exports = { createFingerprinter, CONTENT_LINK_RE };

--- a/scripts/lib/translation-clusters.js
+++ b/scripts/lib/translation-clusters.js
@@ -1,0 +1,107 @@
+'use strict';
+
+/**
+ * translation-clusters.js
+ *
+ * Shared hreflang-cluster discovery, used by both
+ * scripts/audit-translation-parity.js (point-in-time site-wide audit) and
+ * scripts/check-translation-parity.js (per-PR diff gate). Kept in one place
+ * so the two scripts can never silently disagree on what counts as a
+ * cluster, a locale, or an EN anchor.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { globSync } = require('glob');
+
+const SKIP_SEGMENTS = ['embed', 'widget', 'test', 'demo', '404', '_root'];
+const SKIP_DIRS = ['node_modules', 'reports', 'data', 'functions', 'fonts'];
+
+function shouldSkip(root, filePath) {
+  const rel = path.relative(root, filePath).replace(/\\/g, '/');
+  if (rel === '_root.html') return true;
+  const segments = rel.split('/');
+  for (const seg of segments) {
+    const lower = seg.toLowerCase();
+    if (SKIP_SEGMENTS.includes(lower)) return true;
+    if (SKIP_DIRS.includes(lower)) return true;
+    if (/\.(test|demo|widget|embed)\b/i.test(seg)) return true;
+  }
+  return false;
+}
+
+function getAttr(tag, name) {
+  const m = tag.match(new RegExp(name + '\\s*=\\s*(?:"([^"]*)"|\'([^\']*)\')', 'i'));
+  return m ? (m[1] !== undefined ? m[1] : m[2]) : null;
+}
+
+function normalizeUrl(url) {
+  if (!url) return url;
+  return url.trim().replace(/^http:/, 'https:').replace(/\/+$/, '/');
+}
+
+function extractLinks(html) {
+  let canonical = null;
+  const alternates = [];
+  const tagRe = /<link\b[^>]*>/gi;
+  let m;
+  while ((m = tagRe.exec(html))) {
+    const tag = m[0];
+    const rel = (getAttr(tag, 'rel') || '').toLowerCase();
+    const href = getAttr(tag, 'href');
+    if (!href) continue;
+    if (rel === 'canonical') canonical = href;
+    else if (rel === 'alternate') {
+      const hreflang = getAttr(tag, 'hreflang');
+      if (hreflang) alternates.push({ hreflang, href });
+    }
+  }
+  return { canonical, alternates };
+}
+
+/**
+ * Scan every HTML file under `root` and return { byUrl, clusters, localeCodes }.
+ *   byUrl:       normalized canonical URL -> { rel, filePath, canonical, alternates, ownLang, html }
+ *   clusters:    EN canonical URL -> Set of member canonical URLs (includes the EN URL itself)
+ *   localeCodes: Set of every non-"en" hreflang code seen on a self-referencing <link>
+ */
+function discoverClusters(root) {
+  const files = globSync('**/*.html', { cwd: root, absolute: true }).filter((f) => !shouldSkip(root, f));
+
+  const byUrl = new Map();
+  const localeCodes = new Set();
+
+  for (const file of files) {
+    const rel = path.relative(root, file).replace(/\\/g, '/');
+    const html = fs.readFileSync(file, 'utf8');
+    const { canonical, alternates } = extractLinks(html);
+    if (!canonical) continue;
+
+    const canon = normalizeUrl(canonical);
+    const alts = alternates.map((a) => ({ hreflang: a.hreflang, href: normalizeUrl(a.href) }));
+    const selfEntry = alts.find((a) => a.href === canon && a.hreflang !== 'x-default');
+    const ownLang = selfEntry ? selfEntry.hreflang : null;
+    if (ownLang && ownLang !== 'en') localeCodes.add(ownLang.toLowerCase());
+
+    byUrl.set(canon, { rel, filePath: file, canonical: canon, alternates: alts, ownLang, html });
+  }
+
+  const clusters = new Map();
+  for (const [url, rec] of byUrl) {
+    let anchor = null;
+    if (rec.ownLang === 'en') {
+      anchor = rec.canonical;
+    } else {
+      const enAlt = rec.alternates.find((a) => a.hreflang === 'en');
+      if (enAlt) anchor = enAlt.href;
+    }
+    if (!anchor) continue;
+    if (!clusters.has(anchor)) clusters.set(anchor, new Set());
+    clusters.get(anchor).add(url);
+    clusters.get(anchor).add(anchor);
+  }
+
+  return { byUrl, clusters, localeCodes };
+}
+
+module.exports = { shouldSkip, getAttr, normalizeUrl, extractLinks, discoverClusters, SKIP_SEGMENTS, SKIP_DIRS };


### PR DESCRIPTION
## Summary

Adds a two-part translation parity system to catch and prevent content drift between English pages and their locale translations. This addresses a real failure mode (e.g., currency symbol pages added to `/library/` without updating any of 9 locale siblings) by providing both discovery and enforcement.

## Key Changes

- **`scripts/audit-translation-parity.js`** — Point-in-time site-wide audit that diffs a language-independent "structural fingerprint" (internal content links resolved through hreflang clusters, FAQ/`<h2>`/`.symbol-tile` counts) between EN pages and locale siblings. Surfaces drift grouped by root cause (recent EN `feat:` commits whose locale siblings weren't touched), with bulk/coverage-gap pairs bucketed separately to avoid noise. Supports `--report`, `--json`, `--full`, `--show-bulk`, and `--threshold` flags for different views.

- **`scripts/check-translation-parity.js`** — Per-PR enforcement gate (wired into `.github/workflows/validate.yml`). For every changed HTML file whose structural fingerprint actually moved, requires at least one sibling in its hreflang cluster to have been touched in the same PR — unless the pair is listed in `data/translation_parity_exceptions.json`. Fails the PR with the exact file pair and fix instructions. Byte-level edits (typos, meta tweaks) never trigger it.

- **`scripts/lib/translation-clusters.js`** — Shared hreflang cluster discovery used by both audit and enforcement. Scans all HTML files, extracts canonical/alternate links, and builds cluster maps so both scripts define "cluster" and "locale" identically.

- **`scripts/lib/content-fingerprint.js`** — Shared fingerprinting logic. Extracts language-independent structural signals: internal content links (resolved through cluster map so locale-native links and EN equivalents count as a match), FAQ question counts (from JSON-LD), `<h2>` counts, and `.symbol-tile` counts. Provides `fingerprint()`, `diff()`, and `score()` functions used by both audit and enforcement.

- **`data/translation_parity_exceptions.json`** — Ledger of intentional EN ↔ locale divergences (reason + date). Every entry represents an explicit, discussed decision with the user, not silence. Suppresses false positives in both audit and enforcement.

- **`.github/workflows/validate.yml`** — Updated to add `check-translation-parity.js` as a required CI check (same continue-on-error-then-fail pattern as hreflang/library/image validators). Fetch depth set to 0 so the PR branch can be diffed against its base.

- **`package.json`** — Added `audit:translation-parity` and `check:translation-parity` npm scripts.

- **`CLAUDE.md`** — Added "Translation Parity" section documenting the rule (structural edits require sibling sync or explicit exception), the tooling, and the ledger workflow.

- **`data/translation_parity_audit_2026-07-23.md`** — Initial audit snapshot showing 1061 actionable drift pairs and 12 high-confidence EN `feat:` commits with un-synced locale siblings (e.g., the currency-symbols case).

## Implementation Details

- **Fingerprint resolution:** Links are resolved through the hreflang cluster map before comparison, so a locale page linking its own translated sibling (correct locale-native linking) doesn't produce a false-positive diff against the EN page linking the EN slug.

- **Scoring:** Drift is scored by count of differing links + presence of section/FAQ/tile count changes. Pairs are bucketed by score (actionable ≤12, bulk >12) to separate real missed syncs from legitimate translation-coverage gaps.

- **Root-cause grouping:** The audit groups flagged pairs by EN `feat:` commits that landed after the locale sibling's last touch, surfacing the most likely "someone added content and forgot to sync" cases.

- **Enforcement scope:** Only structural changes trigger the check; byte-level edits (typos, meta-description tweaks) are ignored via fingerprint comparison.

- **Exception led

https://claude.ai/code/session_01PNEUzd2LbFhNLWP9BCbnNX