### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/ads-check.yml
+++ b/.github/workflows/ads-check.yml
@@ -18,12 +18,12 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/css-audit.yml
+++ b/.github/workflows/css-audit.yml
@@ -16,12 +16,12 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Run CSS audit
         id: audit
@@ -43,7 +43,7 @@ jobs:
 
       - name: Upload report artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: css-audit-reports
           path: reports/

--- a/.github/workflows/gtm-check.yml
+++ b/.github/workflows/gtm-check.yml
@@ -17,12 +17,12 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/schedule-cache-removal.yml
+++ b/.github/workflows/schedule-cache-removal.yml
@@ -11,7 +11,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Remove Clear-Site-Data
         run: |

--- a/.github/workflows/tweet-queue.yml
+++ b/.github/workflows/tweet-queue.yml
@@ -20,12 +20,12 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       

--- a/.github/workflows/update-sitemap.yml
+++ b/.github/workflows/update-sitemap.yml
@@ -13,14 +13,14 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0  # full history needed for git log lastmod dates
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Run sitemap generator
         run: node scripts/update-sitemap.js

--- a/.github/workflows/update_readme.yml
+++ b/.github/workflows/update_readme.yml
@@ -12,12 +12,12 @@ jobs:
       contents: write
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: 18
+          node-version: 24
 
       - name: Run README sync
         run: node scripts/sync-readme.js

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -95,7 +95,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # check-translation-parity.js diffs this PR against its base branch,
           # which needs real history — a shallow (depth-1) checkout has no
@@ -103,12 +103,12 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/weekly-pr-digest.yml
+++ b/.github/workflows/weekly-pr-digest.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 


### PR DESCRIPTION
## Summary
Updated GitHub Actions workflow dependencies to their latest major versions across all CI/CD pipelines to maintain security, performance, and compatibility with current Node.js and Python runtimes.

## Key Changes
- **actions/checkout**: v4 → v5 (all workflows)
- **actions/setup-node**: v4 → v5 (all workflows)
- **actions/setup-python**: v5 → v6 (validate.yml, tweet-queue.yml, weekly-pr-digest.yml)
- **actions/upload-artifact**: v4 → v6 (css-audit.yml)
- **Node.js runtime**: 20 → 24 (all Node-based workflows)
- **Python runtime**: unchanged at 3.11 (compatible with setup-python v6)

## Affected Workflows
- `.github/workflows/css-audit.yml`
- `.github/workflows/validate.yml`
- `.github/workflows/ads-check.yml`
- `.github/workflows/gtm-check.yml`
- `.github/workflows/update-sitemap.yml`
- `.github/workflows/update_readme.yml`
- `.github/workflows/tweet-queue.yml`
- `.github/workflows/weekly-pr-digest.yml`
- `.github/workflows/schedule-cache-removal.yml`

## Notes
All updates are to official GitHub Actions maintained by GitHub. Node.js 24 is the current LTS and provides improved performance and security. Python 3.11 remains compatible with setup-python v6.

https://claude.ai/code/session_014pwui6zo6tLGkjTmMEVaSk