### PR TITLE
feat: English-Parent-Rule exceptions ledger + gate wiring + ownership-check-before-build rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -744,6 +744,35 @@ same content to the two IT pages, or record the divergence deliberately
 requires an `enUrl`, so it doesn't fit this pair as-is) — not left to drift
 by default.
 
+**Ratified exceptions are ledgered state, not just prose (2026-08-01):**
+every ratified local-only exception above is also recorded in
+**`data/english_parent_exceptions.json`** — the machine-readable ledger
+`scripts/check-locale-parent-gap.js` consults, so a listed page passes the
+gate's `no-en-parent` check and an unlisted one fails it. The prose above
+stays the reasoning of record; the ledger is the state. Same bar as every
+other ledger in this repo: entries are discussed decisions, never added
+unilaterally to make a page pass. Each entry carries a `nextRecheck` date —
+exceptions are standing claims about EN demand, and claims get re-verified,
+not grandfathered.
+
+**When EN demand appears later — ownership check before build (2026-08-01):**
+if EN-side demand evidence surfaces for a page holding a local-only
+exception, do **not** build the EN parent directly. Run the "check who
+already owns it" test (see "Before building a page for a keyword" above) on
+the **English** SERP/GSC first. Two outcomes only:
+
+- **Build** — the EN SERP for the concept is distinct and no existing EN
+  page owns it → build the EN parent, wire the hreflang cluster, and remove
+  the page's `data/english_parent_exceptions.json` entry (it's now a normal
+  translation).
+- **Veto** — the EN SERP consolidates the term onto an existing page (the
+  `fr/calligraphie` trio's situation: real EN "font"/"calligraphy" volume,
+  but building a parent would cannibalize the EN homepage) → record a dated
+  `veto` in the entry's `verdict` and push out `nextRecheck`.
+
+Demand alone never auto-triggers the build — that shortcut is how the
+`vi/chu-kieu/` class of cannibalization happens on the EN side.
+
 ### Locale-native internal linking — check every time you touch a locale page
 
 Whenever you create, edit, or otherwise touch a locale page's prose/FAQ
@@ -1041,8 +1070,8 @@ complete flowchart, and every script's flags/exit codes:
   reason.
 
 **Do not add or edit an entry in `data/locale_parent_gap_audit.json`,
-`data/core_parent_set.json`, or `data/locale_qualification_tiers.json`
-unilaterally.** Every entry in all three reflects a discussed decision
+`data/core_parent_set.json`, `data/locale_qualification_tiers.json`, or
+`data/english_parent_exceptions.json` unilaterally.** Every entry in all three reflects a discussed decision
 between you and the user — the same bar CLAUDE.md's English-Parent Rule sets
 for locale-first exceptions, and the same bar `data/translation_parity_exceptions.json`
 sets for parity divergences. If one of the gap-check scripts flags a
@@ -1079,6 +1108,15 @@ Three recurring points of confusion, each resolved by a real case:
    hold reasoning to the user *before* they decide is part of the override
    being legitimate — a hold silently ignored is a violation, a hold
    knowingly overridden is a decision.
+4. **An all-instruments-null authorization is a bridge, not a pass
+   (2026-08-01).** A `data/locale_parent_gap_audit.json` entry recorded with
+   every instrument `null` (a user authorization in lieu of a real pull) must
+   name a scheduled re-check date in the ops review register, and the entry
+   is complete only when its instruments are backfilled with real numbers or
+   a dated veto is recorded. If a later backfill contradicts the recorded
+   verdict, do not silently flip it — the pages are live by then, so the
+   call (fold/de-index/keep) is a discussion with the user, flagged with the
+   data.
 
 ### Governance arrives mid-flight: merged-in rules bind unshipped work
 

--- a/data/english_parent_exceptions.json
+++ b/data/english_parent_exceptions.json
@@ -1,0 +1,77 @@
+{
+  "_readme": "Machine-readable ledger of the English-Parent Rule's ratified local-only exceptions — locale pages explicitly agreed to exist with NO live English parent (see CLAUDE.md, 'Localization Workflow — the English-Parent Rule', which holds the full narrative for each). This file is the state the tooling consults; the CLAUDE.md prose is the reasoning of record. Read by scripts/check-locale-parent-gap.js: a newly-added locale page whose canonical URL is listed here passes the no-en-parent check instead of failing it. Do NOT add an entry here unilaterally — every entry must reflect a real, discussed ratification with the user, the same bar as data/translation_parity_exceptions.json and data/locale_parent_gap_audit.json. Entry shape: { localeUrl (full canonical https URL, trailing slash), reason (why no EN parent exists — 'no-EN-demand-by-construction' cases vs 'EN-SERP-consolidation' cases are different claims, name which), agreed (YYYY-MM-DD), enDemandBasis (what was known about EN-side demand at ratification), lastRechecked (YYYY-MM-DD or null — date of the last reverse-demand sweep), nextRecheck (YYYY-MM-DD — when the EN side should next be checked), verdict (latest re-check outcome: null until first sweep, then 'exception-stands' | 'veto' (EN demand exists but the EN SERP consolidates the term onto an existing page — building a parent would cannibalize it) | 'build-parent' (EN demand found on a distinct SERP — build the EN parent, wire the cluster, then REMOVE this entry)) }. The standing decision rule when EN demand appears is ownership-check-before-build: demand alone never auto-triggers the EN build — run the 'check who already owns it' test on the English SERP first, then build or record a dated veto.",
+  "exceptions": [
+    {
+      "localeUrl": "https://ultratextgen.com/ja/gal-moji/",
+      "reason": "Japanese hiragana/katakana lookalike-glyph cipher (styles.js Japanese-script-only procedureId). The transform operates on Japanese script; an EN page would not be a translation of this feature. no-EN-demand-by-construction claim.",
+      "agreed": "2026-07-25",
+      "enDemandBasis": "No English speaker searches 'gal moji converter' as a query distinct from the plain homepage generator — asserted at ratification, not instrument-checked.",
+      "lastRechecked": null,
+      "nextRecheck": "2026-09-01",
+      "verdict": null
+    },
+    {
+      "localeUrl": "https://ultratextgen.com/ko/font-byeonhwan/",
+      "reason": "CJK-script-user tool for decorating Latin/English text, distinct in H1/framing from ko's own homepage. Pairs with zh-tw/yingwen-ziti/. no-EN-demand-by-construction claim ('English font generator' is not a distinct EN query from the homepage generator).",
+      "agreed": "2026-07-25",
+      "enDemandBasis": "Asserted at ratification, not instrument-checked.",
+      "lastRechecked": null,
+      "nextRecheck": "2026-09-01",
+      "verdict": null
+    },
+    {
+      "localeUrl": "https://ultratextgen.com/zh-tw/yingwen-ziti/",
+      "reason": "Same ratification and claim shape as ko/font-byeonhwan/ (same 2026-07-25 pass).",
+      "agreed": "2026-07-25",
+      "enDemandBasis": "Asserted at ratification, not instrument-checked.",
+      "lastRechecked": null,
+      "nextRecheck": "2026-09-01",
+      "verdict": null
+    },
+    {
+      "localeUrl": "https://ultratextgen.com/id/tulisan-cuping/",
+      "reason": "Indonesian phonetic cute-typing transform (r→l, s→c, community-fixed forms) operating on Indonesian phonemes — an EN parent would not be a translation of the feature. no-EN-demand-by-construction claim. Precedent, not a template: future locale-slang transforms each need their own demand evidence and discussion.",
+      "agreed": "2026-07-26",
+      "enDemandBasis": "'font cuping'/'cuping font' ≈33,000/mo combined ID-market (KD 19–20); 'cuping' is not a term English speakers search — the ID-side number is measured, the EN-side zero is asserted.",
+      "lastRechecked": null,
+      "nextRecheck": "2026-09-01",
+      "verdict": null
+    },
+    {
+      "localeUrl": "https://ultratextgen.com/fr/calligraphie/",
+      "reason": "EN-SERP-consolidation claim — NOT a no-EN-demand claim: 'calligraphy' has real EN volume, but the EN SERP is believed to consolidate it onto the homepage-type pages (row-17 close-out read), while French GSC shows fr/index.html doesn't compete on this page's queries (76% of impressions on 'calligraphie copier coller' family).",
+      "agreed": "2026-07-26",
+      "enDemandBasis": "EN-side synonym-consolidation premise is INFERRED from the font-converter row-17 close-out, never verified against EN GSC/SERP data for 'calligraphy' specifically — the first reverse-demand sweep must verify it.",
+      "lastRechecked": null,
+      "nextRecheck": "2026-09-01",
+      "verdict": null
+    },
+    {
+      "localeUrl": "https://ultratextgen.com/fr/changeur-de-police/",
+      "reason": "EN-SERP-consolidation claim, same ratification as fr/calligraphie/. Strongest FR ownership evidence of the trio: 100% of impressions on queries fr/index.html never ranks for ('change police'/'changeur de police'). Cluster includes live IT siblings (it/font-copia-e-incolla/, it/caratteri-speciali/) with no EN member — the locale↔locale parity blind spot flagged 2026-07-26 lives on this cluster.",
+      "agreed": "2026-07-26",
+      "enDemandBasis": "Same inferred-not-verified EN consolidation premise as fr/calligraphie/ ('font changer' EN SERP believed to pull the same competitor set as 'font generator').",
+      "lastRechecked": null,
+      "nextRecheck": "2026-09-01",
+      "verdict": null
+    },
+    {
+      "localeUrl": "https://ultratextgen.com/fr/police-d-ecriture/",
+      "reason": "EN-SERP-consolidation claim, same ratification as fr/calligraphie/. Largest and still-growing FR volume of the trio: 'police d'écriture'/'police ecriture' — fr/index.html shows 4 impressions at pos 24 vs this page's 188 at pos 9.6 on the same query.",
+      "agreed": "2026-07-26",
+      "enDemandBasis": "Same inferred-not-verified EN consolidation premise as fr/calligraphie/.",
+      "lastRechecked": null,
+      "nextRecheck": "2026-09-01",
+      "verdict": null
+    },
+    {
+      "localeUrl": "https://ultratextgen.com/fr/ecriture-speciale/",
+      "reason": "Not a ratified keep on demand evidence — the 2026-07-26 GSC pull found negligible volume either way and the page was left as-is while its two siblings (fr/ecriture-style/, fr/generateur-de-texte/) were 301'd to fr/. Listed so the gate and the reverse-demand sweep see it; it is a fold candidate at the next re-check, not a demand-backed exception.",
+      "agreed": "2026-07-26",
+      "enDemandBasis": "Negligible FR volume in the 26-day GSC pull; EN side never checked.",
+      "lastRechecked": null,
+      "nextRecheck": "2026-09-01",
+      "verdict": null
+    }
+  ]
+}

--- a/scripts/check-locale-parent-gap.js
+++ b/scripts/check-locale-parent-gap.js
@@ -30,11 +30,13 @@
 const fs = require('fs');
 const path = require('path');
 const { execFileSync } = require('child_process');
-const { discoverClusters } = require('./lib/translation-clusters');
+const { discoverClusters, normalizeUrl } = require('./lib/translation-clusters');
 const { decide, LOCALES } = require('./lib/locale-parent-registry');
 
 const ROOT = path.resolve(__dirname, '..');
 const GAP_LEDGER_PATH = path.join(ROOT, 'data', 'locale_parent_gap_audit.json');
+const EN_PARENT_EXCEPTIONS_PATH = path.join(ROOT, 'data', 'english_parent_exceptions.json');
+const SITE_ORIGIN = 'https://ultratextgen.com';
 
 const args = process.argv.slice(2);
 const baseIdx = args.indexOf('--base');
@@ -109,6 +111,22 @@ function passingLedgerEntry(pattern, locale) {
   );
 }
 
+// Ratified English-Parent-Rule exceptions — locale pages explicitly agreed to
+// exist with no EN parent (see data/english_parent_exceptions.json's _readme
+// and CLAUDE.md's "Localization Workflow" ratifications). Keyed by normalized
+// canonical URL.
+let enParentExceptionUrls = new Set();
+if (fs.existsSync(EN_PARENT_EXCEPTIONS_PATH)) {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(EN_PARENT_EXCEPTIONS_PATH, 'utf8'));
+    enParentExceptionUrls = new Set(
+      (parsed.exceptions || []).map((e) => normalizeUrl(e.localeUrl)).filter(Boolean)
+    );
+  } catch (e) {
+    console.error(`WARNING: could not parse ${path.relative(ROOT, EN_PARENT_EXCEPTIONS_PATH)}: ${e.message}`);
+  }
+}
+
 // ─── Check every newly-added locale page ───────────────────────────────────
 
 const flagged = [];
@@ -120,16 +138,51 @@ for (const rel of addedFiles) {
   if (!fs.existsSync(filePath)) continue; // deleted later in the same branch
 
   const rec = [...byUrl.values()].find((r) => r.rel === rel);
-  if (!rec) continue; // no canonical tag at all — not part of the hreflang system
-  if (!rec.ownLang || rec.ownLang === 'en') continue;
+  if (!rec) {
+    // No canonical tag at all. A real page always carries one (see CLAUDE.md,
+    // "HTML Page Conventions") — a new locale index.html without it would
+    // otherwise slip past this gate entirely, since it can't join the
+    // hreflang system it's supposed to be checked against.
+    if (!rel.endsWith('/index.html')) continue; // fragments/partials — not pages
+    const impliedUrl = normalizeUrl(`${SITE_ORIGIN}/${rel.replace(/index\.html$/, '')}`);
+    if (enParentExceptionUrls.has(impliedUrl)) continue; // ratified local-only page
+    checked++;
+    flagged.push({
+      rel,
+      localeCode: (rel.match(LOCALE_PREFIX_RE) || [])[1] || '?',
+      problem: 'no-en-parent',
+      detail:
+        'This new locale page has no <link rel="canonical"> tag at all, so it cannot join the hreflang ' +
+        'system and its EN parent can\'t be classified. Add the canonical + hreflang block (see CLAUDE.md, ' +
+        '"HTML Page Conventions" and "Localization Workflow — the English-Parent Rule"), or — if this is a ' +
+        'genuinely local-only page — ratify it with the user and record it in data/english_parent_exceptions.json.',
+    });
+    continue;
+  }
+  if (rec.ownLang === 'en') continue;
+  if (!rec.ownLang) {
+    // No self-referencing hreflang entry (typically no hreflang block at
+    // all). These used to be skipped silently — exactly how a local-only
+    // page could ship ungated. A ratified exception passes here; anything
+    // else falls through and is judged by the no-en-parent branch below.
+    if (enParentExceptionUrls.has(rec.canonical)) continue;
+  }
 
   checked++;
-  const localeCode = rec.ownLang.toLowerCase();
+  const localeCode = rec.ownLang
+    ? rec.ownLang.toLowerCase()
+    : (rel.match(LOCALE_PREFIX_RE) || [])[1] || '?';
 
   const enAlt = rec.alternates.find((a) => a.hreflang === 'en');
   const enRec = enAlt ? byUrl.get(enAlt.href) : null;
 
   if (!enRec) {
+    if (enParentExceptionUrls.has(rec.canonical)) {
+      // Ratified English-Parent-Rule exception — passes by explicit,
+      // recorded decision (data/english_parent_exceptions.json).
+      console.log(`  ratified local-only exception (passes): ${rel}`);
+      continue;
+    }
     flagged.push({
       rel,
       localeCode,
@@ -137,8 +190,10 @@ for (const rel of addedFiles) {
       detail:
         'This new locale page declares no resolvable hreflang="en" alternate, so its EN parent ' +
         "(and therefore its Core Parent Set pattern) can't be classified. Add the hreflang link " +
-        '(see CLAUDE.md, "Localization Workflow — the English-Parent Rule") or run ' +
-        '`npm run sync:locale-mesh -- --fix` if the EN parent already exists.',
+        '(see CLAUDE.md, "Localization Workflow — the English-Parent Rule"), run ' +
+        '`npm run sync:locale-mesh -- --fix` if the EN parent already exists, or — if this is a ' +
+        'genuinely local-only page — ratify it with the user and record it in ' +
+        'data/english_parent_exceptions.json.',
     });
     continue;
   }


### PR DESCRIPTION
## What this does

Makes the English-Parent Rule's ratified local-only exceptions **machine-readable state** instead of CLAUDE.md prose only, and codifies two standing rules agreed 2026-08-01.

### 1. `data/english_parent_exceptions.json` (new)

Ledger of the eight ratified local-only pages (`ja/gal-moji`, `ko/font-byeonhwan`, `zh-tw/yingwen-ziti`, `id/tulisan-cuping`, `fr/calligraphie`, `fr/changeur-de-police`, `fr/police-d-ecriture`, `fr/ecriture-speciale`), each with its ratification date, the demand basis known at ratification (explicitly distinguishing *no-EN-demand-by-construction* claims from *EN-SERP-consolidation* claims), a `nextRecheck` date (first sweep 2026-09-01), and a `verdict` field for re-check outcomes.

### 2. `scripts/check-locale-parent-gap.js` wiring

- A newly-added locale page whose canonical URL is in the ledger now **passes** the `no-en-parent` check; an unlisted one still fails, with the failure text pointing at the ratification path.
- Closes two silent skips: a new locale `index.html` with **no canonical tag** (previously `continue`d past the gate entirely) and one with a canonical but **no hreflang block** (previously skipped via the `ownLang` null check) — both now fail unless ledgered.
- Verified with scratch pages exercising all three paths (no-canonical → fails; canonical-without-EN-alternate → fails; ledgered page → passes); scratch commits dropped before push. `node --check` clean; the gate exits 0 on this branch (no HTML added).

### 3. CLAUDE.md rule text

- **Ratified exceptions are ledgered state, not grandfathered prose** — each carries a `nextRecheck`; claims about EN demand get re-verified.
- **When EN demand appears later: ownership check before build** — demand alone never auto-triggers the EN parent build; run the "check who already owns it" test on the English SERP first, then either build (and retire the ledger entry) or record a dated veto. The `fr/calligraphie` trio is the standing veto example.
- **An all-instruments-null gap-audit authorization is a bridge, not a pass** — it must carry a scheduled re-check date, and the entry is complete only when instruments are backfilled or a dated veto recorded (added as point 4 of "What passes a gate").
- The four-ledger "do not edit unilaterally" list now includes the new file.

No HTML pages are touched; no page content changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015iJb3h5BA1tNNo5qNwV7Hp

---
_Generated by [Claude Code](https://claude.ai/code/session_015iJb3h5BA1tNNo5qNwV7Hp)_