### PR TITLE
fix: wire 37 missing locale hero figures, and the guard that hid them

### DIFF
--- a/assets/hero/cs-generator-prezdivek.svg
+++ b/assets/hero/cs-generator-prezdivek.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 340"
+     width="1200" height="340" role="img">
+  
+  <defs>
+    <linearGradient id="ghcsgenera" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#8b5cf6"/>
+      <stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+    <linearGradient id="gvhcsgenera" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#8b5cf6"/>
+      <stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+    <radialGradient id="glowhcsgenera" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#8b5cf6" stop-opacity="0.18"/>
+      <stop offset="1" stop-color="#8b5cf6" stop-opacity="0"/>
+    </radialGradient>
+    <pattern id="dotshcsgenera" width="22" height="22" patternUnits="userSpaceOnUse">
+      <circle cx="2" cy="2" r="1.4" fill="#1a1a2e" opacity="0.06"/>
+    </pattern>
+  </defs>
+  <rect width="1200" height="340" rx="20" fill="#FBFBFE"/>
+  <rect width="1200" height="340" rx="20" fill="url(#dotshcsgenera)"/>
+  <circle cx="1010" cy="60" r="260" fill="url(#glowhcsgenera)"/>
+  <rect x="0" y="0" width="8" height="340" fill="url(#gvhcsgenera)"/>
+  <g transform="translate(740 -10) scale(1.02)">
+    <path d="M120 86 h120 v40 a60 60 0 0 1 -120 0 Z" fill="url(#ghcsgenera)"/>
+    <path d="M118 96 h-26 a22 22 0 0 0 44 6" fill="none" stroke="#8b5cf6"
+          stroke-width="8"/>
+    <path d="M242 96 h26 a22 22 0 0 1 -44 6" fill="none" stroke="#8b5cf6"
+          stroke-width="8"/>
+    <rect x="168" y="184" width="24" height="44" fill="url(#gvhcsgenera)"/>
+    <rect x="132" y="228" width="96" height="22" rx="8" fill="url(#ghcsgenera)"/>
+    <rect x="146" y="252" width="68" height="20" rx="8" fill="#64748b" opacity="0.5"/>
+    <text x="180" y="142" font-family="DejaVu Sans, sans-serif" font-size="44" fill="#fff"
+          text-anchor="middle">★</text></g>
+  <g transform="translate(420 -10) scale(0.62)" opacity="0.10">
+    <path d="M120 86 h120 v40 a60 60 0 0 1 -120 0 Z" fill="url(#ghcsgenera)"/>
+    <path d="M118 96 h-26 a22 22 0 0 0 44 6" fill="none" stroke="#8b5cf6"
+          stroke-width="8"/>
+    <path d="M242 96 h26 a22 22 0 0 1 -44 6" fill="none" stroke="#8b5cf6"
+          stroke-width="8"/>
+    <rect x="168" y="184" width="24" height="44" fill="url(#gvhcsgenera)"/>
+    <rect x="132" y="228" width="96" height="22" rx="8" fill="url(#ghcsgenera)"/>
+    <rect x="146" y="252" width="68" height="20" rx="8" fill="#64748b" opacity="0.5"/>
+    <text x="180" y="142" font-family="DejaVu Sans, sans-serif" font-size="44" fill="#fff"
+          text-anchor="middle">★</text></g>
+</svg>

--- a/assets/hero/cs-specialni-znaky.svg
+++ b/assets/hero/cs-specialni-znaky.svg
@@ -1,0 +1,87 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 340"
+     width="1200" height="340" role="img">
+  
+  <defs>
+    <linearGradient id="ghcsspecia" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#8b5cf6"/>
+      <stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+    <linearGradient id="gvhcsspecia" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#8b5cf6"/>
+      <stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+    <radialGradient id="glowhcsspecia" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#8b5cf6" stop-opacity="0.18"/>
+      <stop offset="1" stop-color="#8b5cf6" stop-opacity="0"/>
+    </radialGradient>
+    <pattern id="dotshcsspecia" width="22" height="22" patternUnits="userSpaceOnUse">
+      <circle cx="2" cy="2" r="1.4" fill="#1a1a2e" opacity="0.06"/>
+    </pattern>
+  </defs>
+  <rect width="1200" height="340" rx="20" fill="#FBFBFE"/>
+  <rect width="1200" height="340" rx="20" fill="url(#dotshcsspecia)"/>
+  <circle cx="1010" cy="60" r="260" fill="url(#glowhcsspecia)"/>
+  <rect x="0" y="0" width="8" height="340" fill="url(#gvhcsspecia)"/>
+  <g transform="translate(740 -10) scale(1.02)">
+            <rect x="40" y="96" width="84" height="84" rx="18" fill="#fff"
+                  stroke="#1a1a2e" stroke-opacity="0.1"/>
+            <text x="82" y="152" font-family="Liberation Sans, DejaVu Sans, sans-serif" font-size="40"
+                  font-weight="700" font-style="normal" fill="#1a1a2e"
+                  text-anchor="middle">Aa</text>
+            <rect x="140" y="96" width="84" height="84" rx="18" fill="url(#ghcsspecia)"
+                  stroke="#1a1a2e" stroke-opacity="0"/>
+            <text x="182" y="152" font-family="Georgia, 'Liberation Serif', 'DejaVu Serif', serif" font-size="40"
+                  font-weight="400" font-style="italic" fill="#fff"
+                  text-anchor="middle">Aa</text>
+            <rect x="240" y="96" width="84" height="84" rx="18" fill="#fff"
+                  stroke="#1a1a2e" stroke-opacity="0.1"/>
+            <text x="282" y="152" font-family="DejaVu Sans, sans-serif" font-size="40"
+                  font-weight="400" font-style="normal" fill="#1a1a2e"
+                  text-anchor="middle">★</text>
+            <rect x="40" y="200" width="84" height="84" rx="18" fill="#fff"
+                  stroke="#1a1a2e" stroke-opacity="0.1"/>
+            <text x="82" y="256" font-family="Georgia, 'Liberation Serif', 'DejaVu Serif', serif" font-size="40"
+                  font-weight="700" font-style="normal" fill="#1a1a2e"
+                  text-anchor="middle">Aa</text>
+            <rect x="140" y="200" width="84" height="84" rx="18" fill="#fff"
+                  stroke="#1a1a2e" stroke-opacity="0.1"/>
+            <text x="182" y="256" font-family="Liberation Sans, DejaVu Sans, sans-serif" font-size="40"
+                  font-weight="400" font-style="normal" fill="#1a1a2e"
+                  text-anchor="middle">Aa</text>
+            <rect x="240" y="200" width="84" height="84" rx="18" fill="#fff"
+                  stroke="#1a1a2e" stroke-opacity="0.1"/>
+            <text x="282" y="256" font-family="DejaVu Sans, sans-serif" font-size="40"
+                  font-weight="400" font-style="normal" fill="#1a1a2e"
+                  text-anchor="middle">♥</text></g>
+  <g transform="translate(420 -10) scale(0.62)" opacity="0.10">
+            <rect x="40" y="96" width="84" height="84" rx="18" fill="#fff"
+                  stroke="#1a1a2e" stroke-opacity="0.1"/>
+            <text x="82" y="152" font-family="Liberation Sans, DejaVu Sans, sans-serif" font-size="40"
+                  font-weight="700" font-style="normal" fill="#1a1a2e"
+                  text-anchor="middle">Aa</text>
+            <rect x="140" y="96" width="84" height="84" rx="18" fill="url(#ghcsspecia)"
+                  stroke="#1a1a2e" stroke-opacity="0"/>
+            <text x="182" y="152" font-family="Georgia, 'Liberation Serif', 'DejaVu Serif', serif" font-size="40"
+                  font-weight="400" font-style="italic" fill="#fff"
+                  text-anchor="middle">Aa</text>
+            <rect x="240" y="96" width="84" height="84" rx="18" fill="#fff"
+                  stroke="#1a1a2e" stroke-opacity="0.1"/>
+            <text x="282" y="152" font-family="DejaVu Sans, sans-serif" font-size="40"
+                  font-weight="400" font-style="normal" fill="#1a1a2e"
+                  text-anchor="middle">★</text>
+            <rect x="40" y="200" width="84" height="84" rx="18" fill="#fff"
+                  stroke="#1a1a2e" stroke-opacity="0.1"/>
+            <text x="82" y="256" font-family="Georgia, 'Liberation Serif', 'DejaVu Serif', serif" font-size="40"
+                  font-weight="700" font-style="normal" fill="#1a1a2e"
+                  text-anchor="middle">Aa</text>
+            <rect x="140" y="200" width="84" height="84" rx="18" fill="#fff"
+                  stroke="#1a1a2e" stroke-opacity="0.1"/>
+            <text x="182" y="256" font-family="Liberation Sans, DejaVu Sans, sans-serif" font-size="40"
+                  font-weight="400" font-style="normal" fill="#1a1a2e"
+                  text-anchor="middle">Aa</text>
+            <rect x="240" y="200" width="84" height="84" rx="18" fill="#fff"
+                  stroke="#1a1a2e" stroke-opacity="0.1"/>
+            <text x="282" y="256" font-family="DejaVu Sans, sans-serif" font-size="40"
+                  font-weight="400" font-style="normal" fill="#1a1a2e"
+                  text-anchor="middle">♥</text></g>
+</svg>

--- a/assets/hero/hr-generator-nadimaka.svg
+++ b/assets/hero/hr-generator-nadimaka.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 340"
+     width="1200" height="340" role="img">
+  
+  <defs>
+    <linearGradient id="ghhrgenera" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#8b5cf6"/>
+      <stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+    <linearGradient id="gvhhrgenera" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#8b5cf6"/>
+      <stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+    <radialGradient id="glowhhrgenera" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#8b5cf6" stop-opacity="0.18"/>
+      <stop offset="1" stop-color="#8b5cf6" stop-opacity="0"/>
+    </radialGradient>
+    <pattern id="dotshhrgenera" width="22" height="22" patternUnits="userSpaceOnUse">
+      <circle cx="2" cy="2" r="1.4" fill="#1a1a2e" opacity="0.06"/>
+    </pattern>
+  </defs>
+  <rect width="1200" height="340" rx="20" fill="#FBFBFE"/>
+  <rect width="1200" height="340" rx="20" fill="url(#dotshhrgenera)"/>
+  <circle cx="1010" cy="60" r="260" fill="url(#glowhhrgenera)"/>
+  <rect x="0" y="0" width="8" height="340" fill="url(#gvhhrgenera)"/>
+  <g transform="translate(740 -10) scale(1.02)">
+    <path d="M120 86 h120 v40 a60 60 0 0 1 -120 0 Z" fill="url(#ghhrgenera)"/>
+    <path d="M118 96 h-26 a22 22 0 0 0 44 6" fill="none" stroke="#8b5cf6"
+          stroke-width="8"/>
+    <path d="M242 96 h26 a22 22 0 0 1 -44 6" fill="none" stroke="#8b5cf6"
+          stroke-width="8"/>
+    <rect x="168" y="184" width="24" height="44" fill="url(#gvhhrgenera)"/>
+    <rect x="132" y="228" width="96" height="22" rx="8" fill="url(#ghhrgenera)"/>
+    <rect x="146" y="252" width="68" height="20" rx="8" fill="#64748b" opacity="0.5"/>
+    <text x="180" y="142" font-family="DejaVu Sans, sans-serif" font-size="44" fill="#fff"
+          text-anchor="middle">★</text></g>
+  <g transform="translate(420 -10) scale(0.62)" opacity="0.10">
+    <path d="M120 86 h120 v40 a60 60 0 0 1 -120 0 Z" fill="url(#ghhrgenera)"/>
+    <path d="M118 96 h-26 a22 22 0 0 0 44 6" fill="none" stroke="#8b5cf6"
+          stroke-width="8"/>
+    <path d="M242 96 h26 a22 22 0 0 1 -44 6" fill="none" stroke="#8b5cf6"
+          stroke-width="8"/>
+    <rect x="168" y="184" width="24" height="44" fill="url(#gvhhrgenera)"/>
+    <rect x="132" y="228" width="96" height="22" rx="8" fill="url(#ghhrgenera)"/>
+    <rect x="146" y="252" width="68" height="20" rx="8" fill="#64748b" opacity="0.5"/>
+    <text x="180" y="142" font-family="DejaVu Sans, sans-serif" font-size="44" fill="#fff"
+          text-anchor="middle">★</text></g>
+</svg>

--- a/assets/hero/hr-posebni-znakovi.svg
+++ b/assets/hero/hr-posebni-znakovi.svg
@@ -1,0 +1,87 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 340"
+     width="1200" height="340" role="img">
+  
+  <defs>
+    <linearGradient id="ghhrposebn" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#8b5cf6"/>
+      <stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+    <linearGradient id="gvhhrposebn" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#8b5cf6"/>
+      <stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+    <radialGradient id="glowhhrposebn" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#8b5cf6" stop-opacity="0.18"/>
+      <stop offset="1" stop-color="#8b5cf6" stop-opacity="0"/>
+    </radialGradient>
+    <pattern id="dotshhrposebn" width="22" height="22" patternUnits="userSpaceOnUse">
+      <circle cx="2" cy="2" r="1.4" fill="#1a1a2e" opacity="0.06"/>
+    </pattern>
+  </defs>
+  <rect width="1200" height="340" rx="20" fill="#FBFBFE"/>
+  <rect width="1200" height="340" rx="20" fill="url(#dotshhrposebn)"/>
+  <circle cx="1010" cy="60" r="260" fill="url(#glowhhrposebn)"/>
+  <rect x="0" y="0" width="8" height="340" fill="url(#gvhhrposebn)"/>
+  <g transform="translate(740 -10) scale(1.02)">
+            <rect x="40" y="96" width="84" height="84" rx="18" fill="#fff"
+                  stroke="#1a1a2e" stroke-opacity="0.1"/>
+            <text x="82" y="152" font-family="Liberation Sans, DejaVu Sans, sans-serif" font-size="40"
+                  font-weight="700" font-style="normal" fill="#1a1a2e"
+                  text-anchor="middle">Aa</text>
+            <rect x="140" y="96" width="84" height="84" rx="18" fill="url(#ghhrposebn)"
+                  stroke="#1a1a2e" stroke-opacity="0"/>
+            <text x="182" y="152" font-family="Georgia, 'Liberation Serif', 'DejaVu Serif', serif" font-size="40"
+                  font-weight="400" font-style="italic" fill="#fff"
+                  text-anchor="middle">Aa</text>
+            <rect x="240" y="96" width="84" height="84" rx="18" fill="#fff"
+                  stroke="#1a1a2e" stroke-opacity="0.1"/>
+            <text x="282" y="152" font-family="DejaVu Sans, sans-serif" font-size="40"
+                  font-weight="400" font-style="normal" fill="#1a1a2e"
+                  text-anchor="middle">★</text>
+            <rect x="40" y="200" width="84" height="84" rx="18" fill="#fff"
+                  stroke="#1a1a2e" stroke-opacity="0.1"/>
+            <text x="82" y="256" font-family="Georgia, 'Liberation Serif', 'DejaVu Serif', serif" font-size="40"
+                  font-weight="700" font-style="normal" fill="#1a1a2e"
+                  text-anchor="middle">Aa</text>
+            <rect x="140" y="200" width="84" height="84" rx="18" fill="#fff"
+                  stroke="#1a1a2e" stroke-opacity="0.1"/>
+            <text x="182" y="256" font-family="Liberation Sans, DejaVu Sans, sans-serif" font-size="40"
+                  font-weight="400" font-style="normal" fill="#1a1a2e"
+                  text-anchor="middle">Aa</text>
+            <rect x="240" y="200" width="84" height="84" rx="18" fill="#fff"
+                  stroke="#1a1a2e" stroke-opacity="0.1"/>
+            <text x="282" y="256" font-family="DejaVu Sans, sans-serif" font-size="40"
+                  font-weight="400" font-style="normal" fill="#1a1a2e"
+                  text-anchor="middle">♥</text></g>
+  <g transform="translate(420 -10) scale(0.62)" opacity="0.10">
+            <rect x="40" y="96" width="84" height="84" rx="18" fill="#fff"
+                  stroke="#1a1a2e" stroke-opacity="0.1"/>
+            <text x="82" y="152" font-family="Liberation Sans, DejaVu Sans, sans-serif" font-size="40"
+                  font-weight="700" font-style="normal" fill="#1a1a2e"
+                  text-anchor="middle">Aa</text>
+            <rect x="140" y="96" width="84" height="84" rx="18" fill="url(#ghhrposebn)"
+                  stroke="#1a1a2e" stroke-opacity="0"/>
+            <text x="182" y="152" font-family="Georgia, 'Liberation Serif', 'DejaVu Serif', serif" font-size="40"
+                  font-weight="400" font-style="italic" fill="#fff"
+                  text-anchor="middle">Aa</text>
+            <rect x="240" y="96" width="84" height="84" rx="18" fill="#fff"
+                  stroke="#1a1a2e" stroke-opacity="0.1"/>
+            <text x="282" y="152" font-family="DejaVu Sans, sans-serif" font-size="40"
+                  font-weight="400" font-style="normal" fill="#1a1a2e"
+                  text-anchor="middle">★</text>
+            <rect x="40" y="200" width="84" height="84" rx="18" fill="#fff"
+                  stroke="#1a1a2e" stroke-opacity="0.1"/>
+            <text x="82" y="256" font-family="Georgia, 'Liberation Serif', 'DejaVu Serif', serif" font-size="40"
+                  font-weight="700" font-style="normal" fill="#1a1a2e"
+                  text-anchor="middle">Aa</text>
+            <rect x="140" y="200" width="84" height="84" rx="18" fill="#fff"
+                  stroke="#1a1a2e" stroke-opacity="0.1"/>
+            <text x="182" y="256" font-family="Liberation Sans, DejaVu Sans, sans-serif" font-size="40"
+                  font-weight="400" font-style="normal" fill="#1a1a2e"
+                  text-anchor="middle">Aa</text>
+            <rect x="240" y="200" width="84" height="84" rx="18" fill="#fff"
+                  stroke="#1a1a2e" stroke-opacity="0.1"/>
+            <text x="282" y="256" font-family="DejaVu Sans, sans-serif" font-size="40"
+                  font-weight="400" font-style="normal" fill="#1a1a2e"
+                  text-anchor="middle">♥</text></g>
+</svg>

--- a/assets/hero/ro-caractere-speciale.svg
+++ b/assets/hero/ro-caractere-speciale.svg
@@ -1,0 +1,87 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 340"
+     width="1200" height="340" role="img">
+  
+  <defs>
+    <linearGradient id="ghrocaract" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#8b5cf6"/>
+      <stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+    <linearGradient id="gvhrocaract" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#8b5cf6"/>
+      <stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+    <radialGradient id="glowhrocaract" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#8b5cf6" stop-opacity="0.18"/>
+      <stop offset="1" stop-color="#8b5cf6" stop-opacity="0"/>
+    </radialGradient>
+    <pattern id="dotshrocaract" width="22" height="22" patternUnits="userSpaceOnUse">
+      <circle cx="2" cy="2" r="1.4" fill="#1a1a2e" opacity="0.06"/>
+    </pattern>
+  </defs>
+  <rect width="1200" height="340" rx="20" fill="#FBFBFE"/>
+  <rect width="1200" height="340" rx="20" fill="url(#dotshrocaract)"/>
+  <circle cx="1010" cy="60" r="260" fill="url(#glowhrocaract)"/>
+  <rect x="0" y="0" width="8" height="340" fill="url(#gvhrocaract)"/>
+  <g transform="translate(740 -10) scale(1.02)">
+            <rect x="40" y="96" width="84" height="84" rx="18" fill="#fff"
+                  stroke="#1a1a2e" stroke-opacity="0.1"/>
+            <text x="82" y="152" font-family="Liberation Sans, DejaVu Sans, sans-serif" font-size="40"
+                  font-weight="700" font-style="normal" fill="#1a1a2e"
+                  text-anchor="middle">Aa</text>
+            <rect x="140" y="96" width="84" height="84" rx="18" fill="url(#ghrocaract)"
+                  stroke="#1a1a2e" stroke-opacity="0"/>
+            <text x="182" y="152" font-family="Georgia, 'Liberation Serif', 'DejaVu Serif', serif" font-size="40"
+                  font-weight="400" font-style="italic" fill="#fff"
+                  text-anchor="middle">Aa</text>
+            <rect x="240" y="96" width="84" height="84" rx="18" fill="#fff"
+                  stroke="#1a1a2e" stroke-opacity="0.1"/>
+            <text x="282" y="152" font-family="DejaVu Sans, sans-serif" font-size="40"
+                  font-weight="400" font-style="normal" fill="#1a1a2e"
+                  text-anchor="middle">★</text>
+            <rect x="40" y="200" width="84" height="84" rx="18" fill="#fff"
+                  stroke="#1a1a2e" stroke-opacity="0.1"/>
+            <text x="82" y="256" font-family="Georgia, 'Liberation Serif', 'DejaVu Serif', serif" font-size="40"
+                  font-weight="700" font-style="normal" fill="#1a1a2e"
+                  text-anchor="middle">Aa</text>
+            <rect x="140" y="200" width="84" height="84" rx="18" fill="#fff"
+                  stroke="#1a1a2e" stroke-opacity="0.1"/>
+            <text x="182" y="256" font-family="Liberation Sans, DejaVu Sans, sans-serif" font-size="40"
+                  font-weight="400" font-style="normal" fill="#1a1a2e"
+                  text-anchor="middle">Aa</text>
+            <rect x="240" y="200" width="84" height="84" rx="18" fill="#fff"
+                  stroke="#1a1a2e" stroke-opacity="0.1"/>
+            <text x="282" y="256" font-family="DejaVu Sans, sans-serif" font-size="40"
+                  font-weight="400" font-style="normal" fill="#1a1a2e"
+                  text-anchor="middle">♥</text></g>
+  <g transform="translate(420 -10) scale(0.62)" opacity="0.10">
+            <rect x="40" y="96" width="84" height="84" rx="18" fill="#fff"
+                  stroke="#1a1a2e" stroke-opacity="0.1"/>
+            <text x="82" y="152" font-family="Liberation Sans, DejaVu Sans, sans-serif" font-size="40"
+                  font-weight="700" font-style="normal" fill="#1a1a2e"
+                  text-anchor="middle">Aa</text>
+            <rect x="140" y="96" width="84" height="84" rx="18" fill="url(#ghrocaract)"
+                  stroke="#1a1a2e" stroke-opacity="0"/>
+            <text x="182" y="152" font-family="Georgia, 'Liberation Serif', 'DejaVu Serif', serif" font-size="40"
+                  font-weight="400" font-style="italic" fill="#fff"
+                  text-anchor="middle">Aa</text>
+            <rect x="240" y="96" width="84" height="84" rx="18" fill="#fff"
+                  stroke="#1a1a2e" stroke-opacity="0.1"/>
+            <text x="282" y="152" font-family="DejaVu Sans, sans-serif" font-size="40"
+                  font-weight="400" font-style="normal" fill="#1a1a2e"
+                  text-anchor="middle">★</text>
+            <rect x="40" y="200" width="84" height="84" rx="18" fill="#fff"
+                  stroke="#1a1a2e" stroke-opacity="0.1"/>
+            <text x="82" y="256" font-family="Georgia, 'Liberation Serif', 'DejaVu Serif', serif" font-size="40"
+                  font-weight="700" font-style="normal" fill="#1a1a2e"
+                  text-anchor="middle">Aa</text>
+            <rect x="140" y="200" width="84" height="84" rx="18" fill="#fff"
+                  stroke="#1a1a2e" stroke-opacity="0.1"/>
+            <text x="182" y="256" font-family="Liberation Sans, DejaVu Sans, sans-serif" font-size="40"
+                  font-weight="400" font-style="normal" fill="#1a1a2e"
+                  text-anchor="middle">Aa</text>
+            <rect x="240" y="200" width="84" height="84" rx="18" fill="#fff"
+                  stroke="#1a1a2e" stroke-opacity="0.1"/>
+            <text x="282" y="256" font-family="DejaVu Sans, sans-serif" font-size="40"
+                  font-weight="400" font-style="normal" fill="#1a1a2e"
+                  text-anchor="middle">♥</text></g>
+</svg>

--- a/assets/hero/ro-nume-pentru-free-fire.svg
+++ b/assets/hero/ro-nume-pentru-free-fire.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 340"
+     width="1200" height="340" role="img">
+  
+  <defs>
+    <linearGradient id="ghronumepe" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#8b5cf6"/>
+      <stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+    <linearGradient id="gvhronumepe" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#8b5cf6"/>
+      <stop offset="1" stop-color="#3b82f6"/>
+    </linearGradient>
+    <radialGradient id="glowhronumepe" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#8b5cf6" stop-opacity="0.18"/>
+      <stop offset="1" stop-color="#8b5cf6" stop-opacity="0"/>
+    </radialGradient>
+    <pattern id="dotshronumepe" width="22" height="22" patternUnits="userSpaceOnUse">
+      <circle cx="2" cy="2" r="1.4" fill="#1a1a2e" opacity="0.06"/>
+    </pattern>
+  </defs>
+  <rect width="1200" height="340" rx="20" fill="#FBFBFE"/>
+  <rect width="1200" height="340" rx="20" fill="url(#dotshronumepe)"/>
+  <circle cx="1010" cy="60" r="260" fill="url(#glowhronumepe)"/>
+  <rect x="0" y="0" width="8" height="340" fill="url(#gvhronumepe)"/>
+  <g transform="translate(740 -10) scale(1.02)">
+    <path d="M120 86 h120 v40 a60 60 0 0 1 -120 0 Z" fill="url(#ghronumepe)"/>
+    <path d="M118 96 h-26 a22 22 0 0 0 44 6" fill="none" stroke="#8b5cf6"
+          stroke-width="8"/>
+    <path d="M242 96 h26 a22 22 0 0 1 -44 6" fill="none" stroke="#8b5cf6"
+          stroke-width="8"/>
+    <rect x="168" y="184" width="24" height="44" fill="url(#gvhronumepe)"/>
+    <rect x="132" y="228" width="96" height="22" rx="8" fill="url(#ghronumepe)"/>
+    <rect x="146" y="252" width="68" height="20" rx="8" fill="#64748b" opacity="0.5"/>
+    <text x="180" y="142" font-family="DejaVu Sans, sans-serif" font-size="44" fill="#fff"
+          text-anchor="middle">★</text></g>
+  <g transform="translate(420 -10) scale(0.62)" opacity="0.10">
+    <path d="M120 86 h120 v40 a60 60 0 0 1 -120 0 Z" fill="url(#ghronumepe)"/>
+    <path d="M118 96 h-26 a22 22 0 0 0 44 6" fill="none" stroke="#8b5cf6"
+          stroke-width="8"/>
+    <path d="M242 96 h26 a22 22 0 0 1 -44 6" fill="none" stroke="#8b5cf6"
+          stroke-width="8"/>
+    <rect x="168" y="184" width="24" height="44" fill="url(#gvhronumepe)"/>
+    <rect x="132" y="228" width="96" height="22" rx="8" fill="url(#ghronumepe)"/>
+    <rect x="146" y="252" width="68" height="20" rx="8" fill="#64748b" opacity="0.5"/>
+    <text x="180" y="142" font-family="DejaVu Sans, sans-serif" font-size="44" fill="#fff"
+          text-anchor="middle">★</text></g>
+</svg>

--- a/cs/generator-prezdivek/index.html
+++ b/cs/generator-prezdivek/index.html
@@ -188,6 +188,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="breadcrumb-current">Generátor přezdívek</span>
 </nav>
 
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/cs-generator-prezdivek.svg" width="1200" height="340"
+       fetchpriority="high" alt="">
+</figure>
 <!-- HERO -->
 <section class="hero">
   <div class="hero-inner">

--- a/cs/specialni-znaky/index.html
+++ b/cs/specialni-znaky/index.html
@@ -228,6 +228,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <p class="hero-tagline">Sbírka speciálních znaků a Unicode symbolů na kopírování do bia, jména a popisků na Instagramu, TikToku, WhatsApp a Discordu. Klikni na libovolný symbol a hned se zkopíruje.</p>
   </div>
 </section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/cs-specialni-znaky.svg" width="1200" height="340"
+       fetchpriority="high" alt="">
+</figure>
+
 
 <!-- INTRO -->
 <section class="editorial-section">

--- a/hr/generator-nadimaka/index.html
+++ b/hr/generator-nadimaka/index.html
@@ -187,6 +187,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="breadcrumb-current">Generator Nadimaka</span>
 </nav>
 
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/hr-generator-nadimaka.svg" width="1200" height="340"
+       fetchpriority="high" alt="">
+</figure>
 <!-- HERO -->
 <section class="hero">
   <div class="hero-inner">

--- a/hr/posebni-znakovi/index.html
+++ b/hr/posebni-znakovi/index.html
@@ -228,6 +228,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <p class="hero-tagline">Zbirka posebnih znakova i Unicode simbola za bio, ime i nadimak na Instagramu, TikToku, WhatsAppu, Discordu i u igrama. Klikni bilo koji simbol da ga odmah kopiraš.</p>
   </div>
 </section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/hr-posebni-znakovi.svg" width="1200" height="340"
+       fetchpriority="high" alt="">
+</figure>
+
 
 <!-- INTRO -->
 <section class="editorial-section">

--- a/pt/answers/como-mudar-o-nome-do-canal-do-youtube/index.html
+++ b/pt/answers/como-mudar-o-nome-do-canal-do-youtube/index.html
@@ -209,6 +209,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <p class="hero-tagline">O passo a passo no computador e no celular, o limite de 14 dias e a única coisa que uma troca realmente custa.</p>
   </div>
 </section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pt-answers-como-mudar-o-nome-do-canal-do-youtube.svg" width="1200" height="340"
+       fetchpriority="high" alt="">
+</figure>
+
 
 <section class="editorial-section">
   <span class="article-section-label">Resposta curta</span>

--- a/pt/answers/handle-ou-nome-do-canal-do-youtube/index.html
+++ b/pt/answers/handle-ou-nome-do-canal-do-youtube/index.html
@@ -209,6 +209,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <p class="hero-tagline">Dois campos diferentes com regras diferentes — e saber qual é qual evita uma troca de nome recusada.</p>
   </div>
 </section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pt-answers-handle-ou-nome-do-canal-do-youtube.svg" width="1200" height="340"
+       fetchpriority="high" alt="">
+</figure>
+
 
 <section class="editorial-section">
   <span class="article-section-label">Resposta curta</span>

--- a/pt/imprimiveis/alfabeto-cursivo/index.html
+++ b/pt/imprimiveis/alfabeto-cursivo/index.html
@@ -159,6 +159,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       </p>
     </div>
   </section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pt-imprimiveis-alfabeto-cursivo.svg" width="1200" height="340"
+       fetchpriority="high" alt="">
+</figure>
+
 
   <main class="container">
 

--- a/pt/imprimiveis/alfabeto-espanhol/index.html
+++ b/pt/imprimiveis/alfabeto-espanhol/index.html
@@ -168,6 +168,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       </p>
     </div>
   </section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pt-imprimiveis-alfabeto-espanhol.svg" width="1200" height="340"
+       fetchpriority="high" alt="">
+</figure>
+
 
   <main class="container">
 

--- a/pt/imprimiveis/alfabeto-para-colorir/index.html
+++ b/pt/imprimiveis/alfabeto-para-colorir/index.html
@@ -158,6 +158,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       </p>
     </div>
   </section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pt-imprimiveis-alfabeto-para-colorir.svg" width="1200" height="340"
+       fetchpriority="high" alt="">
+</figure>
+
 
   <main class="container">
 

--- a/pt/imprimiveis/index.html
+++ b/pt/imprimiveis/index.html
@@ -206,6 +206,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       </p>
     </div>
   </section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pt-imprimiveis.svg" width="1200" height="340"
+       fetchpriority="high" alt="">
+</figure>
+
 
   <!-- Main Content -->
   <main class="container" style="max-width:900px;">

--- a/pt/imprimiveis/letras-bolha/index.html
+++ b/pt/imprimiveis/letras-bolha/index.html
@@ -189,6 +189,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       </p>
     </div>
   </section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pt-imprimiveis-letras-bolha.svg" width="1200" height="340"
+       fetchpriority="high" alt="">
+</figure>
+
 
   <main class="container">
 

--- a/pt/imprimiveis/nome-para-tracar/index.html
+++ b/pt/imprimiveis/nome-para-tracar/index.html
@@ -160,6 +160,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       </p>
     </div>
   </section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pt-imprimiveis-nome-para-tracar.svg" width="1200" height="340"
+       fetchpriority="high" alt="">
+</figure>
+
 
   <main class="container">
 

--- a/pt/library/alfabeto-grego/index.html
+++ b/pt/library/alfabeto-grego/index.html
@@ -152,6 +152,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <p class="hero-tagline">O alfabeto grego completo — maiúsculas, minúsculas e as variantes matemáticas — pronto para copiar. Clique em qualquer letra para copiar na hora.</p>
   </div>
 </section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pt-library-alfabeto-grego.svg" width="1200" height="340"
+       fetchpriority="high" alt="">
+</figure>
+
 
 <!-- INTRO -->
 <section class="editorial-section">

--- a/pt/library/cat-kaomoji/index.html
+++ b/pt/library/cat-kaomoji/index.html
@@ -146,6 +146,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <p class="hero-tagline">Copie e cole kaomoji de gato — carinhas de texto japonesas de gatinhos fofos com bigodes e patinhas. Clique em qualquer carinha para copiá-la na hora.</p>
   </div>
 </section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pt-library-cat-kaomoji.svg" width="1200" height="340"
+       fetchpriority="high" alt="">
+</figure>
+
 
 <!-- INTRO -->
 <section class="editorial-section">

--- a/pt/library/cute-kaomoji/index.html
+++ b/pt/library/cute-kaomoji/index.html
@@ -146,6 +146,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <p class="hero-tagline">Copie e cole kaomoji fofos — carinhas de texto japonesas fofas e kawaii. Clique em qualquer carinha para copiá-la na hora.</p>
   </div>
 </section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pt-library-cute-kaomoji.svg" width="1200" height="340"
+       fetchpriority="high" alt="">
+</figure>
+
 
 <!-- INTRO -->
 <section class="editorial-section">

--- a/pt/library/happy-kaomoji/index.html
+++ b/pt/library/happy-kaomoji/index.html
@@ -140,6 +140,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <p class="hero-tagline">Copie e cole kaomoji felizes — carinhas de texto japonesas que sorriem e estão alegres. Clique em qualquer carinha para copiá-la na hora.</p>
   </div>
 </section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pt-library-happy-kaomoji.svg" width="1200" height="340"
+       fetchpriority="high" alt="">
+</figure>
+
 
 <!-- INTRO -->
 <section class="editorial-section">

--- a/pt/library/love-kaomoji/index.html
+++ b/pt/library/love-kaomoji/index.html
@@ -146,6 +146,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <p class="hero-tagline">Copie e cole kaomoji de amor — carinhas de texto japonesas para carinho, beijos e abraços. Clique em qualquer carinha para copiá-la na hora.</p>
   </div>
 </section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pt-library-love-kaomoji.svg" width="1200" height="340"
+       fetchpriority="high" alt="">
+</figure>
+
 
 <!-- INTRO -->
 <section class="editorial-section">

--- a/pt/library/naipes-de-baralho/index.html
+++ b/pt/library/naipes-de-baralho/index.html
@@ -137,6 +137,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <p class="hero-tagline">Uma coleção de símbolos de naipes de baralho, dados, peças de dominó e caracteres Unicode de jogos. Clique em qualquer símbolo para copiar na hora.</p>
   </div>
 </section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pt-library-naipes-de-baralho.svg" width="1200" height="340"
+       fetchpriority="high" alt="">
+</figure>
+
 
 <!-- INTRO -->
 <section class="editorial-section">

--- a/pt/library/sad-kaomoji/index.html
+++ b/pt/library/sad-kaomoji/index.html
@@ -140,6 +140,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <p class="hero-tagline">Copie e cole kaomoji tristes — carinhas de texto japonesas melancólicas e decepcionadas. Clique em qualquer carinha para copiá-la na hora.</p>
   </div>
 </section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pt-library-sad-kaomoji.svg" width="1200" height="340"
+       fetchpriority="high" alt="">
+</figure>
+
 
 <!-- INTRO -->
 <section class="editorial-section">

--- a/pt/library/simbolos-de-confirmacao/index.html
+++ b/pt/library/simbolos-de-confirmacao/index.html
@@ -144,6 +144,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <p class="hero-tagline">Uma coleção de símbolos de confirmação (check), marcas de rejeição e indicadores de status para listas, comparações e formatação profissional. Clique em qualquer símbolo para copiar na hora.</p>
   </div>
 </section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pt-library-simbolos-de-confirmacao.svg" width="1200" height="340"
+       fetchpriority="high" alt="">
+</figure>
+
 
 <!-- INTRO -->
 <section class="editorial-section">

--- a/pt/library/simbolos-de-cruz-e-x/index.html
+++ b/pt/library/simbolos-de-cruz-e-x/index.html
@@ -142,6 +142,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <p class="hero-tagline">Todo formato de cruz em Unicode — sinais de multiplicação, marcas de X de votação, cruzes religiosas, cruzes decorativas grossas e símbolos de adaga. Clique em qualquer símbolo para copiar na hora.</p>
   </div>
 </section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pt-library-simbolos-de-cruz-e-x.svg" width="1200" height="340"
+       fetchpriority="high" alt="">
+</figure>
+
 
 <!-- INTRO -->
 <section class="editorial-section">

--- a/pt/library/simbolos-de-marcadores/index.html
+++ b/pt/library/simbolos-de-marcadores/index.html
@@ -150,6 +150,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <p class="hero-tagline">Copie e cole caracteres de marcador (bullet point) para posts do LinkedIn, e-mails, documentos e redes sociais. Clique em qualquer símbolo para copiar na hora.</p>
   </div>
 </section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pt-library-simbolos-de-marcadores.svg" width="1200" height="340"
+       fetchpriority="high" alt="">
+</figure>
+
 
 <!-- INTRO -->
 <section class="editorial-section">

--- a/pt/library/simbolos-japoneses/index.html
+++ b/pt/library/simbolos-japoneses/index.html
@@ -143,6 +143,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <p class="hero-tagline">Kanji, hiragana e katakana com romaji e significado — prontos para bio, legenda e nick. Clique em qualquer caractere para copiar na hora.</p>
   </div>
 </section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pt-library-simbolos-japoneses.svg" width="1200" height="340"
+       fetchpriority="high" alt="">
+</figure>
+
 
 <!-- INTRO -->
 <section class="editorial-section">

--- a/pt/library/simbolos-matematicos/index.html
+++ b/pt/library/simbolos-matematicos/index.html
@@ -153,6 +153,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <p class="hero-tagline">Copie e cole caracteres Unicode de matemática — operadores, letras gregas, teoria dos conjuntos, cálculo e mais. Clique em qualquer símbolo para copiar na hora.</p>
   </div>
 </section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pt-library-simbolos-matematicos.svg" width="1200" height="340"
+       fetchpriority="high" alt="">
+</figure>
+
 
 <!-- INTRO -->
 <section class="editorial-section">

--- a/pt/library/simbolos-musicais/index.html
+++ b/pt/library/simbolos-musicais/index.html
@@ -150,6 +150,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <p class="hero-tagline">Uma coleção de símbolos de notação musical, emojis de instrumentos e caracteres Unicode relacionados a áudio. Clique em qualquer símbolo para copiar na hora.</p>
   </div>
 </section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pt-library-simbolos-musicais.svg" width="1200" height="340"
+       fetchpriority="high" alt="">
+</figure>
+
 
 <!-- INTRO -->
 <section class="editorial-section">

--- a/pt/symbol/emoji-de-borboleta-monarca/index.html
+++ b/pt/symbol/emoji-de-borboleta-monarca/index.html
@@ -150,6 +150,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <p class="hero-tagline">Uma espécie específica, separada do desencontro de renderização entre plataformas do emoji genérico Butterfly — proposta para o Emoji 18.0, previsto para junto do Unicode 18.0 em setembro de 2026. Ainda é só rascunho: não aprovado, e nenhuma fonte a renderiza ainda. Clique para copiar o código mesmo assim.</p>
   </div>
 </section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pt-symbol-emoji-de-borboleta-monarca.svg" width="1200" height="340"
+       fetchpriority="high" alt="">
+</figure>
+
 
 <!-- INTRO -->
 <section class="editorial-section">

--- a/pt/symbol/emoji-de-meteoro/index.html
+++ b/pt/symbol/emoji-de-meteoro/index.html
@@ -150,6 +150,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <p class="hero-tagline">Um meteoro riscando o céu, se separando da crise de identidade que o Cometa carrega há uma década — proposto para o Emoji 18.0, previsto para junto do Unicode 18.0 em setembro de 2026. Ainda é só rascunho: nenhuma fonte o renderiza ainda. Clique para copiar o código mesmo assim.</p>
   </div>
 </section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pt-symbol-emoji-de-meteoro.svg" width="1200" height="340"
+       fetchpriority="high" alt="">
+</figure>
+
 
 <!-- INTRO -->
 <section class="editorial-section">

--- a/pt/symbol/emoji-de-picles/index.html
+++ b/pt/symbol/emoji-de-picles/index.html
@@ -150,6 +150,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <p class="hero-tagline">Um picles inteiro (pepino em conserva), diferente do pepino e da berinjela — proposto para o Emoji 18.0, previsto para junto do Unicode 18.0 em setembro de 2026. Ainda é só rascunho: nenhuma fonte o renderiza ainda. Clique para copiar o código mesmo assim.</p>
   </div>
 </section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pt-symbol-emoji-de-picles.svg" width="1200" height="340"
+       fetchpriority="high" alt="">
+</figure>
+
 
 <!-- INTRO -->
 <section class="editorial-section">

--- a/pt/symbol/emoji-de-polegar-direcional/index.html
+++ b/pt/symbol/emoji-de-polegar-direcional/index.html
@@ -150,6 +150,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <p class="hero-tagline">Um par de gestos apontando direção, não mais um sinal de aprovação — propostos para o Emoji 18.0, previsto para junto do Unicode 18.0 em setembro de 2026. Ainda são só rascunhos: não aprovados, e nenhuma fonte os renderiza ainda. Clique para copiar qualquer um dos códigos mesmo assim.</p>
   </div>
 </section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pt-symbol-emoji-de-polegar-direcional.svg" width="1200" height="340"
+       fetchpriority="high" alt="">
+</figure>
+
 
 <!-- INTRO -->
 <section class="editorial-section">

--- a/pt/symbol/emoji-de-rosto-derretendo/index.html
+++ b/pt/symbol/emoji-de-rosto-derretendo/index.html
@@ -192,6 +192,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <p class="hero-tagline">Um rosto amarelo de sorriso discreto cuja metade de baixo está escorrendo — o jeito padrão de escrever «quero sumir» sem dizer isso. Clique em qualquer símbolo para copiar na hora.</p>
   </div>
 </section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pt-symbol-emoji-de-rosto-derretendo.svg" width="1200" height="340"
+       fetchpriority="high" alt="">
+</figure>
+
 
 <!-- INTRO -->
 <section class="editorial-section">

--- a/pt/symbol/emoji-de-rosto-rachado/index.html
+++ b/pt/symbol/emoji-de-rosto-rachado/index.html
@@ -150,6 +150,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <p class="hero-tagline">Um rosto no meio de uma expressão, rachando sob pressão — proposto para o Emoji 18.0, previsto para junto do Unicode 18.0 em setembro de 2026. Ainda é só rascunho: não aprovado, e nenhuma fonte o renderiza ainda. Clique para copiar o código mesmo assim.</p>
   </div>
 </section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pt-symbol-emoji-de-rosto-rachado.svg" width="1200" height="340"
+       fetchpriority="high" alt="">
+</figure>
+
 
 <!-- INTRO -->
 <section class="editorial-section">

--- a/pt/symbol/sinal-do-dirham/index.html
+++ b/pt/symbol/sinal-do-dirham/index.html
@@ -150,6 +150,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <p class="hero-tagline">O novo símbolo monetário do Banco Central dos Emirados Árabes Unidos, com o código U+20C3, congelado para publicação no Unicode 18.0 — mais consolidado que os emojis rascunho deste mesmo lançamento, mas ainda impossível de digitar em qualquer teclado.</p>
   </div>
 </section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pt-symbol-sinal-do-dirham.svg" width="1200" height="340"
+       fetchpriority="high" alt="">
+</figure>
+
 
 <!-- INTRO -->
 <section class="editorial-section">

--- a/pt/symbol/sinal-do-rial-omanense/index.html
+++ b/pt/symbol/sinal-do-rial-omanense/index.html
@@ -150,6 +150,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <p class="hero-tagline">O símbolo monetário oficial de Omã, revelado no Dia Nacional de 2025 e congelado para publicação no Unicode 18.0 — já aprovado, mas ainda à frente de qualquer teclado ou fonte.</p>
   </div>
 </section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pt-symbol-sinal-do-rial-omanense.svg" width="1200" height="340"
+       fetchpriority="high" alt="">
+</figure>
+
 
 <!-- INTRO -->
 <section class="editorial-section">

--- a/pt/symbol/sinal-do-rial-saudita/index.html
+++ b/pt/symbol/sinal-do-rial-saudita/index.html
@@ -150,6 +150,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <p class="hero-tagline">O símbolo monetário oficial da Arábia Saudita, aprovado por decreto real e codificado no Unicode 17.0 — já definitivo, embora a maioria das fontes e teclados ainda não tenha se atualizado.</p>
   </div>
 </section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pt-symbol-sinal-do-rial-saudita.svg" width="1200" height="340"
+       fetchpriority="high" alt="">
+</figure>
+
 
 <!-- INTRO -->
 <section class="editorial-section">

--- a/pt/symbol/sinal-do-rufiyaa/index.html
+++ b/pt/symbol/sinal-do-rufiyaa/index.html
@@ -201,6 +201,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <p class="hero-tagline">O símbolo monetário próprio das Maldivas, construído a partir da letra thaana ރ — aceito pelo Unicode e à espera da publicação, o que significa que nenhum teclado ou fonte o renderiza ainda.</p>
   </div>
 </section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/pt-symbol-sinal-do-rufiyaa.svg" width="1200" height="340"
+       fetchpriority="high" alt="">
+</figure>
+
 
 <!-- INTRO -->
 <section class="editorial-section">

--- a/ro/caractere-speciale/index.html
+++ b/ro/caractere-speciale/index.html
@@ -257,6 +257,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <p class="hero-tagline">Colecție de caractere speciale și simboluri Unicode de copiat pentru bio, nume, nick și descrieri pe Instagram, TikTok, WhatsApp și Discord. Apeși pe orice simbol ca să-l copiezi pe loc.</p>
   </div>
 </section>
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/ro-caractere-speciale.svg" width="1200" height="340"
+       fetchpriority="high" alt="">
+</figure>
+
 
 <!-- INTRO -->
 <section class="editorial-section">

--- a/ro/nume-pentru-free-fire/index.html
+++ b/ro/nume-pentru-free-fire/index.html
@@ -185,6 +185,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="breadcrumb-current">Nume pentru Free Fire</span>
 </nav>
 
+
+<figure class="page-hero-figure" data-uthero aria-hidden="true">
+  <img src="/assets/hero/ro-nume-pentru-free-fire.svg" width="1200" height="340"
+       fetchpriority="high" alt="">
+</figure>
 <!-- HERO -->
 <section class="hero">
   <div class="hero-inner">

--- a/scripts/generate-site-art.py
+++ b/scripts/generate-site-art.py
@@ -1569,8 +1569,6 @@ PAGES = {
   "pt-fonte-gotica": ("Fonte Gótica", "Letras góticas e dark para copiar",
         P(m_typo, sample="Goth", ff=SERIF, weight="800", size=80, label="dark e dramática"), K_CAT),
   "tr-usecase-zalgo-text": ("Zalgo Metin Oluşturucu", "Ürkütücü bozuk metin oluşturun", m_zalgo, K_USE),
-  "tr-yazi-stilleri": ("Yazı Stilleri", "Değişik yazı tipleri kopyala yapıştır",
-        P(m_typo, sample="Abc", weight="700", size=88, label="kopyala yapıştır"), K_USE),
   "tr-sekilli-nick": ("Şekilli Nick Oluşturucu", "꧁꧂ çerçeveli nickler kopyala yapıştır", m_gamepad, K_USE),
   "tr-usecase-pubg-nick": ("PUBG Şekilli Nick", "PUBG Mobile isimleri ve sembolleri", m_gamepad, K_USE),
   "tr-usecase-free-fire-nick": ("Free Fire Şekilli Nick", "Free Fire isimleri, semboller ve isim kontrolü", m_gamepad, K_USE),
@@ -1608,15 +1606,11 @@ PAGES = {
         P(m_typo, sample=" small", size=44, label="petite écriture"), K_CAT),
   "fr-usecase-pseudo-fortnite": ("Pseudo Fortnite Stylé", "Symboles tryhard et pseudos 16 caractères", m_gamepad, K_USE),
   "fr-usecase-pseudo-free-fire": ("Pseudo Free Fire Stylé", "Symboles ombrelle et pseudos 12 caractères", m_gamepad, K_USE),
-  "fr-ecriture-style": ("Écriture Stylé", "60+ styles d'écriture à copier-coller",
-        P(m_typo, sample="Stylé", weight="700", size=80, label="copier-coller"), K_USE),
   "fr-ecriture-aesthetic": ("Écriture Aesthetic", "Lettres et symboles aesthetic à copier",
         P(m_typo, sample="a e s", size=72, spacing="6", label="a e s t h e t i c"), K_CAT),
   "fr-belle-ecriture": ("Belle Écriture", "Jolies écritures à copier-coller",
         P(m_typo, sample="Belle", ff=SERIF, style="italic", weight="400", size=64,
           label="jolie et élégante"), K_CAT),
-  "fr-generateur-de-texte": ("Générateur de Texte Stylé", "Gratuit, sans inscription",
-        P(m_typo, sample="Abc", weight="700", size=88, label="60+ styles"), K_USE),
   "fr-changeur-de-police": ("Changeur de Police", "Change ton écriture en ligne",
         P(m_transform, a="A", b="𝓐"), K_USE),
   "fr-calligraphie": ("Calligraphie en Ligne", "Alphabet calligraphie à copier-coller",
@@ -1958,8 +1952,6 @@ PAGES = {
         glyphs("❦", "⁂", "§", "Ⅰ", "⟪"), K_LIB),
   "library-dash-hyphen-symbols": ("Dash & Hyphen Symbols", "Em, en and every dash between",
         glyphs("—", "–", "―", "·", "‐"), K_LIB),
-  "library-degree-symbol": ("Degree Symbol", "Temperature, angles and more",
-        glyphs("°", "℃", "℉", "∠", "′"), K_LIB),
   "library-discord-symbols": ("Discord Symbols", "Symbols that paste cleanly in Discord",
         glyphs("✦", "★", "⚔", "♥", "➤"), K_LIB),
   "library-divider-kaomoji": ("Kaomoji Dividers", "Cute text dividers & spacers", m_kaomoji, K_LIB),
@@ -2002,7 +1994,6 @@ PAGES = {
   "library-laughing-kaomoji": ("Laughing Kaomoji", "Giggling, LOL text faces", m_kaomoji, K_LIB),
   "library-lenny-face": ("Lenny Face", "The smirking text face", m_kaomoji, K_LIB),
   "library-line-divider-symbols": ("Line Dividers & Separators", "Break up text beautifully", m_divider, K_LIB),
-  "library-linkedin-comment-styling": ("LinkedIn Comment Styling", "Make your comments stand out", m_chat, K_LIB),
   "library-linkedin-symbol-library": ("LinkedIn Symbol Library", "Professional symbols and bullets",
         glyphs("▸", "✓", "★", "•", "➤"), K_LIB),
   "library-love-kaomoji": ("Love & Heart Kaomoji", "Affectionate text faces", m_kaomoji, K_LIB),
@@ -2049,8 +2040,6 @@ PAGES = {
   "library-transport-symbols": ("Transport & Map Symbols", "Vehicles and travel marks", m_car, K_LIB),
   "library-weather-symbols": ("Weather Symbols & Emojis", "Sun, clouds, rain and snow",
         glyphs("☀", "☁", "☂", "❄", "☼"), K_LIB),
-  "library-whisper-subliminal-symbols": ("Whisper & Subliminal Symbols", "Quiet, faded accents",
-        glyphs("❛", "❜", "✧", "·", "✦"), K_LIB),
   "library-witchy-occult-symbols": ("Witchy & Occult Symbols", "Moons, signs and the arcane",
         glyphs("☽", "☿", "✦", "☉", "♆"), K_LIB),
   "library-x-twitter-symbols": ("X (Twitter) Symbols", "Symbols for posts and your bio", m_xmark, K_LIB),
@@ -2188,8 +2177,6 @@ PAGES = {
         glyphs("✉", "✂", "✎", "☎", "✰"), K_LIB),
   "library-party-celebration-emojis": ("Party & Celebration Emojis", "Confetti for every occasion",
         glyphs("✦", "★", "❉", "✺", "❋"), K_LIB),
-  "library-peace-symbol": ("Peace Symbol", "Signs of calm and harmony",
-        glyphs("☮", "✌", "☯", "♡", "✦"), K_LIB),
   "library-poop-emoji": ("Poop Emoji", "The internet's favourite pile", m_smiley, K_LIB),
   "library-preppy-emoji-combos": ("Preppy Emoji Combos", "Polished, coastal-cool pairings", m_bow, K_LIB),
   "library-pride-lgbtq-symbols": ("Pride & LGBTQ Symbols", "Flags and identity colors, copy-ready",
@@ -2224,8 +2211,6 @@ PAGES = {
   "library-wedding-anniversary-emojis": ("Wedding & Anniversary Emojis", "Love, rings and celebration",
         glyphs("♥", "♡", "❣", "❀", "✦"), K_LIB),
   "library-whatsapp-symbols": ("WhatsApp Symbols", "Symbols that paste cleanly in chats", m_chat, K_LIB),
-  "library-yin-yang-symbol": ("Yin & Yang Symbol", "Balance, duality and trigrams",
-        glyphs("☯", "☰", "☲", "☴", "☵"), K_LIB),
 
   # --- World Cup / football library batch (nations, players, trophies) ---
   "library-algeria-emoji-combos": ("Algeria Emoji Combos", "Fan emoji sets to copy and paste", m_flag, K_LIB),
@@ -2338,7 +2323,6 @@ PAGES = {
   # German
   "de-library-emoji-flags": ("Länderflaggen", "Flaggen-Emojis aller Länder", m_flag, K_LIB),
   # Portuguese
-  "pt-combos-de-emoji": ("Combos de Emoji", "Combinações de emoji para copiar e colar", m_smiley, K_LIB),
   "pt-fontes-para-discord": ("Fontes para Discord", "Letras para nick, canal e bio — sem Nitro", m_chat, K_PLAT),
   "pt-library-emoji-flags": ("Emoji de Bandeiras", "Bandeiras de todos os países", m_flag, K_LIB),
   # Vietnamese
@@ -2352,14 +2336,12 @@ PAGES = {
   "vi-library-bullet-point-symbols": ("Ký Hiệu Chấm Tròn", "Dẫn đầu danh sách thật đẹp",
         glyphs("•", "◦", "▪", "‣", "◆"), K_LIB),
   # Spanish
-  "es-combinaciones-de-emojis": ("Combinaciones de Emojis", "Sets de emoji para copiar y pegar", m_smiley, K_LIB),
   "es-library-emoji-flags": ("Emoji Bandera", "Banderas de todos los países", m_flag, K_LIB),
   "es-letras-en-otros-idiomas": ("Letras en Otros Idiomas", "Alfabetos y letras del mundo para copiar",
         P(m_typo, sample="Åß", size=88, label="letras del mundo"), K_LIB),
   "es-letras-bonitas": ("Letras Bonitas", "Letras lindas para copiar y pegar",
         P(m_typo, sample="Aa", size=88, style="italic", label="letras bonitas"), K_CAT),
   # French
-  "fr-combos-emoji": ("Combos Emoji", "Combinaisons d'emoji à copier-coller", m_smiley, K_LIB),
   "fr-police-discord": ("Police Discord", "Écriture pour pseudo et bio — sans Nitro", m_chat, K_PLAT),
   # Polish
   "pl-literki": ("Literki", "Ładne literki do skopiowania",
@@ -2683,7 +2665,6 @@ PAGES.update({
 "tr-library-japon-alfabesi": ("Japon Alfabesi", "Hiragana, katakana ve kanji kopyala yapıştır", m_kana_grid, K_LIB),
 "tr-library-onay-isaretleri": ("Onay İşaretleri", "Tik, çarpı ve durum sembolleri kopyala", glyphs("✓", "✔", "☑", "✗"), K_LIB),
 "tr-library-ok-isaretleri": ("Ok İşaretleri", "Yön, çift ve emoji oklar kopyala yapıştır", glyphs("→", "⇒", "↩", "➤"), K_LIB),
-"tr-library-tirnak-isareti": ("Tırnak İşareti", "Düz, kıvrık tırnak ve dış tırnak kopyala", glyphs("\"", "“", "”", "«"), K_LIB),
 "tr-library-derece-isareti": ("Derece İşareti", "Sıcaklık, açı ve geometri sembolleri kopyala", glyphs("°", "℃", "∠", "′"), K_LIB),
 "tr-library-para-birimi-sembolleri": ("Para Birimi Sembolleri", "Türk Lirası, euro, dolar ve dünya paraları", glyphs("₺", "€", "$", "£"), K_LIB),
 "tr-library-yunan-alfabesi-sembolleri": ("Yunan Alfabesi Sembolleri", "Alfa, beta, pi ve tüm Yunan harfleri kopyala", glyphs("α", "β", "π", "Ω"), K_LIB),
@@ -2917,6 +2898,43 @@ def main():
     print(f"wrote {n} hero SVGs to assets/hero/ and {n} OG PNGs to assets/og/")
     print(f"wrote homepage card + {len(LOCALIZED_HOME)} localized homepage cards "
           "to assets/og/")
+    report_orphan_keys()
+
+
+def report_orphan_keys():
+    """Report PAGES keys with no live page AND no page referencing their art.
+
+    The loop above has no page-existence guard: it writes art for every key
+    unconditionally, so a key left behind by a retired, renamed or never-built
+    page silently keeps producing an orphan asset pair on every full run. Twelve
+    such keys accumulated undetected (three retired-and-301'd pages, four
+    library->symbol lane migrations, three locale pages whose slug never matched
+    the page's real URL, two pages never built) because nothing looked.
+
+    Deliberately a report, not a skip. A key legitimately need not match a page
+    slug — `learn-hub` serves `learn/index.html` — so skipping on "no directory"
+    would stop generating art that is genuinely in use. Referenced art is
+    therefore never flagged, and the decision to delete a key stays a human one.
+    """
+    import glob as _glob
+    import re as _re
+    pages = [p for p in _glob.glob("**/index.html", recursive=True) if os.sep in p]
+    live = {os.path.dirname(p).replace(os.sep, "-") for p in pages}
+    # One pass over the pages collecting every slug any page actually serves,
+    # rather than re-scanning every page per key (1k keys x 4k pages of file
+    # reads is slow enough that nobody would leave the report enabled).
+    used = set()
+    ref = _re.compile(r'assets/(?:og|hero)/([A-Za-z0-9._-]+)\.(?:png|svg)')
+    for p in pages:
+        with open(p, encoding="utf-8") as fh:
+            used.update(ref.findall(fh.read()))
+    orphans = [s for s in PAGES if s not in live and s not in used]
+    if orphans:
+        print(f"\nORPHAN PAGES KEYS ({len(orphans)}) — no live page, art unreferenced.")
+        print("Each writes an unused asset pair on every full run. Retire the key,")
+        print("or build the page it was added for:")
+        for s in sorted(orphans):
+            print("  -", s)
 
 
 if __name__ == "__main__":

--- a/scripts/wire-site-art.py
+++ b/scripts/wire-site-art.py
@@ -92,7 +92,21 @@ def main():
         scanned += 1
         html = open(path, encoding="utf-8").read()
         original = html
-        if LOGO not in html and "data-uthero" not in html:
+        # This guard was written when the only way to lack a hero figure was to
+        # still be on the generic /logo.png card, so "no logo and no figure"
+        # meant "already done." That stopped being true: a page whose OG got
+        # pointed at real art by any other path (a spec generator, a hand fix)
+        # but never had its figure inserted matches neither arm and becomes
+        # permanently invisible here — no amount of re-running finds it. That is
+        # the whole reason 37 cs/hr/pt/ro pages sat with correct OG art and no
+        # hero, and why re-running the script never surfaced them.
+        #
+        # An explicit `--files` target opts out: naming a page IS the decision
+        # that it needs wiring. An unscoped run keeps the conservative
+        # behaviour, because lanes like EN `symbol/*` hold ~99 figure-less pages
+        # whose heroes are an open question this script must not answer as a
+        # side effect of someone regenerating something else.
+        if not args.files and LOGO not in html and "data-uthero" not in html:
             continue
         slug = slug_for(path)
         if not slug:


### PR DESCRIPTION
## What this fixes

37 `cs`/`hr`/`pt`/`ro` pages were serving OG art with **no hero figure**. Nothing was 404ing — every one had a working `og:image` — so this was a parity gap, not breakage.

It also wasn't 37 oversights. It was one guard in `wire-site-art.py`:

```python
if LOGO not in html and "data-uthero" not in html:
    continue
```

That predicate was correct when the only way to lack a figure was to still be on the generic `/logo.png` card. It stopped being correct once pages started getting real OG art from other paths (a spec generator, a hand fix) without a figure ever being inserted. Such a page matches **neither** arm, so the script skips it — permanently. Re-running could never surface these 37, which is exactly why they accumulated unseen.

An explicit `--files` target now opts out of the guard: naming a page *is* the decision that it needs wiring. An unscoped run keeps the old conservative behaviour deliberately — EN `symbol/*` alone holds ~99 figure-less pages whose heroes are an open question, and regenerating something unrelated must not answer it as a side effect.

## Scope was derived per page, not per directory

A page counts as a gap only when **its own `hreflang="en"` parent declares a hero**. A first pass counted 140 figure-less pages under these four locales; most are house pattern, not defects:

| Excluded | Why |
|---|---|
| 107 `pt/symbol/*` | EN `symbol/*` is 99-of-108 figure-less |
| `guide` indexes | EN `guide/` is 0-of-32, and the script skips `guide/` outright |
| `pt/contador-de-palavras-e-caracteres`, `pt/maiusculas-e-minusculas` | EN parents have no hero either |

Leaving 37 genuine gaps: 13 `pt/library/*` (EN `library/` is 336-of-336), 10 `pt/symbol/*` whose parents are the recent hero-carrying ones, 6 `pt/imprimiveis/*`, 2 `pt/answers/*`, and 6 top-level `cs`/`hr`/`ro` pages.

**Localization was verified before wiring, not assumed.** 31 of the hero SVGs already existed; unlike OG cards, most hero motifs are pure decorative glyphs with no text, so wiring them cannot leak English onto a localized page — checked per file rather than inferred. The 6 `cs`/`hr`/`ro` heroes generated here come from `PAGES` entries that already held correct Czech/Croatian/Romanian strings, and their OG PNGs regenerated **byte-identical**, confirming the existing cards were already current.

## Also: 12 dead `PAGES` keys retired

`generate-site-art.py`'s loop has no page-existence check — it writes art for every key unconditionally, so a key left behind by a retired or renamed page produces an orphan asset pair on every full run.

| Cause | Keys |
|---|---|
| Retired, 301'd | `fr-ecriture-style`, `fr-generateur-de-texte`, `tr-yazi-stilleri` |
| `library/`→`symbol/` migration (targets already have keys) | `library-degree-symbol`, `library-peace-symbol`, `library-yin-yang-symbol`, `tr-library-tirnak-isareti` |
| Slug never matched the real URL | `fr-combos-emoji`, `es-combinaciones-de-emojis`, `pt-combos-de-emoji` — all three pages live under the EN `emoji-combos` slug |
| Never built | `library-linkedin-comment-styling` (5 live pages already own that territory), `library-whisper-subliminal-symbols` |

**Every deletion was gated on the art being unreferenced, not just the page being absent.** `learn-hub` looks identical to these by slug but is live — `learn/index.html` serves its art — so it stays. `report_orphan_keys()` skips referenced art for exactly that reason, and runs in ~0.8s.

The 4 `category-*-*` variant keys it still reports are left in place on purpose: their pages were never built, but `bold-italic` shipped as a sibling, so they may be a roadmap rather than debris. That call isn't mine to make, which is why this reports rather than skips.

## Verification

All five diff-scoped gates pass on the committed branch (uncommitted work is invisible to them, so this was run after committing):

```
check:new-page-images        37 changed, 0 problems
check:translation-parity     0 pairs with unsynced content change
check:faq-schema             16 with FAQ schema, 0 mismatched
check:locale-mesh            0 mesh problems, 0 un-rewritten hub links
check:locale-parent-gap      no newly-added files
validate_library_pages.py    2,599 pages, 0 issues
```

Wiring is idempotent (re-run: 0 written, 37 already-correct), and every wired `<figure>` was confirmed to resolve to a file on disk.

## Not addressed — needs a decision

`pt/espaco-invisivel` declares no `hreflang="en"` at all, so it has **no English parent**. That's an English-Parent Rule question, unrelated to art, surfaced by this scan. Left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EY4PD6amvxV7tadReWJ9U3

---
_Generated by [Claude Code](https://claude.ai/code/session_01EY4PD6amvxV7tadReWJ9U3)_