### PR TITLE
fix: add missing self-referencing hreflang to 12 more EN pages

### DIFF
--- a/library/fraction-symbols/index.html
+++ b/library/fraction-symbols/index.html
@@ -54,6 +54,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 <meta name="description" content="Copy and paste Unicode fraction symbols — halves, thirds, quarters, eighths, fifths, and a build-your-own fraction set with superscript and subscript digits. Click any symbol to copy it instantly.">
 
 <link rel="canonical" href="https://ultratextgen.com/library/fraction-symbols/">
+<link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/fraction-symbols/">
 <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-pecahan/">
 <link rel="alternate" hreflang="ar" href="https://ultratextgen.com/ar/library/fraction-symbols/">
 <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/bunsu-giho/">

--- a/library/line-divider-symbols/index.html
+++ b/library/line-divider-symbols/index.html
@@ -54,6 +54,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 <meta name="description" content="Browse and copy line divider and separator characters — horizontal lines, decorative dividers, ornamental separators, dashes, box-drawing characters, and pre-built divider combos. Click any symbol to copy it instantly.">
 
 <link rel="canonical" href="https://ultratextgen.com/library/line-divider-symbols/">
+<link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/line-divider-symbols/">
 <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-garis/">
 <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/gubunseon-giho/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/library-line-divider-symbols.png">

--- a/printables/best-friend-in-cursive/index.html
+++ b/printables/best-friend-in-cursive/index.html
@@ -50,6 +50,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <title>Best Friend in Cursive — Free Printable | UltraTextGen</title>
   <meta name="description" content="See and print “Best Friend” in cursive — a ready-made worksheet to trace or download as a PNG for BFF notes, bracelets, and yearbooks. Free, no sign-up.">
   <link rel="canonical" href="https://ultratextgen.com/printables/best-friend-in-cursive/">
+<link rel="alternate" hreflang="en" href="https://ultratextgen.com/printables/best-friend-in-cursive/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/best-friend-in-cursive/">
   <meta property="og:title" content="Best Friend in Cursive — Free Printable | UltraTextGen">
   <meta property="og:description" content="See “Best Friend” in flowing cursive script, print or trace it, or download a PNG — for BFF notes, friendship bracelets, and yearbook signing.">

--- a/printables/cross-stitch-letters/index.html
+++ b/printables/cross-stitch-letters/index.html
@@ -50,6 +50,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <title>Cross-Stitch Letter Generator — Free Printable Charts | UltraTextGen</title>
   <meta name="description" content="Turn any word or name into a printable cross-stitch pattern — a charted grid with a stitch-color legend. Download PNG or print. Free, no sign-up.">
   <link rel="canonical" href="https://ultratextgen.com/printables/cross-stitch-letters/">
+<link rel="alternate" hreflang="en" href="https://ultratextgen.com/printables/cross-stitch-letters/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/cross-stitch-letters/">
   <meta property="og:title" content="Cross-Stitch Letter Generator — Free Printable Charts | UltraTextGen">
   <meta property="og:description" content="Turn any word or name into a printable cross-stitch pattern — a charted grid with a stitch-color legend. Download PNG or print. Free, no sign-up.">

--- a/printables/dad-in-cursive/index.html
+++ b/printables/dad-in-cursive/index.html
@@ -50,6 +50,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <title>Dad in Cursive — Free Printable | UltraTextGen</title>
   <meta name="description" content="See and print “Dad” in cursive — a ready-made worksheet with a model row and trace rows, or type your own word. Great for Father’s Day cards. Free, no sign-up.">
   <link rel="canonical" href="https://ultratextgen.com/printables/dad-in-cursive/">
+<link rel="alternate" hreflang="en" href="https://ultratextgen.com/printables/dad-in-cursive/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/dad-in-cursive/">
   <meta property="og:title" content="Dad in Cursive — Free Printable | UltraTextGen">
   <meta property="og:description" content="See “Dad” in flowing cursive script, print a tracing worksheet, or download a PNG. A quick front door for Father’s Day cards and gifts.">

--- a/printables/family-in-cursive/index.html
+++ b/printables/family-in-cursive/index.html
@@ -50,6 +50,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <title>Family in Cursive — Free Printable | UltraTextGen</title>
   <meta name="description" content="See and print “Family” in cursive — a ready-made worksheet to trace or download as a PNG for wall signs, family-tree crafts, and decor. Free, no sign-up.">
   <link rel="canonical" href="https://ultratextgen.com/printables/family-in-cursive/">
+<link rel="alternate" hreflang="en" href="https://ultratextgen.com/printables/family-in-cursive/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/family-in-cursive/">
   <meta property="og:title" content="Family in Cursive — Free Printable | UltraTextGen">
   <meta property="og:description" content="See “Family” in flowing cursive script, print or trace it, or download a PNG — for home decor, wall signs, and family-tree crafts.">

--- a/printables/happy-birthday-in-cursive/index.html
+++ b/printables/happy-birthday-in-cursive/index.html
@@ -50,6 +50,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <title>Happy Birthday in Cursive — Free Printable | UltraTextGen</title>
   <meta name="description" content="See and print “Happy Birthday” in cursive — a ready-made worksheet you can trace or download as a PNG for cards and banners. Type any name too. Free, no sign-up.">
   <link rel="canonical" href="https://ultratextgen.com/printables/happy-birthday-in-cursive/">
+<link rel="alternate" hreflang="en" href="https://ultratextgen.com/printables/happy-birthday-in-cursive/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/happy-birthday-in-cursive/">
   <meta property="og:title" content="Happy Birthday in Cursive — Free Printable | UltraTextGen">
   <meta property="og:description" content="See “Happy Birthday” in flowing cursive script, print or trace it, or download a PNG for birthday cards, banners, and cake toppers.">

--- a/printables/love-in-cursive/index.html
+++ b/printables/love-in-cursive/index.html
@@ -50,6 +50,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <title>Love in Cursive — Free Printable | UltraTextGen</title>
   <meta name="description" content="See and print “Love” in cursive — a ready-made worksheet with a model row and trace rows, or type your own word. Ideal for Valentine’s cards. Free, no sign-up.">
   <link rel="canonical" href="https://ultratextgen.com/printables/love-in-cursive/">
+<link rel="alternate" hreflang="en" href="https://ultratextgen.com/printables/love-in-cursive/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/love-in-cursive/">
   <meta property="og:title" content="Love in Cursive — Free Printable | UltraTextGen">
   <meta property="og:description" content="See “Love” in flowing cursive script, print a tracing worksheet, or download a PNG — for Valentine’s cards, wedding decor, and scrapbooks.">

--- a/printables/mom-in-cursive/index.html
+++ b/printables/mom-in-cursive/index.html
@@ -50,6 +50,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <title>Mom in Cursive — Free Printable | UltraTextGen</title>
   <meta name="description" content="See and print “Mom” in cursive — a ready-made worksheet with a model row and trace rows, or type your own word. Perfect for Mother’s Day cards. Free, no sign-up.">
   <link rel="canonical" href="https://ultratextgen.com/printables/mom-in-cursive/">
+<link rel="alternate" hreflang="en" href="https://ultratextgen.com/printables/mom-in-cursive/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/mom-in-cursive/">
   <meta property="og:title" content="Mom in Cursive — Free Printable | UltraTextGen">
   <meta property="og:description" content="See “Mom” in flowing cursive script, print a tracing worksheet, or download a PNG. A quick front door for Mother’s Day cards and gifts.">

--- a/printables/monogram-maker/index.html
+++ b/printables/monogram-maker/index.html
@@ -50,6 +50,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <title>Monogram Maker — Free Printable Initial Monograms | UltraTextGen</title>
   <meta name="description" content="Turn up to 3 initials into a printable monogram — classic three-letter, stacked, or circle-frame layouts. Download PNG or print. Free, no sign-up.">
   <link rel="canonical" href="https://ultratextgen.com/printables/monogram-maker/">
+<link rel="alternate" hreflang="en" href="https://ultratextgen.com/printables/monogram-maker/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/printables/monogram-maker/">
   <meta property="og:title" content="Monogram Maker — Free Printable Initial Monograms | UltraTextGen">
   <meta property="og:description" content="Turn up to 3 initials into a printable monogram — classic three-letter, stacked, or circle-frame layouts. Download PNG or print. Free, no sign-up.">

--- a/usecase/old-english-translator/index.html
+++ b/usecase/old-english-translator/index.html
@@ -53,6 +53,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <title>Old English Translator — Thee, Thou &amp; Thy Speak | UltraTextGen</title>
   <meta name="description" content="Turn any text into old-fashioned thee/thou English — Shakespearean-style word swaps like thou, thy, art and hath. Type a sentence and get an instant translation. Free, no sign-up.">
   <link rel="canonical" href="https://ultratextgen.com/usecase/old-english-translator/">
+<link rel="alternate" hreflang="en" href="https://ultratextgen.com/usecase/old-english-translator/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/usecase/old-english-translator/">
   <meta property="og:image" content="https://ultratextgen.com/assets/og/usecase-old-english-translator.png">
   <meta property="og:image:width" content="1200">

--- a/usecase/pirate-translator/index.html
+++ b/usecase/pirate-translator/index.html
@@ -53,6 +53,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <title>Pirate Translator — Talk Like a Pirate | UltraTextGen</title>
   <meta name="description" content="Turn any text into pirate speak — ye, matey, arrr and more. Type a sentence and get an instant pirate translation. Free, copy-paste, no sign-up.">
   <link rel="canonical" href="https://ultratextgen.com/usecase/pirate-translator/">
+<link rel="alternate" hreflang="en" href="https://ultratextgen.com/usecase/pirate-translator/">
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/usecase/pirate-translator/">
   <meta property="og:image" content="https://ultratextgen.com/assets/og/usecase-pirate-translator.png">
   <meta property="og:image:width" content="1200">


### PR DESCRIPTION
## Summary
- 12 EN pages (`library/fraction-symbols/`, `library/line-divider-symbols/`, plus 10 `usecase/`/`printables/` pages) had *some* hreflang links but were missing their own self-referencing `hreflang="en"` tag
- This made them invisible to the site's own hreflang-graph tooling (`scripts/lib/translation-clusters.js`, used by `audit-locale-parent-gap.js`, `check-locale-mesh.js`, and the translation-parity checks), even though the pages themselves render fine
- Adds the missing self-reference so these pages are correctly discovered as EN parents in their hreflang clusters

## Test plan
- [x] Ran `node scripts/audit-hreflang.js` to confirm no remaining self-reference gaps on the touched pages
- [x] Spot-checked each file's `<link rel="alternate">` block for correct canonical URL

---
_Generated by [Claude Code](https://claude.ai/code/session_01TExGmrfev8u3ueiirUoM1D)_