### PR TITLE
Update excluded candidates count in language index

### DIFF
--- a/data/local-language/index.json
+++ b/data/local-language/index.json
@@ -25,5 +25,5 @@
     "tr"
   ],
   "total_approved_or_limited_use_phrases": 395,
-  "total_excluded_candidates_or_other": 294
+  "total_excluded_candidates_or_other": 660
 }


### PR DESCRIPTION
## Summary
Updates the total count of excluded candidates or other entries in the local language index data file.

## Changes
- **data/local-language/index.json**: Incremented `total_excluded_candidates_or_other` from 294 to 660

## Details
This change reflects an updated count of excluded candidates or other language entries in the index. The increase of 366 items suggests a data refresh or audit of the language candidate pool.

https://claude.ai/code/session_01JccmUJqmssNqM7MKEK8Vzt