### PR TITLE
fix: complete hreflang mesh for the cross-x-symbols locale cluster

### DIFF
--- a/ar/library/cross-x-symbols/index.html
+++ b/ar/library/cross-x-symbols/index.html
@@ -60,6 +60,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-salib/">
 <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-de-cruz-e-x/">
 <link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/library/kruis-symbool/">
+<link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/gyocha-giho/">
 <link rel="alternate" hreflang="ar" href="https://ultratextgen.com/ar/library/cross-x-symbols/">
 <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/cross-x-symbols/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/ar-library-cross-x-symbols.png">

--- a/es/library/simbolo-x/index.html
+++ b/es/library/simbolo-x/index.html
@@ -57,6 +57,8 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/cross-x-symbols/">
   <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/library/kreuz-x-symbole/">
   <link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/library/simbolo-x/">
+  <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-salib/">
+  <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-de-cruz-e-x/">
   <link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/library/kruis-symbool/">
   <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/gyocha-giho/">
   <link rel="alternate" hreflang="ar" href="https://ultratextgen.com/ar/library/cross-x-symbols/">

--- a/id/library/simbol-salib/index.html
+++ b/id/library/simbol-salib/index.html
@@ -56,6 +56,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 <link rel="canonical" href="https://ultratextgen.com/id/library/simbol-salib/">
 <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/cross-x-symbols/">
 <link rel="alternate" hreflang="de" href="https://ultratextgen.com/de/library/kreuz-x-symbole/">
+<link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/library/simbolo-x/">
 <link rel="alternate" hreflang="id" href="https://ultratextgen.com/id/library/simbol-salib/">
 <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-de-cruz-e-x/">
 <link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/library/kruis-symbool/">

--- a/ko/library/gyocha-giho/index.html
+++ b/ko/library/gyocha-giho/index.html
@@ -61,6 +61,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-de-cruz-e-x/">
 <link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/library/kruis-symbool/">
 <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/gyocha-giho/">
+<link rel="alternate" hreflang="ar" href="https://ultratextgen.com/ar/library/cross-x-symbols/">
 <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/library/cross-x-symbols/">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/ko-library-gyocha-giho.png">
 <meta property="og:image:width" content="1200">

--- a/pt/library/simbolos-de-cruz-e-x/index.html
+++ b/pt/library/simbolos-de-cruz-e-x/index.html
@@ -55,6 +55,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <link rel="canonical" href="https://ultratextgen.com/pt/library/simbolos-de-cruz-e-x/">
 <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/cross-x-symbols/">
+<link rel="alternate" hreflang="es" href="https://ultratextgen.com/es/library/simbolo-x/">
 <link rel="alternate" hreflang="pt" href="https://ultratextgen.com/pt/library/simbolos-de-cruz-e-x/">
 <link rel="alternate" hreflang="nl" href="https://ultratextgen.com/nl/library/kruis-symbool/">
 <link rel="alternate" hreflang="ko" href="https://ultratextgen.com/ko/library/gyocha-giho/">


### PR DESCRIPTION
## Summary

Investigated the "translate `library/cross-x-symbols` into `id/library/`" gap flagged in the private research repo's ID depth batch. Found the assumption was wrong: `id/library/simbol-salib/` already exists as a deliberate, complete Indonesian translation of the EN collection — it covers religious/decorative crosses + daggers, with X-marks/checkmarks intentionally split out to the sibling `id/library/simbol-centang/` page (cross-linked both ways). No new page needed.

While verifying that, found a real bug instead: the hreflang mesh for this 8-locale cluster (en/de/es/id/ko/pt/nl/ar) was incomplete in 5 of the 8 pages — each missing 1–2 cluster members from its `<link rel="alternate" hreflang="...">` block:

- `es/library/simbolo-x/` — missing `id`, `pt`
- `ko/library/gyocha-giho/` — missing `ar`
- `pt/library/simbolos-de-cruz-e-x/` — missing `es`
- `ar/library/cross-x-symbols/` — missing `ko`
- `id/library/simbol-salib/` — missing `es`

This is a completeness gap the existing `audit-hreflang.js`/`check-locale-mesh.js` tooling doesn't catch, since it only checks pairwise reciprocity (A links B implies B links A) rather than full cluster-membership coverage — every link that existed was already reciprocated, so `0 non-reciprocal pairs` was reported even with these gaps present.

- Added the missing `<link rel="alternate" hreflang="...">` entries to all 5 pages so every member of the cluster now declares all 8 locales + `x-default` (9 entries each, matching the already-complete `en`/`de`/`nl` pages).

## Test plan

- [x] `node scripts/check-locale-mesh.js` — 0 mesh problems introduced
- [x] `node scripts/check-translation-parity.js` — 0 unresolved parity drift
- [x] `node scripts/check-faq-schema.js` — 0 mismatched FAQ schema
- [x] `python3 scripts/check-new-page-image-assets.py` — 0 problems (no new pages, no new art needed)
- [x] Manually re-verified all 8 cluster pages now declare identical 9-entry hreflang sets

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PHK7wYCP4TFg2jUHiGAeVK)_