### PR TITLE
Remove underperforming top-banner ad slot

### DIFF
--- a/header.js
+++ b/header.js
@@ -5,19 +5,16 @@
   // this selector only locates the noscript iframe to position the header.
   const GTM_NOSCRIPT_SELECTOR = 'noscript iframe[src*="googletagmanager.com/ns.html"]';
 
-  // Dedicated ad slots — injected once here so every page that loads
-  // header.js gets them automatically, with no per-page markup to maintain.
+  // Dedicated ad slot — injected once here so every page that loads
+  // header.js gets it automatically, with no per-page markup to maintain.
   // Auto ads (Anchor, etc.) still runs from the loader script each page
-  // already ships in <head>; these two are the fixed, hand-placed units.
+  // already ships in <head>; this is the one remaining fixed, hand-placed unit.
+  // A top-banner unit (slot 7584734719) used to live here too — removed
+  // 2026-07-27 after a 7-day AdSense pull showed 3 impressions / SGD0.00
+  // sitewide while permanently reserving 100-250px under the nav on every
+  // pageview. See ultratextgen-lab- docs/adsense-coverage-and-monetization-
+  // diversification-2026-07-16.md §11 for the full analysis.
   const AD_CLIENT = "ca-pub-8242324164413945";
-
-  const topBannerHTML = '<div class="ad-slot ad-top-banner">' +
-      '<ins class="adsbygoogle" style="display:block" ' +
-        'data-ad-client="' + AD_CLIENT + '" ' +
-        'data-ad-slot="7584734719" ' +
-        'data-ad-format="auto" ' +
-        'data-full-width-responsive="true"></ins>' +
-    '</div>';
 
   const rightRailHTML = '<aside class="ad-slot ad-rail-right">' +
       '<ins class="adsbygoogle" style="display:inline-block;width:300px;height:600px" ' +
@@ -460,18 +457,12 @@
       body.insertBefore(header, insertAfter ? insertAfter.nextSibling : body.firstChild);
     }
 
-    // Ad slots: top banner right after the nav, right rail appended to
-    // <body> (it's position:fixed, so its DOM position doesn't matter).
-    const headerEl = document.querySelector("header.header");
-    if (headerEl) {
-      headerEl.insertAdjacentHTML("afterend", topBannerHTML);
-    }
+    // Ad slot: right rail appended to <body> (it's position:fixed, so its
+    // DOM position doesn't matter).
     document.body.insertAdjacentHTML("beforeend", rightRailHTML);
     if (window.adsbygoogle === undefined) {
       window.adsbygoogle = [];
     }
-    // Top banner always requests — it's visible at every viewport width.
-    window.adsbygoogle.push({});
     // Right rail is CSS-hidden below 1600px (see .ad-rail-right in style.css);
     // only request it when it'll actually be seen, so narrow viewports don't
     // burn an impression on a slot nobody can view.

--- a/style.css
+++ b/style.css
@@ -7963,30 +7963,12 @@ body.dark-mode .kana-cell-empty { opacity: 0.35; }
   line-height: 1.4;
 }
 
-/* Dedicated ad slots — injected by header.js on every page.
+/* Dedicated ad slot — injected by header.js on every page.
    Right rail only has room once the viewport clears the 900px container
    plus its own 300px width on both sides without overlapping content. */
 .ad-slot {
   display: flex;
   justify-content: center;
-}
-
-.ad-top-banner {
-  width: 100%;
-  max-width: 900px;
-  margin: 16px auto;
-  padding: 0 24px;
-  box-sizing: border-box;
-  /* Reserve space before the AdSense creative loads so it doesn't push
-     section.hero down once it fills in — this was measured as a real CLS
-     regression (Cloudflare Web Analytics, section.hero up to 0.615). */
-  min-height: 100px;
-}
-
-@media (min-width: 768px) {
-  .ad-top-banner {
-    min-height: 250px;
-  }
 }
 
 .ad-rail-right {


### PR DESCRIPTION
## Summary
Removes the top-banner ad unit (slot 7584734719) that was generating minimal revenue with significant layout cost. Analysis showed 3 impressions / SGD0.00 sitewide over 7 days while permanently reserving 100–250px of vertical space under the nav on every pageview.

## Changes
- **header.js**: Removed `topBannerHTML` variable and its injection logic after the header element
- **header.js**: Removed the `window.adsbygoogle.push({})` call that was requesting the top banner ad
- **header.js**: Updated comments to reflect that only the right-rail ad slot remains as a fixed, hand-placed unit
- **style.css**: Removed `.ad-top-banner` CSS class and its responsive breakpoint rules (100px min-height, 250px at 768px+)
- **style.css**: Updated comment to reflect singular "ad slot" instead of plural "slots"

## Details
The top-banner unit was positioned between the header and page content with responsive spacing (16px margin, 24px horizontal padding). Removal eliminates layout shift and reserved space without impacting the right-rail ad slot, which remains CSS-hidden below 1600px viewport width and only requests when visible.

See `docs/adsense-coverage-and-monetization-diversification-2026-07-16.md §11` for full analysis.

https://claude.ai/code/session_01MYgWzExEmV8D8tQGpejxdY