### PR TITLE
UX: sharpen /library/emoji-combos/ SERP snippet (CTR experiment)

### DIFF
--- a/data/library_page_specs/emoji-combos.json
+++ b/data/library_page_specs/emoji-combos.json
@@ -1,7 +1,7 @@
 {
   "slug": "emoji-combos",
-  "title": "Emoji Combos: Copy & Paste Aesthetic Emoji Combinations",
-  "meta_description": "Browse aesthetic emoji combos for bios, captions, and usernames — soft girl, cottage garden, night sky, and Y2K sets. Click any combo to copy it instantly.",
+  "title": "Emoji Combos — 200+ Aesthetic Copy & Paste Combos",
+  "meta_description": "200+ aesthetic emoji combos to copy & paste — soft girl, Y2K, baddie, kawaii & 20+ more vibes. Tap any combo to copy the whole set for a bio, caption or username.",
   "canonical": "https://ultratextgen.com/library/emoji-combos/",
   "breadcrumb": "Emoji Combos",
   "hero_h1": "Emoji Combos",

--- a/library/emoji-combos/index.html
+++ b/library/emoji-combos/index.html
@@ -13,8 +13,8 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Emoji Combos — 100+ Aesthetic Copy &amp; Paste Combinations</title>
-<meta name="description" content="Emoji combos to copy and paste — 100+ aesthetic emoji combinations (soft girl, cottagecore, Y2K, night sky) for Instagram bios, captions &amp; usernames. One tap to copy.">
+<title>Emoji Combos — 200+ Aesthetic Copy &amp; Paste Combos</title>
+<meta name="description" content="200+ aesthetic emoji combos to copy &amp; paste — soft girl, Y2K, baddie, kawaii &amp; 20+ more vibes. Tap any combo to copy the whole set for a bio, caption or username.">
 
 <link rel="canonical" href="https://ultratextgen.com/library/emoji-combos/">
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/emoji-combos/">
@@ -37,11 +37,11 @@
 <meta property="og:image:height" content="630">
 <meta property="og:image:type" content="image/png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Emoji Combos — 100+ Aesthetic Copy &amp; Paste Combinations">
-<meta name="twitter:description" content="Emoji combos to copy and paste — 100+ aesthetic emoji combinations (soft girl, cottagecore, Y2K, night sky) for Instagram bios, captions &amp; usernames. One tap to copy.">
+<meta name="twitter:title" content="Emoji Combos — 200+ Aesthetic Copy &amp; Paste Combos">
+<meta name="twitter:description" content="200+ aesthetic emoji combos to copy &amp; paste — soft girl, Y2K, baddie, kawaii &amp; 20+ more vibes. Tap any combo to copy the whole set for a bio, caption or username.">
 <meta name="twitter:image" content="https://ultratextgen.com/assets/og/library-emoji-combos.png">
-<meta property="og:title" content="Emoji Combos — 100+ Aesthetic Copy &amp; Paste Combinations">
-<meta property="og:description" content="Emoji combos to copy and paste — 100+ aesthetic emoji combinations (soft girl, cottagecore, Y2K, night sky) for Instagram bios, captions &amp; usernames. One tap to copy.">
+<meta property="og:title" content="Emoji Combos — 200+ Aesthetic Copy &amp; Paste Combos">
+<meta property="og:description" content="200+ aesthetic emoji combos to copy &amp; paste — soft girl, Y2K, baddie, kawaii &amp; 20+ more vibes. Tap any combo to copy the whole set for a bio, caption or username.">
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://ultratextgen.com/library/emoji-combos/">
 
@@ -56,9 +56,9 @@
 {
   "@context": "https://schema.org",
   "@type": "Article",
-  "headline": "Emoji Combos — 100+ Aesthetic Copy & Paste Combinations",
+  "headline": "Emoji Combos — 200+ Aesthetic Copy & Paste Combos",
   "alternateName": ["Emoji Combos Copy and Paste", "Emoji Combo", "Aesthetic Emoji Combos", "Cute Emoji Combinations", "Emoji Combo Ideas", "Bio Emoji Combos", "Soft Girl Emoji Combos", "Aesthetic Emoji Copy and Paste"],
-  "description": "100+ aesthetic emoji combos 🎀🌸✨ to copy and paste for bios, captions, and usernames — soft girl, cottagecore, night sky, Y2K, grunge, and kawaii sets. Tap any combo to copy the whole string instantly.",
+  "description": "200+ aesthetic emoji combos 🎀🌸✨ to copy and paste for bios, captions, and usernames — soft girl, cottagecore, night sky, Y2K, grunge, baddie, and kawaii sets. Tap any combo to copy the whole string instantly.",
   "author": {
     "@type": "Organization",
     "name": "UltraTextGen",
@@ -157,7 +157,7 @@
 <section class="hero">
   <div class="hero-inner">
     <h1 class="hero-headline">Emoji Combos</h1>
-    <p class="hero-tagline">100+ aesthetic emoji combos to copy and paste — soft girl, cottagecore, night sky, Y2K and more. Tap any combo to copy the whole set in one click.</p>
+    <p class="hero-tagline">200+ aesthetic emoji combos to copy and paste — soft girl, cottagecore, night sky, Y2K and more. Tap any combo to copy the whole set in one click.</p>
   </div>
 </section>
 <figure class="page-hero-figure" data-uthero aria-hidden="true">
@@ -169,7 +169,7 @@
 <!-- INTRO -->
 <section class="editorial-section">
   <div class="editorial-block">
-    <p>An <strong>emoji combo</strong> is a short, curated string of emojis that share one mood — think 🎀🌸✨ for a soft-girl bio or 🌙⭐☁️ for a dreamy night theme. It's the fastest way to give an Instagram bio, TikTok caption, Discord status, or username an instant aesthetic. Browse 100+ ready-made combos below grouped by vibe, <strong>tap any one to copy the whole string</strong>, then paste it straight into your profile — no app or sign-up. Want a single color theme, a laugh, or a holiday set? See <a href="/library/color-emoji-combos/">color emoji combos</a>, <a href="/library/funny-emoji-combos/">funny emoji combos</a>, and <a href="/library/seasonal-emoji-combos/">seasonal emoji combos</a>.</p>
+    <p>An <strong>emoji combo</strong> is a short, curated string of emojis that share one mood — think 🎀🌸✨ for a soft-girl bio or 🌙⭐☁️ for a dreamy night theme. It's the fastest way to give an Instagram bio, TikTok caption, Discord status, or username an instant aesthetic. Browse 200+ ready-made combos below grouped by vibe, <strong>tap any one to copy the whole string</strong>, then paste it straight into your profile — no app or sign-up. Want a single color theme, a laugh, or a holiday set? See <a href="/library/color-emoji-combos/">color emoji combos</a>, <a href="/library/funny-emoji-combos/">funny emoji combos</a>, and <a href="/library/seasonal-emoji-combos/">seasonal emoji combos</a>.</p>
   </div>
 </section>
 


### PR DESCRIPTION
The page ranks ~pos 7 with strong content (200 ready-to-paste combos across 27 aesthetics) but converts at 0.72% CTR (last 3mo GSC) — well below the positional baseline. The title/hero undersold the page at "100+" when it actually carries 200 combos.

Snippet-only change to isolate CTR as the variable:
- title / meta description / OG + Twitter tags / JSON-LD headline+description: "100+" -> honest "200+"; lead with aesthetic + copy-&-paste intent; surface the high-converting aesthetics (soft girl, Y2K, baddie, kawaii).
- hero tagline + intro count updated to match (200+).
- synced the SERP fields in data/library_page_specs/emoji-combos.json so a future regenerate doesn't revert the hand-tuned snippet.

No ranking/content/structure change, so any CTR delta over the next ~15 days is attributable to the snippet.


Claude-Session: https://claude.ai/code/session_012z6jFtYD75fxVnJ4abSdVp