### PR TITLE
feat: build not-equal-sign and hamsa-symbol spoke pages

### DIFF
--- a/data/library_page_specs/hamsa-symbol.json
+++ b/data/library_page_specs/hamsa-symbol.json
@@ -1,0 +1,73 @@
+{
+  "slug": "hamsa-symbol",
+  "page_type": "symbol",
+  "title": "Hamsa Symbol: Copy & Paste 🪬 — The Hand of Fatima & Miriam",
+  "meta_description": "Copy and paste the hamsa hand (🪬) — the palm-and-eye amulet known as the Hand of Fatima and the Hand of Miriam, shared as protection against the evil eye across Jewish, Muslim, and Christian traditions. Click any symbol to copy it instantly.",
+  "canonical": "https://ultratextgen.com/symbol/hamsa-symbol/",
+  "breadcrumb": "Hamsa Symbol",
+  "hero_h1": "Hamsa Symbol",
+  "hero_tagline": "The hamsa hand (🪬) is the open-palm Hand of Fatima and Hand of Miriam — the amulet worn against the evil eye across Jewish, Muslim, and Christian traditions alike. Click any symbol to copy it instantly.",
+  "intro": "The hamsa (🪬, U+1FAAC) is an open-hand amulet, usually shown with an eye set in the palm, believed to protect against the evil eye. The same hand shape is called the Hand of Fatima in Islamic tradition and the Hand of Miriam in Jewish tradition, and it has been worn for centuries across North Africa and the Middle East by Muslim, Jewish, and Christian communities alike — one of the rare symbols that unites rather than divides the traditions that claim it. Its name comes from the Semitic word for \"five,\" for the five fingers of the hand. Though the symbol itself is ancient, it only received its own Unicode emoji in 2021.",
+  "date_published": "2026-07-12",
+  "date_modified": "2026-07-12",
+  "copy_pattern": "single",
+  "sections": [
+    {
+      "id": "hamsa-hand",
+      "label": "Hamsa",
+      "h2": "Hamsa Hand (Hand of Fatima / Hand of Miriam)",
+      "intro": "The hamsa emoji — an open palm with an eye at its center. There is no older plain-text version of this glyph; it exists only as a color emoji, added to Unicode in 2021.",
+      "symbols": [
+        { "char": "🪬", "label": "Hamsa" }
+      ]
+    },
+    {
+      "id": "evil-eye-nazar",
+      "label": "Not the Same",
+      "h2": "Evil Eye & Nazar — Often Paired, Not the Same",
+      "intro": "The hamsa is a hand; the nazar is a blue glass eye-bead from Turkish tradition. They are frequently worn together and share the same job of deflecting the evil eye, but they are distinct symbols — don't confuse the two.",
+      "symbols": [
+        { "char": "🧿", "label": "Nazar Amulet (Evil Eye)" },
+        { "char": "👁️", "label": "Eye" },
+        { "char": "👀", "label": "Eyes" },
+        { "char": "🔵", "label": "Blue Circle" }
+      ]
+    },
+    {
+      "id": "protective-hands",
+      "label": "Open Palm",
+      "h2": "Open-Palm & Protection Symbols",
+      "intro": "The open right hand is itself an ancient sign of protection and blessing. These hand and charm emoji echo the hamsa's raised palm in bios and captions.",
+      "symbols": [
+        { "char": "✋", "label": "Raised Hand" },
+        { "char": "🖐", "label": "Hand with Fingers Splayed" },
+        { "char": "🤚", "label": "Raised Back of Hand" },
+        { "char": "🤲", "label": "Palms Up Together" },
+        { "char": "🙏", "label": "Folded Hands" },
+        { "char": "📿", "label": "Prayer Beads" }
+      ]
+    }
+  ],
+  "related": [
+    {
+      "href": "/library/evil-eye-hamsa-symbols/",
+      "title": "Evil Eye & Hamsa Symbols",
+      "desc": "The nazar amulet, hamsa hand, watchful eyes, and the blue-bead palette in one browse-and-copy collection."
+    },
+    {
+      "href": "/library/religious-symbols/",
+      "title": "Religious Symbols",
+      "desc": "Faith and protection symbols from traditions around the world, gathered in one reference."
+    },
+    {
+      "href": "/symbol/star-of-david/",
+      "title": "Star of David",
+      "desc": "Another identity symbol with deep, cross-cultural history and its own dedicated page."
+    },
+    {
+      "href": "/symbol/khanda-symbol/",
+      "title": "Khanda Symbol",
+      "desc": "A faith emblem that, like the hamsa, waited years for its own dedicated Unicode emoji."
+    }
+  ]
+}

--- a/data/library_page_specs/not-equal-sign.json
+++ b/data/library_page_specs/not-equal-sign.json
@@ -1,0 +1,70 @@
+{
+  "slug": "not-equal-sign",
+  "page_type": "symbol",
+  "title": "Not Equal Sign (≠): Copy, Paste & How to Type the Does-Not-Equal Symbol",
+  "meta_description": "Copy and paste the not equal sign (≠), the does-not-equal symbol with no key on any keyboard. How to type it on Mac and Windows, plus why code uses != and <> instead.",
+  "canonical": "https://ultratextgen.com/symbol/not-equal-sign/",
+  "breadcrumb": "Not Equal Sign",
+  "hero_h1": "Not Equal Sign (≠)",
+  "hero_tagline": "The \"does not equal\" symbol — the one math character with no key on any keyboard, which is why code types it as != or <> instead. Click to copy it, then paste it anywhere.",
+  "intro": "The not equal sign (≠, U+2260) is an equals sign with a slash through it: it means two values are not the same. It sits in Unicode's Mathematical Operators block, and unlike + or =, it has no dedicated key on any physical keyboard — which is exactly why so many people end up searching for it, and why almost every programming language and spreadsheet substitutes a typeable stand-in like != or <> instead.",
+  "date_published": "2026-07-12",
+  "date_modified": "2026-07-12",
+  "copy_pattern": "single",
+  "sections": [
+    {
+      "id": "not-equal-to-sign",
+      "label": "Not Equal",
+      "h2": "The Not Equal To Sign (≠)",
+      "intro": "The single Unicode character for \"not equal\" — click to copy, then paste it into a document, formula, bio, or chat.",
+      "symbols": [
+        { "char": "≠", "label": "Not Equal To" }
+      ]
+    },
+    {
+      "id": "negation-family",
+      "label": "Negated Operators",
+      "h2": "Other Negated \"Not\" Operators",
+      "intro": "≠ belongs to a whole family of relations that a slash turns into their opposite. Each of these is its own separate Unicode character — not the ≠ sign.",
+      "symbols": [
+        { "char": "≢", "label": "Not Identical To" },
+        { "char": "≉", "label": "Not Almost Equal To" },
+        { "char": "∉", "label": "Not an Element Of" },
+        { "char": "∌", "label": "Does Not Contain as Member" },
+        { "char": "∤", "label": "Does Not Divide" },
+        { "char": "≁", "label": "Not Tilde" }
+      ]
+    },
+    {
+      "id": "confusable-equality",
+      "label": "Similar Equality Signs",
+      "h2": "Equality Signs People Mix Up With ≠",
+      "intro": "The characters most often confused with ≠ at a glance — each one means something different from \"not equal.\"",
+      "symbols": [
+        { "char": "=", "label": "Equals Sign" },
+        { "char": "≈", "label": "Almost Equal To" },
+        { "char": "≡", "label": "Identical To" },
+        { "char": "≅", "label": "Approximately Equal To" },
+        { "char": "≤", "label": "Less-Than or Equal To" },
+        { "char": "≥", "label": "Greater-Than or Equal To" }
+      ]
+    }
+  ],
+  "related": [
+    {
+      "href": "/library/math-symbols/",
+      "title": "All Math Symbols",
+      "desc": "Operators, Greek letters, set theory, and calculus notation in one reference."
+    },
+    {
+      "href": "/symbol/less-than-greater-than/",
+      "title": "Less Than & Greater Than (< >)",
+      "desc": "The comparison operators that also stand in for not-equal as <> in SQL, Excel, and Pascal."
+    },
+    {
+      "href": "/symbol/plus-minus/",
+      "title": "Plus-Minus (±)",
+      "desc": "Another Mathematical Operators glyph with no key of its own."
+    }
+  ]
+}

--- a/library/evil-eye-hamsa-symbols/index.html
+++ b/library/evil-eye-hamsa-symbols/index.html
@@ -314,6 +314,10 @@
       <h4>Moon &amp; Celestial Symbols</h4>
       <p>Moon phases, stars, and celestial characters to copy and paste.</p>
     </a>
+    <a href="/symbol/hamsa-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Hamsa Symbol</h4>
+      <p>The hamsa hand (🪬) — the Hand of Fatima and Hand of Miriam, shared protection against the evil eye.</p>
+    </a>
   </div>
 </section>
 

--- a/library/math-symbols/index.html
+++ b/library/math-symbols/index.html
@@ -125,7 +125,7 @@
 <section class="editorial-section">
   <div class="editorial-block">
     <p>Mathematical symbols in Unicode make it easy to write equations, formulas, and scientific notation in plain text — no LaTeX or special software needed. These characters are supported in emails, social media, documents, and messaging apps. Browse by category and click any symbol to copy it.</p>
-    <p>Looking for the full story on one specific symbol — its history, alt codes, and platform compatibility? Seven of the symbols below have their own dedicated page: <a href="/symbol/square-root/">square root (√)</a>, <a href="/symbol/infinity/">infinity (∞)</a>, <a href="/symbol/plus-minus/">plus-minus (±)</a>, <a href="/symbol/less-than-greater-than/">less than &amp; greater than (&lt; &gt;)</a>, <a href="/symbol/division-sign/">division sign (÷)</a>, <a href="/symbol/multiplication-sign/">multiplication sign (×)</a>, and <a href="/symbol/squared-cubed/">squared &amp; cubed (² ³)</a>.</p>
+    <p>Looking for the full story on one specific symbol — its history, alt codes, and platform compatibility? Eight of the symbols below have their own dedicated page: <a href="/symbol/square-root/">square root (√)</a>, <a href="/symbol/infinity/">infinity (∞)</a>, <a href="/symbol/plus-minus/">plus-minus (±)</a>, <a href="/symbol/less-than-greater-than/">less than &amp; greater than (&lt; &gt;)</a>, <a href="/symbol/division-sign/">division sign (÷)</a>, <a href="/symbol/multiplication-sign/">multiplication sign (×)</a>, <a href="/symbol/squared-cubed/">squared &amp; cubed (² ³)</a>, and <a href="/symbol/not-equal-sign/">not equal (≠)</a>.</p>
   </div>
 </section>
 
@@ -690,6 +690,10 @@
     <a href="/symbol/squared-cubed/" class="compare-card variant-muted u-no-underline">
       <h4>Squared &amp; Cubed Symbols</h4>
       <p>The two superscript digits old enough to predate the rest of the set.</p>
+    </a>
+    <a href="/symbol/not-equal-sign/" class="compare-card variant-muted u-no-underline">
+      <h4>Not Equal Sign (≠)</h4>
+      <p>The "does not equal" symbol — the one math character with no key on any keyboard, which is why code types it as != or &lt;&gt; instead.</p>
     </a>
   </div>
 </section>

--- a/library/religious-symbols/index.html
+++ b/library/religious-symbols/index.html
@@ -505,6 +505,10 @@
       <h4>Star of David</h4>
       <p>The six-pointed Star of David (✡ ✡️) — the Magen David, or "Shield of David".</p>
     </a>
+    <a href="/symbol/hamsa-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Hamsa Symbol</h4>
+      <p>The hamsa hand (🪬) — the Hand of Fatima and Hand of Miriam, shared protection against the evil eye.</p>
+    </a>
   </div>
 </section>
 

--- a/symbol/hamsa-symbol/index.html
+++ b/symbol/hamsa-symbol/index.html
@@ -1,0 +1,355 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8242324164413945"
+       crossorigin="anonymous"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Hamsa Symbol: Copy &amp; Paste 🪬 — The Hand of Fatima &amp; Miriam</title>
+<meta name="description" content="Copy and paste the hamsa hand (🪬) — the palm-and-eye amulet known as the Hand of Fatima and the Hand of Miriam, shared as protection against the evil eye across Jewish, Muslim, and Christian traditions. Click any symbol to copy it instantly.">
+
+<link rel="canonical" href="https://ultratextgen.com/symbol/hamsa-symbol/">
+<meta property="og:image" content="https://ultratextgen.com/logo.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Hamsa Symbol: Copy &amp; Paste 🪬 — The Hand of Fatima &amp; Miriam">
+<meta name="twitter:description" content="Copy and paste the hamsa hand (🪬) — the palm-and-eye amulet known as the Hand of Fatima and the Hand of Miriam, shared as protection against the evil eye across Jewish, Muslim, and Christian traditions. Click any symbol to copy it instantly.">
+<meta name="twitter:image" content="https://ultratextgen.com/logo.png">
+<meta property="og:title" content="Hamsa Symbol: Copy &amp; Paste 🪬 — The Hand of Fatima &amp; Miriam">
+<meta property="og:description" content="Copy and paste the hamsa hand (🪬) — the palm-and-eye amulet known as the Hand of Fatima and the Hand of Miriam, shared as protection against the evil eye across Jewish, Muslim, and Christian traditions. Click any symbol to copy it instantly.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/symbol/hamsa-symbol/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Hamsa Symbol: Copy & Paste 🪬 — The Hand of Fatima & Miriam",
+  "description": "Copy and paste the hamsa hand (🪬) — the palm-and-eye amulet known as the Hand of Fatima and the Hand of Miriam, shared as protection against the evil eye across Jewish, Muslim, and Christian traditions. Click any symbol to copy it instantly.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "mainEntityOfPage": "https://ultratextgen.com/symbol/hamsa-symbol/",
+  "datePublished": "2026-07-12",
+  "dateModified": "2026-07-12"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://ultratextgen.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Symbols",
+      "item": "https://ultratextgen.com/symbol/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Hamsa Symbol",
+      "item": "https://ultratextgen.com/symbol/hamsa-symbol/"
+    }
+  ]
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What does the hamsa hand mean?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "<p>The hamsa is an open-hand amulet, usually shown with a single eye in the palm, that is meant to protect against the evil eye — the harm believed to come from a jealous or envious stare. Beyond protection, the open right hand has long stood for blessing, power, and strength. Its name comes from the Semitic word for \"five\" (Arabic khamsa, Hebrew hamesh), for the five fingers.</p>"
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Why do Muslims and Jews use the same hamsa symbol?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "<p>Because it is older than both faiths and was shared, not disputed. The same hand is called the Hand of Fatima in Islamic tradition (after Fatima, daughter of the Prophet Muhammad) and the Hand of Miriam in Jewish tradition (after Miriam, sister of Moses and Aaron), and Levantine Christians know it as the Hand of Mary. For centuries Muslim, Jewish, and Christian communities across North Africa and the Middle East wore it against the evil eye. As My Jewish Learning puts it, the symbol \"carries significance to both Jews and Muslims,\" and Sephardic Jewish culture \"flourished alongside Islam.\"</p>"
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does it matter which way the hamsa points — fingers up or down?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "<p>Some folk traditions say a hamsa with the fingers pointing up wards off evil, while one pointing down invites blessings and abundance; others distinguish fingers spread apart from fingers held together. These readings are folkloric and vary from source to source — there is no single authoritative rule, so \"up means one thing, down means another\" is best treated as tradition-dependent rather than fixed.</p>"
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What is the difference between the hamsa and the evil eye (nazar)?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "<p>They are two different objects that share a purpose. The hamsa (🪬) is a hand, often with an eye set in the palm. The nazar (🧿) is a blue-and-white glass eye-bead from Turkish tradition — the nazar boncuğu — with no hand at all. Both are believed to deflect the evil eye and are constantly worn together, which is why they get confused, but the hamsa is the hand and the nazar is the bead.</p>"
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "When was the hamsa emoji added to Unicode?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "<p>🪬 HAMSA (U+1FAAC) was added in Unicode 14.0 and Emoji 14.0, released in September 2021, in the \"Symbols and Pictographs Extended-A\" block — a notably late arrival for a symbol thousands of years old, and years after the nazar bead got its own 🧿 emoji in 2018. On devices last updated before late 2021, the hamsa may still show as an empty \"tofu\" box.</p>"
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<script src="/header.js"></script>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Hamsa Symbol</h1>
+    <p class="hero-tagline">The hamsa hand (🪬) is the open-palm Hand of Fatima and Hand of Miriam — the amulet worn against the evil eye across Jewish, Muslim, and Christian traditions alike. Click any symbol to copy it instantly.</p>
+  </div>
+</section>
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>The hamsa (🪬, U+1FAAC) is an open-hand amulet, usually shown with an eye set in the palm, believed to protect against the evil eye. The same hand shape is called the Hand of Fatima in Islamic tradition and the Hand of Miriam in Jewish tradition, and it has been worn for centuries across North Africa and the Middle East by Muslim, Jewish, and Christian communities alike — one of the rare symbols that unites rather than divides the traditions that claim it. Its name comes from the Semitic word for "five," for the five fingers of the hand. Though the symbol itself is ancient, it only received its own Unicode emoji in 2021.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="hamsa-hand">
+  <span class="article-section-label">Hamsa</span>
+  <h2>Hamsa Hand (Hand of Fatima / Hand of Miriam)</h2>
+  <p class="u-secondary-tight">The hamsa emoji — an open palm with an eye at its center. There is no older plain-text version of this glyph; it exists only as a color emoji, added to Unicode in 2021.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🪬" aria-label="Copy Hamsa">🪬</button>
+      <span class="flag-label">Hamsa</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="evil-eye-nazar">
+  <span class="article-section-label">Not the Same</span>
+  <h2>Evil Eye &amp; Nazar — Often Paired, Not the Same</h2>
+  <p class="u-secondary-tight">The hamsa is a hand; the nazar is a blue glass eye-bead from Turkish tradition. They are frequently worn together and share the same job of deflecting the evil eye, but they are distinct symbols — don't confuse the two.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🧿" aria-label="Copy Nazar Amulet (Evil Eye)">🧿</button>
+      <span class="flag-label">Nazar Amulet (Evil Eye)</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="👁️" aria-label="Copy Eye">👁️</button>
+      <span class="flag-label">Eye</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="👀" aria-label="Copy Eyes">👀</button>
+      <span class="flag-label">Eyes</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🔵" aria-label="Copy Blue Circle">🔵</button>
+      <span class="flag-label">Blue Circle</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="protective-hands">
+  <span class="article-section-label">Open Palm</span>
+  <h2>Open-Palm &amp; Protection Symbols</h2>
+  <p class="u-secondary-tight">The open right hand is itself an ancient sign of protection and blessing. These hand and charm emoji echo the hamsa's raised palm in bios and captions.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="✋" aria-label="Copy Raised Hand">✋</button>
+      <span class="flag-label">Raised Hand</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🖐" aria-label="Copy Hand with Fingers Splayed">🖐</button>
+      <span class="flag-label">Hand with Fingers Splayed</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🤚" aria-label="Copy Raised Back of Hand">🤚</button>
+      <span class="flag-label">Raised Back of Hand</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🤲" aria-label="Copy Palms Up Together">🤲</button>
+      <span class="flag-label">Palms Up Together</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="🙏" aria-label="Copy Folded Hands">🙏</button>
+      <span class="flag-label">Folded Hands</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="📿" aria-label="Copy Prayer Beads">📿</button>
+      <span class="flag-label">Prayer Beads</span>
+    </div>
+  </div>
+</section>
+
+<!-- HISTORY & CONTEXT -->
+<section class="editorial-section" id="history">
+  <span class="article-section-label">History &amp; Context</span>
+  <h2>One hand, many names — and a history older than the faiths that share it</h2>
+  <div class="editorial-block">
+    <p>The word <em>hamsa</em> (also spelled <em>khamsa</em>) comes from the Semitic root for the number five — <em>khamsa</em> in Arabic, <em>hamesh</em> in Hebrew — a reference to the five fingers of the open hand. Popular explanations tie those five fingers to the Five Pillars of Islam, the five books of the Torah, or, in Shia tradition, the five members of the Ahl al-Bayt. Scholars generally treat these tidy one-to-one readings as later interpretations layered onto an older object rather than its original meaning; even the familiar name "Hand of Fatima" appears to be comparatively modern — the Arabic phrase <em>yad Fatima</em> is rare in pre-modern usage and was popularized largely in the colonial period.</p>
+    <p>The hamsa is older than any of the religions now associated with it, but its exact lineage is genuinely uncertain, and reputable sources describe several possible antecedents rather than one clean line of descent. Some trace hand-shaped protective amulets to ancient Mesopotamia, where the hand of the goddess Inanna (later Ishtar) was invoked to keep evil from a home; others point to the Phoenician and Carthaginian world, where an open hand is associated with the goddess Tanit (Tinnit); still others note early Egyptian and Iron-Age Judean hand motifs. Summarizing the scholarship, Wikipedia is careful to present these as potential antecedents whose exact meaning "remains debated." So the honest version of the story is a symbol that clearly predates both Islam and Judaism, with a prehistory that is plural and unsettled rather than a single documented origin.</p>
+    <p>What is not in dispute is that the same hand became a shared protective emblem across faiths. In Islamic tradition it is the Hand of Fatima, after Fatima al-Zahra, daughter of the Prophet Muhammad; in Jewish tradition it is the Hand of Miriam, after Miriam, the sister of Moses and Aaron; among some Levantine Christians it is the Hand of Mary. For centuries, Muslim, Jewish, and Christian communities across North Africa and the Middle East wore versions of it against the evil eye — <em>ayin hara</em> in Hebrew, <em>nazar</em> or <em>ʿayn</em> in Arabic. My Jewish Learning notes that the symbol "carries significance to both Jews and Muslims" and that it "would not be unusual for an Islamic symbol to find its way into Sephardic Jewish culture, which flourished alongside Islam." In recent decades some Middle East peace advocates have deliberately worn the hamsa as a sign of the shared origins and traditions of the two faiths — which is what makes it less a contested symbol than a genuinely common one.</p>
+    <p>Two things cause regular confusion. The first is orientation: some folk traditions hold that a hamsa with the fingers pointing up wards off evil, while one pointing down invites blessings and abundance; others distinguish fingers spread apart (to repel harm) from fingers held together (to bring luck). These readings are folkloric and inconsistent from source to source, so treat any fixed "up means one thing, down means another" rule as tradition-dependent rather than settled. The second is the evil eye itself. The hamsa is a hand, often with a single eye set in the palm; the <em>nazar</em> (🧿) is a separate object — the blue-and-white glass eye-bead of Turkish tradition, the <em>nazar boncuğu</em>. The two are constantly paired because they do the same job, but they are not the same symbol.</p>
+    <p>The hand is thousands of years old; its emoji is not. 🪬 HAMSA (U+1FAAC) was added only in Unicode 14.0 and Emoji 14.0, released in September 2021, in the "Symbols and Pictographs Extended-A" block — a strikingly late arrival for such an old and widely worn symbol, and years after the nazar bead received its own 🧿 emoji in 2018. On devices last updated before late 2021 the hamsa may still render as an empty "tofu" box. Offline, the hamsa has had a parallel modern life: since the late twentieth century it has become a mainstream piece of secular "good luck" and wellness jewelry far beyond the communities it came from, and it is the national emblem of Algeria. That popularity has prompted some discussion about wearing a religiously meaningful symbol detached from its traditions, alongside the counter-view that a charm shared this widely for this long can't be claimed by any single culture.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- HOW TO TYPE IT -->
+<section class="editorial-section" id="how-to-type">
+  <span class="article-section-label">How to Type It</span>
+  <h2>Typing the hamsa by platform</h2>
+  <p class="u-secondary-block">The hamsa is emoji-only — there is no plain-text dingbat version and no named HTML entity, so the emoji keyboard is the main way to enter it. Search the word "hamsa" and it comes up on any device updated since 2021.</p>
+  <div class="data-table-wrap">
+    <table class="data-table">
+      <thead>
+        <tr><th>Platform / Tool</th><th>Method</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>Windows 10 / 11 (emoji picker)</td><td>Press <code>Win + .</code> (period), then search "hamsa"</td></tr>
+        <tr><td>Word / Windows (Unicode input)</td><td>Type <code>1FAAC</code>, then press <code>Alt+X</code></td></tr>
+        <tr><td>Mac</td><td>Character Viewer or emoji picker (<code>Cmd+Ctrl+Space</code>), search "hamsa"</td></tr>
+        <tr><td>iPhone / Android</td><td>Emoji keyboard, search "hamsa" — shipped as a standard emoji since 2021</td></tr>
+        <tr><td>HTML (decimal)</td><td><code>&amp;#129708;</code></td></tr>
+        <tr><td>HTML (hex)</td><td><code>&amp;#x1FAAC;</code> (no named entity exists)</td></tr>
+        <tr><td>CSS <code>content</code></td><td><code>content: "\1FAAC"</code></td></tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- FAQ -->
+<section class="editorial-section" id="faq">
+  <span class="article-section-label">FAQ</span>
+  <h2>Hamsa symbol frequently asked questions</h2>
+  <div class="faq-item">
+    <button class="faq-question" type="button">What does the hamsa hand mean?</button>
+    <div class="faq-answer">
+      <p>The hamsa is an open-hand amulet, usually shown with a single eye in the palm, that is meant to protect against the evil eye — the harm believed to come from a jealous or envious stare. Beyond protection, the open right hand has long stood for blessing, power, and strength. Its name comes from the Semitic word for "five" (Arabic <em>khamsa</em>, Hebrew <em>hamesh</em>), for the five fingers.</p>
+    </div>
+  </div>
+  <div class="faq-item">
+    <button class="faq-question" type="button">Why do Muslims and Jews use the same hamsa symbol?</button>
+    <div class="faq-answer">
+      <p>Because it is older than both faiths and was shared, not disputed. The same hand is called the Hand of Fatima in Islamic tradition (after Fatima, daughter of the Prophet Muhammad) and the Hand of Miriam in Jewish tradition (after Miriam, sister of Moses and Aaron), and Levantine Christians know it as the Hand of Mary. For centuries Muslim, Jewish, and Christian communities across North Africa and the Middle East wore it against the evil eye. As My Jewish Learning puts it, the symbol "carries significance to both Jews and Muslims," and Sephardic Jewish culture "flourished alongside Islam."</p>
+    </div>
+  </div>
+  <div class="faq-item">
+    <button class="faq-question" type="button">Does it matter which way the hamsa points — fingers up or down?</button>
+    <div class="faq-answer">
+      <p>Some folk traditions say a hamsa with the fingers pointing up wards off evil, while one pointing down invites blessings and abundance; others distinguish fingers spread apart from fingers held together. These readings are folkloric and vary from source to source — there is no single authoritative rule, so "up means one thing, down means another" is best treated as tradition-dependent rather than fixed.</p>
+    </div>
+  </div>
+  <div class="faq-item">
+    <button class="faq-question" type="button">What is the difference between the hamsa and the evil eye (nazar)?</button>
+    <div class="faq-answer">
+      <p>They are two different objects that share a purpose. The hamsa (🪬) is a hand, often with an eye set in the palm. The nazar (🧿) is a blue-and-white glass eye-bead from Turkish tradition — the <em>nazar boncuğu</em> — with no hand at all. Both are believed to deflect the evil eye and are constantly worn together, which is why they get confused, but the hamsa is the hand and the nazar is the bead.</p>
+    </div>
+  </div>
+  <div class="faq-item">
+    <button class="faq-question" type="button">When was the hamsa emoji added to Unicode?</button>
+    <div class="faq-answer">
+      <p>🪬 HAMSA (U+1FAAC) was added in Unicode 14.0 and Emoji 14.0, released in September 2021, in the "Symbols and Pictographs Extended-A" block — a notably late arrival for a symbol thousands of years old, and years after the nazar bead got its own 🧿 emoji in 2018. On devices last updated before late 2021, the hamsa may still show as an empty "tofu" box.</p>
+    </div>
+  </div>
+</section>
+
+<script>
+  document.querySelectorAll('.faq-question').forEach(function(btn){
+    btn.addEventListener('click', function(){ this.closest('.faq-item').classList.toggle('open'); });
+  });
+</script>
+
+<div class="section-divider"></div>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Transform text with Unicode fonts</h3>
+  <p>Use UltraTextGen to convert plain text into bold, italic, cursive, and 100+ other Unicode font styles — free and instant.</p>
+  <a href="https://ultratextgen.com/" class="cta-btn">Open UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Related Resources</span>
+  <div class="compare-grid">
+    <a href="/library/evil-eye-hamsa-symbols/" class="compare-card variant-muted u-no-underline">
+      <h4>Evil Eye &amp; Hamsa Symbols</h4>
+      <p>The nazar amulet, hamsa hand, watchful eyes, and the blue-bead palette in one browse-and-copy collection.</p>
+    </a>
+    <a href="/library/religious-symbols/" class="compare-card variant-muted u-no-underline">
+      <h4>Religious Symbols</h4>
+      <p>Faith and protection symbols from traditions around the world, gathered in one reference.</p>
+    </a>
+    <a href="/symbol/star-of-david/" class="compare-card variant-muted u-no-underline">
+      <h4>Star of David</h4>
+      <p>Another identity symbol with deep, cross-cultural history and its own dedicated page.</p>
+    </a>
+    <a href="/symbol/khanda-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>Khanda Symbol</h4>
+      <p>A faith emblem that, like the hamsa, waited years for its own dedicated Unicode emoji.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script src="/symbol-explorer.js"></script>
+<script src="/footer.js"></script>
+</body>
+</html>

--- a/symbol/index.html
+++ b/symbol/index.html
@@ -121,6 +121,10 @@
       <h4>² ³ Squared &amp; Cubed</h4>
       <p>The two superscript digits old enough to predate the rest of the set.</p>
     </a>
+    <a href="/symbol/not-equal-sign/" class="compare-card variant-muted u-no-underline">
+      <h4>≠ Not Equal Sign</h4>
+      <p>The sign with no keyboard key — and why code types it != or &lt;&gt;.</p>
+    </a>
   </div>
 </section>
 
@@ -259,6 +263,10 @@
     <a href="/symbol/khanda-symbol/" class="compare-card variant-muted u-no-underline">
       <h4>🪯 Khanda Symbol</h4>
       <p>The Sikh emblem's 1930s design, and the split from Ik Onkar.</p>
+    </a>
+    <a href="/symbol/hamsa-symbol/" class="compare-card variant-muted u-no-underline">
+      <h4>🪬 Hamsa Symbol</h4>
+      <p>The Hand of Fatima and Hand of Miriam — one protective hand shared across faiths.</p>
     </a>
     <a href="/symbol/cross-symbol/" class="compare-card variant-muted u-no-underline">
       <h4>✝ Cross Symbol</h4>

--- a/symbol/not-equal-sign/index.html
+++ b/symbol/not-equal-sign/index.html
@@ -1,0 +1,361 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P55HXK8Q');</script>
+  <!-- End Google Tag Manager -->
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8242324164413945"
+       crossorigin="anonymous"></script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<title>Not Equal Sign (≠): Copy, Paste &amp; How to Type the Does-Not-Equal Symbol</title>
+<meta name="description" content="Copy and paste the not equal sign (≠), the does-not-equal symbol with no key on any keyboard. How to type it on Mac and Windows, plus why code uses != and &lt;&gt; instead.">
+
+<link rel="canonical" href="https://ultratextgen.com/symbol/not-equal-sign/">
+<meta property="og:image" content="https://ultratextgen.com/logo.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Not Equal Sign (≠): Copy, Paste &amp; How to Type the Does-Not-Equal Symbol">
+<meta name="twitter:description" content="Copy and paste the not equal sign (≠), the does-not-equal symbol with no key on any keyboard. How to type it on Mac and Windows, plus why code uses != and &lt;&gt; instead.">
+<meta name="twitter:image" content="https://ultratextgen.com/logo.png">
+<meta property="og:title" content="Not Equal Sign (≠): Copy, Paste &amp; How to Type the Does-Not-Equal Symbol">
+<meta property="og:description" content="Copy and paste the not equal sign (≠), the does-not-equal symbol with no key on any keyboard. How to type it on Mac and Windows, plus why code uses != and &lt;&gt; instead.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://ultratextgen.com/symbol/not-equal-sign/">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Space+Mono&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/symbol-explorer.css">
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Not Equal Sign (≠): Copy, Paste & How to Type the Does-Not-Equal Symbol",
+  "description": "Copy and paste the not equal sign (≠), the does-not-equal symbol with no key on any keyboard. How to type it on Mac and Windows, plus why code uses != and <> instead.",
+  "author": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "UltraTextGen",
+    "url": "https://ultratextgen.com/"
+  },
+  "mainEntityOfPage": "https://ultratextgen.com/symbol/not-equal-sign/",
+  "datePublished": "2026-07-12",
+  "dateModified": "2026-07-12"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "How do you type the not equal sign (≠)?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "<p>On a Mac, press Option + = and ≠ appears directly. On Windows, the most reliable route is Microsoft Word: type 2260, then press Alt+X to convert it. You can also open Character Map (or WinCompose) and search for \"not equal,\" or simply copy the ≠ from this page. There is no single dedicated key for it on any standard keyboard.</p>"
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Why is there no ≠ key on the keyboard?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "<p>Keyboards are built around ASCII, the original character set, which only includes =, &lt;, and &gt; — not ≠. The not-equal sign lives in Unicode's Mathematical Operators block, which came later. Because programming needed a 'not equal' operator people could actually type, each language built its own from ASCII characters instead, which is why you see != and &lt;&gt; far more often than the real ≠.</p>"
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What's the difference between ≠, !=, <>, and ~=?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "<p>They all mean 'not equal to,' but they come from different places. ≠ (U+2260) is the mathematical symbol. != is the operator in the C family — C, C++, C#, Java, JavaScript, Python, PHP, Go, and Ruby. &lt;&gt; is used in Pascal, BASIC, and standard SQL, and it is also the not-equal operator in Excel and Google Sheets formulas. ~= is used in Lua and MATLAB, and /= in Fortran and Haskell. The ASCII versions exist only because ≠ has no keyboard key.</p>"
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is ≠ the same as ≈ or ≢?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "<p>No — they are three different characters. ≠ (U+2260) means two values are not equal. ≈ (U+2248) means 'approximately' or 'almost equal to.' ≢ (U+2262) means 'not identical to,' the negation of the triple-bar ≡. They look related because each is a variation on the equals sign, but they are not interchangeable.</p>"
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How do you write \"does not equal\" in Excel or Google Sheets?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "<p>In a spreadsheet formula the not-equal operator is &lt;&gt;, not ≠ or !=. For example, =IF(A1&lt;&gt;B1,\"different\",\"same\") returns \"different\" when the two cells do not match. Typing the ≠ symbol into a formula causes an error; &lt;&gt; is the only form the formula engine understands.</p>"
+      }
+    }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://ultratextgen.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Symbols",
+      "item": "https://ultratextgen.com/symbol/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Not Equal Sign",
+      "item": "https://ultratextgen.com/symbol/not-equal-sign/"
+    }
+  ]
+}
+</script>
+</head>
+<body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P55HXK8Q"
+  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<script src="/header.js"></script>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-headline">Not Equal Sign (≠)</h1>
+    <p class="hero-tagline">The "does not equal" symbol — the one math character with no key on any keyboard, which is why code types it as != or &lt;&gt; instead. Click to copy it, then paste it anywhere.</p>
+  </div>
+</section>
+
+<!-- INTRO -->
+<section class="editorial-section">
+  <div class="editorial-block">
+    <p>The not equal sign (≠, U+2260) is an equals sign with a slash through it: it means two values are not the same. It sits in Unicode's Mathematical Operators block, and unlike + or =, it has no dedicated key on any physical keyboard — which is exactly why so many people end up searching for it, and why almost every programming language and spreadsheet substitutes a typeable stand-in like != or &lt;&gt; instead.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="not-equal-to-sign">
+  <span class="article-section-label">Not Equal</span>
+  <h2>The Not Equal To Sign (≠)</h2>
+  <p class="u-secondary-tight">The single Unicode character for "not equal" — click to copy, then paste it into a document, formula, bio, or chat.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="≠" aria-label="Copy Not Equal To">≠</button>
+      <span class="flag-label">Not Equal To</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="negation-family">
+  <span class="article-section-label">Negated Operators</span>
+  <h2>Other Negated "Not" Operators</h2>
+  <p class="u-secondary-tight">≠ belongs to a whole family of relations that a slash turns into their opposite. Each of these is its own separate Unicode character — not the ≠ sign.</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="≢" aria-label="Copy Not Identical To">≢</button>
+      <span class="flag-label">Not Identical To</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="≉" aria-label="Copy Not Almost Equal To">≉</button>
+      <span class="flag-label">Not Almost Equal To</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="∉" aria-label="Copy Not an Element Of">∉</button>
+      <span class="flag-label">Not an Element Of</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="∌" aria-label="Copy Does Not Contain as Member">∌</button>
+      <span class="flag-label">Does Not Contain as Member</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="∤" aria-label="Copy Does Not Divide">∤</button>
+      <span class="flag-label">Does Not Divide</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="≁" aria-label="Copy Not Tilde">≁</button>
+      <span class="flag-label">Not Tilde</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<section class="mood-explainers" id="confusable-equality">
+  <span class="article-section-label">Similar Equality Signs</span>
+  <h2>Equality Signs People Mix Up With ≠</h2>
+  <p class="u-secondary-tight">The characters most often confused with ≠ at a glance — each one means something different from "not equal."</p>
+  <div class="flag-rows">
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="=" aria-label="Copy Equals Sign">=</button>
+      <span class="flag-label">Equals Sign</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="≈" aria-label="Copy Almost Equal To">≈</button>
+      <span class="flag-label">Almost Equal To</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="≡" aria-label="Copy Identical To">≡</button>
+      <span class="flag-label">Identical To</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="≅" aria-label="Copy Approximately Equal To">≅</button>
+      <span class="flag-label">Approximately Equal To</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="≤" aria-label="Copy Less-Than or Equal To">≤</button>
+      <span class="flag-label">Less-Than or Equal To</span>
+    </div>
+    <div class="flag-row">
+      <button class="flag-emoji symbol-tile" data-symbol="≥" aria-label="Copy Greater-Than or Equal To">≥</button>
+      <span class="flag-label">Greater-Than or Equal To</span>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- HISTORY & CONTEXT -->
+<section class="editorial-section" id="history">
+  <span class="article-section-label">History &amp; Context</span>
+  <h2>Where the not equal sign comes from</h2>
+  <div class="editorial-block">
+    <p>The equals sign itself has a clear origin: the Welsh mathematician Robert Recorde introduced <code>=</code> in his 1557 book <i>The Whetstone of Witte</i>, choosing a pair of parallel lines because, in his words, "no two things can be more equal." The not-equal sign is simply that sign negated — a diagonal stroke drawn through it. No single inventor of ≠ is reliably recorded; it generalizes a long-standing mathematical convention in which a slash through a relation flips it to its opposite — the same convention behind ∉ (not an element of), ∤ (does not divide), and ≁ (not similar to).</p>
+    <p>When text went digital, ≠ was encoded at code point U+2260 in Unicode's Mathematical Operators block (U+2200–U+22FF); most references date its addition to Unicode 1.1 in 1993. Its formal Unicode name is simply NOT EQUAL TO, and its decimal value is 8800 — the number that shows up in some of the input methods below.</p>
+    <p>So why does a symbol this common feel so hard to type? Physical keyboards are built around ASCII, the older 128-character set that includes <code>=</code>, <code>&lt;</code>, and <code>&gt;</code> but not ≠. Programming languages, which needed a "not equal" operator people could actually type, each improvised their own ASCII stand-in rather than wait for a key that never came: <code>!=</code> in the C family (C, C++, C#, Java, JavaScript, Python, PHP, Go, Ruby), <code>&lt;&gt;</code> in Pascal, BASIC, and standard SQL, <code>~=</code> in Lua and MATLAB, and <code>/=</code> in Fortran and Haskell. APL, famous for its own non-standard keyboard, is one of the few languages that types the real ≠ directly. That fragmentation is the whole reason this character is searched for so often: the symbol is standard, but the way to type it never was.</p>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- HOW TO TYPE IT -->
+<section class="editorial-section" id="how-to-type">
+  <span class="article-section-label">How to Type It</span>
+  <h2>Typing the not equal sign by platform</h2>
+  <div class="data-table-wrap">
+    <table class="data-table">
+      <thead>
+        <tr><th>Platform / Tool</th><th>Method</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>Mac</td><td>Press <code>Option</code> + <code>=</code> — inserts ≠ directly</td></tr>
+        <tr><td>Word / Windows (Unicode input)</td><td>Type <code>2260</code>, then press <code>Alt+X</code></td></tr>
+        <tr><td>Windows (Character Map / WinCompose)</td><td>Search "not equal" or code point <code>U+2260</code></td></tr>
+        <tr><td>Windows (numeric keypad)</td><td><code>Alt+8800</code> in apps that accept decimal-Unicode input (e.g. Word, WordPad); no legacy code-page Alt code exists, since ≠ is outside Windows-1252</td></tr>
+        <tr><td>iPhone / Android</td><td>No dedicated key — copy it above, or paste from a saved snippet</td></tr>
+        <tr><td>HTML</td><td><code>&amp;ne;</code> (or <code>&amp;#8800;</code> / <code>&amp;#x2260;</code>)</td></tr>
+        <tr><td>CSS <code>content</code></td><td><code>content: "\2260"</code></td></tr>
+        <tr><td>LaTeX (math mode)</td><td><code>\neq</code> or <code>\ne</code></td></tr>
+        <tr><td>Excel / Google Sheets formula</td><td>Use the <code>&lt;&gt;</code> operator, e.g. <code>=IF(A1&lt;&gt;B1,"differ","match")</code> — <code>!=</code> and ≠ don't work in formulas</td></tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- FAQ -->
+<section class="editorial-section" id="faq">
+  <span class="article-section-label">FAQ</span>
+  <h2>Not equal sign frequently asked questions</h2>
+  <div class="faq-item">
+    <button class="faq-question" type="button">How do you type the not equal sign (≠)?</button>
+    <div class="faq-answer">
+      <p>On a Mac, press <code>Option</code> + <code>=</code> and ≠ appears directly. On Windows, the most reliable route is Microsoft Word: type <code>2260</code>, then press <code>Alt+X</code> to convert it. You can also open Character Map (or WinCompose) and search for "not equal," or simply copy the ≠ from this page. There is no single dedicated key for it on any standard keyboard.</p>
+    </div>
+  </div>
+  <div class="faq-item">
+    <button class="faq-question" type="button">Why is there no ≠ key on the keyboard?</button>
+    <div class="faq-answer">
+      <p>Keyboards are built around ASCII, the original character set, which only includes <code>=</code>, <code>&lt;</code>, and <code>&gt;</code> — not ≠. The not-equal sign lives in Unicode's Mathematical Operators block, which came later. Because programming needed a "not equal" operator people could actually type, each language built its own from ASCII characters instead, which is why you see <code>!=</code> and <code>&lt;&gt;</code> far more often than the real ≠.</p>
+    </div>
+  </div>
+  <div class="faq-item">
+    <button class="faq-question" type="button">What's the difference between ≠, !=, &lt;&gt;, and ~=?</button>
+    <div class="faq-answer">
+      <p>They all mean "not equal to," but they come from different places. ≠ (U+2260) is the mathematical symbol. <code>!=</code> is the operator in the C family — C, C++, C#, Java, JavaScript, Python, PHP, Go, and Ruby. <code>&lt;&gt;</code> is used in Pascal, BASIC, and standard SQL, and it is also the not-equal operator in Excel and Google Sheets formulas. <code>~=</code> is used in Lua and MATLAB, and <code>/=</code> in Fortran and Haskell. The ASCII versions exist only because ≠ has no keyboard key.</p>
+    </div>
+  </div>
+  <div class="faq-item">
+    <button class="faq-question" type="button">Is ≠ the same as ≈ or ≢?</button>
+    <div class="faq-answer">
+      <p>No — they are three different characters. ≠ (U+2260) means two values are not equal. ≈ (U+2248) means "approximately" or "almost equal to." ≢ (U+2262) means "not identical to," the negation of the triple-bar ≡. They look related because each is a variation on the equals sign, but they are not interchangeable.</p>
+    </div>
+  </div>
+  <div class="faq-item">
+    <button class="faq-question" type="button">How do you write "does not equal" in Excel or Google Sheets?</button>
+    <div class="faq-answer">
+      <p>In a spreadsheet formula the not-equal operator is <code>&lt;&gt;</code>, not ≠ or <code>!=</code>. For example, <code>=IF(A1&lt;&gt;B1,"different","same")</code> returns "different" when the two cells do not match. Typing the ≠ symbol into a formula causes an error; <code>&lt;&gt;</code> is the only form the formula engine understands.</p>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- CTA -->
+<div class="cta-card">
+  <h3>Transform text with Unicode fonts</h3>
+  <p>Use UltraTextGen to convert plain text into bold, italic, cursive, and 100+ other Unicode font styles — free and instant.</p>
+  <a href="https://ultratextgen.com/" class="cta-btn">Open UltraTextGen →</a>
+</div>
+
+<!-- RELATED -->
+<section class="editorial-section">
+  <span class="article-section-label">Related Resources</span>
+  <div class="compare-grid">
+    <a href="/library/math-symbols/" class="compare-card variant-muted u-no-underline">
+      <h4>All Math Symbols</h4>
+      <p>Operators, Greek letters, set theory, and calculus notation in one reference.</p>
+    </a>
+    <a href="/symbol/less-than-greater-than/" class="compare-card variant-muted u-no-underline">
+      <h4>Less Than &amp; Greater Than (&lt; &gt;)</h4>
+      <p>The comparison operators that also stand in for not-equal as &lt;&gt; in SQL, Excel, and Pascal.</p>
+    </a>
+    <a href="/symbol/plus-minus/" class="compare-card variant-muted u-no-underline">
+      <h4>Plus-Minus (±)</h4>
+      <p>Another Mathematical Operators glyph with no key of its own.</p>
+    </a>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer class="footer">
+  <div class="footer-inner">
+  </div>
+</footer>
+
+<!-- TOAST -->
+<div class="symbol-toast" id="symbolToast" aria-live="polite"></div>
+
+<script>
+  document.querySelectorAll('.faq-question').forEach(function(btn){
+    btn.addEventListener('click', function(){ this.closest('.faq-item').classList.toggle('open'); });
+  });
+</script>
+
+<script src="/symbol-explorer.js"></script>
+<script src="/footer.js"></script>
+</body>
+</html>


### PR DESCRIPTION
The two highest-confirmed-open opportunities from three independent research passes on the /symbol/ pillar (broad-match + Emojipedia + symbl.cc cross-referencing), both previously flagged and left unbuilt:

- /symbol/not-equal-sign/ (≠, U+2260) — 125,320/mo aggregate measured volume, the largest single number found across the whole cluster. Disambiguates against the programming-operator stand-ins (!=, <>, ~=) and the confusable ≈/≤/≥/≢ family, with a full platform typing guide. Promoted from a bare tile in library/math-symbols/ (matching the existing square-root/plus-minus/division-sign promotion pattern).

- /symbol/hamsa-symbol/ (🪬, U+1FAAC) — 39,060/mo aggregate measured volume. Framed as a shared-heritage story (Hand of Fatima / Hand of Miriam, protection against the evil eye across Jewish, Muslim, and Christian tradition) rather than a dispute, with the orientation- meaning folklore explicitly hedged since sources disagree. Linked from both library/evil-eye-hamsa-symbols/ and library/religious-symbols/.

Both pages follow the six-field spoke template (spec JSON -> generator skeleton -> hand-added History/How-to-Type/FAQ+FAQPage JSON-LD), pass sync_symbol_spoke_links.py and validate_library_pages.py clean, and were verified end-to-end in a real headless-Chromium render (copy-to-clipboard, FAQ accordion, no console errors).