### PR TITLE
Add locale parent governance: Core Parent Set + Tier registries + pre-build gap checks

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -3,13 +3,16 @@ name: Validate Site
 # Required, blocking checks for structural correctness that must never merge
 # broken: hreflang reciprocity, /library/ and /symbol/ page structure,
 # per-page social/Pinterest image assets, new/changed pages' image assets
-# specifically, and translation parity — an EN <-> locale content change
-# introduced by this PR without its sibling being updated. Each validator
-# already exits non-zero on failure (see scripts/audit-hreflang.js,
-# scripts/validate_library_pages.py, scripts/check-image-assets.py,
-# scripts/check-new-page-image-assets.py, scripts/check-translation-parity.js)
-# — this workflow is what actually wires that into CI so a PR can't merge
-# broken pages.
+# specifically, translation parity — an EN <-> locale content change
+# introduced by this PR without its sibling being updated — locale mesh
+# health (hreflang reciprocity + locale-native internal links on any locale
+# page this PR touches), and the locale-parent-gap pre-build check on any
+# new locale page. Each validator already exits non-zero on failure (see
+# scripts/audit-hreflang.js, scripts/validate_library_pages.py,
+# scripts/check-image-assets.py, scripts/check-new-page-image-assets.py,
+# scripts/check-translation-parity.js, scripts/check-locale-mesh.js,
+# scripts/check-locale-parent-gap.js) — this workflow is what actually wires
+# that into CI so a PR can't merge broken pages.
 #
 # scripts/check-image-assets.py is a whole-site audit (also requires a
 # Pinterest pin per page) and the site carries a large, deliberately-paced
@@ -20,6 +23,16 @@ name: Validate Site
 # pre-existing site-wide backlog can never make it permanently red. This
 # exists specifically to stop new pages shipping ahead of their hero/OG art —
 # see ultratextgen-lab-'s gsc-technical-seo-leakage-audit-2026-07-24.md §6.
+#
+# scripts/audit-locale-parent-gap.js is likewise a whole-site discovery pass
+# (which Core-parent x qualified-locale cells have near-zero translation
+# coverage and no recorded pre-build gap check) and stays informational for
+# the same reason check-image-assets.py does: the site carries a real,
+# deliberately-paced locale-translation backlog, so this can't be a per-PR
+# gate without being permanently red. scripts/check-locale-mesh.js and
+# scripts/check-locale-parent-gap.js are the diff-scoped gates that actually
+# enforce mesh health and the pre-build gap check on what a PR adds/changes —
+# see CLAUDE.md, "Locale Parent Governance", and docs/locale-parent-governance.md.
 #
 # All steps run every time (continue-on-error on each) so a single PR shows
 # every problem at once instead of stopping at the first failure; the final
@@ -82,6 +95,21 @@ jobs:
         continue-on-error: true
         run: npm run check:translation-parity -- --base origin/${{ github.event.pull_request.base.ref || 'main' }} | tee translation-parity.log
 
+      - name: Run locale mesh check
+        id: locale_mesh
+        continue-on-error: true
+        run: npm run check:locale-mesh -- --base origin/${{ github.event.pull_request.base.ref || 'main' }} | tee locale-mesh.log
+
+      - name: Run locale parent gap check
+        id: locale_parent_gap
+        continue-on-error: true
+        run: npm run check:locale-parent-gap -- --base origin/${{ github.event.pull_request.base.ref || 'main' }} | tee locale-parent-gap.log
+
+      - name: Run locale parent gap audit (whole-site, informational)
+        id: locale_parent_gap_audit
+        continue-on-error: true
+        run: npm run audit:locale-parent-gap | tee locale-parent-gap-audit.log
+
       - name: Build step summary
         if: always()
         run: |
@@ -112,14 +140,33 @@ jobs:
             echo '```'
             cat translation-parity.log
             echo '```'
+            echo ""
+            echo "### Locale mesh check — \`${{ steps.locale_mesh.outcome }}\`"
+            echo '```'
+            cat locale-mesh.log
+            echo '```'
+            echo ""
+            echo "### Locale parent gap check — \`${{ steps.locale_parent_gap.outcome }}\`"
+            echo '```'
+            cat locale-parent-gap.log
+            echo '```'
+            echo ""
+            echo "### Locale parent gap audit (whole-site, informational) — \`${{ steps.locale_parent_gap_audit.outcome }}\`"
+            echo '```'
+            cat locale-parent-gap-audit.log
+            echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Fail the job if any gating validator reported problems
-        # steps.images (the whole-site audit) is deliberately excluded — see
-        # its step name/comment above: it's permanently informational because
-        # of the accepted Pinterest-pin backlog, not because failures there
-        # don't matter. steps.new_images is the actual gate for image assets.
-        if: steps.hreflang.outcome == 'failure' || steps.library.outcome == 'failure' || steps.new_images.outcome == 'failure' || steps.parity.outcome == 'failure'
+        # steps.images and steps.locale_parent_gap_audit (both whole-site
+        # audits) are deliberately excluded — see their step names/comments
+        # above: informational by design (the Pinterest-pin backlog for
+        # images; the site-wide, deliberately-unfinished locale-parent
+        # translation backlog for the gap audit), not because failures there
+        # don't matter. steps.new_images, steps.locale_mesh, and
+        # steps.locale_parent_gap are the diff-scoped gates that actually
+        # enforce these two systems on new/changed pages.
+        if: steps.hreflang.outcome == 'failure' || steps.library.outcome == 'failure' || steps.new_images.outcome == 'failure' || steps.parity.outcome == 'failure' || steps.locale_mesh.outcome == 'failure' || steps.locale_parent_gap.outcome == 'failure'
         run: |
           echo "One or more gating validators failed — see the Summary tab above for details."
           exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -751,6 +751,100 @@ user before recording it as intentional.
 
 ---
 
+## Locale Parent Governance — Core Parent Set, Locale Qualification Tiers, and the pre-build gap check
+
+The English-Parent Rule (above) governs *does a parent exist*. Translation
+Parity (above) governs *do EN and a locale sibling stay in sync after both
+exist*. Neither one answers *should this parent even be mirrored into this
+locale by default*, and the site went a long time answering that question
+by "wait for a forum thread to surface it" — a mechanism with a proven,
+expensive blind spot: EN `/symbol/` had 77 pages, FR `/symbol/` had 6, and
+nothing flagged it until a one-off manual Semrush pull (2026-07-14) found
+**~49,960 searches/month** of directly-evidenced French demand (euro-sign
+14,800/mo, micro-sign 5,400/mo, not-equal-sign 4,190/mo, delta-symbol
+3,600/mo, +11 more slugs) sitting there undetected the whole time the
+English parents were live.
+
+**The rule:** two data-driven registries replace tribal knowledge about
+which parents/locales get mirrored, and the default only flips to "mirror"
+at their intersection:
+
+- **`data/core_parent_set.json`** — tiers page-pattern prefixes (`symbol/*`,
+  `library/*`, `category/*`, specific `usecase/` carve-outs, pillar hub-index
+  overrides, …) as `core` (mirror by default — burden of proof is on NOT
+  translating), `gated` (translate only on a cleared demand check — burden
+  of proof is on translating), or `never`. Most-specific-pattern wins when
+  more than one entry matches a path.
+- **`data/locale_qualification_tiers.json`** — tiers every one of the 28
+  canonical locale codes as Tier 1 (deepen + mirror Core now), Tier 2
+  (qualify via the existing 7-point gate, then mirror Core), or Tier 3
+  (hold/stub, no spec mirroring). `vi` is Tier 2 but explicitly `hold: true`
+  — its problem is an authority/indexing gap, not a content gap; do not add
+  vi content.
+
+`scripts/lib/locale-parent-registry.js`'s `decide(relPath, localeCode)` walks
+the full 5-step flowchart (Tier-3/held locale → skip; script-incompatible
+Core parent → skip this parent here; Core parent → mirror by default; gated
+tail → gate by default; on ship, mesh is generated automatically) and
+returns a decision object, not a bare string. Run
+`node scripts/check-locale-parent-tier.js <path> <locale>` before starting
+any new locale-page work to see exactly what it returns. Full schema, the
+complete flowchart, and every script's flags/exit codes:
+**`docs/locale-parent-governance.md`**.
+
+### Tooling
+
+- **`node scripts/sync-locale-mesh.js`** (`npm run sync:locale-mesh`) —
+  generates the reciprocal hreflang set (by delegating to the existing
+  `scripts/audit-hreflang.js --fix`, gated on this script's own `--fix` flag)
+  and locale-native internal-link rewrites (via the new
+  `scripts/lib/locale-link-rewrite.js`), scoped to `--files <path...>` or the
+  whole tree by default. Report mode (no `--fix`) is safe/read-only; `--fix`
+  mutates in place. This is the Phase-0 "generated, not audited" mesh
+  automation — `scripts/generate_library_page_from_spec.py` calls it
+  automatically (best-effort, `--fix --files <new page>`) right after writing
+  any non-English page; other generators should get the same hook the next
+  time they're touched.
+- **`node scripts/check-locale-mesh.js`** (`npm run check:locale-mesh`) —
+  the enforcing, diff-scoped PR gate, wired into `.github/workflows/validate.yml`.
+  For every changed locale page: fails if its hreflang cluster has a
+  non-reciprocal or headless member, or if it links an English hub/spoke
+  where a locale-native equivalent already exists and wasn't rewritten. Fix
+  is always `npm run sync:locale-mesh -- --fix`.
+- **`node scripts/check-locale-parent-tier.js <path> <locale>`** (`npm run
+  check:locale-parent-tier`) — advisory (always exits 0). Prints the
+  registry's decision for a candidate (parent, locale) pair and, if a
+  pre-build gap check is required, the exact instrument questions to answer.
+  Run this before starting new locale-page work, not after.
+- **`node scripts/audit-locale-parent-gap.js`** (`npm run
+  audit:locale-parent-gap`) — whole-site discovery pass, the systematic
+  version of the FR `/symbol/` find: for every Core parent x qualified
+  locale, flags a cell as an unaudited gap when translation coverage is
+  near-zero and no `data/locale_parent_gap_audit.json` entry exists.
+  Informational only (like `check-image-assets.py`) — the site carries a
+  real, deliberately-paced translation backlog this will not zero out in one
+  pass.
+- **`node scripts/check-locale-parent-gap.js`** (`npm run
+  check:locale-parent-gap`) — the enforcing, diff-scoped PR gate, wired into
+  `.github/workflows/validate.yml`. For every newly-added locale page,
+  requires a passing `data/locale_parent_gap_audit.json` entry whenever the
+  registry's decision needed one (a gated-tail build, a Tier-3/held-locale
+  exception, or a script-incompatible-parent exception) — i.e. the page was
+  built against the registry's default recommendation without a recorded
+  reason.
+
+**Do not add or edit an entry in `data/locale_parent_gap_audit.json`,
+`data/core_parent_set.json`, or `data/locale_qualification_tiers.json`
+unilaterally.** Every entry in all three reflects a discussed decision
+between you and the user — the same bar CLAUDE.md's English-Parent Rule sets
+for locale-first exceptions, and the same bar `data/translation_parity_exceptions.json`
+sets for parity divergences. If one of the gap-check scripts flags a
+missing entry, either raise the divergence with the user or run the actual
+instrument check and record it — don't edit the registry to make a page you
+want to ship pass.
+
+---
+
 ## New pages must ship with their hero/OG/Twitter art in the same change
 
 A new or edited page's `og:image`, `twitter:image`, and (if it declares one)
@@ -929,3 +1023,13 @@ Do not add a test framework unless explicitly requested.
   import the brand skin from `scripts/generate-site-art.py`; do not bundle `.ttf`
   font files; do not invent a pin look (no Poppins/pills/saturated colors/green
   CTA — use the off-white panel + dot grid + purple→blue brand skin).
+- Do not ship a new locale page for a gated-tail parent, or for a Tier-3/held
+  locale, without a recorded, passing entry in
+  `data/locale_parent_gap_audit.json`. See "Locale Parent Governance" above
+  — `scripts/check-locale-parent-gap.js` enforces this in CI, and
+  `scripts/check-locale-parent-tier.js <path> <locale>` tells you the answer
+  before you start building.
+- Do not hand-edit hreflang `<link>` tags or a locale page's internal links
+  to route around a missing sibling or a stale English-hub link — run
+  `npm run sync:locale-mesh -- --fix` instead. See "Locale Parent Governance"
+  above — `scripts/check-locale-mesh.js` enforces the result in CI.

--- a/data/core_parent_set.json
+++ b/data/core_parent_set.json
@@ -1,0 +1,112 @@
+{
+  "_readme": "Core Parent Set registry (data-driven, not tribal knowledge) — implements the 'Two new registries' governance change from the locale/parent strategy decision that authorized this file (see CLAUDE.md, 'Locale Parent Governance'). Read by scripts/lib/locale-parent-registry.js's classifyParent(relPath), which does most-specific-pattern-wins matching against the `parents` array below: a pattern ending in '/*' matches any path under that prefix; a pattern with no '*' (e.g. 'category/index.html') matches only that exact file. When more than one pattern matches a path, the entry whose pattern is the longer/more specific literal prefix wins — this is how, e.g., 'usecase/nickname-generator/*' overrides the general 'usecase/*' gated default for that one spoke, without needing to enumerate every non-core usecase page separately. `tiers` describes each tier's default action and which instrument governs a veto (core) or a pass (gated) — see docs/locale-parent-governance.md for the full per-(parent,locale) decision flowchart. Do NOT edit the tier of a parent, or add/remove/reweight a pattern, unilaterally — every entry here reflects a discussed strategy decision, the same bar CLAUDE.md sets for data/translation_parity_exceptions.json. If a parent's tier looks wrong, raise it with the user first rather than editing this file to fit a page you want to ship.",
+  "tiers": {
+    "core": {
+      "defaultAction": "mirror",
+      "burdenOfProof": "innocent-until-proven-empty",
+      "instrument": "Veto only. A Core parent mirrors into a qualified locale by default; it takes a recorded pre-build check showing genuinely negligible demand (no competitor presence in the locale AND sub-~50/mo keyword signal) to skip it. Record a veto in data/locale_parent_gap_audit.json with verdict \"veto\"."
+    },
+    "gated": {
+      "defaultAction": "do-not-mirror",
+      "burdenOfProof": "guilty-until-proven-present",
+      "instrument": "Pass only. A gated-tail parent does not mirror by default; it takes a recorded pre-build check clearing threshold on ANY of: a ranking competitor in the target locale, four-figure+/mo keyword volume in the target locale, or material EN-page GSC impressions from that locale's language queries. Record a pass in data/locale_parent_gap_audit.json with verdict \"gate-pass\"."
+    },
+    "never": {
+      "defaultAction": "do-not-mirror",
+      "burdenOfProof": "n/a",
+      "instrument": "n/a — never mirror regardless of any demand signal (dated, volatile, or pure-config content)."
+    }
+  },
+  "parents": [
+    {
+      "pattern": "symbol/*",
+      "tier": "core",
+      "scriptIndependent": true,
+      "rationale": "Flagship script-independent single-item Unicode/emoji identity pages — a euro sign is a euro sign in any language. This is literally the FR /symbol/ lane where ~49,960/mo of French demand (euro-sign 14,800, micro-sign 5,400, not-equal-sign 4,190, delta 3,600, +more) sat undetected: EN had 77 symbol pages, FR had 6, and nothing flagged the gap until a manual Semrush pull found it."
+    },
+    {
+      "pattern": "library/*",
+      "tier": "core",
+      "scriptIndependent": true,
+      "rationale": "Flagship script-independent browse/collection pillar — same job as symbol/*, one level up (a currency-symbols or zodiac-signs collection page copies identically regardless of the visitor's language)."
+    },
+    {
+      "pattern": "category/*",
+      "tier": "core",
+      "scriptIndependent": false,
+      "rationale": "Universal, high-EN-authority style pillar (bold/cursive/italic/etc.), but Latin-transform-dependent — the Unicode math-alphanumeric substitutions only make sense for Latin-script text. Mirrors only into Latin-script-qualified locales; for CJK/Arabic/Indic locales substitute the locale's script-appropriate Core subset (symbol/library/name-gen/counter) instead of skipping the locale outright."
+    },
+    {
+      "pattern": "usecase/nickname-generator/*",
+      "tier": "core",
+      "scriptIndependent": true,
+      "rationale": "Generic name/username decoration generator (not a per-game page) — one of the two usecase Core carve-outs the strategy doc names. The underlying job (decorate my display name) is universal, not locale- or script-specific."
+    },
+    {
+      "pattern": "usecase/stylish-name/*",
+      "tier": "core",
+      "scriptIndependent": true,
+      "rationale": "Generic stylish-name generator serving a broad nickname-decoration audience — the other Core usecase carve-out. Distinguished from the per-game name pages below (which stay gated) the same way data/translation_parity_exceptions.json's zh-TW entry already distinguishes this generic EN parent from a locale-specific per-game (Arena of Valor) expansion built on top of it."
+    },
+    {
+      "pattern": "character-counter/*",
+      "tier": "core",
+      "scriptIndependent": true,
+      "rationale": "The invisible-character / blank-text / counter tool the strategy doc names as a Core exception. In the current site structure this job lives as a top-level page (character-counter/), not under usecase/ — tiered here to match the real page rather than inventing a usecase/ path that doesn't exist."
+    },
+    {
+      "pattern": "usecase/*",
+      "tier": "gated",
+      "scriptIndependent": false,
+      "rationale": "Default for the usecase/ section — long-tail spokes (per-game name pages like free-fire-name-generator/valorant-name-generator/clan-tag-generator, niche generators) gate on a pre-build demand check. The two carve-outs above are more specific patterns and win via most-specific-pattern-first precedence, so they don't inherit this default."
+    },
+    {
+      "pattern": "answers/*",
+      "tier": "gated",
+      "scriptIndependent": false,
+      "rationale": "Long-tail zero-click answer spokes — gate on a pre-build demand check (competitor footprint / keyword volume / EN page's own GSC impressions from that locale's language queries)."
+    },
+    {
+      "pattern": "guide/*",
+      "tier": "gated",
+      "scriptIndependent": false,
+      "rationale": "Educational/authority long-tail — gate on a pre-build demand check, same instrument as answers/*."
+    },
+    {
+      "pattern": "category/index.html",
+      "tier": "core",
+      "scriptIndependent": true,
+      "rationale": "Locale pillar hub index page for the Category pillar. Most locales currently route this pillar to the English hub because the locale-native hub was never built ('no locale has those hubs built' for 4 of 7 pillars, per the strategy doc) — this file is Core once built. Marked script-independent (unlike category/* generally) because the hub itself is a nav/browse page, not a Latin-transform generator; the deeper style spokes under category/* keep the script-dependent rule."
+    },
+    {
+      "pattern": "usecase/index.html",
+      "tier": "core",
+      "scriptIndependent": true,
+      "rationale": "Locale pillar hub index page for the Use Cases pillar — same 'hub not built per locale' gap as category/index.html above. Overrides the usecase/* gated default for this one file only; the long-tail spokes beneath it stay gated."
+    },
+    {
+      "pattern": "answers/index.html",
+      "tier": "core",
+      "scriptIndependent": true,
+      "rationale": "Locale pillar hub index page for the Answers pillar — same rationale as usecase/index.html. Overrides the answers/* gated default for this one file only."
+    },
+    {
+      "pattern": "printables/index.html",
+      "tier": "core",
+      "scriptIndependent": true,
+      "rationale": "Locale pillar hub index page for the Printables pillar (grouped with Events as 'Printables/Events' in the strategy doc's pillar count) — same 'hub not built per locale' gap."
+    },
+    {
+      "pattern": "events/index.html",
+      "tier": "core",
+      "scriptIndependent": true,
+      "rationale": "Locale pillar hub index page for the Events (holiday/calendar generator) pillar — same rationale as printables/index.html, grouped with it in the strategy doc's pillar count."
+    },
+    {
+      "pattern": "updates/*",
+      "tier": "never",
+      "scriptIndependent": false,
+      "rationale": "Dated Unicode/platform/game rule-change log — already Pinterest-pin-excluded, low per-page yield, and inherently volatile. Never mirror regardless of demand signal."
+    }
+  ]
+}

--- a/data/locale_parent_gap_audit.json
+++ b/data/locale_parent_gap_audit.json
@@ -1,0 +1,18 @@
+{
+  "_readme": "Ledger of recorded pre-build competitor+keyword gap checks for (Core-parent-pattern, locale) cells and gated-tail-pattern build exceptions — the instrument that replaces incidental discovery (the FR /symbol/ blind spot: EN had 77 symbol pages, FR had 6, and nothing flagged the ~49,960/mo of French demand until a manual Semrush pull found it) with a standing, recorded pass. Read/written by scripts/audit-locale-parent-gap.js (whole-site discovery) and scripts/check-locale-parent-gap.js (per-PR gate). Do NOT add or edit an entry here unilaterally — every entry must reflect a real, run instrument check, discussed with the user the same way data/translation_parity_exceptions.json entries are (see CLAUDE.md, 'Locale Parent Governance'). Entry shape: { pattern (a data/core_parent_set.json pattern string, e.g. \"symbol/*\"), locale (locale code), checkedDate (YYYY-MM-DD), instruments: { competitorFootprintInLocale: bool|null, keywordVolumeInLocaleMonthly: number|null, enGscImpressionsFromLocale: number|null } — null means that instrument was not run/available, not zero, evidence (short citation of where the numbers came from), recordedBy }. verdict: \"mirror\" (Core parent, demand confirms the default — informational, not required for the check to pass), \"veto\" (Core parent, pre-build check showed genuinely negligible demand — overrides the default-mirror), \"gate-pass\" (gated-tail parent, pre-build check cleared threshold — authorizes the build), \"gate-fail\" (gated-tail parent, pre-build check did not clear threshold — build not authorized). scripts/check-locale-parent-gap.js treats \"mirror\" and \"gate-pass\" as passing verdicts for a newly-shipped locale page; \"veto\" and \"gate-fail\" record that a page was deliberately NOT built. Do not invent additional entries with fabricated numbers — every cell without a real entry here is genuinely unaudited right now, which is exactly the gap this tooling exists to surface, not paper over.",
+  "entries": [
+    {
+      "pattern": "symbol/*",
+      "locale": "fr",
+      "checkedDate": "2026-07-14",
+      "instruments": {
+        "competitorFootprintInLocale": true,
+        "keywordVolumeInLocaleMonthly": 49960,
+        "enGscImpressionsFromLocale": null
+      },
+      "verdict": "mirror",
+      "evidence": "euro-sign 14,800/mo, micro-sign 5,400/mo, not-equal-sign 4,190/mo, delta-symbol 3,600/mo + 11 more evidence-backed symbol slugs, ~49,960/mo total French demand found via a manual Semrush pull against 15 missing symbol/ pages",
+      "recordedBy": "governance-tooling-audit"
+    }
+  ]
+}

--- a/data/locale_qualification_tiers.json
+++ b/data/locale_qualification_tiers.json
@@ -1,0 +1,33 @@
+{
+  "_readme": "Locale Qualification Tier registry (data-driven, not tribal knowledge) — the second of the two new registries governing which locales are eligible for the Core Parent Set's default-mirror (see data/core_parent_set.json and CLAUDE.md's 'Locale Parent Governance' section). Read by scripts/lib/locale-parent-registry.js's classifyLocale(code) and decide(). `locales` is keyed by the canonical 28-locale-code list this repo's locale tooling agrees on (mirrors scripts/check-image-assets.py's LOCALES tuple) — every code must appear here so no locale tooling has to guess a default for a code it doesn't recognize. `tier`: 1 = deepen + mirror the Core Parent Set now; 2 = qualify via the existing 7-point language gate, then mirror Core on pass; 3 = hold/stub — no spec mirroring until promoted. `action` is a short human-readable label for the tier. `hold` (only ever true for \"vi\" today) marks a locale that would otherwise be Tier-2-eligible but is explicitly on hold for a non-content reason recorded in `holdReason` — do not add content there even though the tier number alone would allow it. `notes` is optional free text. Do NOT edit any locale's tier/hold flag unilaterally — every entry here reflects a discussed strategy decision, the same bar CLAUDE.md sets for data/translation_parity_exceptions.json. If a locale's tier looks wrong (or a locale needs promoting after passing the 7-point gate), raise it with the user first rather than editing this file to unblock a page you want to ship.",
+  "locales": {
+    "id": { "tier": 1, "action": "deepen-then-mirror-core", "hold": false, "notes": "Retains the standing 60% near-term allocation; already the deepest/highest-yield locale (30 /id/ pages -> 417,877 impressions / 18,913 clicks / 4.5% CTR per the strategy doc's appendix)." },
+    "pt": { "tier": 1, "action": "deepen-then-mirror-core", "hold": false },
+    "de": { "tier": 1, "action": "deepen-then-mirror-core", "hold": false },
+    "fr": { "tier": 1, "action": "deepen-then-mirror-core", "hold": false },
+    "tr": { "tier": 1, "action": "deepen-then-mirror-core", "hold": false },
+    "it": { "tier": 1, "action": "deepen-then-mirror-core", "hold": false },
+    "es": { "tier": 1, "action": "deepen-then-mirror-core", "hold": false },
+    "pl": { "tier": 2, "action": "qualify-then-mirror-core", "hold": false },
+    "nl": { "tier": 2, "action": "qualify-then-mirror-core", "hold": false },
+    "ar": { "tier": 2, "action": "qualify-then-mirror-core", "hold": false },
+    "ko": { "tier": 2, "action": "qualify-then-mirror-core", "hold": false },
+    "ja": { "tier": 2, "action": "qualify-then-mirror-core", "hold": false },
+    "ru": { "tier": 2, "action": "qualify-then-mirror-core", "hold": false },
+    "th": { "tier": 2, "action": "qualify-then-mirror-core", "hold": false },
+    "vi": { "tier": 2, "action": "qualify-then-mirror-core", "hold": true, "holdReason": "Authority/indexing gap — not a content gap. Do not add vi content; it needs backlinks, not translations." },
+    "hi": { "tier": 3, "action": "hold-stub", "hold": false, "notes": "Named individually as Tier 3 in the strategy doc (9 pages at time of writing). No spec mirroring. Consolidate the switcher, validate head-term demand, then promote via the 7-point gate." },
+    "tl": { "tier": 3, "action": "hold-stub", "hold": false, "notes": "Named individually as Tier 3 in the strategy doc (6 pages at time of writing)." },
+    "hu": { "tier": 3, "action": "hold-stub", "hold": false, "notes": "Named individually as Tier 3 in the strategy doc (3 pages at time of writing)." },
+    "bs": { "tier": 3, "action": "hold-stub", "hold": false, "notes": "Not individually qualified in the strategy doc — default conservative tier for the 'shadow/duplicate locales' bucket." },
+    "cs": { "tier": 3, "action": "hold-stub", "hold": false, "notes": "Not individually qualified in the strategy doc — default conservative tier for the 'shadow/duplicate locales' bucket." },
+    "da": { "tier": 3, "action": "hold-stub", "hold": false, "notes": "Not individually qualified in the strategy doc — default conservative tier for the 'shadow/duplicate locales' bucket." },
+    "hr": { "tier": 3, "action": "hold-stub", "hold": false, "notes": "Not individually qualified in the strategy doc — default conservative tier for the 'shadow/duplicate locales' bucket." },
+    "no": { "tier": 3, "action": "hold-stub", "hold": false, "notes": "Not individually qualified in the strategy doc — default conservative tier for the 'shadow/duplicate locales' bucket." },
+    "ro": { "tier": 3, "action": "hold-stub", "hold": false, "notes": "Not individually qualified in the strategy doc — default conservative tier for the 'shadow/duplicate locales' bucket." },
+    "sk": { "tier": 3, "action": "hold-stub", "hold": false, "notes": "Not individually qualified in the strategy doc — default conservative tier for the 'shadow/duplicate locales' bucket." },
+    "sr": { "tier": 3, "action": "hold-stub", "hold": false, "notes": "Not individually qualified in the strategy doc — default conservative tier for the 'shadow/duplicate locales' bucket." },
+    "sv": { "tier": 3, "action": "hold-stub", "hold": false, "notes": "Not individually qualified in the strategy doc — default conservative tier for the 'shadow/duplicate locales' bucket." },
+    "zh-tw": { "tier": 3, "action": "hold-stub", "hold": false, "notes": "Not individually qualified in the strategy doc — default conservative tier for the 'shadow/duplicate locales' bucket." }
+  }
+}

--- a/docs/locale-parent-governance.md
+++ b/docs/locale-parent-governance.md
@@ -1,0 +1,470 @@
+# Locale Parent Governance
+
+This document is the deep reference for the Core Parent Set / Locale
+Qualification Tier registries, the per-(parent, locale) decision flowchart,
+the five scripts that automate and enforce them, and the mesh-automation hook
+wired into `scripts/generate_library_page_from_spec.py`. CLAUDE.md's "Locale
+Parent Governance" section is the short pointer; this is the operating
+manual, in the same spirit as `docs/unicode-library-workflow.md` and
+`docs/pinterest-pin-generation.md`.
+
+It extends (does not replace) two rules already in CLAUDE.md:
+
+- **"Localization Workflow — the English-Parent Rule"** — every locale page
+  has a live English parent; this doc governs *which* parents get mirrored
+  *by default* and *into which locales*, not whether a parent must exist
+  first.
+- **"Locale-native internal linking"** — a locale page's outbound links to a
+  topic that already has a locale-native page must point there, not at the
+  English hub. This doc's mesh-automation tooling (§1) generates that
+  linking at publish time instead of relying on a later audit pass to catch
+  it.
+
+---
+
+## Why this exists
+
+Before this tooling, the site's locale-translation decisions were governed by
+two things: an English-Parent Rule (does a parent exist at all) and a
+7-point demand gate applied ad hoc, mostly triggered by a forum thread
+surfacing. That combination has a proven blind spot: EN `/symbol/` had 77
+pages, FR `/symbol/` had 6, and nobody ran a systematic check on that gap —
+it sat there until a one-off manual Semrush pull (2026-07-14) found
+**~49,960 searches/month** of directly-evidenced French demand (euro-sign
+14,800/mo, micro-sign 5,400/mo, not-equal-sign 4,190/mo, delta-symbol
+3,600/mo, +11 more slugs) that had simply never been looked for.
+
+The fix isn't "translate everything" (the site's own per-page GSC yield data
+argues strongly against a blanket mirror — 30 focused `/id/` pages
+out-earn 240 generic `/library/` pages roughly 20x per page) or "keep waiting
+for a forum thread" (that's the mechanism that produced the blind spot).
+It's a **data-driven default that flips only at a defined intersection**,
+plus a **standing, systematic pre-build check** instead of incidental
+discovery, plus **mesh generation at publish time** instead of manual
+after-the-fact repair. Those are, respectively, items 2, 3, and 1 below.
+
+---
+
+## 1. Mesh automation — hreflang + locale-native links, generated not audited
+
+**The problem this replaces:** `scripts/audit-hreflang.js` and
+`scripts/check-translation-parity.js` are both *audit-and-repair* tools —
+they find drift after it ships and either report it or require a human to
+fix it. CLAUDE.md's "Locale-native internal linking" section documents a
+recurring bug of exactly this shape: PR #586 fixed 3 instances of a locale
+page linking an English hub instead of its own locale-native sibling; a
+same-day follow-up audit found the identical pattern in 21 more locale
+homepages.
+
+**The fix:** generate the correct mesh at publish time instead of relying on
+a later audit.
+
+### `scripts/lib/locale-link-rewrite.js`
+
+Shared library. Exports `findRewriteCandidates({ byUrl, clusters }, page)`,
+where `byUrl`/`clusters` come from `scripts/lib/translation-clusters.js`'s
+`discoverClusters()` and `page` is one of its `byUrl` records.
+
+For the given page (using `page.ownLang` to know "this page's own locale"),
+it scans every `<a href="...">` and flags a candidate when:
+
+- the link target is an **English (non-locale-prefixed)** URL under one of
+  the monitored sections: `category/`, `library/`, `usecase/`, `guide/`,
+  `answers/`, `symbol/`, or any of the eleven platform roots (`discord/`,
+  `facebook/`, `instagram/`, `linkedin/`, `pinterest/`, `snapchat/`,
+  `telegram/`, `tiktok/`, `whatsapp/`, `x/`, `youtube/`);
+- a **locale-native equivalent for this page's own locale already exists**
+  in that URL's hreflang cluster (i.e. there's actually somewhere better to
+  point);
+- the link is **not already correct**.
+
+Two guards keep this from producing false positives:
+
+- **Language-switcher exclusion.** Any `<a>` tag carrying its own `hreflang`
+  attribute (the footer language-switcher pattern, e.g.
+  `<a class="lang-option" href="/discord/" hreflang="en">EN</a>` on a
+  translated Discord page) is skipped — that link is *supposed* to point at
+  the English version; it is not a content link.
+- **Homepage placeholder guard.** `isHomepage()` (copied from
+  `scripts/audit-hreflang.js`'s own guard of the same name) excludes a bare
+  site root or bare locale homepage — mirroring why `audit-hreflang.js`
+  itself never auto-propagates a subpage's placeholder homepage claim as a
+  real sibling relationship.
+
+Each candidate is returned as
+`{ originalHref, rewrittenHref, matchIndex, context }` — `matchIndex`/
+`context` (the exact original `<a ...>` tag text and its string offset) let
+a caller rewrite the page by exact position rather than a blind
+find-and-replace, so a coincidental identical `href` elsewhere on the same
+page that ISN'T a real candidate (e.g. that same language-switcher link) is
+never touched.
+
+### `scripts/sync-locale-mesh.js`
+
+CLI. `node scripts/sync-locale-mesh.js [--files <path...>] [--fix]`
+
+1. **Step 1 — hreflang reciprocity.** Delegates entirely to the existing
+   `scripts/audit-hreflang.js` (never reimplemented). In `--fix` mode, runs
+   `node scripts/audit-hreflang.js --fix` first, site-wide, so link-rewriting
+   in step 2 always sees an accurate, reciprocal cluster map. In report mode
+   (the default — no `--fix`), it instead runs `audit-hreflang.js` **without**
+   `--fix`, purely to surface hreflang health as read-only context.
+
+   **Design note:** the hreflang-repair cascade is gated on *this script's
+   own* `--fix` flag, not unconditional. That's a deliberate choice so a bare
+   `node scripts/sync-locale-mesh.js` stays a safe, side-effect-free report —
+   matching every other `--fix` tool in this repo (`audit-hreflang.js`,
+   `check-translation-parity.js`) where report mode never mutates anything.
+2. **Step 2 — locale-native link candidates.** Uses `discoverClusters()` +
+   `locale-link-rewrite.js`, scoped to `--files` if given (the generator
+   hook's use case — rewrite just the page it just wrote) or the whole tree
+   by default (the manual/backlog use case). Report mode (default) prints
+   each candidate; `--fix` rewrites the `href` in place, at its exact
+   recorded position.
+
+This is a **fixer tool, not a gate** — it always exits 0. See
+`scripts/check-locale-mesh.js` below for the enforcing PR gate.
+
+### `scripts/check-locale-mesh.js`
+
+Diff-scoped PR gate, built on the same git-diff/merge-base structure as
+`scripts/check-translation-parity.js`. `node scripts/check-locale-mesh.js
+[--base <ref>]` (default `origin/main`).
+
+For every HTML file **added or changed** in the branch whose path starts
+with one of the 28 canonical locale codes and is part of an hreflang
+cluster:
+
+- **(a)** fails if that file's cluster has any non-reciprocal or headless
+  member (the same broken/headless/non-reciprocal detection
+  `audit-hreflang.js` runs site-wide, reimplemented here scoped to just this
+  file's own cluster) — message points at `npm run sync:locale-mesh --
+  --fix`;
+- **(b)** fails if `locale-link-rewrite.js` finds any un-rewritten
+  English-hub-link candidate on that file — message quotes the exact `href`
+  and the locale-native target it should point to instead, citing CLAUDE.md's
+  "Locale-native internal linking" section.
+
+Exit 1 on any violation, 0 otherwise. Wired into `.github/workflows/validate.yml`
+as a **gating** step (included in the final failure condition).
+
+### The generation-time hook
+
+`scripts/generate_library_page_from_spec.py` is the primary generator for
+`library/`/`symbol/` pages — the flagship Core, script-independent pillar
+(literally the FR `/symbol/` lane the whole gap-check system exists to
+catch). Right after it writes a new page and prints its success line
+(`out_path.write_text(...)` in `main()`), if the spec's `lang` is not `"en"`
+it calls a small `_sync_locale_mesh()` helper that shells out to:
+
+```
+node scripts/sync-locale-mesh.js --fix --files <path/to/the/new/page/index.html>
+```
+
+This is **best-effort by design** — a missing `node` binary, a non-zero exit,
+or any other failure is caught, printed as a `[warn]`, and swallowed. Page
+generation itself must never break because the mesh-sync hook failed.
+
+This is the **first** generator wired to the hook. Other generators
+(`answers/`, `events/`, `printables/`) should get the same hook the next
+time they're touched — this pass deliberately doesn't attempt to wire all of
+them at once.
+
+---
+
+## 2. The two registries
+
+### `data/core_parent_set.json`
+
+Answers: *which page patterns are Core (mirror by default), gated tail
+(translate only on cleared demand), or never-mirror?*
+
+```json
+{
+  "tiers": { "core": {...}, "gated": {...}, "never": {...} },
+  "parents": [
+    { "pattern": "symbol/*", "tier": "core", "scriptIndependent": true, "rationale": "..." },
+    ...
+  ]
+}
+```
+
+- **`pattern`** — a repo-root-relative prefix. `"symbol/*"` matches
+  `symbol/euro-sign/index.html` and everything else under `symbol/`.
+  `"category/index.html"` (no `*`) matches only that exact file.
+- **`tier`** — `"core"` / `"gated"` / `"never"`.
+- **`scriptIndependent`** — `true` for a parent whose content renders
+  identically regardless of script (a euro sign is a euro sign in French,
+  Japanese, or Arabic); `false` for a Latin-transform-dependent parent
+  (bold/cursive/italic math-alphanumeric substitution only makes sense for
+  Latin-script text). This drives the script-compatibility overlay in the
+  decision flowchart (§3, step 2).
+- **`rationale`** — short citation of why.
+
+**Precedence: most-specific pattern wins.** When more than one pattern
+matches a path, the entry whose pattern has the longer literal (non-wildcard)
+prefix wins. This is how `"usecase/nickname-generator/*"` (a Core carve-out)
+overrides the general `"usecase/*"` (gated) default for that one page,
+without the registry having to enumerate every non-core `usecase/` page
+individually. Implemented in `scripts/lib/locale-parent-registry.js`'s
+`classifyParent()`.
+
+Current membership (see the file's own `rationale` fields for the full
+reasoning on each):
+
+| Pattern | Tier | Script-independent | Note |
+|---|---|---|---|
+| `symbol/*` | core | yes | flagship — the FR gap lane |
+| `library/*` | core | yes | flagship — same job, one level up |
+| `category/*` | core | no | Latin-transform-dependent |
+| `usecase/nickname-generator/*` | core | yes | generic name/username generator |
+| `usecase/stylish-name/*` | core | yes | generic name/username generator |
+| `character-counter/*` | core | yes | invisible-char/blank-text/counter tool (top-level page, not under `usecase/`) |
+| `usecase/*` | gated | no | default for the section; the two carve-outs above win via precedence |
+| `answers/*` | gated | no | long-tail zero-click spokes |
+| `guide/*` | gated | no | long-tail educational spokes |
+| `category/index.html` | core | yes | Category pillar hub (override) |
+| `usecase/index.html` | core | yes | Use Cases pillar hub (override) |
+| `answers/index.html` | core | yes | Answers pillar hub (override) |
+| `printables/index.html` | core | yes | Printables pillar hub (override) |
+| `events/index.html` | core | yes | Events pillar hub (override) |
+| `updates/*` | never | no | dated/volatile log, already Pinterest-pin-excluded |
+
+The five pillar-hub-index overrides exist because most locales don't have
+these hub pages built yet — locale nav currently routes those pillars to the
+English hub for lack of a locale-native one. They're marked Core so they
+mirror once built, without inheriting their section's otherwise-gated
+default (the hub itself is a nav/browse page, distinct from its long-tail
+spokes).
+
+### `data/locale_qualification_tiers.json`
+
+Answers: *which locales are even eligible for the Core Parent Set's
+default-mirror?*
+
+```json
+{
+  "locales": {
+    "fr": { "tier": 1, "action": "deepen-then-mirror-core", "hold": false },
+    "vi": { "tier": 2, "action": "qualify-then-mirror-core", "hold": true, "holdReason": "..." },
+    ...
+  }
+}
+```
+
+Every one of the 28 canonical locale codes (the same list
+`scripts/check-image-assets.py` uses) has an entry, so no locale tool has to
+guess a default for a code it doesn't recognize.
+
+| Tier | Locales | Action |
+|---|---|---|
+| **1** — deepen + mirror Core now | id, pt, de, fr, tr, it, es | `deepen-then-mirror-core` |
+| **2** — qualify via the 7-point gate, then mirror Core | pl, nl, ar, ko, ja, ru, th, **vi** (HOLD) | `qualify-then-mirror-core` |
+| **3** — hold/stub, no spec mirroring | hi, tl, hu, bs, cs, da, hr, no, ro, sk, sr, sv, zh-tw | `hold-stub` |
+
+**`vi` is Tier 2 but `hold: true`.** Per the strategy that authorized this
+registry: vi's problem is an **authority/indexing gap, not a content gap** —
+do not add vi content; it needs backlinks, not translations. `decide()`
+(§3) treats a held locale the same as a stub for build purposes (its own
+`skip-hold-locale` decision, distinct from `skip-stub-locale` only so the
+reason surfaces correctly).
+
+### `scripts/lib/locale-parent-registry.js`
+
+Shared lookup layer both registries above are read through:
+
+- **`classifyParent(relPath)`** — most-specific-pattern-wins lookup against
+  `core_parent_set.json`. Returns the matched entry, or an
+  `{ tier: "unclassified", ... }` fallback (treated like gated tail) if
+  nothing matches.
+- **`classifyLocale(code)`** — lookup against `locale_qualification_tiers.json`.
+  Returns a `{ tier: 3, action: "hold-stub", ... }` fallback for an unknown
+  code.
+- **`decide(relPath, localeCode)`** — the flowchart, §3 below. Returns
+  `{ decision, reason, requiresLedgerEntry, parentInfo, localeInfo }`, not a
+  bare string, so callers can branch on it.
+- **`LOCALES`** — the canonical 28-code array, derived from
+  `locale_qualification_tiers.json` so every script importing it from here
+  automatically agrees.
+
+---
+
+## 3. The decision flowchart
+
+For a candidate pair (parent `P`, locale `L`), walk this in order — first
+stop wins. Steps 1-3 are what `decide()` implements; steps 4-5 are
+procedural and handled elsewhere (noted below).
+
+1. **Is `L` held or a Tier-3 stub?** → `skip-hold-locale` / `skip-stub-locale`.
+   No spec mirroring. (`vi`'s hold is checked first, ahead of the general
+   Tier-3 check, so its distinct reason — authority gap, not stub — surfaces
+   correctly.)
+2. **Is `P` script-incompatible with `L`?** (`P` is Core with
+   `scriptIndependent: false`, and `L` is one of the CJK/Arabic/Indic locales
+   — `ar, hi, ja, ko, th, zh-tw`) → `skip-script-incompatible`. Substitute
+   `L`'s script-appropriate Core subset (symbol/library/name-gen/counter)
+   instead of skipping the locale outright.
+3. **Is `P` in the Core Parent Set?**
+   - **Yes** → `mirror` (default). `requiresLedgerEntry: false` — no ledger
+     entry needed to build it; only a *veto* (deciding NOT to build a Core
+     parent here) needs one.
+   - **No** (gated tail, or tiered `never`) → `gate` (default: do not
+     mirror). `requiresLedgerEntry: true` — a build against this default
+     needs a recorded pass.
+4. **Cannibalization wiring check** (always, both branches, not part of
+   `decide()`): before wiring internal links, confirm `L`'s
+   homepage/hub doesn't already own the term — the `vi/chu-kieu`
+   trap, already documented in CLAUDE.md's "Before building a page for a
+   keyword: check who already owns it". This decides *how* to internally
+   link, not *whether* to ship, so it stays a human/agent judgment call, not
+   an automated classification.
+5. **On ship** (always, not part of `decide()`): the mesh gets generated —
+   §1's `scripts/sync-locale-mesh.js` / `scripts/check-locale-mesh.js`.
+
+Every decision other than `mirror` sets `requiresLedgerEntry: true` — the
+build happened (or is being evaluated) against the registry's default
+recommendation, so it needs a recorded reason in
+`data/locale_parent_gap_audit.json` (§4) to be considered deliberate rather
+than an oversight.
+
+---
+
+## 4. The pre-build gap check
+
+### `data/locale_parent_gap_audit.json`
+
+The ledger — same `_readme` + array shape as
+`data/translation_parity_exceptions.json`. Each entry:
+
+```json
+{
+  "pattern": "symbol/*",
+  "locale": "fr",
+  "checkedDate": "2026-07-14",
+  "instruments": {
+    "competitorFootprintInLocale": true,
+    "keywordVolumeInLocaleMonthly": 49960,
+    "enGscImpressionsFromLocale": null
+  },
+  "verdict": "mirror",
+  "evidence": "euro-sign 14,800/mo, micro-sign 5,400/mo, ...",
+  "recordedBy": "governance-tooling-audit"
+}
+```
+
+`verdict` is one of `mirror` (Core parent, demand confirms the default),
+`veto` (Core parent, pre-build check showed genuinely negligible demand),
+`gate-pass` (gated-tail parent, pre-build check cleared threshold),
+`gate-fail` (gated-tail parent, did not clear threshold). `check-locale-parent-gap.js`
+treats `mirror` and `gate-pass` as passing verdicts for a newly-shipped page.
+
+The file ships seeded with exactly the one real, instrument-backed data
+point already on record — the FR `/symbol/` case above. Every other
+(pattern, locale) cell is genuinely unaudited right now; that's the gap this
+tooling exists to surface, not paper over. **Do not add an entry
+unilaterally** — same bar as `data/translation_parity_exceptions.json`.
+
+### `scripts/audit-locale-parent-gap.js`
+
+Whole-site discovery pass, templated on `scripts/audit-translation-parity.js`'s
+CLI shape. `node scripts/audit-locale-parent-gap.js [--full] [--json <path>]
+[--report <path>.md]`
+
+For every Core-tier pattern × every qualified locale (Tier 1, or Tier 2 and
+not on hold), counts:
+
+- how many EN-canonical pages match that pattern (via `classifyParent()`, so
+  a page is only ever counted once, under its single most-specific match);
+- how many already have a live translation into that locale (via
+  `discoverClusters()`);
+- whether a `locale_parent_gap_audit.json` entry already exists for that
+  cell.
+
+Flags a cell as an **unaudited gap** when coverage is near-zero (translated
+count is 0, or under 10% of the pattern's EN page count) **and** no ledger
+entry exists — the systematic version of the FR `/symbol/` discovery. Ranks
+output by `scriptIndependent` first (per the strategy behind this doc,
+that's where the highest-priority blind spots live), then by missing-page
+count descending. Default output is the ranked gap list; `--full` prints
+every cell, including already-covered/ledgered ones.
+
+This is a **discovery tool, not a gate** — always exits 0, same as
+`audit-translation-parity.js`. Wired into `.github/workflows/validate.yml`
+as an **informational** step (continue-on-error, excluded from the final
+failure condition) for the same reason `check-image-assets.py` is: the site
+carries a real, deliberately-paced translation backlog and this will not (and
+should not) go to zero in one pass.
+
+### `scripts/check-locale-parent-gap.js`
+
+Diff-scoped PR gate, same git-diff/merge-base template as
+`check-translation-parity.js`. `node scripts/check-locale-parent-gap.js
+[--base <ref>]`
+
+For every locale HTML file **newly added** in the branch: resolves its EN
+parent via its hreflang cluster, runs `decide(enParentRelPath, localeCode)`.
+If the result `requiresLedgerEntry` and no ledger entry exists for that
+`(pattern, locale)` pair with a passing verdict (`mirror` or `gate-pass`) →
+**fail**, printing the exact pattern/locale, the missing instrument
+questions (competitor footprint? keyword volume? EN GSC impressions from
+that locale?), and a pointer to record the result or raise it with the user
+first. If the Core-parent default-mirror path applies, no ledger entry is
+required and the file passes silently.
+
+Exit 1 on any violation, 0 otherwise. Wired into `.github/workflows/validate.yml`
+as a **gating** step.
+
+---
+
+## 5. Advisory lookup before you start
+
+### `scripts/check-locale-parent-tier.js`
+
+`node scripts/check-locale-parent-tier.js <relative-path-or-pattern>
+<locale-code>` — prints `decide()`'s result in human-readable form: matched
+pattern, tier, script-independence, locale tier/hold, the decision, the
+reason, and — if a ledger entry is required — the exact instrument questions
+to answer and where to record them.
+
+Run this **before** starting any new locale-page work, e.g.:
+
+```
+node scripts/check-locale-parent-tier.js symbol/pi-symbol fr
+# -> DECISION: mirror (no ledger entry required)
+
+node scripts/check-locale-parent-tier.js category/bold-fonts ja
+# -> DECISION: skip-script-incompatible (ledger entry required to override)
+
+node scripts/check-locale-parent-tier.js usecase/free-fire-name-generator vi
+# -> DECISION: skip-hold-locale (vi is on hold — do not add vi content)
+```
+
+Always exits 0 — it's advisory, not a gate.
+
+---
+
+## npm scripts (all five, plus the two they build on)
+
+| Script | Command | Kind |
+|---|---|---|
+| `sync-locale-mesh.js` | `npm run sync:locale-mesh [-- --fix] [-- --files <path>]` | fixer, exits 0 |
+| `check-locale-mesh.js` | `npm run check:locale-mesh [-- --base <ref>]` | gate, CI-wired |
+| `check-locale-parent-tier.js` | `npm run check:locale-parent-tier <path> <locale>` | advisory, exits 0 |
+| `audit-locale-parent-gap.js` | `npm run audit:locale-parent-gap [-- --full]` | discovery, CI-wired (informational) |
+| `check-locale-parent-gap.js` | `npm run check:locale-parent-gap [-- --base <ref>]` | gate, CI-wired |
+
+---
+
+## What this does NOT do (yet)
+
+- Only `scripts/generate_library_page_from_spec.py` has the mesh-sync hook.
+  `answers/`, `events/`, and `printables/` generators should get the same
+  hook the next time they're touched.
+- `data/locale_parent_gap_audit.json` ships with exactly one real entry. Every
+  other Core-parent × qualified-locale cell is unaudited — `npm run
+  audit:locale-parent-gap` is how that backlog gets worked, not something
+  this tooling fabricates on its own.
+- The script-compatibility overlay (step 2 of the flowchart) is a fixed list
+  of six locale codes (`ar, hi, ja, ko, th, zh-tw`), not a general Unicode
+  script detector. If a new locale is added whose script isn't Latin, add it
+  to `NON_LATIN_LOCALES` in `scripts/lib/locale-parent-registry.js`.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,12 @@
     "check:images": "python3 scripts/check-image-assets.py",
     "check:new-page-images": "python3 scripts/check-new-page-image-assets.py",
     "audit:translation-parity": "node scripts/audit-translation-parity.js",
-    "check:translation-parity": "node scripts/check-translation-parity.js"
+    "check:translation-parity": "node scripts/check-translation-parity.js",
+    "sync:locale-mesh": "node scripts/sync-locale-mesh.js",
+    "check:locale-mesh": "node scripts/check-locale-mesh.js",
+    "check:locale-parent-tier": "node scripts/check-locale-parent-tier.js",
+    "audit:locale-parent-gap": "node scripts/audit-locale-parent-gap.js",
+    "check:locale-parent-gap": "node scripts/check-locale-parent-gap.js"
   },
   "dependencies": {
     "cheerio": "^1.2.0",

--- a/scripts/audit-locale-parent-gap.js
+++ b/scripts/audit-locale-parent-gap.js
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * audit-locale-parent-gap.js
+ *
+ * Whole-site, point-in-time discovery pass: the systematic version of the FR
+ * `/symbol/` blind spot (EN had 77 symbol pages, FR had 6; ~49,960/mo of
+ * directly-evidenced French demand sat undetected until a manual Semrush
+ * pull found it — see data/locale_parent_gap_audit.json for that entry).
+ *
+ * For every Core-tier pattern in data/core_parent_set.json x every qualified
+ * locale in data/locale_qualification_tiers.json (Tier 1, or Tier 2 and not
+ * on hold), this counts:
+ *   - how many EN-canonical pages match that pattern (classified via
+ *     scripts/lib/locale-parent-registry.js's classifyParent(), so a page is
+ *     only ever counted under its single most-specific matching pattern)
+ *   - how many of those already have a live translation into that locale
+ *     (via scripts/lib/translation-clusters.js's discoverClusters())
+ *   - whether data/locale_parent_gap_audit.json already has a recorded entry
+ *     for that (pattern, locale) cell
+ *
+ * A cell is flagged an "unaudited gap" when existing translation coverage is
+ * near-zero AND no ledger entry exists — i.e. nobody has checked, or built,
+ * yet. This is a discovery tool for triage, like audit-translation-parity.js,
+ * NOT a blocking check — see scripts/check-locale-parent-gap.js for the
+ * enforcing per-PR gate.
+ *
+ * Usage:
+ *   node scripts/audit-locale-parent-gap.js                 # ranked gap list
+ *   node scripts/audit-locale-parent-gap.js --full           # every cell, not just gaps
+ *   node scripts/audit-locale-parent-gap.js --json out.json
+ *   node scripts/audit-locale-parent-gap.js --report out.md
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { discoverClusters } = require('./lib/translation-clusters');
+const { classifyParent, classifyLocale, LOCALES, NON_LATIN_LOCALES } = require('./lib/locale-parent-registry');
+
+const ROOT = path.resolve(__dirname, '..');
+const GAP_LEDGER_PATH = path.join(ROOT, 'data', 'locale_parent_gap_audit.json');
+
+const args = process.argv.slice(2);
+const showFull = args.includes('--full');
+const reportIdx = args.indexOf('--report');
+const jsonIdx = args.indexOf('--json');
+const reportPath = reportIdx !== -1 ? args[reportIdx + 1] : null;
+const jsonPath = jsonIdx !== -1 ? args[jsonIdx + 1] : null;
+
+// ─── Load the ledger ────────────────────────────────────────────────────
+
+let ledgerEntries = [];
+if (fs.existsSync(GAP_LEDGER_PATH)) {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(GAP_LEDGER_PATH, 'utf8'));
+    ledgerEntries = Array.isArray(parsed) ? parsed : parsed.entries || [];
+  } catch (e) {
+    console.error(`WARNING: could not parse ${path.relative(ROOT, GAP_LEDGER_PATH)}: ${e.message}`);
+  }
+}
+function findLedgerEntry(pattern, locale) {
+  return ledgerEntries.find((e) => e.pattern === pattern && e.locale === locale) || null;
+}
+
+// ─── Discover every page + its hreflang cluster ────────────────────────
+
+const { byUrl, clusters } = discoverClusters(ROOT);
+
+// ─── Group EN pages by their single, most-specific Core-tier pattern ──────
+
+const corePages = new Map(); // pattern -> { info, pages: [rec,...] }
+for (const [, rec] of byUrl) {
+  if (rec.ownLang !== 'en') continue;
+  const info = classifyParent(rec.rel);
+  if (info.tier !== 'core') continue;
+  if (!corePages.has(info.pattern)) corePages.set(info.pattern, { info, pages: [] });
+  corePages.get(info.pattern).pages.push(rec);
+}
+
+// ─── Qualified locales: Tier 1, or Tier 2 and not on hold ──────────────────
+
+const qualifiedLocales = LOCALES.filter((code) => {
+  const l = classifyLocale(code);
+  return l.tier === 1 || (l.tier === 2 && !l.hold);
+});
+
+// ─── Build the (pattern, locale) cell matrix ───────────────────────────
+
+const cells = [];
+for (const [pattern, { info, pages }] of corePages) {
+  for (const locale of qualifiedLocales) {
+    // Script-compatibility overlay: not a gap, just not applicable.
+    if (info.scriptIndependent === false && NON_LATIN_LOCALES.has(locale)) continue;
+
+    let translated = 0;
+    for (const rec of pages) {
+      const members = clusters.get(rec.canonical);
+      if (!members) continue;
+      const hasLocale = [...members].some((m) => {
+        if (m === rec.canonical) return false;
+        const r = byUrl.get(m);
+        return r && r.ownLang === locale;
+      });
+      if (hasLocale) translated++;
+    }
+
+    const total = pages.length;
+    const missing = total - translated;
+    const ledgerEntry = findLedgerEntry(pattern, locale);
+    const coverageRatio = total > 0 ? translated / total : 0;
+    const nearZero = translated === 0 || coverageRatio < 0.1;
+    const unauditedGap = nearZero && !ledgerEntry;
+
+    cells.push({
+      pattern,
+      locale,
+      scriptIndependent: info.scriptIndependent,
+      total,
+      translated,
+      missing,
+      coverageRatio,
+      ledgerEntry,
+      unauditedGap,
+    });
+  }
+}
+
+// Rank: script-independent blind spots first (per the doc — that's exactly
+// where the FR /symbol/ gold sat), then by missing-page count descending.
+cells.sort((a, b) => {
+  if (a.scriptIndependent !== b.scriptIndependent) return a.scriptIndependent ? -1 : 1;
+  return b.missing - a.missing;
+});
+
+// ─── Report ─────────────────────────────────────────────────────────────
+
+const lines = [];
+const log = (s = '') => {
+  lines.push(s);
+  console.log(s);
+};
+
+const gaps = cells.filter((c) => c.unauditedGap);
+const audited = cells.filter((c) => !c.unauditedGap);
+
+log('Locale Parent Gap Audit');
+log(`  Core-tier patterns with >=1 EN page: ${corePages.size}`);
+log(`  qualified locales checked:           ${qualifiedLocales.length} (${qualifiedLocales.join(', ')})`);
+log(`  (pattern, locale) cells evaluated:   ${cells.length}`);
+log(`  unaudited gaps (near-zero coverage, no ledger entry): ${gaps.length}`);
+log(`  cells with existing coverage or a recorded ledger entry: ${audited.length}`);
+log('');
+
+function printCell(c) {
+  const pct = c.total > 0 ? `${Math.round(c.coverageRatio * 100)}%` : 'n/a';
+  log(
+    `${c.unauditedGap ? '✗' : '✓'} [${c.locale}] ${c.pattern}  ${c.translated}/${c.total} translated (${pct})` +
+      `  scriptIndependent=${c.scriptIndependent}`
+  );
+  if (c.ledgerEntry) {
+    log(`    ledger: verdict=${c.ledgerEntry.verdict} checked=${c.ledgerEntry.checkedDate} — ${c.ledgerEntry.evidence}`);
+  } else if (c.unauditedGap) {
+    log('    no data/locale_parent_gap_audit.json entry — nobody has checked competitor footprint or keyword volume here yet.');
+  }
+  log('');
+}
+
+log('── Unaudited gaps (ranked: script-independent blind spots first, then missing-page count) ──');
+log('');
+for (const c of gaps) printCell(c);
+
+if (showFull) {
+  log('── Every other evaluated cell (already covered or already ledgered) ──');
+  log('');
+  for (const c of audited) printCell(c);
+} else {
+  log(`(${audited.length} covered/ledgered cells omitted — pass --full to print every cell, or --json <path> for raw data.)`);
+  log('');
+}
+
+if (reportPath) {
+  const md = [
+    '# Locale Parent Gap Audit',
+    '',
+    `Generated ${new Date().toISOString().slice(0, 10)}. Run \`node scripts/audit-locale-parent-gap.js\` to regenerate.`,
+    '',
+    '```',
+    ...lines,
+    '```',
+  ].join('\n');
+  fs.writeFileSync(path.resolve(ROOT, reportPath), md, 'utf8');
+  console.log(`\nMarkdown report written to ${reportPath}`);
+}
+
+if (jsonPath) {
+  fs.writeFileSync(path.resolve(ROOT, jsonPath), JSON.stringify(cells, null, 2), 'utf8');
+  console.log(`JSON written to ${jsonPath}`);
+}
+
+// Informational by default — see check-locale-parent-gap.js for the
+// enforcing per-PR gate.
+process.exit(0);

--- a/scripts/check-locale-mesh.js
+++ b/scripts/check-locale-mesh.js
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * check-locale-mesh.js
+ *
+ * Per-PR gate: for every HTML file ADDED or CHANGED in this branch that is a
+ * locale page (path starts with one of the canonical locale codes) and is
+ * part of an hreflang cluster, requires:
+ *
+ *   (a) its cluster has no non-reciprocal or headless member — same
+ *       detection logic as scripts/audit-hreflang.js (broken/non-reciprocal/
+ *       headless pairs), scoped to just this file's own cluster instead of
+ *       the whole site;
+ *   (b) scripts/lib/locale-link-rewrite.js finds no un-rewritten English-hub
+ *       link on this file — i.e. `npm run sync:locale-mesh -- --fix` was run
+ *       before pushing.
+ *
+ * This is the enforcement half of scripts/sync-locale-mesh.js, the same way
+ * check-translation-parity.js enforces what audit-translation-parity.js
+ * would otherwise only ever discover after the fact.
+ *
+ * Usage:
+ *   node scripts/check-locale-mesh.js                 # diff against origin/main
+ *   node scripts/check-locale-mesh.js --base main      # diff against a different ref
+ *
+ * Exit code 0 = clean (or nothing to check), 1 = a mesh problem found.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+const { discoverClusters } = require('./lib/translation-clusters');
+const { findRewriteCandidates } = require('./lib/locale-link-rewrite');
+const { LOCALES } = require('./lib/locale-parent-registry');
+
+const ROOT = path.resolve(__dirname, '..');
+
+const args = process.argv.slice(2);
+const baseIdx = args.indexOf('--base');
+const requestedBase = baseIdx !== -1 ? args[baseIdx + 1] : 'origin/main';
+
+function git(cmdArgs, opts = {}) {
+  return execFileSync('git', cmdArgs, { cwd: ROOT, encoding: 'utf8', ...opts });
+}
+
+function resolveBase(base) {
+  try {
+    git(['rev-parse', '--verify', base], { stdio: 'ignore' });
+    return base;
+  } catch {
+    const branch = base.replace(/^origin\//, '');
+    try {
+      git(['fetch', '--depth=200', 'origin', branch], { stdio: 'ignore' });
+      const candidate = `origin/${branch}`;
+      git(['rev-parse', '--verify', candidate], { stdio: 'ignore' });
+      return candidate;
+    } catch (e) {
+      console.error(`Could not resolve or fetch base ref "${base}": ${e.message}`);
+      process.exit(2);
+    }
+  }
+}
+
+const base = resolveBase(requestedBase);
+
+let mergeBase;
+try {
+  mergeBase = git(['merge-base', base, 'HEAD']).trim();
+} catch (e) {
+  console.error(`Could not compute merge-base of ${base} and HEAD: ${e.message}`);
+  process.exit(2);
+}
+
+const changedFiles = git(['diff', '--name-only', '--diff-filter=ACMR', mergeBase, 'HEAD', '--', '*.html'])
+  .split('\n')
+  .map((l) => l.trim())
+  .filter(Boolean);
+
+if (changedFiles.length === 0) {
+  console.log('Locale Mesh Check: no changed HTML files — nothing to check.');
+  process.exit(0);
+}
+
+const LOCALE_PREFIX_RE = new RegExp(`^(${LOCALES.join('|')})/`);
+const changedLocaleFiles = changedFiles.filter((f) => LOCALE_PREFIX_RE.test(f));
+
+if (changedLocaleFiles.length === 0) {
+  console.log('Locale Mesh Check: no changed locale-page HTML files — nothing to check.');
+  process.exit(0);
+}
+
+// ─── Current site state (HEAD / working tree) ──────────────────────────────
+
+const { byUrl, clusters } = discoverClusters(ROOT);
+
+// enUrl -> Set of member urls (same lookup shape check-translation-parity.js uses)
+const clusterOf = new Map();
+for (const [enUrl, members] of clusters) {
+  for (const m of members) clusterOf.set(m, enUrl);
+}
+
+// ─── (a) reciprocity/headless — same logic as audit-hreflang.js, scoped to one cluster ──
+
+function reciprocityIssuesForCluster(enUrl) {
+  const members = clusters.get(enUrl);
+  if (!members) return [];
+  const issues = [];
+  for (const url of members) {
+    const rec = byUrl.get(url);
+    if (!rec || !rec.alternates || rec.alternates.length === 0) continue; // not a declared cluster page itself
+    for (const alt of rec.alternates) {
+      if (alt.hreflang === 'x-default') continue;
+      if (alt.href === rec.canonical) continue;
+      const target = byUrl.get(alt.href);
+      if (!target) {
+        issues.push({ type: 'broken', from: rec.rel, hreflang: alt.hreflang, href: alt.href });
+        continue;
+      }
+      if (!target.alternates || target.alternates.length === 0) {
+        issues.push({ type: 'headless', from: rec.rel, to: target.rel, hreflang: alt.hreflang });
+        continue;
+      }
+      const linksBack = target.alternates.some((a) => a.href === rec.canonical);
+      if (!linksBack) {
+        issues.push({ type: 'non-reciprocal', from: rec.rel, to: target.rel, hreflang: alt.hreflang });
+      }
+    }
+  }
+  return issues;
+}
+
+const flaggedMesh = []; // { rel, issues }
+const flaggedLinks = []; // { rel, candidates }
+
+for (const rel of changedLocaleFiles) {
+  const filePath = path.join(ROOT, rel);
+  if (!fs.existsSync(filePath)) continue; // deleted file
+
+  const rec = [...byUrl.values()].find((r) => r.rel === rel);
+  if (!rec) continue; // no canonical tag — not part of the hreflang system at all
+
+  const enAnchor = clusterOf.get(rec.canonical) || rec.canonical;
+  const issues = reciprocityIssuesForCluster(enAnchor);
+  if (issues.length) flaggedMesh.push({ rel, issues });
+
+  const candidates = findRewriteCandidates({ byUrl, clusters }, rec);
+  if (candidates.length) flaggedLinks.push({ rel, candidates });
+}
+
+// ─── Report ─────────────────────────────────────────────────────────────
+
+console.log('Locale Mesh Check');
+console.log(`  base:                        ${base} (merge-base ${mergeBase.slice(0, 8)})`);
+console.log(`  changed locale HTML files:   ${changedLocaleFiles.length}`);
+console.log(`  files with mesh (hreflang) problems:      ${flaggedMesh.length}`);
+console.log(`  files with un-rewritten hub-link candidates: ${flaggedLinks.length}`);
+console.log('');
+
+let hasProblems = false;
+
+if (flaggedMesh.length) {
+  hasProblems = true;
+  for (const f of flaggedMesh) {
+    console.log(`✗ ${f.rel} — hreflang cluster has unresolved issue(s):`);
+    for (const issue of f.issues) {
+      if (issue.type === 'broken') {
+        console.log(`    broken target: hreflang="${issue.hreflang}" -> ${issue.href} (page not found)`);
+      } else if (issue.type === 'headless') {
+        console.log(`    headless target: ${issue.to} has no hreflang block of its own (referenced by ${issue.from})`);
+      } else {
+        console.log(`    non-reciprocal: ${issue.from} -> ${issue.to} (missing hreflang="${issue.hreflang}" back)`);
+      }
+    }
+    console.log('    Fix: run `npm run sync:locale-mesh -- --fix` before pushing.');
+    console.log('');
+  }
+}
+
+if (flaggedLinks.length) {
+  hasProblems = true;
+  for (const f of flaggedLinks) {
+    console.log(`✗ ${f.rel} — links an English hub/spoke where a locale-native equivalent already exists:`);
+    for (const c of f.candidates) {
+      console.log(`    "${c.originalHref}"  should point to  "${c.rewrittenHref}"`);
+    }
+    console.log(
+      '    Fix: run `npm run sync:locale-mesh -- --fix` before pushing (see CLAUDE.md, ' +
+        '"Locale-native internal linking").'
+    );
+    console.log('');
+  }
+}
+
+if (hasProblems) {
+  process.exit(1);
+} else {
+  console.log('No locale-mesh problems introduced by this branch.');
+  process.exit(0);
+}

--- a/scripts/check-locale-parent-gap.js
+++ b/scripts/check-locale-parent-gap.js
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * check-locale-parent-gap.js
+ *
+ * Per-PR gate: for every NEW locale HTML file added in this branch (path
+ * starts with a locale code and didn't exist at the merge-base), resolve its
+ * EN parent via its hreflang cluster, classify the (parent, locale) pair
+ * with scripts/lib/locale-parent-registry.js's decide(), and require a
+ * passing data/locale_parent_gap_audit.json entry whenever the decision
+ * needed one — i.e. this page was built against the registry's default
+ * recommendation (a gated-tail parent, a Tier-3/held locale, or a
+ * script-incompatible parent+locale pair) rather than the innocent-by-
+ * default Core-parent mirror path.
+ *
+ * This is the enforcement half of scripts/audit-locale-parent-gap.js, the
+ * same way scripts/check-translation-parity.js enforces what
+ * scripts/audit-translation-parity.js discovers: the audit finds the
+ * existing sitewide backlog; this stops a NEW ungated build from shipping
+ * without a recorded pre-build check.
+ *
+ * Usage:
+ *   node scripts/check-locale-parent-gap.js                 # diff against origin/main
+ *   node scripts/check-locale-parent-gap.js --base main      # diff against a different ref
+ *
+ * Exit code 0 = clean (or nothing new to check), 1 = an unaudited build found.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+const { discoverClusters } = require('./lib/translation-clusters');
+const { decide, LOCALES } = require('./lib/locale-parent-registry');
+
+const ROOT = path.resolve(__dirname, '..');
+const GAP_LEDGER_PATH = path.join(ROOT, 'data', 'locale_parent_gap_audit.json');
+
+const args = process.argv.slice(2);
+const baseIdx = args.indexOf('--base');
+const requestedBase = baseIdx !== -1 ? args[baseIdx + 1] : 'origin/main';
+
+function git(cmdArgs, opts = {}) {
+  return execFileSync('git', cmdArgs, { cwd: ROOT, encoding: 'utf8', ...opts });
+}
+
+function resolveBase(base) {
+  try {
+    git(['rev-parse', '--verify', base], { stdio: 'ignore' });
+    return base;
+  } catch {
+    // Shallow CI checkouts often don't have the base branch locally at all.
+    const branch = base.replace(/^origin\//, '');
+    try {
+      git(['fetch', '--depth=200', 'origin', branch], { stdio: 'ignore' });
+      const candidate = `origin/${branch}`;
+      git(['rev-parse', '--verify', candidate], { stdio: 'ignore' });
+      return candidate;
+    } catch (e) {
+      console.error(`Could not resolve or fetch base ref "${base}": ${e.message}`);
+      process.exit(2);
+    }
+  }
+}
+
+const base = resolveBase(requestedBase);
+
+let mergeBase;
+try {
+  mergeBase = git(['merge-base', base, 'HEAD']).trim();
+} catch (e) {
+  console.error(`Could not compute merge-base of ${base} and HEAD: ${e.message}`);
+  process.exit(2);
+}
+
+// Only newly-ADDED files — this gate is specifically about a brand-new
+// locale page shipping without its required pre-build check, not about
+// edits to an already-shipped one (that's check-translation-parity.js's job).
+const addedFiles = git(['diff', '--name-only', '--diff-filter=A', mergeBase, 'HEAD', '--', '*.html'])
+  .split('\n')
+  .map((l) => l.trim())
+  .filter(Boolean);
+
+if (addedFiles.length === 0) {
+  console.log('Locale Parent Gap Check: no newly-added HTML files — nothing to check.');
+  process.exit(0);
+}
+
+const LOCALE_PREFIX_RE = new RegExp(`^(${LOCALES.join('|')})/`);
+
+// ─── Current site state (HEAD / working tree) ──────────────────────────────
+
+const { byUrl } = discoverClusters(ROOT);
+
+// ─── Ledger ─────────────────────────────────────────────────────────────
+
+let ledgerEntries = [];
+if (fs.existsSync(GAP_LEDGER_PATH)) {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(GAP_LEDGER_PATH, 'utf8'));
+    ledgerEntries = Array.isArray(parsed) ? parsed : parsed.entries || [];
+  } catch (e) {
+    console.error(`WARNING: could not parse ${path.relative(ROOT, GAP_LEDGER_PATH)}: ${e.message}`);
+  }
+}
+function passingLedgerEntry(pattern, locale) {
+  return ledgerEntries.find(
+    (e) => e.pattern === pattern && e.locale === locale && (e.verdict === 'mirror' || e.verdict === 'gate-pass')
+  );
+}
+
+// ─── Check every newly-added locale page ───────────────────────────────────
+
+const flagged = [];
+let checked = 0;
+
+for (const rel of addedFiles) {
+  if (!LOCALE_PREFIX_RE.test(rel)) continue; // not a locale page — not this gate's job
+  const filePath = path.join(ROOT, rel);
+  if (!fs.existsSync(filePath)) continue; // deleted later in the same branch
+
+  const rec = [...byUrl.values()].find((r) => r.rel === rel);
+  if (!rec) continue; // no canonical tag at all — not part of the hreflang system
+  if (!rec.ownLang || rec.ownLang === 'en') continue;
+
+  checked++;
+  const localeCode = rec.ownLang.toLowerCase();
+
+  const enAlt = rec.alternates.find((a) => a.hreflang === 'en');
+  const enRec = enAlt ? byUrl.get(enAlt.href) : null;
+
+  if (!enRec) {
+    flagged.push({
+      rel,
+      localeCode,
+      problem: 'no-en-parent',
+      detail:
+        'This new locale page declares no resolvable hreflang="en" alternate, so its EN parent ' +
+        "(and therefore its Core Parent Set pattern) can't be classified. Add the hreflang link " +
+        '(see CLAUDE.md, "Localization Workflow — the English-Parent Rule") or run ' +
+        '`npm run sync:locale-mesh -- --fix` if the EN parent already exists.',
+    });
+    continue;
+  }
+
+  const result = decide(enRec.rel, localeCode);
+  if (!result.requiresLedgerEntry) continue; // Core-parent default-mirror path — passes silently
+
+  const pass = passingLedgerEntry(result.parentInfo.pattern, localeCode);
+  if (!pass) {
+    flagged.push({ rel, localeCode, enRel: enRec.rel, result, problem: 'missing-ledger-entry' });
+  }
+}
+
+// ─── Report ─────────────────────────────────────────────────────────────
+
+console.log('Locale Parent Gap Check');
+console.log(`  base:                       ${base} (merge-base ${mergeBase.slice(0, 8)})`);
+console.log(`  newly-added HTML files:     ${addedFiles.length}`);
+console.log(`  new locale pages checked:   ${checked}`);
+console.log(`  problems found:             ${flagged.length}`);
+console.log('');
+
+if (flagged.length) {
+  for (const f of flagged) {
+    if (f.problem === 'no-en-parent') {
+      console.log(`✗ ${f.rel} — ${f.detail}`);
+      console.log('');
+      continue;
+    }
+    console.log(`✗ ${f.rel} (locale: ${f.localeCode}) ships against the registry's default, with no recorded pre-build check:`);
+    console.log(`    EN parent:        ${f.enRel}`);
+    console.log(`    matched pattern:  ${f.result.parentInfo.pattern || '(unclassified)'}  (tier: ${f.result.parentInfo.tier})`);
+    console.log(`    decision:         ${f.result.decision}`);
+    console.log(`    reason:           ${f.result.reason}`);
+    console.log(
+      '    Missing instrument questions: competitor footprint in this locale? keyword volume in this locale ' +
+        "(Semrush)? EN page's own GSC impressions from this locale's language queries?"
+    );
+    console.log(
+      '    Fix: record the result in data/locale_parent_gap_audit.json (see its "_readme") once you\'ve run the ' +
+        'check, or raise it with the user before treating it as agreed — same bar as CLAUDE.md\'s English-Parent ' +
+        'Rule exceptions.'
+    );
+    console.log('');
+  }
+  process.exit(1);
+} else {
+  console.log('No newly-added locale page shipped without a required pre-build gap-check record.');
+  process.exit(0);
+}

--- a/scripts/check-locale-parent-tier.js
+++ b/scripts/check-locale-parent-tier.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * check-locale-parent-tier.js
+ *
+ * Advisory CLI over scripts/lib/locale-parent-registry.js's decide(): tells a
+ * human/agent, BEFORE starting any new locale-page work, whether the
+ * (parent, locale) pair they're about to build defaults to mirror or gate
+ * under the Core Parent Set / Locale Qualification Tier registries, and
+ * whether that decision requires a recorded pre-build gap check first (see
+ * data/locale_parent_gap_audit.json).
+ *
+ * This is advisory only — it always exits 0. It does not gate anything by
+ * itself; scripts/check-locale-parent-gap.js is the enforcing PR gate that
+ * actually fails a build lacking a required ledger entry.
+ *
+ * Usage:
+ *   node scripts/check-locale-parent-tier.js <relative-path-or-pattern> <locale-code>
+ *   node scripts/check-locale-parent-tier.js symbol/pi-symbol fr
+ *   node scripts/check-locale-parent-tier.js usecase/free-fire-name-generator vi
+ */
+
+const { decide } = require('./lib/locale-parent-registry');
+
+const [, , relPathArg, localeArg] = process.argv;
+
+if (!relPathArg || !localeArg) {
+  console.log('Usage: node scripts/check-locale-parent-tier.js <relative-path-or-pattern> <locale-code>');
+  console.log('Example: node scripts/check-locale-parent-tier.js symbol/pi-symbol fr');
+  process.exit(0);
+}
+
+const result = decide(relPathArg, localeArg);
+
+console.log(`Locale Parent Tier — ${relPathArg}  x  ${localeArg}`);
+console.log('');
+console.log(`  parent pattern matched:  ${result.parentInfo.pattern || '(none — unclassified)'}`);
+console.log(`  parent tier:             ${result.parentInfo.tier}`);
+console.log(`  script-independent:      ${result.parentInfo.scriptIndependent}`);
+console.log(`  locale tier:             ${result.localeInfo.tier}${result.localeInfo.hold ? ' (HOLD)' : ''}`);
+console.log(`  locale action:           ${result.localeInfo.action}`);
+console.log('');
+console.log(`  DECISION: ${result.decision}`);
+console.log(`  REASON:   ${result.reason}`);
+
+if (result.requiresLedgerEntry) {
+  console.log('');
+  console.log('  This path requires a recorded pre-build check before shipping. See');
+  console.log('  data/locale_parent_gap_audit.json (its own "_readme" has the entry shape) and answer:');
+  console.log('    - competitor footprint: does a real competitor already rank a page for this job in this locale?');
+  console.log('    - keyword volume: what is the monthly search volume for this job in this locale (Semrush / keyword tool)?');
+  console.log("    - EN GSC impressions: how many impressions does the EN parent already draw from this locale's language queries?");
+  console.log('  Record the verdict there, or raise it with the user before treating it as agreed —');
+  console.log("  the same bar CLAUDE.md's English-Parent Rule sets for locale-first exceptions.");
+} else {
+  console.log('');
+  console.log('  No ledger entry required to build this — it is the registry\'s expected default.');
+}
+
+process.exit(0);

--- a/scripts/generate_library_page_from_spec.py
+++ b/scripts/generate_library_page_from_spec.py
@@ -33,6 +33,7 @@ The script refuses to overwrite an existing page unless --force is given.
 import argparse
 import html
 import json
+import subprocess
 import sys
 from pathlib import Path
 
@@ -490,7 +491,59 @@ def main(argv=None):
     print(f"Wrote {out_path.relative_to(REPO)} "
           f"(pattern={spec['copy_pattern']}, "
           f"sections={len(spec['sections'])})")
+
+    if lang != "en":
+        _sync_locale_mesh(out_path)
+
     return 0
+
+
+def _sync_locale_mesh(out_path):
+    """Phase-0 mesh-automation hook: best-effort, in-place hreflang +
+    locale-native-link rewrite for the page just written, via
+    scripts/sync-locale-mesh.js --fix --files <path> (see CLAUDE.md, "Locale
+    Parent Governance" and docs/locale-parent-governance.md).
+
+    This is the first generator wired to the mesh-automation hook — the
+    flagship Core, script-independent pillar (library/symbol pages are
+    literally the FR /symbol/ lane the gap-check tooling exists to catch).
+    Other generators (answers, events, printables) should get the same hook
+    the next time they're touched; this pass only wires this one.
+
+    Deliberately best-effort: a missing `node` binary or a failing sync
+    script must never break page generation itself, so any failure here is
+    reported as a warning and swallowed rather than raised.
+    """
+    rel_path = out_path.relative_to(REPO).as_posix()
+    try:
+        result = subprocess.run(
+            ["node", "scripts/sync-locale-mesh.js", "--fix", "--files", rel_path],
+            cwd=REPO, capture_output=True, text=True, timeout=120,
+        )
+        if result.returncode != 0:
+            sys.stderr.write(
+                f"[warn] scripts/sync-locale-mesh.js --fix --files {rel_path} "
+                f"exited {result.returncode}; continuing without mesh sync.\n"
+            )
+            if result.stderr:
+                sys.stderr.write(result.stderr)
+        else:
+            print(f"Synced locale mesh for {rel_path} (scripts/sync-locale-mesh.js --fix).")
+    except FileNotFoundError:
+        sys.stderr.write(
+            "[warn] `node` not found on PATH; skipped scripts/sync-locale-mesh.js "
+            f"--fix --files {rel_path}. Run it by hand before opening the PR.\n"
+        )
+    except subprocess.TimeoutExpired:
+        sys.stderr.write(
+            f"[warn] scripts/sync-locale-mesh.js --fix --files {rel_path} timed out; "
+            "continuing without mesh sync. Run it by hand before opening the PR.\n"
+        )
+    except Exception as exc:  # noqa: BLE001 - best-effort by design, never break generation
+        sys.stderr.write(
+            f"[warn] scripts/sync-locale-mesh.js hook failed ({exc}); "
+            "continuing without mesh sync. Run it by hand before opening the PR.\n"
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/lib/locale-link-rewrite.js
+++ b/scripts/lib/locale-link-rewrite.js
@@ -1,0 +1,142 @@
+'use strict';
+
+/**
+ * locale-link-rewrite.js
+ *
+ * Given discoverClusters()'s { byUrl, clusters } and one page record, finds
+ * every internal <a href="..."> on that page pointing at an English
+ * (non-locale-prefixed) hub/spoke URL under one of the sections named in
+ * CLAUDE.md's "Locale-native internal linking" rule — category/, library/,
+ * usecase/, guide/, answers/, symbol/, or any of the eleven platform roots —
+ * for which a locale-native equivalent already exists, in THIS page's own
+ * locale, inside that URL's hreflang cluster.
+ *
+ * This turns that CLAUDE.md rule from an after-the-fact audit (fixed
+ * manually across PR #586 and its 21-locale follow-up audit) into
+ * generation-time tooling: scripts/sync-locale-mesh.js is the CLI that
+ * reports/applies these candidates, scripts/check-locale-mesh.js is the PR
+ * gate that requires them already applied.
+ *
+ * Deliberately narrow scope, matching the rule it automates: only the
+ * sections named above are considered, not every internal link on a page
+ * (footer legal links, symbol-explorer runtime hooks, etc. are out of
+ * scope — CLAUDE.md's rule, and the recurring bug it documents, is specific
+ * to these content sections).
+ */
+
+const { getAttr, normalizeUrl } = require('./translation-clusters');
+
+const BASE = 'https://ultratextgen.com';
+
+// Mirrors audit-hreflang.js's isHomepage(): a page's own placeholder link to
+// a bare site root or bare locale homepage is never a rewrite candidate. It
+// wouldn't match MONITORED_PREFIX_RE below anyway (a bare homepage path has
+// no monitored first segment) — kept as an explicit guard per the same
+// defensive reasoning audit-hreflang.js documents, and in case this helper
+// is ever reused against a broader link set.
+function isHomepage(url) {
+  return /^https:\/\/ultratextgen\.com\/([a-z]{2}(-[a-z]+)?\/)?$/.test(url);
+}
+
+const PLATFORM_ROOTS = [
+  'discord',
+  'facebook',
+  'instagram',
+  'linkedin',
+  'pinterest',
+  'snapchat',
+  'telegram',
+  'tiktok',
+  'whatsapp',
+  'x',
+  'youtube',
+];
+
+const MONITORED_SECTIONS = ['category', 'library', 'usecase', 'guide', 'answers', 'symbol', ...PLATFORM_ROOTS];
+
+const MONITORED_PREFIX_RE = new RegExp('^/(' + MONITORED_SECTIONS.join('|') + ')/');
+
+const ANCHOR_RE = /<a\b[^>]*>/gi;
+
+function resolveHref(href) {
+  if (!href) return null;
+  if (href.startsWith('#') || /^(mailto|tel|javascript):/i.test(href)) return null;
+  if (/^https?:\/\//i.test(href)) {
+    const normalized = href.replace(/^http:/, 'https:');
+    if (!normalized.startsWith(BASE)) return null; // external domain — out of scope
+    return normalizeUrl(normalized);
+  }
+  if (href.startsWith('/')) return normalizeUrl(BASE + href);
+  return null; // relative (non-rooted) hrefs aren't the site's internal-link convention
+}
+
+/**
+ * @param {{byUrl: Map, clusters: Map}} clusterData - from discoverClusters()
+ * @param {object} page - a byUrl record: { rel, html, canonical, ownLang, alternates }
+ * @returns {Array<{originalHref: string, rewrittenHref: string, matchIndex: number, context: string}>}
+ */
+function findRewriteCandidates({ byUrl, clusters }, page) {
+  if (!page || !page.ownLang || page.ownLang === 'en') return [];
+
+  const candidates = [];
+  const html = page.html;
+  ANCHOR_RE.lastIndex = 0;
+  let m;
+  while ((m = ANCHOR_RE.exec(html))) {
+    const tag = m[0];
+    const href = getAttr(tag, 'href');
+    if (!href) continue;
+    // A tag carrying its own hreflang attribute is a language-switcher /
+    // explicit cross-locale pointer (e.g. the footer "EN" link on a
+    // translated page), not a content link that should point locale-native —
+    // it is SUPPOSED to point at the English version.
+    if (getAttr(tag, 'hreflang')) continue;
+
+    const resolved = resolveHref(href);
+    if (!resolved || isHomepage(resolved)) continue;
+
+    let pathname;
+    try {
+      pathname = new URL(resolved).pathname;
+    } catch {
+      continue;
+    }
+    if (!MONITORED_PREFIX_RE.test(pathname)) continue; // not a monitored section, or already locale-prefixed
+
+    const targetRec = byUrl.get(resolved);
+    if (!targetRec || targetRec.ownLang !== 'en') continue; // not a known EN canonical page
+
+    const members = clusters.get(targetRec.canonical);
+    if (!members) continue;
+
+    let nativeMember = null;
+    for (const memberUrl of members) {
+      if (memberUrl === targetRec.canonical) continue;
+      const memberRec = byUrl.get(memberUrl);
+      if (memberRec && memberRec.ownLang === page.ownLang) {
+        nativeMember = memberRec;
+        break;
+      }
+    }
+    if (!nativeMember) continue; // no locale-native equivalent exists yet — nothing to rewrite to
+
+    let rewrittenHref;
+    try {
+      rewrittenHref = new URL(nativeMember.canonical).pathname;
+    } catch {
+      continue;
+    }
+    if (rewrittenHref === href || nativeMember.canonical === resolved) continue; // already correct
+
+    candidates.push({
+      originalHref: href,
+      rewrittenHref,
+      matchIndex: m.index,
+      context: tag,
+    });
+  }
+
+  return candidates;
+}
+
+module.exports = { findRewriteCandidates, isHomepage, MONITORED_PREFIX_RE, MONITORED_SECTIONS };

--- a/scripts/lib/locale-parent-registry.js
+++ b/scripts/lib/locale-parent-registry.js
@@ -1,0 +1,216 @@
+'use strict';
+
+/**
+ * locale-parent-registry.js
+ *
+ * Shared lookup layer over the two governance registries added alongside
+ * this file:
+ *   - data/core_parent_set.json          (which page patterns are "Core" —
+ *     mirror by default — vs. "gated tail" vs. "never")
+ *   - data/locale_qualification_tiers.json (which locales are qualified for
+ *     the Core Parent Set's default-mirror at all)
+ *
+ * classifyParent()/classifyLocale() are plain lookups; decide() implements
+ * the 5-step per-(parent, locale) decision flowchart (see CLAUDE.md, "Locale
+ * Parent Governance", and docs/locale-parent-governance.md for the full
+ * writeup) verbatim, steps 1-3, returning a decision object instead of a bare
+ * string so callers (scripts/check-locale-parent-tier.js,
+ * scripts/check-locale-parent-gap.js, scripts/audit-locale-parent-gap.js) can
+ * branch on it. Steps 4 (cannibalization wiring check) and 5 (mesh
+ * generation on ship) are procedural, not classification — they're handled
+ * by scripts/sync-locale-mesh.js and the existing "check who already owns
+ * it" rule in CLAUDE.md, not by this lookup.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const CORE_PARENT_SET_PATH = path.join(ROOT, 'data', 'core_parent_set.json');
+const LOCALE_TIERS_PATH = path.join(ROOT, 'data', 'locale_qualification_tiers.json');
+
+function loadJson(p, fallback) {
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf8'));
+  } catch (e) {
+    console.error(`WARNING: could not parse ${path.relative(ROOT, p)}: ${e.message}`);
+    return fallback;
+  }
+}
+
+const coreParentSet = loadJson(CORE_PARENT_SET_PATH, { tiers: {}, parents: [] });
+const localeTiers = loadJson(LOCALE_TIERS_PATH, { locales: {} });
+
+// The canonical locale-code list, derived from data/locale_qualification_tiers.json
+// rather than hand-duplicated, so every script importing LOCALES from here
+// automatically agrees with the registry (which itself mirrors
+// scripts/check-image-assets.py's LOCALES tuple — see that registry's _readme).
+const LOCALES = Object.keys(localeTiers.locales);
+
+// CJK / Arabic / Indic locales, per the strategy doc's script-compatibility
+// overlay: a Latin-transform-dependent Core parent (scriptIndependent: false,
+// e.g. category/*) is not a real job in these locales.
+const NON_LATIN_LOCALES = new Set(['ar', 'hi', 'ja', 'ko', 'th', 'zh-tw']);
+
+function normalizeRelPath(relPath) {
+  return String(relPath || '')
+    .replace(/^\/+/, '')
+    .replace(/\/+$/, '');
+}
+
+// A pattern ending in "/*" matches the literal prefix or anything nested
+// under it; a pattern with no "*" matches only that exact path (tolerating
+// the caller passing either "category/index.html" or the bare directory
+// "category", and either "symbol/euro-sign" or "symbol/euro-sign/index.html").
+function stripIndexHtml(p) {
+  return p.replace(/\/index\.html$/, '').replace(/^index\.html$/, '');
+}
+
+function patternMatches(pattern, relPath) {
+  const rp = stripIndexHtml(relPath);
+  if (pattern.endsWith('/*')) {
+    const prefix = pattern.slice(0, -2);
+    return rp === prefix || rp.startsWith(prefix + '/');
+  }
+  return rp === stripIndexHtml(pattern);
+}
+
+// Specificity = the length of the pattern's literal (non-wildcard) prefix.
+// Longer literal prefix wins — this is how a specific carve-out like
+// "usecase/nickname-generator/*" (28 chars) outranks the general
+// "usecase/*" (9 chars) default, and an exact hub-index override like
+// "category/index.html" outranks "category/*".
+function specificity(pattern) {
+  return pattern.replace(/\/\*$/, '').length;
+}
+
+const UNCLASSIFIED_PARENT = {
+  pattern: null,
+  tier: 'unclassified',
+  scriptIndependent: null,
+  rationale:
+    'No pattern in data/core_parent_set.json matched this path. Treated like gated tail ' +
+    '(guilty until proven present) out of caution until the registry is updated — raise it ' +
+    "with the user rather than assuming it's Core.",
+};
+
+/**
+ * @param {string} relPath - repo-root-relative path of an EN canonical page,
+ *   e.g. "symbol/euro-sign/index.html" or "symbol/euro-sign".
+ * @returns {{pattern, tier, scriptIndependent, rationale}}
+ */
+function classifyParent(relPath) {
+  const matches = (coreParentSet.parents || []).filter((entry) => patternMatches(entry.pattern, relPath));
+  if (!matches.length) return UNCLASSIFIED_PARENT;
+  matches.sort((a, b) => specificity(b.pattern) - specificity(a.pattern));
+  return matches[0];
+}
+
+const UNKNOWN_LOCALE = {
+  tier: 3,
+  action: 'hold-stub',
+  hold: false,
+  notes:
+    'Locale code not present in data/locale_qualification_tiers.json — treated as unqualified ' +
+    '(Tier 3) by default until the registry is updated.',
+};
+
+/**
+ * @param {string} code - locale code, e.g. "fr", "zh-tw".
+ * @returns {{tier, action, hold, holdReason?, notes?}}
+ */
+function classifyLocale(code) {
+  const rec = localeTiers.locales[String(code || '').toLowerCase()];
+  return rec || UNKNOWN_LOCALE;
+}
+
+/**
+ * The per-(parent, locale) decision flowchart from the strategy doc, steps
+ * 1-3 (first stop wins):
+ *   1. Tier-3 stub locale (or Tier-2-but-held, e.g. vi) -> don't mirror.
+ *   2. Script-incompatible parent for this locale (a Latin-transform Core
+ *      parent into a CJK/Arabic/Indic locale) -> skip this parent here.
+ *   3. Core parent -> mirror by default; gated tail (or "never") -> gate by
+ *      default.
+ *
+ * @param {string} relPath - repo-root-relative path of the EN parent page.
+ * @param {string} localeCode
+ * @returns {{decision, reason, requiresLedgerEntry, parentInfo, localeInfo}}
+ */
+function decide(relPath, localeCode) {
+  const parentInfo = classifyParent(relPath);
+  const localeInfo = classifyLocale(localeCode);
+
+  // Step 1 (+ the vi-style hold case, which the strategy doc treats the same
+  // way as a stub for build purposes: "do not add vi content").
+  if (localeInfo.hold) {
+    return {
+      decision: 'skip-hold-locale',
+      reason: `Locale "${localeCode}" is on an explicit hold: ${localeInfo.holdReason || 'see data/locale_qualification_tiers.json'}`,
+      requiresLedgerEntry: true,
+      parentInfo,
+      localeInfo,
+    };
+  }
+  if (localeInfo.tier === 3) {
+    return {
+      decision: 'skip-stub-locale',
+      reason: `Locale "${localeCode}" is Tier 3 (${localeInfo.action}) — no spec mirroring until it's promoted via the 7-point qualification gate.`,
+      requiresLedgerEntry: true,
+      parentInfo,
+      localeInfo,
+    };
+  }
+
+  // Step 2
+  if (parentInfo.tier === 'core' && parentInfo.scriptIndependent === false && NON_LATIN_LOCALES.has(localeCode)) {
+    return {
+      decision: 'skip-script-incompatible',
+      reason: `"${parentInfo.pattern}" is a Latin-transform-dependent Core parent — not a real job in "${localeCode}" (CJK/Arabic/Indic script). Substitute the locale's script-appropriate Core subset (symbol/library/name-gen/counter) instead of skipping the locale outright.`,
+      requiresLedgerEntry: true,
+      parentInfo,
+      localeInfo,
+    };
+  }
+
+  // Step 3
+  if (parentInfo.tier === 'core') {
+    return {
+      decision: 'mirror',
+      reason: `"${parentInfo.pattern}" is Core and "${localeCode}" is qualified (tier ${localeInfo.tier}) — default is MIRROR. Only veto on a recorded pre-build check showing genuinely negligible demand (data/locale_parent_gap_audit.json, verdict "veto").`,
+      requiresLedgerEntry: false,
+      parentInfo,
+      localeInfo,
+    };
+  }
+
+  if (parentInfo.tier === 'never') {
+    return {
+      decision: 'gate',
+      reason: `"${parentInfo.pattern}" is tiered "never" — it does not mirror regardless of demand signal.`,
+      requiresLedgerEntry: true,
+      parentInfo,
+      localeInfo,
+    };
+  }
+
+  // Gated tail (including the "unclassified" fallback, treated the same way
+  // out of caution).
+  return {
+    decision: 'gate',
+    reason: `"${parentInfo.pattern || '(unclassified)'}" is gated tail — default is DO NOT MIRROR. A build requires a recorded pre-build check clearing threshold (data/locale_parent_gap_audit.json, verdict "gate-pass").`,
+    requiresLedgerEntry: true,
+    parentInfo,
+    localeInfo,
+  };
+}
+
+module.exports = {
+  LOCALES,
+  NON_LATIN_LOCALES,
+  classifyParent,
+  classifyLocale,
+  decide,
+  coreParentSet,
+  localeTiers,
+};

--- a/scripts/sync-locale-mesh.js
+++ b/scripts/sync-locale-mesh.js
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * sync-locale-mesh.js
+ *
+ * Phase-0 mesh automation: generates the reciprocal hreflang set and
+ * locale-native internal links CLAUDE.md's "Locale-native internal linking"
+ * and "Localization Workflow" sections require, instead of leaving them to
+ * manual vigilance (the failure mode PR #586 and its 21-locale follow-up
+ * audit had to hand-repair).
+ *
+ * Two repairs, in order:
+ *   1. hreflang reciprocity + headless targets — delegated entirely to the
+ *      existing scripts/audit-hreflang.js (never reimplemented here). In
+ *      --fix mode, this runs `node scripts/audit-hreflang.js --fix` first,
+ *      site-wide, before touching internal links, so link-rewriting always
+ *      sees an accurate, reciprocal cluster map. In report mode (the
+ *      default — no --fix), it instead runs audit-hreflang.js WITHOUT --fix,
+ *      to surface hreflang health as read-only context alongside the link
+ *      candidates below, without mutating anything.
+ *
+ *      (Design note: hreflang repair is gated on THIS script's own --fix
+ *      flag, not unconditional, specifically so a bare
+ *      `node scripts/sync-locale-mesh.js` stays a safe, side-effect-free
+ *      report — matching audit-hreflang.js's and check-translation-parity.js's
+ *      own report-vs-fix convention, and matching how every other --fix
+ *      tool in this repo behaves. `--fix` is required to mutate anything.)
+ *
+ *   2. locale-native internal-link rewrite candidates — via
+ *      scripts/lib/locale-link-rewrite.js, scoped to --files if given
+ *      (the generator hook's use case: rewrite just the page it *just*
+ *      wrote) or the whole tree by default (the manual/backlog use case).
+ *      Report mode (default) prints each candidate; --fix rewrites the
+ *      href in place, at its exact recorded position (not a blind
+ *      find-and-replace — see rewriteFile() below), so a coincidental
+ *      identical href elsewhere on the page that ISN'T a real candidate
+ *      (e.g. a language-switcher link the candidate-finder already
+ *      excluded) is never touched.
+ *
+ * This is a fixer tool, not a gate — no meaningful "failure" exit here, it
+ * always exits 0 (mirrors audit-hreflang.js's own non-strict tone when not
+ * run with --fix). See scripts/check-locale-mesh.js for the enforcing PR
+ * gate that requires this already applied.
+ *
+ * Usage:
+ *   node scripts/sync-locale-mesh.js                        # report, whole tree
+ *   node scripts/sync-locale-mesh.js --fix                  # fix, whole tree
+ *   node scripts/sync-locale-mesh.js --files id/symbol/foo/index.html --fix
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+const { discoverClusters } = require('./lib/translation-clusters');
+const { findRewriteCandidates } = require('./lib/locale-link-rewrite');
+
+const ROOT = path.resolve(__dirname, '..');
+
+const args = process.argv.slice(2);
+const FIX = args.includes('--fix');
+const filesIdx = args.indexOf('--files');
+const explicitFiles = [];
+if (filesIdx !== -1) {
+  for (let i = filesIdx + 1; i < args.length && !args[i].startsWith('--'); i++) explicitFiles.push(args[i]);
+}
+
+// ─── 1. hreflang reciprocity/headless-target repair — delegate, don't reimplement ──
+
+console.log('Locale Mesh Sync');
+console.log(`  mode: ${FIX ? 'fix' : 'report'}${explicitFiles.length ? `, scoped to ${explicitFiles.length} file(s)` : ', whole tree'}`);
+console.log('');
+console.log(`── Step 1: hreflang reciprocity (scripts/audit-hreflang.js${FIX ? ' --fix' : ''}) ──`);
+console.log('');
+try {
+  execFileSync('node', ['scripts/audit-hreflang.js', ...(FIX ? ['--fix'] : [])], {
+    cwd: ROOT,
+    stdio: 'inherit',
+  });
+} catch {
+  // audit-hreflang.js exits 1 when it finds (or, in report mode, still has)
+  // unresolved issues — that's expected, informational output, not a reason
+  // for this fixer tool to fail.
+}
+console.log('');
+
+// ─── 2. locale-native internal-link rewrite candidates ─────────────────────
+
+console.log('── Step 2: locale-native internal-link candidates (scripts/lib/locale-link-rewrite.js) ──');
+console.log('');
+
+const { byUrl, clusters } = discoverClusters(ROOT);
+
+let targetRecs;
+if (explicitFiles.length) {
+  targetRecs = explicitFiles
+    .map((f) => {
+      const rel = path.relative(ROOT, path.resolve(ROOT, f)).replace(/\\/g, '/');
+      return [...byUrl.values()].find((r) => r.rel === rel);
+    })
+    .filter(Boolean);
+} else {
+  targetRecs = [...byUrl.values()].filter((r) => r.ownLang && r.ownLang !== 'en');
+}
+
+let totalCandidates = 0;
+let filesWithCandidates = 0;
+let filesFixed = 0;
+let hrefsRewritten = 0;
+
+function rewriteFile(rec, candidates) {
+  let html = rec.html;
+  // Splice from the end backward so earlier matchIndex positions stay valid
+  // as later ones are edited.
+  const sorted = [...candidates].sort((a, b) => b.matchIndex - a.matchIndex);
+  for (const c of sorted) {
+    const before = html.slice(0, c.matchIndex);
+    const tagSlice = html.slice(c.matchIndex, c.matchIndex + c.context.length);
+    const after = html.slice(c.matchIndex + c.context.length);
+    if (tagSlice !== c.context) continue; // tree shifted under us — skip rather than corrupt the file
+    const newTag = tagSlice.replace(/(href\s*=\s*)(["'])([^"']*)\2/i, (m0, p1, quote) => `${p1}${quote}${c.rewrittenHref}${quote}`);
+    html = before + newTag + after;
+  }
+  fs.writeFileSync(path.join(ROOT, rec.rel), html, 'utf8');
+}
+
+for (const rec of targetRecs) {
+  const candidates = findRewriteCandidates({ byUrl, clusters }, rec);
+  if (!candidates.length) continue;
+
+  filesWithCandidates++;
+  totalCandidates += candidates.length;
+
+  console.log(`${rec.rel} (locale: ${rec.ownLang}) — ${candidates.length} candidate(s):`);
+  for (const c of candidates) {
+    console.log(`  ${c.originalHref}  ->  ${c.rewrittenHref}`);
+  }
+
+  if (FIX) {
+    rewriteFile(rec, candidates);
+    filesFixed++;
+    hrefsRewritten += candidates.length;
+    console.log(`  fixed: rewrote ${candidates.length} href(s) in ${rec.rel}`);
+  }
+  console.log('');
+}
+
+console.log(`Scanned ${targetRecs.length} locale page(s): ${filesWithCandidates} file(s) with a rewrite candidate, ${totalCandidates} candidate(s) total.`);
+if (FIX) {
+  console.log(`Fixed ${filesFixed} file(s), rewrote ${hrefsRewritten} href(s).`);
+} else if (totalCandidates) {
+  console.log('Run with --fix to rewrite these in place, or `npm run check:locale-mesh` to see this enforced as a PR gate.');
+}
+
+process.exit(0);


### PR DESCRIPTION
## Summary

Implements a data-driven locale parent governance system to replace tribal knowledge about which page patterns should be mirrored into which locales by default. This addresses a proven blind spot: EN `/symbol/` had 77 pages while FR `/symbol/` had only 6, with ~49,960/mo of directly-evidenced French demand going undetected until a manual Semrush audit.

The system introduces two registries, three enforcement scripts, one fixer tool, and mesh-automation hooks wired into the page generator.

## Key Changes

**New Data Registries:**
- `data/core_parent_set.json` — Tiers page-pattern prefixes (`symbol/*`, `library/*`, `category/*`, etc.) as `core` (mirror by default), `gated` (translate only on cleared demand), or `never`. Most-specific-pattern wins when multiple entries match.
- `data/locale_qualification_tiers.json` — Tiers all 28 canonical locale codes as Tier 1 (deepen + mirror Core now), Tier 2 (qualify via 7-point gate), or Tier 3 (hold/stub).
- `data/locale_parent_gap_audit.json` — Ledger of recorded pre-build competitor+keyword gap checks for (pattern, locale) cells.

**New Scripts:**
- `scripts/lib/locale-parent-registry.js` — Shared lookup layer implementing the 5-step per-(parent, locale) decision flowchart (Tier-3/held locale → skip; script-incompatible Core parent → skip; Core parent → mirror; gated tail → gate; mesh generation on ship).
- `scripts/lib/locale-link-rewrite.js` — Finds internal `<a href>` candidates pointing at English hubs where locale-native equivalents exist, for automated rewrite.
- `scripts/sync-locale-mesh.js` — Fixer tool (always exits 0) that generates reciprocal hreflang sets and rewrites locale-native internal links. Delegates hreflang repair to existing `audit-hreflang.js`, then applies link rewrites scoped to `--files` (generator hook use case) or whole tree (manual backlog).
- `scripts/check-locale-mesh.js` — Diff-scoped PR gate (exits 1 on violation) that requires hreflang reciprocity and locale-native link rewrites on any locale page added/changed in the branch.
- `scripts/audit-locale-parent-gap.js` — Whole-site discovery pass that counts EN-canonical pages per Core-tier pattern, existing translations per locale, and flags unaudited gaps (near-zero coverage + no ledger entry).
- `scripts/check-locale-parent-gap.js` — Per-PR gate (exits 1 on violation) that requires a passing `data/locale_parent_gap_audit.json` entry for any newly-added locale page built against a gated-tail parent, Tier-3/held locale, or script-incompatible parent+locale pair.
- `scripts/check-locale-parent-tier.js` — Advisory CLI (always exits 0) that tells a human/agent before starting work whether a (parent, locale) pair defaults to mirror or gate, and whether a ledger entry is required.

**Mesh Automation Hook:**
- `scripts/generate_library_page_from_spec.py` — Wired to call `_sync_locale_mesh()` after writing a non-EN page, which shells out to `node scripts/sync-locale-mesh.js --fix --files <path>`. Best-effort by design; failures are caught and reported as warnings without breaking page generation.

**Documentation & CI:**
- `docs/locale-parent-governance.md` — Deep reference for the registries, decision flowchart, five scripts, and mesh-automation hook (operating manual in the spirit of existing strategy docs).
- `CLAUDE.md` — Added "Locale Parent Governance" section summarizing the two registries, the decision flowchart, and how to run the advisory CLI before starting work.
- `.github/workflows/validate.yml` — Updated to wire `check-locale-mesh.js` and `check-locale-

https://claude.ai/code/session_01197T5mhNAHRNtpMzMRvtUF