### PR TITLE
feat(id): instrument the name checker, repair 3 CTR leaks, surface the checker on ML/PUBG

### DIFF
--- a/id/library/simbol-aesthetic/index.html
+++ b/id/library/simbol-aesthetic/index.html
@@ -50,8 +50,8 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>Simbol Aesthetic — Salin &amp; Tempel Simbol Keren &amp; Estetik</title>
-<meta name="description" content="Salin &amp; tempel simbol aesthetic (symbol aesthetic, simbol estetik) untuk bio, nama, dan caption — kilau, hati, bunga, dan pembatas. Klik untuk menyalin.">
+<title>Simbol Aesthetic ⋆˚✿ Copas Simbol Keren buat Bio &amp; Nama IG</title>
+<meta name="description" content="Copas simbol aesthetic buat bio IG, nama &amp; caption — kilau ⋆˚, hati ♡, bunga ✿, pembatas. Tinggal klik buat nyalin. Simbol estetik gratis, tanpa aplikasi.">
 
 <link rel="canonical" href="https://ultratextgen.com/id/library/simbol-aesthetic/">
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/aesthetic-symbols/">
@@ -74,12 +74,12 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta property="og:image:type" content="image/png">
-<meta property="og:image:alt" content="Simbol Aesthetic — Salin &amp; Tempel Simbol Keren &amp; Estetik">
+<meta property="og:image:alt" content="Simbol Aesthetic ⋆˚✿ Copas Simbol Keren buat Bio &amp; Nama IG">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Simbol Aesthetic — Salin &amp; Tempel Simbol Keren &amp; Estetik">
+<meta name="twitter:title" content="Simbol Aesthetic ⋆˚✿ Copas Simbol Keren buat Bio &amp; Nama IG">
 <meta name="twitter:description" content="Salin &amp; tempel simbol aesthetic untuk bio, nama, dan caption. Simbol huruf aesthetic, simbol keren, kilau, hati, bunga, dan pembatas.">
 <meta name="twitter:image" content="https://ultratextgen.com/assets/og/id-library-simbol-aesthetic.png">
-<meta property="og:title" content="Simbol Aesthetic — Salin &amp; Tempel Simbol Keren &amp; Estetik">
+<meta property="og:title" content="Simbol Aesthetic ⋆˚✿ Copas Simbol Keren buat Bio &amp; Nama IG">
 <meta property="og:description" content="Salin &amp; tempel simbol aesthetic untuk bio, nama, dan caption. Simbol huruf aesthetic, simbol keren, kilau, hati, bunga, dan pembatas.">
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://ultratextgen.com/id/library/simbol-aesthetic/">

--- a/id/tulisan-tebal/index.html
+++ b/id/tulisan-tebal/index.html
@@ -47,7 +47,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
        crossorigin="anonymous"></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Tulisan Tebal &amp; Font Tebal (𝗕𝗼𝗹𝗱) — Generator Copas | UltraTextGen</title>
+  <title>Tulisan Tebal, Font Tebal &amp; Teks Tebal (Bold) — Copas Gratis</title>
   <meta name="description" content="Bikin & copas tulisan tebal, font tebal, dan huruf tebal (𝗯𝗼𝗹𝗱) buat bio IG, status WA, caption, &amp; nickname game. Ketik, salin, tempel — gratis, tanpa aplikasi.">
   <link rel="canonical" href="https://ultratextgen.com/id/tulisan-tebal/">
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/category/bold-fonts/">

--- a/id/usecase/nama-ig-aesthetic/index.html
+++ b/id/usecase/nama-ig-aesthetic/index.html
@@ -50,7 +50,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Nama IG Aesthetic ✧ Username Instagram Keren — Generator &amp; Kumpulan Nama</title>
+  <title>Nama IG Aesthetic ✧ Username IG Aesthetic Girl &amp; Nama Singkat</title>
   <meta name="description" content="Kumpulan nama &amp; username ig aesthetic girl siap copy: nama cowok, nama keren singkat, username bahasa Inggris, sampai gaya xyz. Plus generator font aesthetic gratis — ketik nama kamu, salin, tempel ke Instagram.">
   <link rel="canonical" href="https://ultratextgen.com/id/usecase/nama-ig-aesthetic/">
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/usecase/aesthetic-instagram-names/">
@@ -62,11 +62,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
   <meta property="og:image:type" content="image/png">
-  <meta property="og:image:alt" content="Nama IG Aesthetic ✧ Username Instagram Keren — Generator &amp; Kumpulan Nama">
+  <meta property="og:image:alt" content="Nama IG Aesthetic ✧ Username IG Aesthetic Girl &amp; Nama Singkat">
   <meta name="twitter:image" content="https://ultratextgen.com/assets/og/id-usecase-nama-ig-aesthetic.png">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Nama IG Aesthetic ✧ Username Instagram Keren — Generator &amp; Kumpulan Nama">
+  <meta property="og:title" content="Nama IG Aesthetic ✧ Username IG Aesthetic Girl &amp; Nama Singkat">
   <meta property="og:description" content="Kumpulan nama IG aesthetic siap copy: aesthetic girl, cowok, singkat, bahasa Inggris, sampai username xyz. Plus generator font aesthetic gratis.">
   <meta property="og:url" content="https://ultratextgen.com/id/usecase/nama-ig-aesthetic/">
   <meta property="og:type" content="website">
@@ -74,7 +74,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Nama IG Aesthetic ✧ Username Instagram Keren — Generator &amp; Kumpulan Nama">
+  <meta name="twitter:title" content="Nama IG Aesthetic ✧ Username IG Aesthetic Girl &amp; Nama Singkat">
   <meta name="twitter:description" content="Kumpulan nama IG aesthetic siap copy plus generator font aesthetic gratis. Ketik nama kamu, salin, tempel ke Instagram.">
 
   <link rel="stylesheet" href="/style.css">

--- a/id/usecase/nama-ml-keren/index.html
+++ b/id/usecase/nama-ml-keren/index.html
@@ -205,7 +205,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 <section class="editorial-section">
   <div class="editorial-block">
     <p>Nama ML keren itu kombinasi <strong>font aesthetic</strong> dan <strong>ornamen yang ngebingkai</strong>. Ketik nama kamu di generator atas — langsung muncul versi kursif, gotik, dan small caps yang bisa disalin. Lalu hias pakai simbol dari palet di bawah: payung ꧁ ꧂, tanda silang ☬ ༒, bunga ✿ buat nama girl, sampai katakana メ 彡. Kolom nama Mobile Legends nerima karakter Unicode ini, jadi tampil di profil, chat tim, dan papan peringkat.</p>
-    <p>Catatan penting: MLBB lebih ketat dari Free Fire soal font. Kalau ada gaya yang ditolak atau jadi kotak, pakai <strong>Small Caps</strong> atau <strong>Bold</strong> — dua gaya itu paling aman keterima. Di bawah ada <strong>kumpulan nama ML keren</strong> buat cowok, cewek (girl), dan squad yang tinggal klik buat salin.</p>
+    <p>Catatan penting: MLBB lebih ketat dari Free Fire soal font. Kalau ada gaya yang ditolak atau jadi kotak, pakai <strong>Small Caps</strong> atau <strong>Bold</strong> — dua gaya itu paling aman keterima. Pakai fitur <strong>Cek Nama ML</strong> di generator atas buat mastiin nama kamu muat di batas 16 karakter dan gayanya aman — biar ketahuan sekarang, bukan pas Kartu Ganti Nama udah kepakai. Di bawah ada <strong>kumpulan nama ML keren</strong> buat cowok, cewek (girl), dan squad yang tinggal klik buat salin.</p>
   </div>
 </section>
 

--- a/id/usecase/nama-pubg-keren/index.html
+++ b/id/usecase/nama-pubg-keren/index.html
@@ -211,7 +211,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 <section class="editorial-section">
   <div class="editorial-block">
     <p>Nama PUBG keren hampir selalu punya satu ciri: <strong>simbol jepang</strong>. Yang paling ikonik jelas 亗 — simbol gunung bertingkat yang kelihatan kayak takhta, ditaruh di kiri-kanan nickname biar kesannya conqueror banget. Terus ada goresan katakana メ dan 彡 buat kesan cepat, ツ si senyum santai, sampai payung Jawa ꧁ ꧂ buat yang suka bingkai mewah. Kolom nama PUBG Mobile nerima karakter Unicode ini, jadi nickname kamu tampil rapi di lobby, killfeed, dan daftar clan. Ketik nama kamu di generator atas buat dapet versi bold, gotik, kursif, dan small caps — terus hias pakai simbol dari palet di bawah.</p>
-    <p>Ada juga <strong>bingkai siap pakai</strong> (tinggal ganti tulisan <em>NamaKamu</em>) dan <strong>kumpulan nickname PUBG</strong> — sangar, simbol jepang, cewek, sampai clan tag 4 huruf — semua tinggal klik buat nyalin. Geser ke bawah buat cara ganti nama pakai Rename Card dan trik nama pakai spasi.</p>
+    <p>Ada juga <strong>bingkai siap pakai</strong> (tinggal ganti tulisan <em>NamaKamu</em>) dan <strong>kumpulan nickname PUBG</strong> — sangar, simbol jepang, cewek, sampai clan tag 4 huruf — semua tinggal klik buat nyalin. Geser ke bawah buat cara ganti nama pakai Rename Card dan trik nama pakai spasi. Sebelum kartunya kepakai, cek dulu pakai fitur <strong>Cek Nama PUBG</strong> di generator atas — batas 14 karakter itu sering kepenuhan lebih cepat dari yang keliatan kalau namanya pakai font bergaya, jadi Rename Card kamu nggak kebuang percuma.</p>
   </div>
 </section>
 

--- a/js/gamename/game-rules.js
+++ b/js/gamename/game-rules.js
@@ -475,7 +475,7 @@
     const games = (cfg.games || ["ff"]).filter(function (g) { return RULES[g]; });
     if (!games.length) return;
 
-    const state = { game: games[0], dirty: false };
+    const state = { game: games[0], dirty: false, lastLevel: null, priming: true };
 
     mount.innerHTML = "";
     mount.classList.add("gr-checker");
@@ -494,6 +494,10 @@
         const tab = e.target.closest(".gr-tab");
         if (!tab) return;
         state.game = tab.getAttribute("data-game");
+        // Same name against a different game's rules is a genuinely new check
+        // (a name that fits Discord's 32 may fail Free Fire's weighted 12), so
+        // clear the last verdict rather than suppressing the event as a repeat.
+        state.lastLevel = null;
         render();
       });
       mount.appendChild(tabsWrap);
@@ -600,9 +604,45 @@
           charRow.appendChild(tile);
         });
       }
+
+      reportVerdict(report);
+    }
+
+    /* Completion event. render() runs on every keystroke, so this fires only
+       when the verdict LEVEL actually changes (empty -> ok -> warn -> fail),
+       not per character — a name being typed produces at most a couple of
+       events, not one per key. The empty state is never reported: it is the
+       initial condition, not an outcome the user reached.
+
+       What this is for: the checker is the site's main product-completion
+       surface on the game-name pages and it has never emitted a single event,
+       so nothing downstream can tell whether it is used, whether it catches
+       real problems, or whether it is ignored furniture. `verdict` is the
+       answer the user actually got; `over_limit` separates "too long" from
+       "unsupported characters", which are different product failures with
+       different fixes. */
+    function reportVerdict(report) {
+      const level = report.level;
+      if (!level || level === "empty") return;
+      // The first render happens at init, against whatever the generator was
+      // pre-filled with — reporting it would count page loads as checks. Record
+      // the level so a later real change still registers as a transition, but
+      // don't emit for it.
+      if (state.priming) { state.lastLevel = level; return; }
+      if (level === state.lastLevel) return;
+      state.lastLevel = level;
+
+      window.dataLayer = window.dataLayer || [];
+      window.dataLayer.push({
+        event: "name_check",
+        check_game: state.game,
+        check_verdict: level,
+        check_over_limit: !!(report.limit && report.effective > report.limit)
+      });
     }
 
     render();
+    state.priming = false;
   }
 
   ns.gameRules = {


### PR DESCRIPTION
Three pieces of work, all scoped by first-party GSC evidence (Jul 22 – Aug 2 2026, Indonesia, query × landing page). No new pages, no new URLs.

## 1. Instrument the name checker

`js/gamename/game-rules.js` is the main product-completion surface on the game-name pages and **had never emitted a single analytics event** — `script.js` already fires six event types, this fired none. So nothing downstream could tell whether the checker is used, whether it catches real problems, or whether it's ignored furniture.

Adds a `name_check` dataLayer event with `check_game`, `check_verdict` (ok/warn/fail) and `check_over_limit` — the last separates "too long" from "unsupported characters", which are different product failures with different fixes.

`render()` runs on every keystroke, so the event fires only on verdict **level** change. Two correctness details, both **verified in a real headless Chromium session** rather than assumed:

- The first render happens at init against the generator's pre-filled sample name, so reporting it would have counted page loads as checks. A priming flag records that level without emitting. → **0 events on page load.**
- Switching game tab clears the last verdict, since the same name against different rules is a genuinely new check. → on `usecase/nickname-generator`, one name produced `ff/fail/over_limit=true` → `discord/ok/over_limit=false` → `ff/fail`. That transition *is* the checker's value proposition showing up in the data.

Flood check: ~36 keystrokes across three states produced exactly 3 events.

## 2. CTR repair (titles/meta/OG/Twitter only — no H1, no body, no targeting change)

| Page | Evidence | Fix |
|---|---|---|
| `id/library/simbol-aesthetic/` | `simbol aesthetic` — 6,437 impr @ **0.4%** CTR, pos 6.9 — worst CTR of any sizeable ID page | Title already matched the query exactly, so the loss was *appeal*: it led with formal "Salin & Tempel" where the market searches **copas** (approved lexicon term, 40,300/mo combined, already in the site's own homepage title). Now leads with copas + shows real symbols (BMP codepoints, safe on the Android/Chrome devices that dominate this market). |
| `id/tulisan-tebal/` | `teks tebal` 3,095 impr @ 1.9% — **absent from the title entirely**, while the tail spent characters on a brand suffix | Title now carries all three ranking variants (tulisan tebal 8,012 / font tebal 4,745 / teks tebal 3,095) |
| `id/usecase/nama-ig-aesthetic/` | biggest query is `username ig aesthetic girl` (10,154 impr, pos 5.6); neither "girl" nor "singkat" was in the title. `nama ig keren singkat` leaks worst: 2,292 impr @ **0.6%** | Title now serves the actual top queries instead of the generic "Generator & Kumpulan Nama" |

No new vocabulary introduced — every term is either already on the page or an approved lexicon entry. In particular this does **not** touch ID-064, whose formal promotion is a separate decision dated 2026-08-17; that phrase already led the title before this change.

## 3. Surface the checker (`nama-ml-keren`, `nama-pubg-keren`)

Of the 15 ID pages mounting the checker, these two mounted it but never mentioned it in prose. Both now do, mirroring wording already proven on the FF and COC pages and using each page's own already-documented rename economics.

The PUBG line is deliberately hedged ("sering kepenuhan lebih cepat dari yang keliatan") because that game's rule entry carries `weightUncertain` — the field is believed to count something other than glyphs, but the behaviour is undocumented and this repo does not assert it.

## Deliberately not touched

- **`/id/` homepage** — carries the single largest CTR leak on the site: `font aesthetic`, **125,066 impressions @ 1.2% CTR** from pos 6.8 (~3,489 lost clicks/12d), while `tulisan aesthetic` converts at **5.0%** on the same URL. Its title/H1/meta are under an active measurement whose window opens **2026-08-25**; retitling now would destroy that read. **Queued, not executed — highest-value single item outstanding for this locale.**
- `nama-ff-keren` (43,833 impr @ 4.3%) — inside a live, unconfirmed ranking movement under observation.
- `nama-roblox-keren`, `nama-stumble-guys-keren` — inside an active measurement window whose decision rule turns on internal linking and page changes.
- `nama-ml-keren-cowok`, `nama-ml-keren-girl` — same-locale gendered variants in an unresolved fold-or-ratify decision.

## Validation

All five PR gates pass on the committed diff, plus `validate_library_pages.py` clean (2,599 pages, 0 errors):

```
check-translation-parity   5 changed, 0 unsynced
check-locale-mesh          5 changed, 0 mesh problems
check-locale-parent-gap    no newly-added pages
check-faq-schema           5 with FAQ schema, 0 mismatched
check-new-page-images      5 checked, 0 problems
```

---
_Generated by [Claude Code](https://claude.ai/code/session_015Bsvg4oBiLMXV7ygw6AKN6)_