### PR TITLE
Character counter UX: put the fold in the readout, cut the preamble, and gate the page's own numbers

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -144,6 +144,16 @@ jobs:
         continue-on-error: true
         run: npm run check:funding-choices | tee funding-choices.log
 
+      # Gating. Structural validators cannot see a number written in prose or
+      # in a <meta>, which is how "LinkedIn cuts at 210" survived the rule
+      # changing and how "27 platform limits" stayed in the snippet text long
+      # after the table grew to 38. This asserts every figure these pages
+      # state still matches js/counter/counterRules.js.
+      - name: Run counter claim-consistency check
+        id: counter_claims
+        continue-on-error: true
+        run: npm run check:counter-claims | tee counter-claims.log
+
       - name: Run image asset check (whole-site audit, informational only)
         id: images
         continue-on-error: true
@@ -216,6 +226,7 @@ jobs:
             echo '```'
             echo ""
             echo "### Funding Choices tag check — \`${{ steps.funding_choices.outcome }}\`"
+            echo "### Counter claim-consistency check — \`${{ steps.counter_claims.outcome }}\`"
             echo '```'
             cat funding-choices.log
             echo '```'
@@ -283,7 +294,6 @@ jobs:
         # steps.new_symbol_peer_links, steps.locale_mesh, and
         # steps.locale_parent_gap are the diff-scoped gates that actually
         # enforce these systems on new/changed pages.
-        if: steps.hreflang.outcome == 'failure' || steps.hreflang_completeness.outcome == 'failure' || steps.library.outcome == 'failure' || steps.funding_choices.outcome == 'failure' || steps.new_images.outcome == 'failure' || steps.new_symbol_peer_links.outcome == 'failure' || steps.parity.outcome == 'failure' || steps.locale_mesh.outcome == 'failure' || steps.locale_parent_gap.outcome == 'failure' || steps.faq_schema.outcome == 'failure' || steps.external_refs.outcome == 'failure'
-        run: |
+if: steps.hreflang.outcome == 'failure' || steps.hreflang_completeness.outcome == 'failure' || steps.library.outcome == 'failure' || steps.funding_choices.outcome == 'failure' || steps.new_images.outcome == 'failure' || steps.new_symbol_peer_links.outcome == 'failure' || steps.parity.outcome == 'failure' || steps.locale_mesh.outcome == 'failure' || steps.locale_parent_gap.outcome == 'failure' || steps.faq_schema.outcome == 'failure' || steps.external_refs.outcome == 'failure' || steps.counter_claims.outcome == 'failure'        run: |
           echo "One or more gating validators failed — see the Summary tab above for details."
           exit 1

--- a/character-counter/embed/index.html
+++ b/character-counter/embed/index.html
@@ -51,19 +51,27 @@
   <div class="embed-wrapper">
     <div class="hero-card">
       <h1 class="hero-headline">Character Counter</h1>
-      <p class="hero-tagline">Live word, character, and byte stats, plus a checker for 27 platform limits — counted the way each platform counts.</p>
+      <p class="hero-tagline">Live counts for 38 fields across 17 platforms — counted the way each one counts, with one-click fixes when you are over.</p>
 
       <div class="counter-tool">
-        <div>
+        <div id="platformChecker"></div>
+
+        <div class="counter-field">
           <div class="counter-field-head">
             <label for="counterInput">Your text</label>
             <div class="counter-field-actions">
+              <span class="counter-live" id="counterLiveCount">0 / 280</span>
               <button class="copy-btn" type="button" id="counterCopyBtn">Copy</button>
               <button class="counter-clear-btn" type="button" id="counterClearBtn" hidden>Clear</button>
             </div>
           </div>
           <textarea class="counter-textarea" id="counterInput" placeholder="Type or paste your text here…" spellcheck="false"></textarea>
+          <p class="counter-inspect" id="counterInspect" hidden></p>
         </div>
+
+        <div class="counter-fold" id="counterFold" hidden></div>
+
+        <div class="counter-fix" id="counterFixBar" hidden></div>
 
         <div class="counter-stats-grid">
           <div class="counter-stat"><span class="counter-stat-value" id="statWords">0</span><span class="counter-stat-label">Words</span></div>
@@ -77,8 +85,6 @@
           <div class="counter-stat"><span class="counter-stat-value" id="statUtf16">0</span><span class="counter-stat-label">UTF-16 units</span></div>
           <div class="counter-stat"><span class="counter-stat-value" id="statBytes">0</span><span class="counter-stat-label">UTF-8 bytes</span></div>
         </div>
-
-        <div id="platformChecker"></div>
       </div>
     </div>
 
@@ -91,5 +97,6 @@
   </div>
 
   <script src="/js/counter/counterRules.js"></script>
+  <script src="/js/counter/counterReduce.js"></script>
   <script src="/js/counter/counterController.js" defer></script>
 </body></html>

--- a/character-counter/index.html
+++ b/character-counter/index.html
@@ -69,7 +69,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/character-counter/">
 
   <meta property="og:title" content="Character Counter & Word Counter — Free Online Tool | UltraTextGen">
-  <meta property="og:description" content="Live word, character, sentence, paragraph, and reading-time stats as you type, plus a fit checker for 27 platform character limits that counts the way each platform counts. Free, instant, no signup.">
+  <meta property="og:description" content="Live word, character, sentence, paragraph, and reading-time stats as you type, plus a fit checker for 38 fields across 17 platforms that counts the way each platform counts. Free, instant, no signup.">
   <meta property="og:url" content="https://ultratextgen.com/character-counter/">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://ultratextgen.com/assets/og/character-counter.png">
@@ -79,7 +79,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <meta property="og:image:alt" content="Character Counter & Word Counter — Free Online Tool | UltraTextGen">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Character Counter & Word Counter — Free Online Tool | UltraTextGen">
-  <meta name="twitter:description" content="Live word, character, sentence, paragraph, and reading-time stats as you type, plus a fit checker for 27 platform character limits that counts the way each platform counts. Free, instant, no signup.">
+  <meta name="twitter:description" content="Live word, character, sentence, paragraph, and reading-time stats as you type, plus a fit checker for 38 fields across 17 platforms that counts the way each platform counts. Free, instant, no signup.">
   <meta name="twitter:image" content="https://ultratextgen.com/assets/og/character-counter.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -102,7 +102,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   "inLanguage": "en",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Any",
-  "description": "Live word, character, sentence, paragraph, and reading-time counter, plus a checker for whether your text fits 27 platform character limits, counted the way each platform counts (X weighted counting, SMS GSM-7/Unicode segments, Discord, Instagram, TikTok, and more).",
+  "description": "Live word, character, sentence, paragraph, and reading-time counter, plus a checker for whether your text fits 38 fields across 17 platforms, counted the way each platform counts (X weighted counting, SMS GSM-7/Unicode segments, Discord, Instagram, TikTok, and more).",
   "offers": {
     "@type": "Offer",
     "price": "0",

--- a/character-counter/index.html
+++ b/character-counter/index.html
@@ -205,19 +205,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <section class="hero"><div class="hero-inner"><div class="hero-card">
   <h1 class="hero-headline">Character Counter &amp; Word Counter</h1>
-  <p class="hero-sub">Live word, character, sentence, paragraph, and reading-time stats as you type — plus a checker for whether your text fits X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, and 30+ other fields — then fix it in one click when you are over.</p>
+  <p class="hero-sub">Live counts for 38 fields across 17 platforms — and one-click fixes when you are over.</p>
 </div></div></section>
 
 <main class="container">
-  <section class="editorial-section">
-    <div class="editorial-block">
-      <p>Type or paste any text into the box below and every count updates instantly: words, characters (with and without spaces), sentences, paragraphs, and an estimated reading time. Nothing is uploaded — every number is computed right in your browser. Below the counter, pick a platform from the dropdown to check whether your current text still fits its limit, with the exact character count and how many you have left (or how many you're over by). Need stylish Unicode fonts for the text you just measured? The <a href="/">main UltraTextGen generator</a> turns it into 100+ copy-paste styles.</p>
-    </div>
-  </section>
-
-  <div class="section-divider"></div>
-
-  <div class="counter-tool">
+<div class="counter-tool">
     <div id="platformChecker"></div>
 
     <div class="counter-field">
@@ -257,12 +249,14 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     </div>
   </div>
 
+  <p class="counter-footnote">Everything is computed in your browser — nothing you type is uploaded or stored. Need the text styled too? The <a href="/">UltraTextGen generator</a> turns it into 100+ copy-paste fonts.</p>
+
   <div class="section-divider"></div>
 
   <section class="editorial-section">
     <h2>Hard limits vs. soft limits</h2>
     <p>Two different things get called a "character limit," and it changes what going over actually costs you.</p>
-    <table class="comparison-table">
+    <div class="comparison-table-wrap"><table class="comparison-table">
       <thead><tr><th>Type</th><th>What happens if you go over</th><th>Examples</th></tr></thead>
       <tbody>
         <tr>
@@ -276,34 +270,38 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
           <td>Instagram caption after 125 · LinkedIn post after ~140 on mobile / ~210 on desktop · YouTube description after ~157</td>
         </tr>
       </tbody>
-    </table>
+    </table></div>
     <p>The soft limit is the one most people are actually writing against, and almost no counter shows it. A LinkedIn post has 3,000 characters and roughly 140 useful ones: the rest is behind a tap nobody takes. So the tool above renders the fold directly — type into it and you see the exact text that appears before "see more", with everything after the cut dimmed behind a line, plus how the same opening holds up on every other feed that truncates.</p>
     <p><strong>Where each feed cuts, and on which device:</strong></p>
-    <table class="comparison-table">
-      <thead><tr><th>Feed</th><th>Cuts at</th><th>What that means for a hook</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Feed</th><th class="num">Mobile</th><th class="num">Desktop</th><th>What that means for a hook</th></tr></thead>
       <tbody>
         <tr>
           <td><a href="/linkedin/">LinkedIn post</a></td>
-          <td>~140 mobile<br>~210 desktop</td>
-          <td>Write to 140 and it survives both. This is the widest desktop/mobile gap of any feed here.</td>
+          <td class="num">~140</td>
+          <td class="num">~210</td>
+          <td>Write to 140 and it survives both — the widest device gap of any feed here.</td>
         </tr>
         <tr>
           <td><a href="/instagram/">Instagram caption</a></td>
-          <td>~125</td>
+          <td class="num">~125</td>
+          <td class="num">~125</td>
           <td>The tightest fold on this list — roughly one sentence before "... more".</td>
         </tr>
         <tr>
           <td><a href="/youtube/">YouTube description</a></td>
-          <td>~157</td>
+          <td class="num">~157</td>
+          <td class="num">~157</td>
           <td>What shows under the title before "Show more"; also what search often surfaces.</td>
         </tr>
         <tr>
           <td><a href="/facebook/">Facebook post</a></td>
-          <td>~477</td>
+          <td class="num">~477</td>
+          <td class="num">~477</td>
           <td>The most forgiving fold — a full short paragraph lands before the cut.</td>
         </tr>
       </tbody>
-    </table>
+    </table></div>
     <p>Writing the hook itself is a different craft from measuring it — for what actually earns the tap, see <a href="/guide/style-linkedin-hooks-to-stand-out/">styling LinkedIn hooks to stand out</a>.</p>
     <p>Two honest caveats. These are observed UI behaviour, not published limits, so treat them as "what reliably shows" rather than exact thresholds — and feeds also cut on <em>line count</em>, so three early line breaks can truncate a post well short of any character number. If your opening depends on a list, check it in the real composer too.</p>
   </section>
@@ -315,51 +313,51 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <p>The same limits the live checker above uses, as a reference table. Jump to: <a href="#twitter">X/Twitter</a> · <a href="#discord">Discord</a> · <a href="#instagram">Instagram</a> · <a href="#tiktok">TikTok</a> · <a href="#sms">SMS</a> · <a href="#counting-modes">how each platform counts</a>.</p>
 
     <h3>Posts &amp; messages</h3>
-    <table class="comparison-table">
-      <thead><tr><th>Platform</th><th>Limit</th><th>Notes</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Platform</th><th class="num">Limit</th><th>Notes</th></tr></thead>
       <tbody>
-        <tr id="twitter"><td>X / Twitter post</td><td>280</td><td>Weighted: every URL = 23, most emoji/symbols/styled letters = 2 — see <a href="#counting-modes">how X counts</a></td></tr>
-        <tr id="discord"><td>Discord message</td><td>2,000</td><td>4,000 with Nitro; longer messages become a .txt attachment</td></tr>
-        <tr id="instagram"><td>Instagram caption</td><td>2,200</td><td>Truncated with "more" after the first lines</td></tr>
-        <tr id="tiktok"><td>TikTok caption</td><td>2,200</td><td></td></tr>
-        <tr><td>LinkedIn post</td><td>3,000</td><td>"See more" cuts the hook at ~140 on mobile, ~210 on desktop — write to 140 and it survives both</td></tr>
-        <tr><td>Facebook post</td><td>63,206</td><td></td></tr>
-        <tr><td>YouTube description</td><td>5,000</td><td></td></tr>
-        <tr><td>Pinterest pin description</td><td>500</td><td></td></tr>
-        <tr><td>Telegram message</td><td>4,096</td><td>1,024 for a photo/video caption</td></tr>
-        <tr><td>Threads post</td><td>500</td><td></td></tr>
-        <tr><td>Bluesky post</td><td>300</td><td>Counted by graphemes (what you see), not code points</td></tr>
-        <tr><td>Reddit post title</td><td>300</td><td></td></tr>
-        <tr><td>Zalo post/status</td><td>2,000</td><td></td></tr>
+        <tr id="twitter"><td>X / Twitter post</td><td class="num">280</td><td>Weighted: every URL = 23, most emoji/symbols/styled letters = 2 — see <a href="#counting-modes">how X counts</a></td></tr>
+        <tr id="discord"><td>Discord message</td><td class="num">2,000</td><td>4,000 with Nitro; longer messages become a .txt attachment</td></tr>
+        <tr id="instagram"><td>Instagram caption</td><td class="num">2,200</td><td>Truncated with "more" after the first lines</td></tr>
+        <tr id="tiktok"><td>TikTok caption</td><td class="num">2,200</td><td></td></tr>
+        <tr><td>LinkedIn post</td><td class="num">3,000</td><td>"See more" cuts the hook at ~140 on mobile, ~210 on desktop — write to 140 and it survives both</td></tr>
+        <tr><td>Facebook post</td><td class="num">63,206</td><td></td></tr>
+        <tr><td>YouTube description</td><td class="num">5,000</td><td></td></tr>
+        <tr><td>Pinterest pin description</td><td class="num">500</td><td></td></tr>
+        <tr><td>Telegram message</td><td class="num">4,096</td><td>1,024 for a photo/video caption</td></tr>
+        <tr><td>Threads post</td><td class="num">500</td><td></td></tr>
+        <tr><td>Bluesky post</td><td class="num">300</td><td>Counted by graphemes (what you see), not code points</td></tr>
+        <tr><td>Reddit post title</td><td class="num">300</td><td></td></tr>
+        <tr><td>Zalo post/status</td><td class="num">2,000</td><td></td></tr>
       </tbody>
-    </table>
+    </table></div>
 
     <h3>Bios &amp; profiles</h3>
-    <table class="comparison-table">
-      <thead><tr><th>Field</th><th>Limit</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Field</th><th class="num">Limit</th></tr></thead>
       <tbody>
-        <tr><td>Instagram bio</td><td>150</td></tr>
-        <tr><td>TikTok bio</td><td>80</td></tr>
-        <tr><td>LinkedIn headline</td><td>220</td></tr>
-        <tr><td>WhatsApp About</td><td>139</td></tr>
-        <tr><td>Telegram bio</td><td>70</td></tr>
-        <tr><td>VK status</td><td>140</td></tr>
+        <tr><td>Instagram bio</td><td class="num">150</td></tr>
+        <tr><td>TikTok bio</td><td class="num">80</td></tr>
+        <tr><td>LinkedIn headline</td><td class="num">220</td></tr>
+        <tr><td>WhatsApp About</td><td class="num">139</td></tr>
+        <tr><td>Telegram bio</td><td class="num">70</td></tr>
+        <tr><td>VK status</td><td class="num">140</td></tr>
       </tbody>
-    </table>
+    </table></div>
 
     <h3>Usernames, titles &amp; SMS</h3>
-    <table class="comparison-table">
-      <thead><tr><th>Field</th><th>Limit</th><th>Notes</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Field</th><th class="num">Limit</th><th>Notes</th></tr></thead>
       <tbody>
-        <tr><td>Discord nickname</td><td>32</td><td></td></tr>
-        <tr><td>TikTok username</td><td>24</td><td>Letters, numbers, underscores, periods only</td></tr>
-        <tr><td>Instagram username</td><td>30</td><td></td></tr>
-        <tr><td>YouTube title</td><td>100</td><td></td></tr>
-        <tr><td>SEO meta title</td><td>~60</td><td>Google truncates by pixel width — treat as a guideline</td></tr>
-        <tr><td>SEO meta description</td><td>~155</td><td>Same — pixel-width truncation</td></tr>
-        <tr id="sms"><td>SMS text message</td><td>160 / segment</td><td>Drops to 70 per segment the moment one non-GSM character (emoji, curly quote, ş, ő, Vietnamese diacritics…) appears — see <a href="#counting-modes">SMS counting</a></td></tr>
+        <tr><td>Discord nickname</td><td class="num">32</td><td></td></tr>
+        <tr><td>TikTok username</td><td class="num">24</td><td>Letters, numbers, underscores, periods only</td></tr>
+        <tr><td>Instagram username</td><td class="num">30</td><td></td></tr>
+        <tr><td>YouTube title</td><td class="num">100</td><td></td></tr>
+        <tr><td>SEO meta title</td><td class="num">~60</td><td>Google truncates by pixel width — treat as a guideline</td></tr>
+        <tr><td>SEO meta description</td><td class="num">~155</td><td>Same — pixel-width truncation</td></tr>
+        <tr id="sms"><td>SMS text message</td><td class="num">160 / segment</td><td>Drops to 70 per segment the moment one non-GSM character (emoji, curly quote, ş, ő, Vietnamese diacritics…) appears — see <a href="#counting-modes">SMS counting</a></td></tr>
       </tbody>
-    </table>
+    </table></div>
   </section>
 
   <div class="section-divider"></div>
@@ -367,7 +365,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <section class="editorial-section" id="counting-modes">
     <h2>Why your character count doesn't match the platform's</h2>
     <p>"How many characters is this?" has more than one correct answer, because platforms count in different units. The same text can have four different lengths:</p>
-    <table class="comparison-table">
+    <div class="comparison-table-wrap"><table class="comparison-table">
       <thead><tr><th>Counting mode</th><th>What it measures</th><th>Who uses it</th></tr></thead>
       <tbody>
         <tr><td>Graphemes</td><td>What you visually see — an emoji with skin tone is 1</td><td>Bluesky; roughly how Instagram treats emoji</td></tr>
@@ -375,7 +373,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
         <tr><td>UTF-16 units</td><td>How JavaScript and many apps store text — 𝗯𝗼𝗹𝗱 letters cost 2 each</td><td>HTML form fields (<code>maxlength</code>), many games and app backends</td></tr>
         <tr><td>UTF-8 bytes</td><td>Storage size — é is 2, 中 is 3, 𝗯 is 4</td><td>Amazon listing fields (200-byte titles, 250-byte search terms), Steam names, databases</td></tr>
       </tbody>
-    </table>
+    </table></div>
     <p>All four are shown live in the stats above, so when a form says your text is too long while your word processor disagrees, you can see exactly which count the form is using. Two platforms need special rules on top:</p>
     <p><strong>X / Twitter counts by weight, not characters.</strong> Per X's own published algorithm (the <code>twitter-text</code> library), every URL counts as exactly 23, basic Latin letters count as 1, and almost everything else — CJK characters, most emoji, and every "fancy font" Unicode letter — counts as <strong>2</strong>. A fully styled 𝗯𝗼𝗹𝗱 post therefore fits only 140 visible letters in the 280 budget. The "X / Twitter post" option in the checker above implements this real algorithm.</p>
     <p><strong>SMS is counted in segments, and one character can triple your bill.</strong> A text message holds 160 characters only while every character is in the old GSM-7 alphabet. One emoji, curly quote (’ pasted from Word), or accented letter outside it (ş, ő, ą, Vietnamese diacritics…) silently switches the whole message to Unicode mode — 70 characters per segment, 67 when it splits. The "SMS text message" option above detects this and names the exact character that flipped your message.</p>

--- a/de/woerter-zeichen-zaehlen/index.html
+++ b/de/woerter-zeichen-zaehlen/index.html
@@ -48,7 +48,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Wörter zählen & Zeichen zählen — Kostenloses Online-Tool | UltraTextGen</title>
-  <meta name="description" content="Kostenloser Wörter- und Zeichenzähler. Wörter, Zeichen, Sätze, Absätze und Lesezeit live beim Tippen zählen – plus ein Check für 27 Plattform-Limits: X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS und mehr.">
+  <meta name="description" content="Kostenloser Wörter- und Zeichenzähler. Wörter, Zeichen, Sätze, Absätze und Lesezeit live beim Tippen zählen – plus ein Check für 38 Felder auf 17 Plattform-Limits: X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS und mehr.">
   <link rel="canonical" href="https://ultratextgen.com/de/woerter-zeichen-zaehlen/">
 
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/character-counter/">
@@ -69,7 +69,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/character-counter/">
 
   <meta property="og:title" content="Wörter zählen & Zeichen zählen — Kostenloses Online-Tool | UltraTextGen">
-  <meta property="og:description" content="Wörter, Zeichen, Sätze, Absätze und Lesezeit live beim Tippen zählen, plus ein Fit-Check für 27 Plattform-Zeichenlimits. Kostenlos, sofort, ohne Anmeldung.">
+  <meta property="og:description" content="Wörter, Zeichen, Sätze, Absätze und Lesezeit live beim Tippen zählen, plus ein Fit-Check für 38 Feldern auf 17 Plattformen. Kostenlos, sofort, ohne Anmeldung.">
   <meta property="og:url" content="https://ultratextgen.com/de/woerter-zeichen-zaehlen/">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://ultratextgen.com/assets/og/de-woerter-zeichen-zaehlen.png">
@@ -79,7 +79,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <meta property="og:image:alt" content="Wörter zählen & Zeichen zählen — Kostenloses Online-Tool | UltraTextGen">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Wörter zählen & Zeichen zählen — Kostenloses Online-Tool | UltraTextGen">
-  <meta name="twitter:description" content="Wörter, Zeichen, Sätze, Absätze und Lesezeit live beim Tippen zählen, plus ein Fit-Check für 27 Plattform-Zeichenlimits. Kostenlos, sofort, ohne Anmeldung.">
+  <meta name="twitter:description" content="Wörter, Zeichen, Sätze, Absätze und Lesezeit live beim Tippen zählen, plus ein Fit-Check für 38 Feldern auf 17 Plattformen. Kostenlos, sofort, ohne Anmeldung.">
   <meta name="twitter:image" content="https://ultratextgen.com/assets/og/de-woerter-zeichen-zaehlen.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -253,19 +253,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <section class="hero"><div class="hero-inner"><div class="hero-card">
   <h1 class="hero-headline">Wörter zählen &amp; Zeichen zählen</h1>
-  <p class="hero-sub">Wörter, Zeichen, Sätze, Absätze und Lesezeit live beim Tippen – plus ein Check, ob dein Text ins Limit von X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS und 18 weiteren Plattformen passt.</p>
+  <p class="hero-sub">Live-Zählung für 38 Felder auf 17 Plattformen – plus Ein-Klick-Korrekturen, wenn du drüber bist.</p>
 </div></div></section>
 
 <main class="container">
-  <section class="editorial-section">
-    <div class="editorial-block">
-      <p>Tippe oder füge einen beliebigen Text in das Feld unten ein – jede Zahl aktualisiert sich sofort: Wörter, Zeichen (mit und ohne Leerzeichen), Sätze, Absätze und eine geschätzte Lesezeit. Nichts wird hochgeladen – jede Zahl wird direkt in deinem Browser berechnet. Über dem Textfeld wählst du zuerst aus, wohin der Text soll: Der Check zählt dann genau so, wie diese Plattform zählt, und zeigt dir live, wie viele Zeichen dir noch bleiben oder wie weit du drüber bist. Und wenn du drüber bist, bleibt es nicht bei der schlechten Nachricht – du bekommst konkrete Korrekturen mit der jeweiligen Ersparnis vorgeschlagen, jede mit einem Klick anwendbar und jederzeit rückgängig zu machen. Brauchst du für den gerade gemessenen Text noch eine stylische Unicode-Schrift? Der <a href="/de/">UltraTextGen-Hauptgenerator</a> macht daraus über 100 Copy-Paste-Stile.</p>
-    </div>
-  </section>
-
-  <div class="section-divider"></div>
-
-  <div class="counter-tool">
+<div class="counter-tool">
     <div id="platformChecker"></div>
 
     <div class="counter-field">
@@ -307,12 +299,14 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     </div>
   </div>
 
+  <p class="counter-footnote">Alles wird in deinem Browser berechnet – nichts von dem, was du tippst, wird hochgeladen oder gespeichert. Brauchst du den Text auch in einer stylischen Schrift? Der <a href="/de/">UltraTextGen-Generator</a> macht daraus über 100 Copy-Paste-Schriften.</p>
+
   <div class="section-divider"></div>
 
   <section class="editorial-section">
     <h2>Harte und weiche Limits</h2>
     <p>Zwei ganz verschiedene Dinge heißen „Zeichenlimit“ – und davon hängt ab, was ein Überschreiten dich tatsächlich kostet.</p>
-    <table class="comparison-table">
+    <div class="comparison-table-wrap"><table class="comparison-table">
       <thead><tr><th>Art</th><th>Was passiert, wenn du drüber bist</th><th>Beispiele</th></tr></thead>
       <tbody>
         <tr>
@@ -326,34 +320,38 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
           <td>Instagram-Bildunterschrift ab 125 · LinkedIn-Beitrag ab ca. 140 (mobil) / 210 (Desktop) · YouTube-Beschreibung ab ca. 157</td>
         </tr>
       </tbody>
-    </table>
+    </table></div>
     <p>Das weiche Limit ist das, gegen das die meisten tatsächlich schreiben – und fast kein Zähler zeigt es an. Ein LinkedIn-Beitrag hat 3.000 Zeichen und ungefähr 140 nützliche: Der Rest liegt hinter einem Tippen, das kaum jemand macht. Deshalb stellt der Zähler oben den Schnitt direkt dar – tipp etwas ein, und du siehst genau den Text, der vor „mehr anzeigen“ erscheint, alles dahinter abgeblendet hinter einer Trennlinie, dazu, wie derselbe Einstieg in jedem anderen Feed dasteht, der abschneidet.</p>
     <p><strong>Wo jeder Feed abschneidet – und auf welchem Gerät:</strong></p>
-    <table class="comparison-table">
-      <thead><tr><th>Feed</th><th>Schnitt bei</th><th>Was das für den Aufhänger bedeutet</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Feed</th><th class="num">Handy</th><th class="num">Desktop</th><th>Was das für den Aufhänger bedeutet</th></tr></thead>
       <tbody>
         <tr>
           <td>LinkedIn-Beitrag</td>
-          <td>ca. 140 Handy<br>ca. 210 Desktop</td>
+          <td class="num">ca. 140</td>
+          <td class="num">ca. 210</td>
           <td>Schreib auf 140 hin, dann überlebt der Einstieg beides. Das ist die größte Lücke zwischen Handy und Desktop in dieser Liste.</td>
         </tr>
         <tr>
           <td><a href="/de/schriftarten-fuer-instagram/">Instagram-Bildunterschrift</a></td>
-          <td>ca. 125</td>
+          <td class="num">ca. 125</td>
+          <td class="num">ca. 125</td>
           <td>Der knappste Schnitt hier – etwa ein Satz, bevor „… mehr“ kommt.</td>
         </tr>
         <tr>
           <td>YouTube-Beschreibung</td>
-          <td>ca. 157</td>
+          <td class="num">ca. 157</td>
+          <td class="num">ca. 157</td>
           <td>Was unter dem Titel steht, bevor „Mehr ansehen“ kommt – und oft auch das, was in der Suche auftaucht.</td>
         </tr>
         <tr>
           <td><a href="/de/schriftarten-fuer-facebook/">Facebook-Beitrag</a></td>
-          <td>ca. 477</td>
+          <td class="num">ca. 477</td>
+          <td class="num">ca. 477</td>
           <td>Der großzügigste Schnitt – ein ganzer kurzer Absatz landet noch davor.</td>
         </tr>
       </tbody>
-    </table>
+    </table></div>
     <p>Zwei ehrliche Einschränkungen. Das sind beobachtete Oberflächen, keine veröffentlichten Limits – nimm sie also als „was zuverlässig zu sehen ist“ und nicht als exakte Schwellenwerte. Und Feeds schneiden auch nach <em>Zeilenzahl</em> ab: Drei frühe Zeilenumbrüche können einen Beitrag deutlich vor jeder Zeichenzahl kappen. Wenn dein Einstieg von einer Aufzählung lebt, prüf ihn zusätzlich im echten Editor.</p>
     <p>Eine ebenso häufige, aber ganz andere Situation: Deutsche Hausarbeiten, Bachelorarbeiten und Klausuren geben oft eine feste Wort- oder Zeichenzahl statt einer Seitenzahl vor. Das hat mit Social-Media-Limits nichts zu tun, lässt sich mit demselben Zähler aber genauso prüfen – <a href="#leerzeichen">mit oder ohne Leerzeichen</a> ist dabei die entscheidende Frage.</p>
   </section>
@@ -365,51 +363,51 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <p>Dieselben Limits, mit denen der Live-Check oben rechnet – hier als Nachschlagetabelle.</p>
 
     <h3>Beiträge &amp; Nachrichten</h3>
-    <table class="comparison-table">
-      <thead><tr><th>Plattform</th><th>Limit</th><th>Hinweis</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Plattform</th><th class="num">Limit</th><th>Hinweis</th></tr></thead>
       <tbody>
-        <tr><td>X- / Twitter-Beitrag</td><td>280</td><td>Gewichtet: jede URL = 23, die meisten Emojis, Symbole und verzierten Buchstaben = je 2 – siehe <a href="#zaehlweisen">wie X zählt</a></td></tr>
-        <tr><td>Discord-Nachricht</td><td>2.000</td><td>4.000 mit Nitro; längere Nachrichten werden zum .txt-Anhang</td></tr>
-        <tr><td>Instagram-Bildunterschrift</td><td>2.200</td><td>Nach den ersten Zeilen mit „mehr“ abgeschnitten</td></tr>
-        <tr><td>TikTok-Bildunterschrift</td><td>2.200</td><td></td></tr>
-        <tr><td>LinkedIn-Beitrag</td><td>3.000</td><td>„Mehr anzeigen“ schneidet je nach Gerät schon nach 200–700 Zeichen ab</td></tr>
-        <tr><td>Facebook-Beitrag</td><td>63.206</td><td></td></tr>
-        <tr><td>YouTube-Beschreibung</td><td>5.000</td><td></td></tr>
-        <tr><td>Pinterest-Pin-Beschreibung</td><td>500</td><td></td></tr>
-        <tr><td>Telegram-Nachricht</td><td>4.096</td><td>1.024 für eine Foto-/Video-Beschriftung</td></tr>
-        <tr><td>Threads-Beitrag</td><td>500</td><td></td></tr>
-        <tr><td>Bluesky-Beitrag</td><td>300</td><td>Zählt nach Graphemen (was du siehst), nicht nach Codepunkten</td></tr>
-        <tr><td>Reddit-Beitragstitel</td><td>300</td><td></td></tr>
-        <tr><td>Zalo-Beitrag/Status</td><td>2.000</td><td></td></tr>
+        <tr><td>X- / Twitter-Beitrag</td><td class="num">280</td><td>Gewichtet: jede URL = 23, die meisten Emojis, Symbole und verzierten Buchstaben = je 2 – siehe <a href="#zaehlweisen">wie X zählt</a></td></tr>
+        <tr><td>Discord-Nachricht</td><td class="num">2.000</td><td>4.000 mit Nitro; längere Nachrichten werden zum .txt-Anhang</td></tr>
+        <tr><td>Instagram-Bildunterschrift</td><td class="num">2.200</td><td>Nach den ersten Zeilen mit „mehr“ abgeschnitten</td></tr>
+        <tr><td>TikTok-Bildunterschrift</td><td class="num">2.200</td><td></td></tr>
+        <tr><td>LinkedIn-Beitrag</td><td class="num">3.000</td><td>„Mehr anzeigen“ schneidet je nach Gerät schon nach 200–700 Zeichen ab</td></tr>
+        <tr><td>Facebook-Beitrag</td><td class="num">63.206</td><td></td></tr>
+        <tr><td>YouTube-Beschreibung</td><td class="num">5.000</td><td></td></tr>
+        <tr><td>Pinterest-Pin-Beschreibung</td><td class="num">500</td><td></td></tr>
+        <tr><td>Telegram-Nachricht</td><td class="num">4.096</td><td>1.024 für eine Foto-/Video-Beschriftung</td></tr>
+        <tr><td>Threads-Beitrag</td><td class="num">500</td><td></td></tr>
+        <tr><td>Bluesky-Beitrag</td><td class="num">300</td><td>Zählt nach Graphemen (was du siehst), nicht nach Codepunkten</td></tr>
+        <tr><td>Reddit-Beitragstitel</td><td class="num">300</td><td></td></tr>
+        <tr><td>Zalo-Beitrag/Status</td><td class="num">2.000</td><td></td></tr>
       </tbody>
-    </table>
+    </table></div>
 
     <h3>Bios &amp; Profile</h3>
-    <table class="comparison-table">
-      <thead><tr><th>Feld</th><th>Limit</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Feld</th><th class="num">Limit</th></tr></thead>
       <tbody>
-        <tr><td>Instagram-Bio</td><td>150</td></tr>
-        <tr><td>TikTok-Bio</td><td>80</td></tr>
-        <tr><td>LinkedIn-Headline</td><td>220</td></tr>
-        <tr><td>WhatsApp-Info</td><td>139</td></tr>
-        <tr><td>Telegram-Bio</td><td>70</td></tr>
-        <tr><td>VK-Status</td><td>140</td></tr>
+        <tr><td>Instagram-Bio</td><td class="num">150</td></tr>
+        <tr><td>TikTok-Bio</td><td class="num">80</td></tr>
+        <tr><td>LinkedIn-Headline</td><td class="num">220</td></tr>
+        <tr><td>WhatsApp-Info</td><td class="num">139</td></tr>
+        <tr><td>Telegram-Bio</td><td class="num">70</td></tr>
+        <tr><td>VK-Status</td><td class="num">140</td></tr>
       </tbody>
-    </table>
+    </table></div>
 
     <h3>Benutzernamen, Titel &amp; SMS</h3>
-    <table class="comparison-table">
-      <thead><tr><th>Feld</th><th>Limit</th><th>Hinweis</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Feld</th><th class="num">Limit</th><th>Hinweis</th></tr></thead>
       <tbody>
-        <tr><td>Discord-Spitzname</td><td>32</td><td></td></tr>
-        <tr><td>TikTok-Benutzername</td><td>24</td><td>Nur Buchstaben, Zahlen, Unterstriche und Punkte</td></tr>
-        <tr><td>Instagram-Benutzername</td><td>30</td><td></td></tr>
-        <tr><td>YouTube-Titel</td><td>100</td><td></td></tr>
-        <tr><td>SEO-Meta-Titel</td><td>~60</td><td>Google schneidet nach Pixelbreite ab – als Richtwert verstehen</td></tr>
-        <tr><td>SEO-Meta-Beschreibung</td><td>~155</td><td>Ebenfalls Pixelbreite, keine feste Zeichenzahl</td></tr>
-        <tr><td>SMS (Textnachricht)</td><td>160 / Segment</td><td>Fällt auf 70 pro Segment, sobald ein Zeichen außerhalb von GSM-7 auftaucht (Emoji, typografische Anführungszeichen, ő, ą …) – siehe <a href="#sms">SMS-Zählung</a></td></tr>
+        <tr><td>Discord-Spitzname</td><td class="num">32</td><td></td></tr>
+        <tr><td>TikTok-Benutzername</td><td class="num">24</td><td>Nur Buchstaben, Zahlen, Unterstriche und Punkte</td></tr>
+        <tr><td>Instagram-Benutzername</td><td class="num">30</td><td></td></tr>
+        <tr><td>YouTube-Titel</td><td class="num">100</td><td></td></tr>
+        <tr><td>SEO-Meta-Titel</td><td class="num">~60</td><td>Google schneidet nach Pixelbreite ab – als Richtwert verstehen</td></tr>
+        <tr><td>SEO-Meta-Beschreibung</td><td class="num">~155</td><td>Ebenfalls Pixelbreite, keine feste Zeichenzahl</td></tr>
+        <tr><td>SMS (Textnachricht)</td><td class="num">160 / Segment</td><td>Fällt auf 70 pro Segment, sobald ein Zeichen außerhalb von GSM-7 auftaucht (Emoji, typografische Anführungszeichen, ő, ą …) – siehe <a href="#sms">SMS-Zählung</a></td></tr>
       </tbody>
-    </table>
+    </table></div>
   </section>
 
   <div class="section-divider"></div>
@@ -417,7 +415,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <section class="editorial-section" id="zaehlweisen">
     <h2>Warum deine Zeichenzahl nicht zur Plattform passt</h2>
     <p>„Wie viele Zeichen sind das?“ hat mehr als eine richtige Antwort, weil Plattformen in unterschiedlichen Einheiten zählen. Derselbe Text hat vier verschiedene Längen:</p>
-    <table class="comparison-table">
+    <div class="comparison-table-wrap"><table class="comparison-table">
       <thead><tr><th>Zählweise</th><th>Was gemessen wird</th><th>Wer so zählt</th></tr></thead>
       <tbody>
         <tr><td>Grapheme</td><td>Was du siehst – ein Emoji mit Hautton ist 1</td><td>Bluesky; ungefähr auch Instagrams Umgang mit Emojis</td></tr>
@@ -425,7 +423,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
         <tr><td>UTF-16-Einheiten</td><td>Wie JavaScript und viele Apps Text speichern – 𝗳𝗲𝘁𝘁𝗲 Buchstaben kosten je 2</td><td>HTML-Formularfelder (<code>maxlength</code>), viele Spiele und App-Backends</td></tr>
         <tr><td>UTF-8-Bytes</td><td>Speichergröße – ä ist 2, 中 ist 3, 𝗯 ist 4</td><td>Amazon-Listing-Felder, Steam-Namen, Datenbanken</td></tr>
       </tbody>
-    </table>
+    </table></div>
     <p>Alle vier siehst du oben live. Wenn ein Formular behauptet, dein Text sei zu lang, während Word etwas anderes anzeigt, kannst du hier ablesen, welche Zählweise das Formular benutzt. Zwei Plattformen brauchen zusätzlich eigene Regeln:</p>
     <p><strong>X/Twitter zählt nach Gewicht, nicht nach Zeichen.</strong> Nach dem von X selbst veröffentlichten Algorithmus (der <code>twitter-text</code>-Bibliothek) zählt jede URL exakt 23, lateinische Grundbuchstaben zählen 1 – und fast alles andere, also CJK-Zeichen, die meisten Emojis und jeder verzierte Unicode-Buchstabe, zählt <strong>2</strong>. Ein komplett 𝗳𝗲𝘁𝘁 gesetzter Beitrag hat deshalb nur 140 sichtbare Buchstaben Platz. Die X-Optionen im Check oben rechnen genau nach diesem Algorithmus.</p>
     <p><strong>Bei der SMS entscheidet ein einziges Zeichen über den Preis.</strong> Eine Nachricht fasst 160 Zeichen nur, solange jedes Zeichen im alten GSM-7-Alphabet liegt – die deutschen Umlaute ä, ö, ü und das ß gehören dazu. Ein Emoji, ein typografisches Anführungszeichen aus Word oder ein Buchstabe außerhalb des Alphabets schaltet die ganze Nachricht still auf 70 Zeichen pro Segment um. Mehr dazu im <a href="#sms">SMS-Abschnitt</a> weiter unten.</p>
@@ -562,6 +560,9 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     undo: "Rückgängig",
     applied: "Angewendet",
     segShort: "Seg.",
+    pastFold: "Passt – Schnitt bei {n} ⚠",
+    showAllFits: "Alle {n} anzeigen",
+    showFewerFits: "Weniger anzeigen",
     foldHeading: "Was Leser vor „mehr anzeigen“ sehen",
     foldMore: "mehr anzeigen",
     foldMeta: "{shown} von {total} Zeichen sichtbar · {hidden} verborgen hinter dem Aufklappen",

--- a/embed/character-counter/index.html
+++ b/embed/character-counter/index.html
@@ -130,7 +130,7 @@
       <ul class="embed-notes-list">
         <li>The widget is responsive and works well in containers from 320px to full width.</li>
         <li>Counts words, characters (with and without spaces), sentences, paragraphs, lines, reading time, graphemes, UTF-16 units, and UTF-8 bytes — all live, no submit button.</li>
-        <li>The platform checker covers 27 limits (X/Twitter, Instagram, TikTok, LinkedIn, Discord, SMS, and more) and counts each one the way that platform actually counts — X's weighted algorithm, real SMS GSM-7/Unicode segments.</li>
+        <li>The platform checker covers 38 fields across 17 platforms (X/Twitter, Instagram, TikTok, LinkedIn, Discord, SMS, and more) and counts each one the way that platform actually counts — X's weighted algorithm, real SMS GSM-7/Unicode segments.</li>
         <li>The attribution link at the bottom of the widget should remain visible. It keeps the tool free for everyone.</li>
         <li>No API key or account needed — just paste the iframe code and you're done.</li>
         <li>The widget loads its own styles and scripts — it won't conflict with your site's CSS or JavaScript.</li>

--- a/es/contador-de-palabras-y-caracteres/index.html
+++ b/es/contador-de-palabras-y-caracteres/index.html
@@ -48,7 +48,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Contador de Palabras y Caracteres — Herramienta Online Gratis | UltraTextGen</title>
-  <meta name="description" content="Contador de palabras y contador de caracteres gratis. Estadísticas en vivo de palabras, caracteres, oraciones, párrafos y tiempo de lectura mientras escribes, más un verificador de límites para 27 plataformas — X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS y más.">
+  <meta name="description" content="Contador de palabras y contador de caracteres gratis. Estadísticas en vivo de palabras, caracteres, oraciones, párrafos y tiempo de lectura mientras escribes, más un verificador de límites para 38 campos en 17 plataformas — X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS y más.">
   <link rel="canonical" href="https://ultratextgen.com/es/contador-de-palabras-y-caracteres/">
 
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/character-counter/">
@@ -158,19 +158,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <section class="hero"><div class="hero-inner"><div class="hero-card">
   <h1 class="hero-headline">Contador de Palabras y Caracteres</h1>
-  <p class="hero-sub">Estadísticas en vivo de palabras, caracteres, oraciones, párrafos y tiempo de lectura mientras escribes — más un verificador de si tu texto cabe en los límites de X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS y otras 18 plataformas, y arreglos de un clic cuando te pasas.</p>
+  <p class="hero-sub">Conteo en vivo de 38 campos en 17 plataformas — y arreglos de un clic cuando te pasas.</p>
 </div></div></section>
 
 <main class="container">
-  <section class="editorial-section">
-    <div class="editorial-block">
-      <p>Empieza por decir adónde va el texto: elige la plataforma y el campo justo encima del cuadro y todo se cuenta como cuenta ese destino, no con un número genérico. Escribe o pega debajo y cada estadística se actualiza al instante: palabras, caracteres (con y sin espacios), oraciones, párrafos y una estimación del tiempo de lectura. Nada se sube — cada número se calcula directamente en tu navegador. Y si te pasas del límite, la herramienta no se queda ahí: te propone recortes concretos con el ahorro exacto de cada uno, a un clic y con opción de deshacer. ¿Necesitas fuentes Unicode con estilo para el texto que acabas de medir? El <a href="/es/">generador principal de UltraTextGen</a> lo convierte en más de 100 estilos para copiar y pegar.</p>
-    </div>
-  </section>
-
-  <div class="section-divider"></div>
-
-  <div class="counter-tool">
+<div class="counter-tool">
     <div id="platformChecker"></div>
 
     <div class="counter-field">
@@ -210,12 +202,14 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     </div>
   </div>
 
+  <p class="counter-footnote">Todo se calcula en tu navegador — nada de lo que escribes se sube ni se guarda. ¿Quieres además el texto con estilo? El <a href="/es/">generador de UltraTextGen</a> lo convierte en más de 100 fuentes para copiar y pegar.</p>
+
   <div class="section-divider"></div>
 
   <section class="editorial-section">
     <h2>Límites estrictos y límites blandos</h2>
     <p>Dos cosas muy distintas se llaman «límite de caracteres», y la diferencia cambia lo que te cuesta pasarte.</p>
-    <table class="comparison-table">
+    <div class="comparison-table-wrap"><table class="comparison-table">
       <thead><tr><th>Tipo</th><th>Qué pasa si te pasas</th><th>Ejemplos</th></tr></thead>
       <tbody>
         <tr>
@@ -229,34 +223,38 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
           <td>Descripción de Instagram a partir de 125 · Publicación de LinkedIn a partir de ~140 en móvil / ~210 en escritorio · Descripción de YouTube a partir de ~157</td>
         </tr>
       </tbody>
-    </table>
+    </table></div>
     <p>El límite blando es contra el que casi todo el mundo escribe en realidad, y casi ningún contador lo enseña. Una publicación de LinkedIn tiene 3.000 caracteres y unos 140 útiles: el resto queda detrás de un toque que casi nadie da. Por eso el contador de arriba dibuja el corte directamente: escribe algo y verás el texto exacto que aparece antes de «ver más», con todo lo demás atenuado tras una línea, además de cómo aguanta ese mismo arranque en el resto de feeds que recortan.</p>
     <p><strong>Dónde corta cada feed y en qué dispositivo:</strong></p>
-    <table class="comparison-table">
-      <thead><tr><th>Feed</th><th>Corta a los</th><th>Qué significa para el gancho</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Feed</th><th class="num">Móvil</th><th class="num">Escritorio</th><th>Qué significa para el gancho</th></tr></thead>
       <tbody>
         <tr>
           <td>Publicación de LinkedIn</td>
-          <td>~140 en móvil<br>~210 en escritorio</td>
+          <td class="num">~140</td>
+          <td class="num">~210</td>
           <td>Escribe pensando en 140 y el arranque sobrevive a los dos. Es la mayor diferencia entre móvil y escritorio de toda la lista.</td>
         </tr>
         <tr>
           <td><a href="/es/fuentes-para-instagram/">Descripción de Instagram</a></td>
-          <td>~125</td>
+          <td class="num">~125</td>
+          <td class="num">~125</td>
           <td>El corte más justo de la lista: aproximadamente una frase antes del «… más».</td>
         </tr>
         <tr>
           <td>Descripción de YouTube</td>
-          <td>~157</td>
+          <td class="num">~157</td>
+          <td class="num">~157</td>
           <td>Lo que se ve bajo el título antes de «Mostrar más»; también es lo que suele aparecer en el buscador.</td>
         </tr>
         <tr>
           <td><a href="/es/letras-para-facebook/">Publicación de Facebook</a></td>
-          <td>~477</td>
+          <td class="num">~477</td>
+          <td class="num">~477</td>
           <td>El corte más generoso: entra un párrafo corto entero antes de que llegue.</td>
         </tr>
       </tbody>
-    </table>
+    </table></div>
     <p>Dos advertencias honestas. Son comportamientos observados de la interfaz, no límites publicados, así que tómalos como «lo que se ve de forma fiable» y no como umbrales exactos. Y los feeds también cortan por <em>número de líneas</em>: tres saltos de línea al principio pueden recortar una publicación mucho antes de cualquier cifra de caracteres. Si tu arranque depende de una lista, compruébalo también en el editor real.</p>
   </section>
 
@@ -267,51 +265,51 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <p>Los mismos límites que usa el verificador de arriba, en forma de tabla de consulta. Ir a: <a href="#twitter">X/Twitter</a> · <a href="#discord">Discord</a> · <a href="#instagram">Instagram</a> · <a href="#tiktok">TikTok</a> · <a href="#sms">SMS</a> · <a href="#unidades-de-conteo">cómo cuenta cada plataforma</a>.</p>
 
     <h3>Publicaciones y mensajes</h3>
-    <table class="comparison-table">
-      <thead><tr><th>Plataforma</th><th>Límite</th><th>Notas</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Plataforma</th><th class="num">Límite</th><th>Notas</th></tr></thead>
       <tbody>
-        <tr id="twitter"><td>Publicación en X / Twitter</td><td>280</td><td>Conteo ponderado: cada URL = 23, y la mayoría de emojis, símbolos y letras con estilo = 2 — ver <a href="#unidades-de-conteo">cómo cuenta X</a></td></tr>
-        <tr id="discord"><td>Mensaje de Discord</td><td>2.000</td><td>4.000 con Nitro; los mensajes más largos se convierten en un adjunto .txt</td></tr>
-        <tr id="instagram"><td>Descripción de Instagram</td><td>2.200</td><td>Se recorta con «más» tras las primeras líneas</td></tr>
-        <tr id="tiktok"><td>Descripción de TikTok</td><td>2.200</td><td></td></tr>
-        <tr><td>Publicación de LinkedIn</td><td>3.000</td><td>El «ver más» recorta hacia los 200–700 caracteres según el dispositivo</td></tr>
-        <tr><td>Publicación de Facebook</td><td>63.206</td><td></td></tr>
-        <tr><td>Descripción de YouTube</td><td>5.000</td><td></td></tr>
-        <tr><td>Descripción de pin de Pinterest</td><td>500</td><td></td></tr>
-        <tr><td>Mensaje de Telegram</td><td>4.096</td><td>1.024 para la descripción de una foto o un vídeo</td></tr>
-        <tr><td>Publicación de Threads</td><td>500</td><td></td></tr>
-        <tr><td>Publicación de Bluesky</td><td>300</td><td>Cuenta grafemas (lo que ves), no puntos de código</td></tr>
-        <tr><td>Título de publicación de Reddit</td><td>300</td><td></td></tr>
-        <tr><td>Publicación/estado de Zalo</td><td>2.000</td><td></td></tr>
+        <tr id="twitter"><td>Publicación en X / Twitter</td><td class="num">280</td><td>Conteo ponderado: cada URL = 23, y la mayoría de emojis, símbolos y letras con estilo = 2 — ver <a href="#unidades-de-conteo">cómo cuenta X</a></td></tr>
+        <tr id="discord"><td>Mensaje de Discord</td><td class="num">2.000</td><td>4.000 con Nitro; los mensajes más largos se convierten en un adjunto .txt</td></tr>
+        <tr id="instagram"><td>Descripción de Instagram</td><td class="num">2.200</td><td>Se recorta con «más» tras las primeras líneas</td></tr>
+        <tr id="tiktok"><td>Descripción de TikTok</td><td class="num">2.200</td><td></td></tr>
+        <tr><td>Publicación de LinkedIn</td><td class="num">3.000</td><td>El «ver más» recorta hacia los 200–700 caracteres según el dispositivo</td></tr>
+        <tr><td>Publicación de Facebook</td><td class="num">63.206</td><td></td></tr>
+        <tr><td>Descripción de YouTube</td><td class="num">5.000</td><td></td></tr>
+        <tr><td>Descripción de pin de Pinterest</td><td class="num">500</td><td></td></tr>
+        <tr><td>Mensaje de Telegram</td><td class="num">4.096</td><td>1.024 para la descripción de una foto o un vídeo</td></tr>
+        <tr><td>Publicación de Threads</td><td class="num">500</td><td></td></tr>
+        <tr><td>Publicación de Bluesky</td><td class="num">300</td><td>Cuenta grafemas (lo que ves), no puntos de código</td></tr>
+        <tr><td>Título de publicación de Reddit</td><td class="num">300</td><td></td></tr>
+        <tr><td>Publicación/estado de Zalo</td><td class="num">2.000</td><td></td></tr>
       </tbody>
-    </table>
+    </table></div>
 
     <h3>Bios y perfiles</h3>
-    <table class="comparison-table">
-      <thead><tr><th>Campo</th><th>Límite</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Campo</th><th class="num">Límite</th></tr></thead>
       <tbody>
-        <tr><td>Biografía de Instagram</td><td>150</td></tr>
-        <tr><td>Biografía de TikTok</td><td>80</td></tr>
-        <tr><td>Titular de LinkedIn</td><td>220</td></tr>
-        <tr><td>Info de WhatsApp</td><td>139</td></tr>
-        <tr><td>Biografía de Telegram</td><td>70</td></tr>
-        <tr><td>Estado de VK</td><td>140</td></tr>
+        <tr><td>Biografía de Instagram</td><td class="num">150</td></tr>
+        <tr><td>Biografía de TikTok</td><td class="num">80</td></tr>
+        <tr><td>Titular de LinkedIn</td><td class="num">220</td></tr>
+        <tr><td>Info de WhatsApp</td><td class="num">139</td></tr>
+        <tr><td>Biografía de Telegram</td><td class="num">70</td></tr>
+        <tr><td>Estado de VK</td><td class="num">140</td></tr>
       </tbody>
-    </table>
+    </table></div>
 
     <h3>Nombres de usuario, títulos y SMS</h3>
-    <table class="comparison-table">
-      <thead><tr><th>Campo</th><th>Límite</th><th>Notas</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Campo</th><th class="num">Límite</th><th>Notas</th></tr></thead>
       <tbody>
-        <tr><td>Apodo de Discord</td><td>32</td><td></td></tr>
-        <tr><td>Nombre de usuario de TikTok</td><td>24</td><td>Solo letras, números, guiones bajos y puntos</td></tr>
-        <tr><td>Nombre de usuario de Instagram</td><td>30</td><td></td></tr>
-        <tr><td>Título de YouTube</td><td>100</td><td></td></tr>
-        <tr><td>Meta título SEO</td><td>~60</td><td>Google recorta por ancho en píxeles — tómalo como orientación</td></tr>
-        <tr><td>Meta descripción SEO</td><td>~155</td><td>Igual — el recorte es por ancho en píxeles</td></tr>
-        <tr id="sms"><td>Mensaje SMS</td><td>160 / segmento</td><td>Baja a 70 por segmento en cuanto aparece un carácter fuera del GSM-7 (un emoji, una comilla tipográfica, una á, una í…) — ver <a href="#unidades-de-conteo">cómo se cuentan los SMS</a></td></tr>
+        <tr><td>Apodo de Discord</td><td class="num">32</td><td></td></tr>
+        <tr><td>Nombre de usuario de TikTok</td><td class="num">24</td><td>Solo letras, números, guiones bajos y puntos</td></tr>
+        <tr><td>Nombre de usuario de Instagram</td><td class="num">30</td><td></td></tr>
+        <tr><td>Título de YouTube</td><td class="num">100</td><td></td></tr>
+        <tr><td>Meta título SEO</td><td class="num">~60</td><td>Google recorta por ancho en píxeles — tómalo como orientación</td></tr>
+        <tr><td>Meta descripción SEO</td><td class="num">~155</td><td>Igual — el recorte es por ancho en píxeles</td></tr>
+        <tr id="sms"><td>Mensaje SMS</td><td class="num">160 / segmento</td><td>Baja a 70 por segmento en cuanto aparece un carácter fuera del GSM-7 (un emoji, una comilla tipográfica, una á, una í…) — ver <a href="#unidades-de-conteo">cómo se cuentan los SMS</a></td></tr>
       </tbody>
-    </table>
+    </table></div>
   </section>
 
   <div class="section-divider"></div>
@@ -319,7 +317,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <section class="editorial-section" id="unidades-de-conteo">
     <h2>Por qué tu conteo de caracteres no coincide con el de la plataforma</h2>
     <p>«¿Cuántos caracteres tiene esto?» tiene más de una respuesta correcta, porque cada plataforma cuenta en una unidad distinta. El mismo texto puede tener cuatro longitudes diferentes:</p>
-    <table class="comparison-table">
+    <div class="comparison-table-wrap"><table class="comparison-table">
       <thead><tr><th>Unidad de conteo</th><th>Qué mide</th><th>Quién la usa</th></tr></thead>
       <tbody>
         <tr><td>Grafemas</td><td>Lo que ves: un emoji con tono de piel es 1</td><td>Bluesky; y más o menos cómo trata Instagram los emojis</td></tr>
@@ -327,7 +325,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
         <tr><td>Unidades UTF-16</td><td>Cómo guardan el texto JavaScript y muchas apps: cada letra 𝗻𝗲𝗴𝗿𝗶𝘁𝗮 cuesta 2</td><td>Campos de formulario HTML (<code>maxlength</code>), muchos juegos y back-ends de apps</td></tr>
         <tr><td>Bytes UTF-8</td><td>Tamaño de almacenamiento: é son 2, 中 son 3, 𝗯 son 4</td><td>Fichas de producto de Amazon (títulos de 200 bytes), nombres de Steam, bases de datos</td></tr>
       </tbody>
-    </table>
+    </table></div>
     <p>Las cuatro se muestran en vivo en las estadísticas de arriba, así que cuando un formulario te diga que el texto es demasiado largo y tu procesador de textos opine lo contrario, puedes ver exactamente qué unidad está usando el formulario. Hay dos casos que además necesitan reglas propias:</p>
     <p><strong>X / Twitter cuenta por peso, no por caracteres.</strong> Según el algoritmo que la propia X publica (la librería <code>twitter-text</code>), cada URL cuenta exactamente 23, las letras latinas básicas cuentan 1 y casi todo lo demás — los caracteres CJK, la mayoría de emojis y todas las letras Unicode «con estilo» — cuenta <strong>2</strong>. Por eso una publicación entera en 𝗻𝗲𝗴𝗿𝗶𝘁𝗮 solo admite 140 letras visibles dentro del presupuesto de 280. La opción «Publicación en X / Twitter» del verificador implementa ese algoritmo real.</p>
     <p><strong>Un SMS se cuenta por segmentos, y en español es fácil salirse del alfabeto barato.</strong> Un mensaje admite 160 caracteres solo mientras todos ellos estén en el viejo alfabeto GSM-7. La buena noticia es que la ñ, la é y los signos ¡ y ¿ sí están dentro; la mala, que la á, la í, la ó y la ú no. Una sola de ellas — o un emoji, o una comilla tipográfica pegada desde Word — pasa el mensaje entero a modo Unicode: 70 caracteres por segmento, 67 cuando se parte en varios. La opción «SMS» de arriba detecta el cambio y te nombra el carácter exacto que lo ha provocado.</p>
@@ -446,6 +444,9 @@ window.UTG_COUNTER_I18N = {
   applied: "Aplicado",
   fitsHeading: "Dónde más cabe este texto",
   segShort: "segm.",
+  pastFold: "Cabe — corta en {n} ⚠",
+  showAllFits: "Ver los {n}",
+  showFewerFits: "Ver menos",
   foldHeading: "Lo que la gente ve antes de «ver más»",
   foldMore: "ver más",
   foldMeta: "{shown} de {total} caracteres a la vista · {hidden} ocultos tras el toque",

--- a/fi/merkkilaskuri/index.html
+++ b/fi/merkkilaskuri/index.html
@@ -153,19 +153,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <section class="hero"><div class="hero-inner"><div class="hero-card">
   <h1 class="hero-headline">Merkkilaskuri ja sanalaskuri</h1>
-  <p class="hero-sub">Sanat, merkit, virkkeet, kappaleet ja lukuaika päivittyvät kirjoittaessasi — ja tarkistin kertoo, mahtuuko tekstisi X:n, Instagramin, TikTokin, LinkedInin, YouTuben, Discordin, Telegramin, tekstiviestin ja 18 muun palvelun rajaan.</p>
+  <p class="hero-sub">Reaaliaikaiset laskurit 38 kentälle 17 palvelussa — ja yhden klikkauksen korjaukset, kun menet yli.</p>
 </div></div></section>
 
 <main class="container">
-  <section class="editorial-section">
-    <div class="editorial-block">
-      <p>Kirjoita tai liitä mikä tahansa teksti, niin jokainen luku päivittyy heti: sanat, merkit (välilyöntien kanssa ja ilman), virkkeet, kappaleet ja arvioitu lukuaika. Valitse tekstikentän yläpuolelta, minne teksti on menossa — silloin laskuri laskee sen täsmälleen niin kuin kyseinen palvelu laskee ja kertoo, montako merkkiä on jäljellä tai montako yli mennään. Ja jos yli mennään, se kertoo myös mitä kannattaa karsia: yksi klikkaus, ja jokainen korjaus on peruttavissa. Mitään ei lähetetä eteenpäin — jokainen luku lasketaan suoraan selaimessasi. Tarvitsetko juuri mittaamallesi tekstille tyylikkään Unicode-fontin? <a href="/fi/">UltraTextGenin suomenkielinen generaattori</a> muuntaa sen yli sadaksi kopioitavaksi tyyliksi.</p>
-    </div>
-  </section>
-
-  <div class="section-divider"></div>
-
-  <div class="counter-tool">
+<div class="counter-tool">
     <div id="platformChecker"></div>
 
     <div class="counter-field">
@@ -205,12 +197,14 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     </div>
   </div>
 
+  <p class="counter-footnote">Kaikki lasketaan selaimessasi — mitään kirjoittamaasi ei lähetetä eteenpäin eikä tallenneta. Tarvitseeko teksti myös tyylin? <a href="/fi/">UltraTextGen-generaattori</a> muuntaa sen yli sadaksi kopioitavaksi fontiksi.</p>
+
   <div class="section-divider"></div>
 
   <section class="editorial-section">
     <h2>Kovat ja pehmeät rajat</h2>
     <p>“Merkkiraja” tarkoittaa kahta eri asiaa, ja siitä riippuu, mitä rajan ylittäminen oikeasti maksaa.</p>
-    <table class="comparison-table">
+    <div class="comparison-table-wrap"><table class="comparison-table">
       <thead><tr><th>Tyyppi</th><th>Mitä tapahtuu, jos menet yli</th><th>Esimerkkejä</th></tr></thead>
       <tbody>
         <tr>
@@ -224,34 +218,38 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
           <td>Instagram-kuvateksti 125 merkin jälkeen · LinkedIn-julkaisu n. 140 (mobiili) / 210 (työpöytä) jälkeen · YouTube-kuvaus n. 157 jälkeen</td>
         </tr>
       </tbody>
-    </table>
+    </table></div>
     <p>Pehmeä raja on se, jota useimmat oikeasti kirjoittavat vastaan, eikä juuri mikään laskuri näytä sitä. LinkedIn-julkaisuun mahtuu 3 000 merkkiä ja niistä noin 140 on käyttökelpoisia: loput jäävät napautuksen taakse, jota kukaan ei tee. Siksi yllä oleva työkalu piirtää katkaisukohdan suoraan näkyviin — kirjoita kenttään, niin näet täsmälleen sen tekstin, joka näkyy ennen “näytä lisää” -linkkiä, loppuosan himmennettynä katkaisuviivan takana, ja sen, kestääkö sama aloitus katkaisun myös muissa syötteissä.</p>
     <p><strong>Missä kohtaa kukin syöte katkaisee, ja millä laitteella:</strong></p>
-    <table class="comparison-table">
-      <thead><tr><th>Syöte</th><th>Katkaisee kohdassa</th><th>Mitä se tarkoittaa aloitukselle</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Syöte</th><th class="num">Puhelin</th><th class="num">Työpöytä</th><th>Mitä se tarkoittaa aloitukselle</th></tr></thead>
       <tbody>
         <tr>
           <td>LinkedIn-julkaisu</td>
-          <td>~140 puhelimessa<br>~210 työpöydällä</td>
+          <td class="num">~140</td>
+          <td class="num">~210</td>
           <td>Kirjoita aloitus 140 merkkiin, niin se kestää molemmissa. Tässä on listan suurin ero puhelimen ja työpöydän välillä.</td>
         </tr>
         <tr>
           <td><a href="/fi/instagram-fontit/">Instagram-kuvateksti</a></td>
-          <td>~125</td>
+          <td class="num">~125</td>
+          <td class="num">~125</td>
           <td>Listan tiukin katkaisu — noin yksi virke ennen kuin tulee “… lisää”.</td>
         </tr>
         <tr>
           <td>YouTube-kuvaus</td>
-          <td>~157</td>
+          <td class="num">~157</td>
+          <td class="num">~157</td>
           <td>Se osa, joka näkyy otsikon alla ennen “Näytä lisää” -painiketta; usein myös se, minkä haku nostaa esiin.</td>
         </tr>
         <tr>
           <td>Facebook-julkaisu</td>
-          <td>~477</td>
+          <td class="num">~477</td>
+          <td class="num">~477</td>
           <td>Listan armollisin katkaisu — kokonainen lyhyt kappale ehtii ennen katkaisua.</td>
         </tr>
       </tbody>
-    </table>
+    </table></div>
     <p>Kaksi rehellistä varausta. Nämä ovat käyttöliittymästä havaittua käytöstä, eivät julkaistuja rajoja, joten pidä niitä pikemminkin “sinä määränä, joka luotettavasti näkyy” kuin tarkkoina kynnyksinä — ja syötteet katkaisevat myös <em>rivimäärän</em> perusteella, joten kolme rivinvaihtoa heti alussa voi katkaista julkaisun kauas ennen mitään merkkilukua. Jos aloituksesi nojaa listaan, kokeile se myös oikeassa julkaisukentässä.</p>
   </section>
 
@@ -262,51 +260,51 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <p>Samat rajat, joita yllä oleva tarkistin käyttää, taulukkona. Siirry kohtaan: <a href="#twitter">X/Twitter</a> · <a href="#discord">Discord</a> · <a href="#instagram">Instagram</a> · <a href="#tiktok">TikTok</a> · <a href="#sms">tekstiviesti</a> · <a href="#counting-modes">miten kukin palvelu laskee</a>.</p>
 
     <h3>Julkaisut ja viestit</h3>
-    <table class="comparison-table">
-      <thead><tr><th>Palvelu</th><th>Raja</th><th>Huomioita</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Palvelu</th><th class="num">Raja</th><th>Huomioita</th></tr></thead>
       <tbody>
-        <tr id="twitter"><td>X / Twitter -julkaisu</td><td>280</td><td>Painotettu laskenta: jokainen linkki = 23, useimmat emojit, symbolit ja tyylitellyt kirjaimet = 2 — katso <a href="#counting-modes">miten X laskee</a></td></tr>
-        <tr id="discord"><td>Discord-viesti</td><td>2 000</td><td>Nitrolla 4 000; pidemmästä viestistä tulee .txt-liite</td></tr>
-        <tr id="instagram"><td>Instagram-kuvateksti</td><td>2 200</td><td>Katkeaa ensimmäisten rivien jälkeen “lisää”-linkkiin</td></tr>
-        <tr id="tiktok"><td>TikTok-kuvateksti</td><td>2 200</td><td></td></tr>
-        <tr><td>LinkedIn-julkaisu</td><td>3 000</td><td>“Näytä lisää” katkaisee laitteesta riippuen noin 200–700 merkin kohdalla</td></tr>
-        <tr><td>Facebook-julkaisu</td><td>63 206</td><td></td></tr>
-        <tr><td>YouTube-kuvaus</td><td>5 000</td><td></td></tr>
-        <tr><td>Pinterestin pinin kuvaus</td><td>500</td><td></td></tr>
-        <tr><td>Telegram-viesti</td><td>4 096</td><td>Kuvan tai videon tekstille 1 024</td></tr>
-        <tr><td>Threads-julkaisu</td><td>500</td><td></td></tr>
-        <tr><td>Bluesky-julkaisu</td><td>300</td><td>Lasketaan grafeemeina (sen mukaan mitä näet), ei koodipisteinä</td></tr>
-        <tr><td>Redditin julkaisun otsikko</td><td>300</td><td></td></tr>
-        <tr><td>Zalo-julkaisu/tila</td><td>2 000</td><td></td></tr>
+        <tr id="twitter"><td>X / Twitter -julkaisu</td><td class="num">280</td><td>Painotettu laskenta: jokainen linkki = 23, useimmat emojit, symbolit ja tyylitellyt kirjaimet = 2 — katso <a href="#counting-modes">miten X laskee</a></td></tr>
+        <tr id="discord"><td>Discord-viesti</td><td class="num">2 000</td><td>Nitrolla 4 000; pidemmästä viestistä tulee .txt-liite</td></tr>
+        <tr id="instagram"><td>Instagram-kuvateksti</td><td class="num">2 200</td><td>Katkeaa ensimmäisten rivien jälkeen “lisää”-linkkiin</td></tr>
+        <tr id="tiktok"><td>TikTok-kuvateksti</td><td class="num">2 200</td><td></td></tr>
+        <tr><td>LinkedIn-julkaisu</td><td class="num">3 000</td><td>“Näytä lisää” katkaisee laitteesta riippuen noin 200–700 merkin kohdalla</td></tr>
+        <tr><td>Facebook-julkaisu</td><td class="num">63 206</td><td></td></tr>
+        <tr><td>YouTube-kuvaus</td><td class="num">5 000</td><td></td></tr>
+        <tr><td>Pinterestin pinin kuvaus</td><td class="num">500</td><td></td></tr>
+        <tr><td>Telegram-viesti</td><td class="num">4 096</td><td>Kuvan tai videon tekstille 1 024</td></tr>
+        <tr><td>Threads-julkaisu</td><td class="num">500</td><td></td></tr>
+        <tr><td>Bluesky-julkaisu</td><td class="num">300</td><td>Lasketaan grafeemeina (sen mukaan mitä näet), ei koodipisteinä</td></tr>
+        <tr><td>Redditin julkaisun otsikko</td><td class="num">300</td><td></td></tr>
+        <tr><td>Zalo-julkaisu/tila</td><td class="num">2 000</td><td></td></tr>
       </tbody>
-    </table>
+    </table></div>
 
     <h3>Biot ja profiilit</h3>
-    <table class="comparison-table">
-      <thead><tr><th>Kenttä</th><th>Raja</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Kenttä</th><th class="num">Raja</th></tr></thead>
       <tbody>
-        <tr><td>Instagram-bio</td><td>150</td></tr>
-        <tr><td>TikTok-bio</td><td>80</td></tr>
-        <tr><td>LinkedIn-otsikko</td><td>220</td></tr>
-        <tr><td>WhatsAppin tiedot</td><td>139</td></tr>
-        <tr><td>Telegram-bio</td><td>70</td></tr>
-        <tr><td>VK-tila</td><td>140</td></tr>
+        <tr><td>Instagram-bio</td><td class="num">150</td></tr>
+        <tr><td>TikTok-bio</td><td class="num">80</td></tr>
+        <tr><td>LinkedIn-otsikko</td><td class="num">220</td></tr>
+        <tr><td>WhatsAppin tiedot</td><td class="num">139</td></tr>
+        <tr><td>Telegram-bio</td><td class="num">70</td></tr>
+        <tr><td>VK-tila</td><td class="num">140</td></tr>
       </tbody>
-    </table>
+    </table></div>
 
     <h3>Käyttäjätunnukset, otsikot ja tekstiviesti</h3>
-    <table class="comparison-table">
-      <thead><tr><th>Kenttä</th><th>Raja</th><th>Huomioita</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Kenttä</th><th class="num">Raja</th><th>Huomioita</th></tr></thead>
       <tbody>
-        <tr><td>Discord-nimimerkki</td><td>32</td><td></td></tr>
-        <tr><td>TikTok-käyttäjätunnus</td><td>24</td><td>Vain kirjaimet, numerot, alaviivat ja pisteet</td></tr>
-        <tr><td>Instagram-käyttäjätunnus</td><td>30</td><td></td></tr>
-        <tr><td>YouTube-otsikko</td><td>100</td><td></td></tr>
-        <tr><td>Sivun otsikko (SEO)</td><td>~60</td><td>Google katkaisee pikselileveyden mukaan — pidä lukua ohjeena</td></tr>
-        <tr><td>Metakuvaus (SEO)</td><td>~155</td><td>Sama juttu — katkaisu pikselileveyden mukaan</td></tr>
-        <tr id="sms"><td>Tekstiviesti</td><td>160 / osa</td><td>Putoaa 70:een heti kun mukana on yksikin GSM-merkistön ulkopuolinen merkki (emoji, kaareva lainausmerkki, ş, ő…). <strong>Ä, ö ja å eivät ole tällaisia</strong> — ne kuuluvat GSM-merkistöön; katso <a href="#counting-modes">tekstiviestin laskenta</a></td></tr>
+        <tr><td>Discord-nimimerkki</td><td class="num">32</td><td></td></tr>
+        <tr><td>TikTok-käyttäjätunnus</td><td class="num">24</td><td>Vain kirjaimet, numerot, alaviivat ja pisteet</td></tr>
+        <tr><td>Instagram-käyttäjätunnus</td><td class="num">30</td><td></td></tr>
+        <tr><td>YouTube-otsikko</td><td class="num">100</td><td></td></tr>
+        <tr><td>Sivun otsikko (SEO)</td><td class="num">~60</td><td>Google katkaisee pikselileveyden mukaan — pidä lukua ohjeena</td></tr>
+        <tr><td>Metakuvaus (SEO)</td><td class="num">~155</td><td>Sama juttu — katkaisu pikselileveyden mukaan</td></tr>
+        <tr id="sms"><td>Tekstiviesti</td><td class="num">160 / osa</td><td>Putoaa 70:een heti kun mukana on yksikin GSM-merkistön ulkopuolinen merkki (emoji, kaareva lainausmerkki, ş, ő…). <strong>Ä, ö ja å eivät ole tällaisia</strong> — ne kuuluvat GSM-merkistöön; katso <a href="#counting-modes">tekstiviestin laskenta</a></td></tr>
       </tbody>
-    </table>
+    </table></div>
   </section>
 
   <div class="section-divider"></div>
@@ -314,7 +312,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <section class="editorial-section" id="counting-modes">
     <h2>Miksi merkkimäärä voi erota alustan laskennasta?</h2>
     <p>”Montako merkkiä tässä on?” -kysymykseen on useampi oikea vastaus, koska palvelut laskevat eri yksiköissä. Samalla tekstillä voi olla neljä eri pituutta:</p>
-    <table class="comparison-table">
+    <div class="comparison-table-wrap"><table class="comparison-table">
       <thead><tr><th>Laskentatapa</th><th>Mitä mittaa</th><th>Kuka käyttää</th></tr></thead>
       <tbody>
         <tr><td>Grafeemit</td><td>Sen mitä silmä näkee — ihonsävyllinen emoji on 1</td><td>Bluesky; suunnilleen näin Instagram kohtelee emojeita</td></tr>
@@ -322,7 +320,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
         <tr><td>UTF-16-yksiköt</td><td>Miten JavaScript ja moni sovellus tallentaa tekstin — 𝗹𝗶𝗵𝗮𝘃𝗮𝘁 kirjaimet maksavat 2 kukin</td><td>HTML-lomakkeiden kentät (<code>maxlength</code>), moni peli ja sovelluksen taustajärjestelmä</td></tr>
         <tr><td>UTF-8-tavut</td><td>Tallennuskoko — ä on 2, 中 on 3, 𝗯 on 4</td><td>Amazonin tuotekentät, Steam-nimet, tietokannat</td></tr>
       </tbody>
-    </table>
+    </table></div>
     <p>Kaikki neljä näkyvät reaaliajassa yllä olevissa tilastoissa, joten kun jokin lomake väittää tekstiäsi liian pitkäksi ja tekstinkäsittelyohjelma on eri mieltä, näet heti kumpaa lukua lomake käyttää. Kaksi kohdetta tarvitsee tämän päälle vielä oman sääntönsä:</p>
     <p><strong>X / Twitter laskee painolla, ei merkeillä.</strong> X:n itsensä julkaiseman algoritmin mukaan (<code>twitter-text</code>-kirjasto) jokainen URL on tasan 23 ja lähes kaikki U+10FF:n yläpuolelta — kiinalaiset merkit, useimmat emojit ja jokainen “koristeellinen” Unicode-kirjain — painaa <strong>2</strong>. Ä, ö ja å jäävät painon 1 alueelle (U+0000–U+10FF), joten skandit eivät vie X:ssä yhtään enempää tilaa kuin muutkaan kirjaimet. Kokonaan 𝗹𝗶𝗵𝗮𝘃𝗼𝗶𝗱𝘂𝗹𝗹𝗮 tyylillä kirjoitettuun julkaisuun mahtuu sen sijaan vain 140 näkyvää kirjainta 280:n budjetista. Tarkistimen “X / Twitter” -valinta toteuttaa tämän oikean algoritmin.</p>
     <p><strong>Tekstiviesti lasketaan osissa — mutta ä ja ö eivät ole syyllisiä.</strong> Viestiin mahtuu 160 merkkiä niin kauan kuin jokainen merkki kuuluu vanhaan GSM-7-aakkostoon, ja suomalaisittain tärkein tieto on, että <strong>ä, ö ja å kuuluvat siihen</strong>: suomenkielinen viesti pysyy 160 merkissä ilman mitään temppuja. Sen sijaan yksi emoji, tekstinkäsittelystä liitetty kaareva lainausmerkki (’) tai GSM-merkistön ulkopuolinen tarkkeellinen kirjain pudottaa koko viestin Unicode-tilaan: 70 merkkiä osaa kohti, ja pilkkoutuvassa viestissä 67. Tarkistimen “Tekstiviesti”-valinta havaitsee tämän ja näyttää täsmälleen sen merkin, joka muutoksen aiheutti — ja yhden klikkauksen “Tee tekstiviestiystävälliseksi” -korjaus siivoaa ne pois.</p>
@@ -423,6 +421,9 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     foldMeta: "{shown}/{total} merkki\u00e4 n\u00e4kyviss\u00e4 \u00b7 {hidden} piilossa napautuksen takana",
     foldRoom: "Aloitusta j\u00e4ljell\u00e4 {n} merkki\u00e4 ennen katkaisua",
     foldDevices: "Puhelimessa katkaisu on kohdassa {m}, ty\u00f6p\u00f6yd\u00e4ll\u00e4 {d}.",
+    pastFold: "Mahtuu \u2014 katkeaa kohdassa {n} \u26a0",
+    showAllFits: "N\u00e4yt\u00e4 kaikki ({n})",
+    showFewerFits: "N\u00e4yt\u00e4 v\u00e4hemm\u00e4n",
     overBy: "Yli rajan {n} merkki\u00e4 \u2014 valitse korjaus:",
     trimToFit: "Katkaise mahtumaan",
     undo: "Kumoa",

--- a/fr/compteur-de-mots-et-de-caracteres/index.html
+++ b/fr/compteur-de-mots-et-de-caracteres/index.html
@@ -245,19 +245,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <section class="hero"><div class="hero-inner"><div class="hero-card">
   <h1 class="hero-headline">Compteur de Mots et de Caractères</h1>
-  <p class="hero-sub">Statistiques en direct sur les mots, caractères, phrases, paragraphes et le temps de lecture pendant que tu tapes — plus un vérificateur pour savoir si ton texte respecte les limites de X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS et 18 autres plateformes.</p>
+  <p class="hero-sub">Comptage en direct pour 38 champs sur 17 plateformes — et des corrections en un clic quand tu dépasses.</p>
 </div></div></section>
 
 <main class="container">
-  <section class="editorial-section">
-    <div class="editorial-block">
-      <p>Tape ou colle n'importe quel texte dans le champ ci-dessous et chaque statistique se met à jour instantanément : mots, caractères (avec et sans espaces), phrases, paragraphes et un temps de lecture estimé. Rien n'est envoyé — chaque nombre est calculé directement dans ton navigateur. Au-dessus du champ de saisie, commence par indiquer où va ce texte : le vérificateur compte alors exactement comme cette destination compte, et t'affiche en direct ce qu'il te reste ou de combien tu dépasses. Et si tu dépasses, ça ne s'arrête pas à la mauvaise nouvelle — l'outil te propose des corrections concrètes avec le gain de chacune, applicables en un clic et annulables à tout moment. Besoin de belles polices Unicode pour le texte que tu viens de mesurer ? Le <a href="/fr/">générateur UltraTextGen</a> le transforme en plus de 100 styles à copier-coller.</p>
-    </div>
-  </section>
-
-  <div class="section-divider"></div>
-
-  <div class="counter-tool">
+<div class="counter-tool">
     <div id="platformChecker"></div>
 
     <div class="counter-field">
@@ -298,12 +290,14 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     </div>
   </div>
 
+  <p class="counter-footnote">Tout est calculé dans ton navigateur — rien de ce que tu tapes n'est envoyé ni conservé. Besoin aussi d'un texte stylé ? Le <a href="/fr/">générateur UltraTextGen</a> le transforme en plus de 100 polices à copier-coller.</p>
+
   <div class="section-divider"></div>
 
   <section class="editorial-section">
     <h2>Limites strictes et limites souples</h2>
     <p>Deux choses très différentes s'appellent « limite de caractères », et ça change ce qu'un dépassement te coûte vraiment.</p>
-    <table class="comparison-table">
+    <div class="comparison-table-wrap"><table class="comparison-table">
       <thead><tr><th>Type</th><th>Ce qui se passe si tu dépasses</th><th>Exemples</th></tr></thead>
       <tbody>
         <tr>
@@ -317,34 +311,38 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
           <td>Légende Instagram après 125 · publication LinkedIn après ~140 sur mobile / ~210 sur ordinateur · description YouTube après ~157</td>
         </tr>
       </tbody>
-    </table>
+    </table></div>
     <p>La limite souple est celle contre laquelle on écrit vraiment, et presque aucun compteur ne l'affiche. Une publication LinkedIn dispose de 3 000 caractères et d'environ 140 utiles : le reste est derrière un clic que personne ne fait. C'est pour ça que le compteur ci-dessus dessine la coupure directement — tape ton texte et tu vois exactement ce qui s'affiche avant « voir plus », le reste grisé derrière un trait, plus la façon dont la même accroche tient sur chacun des autres fils qui tronquent.</p>
     <p><strong>Où chaque fil coupe, et sur quel appareil :</strong></p>
-    <table class="comparison-table">
-      <thead><tr><th>Fil</th><th>Coupe à</th><th>Ce que ça implique pour l'accroche</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Fil</th><th class="num">Mobile</th><th class="num">Ordinateur</th><th>Ce que ça implique pour l'accroche</th></tr></thead>
       <tbody>
         <tr>
           <td><a href="/fr/police-linkedin/">Publication LinkedIn</a></td>
-          <td>~140 sur mobile<br>~210 sur ordinateur</td>
+          <td class="num">~140</td>
+          <td class="num">~210</td>
           <td>Écris pour 140 et l'accroche survit aux deux. C'est le plus grand écart mobile/ordinateur de la liste.</td>
         </tr>
         <tr>
           <td><a href="/fr/police-instagram/">Légende Instagram</a></td>
-          <td>~125</td>
+          <td class="num">~125</td>
+          <td class="num">~125</td>
           <td>La coupure la plus serrée ici — une phrase environ avant le « … plus ».</td>
         </tr>
         <tr>
           <td>Description YouTube</td>
-          <td>~157</td>
+          <td class="num">~157</td>
+          <td class="num">~157</td>
           <td>Ce qui s'affiche sous le titre avant « Afficher plus » — et souvent ce que la recherche remonte.</td>
         </tr>
         <tr>
           <td><a href="/fr/ecriture-facebook/">Publication Facebook</a></td>
-          <td>~477</td>
+          <td class="num">~477</td>
+          <td class="num">~477</td>
           <td>La coupure la plus généreuse — un court paragraphe entier passe avant.</td>
         </tr>
       </tbody>
-    </table>
+    </table></div>
     <p>Deux réserves honnêtes. Ce sont des comportements d'interface observés, pas des limites publiées : prends-les comme « ce qui s'affiche de façon fiable » plutôt que comme des seuils exacts. Et les fils coupent aussi au <em>nombre de lignes</em> : trois retours à la ligne placés tôt peuvent tronquer une publication bien avant n'importe quel chiffre. Si ton accroche repose sur une liste, vérifie-la aussi dans le vrai éditeur.</p>
     <p>Ces limites n'ont rien à voir avec un autre cas très courant en France : les quotas de mots imposés pour une dissertation, un mémoire ou un devoir au lycée, et le plafond de <a href="#parcoursup">1 500 caractères de Parcoursup</a>. La logique est académique, pas technique — mais le même compteur y répond aussi bien.</p>
   </section>
@@ -356,51 +354,51 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <p>Les mêmes limites que celles utilisées par le vérificateur en direct ci-dessus, sous forme de tableau de référence. Aller à : <a href="#twitter">X/Twitter</a> · <a href="#discord">Discord</a> · <a href="#instagram">Instagram</a> · <a href="#tiktok">TikTok</a> · <a href="#sms">SMS</a> · <a href="#modes-de-comptage">comment chaque plateforme compte</a>.</p>
 
     <h3>Publications et messages</h3>
-    <table class="comparison-table">
-      <thead><tr><th>Plateforme</th><th>Limite</th><th>Remarques</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Plateforme</th><th class="num">Limite</th><th>Remarques</th></tr></thead>
       <tbody>
-        <tr id="twitter"><td>Publication X / Twitter</td><td>280</td><td>Comptage pondéré : chaque URL = 23, la plupart des emojis, symboles et lettres stylées = 2 — voir <a href="#modes-de-comptage">comment X compte</a></td></tr>
-        <tr id="discord"><td>Message Discord</td><td>2 000</td><td>4 000 avec Nitro ; au-delà, le message devient une pièce jointe .txt</td></tr>
-        <tr id="instagram"><td>Légende Instagram</td><td>2 200</td><td>Tronquée par « plus » après les premières lignes</td></tr>
-        <tr id="tiktok"><td>Légende TikTok</td><td>2 200</td><td></td></tr>
-        <tr><td>Publication LinkedIn</td><td>3 000</td><td>« Voir plus » tronque entre 200 et 700 caractères selon l'appareil</td></tr>
-        <tr><td>Publication Facebook</td><td>63 206</td><td></td></tr>
-        <tr><td>Description YouTube</td><td>5 000</td><td></td></tr>
-        <tr><td>Description d'épingle Pinterest</td><td>500</td><td></td></tr>
-        <tr><td>Message Telegram</td><td>4 096</td><td>1 024 pour une légende photo/vidéo</td></tr>
-        <tr><td>Publication Threads</td><td>500</td><td></td></tr>
-        <tr><td>Publication Bluesky</td><td>300</td><td>Compté en graphèmes (ce que tu vois), pas en points de code</td></tr>
-        <tr><td>Titre de post Reddit</td><td>300</td><td></td></tr>
-        <tr><td>Publication/statut Zalo</td><td>2 000</td><td></td></tr>
+        <tr id="twitter"><td>Publication X / Twitter</td><td class="num">280</td><td>Comptage pondéré : chaque URL = 23, la plupart des emojis, symboles et lettres stylées = 2 — voir <a href="#modes-de-comptage">comment X compte</a></td></tr>
+        <tr id="discord"><td>Message Discord</td><td class="num">2 000</td><td>4 000 avec Nitro ; au-delà, le message devient une pièce jointe .txt</td></tr>
+        <tr id="instagram"><td>Légende Instagram</td><td class="num">2 200</td><td>Tronquée par « plus » après les premières lignes</td></tr>
+        <tr id="tiktok"><td>Légende TikTok</td><td class="num">2 200</td><td></td></tr>
+        <tr><td>Publication LinkedIn</td><td class="num">3 000</td><td>« Voir plus » tronque entre 200 et 700 caractères selon l'appareil</td></tr>
+        <tr><td>Publication Facebook</td><td class="num">63 206</td><td></td></tr>
+        <tr><td>Description YouTube</td><td class="num">5 000</td><td></td></tr>
+        <tr><td>Description d'épingle Pinterest</td><td class="num">500</td><td></td></tr>
+        <tr><td>Message Telegram</td><td class="num">4 096</td><td>1 024 pour une légende photo/vidéo</td></tr>
+        <tr><td>Publication Threads</td><td class="num">500</td><td></td></tr>
+        <tr><td>Publication Bluesky</td><td class="num">300</td><td>Compté en graphèmes (ce que tu vois), pas en points de code</td></tr>
+        <tr><td>Titre de post Reddit</td><td class="num">300</td><td></td></tr>
+        <tr><td>Publication/statut Zalo</td><td class="num">2 000</td><td></td></tr>
       </tbody>
-    </table>
+    </table></div>
 
     <h3>Bios et profils</h3>
-    <table class="comparison-table">
-      <thead><tr><th>Champ</th><th>Limite</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Champ</th><th class="num">Limite</th></tr></thead>
       <tbody>
-        <tr><td>Bio Instagram</td><td>150</td></tr>
-        <tr><td>Bio TikTok</td><td>80</td></tr>
-        <tr><td>Titre LinkedIn</td><td>220</td></tr>
-        <tr><td>À propos WhatsApp</td><td>139</td></tr>
-        <tr><td>Bio Telegram</td><td>70</td></tr>
-        <tr><td>Statut VK</td><td>140</td></tr>
+        <tr><td>Bio Instagram</td><td class="num">150</td></tr>
+        <tr><td>Bio TikTok</td><td class="num">80</td></tr>
+        <tr><td>Titre LinkedIn</td><td class="num">220</td></tr>
+        <tr><td>À propos WhatsApp</td><td class="num">139</td></tr>
+        <tr><td>Bio Telegram</td><td class="num">70</td></tr>
+        <tr><td>Statut VK</td><td class="num">140</td></tr>
       </tbody>
-    </table>
+    </table></div>
 
     <h3>Noms d'utilisateur, titres et SMS</h3>
-    <table class="comparison-table">
-      <thead><tr><th>Champ</th><th>Limite</th><th>Remarques</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Champ</th><th class="num">Limite</th><th>Remarques</th></tr></thead>
       <tbody>
-        <tr><td>Pseudo Discord</td><td>32</td><td></td></tr>
-        <tr><td>Nom d'utilisateur TikTok</td><td>24</td><td>Lettres, chiffres, tirets bas et points uniquement</td></tr>
-        <tr><td>Nom d'utilisateur Instagram</td><td>30</td><td></td></tr>
-        <tr><td>Titre YouTube</td><td>100</td><td></td></tr>
-        <tr><td>Balise meta titre SEO</td><td>~60</td><td>Google tronque selon la largeur en pixels — à prendre comme un ordre de grandeur</td></tr>
-        <tr><td>Balise meta description SEO</td><td>~155</td><td>Idem : troncature en pixels, pas en caractères</td></tr>
-        <tr id="sms"><td>SMS (message texte)</td><td>160 / segment</td><td>Tombe à 70 par segment dès qu'un caractère sort de l'alphabet GSM-7 (emoji, apostrophe courbe, â, ê, ô, œ…) — voir <a href="#modes-de-comptage">le comptage SMS</a></td></tr>
+        <tr><td>Pseudo Discord</td><td class="num">32</td><td></td></tr>
+        <tr><td>Nom d'utilisateur TikTok</td><td class="num">24</td><td>Lettres, chiffres, tirets bas et points uniquement</td></tr>
+        <tr><td>Nom d'utilisateur Instagram</td><td class="num">30</td><td></td></tr>
+        <tr><td>Titre YouTube</td><td class="num">100</td><td></td></tr>
+        <tr><td>Balise meta titre SEO</td><td class="num">~60</td><td>Google tronque selon la largeur en pixels — à prendre comme un ordre de grandeur</td></tr>
+        <tr><td>Balise meta description SEO</td><td class="num">~155</td><td>Idem : troncature en pixels, pas en caractères</td></tr>
+        <tr id="sms"><td>SMS (message texte)</td><td class="num">160 / segment</td><td>Tombe à 70 par segment dès qu'un caractère sort de l'alphabet GSM-7 (emoji, apostrophe courbe, â, ê, ô, œ…) — voir <a href="#modes-de-comptage">le comptage SMS</a></td></tr>
       </tbody>
-    </table>
+    </table></div>
   </section>
 
   <div class="section-divider"></div>
@@ -408,7 +406,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <section class="editorial-section" id="modes-de-comptage">
     <h2>Pourquoi ton compte de caractères ne correspond pas à celui de la plateforme</h2>
     <p>« Ça fait combien de caractères ? » a plus d'une bonne réponse, parce que les plateformes ne comptent pas dans la même unité. Un même texte a quatre longueurs différentes :</p>
-    <table class="comparison-table">
+    <div class="comparison-table-wrap"><table class="comparison-table">
       <thead><tr><th>Mode de comptage</th><th>Ce qui est mesuré</th><th>Qui l'utilise</th></tr></thead>
       <tbody>
         <tr><td>Graphèmes</td><td>Ce que tu vois — un emoji avec teinte de peau vaut 1</td><td>Bluesky ; à peu près la façon dont Instagram traite les emojis</td></tr>
@@ -416,7 +414,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
         <tr><td>Unités UTF-16</td><td>La façon dont JavaScript et beaucoup d'applications stockent le texte — les lettres 𝗴𝗿𝗮𝘀𝘀𝗲𝘀 coûtent 2 chacune</td><td>Champs de formulaire HTML (<code>maxlength</code>), jeux vidéo, back-ends d'applications</td></tr>
         <tr><td>Octets UTF-8</td><td>Le poids de stockage — é vaut 2, 中 vaut 3, 𝗯 vaut 4</td><td>Fiches produit Amazon, pseudos Steam, bases de données</td></tr>
       </tbody>
-    </table>
+    </table></div>
     <p>Les quatre s'affichent en direct dans les statistiques ci-dessus : quand un formulaire prétend que ton texte est trop long alors que ton traitement de texte dit le contraire, tu vois immédiatement quelle unité ce formulaire utilise. Deux plateformes ajoutent leurs propres règles par-dessus :</p>
     <p><strong>X/Twitter compte au poids, pas au caractère.</strong> D'après l'algorithme publié par X lui-même (la bibliothèque <code>twitter-text</code>), chaque URL vaut exactement 23, les lettres latines de base valent 1, et à peu près tout le reste — caractères CJK, la plupart des emojis et chaque lettre Unicode stylée — vaut <strong>2</strong>. Une publication entièrement en 𝗴𝗿𝗮𝘀 ne tient donc que 140 lettres visibles sur les 280. Les options X du vérificateur ci-dessus appliquent réellement cet algorithme.</p>
     <p><strong>Un SMS se compte en segments, et un seul caractère peut tripler la facture.</strong> Un message tient 160 caractères tant que tous ses caractères appartiennent au vieil alphabet GSM-7. Bonne nouvelle pour le français : é, è, à, ù et le Ç majuscule en font partie. Mais les accents circonflexes (â, ê, î, ô, û), les trémas (ë, ï), le ç minuscule, la ligature œ, les guillemets « », l'apostrophe courbe ’ et l'espace fine insécable qui précède ; : ! ? n'y sont pas — et un seul d'entre eux fait basculer tout le message en mode Unicode : 70 caractères par segment, 67 dès qu'il se scinde. Autrement dit, « août » ou « c'est prêt ! » copié depuis Word peut suffire à doubler le coût d'un envoi. L'option SMS du vérificateur détecte le basculement et te nomme le caractère exact qui l'a provoqué.</p>
@@ -554,6 +552,9 @@ window.UTG_COUNTER_I18N = {
   undo: "Annuler",
   applied: "Appliqué",
   segShort: "seg.",
+  pastFold: "Passe — coupé à {n} ⚠",
+  showAllFits: "Afficher les {n}",
+  showFewerFits: "Afficher moins",
   foldHeading: "Ce que les gens voient avant « voir plus »",
   foldMore: "voir plus",
   foldMeta: "{shown} caractères affichés sur {total} · {hidden} cachés derrière le clic",

--- a/id/penghitung-kata-dan-karakter/index.html
+++ b/id/penghitung-kata-dan-karakter/index.html
@@ -48,7 +48,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Penghitung Kata dan Karakter — Alat Online Gratis | UltraTextGen</title>
-  <meta name="description" content="Penghitung karakter dan kata gratis. Statistik langsung — kata, karakter, kalimat, paragraf, dan waktu baca — plus pengecekan batas untuk 27 platform: X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS, dan lainnya.">
+  <meta name="description" content="Penghitung karakter dan kata gratis. Statistik langsung — kata, karakter, kalimat, paragraf, dan waktu baca — plus pengecekan batas untuk 38 kolom di 17 platform: X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS, dan lainnya.">
   <link rel="canonical" href="https://ultratextgen.com/id/penghitung-kata-dan-karakter/">
 
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/character-counter/">
@@ -69,7 +69,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/character-counter/">
 
   <meta property="og:title" content="Penghitung Kata dan Karakter — Alat Online Gratis | UltraTextGen">
-  <meta property="og:description" content="Statistik kata, karakter, kalimat, paragraf, dan waktu baca secara langsung saat kamu mengetik, plus pengecekan apakah teks kamu muat di batas karakter 27 platform. Gratis, instan, tanpa daftar.">
+  <meta property="og:description" content="Statistik kata, karakter, kalimat, paragraf, dan waktu baca secara langsung saat kamu mengetik, plus pengecekan apakah teks kamu muat di batas karakter 38 kolom di 17 platform. Gratis, instan, tanpa daftar.">
   <meta property="og:url" content="https://ultratextgen.com/id/penghitung-kata-dan-karakter/">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://ultratextgen.com/assets/og/id-penghitung-kata-dan-karakter.png">
@@ -79,7 +79,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <meta property="og:image:alt" content="Penghitung Kata dan Karakter — Alat Online Gratis | UltraTextGen">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Penghitung Kata dan Karakter — Alat Online Gratis | UltraTextGen">
-  <meta name="twitter:description" content="Statistik kata, karakter, kalimat, paragraf, dan waktu baca secara langsung saat kamu mengetik, plus pengecekan apakah teks kamu muat di batas karakter 27 platform. Gratis, instan, tanpa daftar.">
+  <meta name="twitter:description" content="Statistik kata, karakter, kalimat, paragraf, dan waktu baca secara langsung saat kamu mengetik, plus pengecekan apakah teks kamu muat di batas karakter 38 kolom di 17 platform. Gratis, instan, tanpa daftar.">
   <meta name="twitter:image" content="https://ultratextgen.com/assets/og/id-penghitung-kata-dan-karakter.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -157,19 +157,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <section class="hero"><div class="hero-inner"><div class="hero-card">
   <h1 class="hero-headline">Penghitung Kata dan Karakter</h1>
-  <p class="hero-sub">Statistik kata, karakter, kalimat, paragraf, dan waktu baca secara langsung saat kamu mengetik — plus pengecekan apakah teks kamu muat di batas karakter X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS, dan 18 platform lainnya.</p>
+  <p class="hero-sub">Hitungan langsung untuk 38 kolom di 17 platform — plus perbaikan sekali klik kalau kelebihan.</p>
 </div></div></section>
 
 <main class="container">
-  <section class="editorial-section">
-    <div class="editorial-block">
-      <p>Pilih dulu ke mana teks kamu akan dikirim lewat menu tepat di atas kotak, lalu ketik atau tempel teksnya: setiap hitungan langsung diperbarui — kata, karakter (dengan dan tanpa spasi), kalimat, paragraf, dan perkiraan waktu baca — dan pengeceknya menghitung persis seperti platform tujuan menghitung, lengkap dengan sisa karakter atau berapa banyak kelebihannya. Kalau kelebihan, alat ini tidak berhenti di situ: ia menawarkan cara-cara memangkasnya lengkap dengan penghematan masing-masing, cukup sekali klik dan bisa dibatalkan. Tidak ada yang diunggah — semua angka dihitung langsung di browser kamu. Butuh font Unicode kece buat teks yang baru saja kamu ukur? <a href="/id/">Generator utama UltraTextGen</a> mengubahnya jadi 100+ gaya copy-paste.</p>
-    </div>
-  </section>
-
-  <div class="section-divider"></div>
-
-  <div class="counter-tool">
+<div class="counter-tool">
     <div id="platformChecker"></div>
 
     <div class="counter-field">
@@ -209,12 +201,14 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     </div>
   </div>
 
+  <p class="counter-footnote">Semuanya dihitung di browser kamu — tidak ada yang diunggah atau disimpan. Butuh teksnya bergaya juga? <a href="/id/">Generator UltraTextGen</a> mengubahnya jadi 100+ font copy-paste.</p>
+
   <div class="section-divider"></div>
 
   <section class="editorial-section">
     <h2>Batas keras vs batas lunak</h2>
     <p>Ada dua hal berbeda yang sama-sama disebut "batas karakter", dan konsekuensi kelebihannya tidak sama.</p>
-    <table class="comparison-table">
+    <div class="comparison-table-wrap"><table class="comparison-table">
       <thead><tr><th>Jenis</th><th>Apa yang terjadi kalau kelebihan</th><th>Contoh</th></tr></thead>
       <tbody>
         <tr>
@@ -228,34 +222,38 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
           <td>Caption Instagram setelah 125 · Postingan LinkedIn setelah ~140 di ponsel / ~210 di desktop · Deskripsi YouTube setelah ~157</td>
         </tr>
       </tbody>
-    </table>
+    </table></div>
     <p>Batas lunak inilah yang sebenarnya jadi patokan menulis kebanyakan orang, dan hampir tidak ada penghitung yang menampilkannya. Satu postingan LinkedIn punya jatah 3.000 karakter tapi cuma sekitar 140 karakter yang benar-benar kepakai: sisanya ada di balik ketukan yang jarang dilakukan orang. Makanya alat di atas menggambar titik potongnya langsung — ketik di sana dan kamu langsung melihat teks persis yang muncul sebelum "selengkapnya", dengan semua yang ada di balik garis potong diredupkan, plus apakah pembuka yang sama masih bertahan di feed lain yang juga memotong.</p>
     <p><strong>Di mana tiap feed memotong, dan di perangkat apa:</strong></p>
-    <table class="comparison-table">
-      <thead><tr><th>Feed</th><th>Memotong di</th><th>Artinya buat kalimat pembuka</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Feed</th><th class="num">HP</th><th class="num">Desktop</th><th>Artinya buat kalimat pembuka</th></tr></thead>
       <tbody>
         <tr>
           <td>Postingan LinkedIn</td>
-          <td>~140 di HP<br>~210 di desktop</td>
-          <td>Tulis sampai 140 saja dan pembukanya aman di dua-duanya. Ini selisih HP–desktop terbesar di daftar ini.</td>
+          <td class="num">~140</td>
+          <td class="num">~210</td>
+          <td>Tulis sampai 140 saja dan pembukanya aman di dua-duanya — selisih perangkat terbesar di daftar ini.</td>
         </tr>
         <tr>
           <td><a href="/id/font-ig/">Caption Instagram</a></td>
-          <td>~125</td>
+          <td class="num">~125</td>
+          <td class="num">~125</td>
           <td>Potongan paling ketat di daftar ini — kira-kira cuma satu kalimat sebelum muncul "… selengkapnya".</td>
         </tr>
         <tr>
           <td>Deskripsi YouTube</td>
-          <td>~157</td>
+          <td class="num">~157</td>
+          <td class="num">~157</td>
           <td>Bagian yang tampil di bawah judul sebelum tombol "Tampilkan lainnya"; sering ini juga yang diambil mesin pencari.</td>
         </tr>
         <tr>
           <td><a href="/id/font-facebook/">Postingan Facebook</a></td>
-          <td>~477</td>
+          <td class="num">~477</td>
+          <td class="num">~477</td>
           <td>Potongan paling longgar — satu paragraf pendek utuh masih masuk sebelum garis potong.</td>
         </tr>
       </tbody>
-    </table>
+    </table></div>
     <p>Dua catatan jujur. Angka-angka ini hasil pengamatan tampilan, bukan batas resmi yang diumumkan platform, jadi anggap sebagai "yang biasanya tampil" ketimbang ambang yang persis — dan feed juga memotong berdasarkan <em>jumlah baris</em>, jadi tiga kali ganti baris di awal bisa memotong postingan jauh sebelum angka karakter mana pun tercapai. Kalau pembukaan kamu bergantung pada daftar berpoin, cek juga langsung di composer aslinya.</p>
   </section>
 
@@ -266,51 +264,51 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <p>Batas yang sama persis dengan yang dipakai pengecek di atas, dalam bentuk tabel rujukan. Lompat ke: <a href="#twitter">X/Twitter</a> · <a href="#discord">Discord</a> · <a href="#instagram">Instagram</a> · <a href="#tiktok">TikTok</a> · <a href="#sms">SMS</a> · <a href="#cara-hitung">cara tiap platform menghitung</a>.</p>
 
     <h3>Postingan &amp; pesan</h3>
-    <table class="comparison-table">
-      <thead><tr><th>Platform</th><th>Batas</th><th>Catatan</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Platform</th><th class="num">Batas</th><th>Catatan</th></tr></thead>
       <tbody>
-        <tr id="twitter"><td>Postingan X / Twitter</td><td>280</td><td>Dihitung berbobot: setiap URL = 23, sebagian besar emoji/simbol/huruf bergaya = 2 — lihat <a href="#cara-hitung">cara X menghitung</a></td></tr>
-        <tr id="discord"><td>Pesan Discord</td><td>2.000</td><td>4.000 dengan Nitro; pesan yang lebih panjang berubah jadi lampiran .txt</td></tr>
-        <tr id="instagram"><td>Caption Instagram</td><td>2.200</td><td>Dipotong dengan "selengkapnya" setelah beberapa baris pertama</td></tr>
-        <tr id="tiktok"><td>Caption TikTok</td><td>2.200</td><td></td></tr>
-        <tr><td>Postingan LinkedIn</td><td>3.000</td><td>"Lihat selengkapnya" memotong sekitar 200–700 karakter tergantung perangkat</td></tr>
-        <tr><td>Postingan Facebook</td><td>63.206</td><td></td></tr>
-        <tr><td>Deskripsi video YouTube</td><td>5.000</td><td></td></tr>
-        <tr><td>Deskripsi pin Pinterest</td><td>500</td><td></td></tr>
-        <tr><td>Pesan Telegram</td><td>4.096</td><td>1.024 untuk caption foto/video</td></tr>
-        <tr><td>Postingan Threads</td><td>500</td><td></td></tr>
-        <tr><td>Postingan Bluesky</td><td>300</td><td>Dihitung per grafem (yang kamu lihat), bukan code point</td></tr>
-        <tr><td>Judul postingan Reddit</td><td>300</td><td></td></tr>
-        <tr><td>Postingan/status Zalo</td><td>2.000</td><td></td></tr>
+        <tr id="twitter"><td>Postingan X / Twitter</td><td class="num">280</td><td>Dihitung berbobot: setiap URL = 23, sebagian besar emoji/simbol/huruf bergaya = 2 — lihat <a href="#cara-hitung">cara X menghitung</a></td></tr>
+        <tr id="discord"><td>Pesan Discord</td><td class="num">2.000</td><td>4.000 dengan Nitro; pesan yang lebih panjang berubah jadi lampiran .txt</td></tr>
+        <tr id="instagram"><td>Caption Instagram</td><td class="num">2.200</td><td>Dipotong dengan "selengkapnya" setelah beberapa baris pertama</td></tr>
+        <tr id="tiktok"><td>Caption TikTok</td><td class="num">2.200</td><td></td></tr>
+        <tr><td>Postingan LinkedIn</td><td class="num">3.000</td><td>"Lihat selengkapnya" memotong sekitar 200–700 karakter tergantung perangkat</td></tr>
+        <tr><td>Postingan Facebook</td><td class="num">63.206</td><td></td></tr>
+        <tr><td>Deskripsi video YouTube</td><td class="num">5.000</td><td></td></tr>
+        <tr><td>Deskripsi pin Pinterest</td><td class="num">500</td><td></td></tr>
+        <tr><td>Pesan Telegram</td><td class="num">4.096</td><td>1.024 untuk caption foto/video</td></tr>
+        <tr><td>Postingan Threads</td><td class="num">500</td><td></td></tr>
+        <tr><td>Postingan Bluesky</td><td class="num">300</td><td>Dihitung per grafem (yang kamu lihat), bukan code point</td></tr>
+        <tr><td>Judul postingan Reddit</td><td class="num">300</td><td></td></tr>
+        <tr><td>Postingan/status Zalo</td><td class="num">2.000</td><td></td></tr>
       </tbody>
-    </table>
+    </table></div>
 
     <h3>Bio &amp; profil</h3>
-    <table class="comparison-table">
-      <thead><tr><th>Kolom</th><th>Batas</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Kolom</th><th class="num">Batas</th></tr></thead>
       <tbody>
-        <tr><td>Bio Instagram</td><td>150</td></tr>
-        <tr><td>Bio TikTok</td><td>80</td></tr>
-        <tr><td>Headline LinkedIn</td><td>220</td></tr>
-        <tr><td>Info WhatsApp</td><td>139</td></tr>
-        <tr><td>Bio Telegram</td><td>70</td></tr>
-        <tr><td>Status VK</td><td>140</td></tr>
+        <tr><td>Bio Instagram</td><td class="num">150</td></tr>
+        <tr><td>Bio TikTok</td><td class="num">80</td></tr>
+        <tr><td>Headline LinkedIn</td><td class="num">220</td></tr>
+        <tr><td>Info WhatsApp</td><td class="num">139</td></tr>
+        <tr><td>Bio Telegram</td><td class="num">70</td></tr>
+        <tr><td>Status VK</td><td class="num">140</td></tr>
       </tbody>
-    </table>
+    </table></div>
 
     <h3>Username, judul &amp; SMS</h3>
-    <table class="comparison-table">
-      <thead><tr><th>Kolom</th><th>Batas</th><th>Catatan</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Kolom</th><th class="num">Batas</th><th>Catatan</th></tr></thead>
       <tbody>
-        <tr><td>Nickname Discord</td><td>32</td><td></td></tr>
-        <tr><td>Username TikTok</td><td>24</td><td>Hanya huruf, angka, garis bawah, dan titik</td></tr>
-        <tr><td>Username Instagram</td><td>30</td><td></td></tr>
-        <tr><td>Judul video YouTube</td><td>100</td><td></td></tr>
-        <tr><td>Judul meta SEO</td><td>~60</td><td>Google memotong berdasarkan lebar piksel — anggap sebagai panduan</td></tr>
-        <tr><td>Deskripsi meta SEO</td><td>~155</td><td>Sama — dipotong berdasarkan lebar piksel</td></tr>
-        <tr id="sms"><td>Pesan SMS</td><td>160 / segmen</td><td>Turun jadi 70 per segmen begitu muncul satu karakter di luar GSM-7 (emoji, tanda kutip melengkung dari Word, é, ş…) — lihat <a href="#cara-hitung">cara hitung SMS</a></td></tr>
+        <tr><td>Nickname Discord</td><td class="num">32</td><td></td></tr>
+        <tr><td>Username TikTok</td><td class="num">24</td><td>Hanya huruf, angka, garis bawah, dan titik</td></tr>
+        <tr><td>Username Instagram</td><td class="num">30</td><td></td></tr>
+        <tr><td>Judul video YouTube</td><td class="num">100</td><td></td></tr>
+        <tr><td>Judul meta SEO</td><td class="num">~60</td><td>Google memotong berdasarkan lebar piksel — anggap sebagai panduan</td></tr>
+        <tr><td>Deskripsi meta SEO</td><td class="num">~155</td><td>Sama — dipotong berdasarkan lebar piksel</td></tr>
+        <tr id="sms"><td>Pesan SMS</td><td class="num">160 / segmen</td><td>Turun jadi 70 per segmen begitu muncul satu karakter di luar GSM-7 (emoji, tanda kutip melengkung dari Word, é, ş…) — lihat <a href="#cara-hitung">cara hitung SMS</a></td></tr>
       </tbody>
-    </table>
+    </table></div>
   </section>
 
   <div class="section-divider"></div>
@@ -318,7 +316,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <section class="editorial-section" id="cara-hitung">
     <h2>Kenapa jumlah karakter kamu beda dengan hitungan platform</h2>
     <p>"Ini berapa karakter?" punya lebih dari satu jawaban benar, karena tiap platform menghitung dengan satuan berbeda. Teks yang sama persis bisa punya empat panjang:</p>
-    <table class="comparison-table">
+    <div class="comparison-table-wrap"><table class="comparison-table">
       <thead><tr><th>Cara hitung</th><th>Yang diukur</th><th>Siapa yang pakai</th></tr></thead>
       <tbody>
         <tr><td>Grafem</td><td>Persis yang kamu lihat — satu emoji dengan warna kulit dihitung 1</td><td>Bluesky; kurang lebih cara Instagram memperlakukan emoji</td></tr>
@@ -326,7 +324,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
         <tr><td>Unit UTF-16</td><td>Cara JavaScript dan banyak aplikasi menyimpan teks — setiap huruf 𝗯𝗼𝗹𝗱 dihitung 2</td><td>Form HTML (<code>maxlength</code>), banyak game dan backend aplikasi</td></tr>
         <tr><td>Byte UTF-8</td><td>Ukuran penyimpanan — é = 2, 中 = 3, 𝗯 = 4</td><td>Kolom listing Amazon (judul 200 byte), nama Steam, database</td></tr>
       </tbody>
-    </table>
+    </table></div>
     <p>Keempatnya tampil langsung di statistik di atas, jadi kalau sebuah form bilang teks kamu kepanjangan padahal menurut hitunganmu tidak, kamu bisa melihat persis angka mana yang dipakai form itu. Kabar baiknya untuk bahasa Indonesia: karena tulisan Indonesia memakai huruf Latin polos tanpa diakritik, keempat angka itu biasanya sama besar — yang membuatnya melenceng justru emoji, tanda kutip melengkung hasil salin-tempel dari Word, dan huruf bergaya. Dua platform butuh aturan khusus di atas itu:</p>
     <p><strong>X / Twitter menghitung berdasarkan bobot, bukan karakter.</strong> Sesuai algoritma yang X publikasikan sendiri (pustaka <code>twitter-text</code>), setiap URL dihitung tepat 23, huruf Latin dasar dihitung 1, dan hampir semua sisanya — karakter CJK, sebagian besar emoji, dan setiap huruf Unicode bergaya — dihitung <strong>2</strong>. Postingan yang seluruhnya ditulis 𝗯𝗼𝗹𝗱 karena itu hanya muat 140 huruf terlihat dari jatah 280. Opsi "X / Twitter" di pengecek atas menjalankan algoritma asli ini.</p>
     <p><strong>SMS dihitung per segmen, dan satu karakter bisa melipatgandakan tagihanmu.</strong> Satu SMS memuat 160 karakter hanya selama semua karakternya ada di alfabet GSM-7 lama — dan untuk teks berbahasa Indonesia biasa, itu hampir selalu terpenuhi. Yang merusaknya justru hal kecil: satu emoji, satu tanda kutip melengkung (’ hasil tempel dari Word), atau satu huruf beraksen dari nama asing diam-diam memindahkan seluruh pesan ke mode Unicode — 70 karakter per segmen, 67 kalau pesannya terpecah. Opsi "SMS (1 pesan)" di atas mendeteksinya dan menyebutkan karakter persis yang menjadi penyebabnya.</p>
@@ -426,6 +424,9 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     foldMeta: "{shown} dari {total} karakter tampil · {hidden} tersembunyi di balik ketukan",
     foldRoom: "Sisa {n} karakter pembuka sebelum kena potong",
     foldDevices: "HP memotong di {m}, desktop di {d}.",
+    pastFold: "Muat — kepotong di {n} ⚠",
+    showAllFits: "Tampilkan semua {n}",
+    showFewerFits: "Tampilkan lebih sedikit",
     overBy: "Kelebihan {n} — pilih cara memangkasnya:",
     trimToFit: "Potong biar muat",
     undo: "Batalkan",

--- a/it/contatore-di-parole-e-caratteri/index.html
+++ b/it/contatore-di-parole-e-caratteri/index.html
@@ -164,19 +164,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <section class="hero"><div class="hero-inner"><div class="hero-card">
   <h1 class="hero-headline">Contatore di Parole e Caratteri</h1>
-  <p class="hero-sub">Statistiche in tempo reale su parole, caratteri, frasi, paragrafi e tempo di lettura mentre scrivi — più un verificatore per sapere se il tuo testo rientra nei limiti di X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS e altre 27 piattaforme, con correzioni a un clic quando lo superi.</p>
+  <p class="hero-sub">Conteggio in tempo reale per 38 campi su 17 piattaforme — e correzioni a un clic quando lo superi.</p>
 </div></div></section>
 
 <main class="container">
-  <section class="editorial-section">
-    <div class="editorial-block">
-      <p>Parti da dove va a finire il testo: scegli la piattaforma e il campo subito sopra il riquadro e tutto viene contato come lo conta quella destinazione, non con un numero generico. Scrivi o incolla qui sotto e ogni statistica si aggiorna all'istante: parole, caratteri (con e senza spazi), frasi, paragrafi e una stima del tempo di lettura. Nulla viene caricato — ogni numero è calcolato direttamente nel tuo browser. E se superi il limite lo strumento non si ferma lì: ti propone tagli concreti, con il risparmio esatto di ciascuno, a un clic e con la possibilità di annullare. Ti serve quel testo in un font Unicode particolare? Il <a href="/it/">generatore principale di UltraTextGen</a> lo trasforma in oltre 100 stili da copiare e incollare.</p>
-    </div>
-  </section>
-
-  <div class="section-divider"></div>
-
-  <div class="counter-tool">
+<div class="counter-tool">
     <div id="platformChecker"></div>
 
     <div class="counter-field">
@@ -217,12 +209,14 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     </div>
   </div>
 
+  <p class="counter-footnote">Tutto viene calcolato nel tuo browser — nulla di ciò che scrivi viene caricato o conservato. Ti serve il testo anche stilizzato? Il <a href="/it/">generatore UltraTextGen</a> lo trasforma in oltre 100 font da copiare e incollare.</p>
+
   <div class="section-divider"></div>
 
   <section class="editorial-section">
     <h2>Limiti rigidi e limiti morbidi</h2>
     <p>Due cose molto diverse vengono chiamate «limite di caratteri», e la differenza cambia quanto ti costa superarlo.</p>
-    <table class="comparison-table">
+    <div class="comparison-table-wrap"><table class="comparison-table">
       <thead><tr><th>Tipo</th><th>Cosa succede se lo superi</th><th>Esempi</th></tr></thead>
       <tbody>
         <tr>
@@ -236,34 +230,38 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
           <td>Didascalia Instagram dopo 125 · Post LinkedIn dopo ~140 su mobile / ~210 su desktop · Descrizione YouTube dopo ~157</td>
         </tr>
       </tbody>
-    </table>
+    </table></div>
     <p>Il limite morbido è quello contro cui si scrive davvero, e quasi nessun contatore lo mostra. Un post LinkedIn ha 3.000 caratteri e circa 140 caratteri utili: tutto il resto sta dietro un tocco che quasi nessuno fa. Per questo il verificatore qui sopra disegna il taglio: scrivi e vedi esattamente il testo che compare prima di «altro», con la parte successiva sfumata sotto una linea, e capisci se la stessa apertura regge anche su tutti gli altri feed che troncano.</p>
     <p><strong>Dove taglia ogni feed, e su quale dispositivo:</strong></p>
-    <table class="comparison-table">
-      <thead><tr><th>Feed</th><th>Taglia a</th><th>Cosa significa per l'apertura</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Feed</th><th class="num">Mobile</th><th class="num">Desktop</th><th>Cosa significa per l'apertura</th></tr></thead>
       <tbody>
         <tr>
           <td>Post LinkedIn</td>
-          <td>~140 su mobile<br>~210 su desktop</td>
+          <td class="num">~140</td>
+          <td class="num">~210</td>
           <td>Se stai entro 140 regge su entrambi. È il divario mobile/desktop più ampio di tutta la lista.</td>
         </tr>
         <tr>
           <td><a href="/it/font-instagram/">Didascalia Instagram</a></td>
-          <td>~125</td>
+          <td class="num">~125</td>
+          <td class="num">~125</td>
           <td>Il taglio più stretto di questo elenco: poco più di una frase prima di «... altro».</td>
         </tr>
         <tr>
           <td>Descrizione YouTube</td>
-          <td>~157</td>
+          <td class="num">~157</td>
+          <td class="num">~157</td>
           <td>Quello che si legge sotto il titolo prima di «Mostra altro», ed è spesso anche ciò che finisce nella ricerca.</td>
         </tr>
         <tr>
           <td><a href="/it/font-facebook/">Post Facebook</a></td>
-          <td>~477</td>
+          <td class="num">~477</td>
+          <td class="num">~477</td>
           <td>Il taglio più generoso: prima del limite ci sta un intero paragrafo breve.</td>
         </tr>
       </tbody>
-    </table>
+    </table></div>
     <p>Due avvertenze oneste. Questi numeri nascono dall'osservazione dell'interfaccia, non da limiti pubblicati: vanno letti come «quanto si vede in modo affidabile», non come soglie esatte. E i feed tagliano anche in base al <em>numero di righe</em>, quindi tre interruzioni di riga all'inizio possono troncare un post ben prima di qualsiasi conteggio di caratteri. Se l'apertura si regge su un elenco, provala anche nell'editor vero della piattaforma.</p>
     <p>Nulla di tutto questo riguarda un altro caso d'uso molto comune in Italia: i limiti di parole richiesti per un tema delle superiori, una tesina d'esame o una tesi di laurea, che rispondono a una logica accademica ben distinta dai limiti di caratteri dei social — vedi la domanda dedicata nella FAQ qui sotto.</p>
   </section>
@@ -275,51 +273,51 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <p>Gli stessi limiti che usa il verificatore qui sopra, in forma di tabella di consultazione. Vai a: <a href="#twitter">X/Twitter</a> · <a href="#discord">Discord</a> · <a href="#instagram">Instagram</a> · <a href="#tiktok">TikTok</a> · <a href="#sms">SMS</a> · <a href="#unita-di-conteggio">come conta ogni piattaforma</a>.</p>
 
     <h3>Post e messaggi</h3>
-    <table class="comparison-table">
-      <thead><tr><th>Piattaforma</th><th>Limite</th><th>Note</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Piattaforma</th><th class="num">Limite</th><th>Note</th></tr></thead>
       <tbody>
-        <tr id="twitter"><td>Post su X / Twitter</td><td>280</td><td>Conteggio pesato: ogni URL = 23, e la maggior parte di emoji, simboli e lettere stilizzate = 2 — vedi <a href="#unita-di-conteggio">come conta X</a></td></tr>
-        <tr id="discord"><td>Messaggio Discord</td><td>2.000</td><td>4.000 con Nitro; i messaggi più lunghi diventano un allegato .txt</td></tr>
-        <tr id="instagram"><td>Didascalia Instagram</td><td>2.200</td><td>Troncata con «altro» dopo le prime righe</td></tr>
-        <tr id="tiktok"><td>Didascalia TikTok</td><td>2.200</td><td></td></tr>
-        <tr><td>Post LinkedIn</td><td>3.000</td><td>Il «vedi altro» tronca intorno ai 200–700 caratteri a seconda del dispositivo</td></tr>
-        <tr><td>Post Facebook</td><td>63.206</td><td></td></tr>
-        <tr><td>Descrizione YouTube</td><td>5.000</td><td></td></tr>
-        <tr><td>Descrizione pin Pinterest</td><td>500</td><td></td></tr>
-        <tr><td>Messaggio Telegram</td><td>4.096</td><td>1.024 per la didascalia di una foto o di un video</td></tr>
-        <tr><td>Post Threads</td><td>500</td><td></td></tr>
-        <tr><td>Post Bluesky</td><td>300</td><td>Conta i grafemi (quello che vedi), non i punti di codice</td></tr>
-        <tr><td>Titolo di post su Reddit</td><td>300</td><td></td></tr>
-        <tr><td>Post/stato Zalo</td><td>2.000</td><td></td></tr>
+        <tr id="twitter"><td>Post su X / Twitter</td><td class="num">280</td><td>Conteggio pesato: ogni URL = 23, e la maggior parte di emoji, simboli e lettere stilizzate = 2 — vedi <a href="#unita-di-conteggio">come conta X</a></td></tr>
+        <tr id="discord"><td>Messaggio Discord</td><td class="num">2.000</td><td>4.000 con Nitro; i messaggi più lunghi diventano un allegato .txt</td></tr>
+        <tr id="instagram"><td>Didascalia Instagram</td><td class="num">2.200</td><td>Troncata con «altro» dopo le prime righe</td></tr>
+        <tr id="tiktok"><td>Didascalia TikTok</td><td class="num">2.200</td><td></td></tr>
+        <tr><td>Post LinkedIn</td><td class="num">3.000</td><td>Il «vedi altro» tronca intorno ai 200–700 caratteri a seconda del dispositivo</td></tr>
+        <tr><td>Post Facebook</td><td class="num">63.206</td><td></td></tr>
+        <tr><td>Descrizione YouTube</td><td class="num">5.000</td><td></td></tr>
+        <tr><td>Descrizione pin Pinterest</td><td class="num">500</td><td></td></tr>
+        <tr><td>Messaggio Telegram</td><td class="num">4.096</td><td>1.024 per la didascalia di una foto o di un video</td></tr>
+        <tr><td>Post Threads</td><td class="num">500</td><td></td></tr>
+        <tr><td>Post Bluesky</td><td class="num">300</td><td>Conta i grafemi (quello che vedi), non i punti di codice</td></tr>
+        <tr><td>Titolo di post su Reddit</td><td class="num">300</td><td></td></tr>
+        <tr><td>Post/stato Zalo</td><td class="num">2.000</td><td></td></tr>
       </tbody>
-    </table>
+    </table></div>
 
     <h3>Bio e profili</h3>
-    <table class="comparison-table">
-      <thead><tr><th>Campo</th><th>Limite</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Campo</th><th class="num">Limite</th></tr></thead>
       <tbody>
-        <tr><td>Bio Instagram</td><td>150</td></tr>
-        <tr><td>Bio TikTok</td><td>80</td></tr>
-        <tr><td>Titolo LinkedIn (headline)</td><td>220</td></tr>
-        <tr><td>Info WhatsApp</td><td>139</td></tr>
-        <tr><td>Bio Telegram</td><td>70</td></tr>
-        <tr><td>Stato VK</td><td>140</td></tr>
+        <tr><td>Bio Instagram</td><td class="num">150</td></tr>
+        <tr><td>Bio TikTok</td><td class="num">80</td></tr>
+        <tr><td>Titolo LinkedIn (headline)</td><td class="num">220</td></tr>
+        <tr><td>Info WhatsApp</td><td class="num">139</td></tr>
+        <tr><td>Bio Telegram</td><td class="num">70</td></tr>
+        <tr><td>Stato VK</td><td class="num">140</td></tr>
       </tbody>
-    </table>
+    </table></div>
 
     <h3>Nomi utente, titoli e SMS</h3>
-    <table class="comparison-table">
-      <thead><tr><th>Campo</th><th>Limite</th><th>Note</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Campo</th><th class="num">Limite</th><th>Note</th></tr></thead>
       <tbody>
-        <tr><td>Soprannome Discord</td><td>32</td><td></td></tr>
-        <tr><td>Nome utente TikTok</td><td>24</td><td>Solo lettere, numeri, trattini bassi e punti</td></tr>
-        <tr><td>Nome utente Instagram</td><td>30</td><td></td></tr>
-        <tr><td>Titolo YouTube</td><td>100</td><td></td></tr>
-        <tr><td>Meta title SEO</td><td>~60</td><td>Google tronca in base alla larghezza in pixel — prendilo come indicazione</td></tr>
-        <tr><td>Meta description SEO</td><td>~155</td><td>Stessa cosa — il taglio è per larghezza in pixel</td></tr>
-        <tr id="sms"><td>Messaggio SMS</td><td>160 / segmento</td><td>Scende a 70 per segmento appena compare un carattere fuori dal GSM-7 (un'emoji, un apostrofo curvo, un trattino lungo…) — vedi <a href="#unita-di-conteggio">come si contano gli SMS</a></td></tr>
+        <tr><td>Soprannome Discord</td><td class="num">32</td><td></td></tr>
+        <tr><td>Nome utente TikTok</td><td class="num">24</td><td>Solo lettere, numeri, trattini bassi e punti</td></tr>
+        <tr><td>Nome utente Instagram</td><td class="num">30</td><td></td></tr>
+        <tr><td>Titolo YouTube</td><td class="num">100</td><td></td></tr>
+        <tr><td>Meta title SEO</td><td class="num">~60</td><td>Google tronca in base alla larghezza in pixel — prendilo come indicazione</td></tr>
+        <tr><td>Meta description SEO</td><td class="num">~155</td><td>Stessa cosa — il taglio è per larghezza in pixel</td></tr>
+        <tr id="sms"><td>Messaggio SMS</td><td class="num">160 / segmento</td><td>Scende a 70 per segmento appena compare un carattere fuori dal GSM-7 (un'emoji, un apostrofo curvo, un trattino lungo…) — vedi <a href="#unita-di-conteggio">come si contano gli SMS</a></td></tr>
       </tbody>
-    </table>
+    </table></div>
   </section>
 
   <div class="section-divider"></div>
@@ -327,7 +325,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <section class="editorial-section" id="unita-di-conteggio">
     <h2>Perché il tuo conteggio non coincide con quello della piattaforma</h2>
     <p>«Quanti caratteri sono?» ha più di una risposta corretta, perché ogni piattaforma conta in un'unità diversa. Lo stesso testo può avere quattro lunghezze:</p>
-    <table class="comparison-table">
+    <div class="comparison-table-wrap"><table class="comparison-table">
       <thead><tr><th>Unità di conteggio</th><th>Cosa misura</th><th>Chi la usa</th></tr></thead>
       <tbody>
         <tr><td>Grafemi</td><td>Quello che vedi: un'emoji con tonalità della pelle è 1</td><td>Bluesky; e più o meno il modo in cui Instagram tratta le emoji</td></tr>
@@ -335,7 +333,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
         <tr><td>Unità UTF-16</td><td>Come JavaScript e molte app memorizzano il testo: ogni lettera in 𝗴𝗿𝗮𝘀𝘀𝗲𝘁𝘁𝗼 costa 2</td><td>Campi di form HTML (<code>maxlength</code>), molti giochi e back-end di app</td></tr>
         <tr><td>Byte UTF-8</td><td>Spazio occupato: é sono 2, 中 sono 3, 𝗯 sono 4</td><td>Campi delle schede prodotto Amazon (titoli da 200 byte), nomi su Steam, database</td></tr>
       </tbody>
-    </table>
+    </table></div>
     <p>Tutte e quattro sono nelle statistiche qui sopra, aggiornate in tempo reale: quando un form ti dice che il testo è troppo lungo e il tuo editor di testo sostiene il contrario, puoi vedere esattamente quale unità sta usando il form. Due casi hanno bisogno di regole proprie:</p>
     <p><strong>X / Twitter conta a peso, non a caratteri.</strong> Secondo l'algoritmo pubblicato da X stessa (la libreria <code>twitter-text</code>), ogni URL conta esattamente 23, le lettere latine di base contano 1 e quasi tutto il resto — caratteri CJK, gran parte delle emoji e ogni lettera Unicode «stilizzata» — conta <strong>2</strong>. Per questo un post interamente in 𝗴𝗿𝗮𝘀𝘀𝗲𝘁𝘁𝗼 ci sta con sole 140 lettere visibili dentro il budget di 280. L'opzione «Post su X / Twitter» del verificatore implementa proprio quell'algoritmo.</p>
     <p><strong>Gli SMS si contano a segmenti, e in italiano a farli scattare è quasi sempre l'apostrofo.</strong> Un messaggio tiene 160 caratteri solo finché ogni carattere sta nel vecchio alfabeto GSM-7. Qui l'italiano è fortunato: à, è, é, ì, ò e ù ci sono tutte, quindi le nostre accentate non costano nulla in più. A far passare l'intero messaggio in modalità Unicode — 70 caratteri per segmento, 67 quando si divide — sono un'emoji, un trattino lungo, le virgolette curve «intelligenti» e soprattutto l'apostrofo tipografico ’ che Word inserisce al posto di quello dritto in «l'italiano», «un'ora», «po'». L'opzione «SMS» qui sopra rileva il passaggio e ti nomina il carattere esatto che l'ha causato.</p>
@@ -473,6 +471,9 @@ window.UTG_COUNTER_I18N = {
   platformLabel: "Piattaforma",
   fieldLabel: "Campo",
   visibleNote: "Si vedono solo i primi {n} caratteri prima che il resto venga troncato — metti davanti quello che conta.",
+  pastFold: "Rientra — taglio a {n} ⚠",
+  showAllFits: "Mostra tutti i {n}",
+  showFewerFits: "Mostra meno",
   foldHeading: "Quello che si vede prima di «altro»",
   foldMore: "altro",
   foldMeta: "{shown} caratteri visibili su {total} · {hidden} nascosti dietro il tocco",

--- a/ja/mojisu-kaunto/index.html
+++ b/ja/mojisu-kaunto/index.html
@@ -48,7 +48,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>文字数カウント — 文字数を数える無料ツール｜UltraTextGen</title>
-  <meta name="description" content="無料の文字数カウントツール。入力と同時に文字数（空白除く含む）・行数・原稿用紙換算をリアルタイムで表示します。全角・半角も1文字ずつ正確に文字カウントし、X（旧Twitter）やInstagramなど27種類の文字数制限チェックにも対応。">
+  <meta name="description" content="無料の文字数カウントツール。入力と同時に文字数（空白除く含む）・行数・原稿用紙換算をリアルタイムで表示します。全角・半角も1文字ずつ正確に文字カウントし、X（旧Twitter）やInstagramなど17サービス38項目の文字数制限チェックにも対応。">
   <link rel="canonical" href="https://ultratextgen.com/ja/mojisu-kaunto/">
 
   <link rel="alternate" hreflang="ja" href="https://ultratextgen.com/ja/mojisu-kaunto/">
@@ -69,7 +69,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/character-counter/">
 
   <meta property="og:title" content="文字数カウント — 文字数を数える無料ツール｜UltraTextGen">
-  <meta property="og:description" content="文字数・行数・原稿用紙換算をリアルタイム表示。全角・半角も正確にカウントし、X（旧Twitter）・Instagram・TikTokなど27種類の文字数制限チェックにも対応。無料・登録不要・クライアントサイドのみ。">
+  <meta property="og:description" content="文字数・行数・原稿用紙換算をリアルタイム表示。全角・半角も正確にカウントし、X（旧Twitter）・Instagram・TikTokなど17サービス38項目の文字数制限チェックにも対応。無料・登録不要・クライアントサイドのみ。">
   <meta property="og:url" content="https://ultratextgen.com/ja/mojisu-kaunto/">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://ultratextgen.com/assets/og/ja-mojisu-kaunto.png">
@@ -79,7 +79,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <meta property="og:image:alt" content="文字数カウント — 文字数を数える無料ツール｜UltraTextGen">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="文字数カウント — 文字数を数える無料ツール｜UltraTextGen">
-  <meta name="twitter:description" content="文字数・行数・原稿用紙換算をリアルタイム表示。全角・半角も正確にカウントし、X（旧Twitter）・Instagram・TikTokなど27種類の文字数制限チェックにも対応。無料・登録不要・クライアントサイドのみ。">
+  <meta name="twitter:description" content="文字数・行数・原稿用紙換算をリアルタイム表示。全角・半角も正確にカウントし、X（旧Twitter）・Instagram・TikTokなど17サービス38項目の文字数制限チェックにも対応。無料・登録不要・クライアントサイドのみ。">
   <meta name="twitter:image" content="https://ultratextgen.com/assets/og/ja-mojisu-kaunto.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -102,7 +102,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   "inLanguage": "ja",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Any",
-  "description": "入力と同時に文字数（空白込み・空白除く）・行数・段落・読了時間・原稿用紙換算をリアルタイム表示する無料の文字数カウントツール。X（旧Twitter）の重み付きカウントやSMSのセグメント計算を含む27種類のプラットフォーム文字数制限チェック付き。すべてブラウザ内で完結します。",
+  "description": "入力と同時に文字数（空白込み・空白除く）・行数・段落・読了時間・原稿用紙換算をリアルタイム表示する無料の文字数カウントツール。X（旧Twitter）の重み付きカウントやSMSのセグメント計算を含む17サービス38項目文字数制限チェック付き。すべてブラウザ内で完結します。",
   "offers": {
     "@type": "Offer",
     "price": "0",
@@ -159,19 +159,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <section class="hero"><div class="hero-inner"><div class="hero-card">
   <h1 class="hero-headline">文字数カウント</h1>
-  <p class="hero-sub">入力と同時に文字数（空白込み・空白除く）・行数・段落・読了時間・原稿用紙換算をリアルタイム表示。X（旧Twitter）、Instagram、TikTok、YouTube、Discord、SMSなど27種類の文字数制限に収まるかどうかも、各プラットフォームの実際の数え方でチェックできます。</p>
+  <p class="hero-sub">17サービス38項目の文字数制限をリアルタイム判定。オーバーしてもワンクリックで調整。</p>
 </div></div></section>
 
 <main class="container">
-  <section class="editorial-section">
-    <div class="editorial-block">
-      <p>まずボックスのすぐ上で投稿先を選び、文章を入力または貼り付けてください。文字数（空白込み・空白除く）、行数、段落数、読了時間、400字詰め原稿用紙の換算枚数がすべて即座に更新され、チェッカーは選んだ投稿先が実際に使っている数え方でカウントして、残り文字数（またはオーバー分）を表示します。オーバーした場合もそこで終わりません — 何をどれだけ削れば収まるかを削減量つきで提示し、どれもワンクリックで適用・取り消しできます。送信ボタンはなく、入力内容がアップロードされることもありません — すべての数値はブラウザ内だけで計算されます。数え終えた文章をおしゃれなUnicodeフォントにしたいときは、<a href="/ja/">UltraTextGenのフォント変換</a>が100種類以上のコピペ対応スタイルに変換します。</p>
-    </div>
-  </section>
-
-  <div class="section-divider"></div>
-
-  <div class="counter-tool">
+<div class="counter-tool">
     <div id="platformChecker"></div>
 
     <div class="counter-field">
@@ -212,12 +204,14 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     </div>
   </div>
 
+  <p class="counter-footnote">すべてブラウザ内で計算しているので、入力した内容がアップロードされたり保存されたりすることはありません。文字も装飾したいときは、<a href="/ja/">UltraTextGenのフォント変換</a>が100種類以上のコピペ対応フォントに変換します。</p>
+
   <div class="section-divider"></div>
 
   <section class="editorial-section">
     <h2>ハードリミットとソフトリミット</h2>
     <p>「文字数制限」と呼ばれるものには性質の違う2種類があり、オーバーしたときの結果もまったく違います。</p>
-    <table class="comparison-table">
+    <div class="comparison-table-wrap"><table class="comparison-table">
       <thead><tr><th>種類</th><th>オーバーするとどうなるか</th><th>例</th></tr></thead>
       <tbody>
         <tr>
@@ -231,35 +225,39 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
           <td>Instagramキャプションは125以降 · LinkedIn投稿はモバイル約140／PC約210以降 · YouTube説明欄は約157以降</td>
         </tr>
       </tbody>
-    </table>
+    </table></div>
     <p>多くの人が実際に書きながら意識しているのはソフトリミットのほうなのに、それを表示するカウンターはほとんどありません。LinkedIn投稿は3,000文字入りますが、実際に読まれるのは冒頭のおよそ140文字だけで、残りは誰も押さないタップの向こう側にあります。だから上のツールは折りたたみの位置そのものを描き出します — 入力すると、「もっと見る」の前に表示される文章がそのまま見え、カットラインより後ろは薄く表示され、同じ書き出しが折りたたみのある他の場所でも通用するかどうかまで並べて確認できます。</p>
     <p>ここで大事なのは、<strong>折りたたみは画面に表示される文字数で決まる</strong>という点です。UTF-8では3バイトを消費する日本語も、折りたたみの計算では1文字は1文字。Instagramの125文字の折りたたみには日本語でもちょうど125文字入り、バイト数のぶん短くなることはありません。バイト数が効いてくるのは「投稿が通るかどうか」を決めるハードリミットの側だけで、折りたたみとは別の話です。</p>
     <p><strong>どこで折りたたまれるか、デバイス別:</strong></p>
-    <table class="comparison-table">
-      <thead><tr><th>投稿先</th><th>折りたたみ位置</th><th>書き出しにとっての意味</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>投稿先</th><th class="num">スマホ</th><th class="num">PC</th><th>書き出しにとっての意味</th></tr></thead>
       <tbody>
         <tr>
           <td>LinkedIn投稿</td>
-          <td>スマホ 約140<br>PC 約210</td>
-          <td>140文字に収めれば両方で生き残ります。この表の中でスマホとPCの差がいちばん大きい場所です。</td>
+          <td class="num">約140</td>
+          <td class="num">約210</td>
+          <td>140文字に収めれば両方で生き残ります。この表の中でデバイス差がいちばん大きい場所です。</td>
         </tr>
         <tr>
           <td><a href="/ja/insta-font/">Instagramキャプション</a></td>
-          <td>約125</td>
+          <td class="num">約125</td>
+          <td class="num">約125</td>
           <td>この表でいちばん厳しい折りたたみ。「… 続きを読む」まで、およそ1文しかありません。</td>
         </tr>
         <tr>
           <td>YouTube説明欄</td>
-          <td>約157</td>
+          <td class="num">約157</td>
+          <td class="num">約157</td>
           <td>タイトルの下に「もっと見る」の前まで表示される部分。検索結果に拾われるのも多くはここです。</td>
         </tr>
         <tr>
           <td>Facebook投稿</td>
-          <td>約477</td>
+          <td class="num">約477</td>
+          <td class="num">約477</td>
           <td>いちばん余裕のある折りたたみ。短い段落なら丸ごとカットラインの手前に収まります。</td>
         </tr>
       </tbody>
-    </table>
+    </table></div>
     <p>正直に2点。これらは公表された制限ではなく実際のUIで観測された挙動なので、厳密なしきい値ではなく「確実に表示される目安」として扱ってください。また各サービスは<em>行数</em>でも折りたたむため、冒頭で改行を3回入れれば、どの文字数にも届かないうちに折りたたまれます。書き出しが箇条書きに頼っているなら、実際の投稿画面でも確認してください。</p>
   </section>
 
@@ -268,7 +266,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <section class="editorial-section" id="counting-modes">
     <h2>文字数がフォームやアプリの表示と合わない理由</h2>
     <p>「これは何文字？」の答えは1つではありません。数える単位がサービスごとに違うからです。日本語ユーザーにとって最も重要なのは、<strong>日本語1文字＝1コードポイント＝1 UTF-16単位ですが、UTF-8では3バイト</strong>だという点です。つまり「文字数」で数えれば余裕があるのに、バイト数で制限しているフォームやシステムには弾かれる、ということが起こります。同じ文章に4通りの長さがあると考えてください。</p>
-    <table class="comparison-table">
+    <div class="comparison-table-wrap"><table class="comparison-table">
       <thead><tr><th>数え方</th><th>何を測っているか</th><th>日本語だとどうなるか</th></tr></thead>
       <tbody>
         <tr><td>書記素</td><td>見た目どおりの文字。肌色付きの絵文字も1</td><td>「あ」＝1。Blueskyが採用</td></tr>
@@ -276,7 +274,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
         <tr><td>UTF-16単位</td><td>JavaScriptや多くのアプリの内部保存形式</td><td>「あ」＝1だが装飾フォントの英数字は2。HTMLフォームの<code>maxlength</code>、ゲームやアプリのバックエンド</td></tr>
         <tr><td>UTF-8バイト</td><td>保存サイズ</td><td><strong>「あ」＝3バイト</strong>。データベースの<code>VARCHAR</code>、Amazonの商品情報欄、Steam名、古い業務システムやCSV連携</td></tr>
       </tbody>
-    </table>
+    </table></div>
     <p>この差は実務でそのまま効いてきます。たとえば「255バイトまで」のデータベース項目には、日本語なら85文字しか入りません。上の「書記素（見た目の文字）」「UTF-16単位」「UTF-8バイト」のタイルは入力と同時にすべて更新されるので、フォームが「長すぎます」と言うのにこちらの文字数は足りている、という場面で、そのフォームがどの単位で数えているのかをその場で突き止められます。なお全角・半角の扱いは日本のフォーム特有の論点なので、<a href="#zenkaku-hankaku">全角・半角の数え方</a>で個別に説明しています。</p>
     <p>この4つに加えて、独自ルールを持つサービスが2つあります。<strong>X（旧Twitter）は文字数ではなく重みで数え</strong>、日本語1文字は2カウントになります（詳しくは<a href="#x-twitter">X（旧Twitter）の文字数</a>）。<strong>SMSは「通数」で数え</strong>、日本語はGSM-7の文字セットに含まれないため常にUnicode扱いとなり、1通70文字（分割時は67文字）に下がります。半角英数字だけで書けば1通160文字です。</p>
   </section>
@@ -313,51 +311,51 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <p>上のチェッカーが実際に使っている制限を、そのまま参照表にしたものです。ジャンプ：<a href="#twitter">X/Twitter</a> · <a href="#discord">Discord</a> · <a href="#instagram">Instagram</a> · <a href="#tiktok">TikTok</a> · <a href="#sms">SMS</a> · <a href="#counting-modes">各サービスの数え方</a>。</p>
 
     <h3>投稿・メッセージ</h3>
-    <table class="comparison-table">
-      <thead><tr><th>プラットフォーム</th><th>上限</th><th>補足</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>プラットフォーム</th><th class="num">上限</th><th>補足</th></tr></thead>
       <tbody>
-        <tr id="twitter"><td>X（旧Twitter）ポスト</td><td>280</td><td>重み付きカウント：URLは常に23、日本語・絵文字・装飾フォントは1文字＝2のため日本語では実質約140字</td></tr>
-        <tr id="discord"><td>Discord メッセージ</td><td>2,000</td><td>Nitro加入時は4,000。それより長いと.txt添付に変換される</td></tr>
-        <tr id="instagram"><td>Instagram キャプション</td><td>2,200</td><td>冒頭数行のあとは「続きを読む」で折りたたまれる</td></tr>
-        <tr id="tiktok"><td>TikTok キャプション</td><td>2,200</td><td></td></tr>
-        <tr><td>LinkedIn 投稿</td><td>3,000</td><td>端末により約200〜700文字で「もっと見る」に折りたたまれる</td></tr>
-        <tr><td>Facebook 投稿</td><td>63,206</td><td></td></tr>
-        <tr><td>YouTube 説明欄</td><td>5,000</td><td></td></tr>
-        <tr><td>Pinterest ピン説明文</td><td>500</td><td></td></tr>
-        <tr><td>Telegram メッセージ</td><td>4,096</td><td>写真・動画のキャプションは1,024</td></tr>
-        <tr><td>Threads 投稿</td><td>500</td><td></td></tr>
-        <tr><td>Bluesky 投稿</td><td>300</td><td>コードポイントではなく書記素（見た目の文字）で判定</td></tr>
-        <tr><td>Reddit 投稿タイトル</td><td>300</td><td></td></tr>
-        <tr><td>Zalo 投稿・ステータス</td><td>2,000</td><td></td></tr>
+        <tr id="twitter"><td>X（旧Twitter）ポスト</td><td class="num">280</td><td>重み付きカウント：URLは常に23、日本語・絵文字・装飾フォントは1文字＝2のため日本語では実質約140字</td></tr>
+        <tr id="discord"><td>Discord メッセージ</td><td class="num">2,000</td><td>Nitro加入時は4,000。それより長いと.txt添付に変換される</td></tr>
+        <tr id="instagram"><td>Instagram キャプション</td><td class="num">2,200</td><td>冒頭数行のあとは「続きを読む」で折りたたまれる</td></tr>
+        <tr id="tiktok"><td>TikTok キャプション</td><td class="num">2,200</td><td></td></tr>
+        <tr><td>LinkedIn 投稿</td><td class="num">3,000</td><td>端末により約200〜700文字で「もっと見る」に折りたたまれる</td></tr>
+        <tr><td>Facebook 投稿</td><td class="num">63,206</td><td></td></tr>
+        <tr><td>YouTube 説明欄</td><td class="num">5,000</td><td></td></tr>
+        <tr><td>Pinterest ピン説明文</td><td class="num">500</td><td></td></tr>
+        <tr><td>Telegram メッセージ</td><td class="num">4,096</td><td>写真・動画のキャプションは1,024</td></tr>
+        <tr><td>Threads 投稿</td><td class="num">500</td><td></td></tr>
+        <tr><td>Bluesky 投稿</td><td class="num">300</td><td>コードポイントではなく書記素（見た目の文字）で判定</td></tr>
+        <tr><td>Reddit 投稿タイトル</td><td class="num">300</td><td></td></tr>
+        <tr><td>Zalo 投稿・ステータス</td><td class="num">2,000</td><td></td></tr>
       </tbody>
-    </table>
+    </table></div>
 
     <h3>プロフィール・自己紹介</h3>
-    <table class="comparison-table">
-      <thead><tr><th>入力欄</th><th>上限</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>入力欄</th><th class="num">上限</th></tr></thead>
       <tbody>
-        <tr><td>Instagram プロフィール（自己紹介）</td><td>150</td></tr>
-        <tr><td>TikTok 自己紹介</td><td>80</td></tr>
-        <tr><td>LinkedIn ヘッドライン</td><td>220</td></tr>
-        <tr><td>WhatsApp 自己紹介</td><td>139</td></tr>
-        <tr><td>Telegram 自己紹介</td><td>70</td></tr>
-        <tr><td>VK ステータス</td><td>140</td></tr>
+        <tr><td>Instagram プロフィール（自己紹介）</td><td class="num">150</td></tr>
+        <tr><td>TikTok 自己紹介</td><td class="num">80</td></tr>
+        <tr><td>LinkedIn ヘッドライン</td><td class="num">220</td></tr>
+        <tr><td>WhatsApp 自己紹介</td><td class="num">139</td></tr>
+        <tr><td>Telegram 自己紹介</td><td class="num">70</td></tr>
+        <tr><td>VK ステータス</td><td class="num">140</td></tr>
       </tbody>
-    </table>
+    </table></div>
 
     <h3>ユーザーネーム・タイトル・SMS</h3>
-    <table class="comparison-table">
-      <thead><tr><th>入力欄</th><th>上限</th><th>補足</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>入力欄</th><th class="num">上限</th><th>補足</th></tr></thead>
       <tbody>
-        <tr><td>Discord ニックネーム</td><td>32</td><td></td></tr>
-        <tr><td>TikTok ユーザーネーム</td><td>24</td><td>半角英数字・アンダースコア・ピリオドのみ</td></tr>
-        <tr><td>Instagram ユーザーネーム</td><td>30</td><td></td></tr>
-        <tr><td>YouTube タイトル</td><td>100</td><td></td></tr>
-        <tr><td>メタタイトル（SEO）</td><td>約60</td><td>Googleはピクセル幅で切るため目安として扱う</td></tr>
-        <tr><td>メタディスクリプション（SEO）</td><td>約155</td><td>同じくピクセル幅で切られる</td></tr>
-        <tr id="sms"><td>SMS（ショートメール）</td><td>160 / 1通</td><td>GSM-7の文字だけの場合。<strong>日本語は必ずUnicode扱いになるため実質1通70文字</strong>（分割時は67文字）</td></tr>
+        <tr><td>Discord ニックネーム</td><td class="num">32</td><td></td></tr>
+        <tr><td>TikTok ユーザーネーム</td><td class="num">24</td><td>半角英数字・アンダースコア・ピリオドのみ</td></tr>
+        <tr><td>Instagram ユーザーネーム</td><td class="num">30</td><td></td></tr>
+        <tr><td>YouTube タイトル</td><td class="num">100</td><td></td></tr>
+        <tr><td>メタタイトル（SEO）</td><td class="num">約60</td><td>Googleはピクセル幅で切るため目安として扱う</td></tr>
+        <tr><td>メタディスクリプション（SEO）</td><td class="num">約155</td><td>同じくピクセル幅で切られる</td></tr>
+        <tr id="sms"><td>SMS（ショートメール）</td><td class="num">160 / 1通</td><td>GSM-7の文字だけの場合。<strong>日本語は必ずUnicode扱いになるため実質1通70文字</strong>（分割時は67文字）</td></tr>
       </tbody>
-    </table>
+    </table></div>
     <p>日本でよく使われるサービスのうち、<strong>LINEのひとこと（ステータスメッセージ）は500文字</strong>です。LINEは上のチェッカーの対象外なので、文字数だけを見て判断してください。</p>
   </section>
 
@@ -460,6 +458,9 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     foldMeta: "{total}文字中{shown}文字を表示 · {hidden}文字はタップの向こう側",
     foldRoom: "折りたたみまで、書き出しに使える残り{n}文字",
     foldDevices: "スマホは{m}文字、PCは{d}文字で折りたたみ。",
+    pastFold: "収まるが{n}字で省略 ⚠",
+    showAllFits: "すべて表示（{n}）",
+    showFewerFits: "表示を減らす",
     overBy: "{n}オーバーしています — 対処法を選んでください：",
     trimToFit: "収まる長さに切り詰める",
     undo: "元に戻す",

--- a/js/counter/counter.test.html
+++ b/js/counter/counter.test.html
@@ -82,6 +82,9 @@
     undo: "Rückgängig",
     fitsHeading: "Wo dieser Text sonst noch passt",
     segShort: "Seg.",
+    pastFold: "Passt \u2014 abgeschnitten bei {n}",
+    showAllFits: "Alle {n} anzeigen",
+    showFewerFits: "Weniger anzeigen",
     foldHeading: "Was vor \u201eMehr anzeigen\u201c sichtbar ist",
     foldMore: "mehr anzeigen",
     foldMeta: "{shown} von {total} Zeichen sichtbar \u00b7 {hidden} verborgen",
@@ -221,14 +224,18 @@ window.addEventListener("load", function () {
   t("empty text: fit grid hidden", $("#counterFitGrid").hidden, true);
   type("y".repeat(150));
   const chips = $$("#counterFitGrid .cc-fit-chip");
-  t("fit grid renders every rule", chips.length, window.UltraTextGen.counterRules.LIMITS.length);
+  t("fit grid collapses rather than dumping every rule", chips.length, 12);
   t("over-limit chips come first", chips[0].classList.contains("is-unfit"), true);
-  t("headroom chips come last", chips[chips.length - 1].classList.contains("is-fit"), true);
-  const unfit = chips.filter((c) => c.classList.contains("is-unfit"));
+  t("the active destination is always pinned into the collapsed view",
+    chips.some((c) => c.classList.contains("is-active")), true);
+  const unfit = chips.filter((c) => c.classList.contains("is-unfit") && !c.classList.contains("is-active"));
   const dist = unfit.map((c) => Math.abs(parseInt(c.querySelector(".cc-fit-num").textContent.replace(/[^\d]/g, ""), 10)));
   t("over-limit chips ordered nearest-first", dist.slice().sort((a, b) => a - b), dist);
   t("active destination marked", chips.filter((c) => c.classList.contains("is-active")).length, 1);
-  t("chip names use the locale labels", chips.some((c) => c.textContent.indexOf("X-Beitrag") === 0), true);
+  $("#counterFitGrid .cc-fit-toggle").click();
+  t("chip names use the locale labels",
+    $$("#counterFitGrid .cc-fit-chip").some((c) => c.textContent.indexOf("X-Beitrag") === 0), true);
+  $("#counterFitGrid .cc-fit-toggle").click();
 
   /* ---------- 8. SMS is segment-aware end to end ---------- */
   platformSel.value = "sms";
@@ -310,6 +317,53 @@ window.addEventListener("load", function () {
   platformSel.value = "x";
   platformSel.dispatchEvent(new Event("change", { bubbles: true }));
   t("non-folding destination hides the panel", fold.hidden, true);
+
+
+  /* ---------- 12. the three-state badge: the fold is in the readout ---------- */
+  const badge = () => $("#platformChecker .cc-badge");
+  const barFill = () => $("#platformChecker .cc-bar-fill");
+  const foldTick = () => $("#platformChecker .cc-bar-fold");
+  platformSel.value = "linkedin";
+  platformSel.dispatchEvent(new Event("change", { bubbles: true }));
+  fieldSel.value = "li-post"; fieldSel.dispatchEvent(new Event("change", { bubbles: true }));
+
+  type("A short hook.");
+  t("well inside the fold: green", badge().className.indexOf("cc-badge-ok") > -1, true);
+  t("green state is not amber", badge().className.indexOf("cc-badge-warn") > -1, false);
+
+  type("z".repeat(680));
+  t("fits the limit but past the fold: AMBER, not green",
+    [badge().className.indexOf("cc-badge-warn") > -1, badge().className.indexOf("cc-badge-ok") > -1], [true, false]);
+  t("amber badge names the cut point", badge().textContent.indexOf("140") > -1, true);
+  t("amber badge text is translated", badge().textContent.indexOf("abgeschnitten") > -1, true);
+  t("bar fill goes amber too", barFill().classList.contains("is-past-fold"), true);
+
+  type("z".repeat(3200));
+  t("over the hard limit: red beats amber",
+    [badge().className.indexOf("cc-badge-fail") > -1, badge().className.indexOf("cc-badge-warn") > -1], [true, false]);
+
+  t("fold tick shown on a folding field", foldTick().hidden, false);
+  t("fold tick sits at fold/limit along the bar",
+    Math.abs(parseFloat(foldTick().style.left) - (140 / 3000 * 100)) < 0.01, true);
+  platformSel.value = "x";
+  platformSel.dispatchEvent(new Event("change", { bubbles: true }));
+  type("z".repeat(100));
+  t("non-folding field hides the tick", foldTick().hidden, true);
+  t("non-folding field never goes amber", badge().className.indexOf("cc-badge-warn") > -1, false);
+
+  /* ---------- 13. the fit grid no longer dumps 38 chips ---------- */
+  type("z".repeat(150));
+  const chipsNow = () => $$("#counterFitGrid .cc-fit-chip");
+  const toggle = () => $("#counterFitGrid .cc-fit-toggle");
+  t("collapsed by default", chipsNow().length, 12);
+  t("toggle offered", !!toggle(), true);
+  t("toggle is translated and counts the rest", toggle().textContent, "Alle 38 anzeigen");
+  t("collapsed view leads with what is broken", chipsNow()[0].classList.contains("is-unfit"), true);
+  toggle().click();
+  t("expanding shows every rule", chipsNow().length, 38);
+  t("toggle flips to collapse", toggle().textContent, "Weniger anzeigen");
+  toggle().click();
+  t("collapsing again returns to the preview", chipsNow().length, 12);
 
   const summary = (fail ? fail + " FAILED, " : "") + pass + " passed";
   document.getElementById("results").textContent = lines.join("\n") + "\n\n" + summary;

--- a/js/counter/counterController.js
+++ b/js/counter/counterController.js
@@ -79,6 +79,9 @@
     reducers: null,
     reducerHints: null,
     segShort: "seg",
+    pastFold: null,
+    showAllFits: "Show all {n}",
+    showFewerFits: "Show fewer",
     /* The fold layer. Every string a locale page must translate. */
     foldHeading: "What people see before \u201csee more\u201d",
     foldMore: "see more",
@@ -151,6 +154,7 @@
 
     let checker = null;
     let undoValue = null;
+    let fitGridExpanded = false;
 
     function activeLimitId() {
       return checker ? checker.getLimitId() : (rules ? rules.LIMITS[0].id : null);
@@ -330,7 +334,26 @@
         if (a.fits !== b.fits) return a.fits ? 1 : -1;
         return Math.abs(a.remaining) - Math.abs(b.remaining);
       });
-      rows.forEach((row) => {
+      /* 38 chips at once is a wall, not an answer. Show the ones a writer can
+         act on — everything the text already breaks, plus the nearest few it
+         still fits — and keep the rest one click away. Ordering already puts
+         the boundary cases first, so this is a prefix, not a filter. */
+      const PREVIEW = 12;
+      const collapsed = rows.length > PREVIEW && !fitGridExpanded;
+      let shown = rows;
+      if (collapsed) {
+        shown = rows.slice(0, PREVIEW);
+        /* The destination you actually selected must never be the one the
+           collapse hides — and it sorts to the bottom precisely when it has
+           the most headroom, which is exactly when you are least worried and
+           most likely to trust the grid. Pin it in. */
+        if (!shown.some((r) => r.rule.id === activeId)) {
+          const active = rows.find((r) => r.rule.id === activeId);
+          if (active) shown = shown.slice(0, PREVIEW - 1).concat([active]);
+        }
+      }
+
+      shown.forEach((row) => {
         const chip = el("span", "cc-fit-chip " + (row.fits ? "is-fit" : "is-unfit"));
         if (row.rule.id === activeId) chip.classList.add("is-active");
         const name = (I18N.labels && I18N.labels[row.rule.id]) || row.rule.label;
@@ -340,6 +363,19 @@
           : "−" + Math.abs(row.remaining).toLocaleString()));
         fitGrid.appendChild(chip);
       });
+
+      if (rows.length > PREVIEW) {
+        const toggle = el("button", "cc-fit-toggle");
+        toggle.type = "button";
+        toggle.textContent = collapsed
+          ? fmt(I18N.showAllFits, { n: rows.length })
+          : I18N.showFewerFits;
+        toggle.addEventListener("click", () => {
+          fitGridExpanded = !fitGridExpanded;
+          renderFitGrid();
+        });
+        fitGrid.appendChild(toggle);
+      }
     }
 
     /* ---------- 1. MEASURE ---------- */
@@ -432,6 +468,7 @@
           smsSegments: I18N.smsSegments || undefined,
           smsUnicode: I18N.smsUnicode || undefined,
           visibleNote: I18N.visibleNote || undefined,
+          pastFold: I18N.pastFold || undefined,
           platformLabel: I18N.platformLabel || undefined,
           fieldLabel: I18N.fieldLabel || undefined
         },

--- a/js/counter/counterRules.js
+++ b/js/counter/counterRules.js
@@ -394,7 +394,13 @@
 
     const bar = el("div", "cc-bar");
     const fill = el("div", "cc-bar-fill");
+    /* A tick on the bar where the feed truncates. Without it the bar answers
+       only "will this send", which on a 3,000-character field is a question
+       nobody is asking. */
+    const foldMark = el("span", "cc-bar-fold");
+    foldMark.hidden = true;
     bar.appendChild(fill);
+    bar.appendChild(foldMark);
     mount.appendChild(bar);
 
     const note = el("div", "cc-note");
@@ -437,8 +443,18 @@
       const report = analyze(value, state.limitId);
       const rule = report.rule;
 
-      badge.className = "cc-badge cc-badge-" + (report.glyphs === 0 ? "empty" : report.fits ? "ok" : "fail");
-      badge.textContent = report.glyphs === 0 ? "" : (report.fits ? (text.ok || "Fits ✓") : (text.fail || "Over the limit ✕"));
+      /* Three states, not two. "Fits" and "over the limit" leave out the one
+         that matters most on a feed field: it will post, and almost nobody
+         will read past the cut. That gets its own amber state rather than a
+         green tick and a footnote. */
+      const fold = foldInfo(value, state.limitId);
+      const pastFold = !!(fold && fold.truncated && report.fits);
+      const status = report.glyphs === 0 ? "empty" : !report.fits ? "fail" : pastFold ? "warn" : "ok";
+      badge.className = "cc-badge cc-badge-" + status;
+      badge.textContent = status === "empty" ? ""
+        : status === "fail" ? (text.fail || "Over the limit ✕")
+        : status === "warn" ? fmt(text.pastFold || "Fits — cut at {n} ⚠", { n: fold.at })
+        : (text.ok || "Fits ✓");
 
       count.textContent = report.glyphs.toLocaleString() + " / " + report.limit.toLocaleString();
       count.classList.toggle("is-over", !report.fits);
@@ -446,7 +462,16 @@
       const pct = Math.min(100, (report.glyphs / report.limit) * 100);
       fill.style.width = pct + "%";
       fill.classList.toggle("is-over", !report.fits);
-      fill.classList.toggle("is-close", report.fits && pct >= 90);
+      fill.classList.toggle("is-past-fold", pastFold);
+      fill.classList.toggle("is-close", report.fits && !pastFold && pct >= 90);
+
+      if (fold && rule.limit) {
+        foldMark.hidden = false;
+        foldMark.style.left = Math.min(100, (fold.at / rule.limit) * 100) + "%";
+        foldMark.title = fold.label;
+      } else {
+        foldMark.hidden = true;
+      }
 
       const notes = [];
       if (report.mode === "x-weighted" && report.glyphs > 0) {

--- a/ko/geuljasu-segi/index.html
+++ b/ko/geuljasu-segi/index.html
@@ -160,19 +160,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <section class="hero"><div class="hero-inner"><div class="hero-card">
   <h1 class="hero-headline">글자수세기</h1>
-  <p class="hero-sub">입력하는 즉시 글자 수(공백 포함/제외), 단어 수, 문장·문단 수, 읽기 시간이 실시간으로 집계돼요. 자기소개서(자소서) 글자수 확인은 물론, X(트위터)·인스타그램·카카오톡·유튜브·디스코드 등 플랫폼별 글자수 제한에 맞는지도 바로 확인할 수 있어요.</p>
+  <p class="hero-sub">17개 플랫폼 38개 입력란의 글자수 제한을 실시간으로 확인하고, 넘치면 한 번의 클릭으로 정리하세요.</p>
 </div></div></section>
 
 <main class="container">
-  <section class="editorial-section">
-    <div class="editorial-block">
-      <p>입력창 바로 위에서 글이 올라갈 곳을 먼저 고르고, 글을 쓰거나 붙여넣으세요. 단어 수, 글자 수(공백 포함·제외), 문장 수, 문단 수, 읽기 시간이 즉시 갱신되고, 확인 도구는 그 플랫폼이 실제로 세는 방식 그대로 계산해서 몇 자가 남았는지(또는 몇 자를 초과했는지) 알려 줘요. 초과했을 때 그냥 알려 주고 끝나지 않아요 — 무엇을 얼마나 줄일 수 있는지 절약되는 글자 수와 함께 제안하고, 전부 한 번의 클릭으로 적용하고 되돌릴 수 있어요. 어떤 것도 서버로 전송되지 않고 모든 계산은 브라우저 안에서만 이루어져요. 방금 잰 텍스트를 예쁜 유니코드 글꼴로 바꾸고 싶다면 <a href="/ko/">UltraTextGen 한국어 글씨체 변환기</a>가 100가지 이상의 복사–붙여넣기 스타일로 바꿔 드려요.</p>
-    </div>
-  </section>
-
-  <div class="section-divider"></div>
-
-  <div class="counter-tool">
+<div class="counter-tool">
     <div id="platformChecker"></div>
 
     <div class="counter-field">
@@ -212,12 +204,14 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     </div>
   </div>
 
+  <p class="counter-footnote">모든 계산은 브라우저 안에서만 이루어져요 — 입력한 글은 전송되거나 저장되지 않아요. 글씨체까지 바꾸고 싶다면 <a href="/ko/">UltraTextGen 변환기</a>가 100가지 이상의 복사–붙여넣기 글꼴로 바꿔 드려요.</p>
+
   <div class="section-divider"></div>
 
   <section class="editorial-section">
     <h2>하드 리밋과 소프트 리밋</h2>
     <p>'글자수 제한'이라고 불리는 것에는 성격이 다른 두 가지가 있고, 넘겼을 때 치르는 대가도 달라요.</p>
-    <table class="comparison-table">
+    <div class="comparison-table-wrap"><table class="comparison-table">
       <thead><tr><th>종류</th><th>초과하면 어떻게 되나요</th><th>예시</th></tr></thead>
       <tbody>
         <tr>
@@ -231,35 +225,39 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
           <td>인스타그램 캡션 125자 이후 · 링크드인 게시물 모바일 약 140자 / PC 약 210자 이후 · 유튜브 설명 약 157자 이후</td>
         </tr>
       </tbody>
-    </table>
+    </table></div>
     <p>정작 대부분의 사람이 실제로 맞춰 쓰는 건 소프트 리밋인데, 이걸 보여 주는 글자수 세기 도구는 거의 없어요. 링크드인 게시물은 3,000자까지 쓸 수 있지만 실제로 읽히는 건 앞의 140자 정도고, 나머지는 아무도 누르지 않는 터치 뒤에 있어요. 그래서 위 도구는 잘리는 지점을 그대로 그려서 보여 줘요 — 입력해 보면 '더 보기' 앞에 실제로 나오는 문장이 그대로 보이고, 잘림선 뒤는 흐리게 처리되며, 같은 첫머리가 잘림이 있는 다른 곳에서도 살아남는지까지 함께 확인할 수 있어요.</p>
     <p>한 가지 짚어 둘 게 있어요. <strong>잘림은 화면에 보이는 글자 수로 셉니다.</strong> UTF-8로는 3바이트를 쓰는 한글도 잘림 계산에서는 한 글자가 그냥 한 글자예요. 인스타그램의 125자 잘림에는 한글도 정확히 125자가 들어가고, 바이트 때문에 줄어들지 않아요. 바이트가 발목을 잡는 건 '올라가느냐 마느냐'를 결정하는 하드 리밋 쪽뿐이에요.</p>
     <p><strong>어디에서, 어떤 기기에서 잘리는지:</strong></p>
-    <table class="comparison-table">
-      <thead><tr><th>올리는 곳</th><th>잘리는 지점</th><th>첫머리에 주는 의미</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>올리는 곳</th><th class="num">휴대폰</th><th class="num">PC</th><th>첫머리에 주는 의미</th></tr></thead>
       <tbody>
         <tr>
           <td>링크드인 게시물</td>
-          <td>휴대폰 약 140<br>PC 약 210</td>
-          <td>140자 안에 쓰면 둘 다에서 살아남아요. 이 표에서 휴대폰과 PC 차이가 가장 큰 곳이에요.</td>
+          <td class="num">약 140</td>
+          <td class="num">약 210</td>
+          <td>140자 안에 쓰면 둘 다에서 살아남아요. 이 표에서 기기 간 차이가 가장 큰 곳이에요.</td>
         </tr>
         <tr>
           <td><a href="/ko/insta-font/">인스타그램 캡션</a></td>
-          <td>약 125</td>
+          <td class="num">약 125</td>
+          <td class="num">약 125</td>
           <td>이 표에서 가장 빡빡한 잘림 — '… 더 보기'까지 대략 한 문장이에요.</td>
         </tr>
         <tr>
           <td>유튜브 설명</td>
-          <td>약 157</td>
+          <td class="num">약 157</td>
+          <td class="num">약 157</td>
           <td>제목 아래 '더보기' 앞까지 보이는 부분이고, 검색에 걸리는 것도 보통 여기예요.</td>
         </tr>
         <tr>
           <td>페이스북 게시물</td>
-          <td>약 477</td>
+          <td class="num">약 477</td>
+          <td class="num">약 477</td>
           <td>가장 넉넉한 잘림 — 짧은 문단 하나는 통째로 잘림선 앞에 들어가요.</td>
         </tr>
       </tbody>
-    </table>
+    </table></div>
     <p>솔직하게 두 가지. 이 숫자들은 플랫폼이 공개한 제한이 아니라 실제 화면에서 관찰한 동작이라, 정확한 임계값이라기보다 '확실히 보이는 정도'로 봐 주세요. 그리고 각 서비스는 <em>줄 수</em>로도 잘라요. 앞부분에서 줄바꿈을 세 번만 해도 어떤 글자수에도 닿기 전에 잘립니다. 첫머리가 목록에 기대고 있다면 실제 작성 화면에서도 확인해 보세요.</p>
   </section>
 
@@ -268,7 +266,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <section class="editorial-section" id="counting-modes">
     <h2>플랫폼이 세는 글자수와 내 글자수가 다른 이유</h2>
     <p>'이거 몇 자예요?'에는 정답이 하나가 아니에요. 서비스마다 세는 단위가 다르기 때문이에요. 한국어 사용자에게 가장 중요한 건 이 지점이에요: <strong>한글 한 글자는 1 코드포인트, 1 UTF-16 단위지만, UTF-8로는 3바이트</strong>예요. 그래서 글자 수로는 여유가 있는데도 바이트로 제한하는 입력 폼이나 시스템에서는 '너무 깁니다'라며 거부당하는 일이 생겨요. 같은 글에 길이가 네 가지 있다고 생각하면 돼요.</p>
-    <table class="comparison-table">
+    <div class="comparison-table-wrap"><table class="comparison-table">
       <thead><tr><th>세는 방식</th><th>무엇을 재나요</th><th>한글에서는</th></tr></thead>
       <tbody>
         <tr><td>자소 단위(그래핌)</td><td>눈에 보이는 그대로 — 피부색이 붙은 이모지도 1</td><td>'한' = 1. 블루스카이가 사용</td></tr>
@@ -276,7 +274,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
         <tr><td>UTF-16 단위</td><td>자바스크립트와 많은 앱이 글을 저장하는 방식</td><td>'한' = 1이지만 특수 글꼴 영문은 2. HTML 폼의 <code>maxlength</code>, 게임·앱 백엔드</td></tr>
         <tr><td>UTF-8 바이트</td><td>저장 용량</td><td><strong>'한' = 3바이트</strong>. 데이터베이스 <code>VARCHAR</code>, 아마존 상품 정보란, 스팀 이름, 오래된 업무 시스템</td></tr>
       </tbody>
-    </table>
+    </table></div>
     <p>이 차이는 실무에서 그대로 드러나요. 예를 들어 '255바이트까지'인 항목에는 한글이 85자밖에 안 들어가요. 위의 '자소 단위(보이는 글자)', 'UTF-16 단위', 'UTF-8 바이트' 타일은 입력과 동시에 모두 갱신되니, 폼은 길다고 하는데 내 글자 수는 모자랄 때 그 폼이 어떤 단위로 세는지 바로 짚어낼 수 있어요. 공백 포함·제외 문제는 이와 별개의 한국식 기준이라 <a href="#gongbaek">공백 포함 vs 공백 제외</a>에서 따로 설명했어요.</p>
     <p>여기에 더해 자기만의 규칙을 쓰는 곳이 두 군데 있어요. <strong>X(트위터)는 글자가 아니라 가중치로 세서</strong> 한글 한 글자가 2로 계산돼요(자세히는 <a href="#x-twitter">X에서 한글은 몇 자까지</a>). <strong>SMS는 '건'으로 세는데</strong>, 한글은 GSM-7 문자 집합에 없어서 항상 유니코드로 처리되고 1건당 70자(분할되면 67자)로 떨어져요. 영문·숫자만 쓰면 1건에 160자예요.</p>
   </section>
@@ -312,51 +310,51 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <p>위의 실시간 확인 도구가 실제로 쓰는 제한을 그대로 표로 정리했어요. 바로 가기: <a href="#twitter">X/트위터</a> · <a href="#discord">디스코드</a> · <a href="#instagram">인스타그램</a> · <a href="#tiktok">틱톡</a> · <a href="#sms">SMS</a> · <a href="#counting-modes">플랫폼별 세는 방식</a>.</p>
 
     <h3>게시물 &amp; 메시지</h3>
-    <table class="comparison-table">
-      <thead><tr><th>플랫폼</th><th>제한</th><th>비고</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>플랫폼</th><th class="num">제한</th><th>비고</th></tr></thead>
       <tbody>
-        <tr id="twitter"><td>X(트위터) 게시물</td><td>280</td><td>가중치 방식 — URL은 항상 23, 한글·이모지·특수 글꼴은 글자당 2라 한글로만 쓰면 실질 약 140자</td></tr>
-        <tr id="discord"><td>디스코드 메시지</td><td>2,000</td><td>니트로 구독 시 4,000. 더 길면 .txt 첨부파일로 바뀜</td></tr>
-        <tr id="instagram"><td>인스타그램 캡션</td><td>2,200</td><td>첫 몇 줄 이후 '더 보기'로 접힘</td></tr>
-        <tr id="tiktok"><td>틱톡 캡션</td><td>2,200</td><td></td></tr>
-        <tr><td>링크드인 게시물</td><td>3,000</td><td>기기에 따라 약 200~700자에서 '더 보기'로 접힘</td></tr>
-        <tr><td>페이스북 게시물</td><td>63,206</td><td></td></tr>
-        <tr><td>유튜브 설명</td><td>5,000</td><td></td></tr>
-        <tr><td>핀터레스트 핀 설명</td><td>500</td><td></td></tr>
-        <tr><td>텔레그램 메시지</td><td>4,096</td><td>사진·영상 캡션은 1,024</td></tr>
-        <tr><td>스레드 게시물</td><td>500</td><td></td></tr>
-        <tr><td>블루스카이 게시물</td><td>300</td><td>코드포인트가 아니라 자소 단위(보이는 글자)로 셈</td></tr>
-        <tr><td>레딧 게시물 제목</td><td>300</td><td></td></tr>
-        <tr><td>잘로 게시물·상태</td><td>2,000</td><td></td></tr>
+        <tr id="twitter"><td>X(트위터) 게시물</td><td class="num">280</td><td>가중치 방식 — URL은 항상 23, 한글·이모지·특수 글꼴은 글자당 2라 한글로만 쓰면 실질 약 140자</td></tr>
+        <tr id="discord"><td>디스코드 메시지</td><td class="num">2,000</td><td>니트로 구독 시 4,000. 더 길면 .txt 첨부파일로 바뀜</td></tr>
+        <tr id="instagram"><td>인스타그램 캡션</td><td class="num">2,200</td><td>첫 몇 줄 이후 '더 보기'로 접힘</td></tr>
+        <tr id="tiktok"><td>틱톡 캡션</td><td class="num">2,200</td><td></td></tr>
+        <tr><td>링크드인 게시물</td><td class="num">3,000</td><td>기기에 따라 약 200~700자에서 '더 보기'로 접힘</td></tr>
+        <tr><td>페이스북 게시물</td><td class="num">63,206</td><td></td></tr>
+        <tr><td>유튜브 설명</td><td class="num">5,000</td><td></td></tr>
+        <tr><td>핀터레스트 핀 설명</td><td class="num">500</td><td></td></tr>
+        <tr><td>텔레그램 메시지</td><td class="num">4,096</td><td>사진·영상 캡션은 1,024</td></tr>
+        <tr><td>스레드 게시물</td><td class="num">500</td><td></td></tr>
+        <tr><td>블루스카이 게시물</td><td class="num">300</td><td>코드포인트가 아니라 자소 단위(보이는 글자)로 셈</td></tr>
+        <tr><td>레딧 게시물 제목</td><td class="num">300</td><td></td></tr>
+        <tr><td>잘로 게시물·상태</td><td class="num">2,000</td><td></td></tr>
       </tbody>
-    </table>
+    </table></div>
 
     <h3>소개 &amp; 프로필</h3>
-    <table class="comparison-table">
-      <thead><tr><th>항목</th><th>제한</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>항목</th><th class="num">제한</th></tr></thead>
       <tbody>
-        <tr><td>인스타그램 소개(바이오)</td><td>150</td></tr>
-        <tr><td>틱톡 소개(바이오)</td><td>80</td></tr>
-        <tr><td>링크드인 헤드라인</td><td>220</td></tr>
-        <tr><td>왓츠앱 정보</td><td>139</td></tr>
-        <tr><td>텔레그램 소개</td><td>70</td></tr>
-        <tr><td>VK 상태</td><td>140</td></tr>
+        <tr><td>인스타그램 소개(바이오)</td><td class="num">150</td></tr>
+        <tr><td>틱톡 소개(바이오)</td><td class="num">80</td></tr>
+        <tr><td>링크드인 헤드라인</td><td class="num">220</td></tr>
+        <tr><td>왓츠앱 정보</td><td class="num">139</td></tr>
+        <tr><td>텔레그램 소개</td><td class="num">70</td></tr>
+        <tr><td>VK 상태</td><td class="num">140</td></tr>
       </tbody>
-    </table>
+    </table></div>
 
     <h3>사용자명, 제목 &amp; SMS</h3>
-    <table class="comparison-table">
-      <thead><tr><th>항목</th><th>제한</th><th>비고</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>항목</th><th class="num">제한</th><th>비고</th></tr></thead>
       <tbody>
-        <tr><td>디스코드 별명</td><td>32</td><td></td></tr>
-        <tr><td>틱톡 사용자명</td><td>24</td><td>영문·숫자·밑줄·마침표만 가능</td></tr>
-        <tr><td>인스타그램 사용자명</td><td>30</td><td></td></tr>
-        <tr><td>유튜브 제목</td><td>100</td><td></td></tr>
-        <tr><td>SEO 메타 제목</td><td>약 60</td><td>구글은 픽셀 너비로 자르므로 참고 기준으로 보세요</td></tr>
-        <tr><td>SEO 메타 설명</td><td>약 155</td><td>마찬가지로 픽셀 너비로 잘림</td></tr>
-        <tr id="sms"><td>SMS 문자메시지</td><td>160 / 1건</td><td>GSM-7 문자만 썼을 때. <strong>한글은 항상 유니코드로 처리되어 실질 1건 70자</strong>(분할 시 67자)</td></tr>
+        <tr><td>디스코드 별명</td><td class="num">32</td><td></td></tr>
+        <tr><td>틱톡 사용자명</td><td class="num">24</td><td>영문·숫자·밑줄·마침표만 가능</td></tr>
+        <tr><td>인스타그램 사용자명</td><td class="num">30</td><td></td></tr>
+        <tr><td>유튜브 제목</td><td class="num">100</td><td></td></tr>
+        <tr><td>SEO 메타 제목</td><td class="num">약 60</td><td>구글은 픽셀 너비로 자르므로 참고 기준으로 보세요</td></tr>
+        <tr><td>SEO 메타 설명</td><td class="num">약 155</td><td>마찬가지로 픽셀 너비로 잘림</td></tr>
+        <tr id="sms"><td>SMS 문자메시지</td><td class="num">160 / 1건</td><td>GSM-7 문자만 썼을 때. <strong>한글은 항상 유니코드로 처리되어 실질 1건 70자</strong>(분할 시 67자)</td></tr>
       </tbody>
-    </table>
+    </table></div>
     <p>국내 서비스 중 <strong>카카오톡 상태메시지는 60자</strong>예요. 카카오톡은 위 확인 도구에 포함되어 있지 않으니 '글자 수(공백 포함)' 값만 보고 맞추면 돼요.</p>
   </section>
 
@@ -455,6 +453,9 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     foldMeta: "{total}자 중 {shown}자 표시 · {hidden}자는 터치 뒤에 숨어요",
     foldRoom: "잘리기까지 첫머리에 쓸 수 있는 {n}자 남음",
     foldDevices: "휴대폰은 {m}자, PC는 {d}자에서 잘려요.",
+    pastFold: "들어가지만 {n}자에서 잘림 ⚠",
+    showAllFits: "전체 {n}개 보기",
+    showFewerFits: "간단히 보기",
     overBy: "{n}자 초과했어요 — 줄이는 방법을 골라 보세요:",
     trimToFit: "제한에 맞게 자르기",
     undo: "되돌리기",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "audit:locale-parent-gap": "node scripts/audit-locale-parent-gap.js",
     "check:locale-parent-gap": "node scripts/check-locale-parent-gap.js",
     "check:external-refs": "node scripts/check-external-refs.js",
-    "refresh:events": "python3 scripts/refresh-event-pages.py"
+    "refresh:events": "python3 scripts/refresh-event-pages.py",
+    "check:counter-claims": "node scripts/check-counter-claims.js"
   },
   "dependencies": {
     "cheerio": "^1.2.0",

--- a/pl/licznik-slow-i-znakow/index.html
+++ b/pl/licznik-slow-i-znakow/index.html
@@ -48,7 +48,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Licznik Słów i Znaków — Darmowe Narzędzie Online | UltraTextGen</title>
-  <meta name="description" content="Darmowy licznik znaków i licznik słów. Statystyki na żywo — słowa, znaki, zdania, akapity i czas czytania — plus sprawdzian limitów dla 27 platform: X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS i inne.">
+  <meta name="description" content="Darmowy licznik znaków i licznik słów. Statystyki na żywo — słowa, znaki, zdania, akapity i czas czytania — plus sprawdzian limitów dla 38 pól na 17 platformach: X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS i inne.">
   <link rel="canonical" href="https://ultratextgen.com/pl/licznik-slow-i-znakow/">
 
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/character-counter/">
@@ -69,7 +69,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/character-counter/">
 
   <meta property="og:title" content="Licznik Słów i Znaków — Darmowe Narzędzie Online | UltraTextGen">
-  <meta property="og:description" content="Statystyki słów, znaków, zdań, akapitów i czasu czytania na żywo podczas pisania, plus sprawdzian dopasowania do limitów znaków 27 platform. Za darmo, natychmiast, bez rejestracji.">
+  <meta property="og:description" content="Statystyki słów, znaków, zdań, akapitów i czasu czytania na żywo podczas pisania, plus sprawdzian dopasowania do limitów znaków 38 pól na 17 platformach. Za darmo, natychmiast, bez rejestracji.">
   <meta property="og:url" content="https://ultratextgen.com/pl/licznik-slow-i-znakow/">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://ultratextgen.com/assets/og/pl-licznik-slow-i-znakow.png">
@@ -79,7 +79,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <meta property="og:image:alt" content="Licznik Słów i Znaków — Darmowe Narzędzie Online | UltraTextGen">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Licznik Słów i Znaków — Darmowe Narzędzie Online | UltraTextGen">
-  <meta name="twitter:description" content="Statystyki słów, znaków, zdań, akapitów i czasu czytania na żywo podczas pisania, plus sprawdzian dopasowania do limitów znaków 27 platform. Za darmo, natychmiast, bez rejestracji.">
+  <meta name="twitter:description" content="Statystyki słów, znaków, zdań, akapitów i czasu czytania na żywo podczas pisania, plus sprawdzian dopasowania do limitów znaków 38 pól na 17 platformach. Za darmo, natychmiast, bez rejestracji.">
   <meta name="twitter:image" content="https://ultratextgen.com/assets/og/pl-licznik-slow-i-znakow.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -161,19 +161,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <section class="hero"><div class="hero-inner"><div class="hero-card">
   <h1 class="hero-headline">Licznik Słów i Znaków</h1>
-  <p class="hero-sub">Statystyki słów, znaków, zdań, akapitów i czasu czytania na żywo podczas pisania — plus sprawdzian, czy Twój tekst mieści się w limitach X/Twittera, Instagrama, TikToka, LinkedIn, YouTube, Discorda, Telegrama, SMS-ów i 18 innych platform.</p>
+  <p class="hero-sub">Liczniki na żywo dla 38 pól na 17 platformach — i poprawki jednym kliknięciem, gdy przekraczasz limit.</p>
 </div></div></section>
 
 <main class="container">
-  <section class="editorial-section">
-    <div class="editorial-block">
-      <p>Wpisz lub wklej dowolny tekst, a każda statystyka zaktualizuje się natychmiast: słowa, znaki (ze spacjami i bez), zdania, akapity, czas czytania oraz strony rozliczeniowe. Nad polem tekstowym wybierz, dokąd ten tekst trafia — licznik przeliczy go wtedy dokładnie tak, jak liczy to miejsce, i pokaże, ile Ci jeszcze zostało albo o ile przekraczasz limit. A gdy przekraczasz, podpowie, co konkretnie wyciąć, żeby się zmieścić — jednym kliknięciem i z możliwością cofnięcia. Nic nie jest wysyłane: każda liczba powstaje w Twojej przeglądarce. Potrzebujesz stylowej czcionki Unicode dla tekstu, który właśnie zmierzyłeś? <a href="/pl/">Główny generator UltraTextGen</a> zamieni go w ponad 100 stylów do skopiowania i wklejenia.</p>
-    </div>
-  </section>
-
-  <div class="section-divider"></div>
-
-  <div class="counter-tool">
+<div class="counter-tool">
     <div id="platformChecker"></div>
 
     <div class="counter-field">
@@ -215,12 +207,14 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     </div>
   </div>
 
+  <p class="counter-footnote">Wszystko liczy się w Twojej przeglądarce — nic, co wpiszesz, nie jest wysyłane ani zapisywane. Potrzebujesz tego tekstu również ostylowanego? <a href="/pl/">Generator UltraTextGen</a> zamieni go w ponad 100 czcionek do skopiowania i wklejenia.</p>
+
   <div class="section-divider"></div>
 
   <section class="editorial-section">
     <h2>Limity twarde a limity miękkie</h2>
     <p>„Limit znaków” oznacza dwie różne rzeczy, a od tego zależy, co naprawdę kosztuje Cię przekroczenie.</p>
-    <table class="comparison-table">
+    <div class="comparison-table-wrap"><table class="comparison-table">
       <thead><tr><th>Rodzaj</th><th>Co się dzieje po przekroczeniu</th><th>Przykłady</th></tr></thead>
       <tbody>
         <tr>
@@ -234,34 +228,38 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
           <td>Podpis na Instagramie po 125 · post na LinkedIn po ok. 140 (mobile) / 210 (desktop) · opis na YouTube po ok. 157</td>
         </tr>
       </tbody>
-    </table>
+    </table></div>
     <p>To limit miękki jest tym, pod który naprawdę się pisze, i prawie żaden licznik go nie pokazuje. Post na LinkedIn ma 3000 znaków i mniej więcej 140 użytecznych: cała reszta siedzi za kliknięciem, którego nikt nie wykonuje. Dlatego sprawdzian nad polem tekstowym rysuje miejsce ucięcia wprost — piszesz i od razu widzisz dokładnie ten fragment, który pokaże się przed „zobacz więcej”, z resztą przygaszoną pod linią cięcia, a obok to, czy ten sam początek broni się na każdym innym feedzie, który przycina.</p>
     <p><strong>Gdzie ucina każdy feed i na jakim urządzeniu:</strong></p>
-    <table class="comparison-table">
-      <thead><tr><th>Feed</th><th>Ucina po</th><th>Co to znaczy dla początku</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Feed</th><th class="num">Telefon</th><th class="num">Komputer</th><th>Co to znaczy dla początku</th></tr></thead>
       <tbody>
         <tr>
           <td>Post na LinkedIn</td>
-          <td>ok. 140 na telefonie<br>ok. 210 na komputerze</td>
+          <td class="num">ok. 140</td>
+          <td class="num">ok. 210</td>
           <td>Napisz do 140, a przetrwa w obu miejscach. To największa różnica między telefonem a komputerem z całej listy.</td>
         </tr>
         <tr>
           <td><a href="/pl/czcionki-na-instagram/">Podpis na Instagramie</a></td>
-          <td>ok. 125</td>
+          <td class="num">ok. 125</td>
+          <td class="num">ok. 125</td>
           <td>Najostrzejsze ucięcie z tej listy — mniej więcej jedno zdanie przed „... więcej”.</td>
         </tr>
         <tr>
           <td>Opis na YouTube</td>
-          <td>ok. 157</td>
+          <td class="num">ok. 157</td>
+          <td class="num">ok. 157</td>
           <td>Tyle widać pod tytułem przed „Pokaż więcej”, i to zwykle ten fragment trafia do wyników wyszukiwania.</td>
         </tr>
         <tr>
           <td><a href="/pl/czcionki-na-facebook/">Post na Facebooku</a></td>
-          <td>ok. 477</td>
+          <td class="num">ok. 477</td>
+          <td class="num">ok. 477</td>
           <td>Najbardziej wyrozumiałe ucięcie — przed cięciem mieści się cały krótki akapit.</td>
         </tr>
       </tbody>
-    </table>
+    </table></div>
     <p>Dwa uczciwe zastrzeżenia. To są zaobserwowane zachowania interfejsu, a nie limity ogłoszone przez platformy, więc traktuj je jako „tyle widać niezawodnie”, a nie jako dokładne progi. Poza tym feedy ucinają też po <em>liczbie wierszy</em>, więc trzy wczesne złamania linii potrafią zwinąć post dużo wcześniej, niż wynikałoby z jakiejkolwiek liczby znaków. Jeśli Twój początek opiera się na wyliczance, sprawdź go dodatkowo w prawdziwym oknie publikacji.</p>
   </section>
 
@@ -272,51 +270,51 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <p>Te same limity, których używa narzędzie powyżej, zebrane w tabeli. Przejdź do: <a href="#twitter">X/Twitter</a> · <a href="#discord">Discord</a> · <a href="#instagram">Instagram</a> · <a href="#tiktok">TikTok</a> · <a href="#sms">SMS</a> · <a href="#counting-modes">jak liczy każda platforma</a>.</p>
 
     <h3>Posty i wiadomości</h3>
-    <table class="comparison-table">
-      <thead><tr><th>Platforma</th><th>Limit</th><th>Uwagi</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Platforma</th><th class="num">Limit</th><th>Uwagi</th></tr></thead>
       <tbody>
-        <tr id="twitter"><td>Post na X / Twitterze</td><td>280</td><td>Liczone wagowo: każdy link = 23, większość emoji, symboli i ozdobnych liter = 2 — zobacz <a href="#counting-modes">jak liczy X</a></td></tr>
-        <tr id="discord"><td>Wiadomość na Discordzie</td><td>2000</td><td>4000 z Nitro; dłuższe wiadomości zamieniają się w załącznik .txt</td></tr>
-        <tr id="instagram"><td>Podpis na Instagramie</td><td>2200</td><td>Po pierwszych linijkach zwijany do „więcej”</td></tr>
-        <tr id="tiktok"><td>Podpis na TikToku</td><td>2200</td><td></td></tr>
-        <tr><td>Post na LinkedIn</td><td>3000</td><td>„Zobacz więcej” przycina po ok. 200–700 znakach, zależnie od urządzenia</td></tr>
-        <tr><td>Post na Facebooku</td><td>63&nbsp;206</td><td></td></tr>
-        <tr><td>Opis filmu na YouTube</td><td>5000</td><td></td></tr>
-        <tr><td>Opis pinu na Pintereście</td><td>500</td><td></td></tr>
-        <tr><td>Wiadomość na Telegramie</td><td>4096</td><td>1024 dla podpisu zdjęcia lub wideo</td></tr>
-        <tr><td>Post na Threads</td><td>500</td><td></td></tr>
-        <tr><td>Post na Bluesky</td><td>300</td><td>Liczone grafemami (tym, co widać), a nie punktami kodowymi</td></tr>
-        <tr><td>Tytuł posta na Reddicie</td><td>300</td><td></td></tr>
-        <tr><td>Post/status na Zalo</td><td>2000</td><td></td></tr>
+        <tr id="twitter"><td>Post na X / Twitterze</td><td class="num">280</td><td>Liczone wagowo: każdy link = 23, większość emoji, symboli i ozdobnych liter = 2 — zobacz <a href="#counting-modes">jak liczy X</a></td></tr>
+        <tr id="discord"><td>Wiadomość na Discordzie</td><td class="num">2000</td><td>4000 z Nitro; dłuższe wiadomości zamieniają się w załącznik .txt</td></tr>
+        <tr id="instagram"><td>Podpis na Instagramie</td><td class="num">2200</td><td>Po pierwszych linijkach zwijany do „więcej”</td></tr>
+        <tr id="tiktok"><td>Podpis na TikToku</td><td class="num">2200</td><td></td></tr>
+        <tr><td>Post na LinkedIn</td><td class="num">3000</td><td>„Zobacz więcej” przycina po ok. 200–700 znakach, zależnie od urządzenia</td></tr>
+        <tr><td>Post na Facebooku</td><td class="num">63&nbsp;206</td><td></td></tr>
+        <tr><td>Opis filmu na YouTube</td><td class="num">5000</td><td></td></tr>
+        <tr><td>Opis pinu na Pintereście</td><td class="num">500</td><td></td></tr>
+        <tr><td>Wiadomość na Telegramie</td><td class="num">4096</td><td>1024 dla podpisu zdjęcia lub wideo</td></tr>
+        <tr><td>Post na Threads</td><td class="num">500</td><td></td></tr>
+        <tr><td>Post na Bluesky</td><td class="num">300</td><td>Liczone grafemami (tym, co widać), a nie punktami kodowymi</td></tr>
+        <tr><td>Tytuł posta na Reddicie</td><td class="num">300</td><td></td></tr>
+        <tr><td>Post/status na Zalo</td><td class="num">2000</td><td></td></tr>
       </tbody>
-    </table>
+    </table></div>
 
     <h3>Bio i profile</h3>
-    <table class="comparison-table">
-      <thead><tr><th>Pole</th><th>Limit</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Pole</th><th class="num">Limit</th></tr></thead>
       <tbody>
-        <tr><td>Bio na Instagramie</td><td>150</td></tr>
-        <tr><td>Bio na TikToku</td><td>80</td></tr>
-        <tr><td>Nagłówek na LinkedIn</td><td>220</td></tr>
-        <tr><td>Sekcja „Info” na WhatsAppie</td><td>139</td></tr>
-        <tr><td>Bio na Telegramie</td><td>70</td></tr>
-        <tr><td>Status na VK</td><td>140</td></tr>
+        <tr><td>Bio na Instagramie</td><td class="num">150</td></tr>
+        <tr><td>Bio na TikToku</td><td class="num">80</td></tr>
+        <tr><td>Nagłówek na LinkedIn</td><td class="num">220</td></tr>
+        <tr><td>Sekcja „Info” na WhatsAppie</td><td class="num">139</td></tr>
+        <tr><td>Bio na Telegramie</td><td class="num">70</td></tr>
+        <tr><td>Status na VK</td><td class="num">140</td></tr>
       </tbody>
-    </table>
+    </table></div>
 
     <h3>Nazwy użytkownika, tytuły i SMS</h3>
-    <table class="comparison-table">
-      <thead><tr><th>Pole</th><th>Limit</th><th>Uwagi</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Pole</th><th class="num">Limit</th><th>Uwagi</th></tr></thead>
       <tbody>
-        <tr><td>Pseudonim na Discordzie</td><td>32</td><td></td></tr>
-        <tr><td>Nazwa użytkownika na TikToku</td><td>24</td><td>Tylko litery, cyfry, podkreślenia i kropki</td></tr>
-        <tr><td>Nazwa użytkownika na Instagramie</td><td>30</td><td></td></tr>
-        <tr><td>Tytuł filmu na YouTube</td><td>100</td><td></td></tr>
-        <tr><td>Tytuł meta pod SEO</td><td>~60</td><td>Google przycina według szerokości w pikselach — traktuj to jak wskazówkę</td></tr>
-        <tr><td>Opis meta pod SEO</td><td>~155</td><td>Tak samo — przycięcie według szerokości w pikselach</td></tr>
-        <tr id="sms"><td>Wiadomość SMS</td><td>160 / segment</td><td>Spada do 70 na segment, gdy pojawi się choć jeden znak spoza GSM-7 — a polskie ą ć ę ł ń ó ś ź ż są poza nim, więc SMS po polsku niemal zawsze liczy się po 70; zobacz <a href="#counting-modes">liczenie SMS-ów</a></td></tr>
+        <tr><td>Pseudonim na Discordzie</td><td class="num">32</td><td></td></tr>
+        <tr><td>Nazwa użytkownika na TikToku</td><td class="num">24</td><td>Tylko litery, cyfry, podkreślenia i kropki</td></tr>
+        <tr><td>Nazwa użytkownika na Instagramie</td><td class="num">30</td><td></td></tr>
+        <tr><td>Tytuł filmu na YouTube</td><td class="num">100</td><td></td></tr>
+        <tr><td>Tytuł meta pod SEO</td><td class="num">~60</td><td>Google przycina według szerokości w pikselach — traktuj to jak wskazówkę</td></tr>
+        <tr><td>Opis meta pod SEO</td><td class="num">~155</td><td>Tak samo — przycięcie według szerokości w pikselach</td></tr>
+        <tr id="sms"><td>Wiadomość SMS</td><td class="num">160 / segment</td><td>Spada do 70 na segment, gdy pojawi się choć jeden znak spoza GSM-7 — a polskie ą ć ę ł ń ó ś ź ż są poza nim, więc SMS po polsku niemal zawsze liczy się po 70; zobacz <a href="#counting-modes">liczenie SMS-ów</a></td></tr>
       </tbody>
-    </table>
+    </table></div>
   </section>
 
   <div class="section-divider"></div>
@@ -324,7 +322,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <section class="editorial-section" id="counting-modes">
     <h2>Dlaczego Twoja liczba znaków nie zgadza się z tą z platformy</h2>
     <p>Na pytanie „ile to znaków?” jest więcej niż jedna poprawna odpowiedź, bo platformy liczą w różnych jednostkach. Ten sam tekst może mieć cztery różne długości:</p>
-    <table class="comparison-table">
+    <div class="comparison-table-wrap"><table class="comparison-table">
       <thead><tr><th>Sposób liczenia</th><th>Co mierzy</th><th>Kto tak liczy</th></tr></thead>
       <tbody>
         <tr><td>Grafemy</td><td>To, co faktycznie widać — emoji z odcieniem skóry to 1</td><td>Bluesky; z grubsza tak samo Instagram traktuje emoji</td></tr>
@@ -332,7 +330,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
         <tr><td>Jednostki UTF-16</td><td>Sposób, w jaki tekst przechowuje JavaScript i wiele aplikacji — litery 𝗽𝗼𝗴𝗿𝘂𝗯𝗶𝗼𝗻𝗲 kosztują po 2</td><td>Pola formularzy HTML (<code>maxlength</code>), wiele gier i backendów aplikacji</td></tr>
         <tr><td>Bajty UTF-8</td><td>Rozmiar zapisu — ó to 2, 中 to 3, 𝗯 to 4</td><td>Pola ofert Amazona, nazwy na Steamie, bazy danych</td></tr>
       </tbody>
-    </table>
+    </table></div>
     <p>Wszystkie cztery widzisz na żywo w statystykach powyżej, więc gdy formularz twierdzi, że tekst jest za długi, a edytor tekstu się z tym nie zgadza, od razu wiadomo, którą jednostką liczy formularz. Dwa miejsca wymagają jeszcze dodatkowej reguły:</p>
     <p><strong>X / Twitter liczy wagowo, a nie po znakach.</strong> Zgodnie z opublikowanym przez X algorytmem (biblioteka <code>twitter-text</code>) każdy adres URL liczy się dokładnie jako 23, podstawowe litery łacińskie jako 1, a niemal wszystko inne — znaki CJK, większość emoji i każda „ozdobna” litera Unicode — jako <strong>2</strong>. Post w całości zapisany 𝗽𝗼𝗴𝗿𝘂𝗯𝗶𝗲𝗻𝗶𝗲𝗺 zmieści więc tylko 140 widocznych liter w budżecie 280. Opcja „X / Twitter” w sprawdzaniu powyżej stosuje ten prawdziwy algorytm. Polskie ą, ć, ę, ł, ń, ó, ś, ź, ż mieszczą się w zakresie o wadze 1, więc na X nie kosztują więcej niż zwykłe litery.</p>
     <p><strong>SMS liczy się w segmentach — a po polsku segment prawie zawsze ma 70 znaków.</strong> Wiadomość mieści 160 znaków tylko dopóty, dopóki wszystkie znaki należą do starego alfabetu GSM-7. Polskie znaki diakrytyczne — ą, ć, ę, ł, ń, ó, ś, ź, ż — do niego <em>nie</em> należą, podobnie jak emoji i cudzysłowy drukarskie „ ” wklejone z Worda. Wystarczy jeden taki znak, żeby cała wiadomość przeszła w tryb Unicode: 70 znaków na segment, a przy dłuższych wiadomościach 67. Dlatego „Dziękuję” zamiast „Dziekuje” potrafi zamienić jednego SMS-a w dwa — i to jest powód, dla którego masowe wysyłki po polsku często idą bez ogonków. Opcja „SMS” w sprawdzaniu powyżej wykrywa to i pokazuje dokładnie ten znak, który przełączył wiadomość.</p>
@@ -456,6 +454,9 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     foldMeta: "Widoczne: {shown} z {total} znaków · {hidden} ukrytych za kliknięciem",
     foldRoom: "Zostało jeszcze {n} znaków, zanim tekst zostanie zwinięty",
     foldDevices: "Na telefonie ucięcie po {m}, na komputerze po {d}.",
+    pastFold: "Mieści się — ucięte na {n} ⚠",
+    showAllFits: "Pokaż wszystkie ({n})",
+    showFewerFits: "Pokaż mniej",
     platformLabel: "Platforma",
     fieldLabel: "Pole",
     overBy: "Przekraczasz o {n} — wybierz poprawkę:",

--- a/pt/contador-de-palavras-e-caracteres/index.html
+++ b/pt/contador-de-palavras-e-caracteres/index.html
@@ -48,7 +48,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Contador de Palavras e Caracteres — Ferramenta Online Grátis | UltraTextGen</title>
-  <meta name="description" content="Contador de caracteres e contador de palavras grátis. Contagem ao vivo de palavras, caracteres, frases, parágrafos e tempo de leitura enquanto você digita, mais um verificador de limite para 27 plataformas — X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS e mais.">
+  <meta name="description" content="Contador de caracteres e contador de palavras grátis. Contagem ao vivo de palavras, caracteres, frases, parágrafos e tempo de leitura enquanto você digita, mais um verificador de limite para 38 campos em 17 plataformas — X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS e mais.">
   <link rel="canonical" href="https://ultratextgen.com/pt/contador-de-palavras-e-caracteres/">
 
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/character-counter/">
@@ -69,7 +69,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/character-counter/">
 
   <meta property="og:title" content="Contador de Palavras e Caracteres — Ferramenta Online Grátis | UltraTextGen">
-  <meta property="og:description" content="Contagem ao vivo de palavras, caracteres, frases, parágrafos e tempo de leitura, mais um verificador de limite para 27 plataformas. Grátis, instantâneo, sem cadastro.">
+  <meta property="og:description" content="Contagem ao vivo de palavras, caracteres, frases, parágrafos e tempo de leitura, mais um verificador de limite para 38 campos em 17 plataformas. Grátis, instantâneo, sem cadastro.">
   <meta property="og:url" content="https://ultratextgen.com/pt/contador-de-palavras-e-caracteres/">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="UltraTextGen">
@@ -80,7 +80,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <meta property="og:image:alt" content="Contador de Palavras e Caracteres — Ferramenta Online Grátis | UltraTextGen">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Contador de Palavras e Caracteres — Ferramenta Online Grátis | UltraTextGen">
-  <meta name="twitter:description" content="Contagem ao vivo de palavras, caracteres, frases, parágrafos e tempo de leitura, mais um verificador de limite para 27 plataformas. Grátis, instantâneo, sem cadastro.">
+  <meta name="twitter:description" content="Contagem ao vivo de palavras, caracteres, frases, parágrafos e tempo de leitura, mais um verificador de limite para 38 campos em 17 plataformas. Grátis, instantâneo, sem cadastro.">
   <meta name="twitter:image" content="https://ultratextgen.com/assets/og/pt-contador-de-palavras-e-caracteres.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -161,19 +161,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <section class="hero"><div class="hero-inner"><div class="hero-card">
   <h1 class="hero-headline">Contador de Palavras e Caracteres</h1>
-  <p class="hero-sub">Contagem ao vivo de palavras, caracteres, frases, parágrafos e tempo de leitura enquanto você digita — mais um verificador de se o seu texto cabe nos limites de X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS e outras 18 plataformas, com ajustes de um clique quando você passa.</p>
+  <p class="hero-sub">Contagem ao vivo de 38 campos em 17 plataformas — e ajustes de um clique quando você passa.</p>
 </div></div></section>
 
 <main class="container">
-  <section class="editorial-section">
-    <div class="editorial-block">
-      <p>Comece dizendo para onde o texto vai: escolha a plataforma e o campo logo acima da caixa e tudo passa a ser contado do jeito que aquele destino conta, e não com um número genérico. Digite ou cole abaixo e cada estatística se atualiza na hora: palavras, caracteres (com e sem espaços), frases, parágrafos e uma estimativa do tempo de leitura. Nada é enviado — cada número é calculado direto no seu navegador. E se você passar do limite, a ferramenta não para por aí: ela sugere cortes concretos, com a economia exata de cada um, num clique e com opção de desfazer. Precisa de fontes Unicode estilosas para o texto que você acabou de medir? O <a href="/pt/">gerador principal do UltraTextGen</a> transforma ele em mais de 100 estilos para copiar e colar.</p>
-    </div>
-  </section>
-
-  <div class="section-divider"></div>
-
-  <div class="counter-tool">
+<div class="counter-tool">
     <div id="platformChecker"></div>
 
     <div class="counter-field">
@@ -214,12 +206,14 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     </div>
   </div>
 
+  <p class="counter-footnote">Tudo é calculado no seu navegador — nada do que você digita é enviado ou armazenado. Quer o texto estilizado também? O <a href="/pt/">gerador do UltraTextGen</a> transforma ele em mais de 100 fontes para copiar e colar.</p>
+
   <div class="section-divider"></div>
 
   <section class="editorial-section">
     <h2>Limite rígido e limite flexível</h2>
     <p>Duas coisas bem diferentes são chamadas de «limite de caracteres», e a diferença muda o que passar do limite custa para você.</p>
-    <table class="comparison-table">
+    <div class="comparison-table-wrap"><table class="comparison-table">
       <thead><tr><th>Tipo</th><th>O que acontece se você passar</th><th>Exemplos</th></tr></thead>
       <tbody>
         <tr>
@@ -233,34 +227,38 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
           <td>Legenda do Instagram depois de 125 · Post do LinkedIn depois de ~140 no celular / ~210 no computador · Descrição do YouTube depois de ~157</td>
         </tr>
       </tbody>
-    </table>
+    </table></div>
     <p>O limite flexível é aquele contra o qual quase todo mundo escreve de verdade, e quase nenhum contador mostra. Um post do LinkedIn tem 3.000 caracteres e uns 140 úteis: o resto fica atrás de um toque que quase ninguém dá. Por isso o contador acima desenha o corte direto — digite e você vê exatamente o texto que aparece antes do «ver mais», com todo o resto esmaecido atrás de uma linha, além de como essa mesma abertura se sai em cada outro feed que corta.</p>
     <p><strong>Onde cada feed corta, e em qual aparelho:</strong></p>
-    <table class="comparison-table">
-      <thead><tr><th>Feed</th><th>Corta em</th><th>O que isso significa para o gancho</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Feed</th><th class="num">Celular</th><th class="num">Computador</th><th>O que isso significa para o gancho</th></tr></thead>
       <tbody>
         <tr>
           <td>Post do LinkedIn</td>
-          <td>~140 no celular<br>~210 no computador</td>
+          <td class="num">~140</td>
+          <td class="num">~210</td>
           <td>Escreva pensando em 140 e a abertura sobrevive aos dois. É a maior diferença entre celular e computador desta lista.</td>
         </tr>
         <tr>
           <td><a href="/pt/fontes-para-instagram/">Legenda do Instagram</a></td>
-          <td>~125</td>
+          <td class="num">~125</td>
+          <td class="num">~125</td>
           <td>O corte mais apertado da lista — mais ou menos uma frase antes do «… mais».</td>
         </tr>
         <tr>
           <td>Descrição do YouTube</td>
-          <td>~157</td>
+          <td class="num">~157</td>
+          <td class="num">~157</td>
           <td>O que aparece abaixo do título antes do «Mostrar mais» — e muitas vezes o que a busca exibe.</td>
         </tr>
         <tr>
           <td><a href="/pt/fontes-para-facebook/">Post do Facebook</a></td>
-          <td>~477</td>
+          <td class="num">~477</td>
+          <td class="num">~477</td>
           <td>O corte mais generoso — um parágrafo curto inteiro cabe antes dele.</td>
         </tr>
       </tbody>
-    </table>
+    </table></div>
     <p>Duas ressalvas honestas. Esses números vêm do comportamento observado da interface, não de limites publicados: encare-os como «o que aparece de forma confiável», e não como um valor exato. E os feeds também cortam por <em>número de linhas</em>: três quebras de linha logo no começo podem cortar um post bem antes de qualquer contagem de caracteres. Se a sua abertura depende de uma lista, teste também no editor real.</p>
   </section>
 
@@ -271,51 +269,51 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <p>Os mesmos limites que o verificador acima usa, em forma de tabela de consulta. Pule para: <a href="#twitter">X/Twitter</a> · <a href="#discord">Discord</a> · <a href="#instagram">Instagram</a> · <a href="#tiktok">TikTok</a> · <a href="#sms">SMS</a> · <a href="#unidades-de-contagem">como cada plataforma conta</a>.</p>
 
     <h3>Posts e mensagens</h3>
-    <table class="comparison-table">
-      <thead><tr><th>Plataforma</th><th>Limite</th><th>Observações</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Plataforma</th><th class="num">Limite</th><th>Observações</th></tr></thead>
       <tbody>
-        <tr id="twitter"><td>Post no X / Twitter</td><td>280</td><td>Contagem ponderada: cada URL = 23, e a maioria dos emojis, símbolos e letras estilizadas = 2 — veja <a href="#unidades-de-contagem">como o X conta</a></td></tr>
-        <tr id="discord"><td>Mensagem do Discord</td><td>2.000</td><td>4.000 com Nitro; mensagens maiores viram um anexo .txt</td></tr>
-        <tr id="instagram"><td>Legenda do Instagram</td><td>2.200</td><td>Cortada com «mais» depois das primeiras linhas</td></tr>
-        <tr id="tiktok"><td>Legenda do TikTok</td><td>2.200</td><td></td></tr>
-        <tr><td>Post do LinkedIn</td><td>3.000</td><td>O «ver mais» corta por volta de 200–700 caracteres, dependendo do aparelho</td></tr>
-        <tr><td>Post do Facebook</td><td>63.206</td><td></td></tr>
-        <tr><td>Descrição do YouTube</td><td>5.000</td><td></td></tr>
-        <tr><td>Descrição de pin do Pinterest</td><td>500</td><td></td></tr>
-        <tr><td>Mensagem do Telegram</td><td>4.096</td><td>1.024 para a legenda de uma foto ou vídeo</td></tr>
-        <tr><td>Post do Threads</td><td>500</td><td></td></tr>
-        <tr><td>Post do Bluesky</td><td>300</td><td>Contado por grafemas (o que você vê), e não por pontos de código</td></tr>
-        <tr><td>Título de post do Reddit</td><td>300</td><td></td></tr>
-        <tr><td>Post/status do Zalo</td><td>2.000</td><td></td></tr>
+        <tr id="twitter"><td>Post no X / Twitter</td><td class="num">280</td><td>Contagem ponderada: cada URL = 23, e a maioria dos emojis, símbolos e letras estilizadas = 2 — veja <a href="#unidades-de-contagem">como o X conta</a></td></tr>
+        <tr id="discord"><td>Mensagem do Discord</td><td class="num">2.000</td><td>4.000 com Nitro; mensagens maiores viram um anexo .txt</td></tr>
+        <tr id="instagram"><td>Legenda do Instagram</td><td class="num">2.200</td><td>Cortada com «mais» depois das primeiras linhas</td></tr>
+        <tr id="tiktok"><td>Legenda do TikTok</td><td class="num">2.200</td><td></td></tr>
+        <tr><td>Post do LinkedIn</td><td class="num">3.000</td><td>O «ver mais» corta por volta de 200–700 caracteres, dependendo do aparelho</td></tr>
+        <tr><td>Post do Facebook</td><td class="num">63.206</td><td></td></tr>
+        <tr><td>Descrição do YouTube</td><td class="num">5.000</td><td></td></tr>
+        <tr><td>Descrição de pin do Pinterest</td><td class="num">500</td><td></td></tr>
+        <tr><td>Mensagem do Telegram</td><td class="num">4.096</td><td>1.024 para a legenda de uma foto ou vídeo</td></tr>
+        <tr><td>Post do Threads</td><td class="num">500</td><td></td></tr>
+        <tr><td>Post do Bluesky</td><td class="num">300</td><td>Contado por grafemas (o que você vê), e não por pontos de código</td></tr>
+        <tr><td>Título de post do Reddit</td><td class="num">300</td><td></td></tr>
+        <tr><td>Post/status do Zalo</td><td class="num">2.000</td><td></td></tr>
       </tbody>
-    </table>
+    </table></div>
 
     <h3>Bios e perfis</h3>
-    <table class="comparison-table">
-      <thead><tr><th>Campo</th><th>Limite</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Campo</th><th class="num">Limite</th></tr></thead>
       <tbody>
-        <tr><td>Bio do Instagram</td><td>150</td></tr>
-        <tr><td>Bio do TikTok</td><td>80</td></tr>
-        <tr><td>Título do LinkedIn</td><td>220</td></tr>
-        <tr><td>Recado do WhatsApp</td><td>139</td></tr>
-        <tr><td>Bio do Telegram</td><td>70</td></tr>
-        <tr><td>Status do VK</td><td>140</td></tr>
+        <tr><td>Bio do Instagram</td><td class="num">150</td></tr>
+        <tr><td>Bio do TikTok</td><td class="num">80</td></tr>
+        <tr><td>Título do LinkedIn</td><td class="num">220</td></tr>
+        <tr><td>Recado do WhatsApp</td><td class="num">139</td></tr>
+        <tr><td>Bio do Telegram</td><td class="num">70</td></tr>
+        <tr><td>Status do VK</td><td class="num">140</td></tr>
       </tbody>
-    </table>
+    </table></div>
 
     <h3>Nomes de usuário, títulos e SMS</h3>
-    <table class="comparison-table">
-      <thead><tr><th>Campo</th><th>Limite</th><th>Observações</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Campo</th><th class="num">Limite</th><th>Observações</th></tr></thead>
       <tbody>
-        <tr><td>Apelido do Discord</td><td>32</td><td></td></tr>
-        <tr><td>Nome de usuário do TikTok</td><td>24</td><td>Só letras, números, sublinhados e pontos</td></tr>
-        <tr><td>Nome de usuário do Instagram</td><td>30</td><td></td></tr>
-        <tr><td>Título do YouTube</td><td>100</td><td></td></tr>
-        <tr><td>Meta título (SEO)</td><td>~60</td><td>O Google corta pela largura em pixels — trate como referência</td></tr>
-        <tr><td>Meta descrição (SEO)</td><td>~155</td><td>Mesma coisa — o corte é por largura em pixels</td></tr>
-        <tr id="sms"><td>Mensagem SMS</td><td>160 / segmento</td><td>Cai para 70 por segmento assim que aparece um caractere fora do GSM-7 (um emoji, uma aspa curva, um ã, um ç…) — veja <a href="#unidades-de-contagem">como o SMS é contado</a></td></tr>
+        <tr><td>Apelido do Discord</td><td class="num">32</td><td></td></tr>
+        <tr><td>Nome de usuário do TikTok</td><td class="num">24</td><td>Só letras, números, sublinhados e pontos</td></tr>
+        <tr><td>Nome de usuário do Instagram</td><td class="num">30</td><td></td></tr>
+        <tr><td>Título do YouTube</td><td class="num">100</td><td></td></tr>
+        <tr><td>Meta título (SEO)</td><td class="num">~60</td><td>O Google corta pela largura em pixels — trate como referência</td></tr>
+        <tr><td>Meta descrição (SEO)</td><td class="num">~155</td><td>Mesma coisa — o corte é por largura em pixels</td></tr>
+        <tr id="sms"><td>Mensagem SMS</td><td class="num">160 / segmento</td><td>Cai para 70 por segmento assim que aparece um caractere fora do GSM-7 (um emoji, uma aspa curva, um ã, um ç…) — veja <a href="#unidades-de-contagem">como o SMS é contado</a></td></tr>
       </tbody>
-    </table>
+    </table></div>
   </section>
 
   <div class="section-divider"></div>
@@ -323,7 +321,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <section class="editorial-section" id="unidades-de-contagem">
     <h2>Por que a sua contagem não bate com a da plataforma</h2>
     <p>«Quantos caracteres tem isso?» tem mais de uma resposta certa, porque cada plataforma conta numa unidade diferente. O mesmo texto pode ter quatro tamanhos:</p>
-    <table class="comparison-table">
+    <div class="comparison-table-wrap"><table class="comparison-table">
       <thead><tr><th>Unidade de contagem</th><th>O que ela mede</th><th>Quem usa</th></tr></thead>
       <tbody>
         <tr><td>Grafemas</td><td>O que você vê na tela: um emoji com tom de pele é 1</td><td>Bluesky; e mais ou menos como o Instagram trata emoji</td></tr>
@@ -331,7 +329,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
         <tr><td>Unidades UTF-16</td><td>Como o JavaScript e muitos apps guardam texto: cada letra 𝗻𝗲𝗴𝗿𝗶𝘁𝗼 custa 2</td><td>Campos de formulário HTML (<code>maxlength</code>), muitos jogos e back-ends de app</td></tr>
         <tr><td>Bytes UTF-8</td><td>Tamanho em armazenamento: é são 2, 中 são 3, 𝗯 são 4</td><td>Campos de anúncio da Amazon (títulos de 200 bytes), nomes na Steam, bancos de dados</td></tr>
       </tbody>
-    </table>
+    </table></div>
     <p>As quatro aparecem ao vivo nas estatísticas acima, então quando um formulário disser que o seu texto é longo demais e o seu editor de texto discordar, dá para ver exatamente qual contagem o formulário está usando. Dois casos ainda precisam de regra própria:</p>
     <p><strong>O X / Twitter conta por peso, não por caractere.</strong> Pelo algoritmo que o próprio X publica (a biblioteca <code>twitter-text</code>), cada URL conta exatamente 23, letras latinas básicas contam 1 e quase todo o resto — caracteres CJK, a maioria dos emojis e toda letra Unicode «estilizada» — conta <strong>2</strong>. Por isso um post inteiro em 𝗻𝗲𝗴𝗿𝗶𝘁𝗼 só cabe 140 letras visíveis dentro dos 280. A opção «Post no X / Twitter» do verificador implementa esse algoritmo de verdade.</p>
     <p><strong>SMS é contado em segmentos, e o português quase sempre sai do alfabeto barato.</strong> Uma mensagem só cabe 160 caracteres enquanto todos eles estiverem no velho alfabeto GSM-7 — e ele é curto: à, é, è, ì, ò, ù, ñ e ü passam, mas ã, õ, ç, ê, ô, á, í, ó e ú não. Ou seja, um simples «não», «coração» ou «você» já muda a mensagem inteira para o modo Unicode: 70 caracteres por segmento, 67 quando ela se divide em vários. Vale o mesmo para um emoji ou uma aspa curva colada do Word. Escolha «SMS» acima e o contador mostra em que modo você está e qual caractere exato causou a virada.</p>
@@ -343,14 +341,14 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <h2>Com espaço ou sem espaço? E o que é uma lauda?</h2>
     <p>Sistemas de submissão — revistas acadêmicas, plataformas de eventos, formulários de inscrição — em regra contam os caracteres <strong>com espaço</strong>: o campo simplesmente conta tudo o que você digita, e um espaço é um caractere como qualquer outro. Por isso o contador acima mostra os dois números ao vivo, lado a lado: use «Caracteres» (com espaços) sempre que o edital não especificar, e «Caracteres (sem espaços)» só quando o texto pedir isso por escrito.</p>
     <p>Já a <strong>lauda</strong> não tem um padrão único no Brasil — cada redação, editora ou prestador define a sua:</p>
-    <table class="comparison-table">
+    <div class="comparison-table-wrap"><table class="comparison-table">
       <thead><tr><th>Definição de lauda</th><th>Contagem</th></tr></thead>
       <tbody>
         <tr><td>Lauda jornalística clássica</td><td>1.800 caracteres sem espaço</td></tr>
         <tr><td>Variante comum em tradução e revisão</td><td>2.000 caracteres (com ou sem espaços, conforme o prestador)</td></tr>
         <tr><td>Lauda editorial — a usada pelo medidor acima</td><td>2.100 caracteres com espaços</td></tr>
       </tbody>
-    </table>
+    </table></div>
     <p>A estatística «Laudas» acima usa <strong>2.100 caracteres com espaços</strong> por lauda. Antes de fechar um orçamento ou entregar um trabalho medido em laudas, confirme qual definição o cliente, a editora ou a banca usa — entre 1.800 sem espaço e 2.100 com espaços, o mesmo texto muda de tamanho em laudas.</p>
     <p>Plataformas de venda têm tetos rígidos parecidos: no Mercado Livre, o título de um anúncio aceita no máximo <strong>60 caracteres</strong> — passe disso e o site recusa com um aviso do tipo «Reduza o título». Cole o título no contador acima e acompanhe a estatística «Caracteres» antes de publicar.</p>
   </section>
@@ -470,6 +468,9 @@ window.UTG_COUNTER_I18N = {
   applied: "Aplicado",
   fitsHeading: "Onde mais esse texto cabe",
   segShort: "segm.",
+  pastFold: "Cabe — corta em {n} ⚠",
+  showAllFits: "Ver todos os {n}",
+  showFewerFits: "Ver menos",
   foldHeading: "O que as pessoas veem antes do «ver mais»",
   foldMore: "ver mais",
   foldMeta: "{shown} de {total} caracteres à vista · {hidden} escondidos atrás do toque",

--- a/ru/schetchik-slov-i-simvolov/index.html
+++ b/ru/schetchik-slov-i-simvolov/index.html
@@ -161,19 +161,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <section class="hero"><div class="hero-inner"><div class="hero-card">
   <h1 class="hero-headline">Счётчик символов и слов</h1>
-  <p class="hero-sub">Слова, символы, предложения, абзацы и время чтения считаются на лету по мере набора — плюс проверка, помещается ли текст в лимиты ВКонтакте, Telegram, X/Twitter, Instagram, TikTok, YouTube, Discord и других платформ.</p>
+  <p class="hero-sub">Подсчёт на лету для 38 полей на 17 платформах — и исправления в один клик, если вы вышли за лимит.</p>
 </div></div></section>
 
 <main class="container">
-  <section class="editorial-section">
-    <div class="editorial-block">
-      <p>Введите или вставьте любой текст — и все показатели обновятся мгновенно: слова, символы (с пробелами и без), предложения, абзацы, время чтения и тысячи знаков. Над полем ввода выберите, куда пойдёт этот текст: счётчик посчитает его ровно так, как считает эта площадка, и покажет, сколько символов осталось или на сколько вы вышли за лимит. А если вышли — подскажет, что именно вырезать, чтобы уместиться: одно нажатие, и всё можно отменить. Ничто не загружается на сервер — каждое число считается прямо в вашем браузере. Нужны стильные Unicode-шрифты для только что посчитанного текста? <a href="/ru/">Основной генератор UltraTextGen</a> превратит его в более чем 100 стилей для копирования и вставки.</p>
-    </div>
-  </section>
-
-  <div class="section-divider"></div>
-
-  <div class="counter-tool">
+<div class="counter-tool">
     <div id="platformChecker"></div>
 
     <div class="counter-field">
@@ -214,12 +206,14 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     </div>
   </div>
 
+  <p class="counter-footnote">Всё считается прямо в вашем браузере — ничто из введённого не загружается и не сохраняется. Нужен ещё и стильный шрифт? <a href="/ru/">Генератор UltraTextGen</a> превратит текст в более чем 100 шрифтов для копирования и вставки.</p>
+
   <div class="section-divider"></div>
 
   <section class="editorial-section">
     <h2>Жёсткие и мягкие лимиты</h2>
     <p>«Лимитом символов» называют две разные вещи, и от этого зависит, чем именно обернётся превышение.</p>
-    <table class="comparison-table">
+    <div class="comparison-table-wrap"><table class="comparison-table">
       <thead><tr><th>Тип</th><th>Что будет при превышении</th><th>Примеры</th></tr></thead>
       <tbody>
         <tr>
@@ -233,34 +227,38 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
           <td>Подпись в Instagram после 125 · пост в LinkedIn после ~140 на мобильном / ~210 на десктопе · описание на YouTube после ~157</td>
         </tr>
       </tbody>
-    </table>
+    </table></div>
     <p>Именно под мягкий лимит люди и пишут на самом деле, но почти ни один счётчик его не показывает. У поста в LinkedIn 3000 символов — и примерно 140 полезных: всё остальное спрятано за нажатием, которого почти никто не делает. Поэтому проверка над полем ввода рисует место сворачивания прямо: вы пишете и сразу видите тот самый фрагмент, который покажется до «ещё», а всё, что после среза, приглушено под линией; рядом видно и то, выдерживает ли это же начало сворачивание в остальных лентах.</p>
     <p><strong>Где сворачивает каждая лента и на каком устройстве:</strong></p>
-    <table class="comparison-table">
-      <thead><tr><th>Лента</th><th>Сворачивает на</th><th>Что это значит для первой фразы</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Лента</th><th class="num">Телефон</th><th class="num">Компьютер</th><th>Что это значит для первой фразы</th></tr></thead>
       <tbody>
         <tr>
           <td>Пост в LinkedIn</td>
-          <td>~140 на телефоне<br>~210 на компьютере</td>
+          <td class="num">~140</td>
+          <td class="num">~210</td>
           <td>Уложитесь в 140 — и начало уцелеет и там, и там. Самый большой разрыв между телефоном и компьютером во всём списке.</td>
         </tr>
         <tr>
           <td><a href="/ru/shrift-dlya-instagram/">Подпись в Instagram</a></td>
-          <td>~125</td>
+          <td class="num">~125</td>
+          <td class="num">~125</td>
           <td>Самый жёсткий срез в списке — примерно одно предложение до «... ещё».</td>
         </tr>
         <tr>
           <td>Описание на YouTube</td>
-          <td>~157</td>
+          <td class="num">~157</td>
+          <td class="num">~157</td>
           <td>Столько видно под названием ролика до кнопки «Ещё»; этот же фрагмент чаще всего попадает и в поиск.</td>
         </tr>
         <tr>
           <td>Пост в Facebook</td>
-          <td>~477</td>
+          <td class="num">~477</td>
+          <td class="num">~477</td>
           <td>Самый щадящий срез — до сворачивания помещается целый короткий абзац.</td>
         </tr>
       </tbody>
-    </table>
+    </table></div>
     <p>Две честные оговорки. Это наблюдаемое поведение интерфейса, а не опубликованные лимиты: читайте их как «столько видно стабильно», а не как точные пороги. И ленты сворачивают текст ещё и по <em>числу строк</em>, поэтому три переноса строки в самом начале свернут пост гораздо раньше любого числа символов. Если начало держится на списке, проверьте его и в самом окне публикации.</p>
   </section>
 
@@ -271,52 +269,52 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <p>Те же лимиты, которыми пользуется счётчик выше, — в виде справочной таблицы. Перейти к: <a href="#vk">ВКонтакте</a> · <a href="#twitter">X/Twitter</a> · <a href="#discord">Discord</a> · <a href="#instagram">Instagram</a> · <a href="#tiktok">TikTok</a> · <a href="#sms">SMS</a> · <a href="#counting-modes">как считает каждая площадка</a>.</p>
 
     <h3>Посты и сообщения</h3>
-    <table class="comparison-table">
-      <thead><tr><th>Площадка</th><th>Лимит</th><th>Примечания</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Площадка</th><th class="num">Лимит</th><th>Примечания</th></tr></thead>
       <tbody>
-        <tr id="vk"><td>Запись ВКонтакте (стена)</td><td>15 940</td><td>Личное сообщение — 4096</td></tr>
-        <tr id="twitter"><td>Пост в X / Twitter</td><td>280</td><td>Считается по весу: каждая ссылка = 23, большинство эмодзи, символов и декоративных букв = 2 — см. <a href="#counting-modes">как считает X</a></td></tr>
-        <tr id="discord"><td>Сообщение в Discord</td><td>2000</td><td>4000 с Nitro; более длинное сообщение превращается в вложение .txt</td></tr>
-        <tr id="instagram"><td>Подпись в Instagram</td><td>2200</td><td>После первых строк сворачивается в «ещё»</td></tr>
-        <tr id="tiktok"><td>Подпись в TikTok</td><td>2200</td><td></td></tr>
-        <tr><td>Пост в LinkedIn</td><td>3000</td><td>«Показать ещё» сворачивает примерно после 200–700 символов, в зависимости от устройства</td></tr>
-        <tr><td>Пост в Facebook</td><td>63 206</td><td></td></tr>
-        <tr><td>Описание видео на YouTube</td><td>5000</td><td></td></tr>
-        <tr><td>Описание пина в Pinterest</td><td>500</td><td></td></tr>
-        <tr><td>Сообщение в Telegram</td><td>4096</td><td>1024 для подписи к фото или видео</td></tr>
-        <tr><td>Пост в Threads</td><td>500</td><td></td></tr>
-        <tr><td>Пост в Bluesky</td><td>300</td><td>Считается по графемам (по тому, что видно), а не по кодовым точкам</td></tr>
-        <tr><td>Заголовок поста на Reddit</td><td>300</td><td></td></tr>
-        <tr><td>Пост/статус в Zalo</td><td>2000</td><td></td></tr>
+        <tr id="vk"><td>Запись ВКонтакте (стена)</td><td class="num">15 940</td><td>Личное сообщение — 4096</td></tr>
+        <tr id="twitter"><td>Пост в X / Twitter</td><td class="num">280</td><td>Считается по весу: каждая ссылка = 23, большинство эмодзи, символов и декоративных букв = 2 — см. <a href="#counting-modes">как считает X</a></td></tr>
+        <tr id="discord"><td>Сообщение в Discord</td><td class="num">2000</td><td>4000 с Nitro; более длинное сообщение превращается в вложение .txt</td></tr>
+        <tr id="instagram"><td>Подпись в Instagram</td><td class="num">2200</td><td>После первых строк сворачивается в «ещё»</td></tr>
+        <tr id="tiktok"><td>Подпись в TikTok</td><td class="num">2200</td><td></td></tr>
+        <tr><td>Пост в LinkedIn</td><td class="num">3000</td><td>«Показать ещё» сворачивает примерно после 200–700 символов, в зависимости от устройства</td></tr>
+        <tr><td>Пост в Facebook</td><td class="num">63 206</td><td></td></tr>
+        <tr><td>Описание видео на YouTube</td><td class="num">5000</td><td></td></tr>
+        <tr><td>Описание пина в Pinterest</td><td class="num">500</td><td></td></tr>
+        <tr><td>Сообщение в Telegram</td><td class="num">4096</td><td>1024 для подписи к фото или видео</td></tr>
+        <tr><td>Пост в Threads</td><td class="num">500</td><td></td></tr>
+        <tr><td>Пост в Bluesky</td><td class="num">300</td><td>Считается по графемам (по тому, что видно), а не по кодовым точкам</td></tr>
+        <tr><td>Заголовок поста на Reddit</td><td class="num">300</td><td></td></tr>
+        <tr><td>Пост/статус в Zalo</td><td class="num">2000</td><td></td></tr>
       </tbody>
-    </table>
+    </table></div>
 
     <h3>Профили и статусы</h3>
-    <table class="comparison-table">
-      <thead><tr><th>Поле</th><th>Лимит</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Поле</th><th class="num">Лимит</th></tr></thead>
       <tbody>
-        <tr><td>Статус ВКонтакте</td><td>140</td></tr>
-        <tr><td>Описание профиля Instagram</td><td>150</td></tr>
-        <tr><td>Описание профиля TikTok</td><td>80</td></tr>
-        <tr><td>Заголовок профиля LinkedIn</td><td>220</td></tr>
-        <tr><td>Статус «О себе» в WhatsApp</td><td>139</td></tr>
-        <tr><td>Описание профиля Telegram</td><td>70</td></tr>
+        <tr><td>Статус ВКонтакте</td><td class="num">140</td></tr>
+        <tr><td>Описание профиля Instagram</td><td class="num">150</td></tr>
+        <tr><td>Описание профиля TikTok</td><td class="num">80</td></tr>
+        <tr><td>Заголовок профиля LinkedIn</td><td class="num">220</td></tr>
+        <tr><td>Статус «О себе» в WhatsApp</td><td class="num">139</td></tr>
+        <tr><td>Описание профиля Telegram</td><td class="num">70</td></tr>
       </tbody>
-    </table>
+    </table></div>
 
     <h3>Ники, заголовки и SMS</h3>
-    <table class="comparison-table">
-      <thead><tr><th>Поле</th><th>Лимит</th><th>Примечания</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Поле</th><th class="num">Лимит</th><th>Примечания</th></tr></thead>
       <tbody>
-        <tr><td>Ник на сервере Discord</td><td>32</td><td></td></tr>
-        <tr><td>Имя пользователя TikTok</td><td>24</td><td>Только буквы, цифры, подчёркивания и точки</td></tr>
-        <tr><td>Имя пользователя Instagram</td><td>30</td><td></td></tr>
-        <tr><td>Название видео на YouTube</td><td>100</td><td></td></tr>
-        <tr><td>SEO title (заголовок)</td><td>~60</td><td>Google обрезает по ширине в пикселях — считайте это ориентиром</td></tr>
-        <tr><td>SEO description (описание)</td><td>~155</td><td>То же самое — обрезка по ширине в пикселях</td></tr>
-        <tr id="sms"><td>SMS</td><td>160 / сегмент</td><td>Кириллицы нет в алфавите GSM-7, поэтому <strong>любое сообщение на русском — 70 символов в сегменте</strong>, а не 160 — см. <a href="#counting-modes">как считается SMS</a></td></tr>
+        <tr><td>Ник на сервере Discord</td><td class="num">32</td><td></td></tr>
+        <tr><td>Имя пользователя TikTok</td><td class="num">24</td><td>Только буквы, цифры, подчёркивания и точки</td></tr>
+        <tr><td>Имя пользователя Instagram</td><td class="num">30</td><td></td></tr>
+        <tr><td>Название видео на YouTube</td><td class="num">100</td><td></td></tr>
+        <tr><td>SEO title (заголовок)</td><td class="num">~60</td><td>Google обрезает по ширине в пикселях — считайте это ориентиром</td></tr>
+        <tr><td>SEO description (описание)</td><td class="num">~155</td><td>То же самое — обрезка по ширине в пикселях</td></tr>
+        <tr id="sms"><td>SMS</td><td class="num">160 / сегмент</td><td>Кириллицы нет в алфавите GSM-7, поэтому <strong>любое сообщение на русском — 70 символов в сегменте</strong>, а не 160 — см. <a href="#counting-modes">как считается SMS</a></td></tr>
       </tbody>
-    </table>
+    </table></div>
   </section>
 
   <div class="section-divider"></div>
@@ -324,7 +322,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <section class="editorial-section" id="counting-modes">
     <h2>Почему ваше число символов не совпадает с числом платформы</h2>
     <p>У вопроса «сколько тут символов?» больше одного правильного ответа: площадки считают в разных единицах. У одного и того же текста может быть четыре разных длины:</p>
-    <table class="comparison-table">
+    <div class="comparison-table-wrap"><table class="comparison-table">
       <thead><tr><th>Единица подсчёта</th><th>Что измеряет</th><th>Кто так считает</th></tr></thead>
       <tbody>
         <tr><td>Графемы</td><td>То, что видно глазом — эмодзи с оттенком кожи это 1</td><td>Bluesky; примерно так же Instagram обходится с эмодзи</td></tr>
@@ -332,7 +330,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
         <tr><td>Единицы UTF-16</td><td>Как текст хранят JavaScript и многие приложения — декоративные буквы вроде 𝗯𝗼𝗹𝗱 стоят по 2</td><td>Поля HTML-форм (<code>maxlength</code>), многие игры и бэкенды приложений</td></tr>
         <tr><td>Байты UTF-8</td><td>Размер записи — русская буква это 2, 中 — 3, 𝗯 — 4</td><td>Поля товаров Amazon, имена в Steam, базы данных</td></tr>
       </tbody>
-    </table>
+    </table></div>
     <p>Все четыре величины показаны выше на лету, так что если форма считает текст слишком длинным, а текстовый редактор с ней не согласен, сразу видно, какой именно единицей меряет форма. Двум площадкам нужны отдельные правила сверх этого:</p>
     <p><strong>X / Twitter считает по весу, а не по символам.</strong> По опубликованному самой X алгоритму (библиотека <code>twitter-text</code>) каждая ссылка считается ровно за 23, а почти всё, что лежит выше U+10FF, — иероглифы, большинство эмодзи и каждая «декоративная» буква Unicode — за <strong>2</strong>. Кириллица в этот диапазон не попадает и весит <strong>1</strong> — ровно как латиница, так что пост на русском вмещает полные 280 знаков. А вот текст, набранный декоративным шрифтом (𝗯𝗼𝗹𝗱, 𝓼𝓬𝓻𝓲𝓹𝓽 — такие алфавиты в Unicode есть в основном для латиницы), урезает бюджет вдвое: 140 видимых букв вместо 280. Вариант «X / Twitter» в проверке выше применяет этот настоящий алгоритм.</p>
     <p><strong>SMS считается сегментами, и на русском сегмент всегда 70 символов.</strong> Сообщение вмещает 160 символов только пока все знаки входят в старый алфавит GSM-7 — а кириллицы в нём нет вообще, ни одной буквы. Поэтому любое русскоязычное SMS кодируется как UCS-2: <strong>70 символов в сегменте</strong>, а при разбиении на части — 67. Отсюда и разница в цене: сообщение на 200 символов на латинице уйдёт двумя сегментами, а на русском — тремя. Эмодзи и «кавычки-ёлочки», вставленные из Word, дают тот же эффект и для латиницы. Вариант «SMS» в проверке выше определяет это автоматически и показывает число сегментов, кодировку и точный символ, который перевёл сообщение в режим Unicode.</p>
@@ -470,6 +468,9 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       foldMeta: "Видно {shown} символов из {total} · {hidden} скрыто за нажатием",
       foldRoom: "До сворачивания осталось ещё {n} символов",
       foldDevices: "На телефоне сворачивает на {m}, на компьютере — на {d}.",
+      pastFold: "Влезает — срез на {n} ⚠",
+      showAllFits: "Показать все ({n})",
+      showFewerFits: "Показать меньше",
       platformLabel: "Площадка",
       fieldLabel: "Поле",
       overBy: "Превышение на {n} — выберите, что исправить:",

--- a/scripts/check-counter-claims.js
+++ b/scripts/check-counter-claims.js
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+/* ==========================================================
+   check-counter-claims.js
+
+   Every other validator in this repo checks STRUCTURE — links, headings,
+   FAQ counts, hreflang, image assets. None of them checks whether a
+   *number written in prose* still matches the code that produces it.
+
+   That gap has now shipped twice on one page in one week:
+     · "LinkedIn cuts at 210" stayed on 14 locale pages after the rule
+       became 140 mobile / 210 desktop — so a page carried a fold table
+       saying 140/210 a few hundred pixels below a row saying 210.
+     · "27 platform character limits" sat in the meta and OG descriptions
+       of 12 pages — the number Google prints in the snippet — long after
+       the table grew to 38 fields across 17 platforms.
+
+   Both times every gate was green, because a number inside a <td> or a
+   <meta> is invisible to a structural diff by design.
+
+   Numbers are language-independent, which is what makes this checkable
+   across all fifteen counter pages at once without translating anything.
+
+   Two checks:
+     1. AGGREGATE CLAIMS — any figure written next to a platform/field
+        word ("38 fields", "17 platforms", and the same in every locale's
+        language) must equal LIMITS.length / PLATFORMS.length.
+     2. TABLE FIGURES — every number in a reference table's numeric cell
+        (<td class="num">) must be a real limit or fold from the rule
+        table, not a remembered one.
+
+   Usage:  node scripts/check-counter-claims.js [--verbose]
+   Exits non-zero when a page states a number the code does not.
+   ========================================================== */
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const ROOT = path.resolve(__dirname, "..");
+const VERBOSE = process.argv.includes("--verbose");
+
+/* ---------- load the rule table itself, not a copy of it ---------- */
+const sandbox = { window: {} };
+new Function("window", fs.readFileSync(path.join(ROOT, "js/counter/counterRules.js"), "utf8"))(sandbox.window);
+const RULES = sandbox.window.UltraTextGen.counterRules;
+const { LIMITS, PLATFORMS } = RULES;
+
+const FIELD_COUNT = LIMITS.length;
+const PLATFORM_COUNT = PLATFORMS.length;
+
+/* Numbers a counter page is legitimately allowed to print in a numeric
+   table cell: every hard limit, every fold, both device folds, and the
+   SMS/X constants the counting sections explain. */
+const VALID_FIGURES = new Set();
+LIMITS.forEach((r) => {
+  VALID_FIGURES.add(r.limit);
+  if (r.visibleAt) VALID_FIGURES.add(r.visibleAt);
+  if (r.foldDesktop) VALID_FIGURES.add(r.foldDesktop);
+});
+[160, 153, 70, 67, 23, 1, 2, 3, 4].forEach((n) => VALID_FIGURES.add(n));
+
+/* Words meaning "platform" or "field" across the locales this page ships
+   in. Only used to find the number sitting next to them. */
+const AGGREGATE_WORDS = [
+  "platform", "platforms", "plataforma", "plataformas", "plateforme", "plateformes",
+  "piattaforme", "piattaforma", "platformy", "platform", "platformu", "platformun",
+  "plattform", "plattformen", "alusta", "alustan", "nền tảng", "пл供", "платформ",
+  "платформы", "платформам", "プラットフォーム", "플랫폼", "平台",
+  "field", "fields", "campo", "campos", "champ", "champs", "campi", "kenttä",
+  "alan", "alanı", "поле", "полей", "項目", "필드", "欄位"
+];
+
+function walkCounterPages() {
+  const out = [];
+  const seen = new Set();
+  const stack = [ROOT];
+  while (stack.length) {
+    const dir = stack.pop();
+    let entries;
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch (e) { continue; }
+    for (const e of entries) {
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) {
+        if (["node_modules", ".git", "assets", "scripts"].includes(e.name)) continue;
+        stack.push(full);
+      } else if (e.name === "index.html") {
+        const rel = path.relative(ROOT, full);
+        if (seen.has(rel)) continue;
+        const src = fs.readFileSync(full, "utf8");
+        if (src.includes("js/counter/counterRules.js")) { seen.add(rel); out.push({ rel, src }); }
+      }
+    }
+  }
+  return out.sort((a, b) => a.rel.localeCompare(b.rel));
+}
+
+function stripTags(s) {
+  return s.replace(/<script[\s\S]*?<\/script>/g, " ")
+          .replace(/<style[\s\S]*?<\/style>/g, " ")
+          .replace(/<[^>]+>/g, " ")
+          .replace(/&[a-z]+;/g, " ");
+}
+
+/* Aggregate claims are only meaningful inside a single run of prose. Split on
+   tag boundaries first, so a figure in one table cell can never be read as
+   modifying a word in the next one — that false positive ("2 | Fields") is
+   otherwise guaranteed by any table with a numeric column. */
+function textRuns(src) {
+  return src.replace(/<script[\s\S]*?<\/script>/g, "<>")
+            .replace(/<style[\s\S]*?<\/style>/g, "<>")
+            .split(/<[^>]+>/)
+            .map((t) => t.replace(/&[a-z]+;/g, " ").trim())
+            .filter(Boolean)
+            .concat(metaDescriptions(src));
+}
+
+/* Meta/OG descriptions are prose too, and are where the "27 limits" claim
+   actually lived — invisible to any body-text scan. */
+function metaDescriptions(src) {
+  const out = [];
+  const re = /<meta[^>]+(?:name|property)="(?:description|og:description|twitter:description)"[^>]*content="([^"]*)"/gi;
+  let m;
+  while ((m = re.exec(src))) out.push(m[1]);
+  return out;
+}
+
+/** Numbers written immediately before or after a platform/field word. */
+function aggregateClaims(text) {
+  const claims = [];
+  const words = AGGREGATE_WORDS.map((w) => w.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|");
+  const re = new RegExp("(\\d{1,3})\\s*(?:\\+)?\\s*(?:" + words + ")\\b", "gi");
+  let m;
+  while ((m = re.exec(text))) claims.push({ n: Number(m[1]), text: m[0].trim() });
+  // e.g. Japanese/Chinese put the number after the noun
+  const re2 = new RegExp("(?:" + words + ")\\s*(\\d{1,3})\\b", "gi");
+  while ((m = re2.exec(text))) claims.push({ n: Number(m[1]), text: m[0].trim() });
+  return claims;
+}
+
+/** Figures printed in a reference table's numeric cells. */
+function tableFigures(src) {
+  const out = [];
+  const re = /<t[dh][^>]*class="[^"]*\bnum\b[^"]*"[^>]*>(.*?)<\/t[dh]>/gs;
+  let m;
+  while ((m = re.exec(src))) {
+    const cell = stripTags(m[1]);
+    /* Thousands separators are locale-specific: "63,206" (en), "63.206" (de),
+       "63 206" (fr/pl, often a non-breaking or narrow space). Each must read
+       as one number, not as a boundary between two. */
+    const nums = cell.match(/\d(?:[\d,.\u00a0\u202f\u2009 ]*\d)?/g) || [];
+    nums.forEach((raw) => {
+      const n = Number(raw.replace(/[,.\u00a0\u202f\u2009 ]/g, ""));
+      if (Number.isFinite(n) && n > 0) out.push({ n, cell: cell.trim() });
+    });
+  }
+  return out;
+}
+
+const pages = walkCounterPages();
+const problems = [];
+
+for (const { rel, src } of pages) {
+  for (const c of textRuns(src).flatMap(aggregateClaims)) {
+    if (c.n !== FIELD_COUNT && c.n !== PLATFORM_COUNT) {
+      problems.push({
+        rel,
+        kind: "aggregate",
+        msg: `states "${c.text}" — the rule table has ${FIELD_COUNT} fields across ${PLATFORM_COUNT} platforms`
+      });
+    }
+  }
+
+  for (const f of tableFigures(src)) {
+    if (!VALID_FIGURES.has(f.n)) {
+      problems.push({
+        rel,
+        kind: "figure",
+        msg: `numeric table cell "${f.cell}" contains ${f.n}, which is not a limit or fold in the rule table`
+      });
+    }
+  }
+}
+
+const byPage = new Map();
+problems.forEach((p) => {
+  if (!byPage.has(p.rel)) byPage.set(p.rel, []);
+  byPage.get(p.rel).push(p);
+});
+
+console.log("Counter Claim Consistency Check");
+console.log(`  rule table:      ${FIELD_COUNT} fields across ${PLATFORM_COUNT} platforms`);
+console.log(`  pages scanned:   ${pages.length}`);
+console.log(`  pages with a stale claim: ${byPage.size}`);
+console.log("");
+
+if (VERBOSE) pages.forEach((p) => { if (!byPage.has(p.rel)) console.log("  ok  " + p.rel); });
+
+if (byPage.size === 0) {
+  console.log("Every number these pages state matches the rule table they describe. ✓");
+  process.exit(0);
+}
+
+for (const [rel, list] of byPage) {
+  console.log(`  ${rel}`);
+  list.forEach((p) => console.log(`     • ${p.msg}`));
+}
+console.log("");
+console.log("Fix: update the prose/meta to match js/counter/counterRules.js, which is the");
+console.log("source of truth — or, if the rule table is what is wrong, fix that instead.");
+process.exit(1);

--- a/scripts/check-counter-claims.js
+++ b/scripts/check-counter-claims.js
@@ -48,16 +48,38 @@ const { LIMITS, PLATFORMS } = RULES;
 const FIELD_COUNT = LIMITS.length;
 const PLATFORM_COUNT = PLATFORMS.length;
 
-/* Numbers a counter page is legitimately allowed to print in a numeric
-   table cell: every hard limit, every fold, both device folds, and the
-   SMS/X constants the counting sections explain. */
-const VALID_FIGURES = new Set();
-LIMITS.forEach((r) => {
-  VALID_FIGURES.add(r.limit);
-  if (r.visibleAt) VALID_FIGURES.add(r.visibleAt);
-  if (r.foldDesktop) VALID_FIGURES.add(r.foldDesktop);
-});
-[160, 153, 70, 67, 23, 1, 2, 3, 4].forEach((n) => VALID_FIGURES.add(n));
+/* Numbers a counter page is legitimately allowed to print in a numeric table
+   cell: every hard limit, every fold, both device folds, and the SMS/X
+   constants the counting sections explain.
+
+   Derived PER PAGE, because a locale page may inject its own rules at runtime
+   — the Russian page adds vk-post (15,940) and vk-message, which exist in no
+   shared file. Checking those pages against the base table alone reported
+   their own correct figures as errors, which is how a checker earns the
+   reputation that gets it ignored. */
+const BASE_CONSTANTS = [160, 153, 70, 67, 23, 1, 2, 3, 4];
+
+function figuresFor(src) {
+  const w = {};
+  new Function("window", fs.readFileSync(path.join(ROOT, "js/counter/counterRules.js"), "utf8"))(w);
+  /* Replay only inline scripts that touch the rule table, in a sandbox with no
+     document — a page's UI wiring must not run, and anything that throws is
+     simply skipped. */
+  const inline = src.match(/<script>([\s\S]*?)<\/script>/g) || [];
+  inline.forEach((block) => {
+    const body = block.replace(/^<script>/, "").replace(/<\/script>$/, "");
+    if (!/counterRules|LIMITS/.test(body)) return;
+    try { new Function("window", body)(w); } catch (e) { /* not our concern */ }
+  });
+  const rules = (w.UltraTextGen && w.UltraTextGen.counterRules) || RULES;
+  const set = new Set(BASE_CONSTANTS);
+  rules.LIMITS.forEach((r) => {
+    set.add(r.limit);
+    if (r.visibleAt) set.add(r.visibleAt);
+    if (r.foldDesktop) set.add(r.foldDesktop);
+  });
+  return set;
+}
 
 /* Words meaning "platform" or "field" across the locales this page ships
    in. Only used to find the number sitting next to them. */
@@ -115,13 +137,35 @@ function textRuns(src) {
 }
 
 /* Meta/OG descriptions are prose too, and are where the "27 limits" claim
-   actually lived — invisible to any body-text scan. */
+   actually lived — invisible to any body-text scan. So is the `description`
+   inside the WebApplication/WebSite JSON-LD, which the tag-stripping pass
+   deliberately throws away: the first version of this script missed exactly
+   that, and three CJK pages were still asserting 27 there. Structured data
+   makes a claim to machines the same way a meta tag does. */
 function metaDescriptions(src) {
   const out = [];
   const re = /<meta[^>]+(?:name|property)="(?:description|og:description|twitter:description)"[^>]*content="([^"]*)"/gi;
   let m;
   while ((m = re.exec(src))) out.push(m[1]);
+
+  const ld = /<script type="application\/ld\+json">([\s\S]*?)<\/script>/gi;
+  while ((m = ld.exec(src))) {
+    let data;
+    try { data = JSON.parse(m[1]); } catch (e) { continue; }
+    collectStrings(data, out);
+  }
   return out;
+}
+
+/* Any human-readable string anywhere in a JSON-LD graph. Walking the whole
+   structure rather than naming fields means a claim moved into `abstract`,
+   `disambiguatingDescription` or a nested offer is still checked. */
+function collectStrings(node, out, depth) {
+  const d = depth || 0;
+  if (d > 8 || node == null) return;
+  if (typeof node === "string") { if (node.length > 12) out.push(node); return; }
+  if (Array.isArray(node)) { node.forEach((n) => collectStrings(n, out, d + 1)); return; }
+  if (typeof node === "object") Object.values(node).forEach((n) => collectStrings(n, out, d + 1));
 }
 
 /** Numbers written immediately before or after a platform/field word. */
@@ -134,6 +178,16 @@ function aggregateClaims(text) {
   // e.g. Japanese/Chinese put the number after the noun
   const re2 = new RegExp("(?:" + words + ")\\s*(\\d{1,3})\\b", "gi");
   while ((m = re2.exec(text))) claims.push({ n: Number(m[1]), text: m[0].trim() });
+
+  /* CJK counts with a measure word between the figure and the noun —
+     "27種類のプラットフォーム", "27 種平台" — so the adjacency the two patterns
+     above rely on never holds, and three pages kept asserting 27 unnoticed.
+     Deliberately requires BOTH the measure word and a platform/limit noun
+     right after it, so an ordinary phrase like "4種類の数え方" (four counting
+     modes, which these pages legitimately say) is not swept up. */
+  const CJK = /(\d{1,3})\s*(?:種類|種|個|款)\s*(?:の|之)?\s*(?:プラットフォーム|サービス|平台|文字数制限|字數限制|文字制限|플랫폼)/g;
+  while ((m = CJK.exec(text))) claims.push({ n: Number(m[1]), text: m[0].trim() });
+
   return claims;
 }
 
@@ -170,8 +224,9 @@ for (const { rel, src } of pages) {
     }
   }
 
+  const validFigures = figuresFor(src);
   for (const f of tableFigures(src)) {
-    if (!VALID_FIGURES.has(f.n)) {
+    if (!validFigures.has(f.n)) {
       problems.push({
         rel,
         kind: "figure",

--- a/style.css
+++ b/style.css
@@ -3008,21 +3008,63 @@ button.clear-decoration {
 }
 
 /* Which-format comparison table (was inline-styled in the page HTML) */
+/* Reference tables carry a lot of this site's value, so they get a real
+   style rather than bare padding: row rules for tracking across a wide row,
+   a zebra tint, tabular numerals so figures line up in a column, and a
+   scroll container so a wide table never forces the page sideways on a
+   phone. Numeric columns are opted in with .num. */
+.comparison-table-wrap {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  margin: 1rem 0;
+}
+
 .comparison-table {
   width: 100%;
   border-collapse: collapse;
   margin: 1rem 0;
+  font-size: 0.92rem;
+  line-height: 1.5;
+}
+
+.comparison-table-wrap .comparison-table {
+  margin: 0;
+  min-width: 34rem;
 }
 
 .comparison-table th {
   text-align: left;
-  padding: 0.75rem;
-  border-bottom: 2px solid rgba(255, 255, 255, 0.15);
+  padding: 0.6rem 0.75rem;
+  border-bottom: 2px solid var(--border-color, rgba(127, 127, 127, 0.35));
+  font-size: 0.8rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  white-space: nowrap;
 }
 
 .comparison-table td {
-  padding: 0.75rem;
+  padding: 0.6rem 0.75rem;
+  border-bottom: 1px solid var(--border-light, rgba(127, 127, 127, 0.18));
+  vertical-align: top;
 }
+
+.comparison-table tbody tr:nth-child(even) {
+  background: var(--border-light, rgba(127, 127, 127, 0.06));
+}
+
+.comparison-table tbody tr:last-child td { border-bottom: none; }
+
+/* Number columns: right-aligned, tabular, and never wrapped mid-figure. */
+.comparison-table th.num,
+.comparison-table td.num {
+  text-align: right;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+/* First column is the row's identity — let it keep its own weight. */
+.comparison-table td:first-child { font-weight: 600; }
 
 /* Visible Breadcrumb Navigation */
 .breadcrumbs {
@@ -7233,11 +7275,14 @@ body.dark-mode .kana-cell-empty { opacity: 0.35; }
   border: 1px solid transparent;
 }
 .cc-badge-ok { color: var(--ts-safe); border-color: var(--ts-safe); }
+.cc-badge-warn { color: var(--ts-warn, #d99100); border-color: var(--ts-warn, #d99100); }
 .cc-badge-fail { color: var(--ts-fail); border-color: var(--ts-fail); }
 .cc-badge-empty { color: var(--text-muted); }
 .cc-count { color: var(--text-secondary); font-variant-numeric: tabular-nums; }
 .cc-count.is-over { color: var(--ts-fail); font-weight: 700; }
 .cc-bar {
+  position: relative;
+  overflow: visible;
   height: 6px;
   border-radius: 999px;
   background: var(--border-light);
@@ -7251,6 +7296,17 @@ body.dark-mode .kana-cell-empty { opacity: 0.35; }
   transition: width 0.15s ease;
 }
 .cc-bar-fill.is-over { background: var(--ts-fail); }
+.cc-bar-fill.is-past-fold { background: var(--ts-warn, #d99100); }
+/* Where the feed truncates, marked on the bar itself. */
+.cc-bar-fold {
+  position: absolute;
+  top: -2px;
+  width: 2px;
+  height: 10px;
+  margin-left: -1px;
+  border-radius: 1px;
+  background: var(--text-secondary);
+}
 .cc-note {
   margin-top: 0.5rem;
   font-size: 0.82rem;
@@ -7381,6 +7437,15 @@ body.dark-mode .kana-cell-empty { opacity: 0.35; }
   margin-top: 0.6rem;
 }
 
+.counter-footnote {
+  max-width: 900px;
+  margin: 0.75rem auto 0;
+  padding: 0 24px;
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  line-height: 1.6;
+}
+
 /* Fits-everywhere grid */
 .counter-fits { margin-top: 1rem; }
 .counter-fits-head {
@@ -7402,6 +7467,16 @@ body.dark-mode .kana-cell-empty { opacity: 0.35; }
 .cc-fit-chip.is-unfit { color: var(--ts-fail); border-color: var(--ts-fail); }
 .cc-fit-chip.is-active { border-color: var(--accent-color, #6c4df6); font-weight: 600; }
 .cc-fit-num { font-variant-numeric: tabular-nums; opacity: 0.85; }
+.cc-fit-toggle {
+  border: none;
+  background: none;
+  padding: 0.25rem 0.4rem;
+  font: inherit;
+  font-size: 0.78rem;
+  color: var(--accent-color, #6c4df6);
+  cursor: pointer;
+  text-decoration: underline;
+}
 
 /* Inline "name check" callout — the game-rules checker rendered as a compact
    live readout inside the generator card (between the input and the decoration

--- a/tr/karakter-sayaci/index.html
+++ b/tr/karakter-sayaci/index.html
@@ -48,7 +48,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Karakter Sayacı ve Kelime Sayacı — Ücretsiz Online Araç | UltraTextGen</title>
-  <meta name="description" content="Ücretsiz karakter sayacı ve kelime sayacı. Yazarken canlı kelime, karakter, cümle, paragraf ve okuma süresi istatistikleri, artı 27 platform sınırı için kontrol — X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS ve daha fazlası.">
+  <meta name="description" content="Ücretsiz karakter sayacı ve kelime sayacı. Yazarken canlı kelime, karakter, cümle, paragraf ve okuma süresi istatistikleri, artı 17 platformda 38 alan sınırı için kontrol — X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS ve daha fazlası.">
   <link rel="canonical" href="https://ultratextgen.com/tr/karakter-sayaci/">
 
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/character-counter/">
@@ -69,7 +69,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/character-counter/">
 
   <meta property="og:title" content="Karakter Sayacı ve Kelime Sayacı — Ücretsiz Online Araç | UltraTextGen">
-  <meta property="og:description" content="Yazarken canlı kelime, karakter, cümle, paragraf ve okuma süresi istatistikleri, artı 27 platformun karakter sınırı için sığma kontrolü. Ücretsiz, anında, üyeliksiz.">
+  <meta property="og:description" content="Yazarken canlı kelime, karakter, cümle, paragraf ve okuma süresi istatistikleri, artı 17 platformdaki 38 alanın karakter sınırı için sığma kontrolü. Ücretsiz, anında, üyeliksiz.">
   <meta property="og:url" content="https://ultratextgen.com/tr/karakter-sayaci/">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://ultratextgen.com/assets/og/tr-karakter-sayaci.png">
@@ -79,7 +79,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <meta property="og:image:alt" content="Karakter Sayacı ve Kelime Sayacı — Ücretsiz Online Araç | UltraTextGen">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Karakter Sayacı ve Kelime Sayacı — Ücretsiz Online Araç | UltraTextGen">
-  <meta name="twitter:description" content="Yazarken canlı kelime, karakter, cümle, paragraf ve okuma süresi istatistikleri, artı 27 platformun karakter sınırı için sığma kontrolü. Ücretsiz, anında, üyeliksiz.">
+  <meta name="twitter:description" content="Yazarken canlı kelime, karakter, cümle, paragraf ve okuma süresi istatistikleri, artı 17 platformdaki 38 alanın karakter sınırı için sığma kontrolü. Ücretsiz, anında, üyeliksiz.">
   <meta name="twitter:image" content="https://ultratextgen.com/assets/og/tr-karakter-sayaci.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -161,19 +161,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <section class="hero"><div class="hero-inner"><div class="hero-card">
   <h1 class="hero-headline">Karakter Sayacı ve Kelime Sayacı</h1>
-  <p class="hero-sub">Yazarken canlı kelime, karakter, cümle, paragraf ve okuma süresi istatistikleri — artı metnin X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS ve 18 diğer platformun sınırına sığıp sığmadığını gösteren kontrol.</p>
+  <p class="hero-sub">17 platformdaki 38 alan için canlı sayım — ve sınırı aştığında tek tıkla düzeltmeler.</p>
 </div></div></section>
 
 <main class="container">
-  <section class="editorial-section">
-    <div class="editorial-block">
-      <p>Herhangi bir metni yaz ya da yapıştır; her sayı anında güncellenir: kelimeler, karakterler (boşluklu ve boşluksuz), cümleler, paragraflar, okuma süresi ve çeviri sayfası karşılığı. Metin kutusunun üstünden bu metnin nereye gideceğini seç — sayaç o zaman tam olarak oranın saydığı gibi sayar ve kaç karakterin kaldığını ya da sınırı ne kadar aştığını gösterir. Aştığındaysa sığdırmak için neyi kesmen gerektiğini de söyler: tek tıkla uygulanır, tek tıkla geri alınır. Hiçbir şey yüklenmez — her sayı doğrudan tarayıcında hesaplanır. Az önce ölçtüğün metni şık Unicode fontlarla mı yazmak istiyorsun? <a href="/tr/">UltraTextGen'in ana üreticisi</a> onu 100'den fazla kopyala-yapıştır stile çevirir.</p>
-    </div>
-  </section>
-
-  <div class="section-divider"></div>
-
-  <div class="counter-tool">
+<div class="counter-tool">
     <div id="platformChecker"></div>
 
     <div class="counter-field">
@@ -214,12 +206,14 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     </div>
   </div>
 
+  <p class="counter-footnote">Her şey tarayıcında hesaplanır — yazdığın hiçbir şey yüklenmez ya da saklanmaz. Metin şık da görünsün mü? <a href="/tr/">UltraTextGen üreticisi</a> onu 100'den fazla kopyala-yapıştır fonta çevirir.</p>
+
   <div class="section-divider"></div>
 
   <section class="editorial-section">
     <h2>Katı sınırlar ve yumuşak sınırlar</h2>
     <p>«Karakter sınırı» denen şey aslında iki farklı şeydir ve aşmanın sana neye mal olacağı buna bağlıdır.</p>
-    <table class="comparison-table">
+    <div class="comparison-table-wrap"><table class="comparison-table">
       <thead><tr><th>Tür</th><th>Aşarsan ne olur</th><th>Örnekler</th></tr></thead>
       <tbody>
         <tr>
@@ -233,34 +227,38 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
           <td>Instagram açıklaması 125'ten sonra · LinkedIn gönderisi mobilde ~140, masaüstünde ~210'dan sonra · YouTube açıklaması ~157'den sonra</td>
         </tr>
       </tbody>
-    </table>
+    </table></div>
     <p>İnsanların aslında karşı yazdığı sınır yumuşak olanıdır ve neredeyse hiçbir sayaç onu göstermez. Bir LinkedIn gönderisinin 3.000 karakteri vardır, işe yarayanı ise yaklaşık 140: gerisi kimsenin dokunmadığı bir bağlantının arkasında kalır. Bu yüzden yukarıdaki kontrol kesme çizgisini doğrudan çiziyor — yazdıkça «daha fazlasını gör» öncesinde çıkacak metni birebir görüyorsun, sonrası bir çizginin altında soluk duruyor; aynı girişin kesme yapan diğer akışlarda da ayakta kalıp kalmadığı hemen yanında.</p>
     <p><strong>Hangi akış nerede ve hangi cihazda kesiyor:</strong></p>
-    <table class="comparison-table">
-      <thead><tr><th>Akış</th><th>Kestiği yer</th><th>Giriş için ne anlama geliyor</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Akış</th><th class="num">Mobil</th><th class="num">Masaüstü</th><th>Giriş için ne anlama geliyor</th></tr></thead>
       <tbody>
         <tr>
           <td>LinkedIn gönderisi</td>
-          <td>~140 mobilde<br>~210 masaüstünde</td>
+          <td class="num">~140</td>
+          <td class="num">~210</td>
           <td>140'a göre yazarsan ikisinde de ayakta kalır. Listedeki en geniş mobil/masaüstü farkı bu.</td>
         </tr>
         <tr>
           <td><a href="/tr/instagram-yazi-tipi/">Instagram açıklaması</a></td>
-          <td>~125</td>
+          <td class="num">~125</td>
+          <td class="num">~125</td>
           <td>Listedeki en dar kesme — «... devamı»ndan önce aşağı yukarı tek bir cümle.</td>
         </tr>
         <tr>
           <td>YouTube açıklaması</td>
-          <td>~157</td>
+          <td class="num">~157</td>
+          <td class="num">~157</td>
           <td>Başlığın altında «Daha fazlasını göster» öncesinde görünen kısım; aramada da genelde bu kısım çıkar.</td>
         </tr>
         <tr>
           <td>Facebook gönderisi</td>
-          <td>~477</td>
+          <td class="num">~477</td>
+          <td class="num">~477</td>
           <td>En cömert kesme — kesilmeden önce kısa bir paragrafın tamamı sığar.</td>
         </tr>
       </tbody>
-    </table>
+    </table></div>
     <p>İki dürüst uyarı. Bu sayılar platformların yayımladığı sınırlar değil, arayüzde gözlenen davranışlar; yani «kesin eşik» diye değil, «güvenle görünen kadarı» diye okunmalı. Ayrıca akışlar <em>satır sayısına</em> göre de kesiyor: başta üç satır sonu, herhangi bir karakter sayısının çok altında bir yerde gönderiyi kesebilir. Girişin bir listeye dayanıyorsa bir de gerçek paylaşım ekranında dene.</p>
   </section>
 
@@ -271,51 +269,51 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <p>Yukarıdaki canlı kontrolün kullandığı sınırların aynısı, referans tablosu olarak. Şuraya atla: <a href="#twitter">X/Twitter</a> · <a href="#discord">Discord</a> · <a href="#instagram">Instagram</a> · <a href="#tiktok">TikTok</a> · <a href="#sms">SMS</a> · <a href="#counting-modes">her platform nasıl sayıyor</a>.</p>
 
     <h3>Gönderiler ve mesajlar</h3>
-    <table class="comparison-table">
-      <thead><tr><th>Platform</th><th>Sınır</th><th>Notlar</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Platform</th><th class="num">Sınır</th><th>Notlar</th></tr></thead>
       <tbody>
-        <tr id="twitter"><td>X / Twitter gönderisi</td><td>280</td><td>Ağırlıklı sayım: her bağlantı = 23; emojilerin, sembollerin ve süslü harflerin çoğu = 2 — <a href="#counting-modes">X nasıl sayıyor</a></td></tr>
-        <tr id="discord"><td>Discord mesajı</td><td>2.000</td><td>Nitro ile 4.000; daha uzun mesajlar .txt ekine dönüşür</td></tr>
-        <tr id="instagram"><td>Instagram açıklaması</td><td>2.200</td><td>İlk satırlardan sonra «devamı» ile kesilir</td></tr>
-        <tr id="tiktok"><td>TikTok açıklaması</td><td>2.200</td><td></td></tr>
-        <tr><td>LinkedIn gönderisi</td><td>3.000</td><td>«Daha fazla gör» cihaza göre 200–700 karakter civarında keser</td></tr>
-        <tr><td>Facebook gönderisi</td><td>63.206</td><td></td></tr>
-        <tr><td>YouTube video açıklaması</td><td>5.000</td><td></td></tr>
-        <tr><td>Pinterest pin açıklaması</td><td>500</td><td></td></tr>
-        <tr><td>Telegram mesajı</td><td>4.096</td><td>Fotoğraf/video açıklaması için 1.024</td></tr>
-        <tr><td>Threads gönderisi</td><td>500</td><td></td></tr>
-        <tr><td>Bluesky gönderisi</td><td>300</td><td>Kod noktasına göre değil, grafeme (gördüğün şeye) göre sayılır</td></tr>
-        <tr><td>Reddit gönderi başlığı</td><td>300</td><td></td></tr>
-        <tr><td>Zalo gönderisi/durumu</td><td>2.000</td><td></td></tr>
+        <tr id="twitter"><td>X / Twitter gönderisi</td><td class="num">280</td><td>Ağırlıklı sayım: her bağlantı = 23; emojilerin, sembollerin ve süslü harflerin çoğu = 2 — <a href="#counting-modes">X nasıl sayıyor</a></td></tr>
+        <tr id="discord"><td>Discord mesajı</td><td class="num">2.000</td><td>Nitro ile 4.000; daha uzun mesajlar .txt ekine dönüşür</td></tr>
+        <tr id="instagram"><td>Instagram açıklaması</td><td class="num">2.200</td><td>İlk satırlardan sonra «devamı» ile kesilir</td></tr>
+        <tr id="tiktok"><td>TikTok açıklaması</td><td class="num">2.200</td><td></td></tr>
+        <tr><td>LinkedIn gönderisi</td><td class="num">3.000</td><td>«Daha fazla gör» cihaza göre 200–700 karakter civarında keser</td></tr>
+        <tr><td>Facebook gönderisi</td><td class="num">63.206</td><td></td></tr>
+        <tr><td>YouTube video açıklaması</td><td class="num">5.000</td><td></td></tr>
+        <tr><td>Pinterest pin açıklaması</td><td class="num">500</td><td></td></tr>
+        <tr><td>Telegram mesajı</td><td class="num">4.096</td><td>Fotoğraf/video açıklaması için 1.024</td></tr>
+        <tr><td>Threads gönderisi</td><td class="num">500</td><td></td></tr>
+        <tr><td>Bluesky gönderisi</td><td class="num">300</td><td>Kod noktasına göre değil, grafeme (gördüğün şeye) göre sayılır</td></tr>
+        <tr><td>Reddit gönderi başlığı</td><td class="num">300</td><td></td></tr>
+        <tr><td>Zalo gönderisi/durumu</td><td class="num">2.000</td><td></td></tr>
       </tbody>
-    </table>
+    </table></div>
 
     <h3>Biyografi ve profiller</h3>
-    <table class="comparison-table">
-      <thead><tr><th>Alan</th><th>Sınır</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Alan</th><th class="num">Sınır</th></tr></thead>
       <tbody>
-        <tr><td>Instagram biyografisi</td><td>150</td></tr>
-        <tr><td>TikTok biyografisi</td><td>80</td></tr>
-        <tr><td>LinkedIn başlığı</td><td>220</td></tr>
-        <tr><td>WhatsApp Hakkında yazısı</td><td>139</td></tr>
-        <tr><td>Telegram biyografisi</td><td>70</td></tr>
-        <tr><td>VK durumu</td><td>140</td></tr>
+        <tr><td>Instagram biyografisi</td><td class="num">150</td></tr>
+        <tr><td>TikTok biyografisi</td><td class="num">80</td></tr>
+        <tr><td>LinkedIn başlığı</td><td class="num">220</td></tr>
+        <tr><td>WhatsApp Hakkında yazısı</td><td class="num">139</td></tr>
+        <tr><td>Telegram biyografisi</td><td class="num">70</td></tr>
+        <tr><td>VK durumu</td><td class="num">140</td></tr>
       </tbody>
-    </table>
+    </table></div>
 
     <h3>Kullanıcı adları, başlıklar ve SMS</h3>
-    <table class="comparison-table">
-      <thead><tr><th>Alan</th><th>Sınır</th><th>Notlar</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Alan</th><th class="num">Sınır</th><th>Notlar</th></tr></thead>
       <tbody>
-        <tr><td>Discord takma adı</td><td>32</td><td></td></tr>
-        <tr><td>TikTok kullanıcı adı</td><td>24</td><td>Sadece harf, rakam, alt çizgi ve nokta</td></tr>
-        <tr><td>Instagram kullanıcı adı</td><td>30</td><td></td></tr>
-        <tr><td>YouTube video başlığı</td><td>100</td><td></td></tr>
-        <tr><td>SEO meta başlığı</td><td>~60</td><td>Google piksel genişliğine göre keser — bunu bir ölçüt olarak al</td></tr>
-        <tr><td>SEO meta açıklaması</td><td>~155</td><td>Aynı şekilde — piksel genişliğine göre kesilir</td></tr>
-        <tr id="sms"><td>Kısa mesaj (SMS)</td><td>160 / segment</td><td>GSM-7 dışında tek bir karakter (emoji, kıvrık tırnak, ş, ğ, ı…) yeter ve segment başına 70'e düşer — <a href="#sms-turkce">Türkçe karakterler ve SMS</a></td></tr>
+        <tr><td>Discord takma adı</td><td class="num">32</td><td></td></tr>
+        <tr><td>TikTok kullanıcı adı</td><td class="num">24</td><td>Sadece harf, rakam, alt çizgi ve nokta</td></tr>
+        <tr><td>Instagram kullanıcı adı</td><td class="num">30</td><td></td></tr>
+        <tr><td>YouTube video başlığı</td><td class="num">100</td><td></td></tr>
+        <tr><td>SEO meta başlığı</td><td class="num">~60</td><td>Google piksel genişliğine göre keser — bunu bir ölçüt olarak al</td></tr>
+        <tr><td>SEO meta açıklaması</td><td class="num">~155</td><td>Aynı şekilde — piksel genişliğine göre kesilir</td></tr>
+        <tr id="sms"><td>Kısa mesaj (SMS)</td><td class="num">160 / segment</td><td>GSM-7 dışında tek bir karakter (emoji, kıvrık tırnak, ş, ğ, ı…) yeter ve segment başına 70'e düşer — <a href="#sms-turkce">Türkçe karakterler ve SMS</a></td></tr>
       </tbody>
-    </table>
+    </table></div>
   </section>
 
   <div class="section-divider"></div>
@@ -323,7 +321,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <section class="editorial-section" id="counting-modes">
     <h2>Karakter sayın neden platformunkiyle uyuşmuyor</h2>
     <p>«Bu kaç karakter?» sorusunun birden fazla doğru cevabı var, çünkü platformlar farklı birimlerle sayıyor. Aynı metnin dört farklı uzunluğu olabilir:</p>
-    <table class="comparison-table">
+    <div class="comparison-table-wrap"><table class="comparison-table">
       <thead><tr><th>Sayım birimi</th><th>Neyi ölçer</th><th>Kim kullanır</th></tr></thead>
       <tbody>
         <tr><td>Grafem</td><td>Gözünle gördüğün şey — ten rengi olan bir emoji 1'dir</td><td>Bluesky; Instagram'ın emojiye yaklaşımı da kabaca böyle</td></tr>
@@ -331,7 +329,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
         <tr><td>UTF-16 birimi</td><td>JavaScript'in ve birçok uygulamanın metni sakladığı biçim — 𝗸𝗮𝗹𝗶𝗻 harfler 2'şer tutar</td><td>HTML form alanları (<code>maxlength</code>), birçok oyun ve uygulama arka ucu</td></tr>
         <tr><td>UTF-8 bayt</td><td>Kapladığı yer — ş 2, 中 3, 𝗯 4 bayttır</td><td>Amazon ürün alanları, Steam adları, veritabanları</td></tr>
       </tbody>
-    </table>
+    </table></div>
     <p>Dördü de yukarıdaki istatistiklerde canlı duruyor; bir form «metnin çok uzun» derken kelime işlemcin aynı fikirde değilse, formun hangi birimi kullandığını doğrudan görebilirsin. İki hedef bunun üstüne ayrı bir kural ister:</p>
     <p><strong>X / Twitter karaktere göre değil, ağırlığa göre sayar.</strong> X'in kendi yayımladığı algoritmaya göre (<code>twitter-text</code> kütüphanesi) her URL tam olarak 23, temel Latin harfleri 1, geri kalan neredeyse her şey — CJK karakterleri, emojilerin çoğu ve her «süslü font» Unicode harfi — <strong>2</strong> sayılır. Bu yüzden tamamı 𝗸𝗮𝗹𝗶𝗻 yazılmış bir gönderi 280'lik bütçeye yalnızca 140 görünür harf sığdırır. Türkçe'nin ç, ş, ğ, ı, ö, ü harfleri ağırlığı 1 olan aralıkta kalır; yani X'te normal harflerden fazla tutmazlar. Yukarıdaki kontroldeki «X / Twitter» seçeneği bu gerçek algoritmayı uygular.</p>
     <p><strong>SMS ise segmentle sayılır ve Türkçe'de tek bir ş bunu 160'tan 70'e düşürür.</strong> Bu, Türkçe yazan herkesi doğrudan ilgilendirdiği için ayrı bir bölümde anlattık: <a href="#sms-turkce">Türkçe karakterler ve SMS</a>.</p>
@@ -459,6 +457,9 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     foldMeta: "{total} karakterin {shown} tanesi görünüyor · {hidden} tanesi dokunmanın arkasında",
     foldRoom: "Girişin kesilmesine {n} karakter kaldı",
     foldDevices: "Mobilde {m}, masaüstünde {d} karakterde kesiliyor.",
+    pastFold: "Sığıyor — {n}'de kesiliyor ⚠",
+    showAllFits: "Tümünü göster ({n})",
+    showFewerFits: "Daha az göster",
     platformLabel: "Platform",
     fieldLabel: "Alan",
     overBy: "{n} karakter aştın — bir çözüm seç:",

--- a/vi/dem-tu-dem-ky-tu/index.html
+++ b/vi/dem-tu-dem-ky-tu/index.html
@@ -48,7 +48,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Đếm Từ &amp; Đếm Ký Tự — Công Cụ Miễn Phí Trực Tuyến | UltraTextGen</title>
-  <meta name="description" content="Công cụ đếm từ và đếm ký tự miễn phí. Xem số từ, ký tự, câu, đoạn văn và thời gian đọc cập nhật trực tiếp khi bạn gõ, kèm bộ kiểm tra giới hạn ký tự cho 27 nền tảng — Zalo, X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS và nhiều hơn nữa.">
+  <meta name="description" content="Công cụ đếm từ và đếm ký tự miễn phí. Xem số từ, ký tự, câu, đoạn văn và thời gian đọc cập nhật trực tiếp khi bạn gõ, kèm bộ kiểm tra giới hạn ký tự cho 38 trường trên 17 nền tảng — Zalo, X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS và nhiều hơn nữa.">
   <link rel="canonical" href="https://ultratextgen.com/vi/dem-tu-dem-ky-tu/">
 
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/character-counter/">
@@ -69,7 +69,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/character-counter/">
 
   <meta property="og:title" content="Đếm Từ &amp; Đếm Ký Tự — Công Cụ Miễn Phí Trực Tuyến | UltraTextGen">
-  <meta property="og:description" content="Xem số từ, ký tự, câu, đoạn văn và thời gian đọc cập nhật trực tiếp khi bạn gõ, kèm bộ kiểm tra giới hạn ký tự cho 27 nền tảng. Miễn phí, tức thì, không cần đăng ký.">
+  <meta property="og:description" content="Xem số từ, ký tự, câu, đoạn văn và thời gian đọc cập nhật trực tiếp khi bạn gõ, kèm bộ kiểm tra giới hạn ký tự cho 38 trường trên 17 nền tảng. Miễn phí, tức thì, không cần đăng ký.">
   <meta property="og:url" content="https://ultratextgen.com/vi/dem-tu-dem-ky-tu/">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://ultratextgen.com/assets/og/vi-dem-tu-dem-ky-tu.png">
@@ -79,7 +79,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <meta property="og:image:alt" content="Đếm Từ &amp; Đếm Ký Tự — Công Cụ Miễn Phí Trực Tuyến | UltraTextGen">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Đếm Từ &amp; Đếm Ký Tự — Công Cụ Miễn Phí Trực Tuyến | UltraTextGen">
-  <meta name="twitter:description" content="Xem số từ, ký tự, câu, đoạn văn và thời gian đọc cập nhật trực tiếp khi bạn gõ, kèm bộ kiểm tra giới hạn ký tự cho 27 nền tảng. Miễn phí, tức thì, không cần đăng ký.">
+  <meta name="twitter:description" content="Xem số từ, ký tự, câu, đoạn văn và thời gian đọc cập nhật trực tiếp khi bạn gõ, kèm bộ kiểm tra giới hạn ký tự cho 38 trường trên 17 nền tảng. Miễn phí, tức thì, không cần đăng ký.">
   <meta name="twitter:image" content="https://ultratextgen.com/assets/og/vi-dem-tu-dem-ky-tu.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -159,19 +159,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <section class="hero"><div class="hero-inner"><div class="hero-card">
   <h1 class="hero-headline">Đếm Từ &amp; Đếm Ký Tự</h1>
-  <p class="hero-sub">Số từ, ký tự, câu, đoạn văn và thời gian đọc cập nhật ngay khi bạn gõ — cùng bộ kiểm tra xem văn bản có vừa giới hạn của Zalo, X/Twitter, Instagram, TikTok, LinkedIn, YouTube, Discord, Telegram, SMS và 17 nền tảng khác.</p>
+  <p class="hero-sub">Đếm trực tiếp cho 38 ô nhập trên 17 nền tảng — và sửa chỉ một cú nhấp khi bạn vượt giới hạn.</p>
 </div></div></section>
 
 <main class="container">
-  <section class="editorial-section">
-    <div class="editorial-block">
-      <p>Chọn nơi văn bản sẽ được đăng ở ngay phía trên ô nhập, rồi gõ hoặc dán nội dung vào: mọi số liệu cập nhật tức thì — số từ, số ký tự (có và không có khoảng trắng), số câu, số đoạn văn và thời gian đọc ước tính — và bộ kiểm tra đếm đúng theo cách nền tảng đó đếm, kèm số ký tự bạn còn dư hoặc đã vượt. Nếu vượt, công cụ không dừng ở việc báo lỗi: nó đề xuất từng cách cắt ngắn kèm số ký tự tiết kiệm được, mỗi cách chỉ một cú nhấp và hoàn tác được. Không có gì được tải lên cả — mọi con số đều được tính ngay trong trình duyệt của bạn. Cần font chữ Unicode đẹp cho đoạn văn bản bạn vừa đo? <a href="/vi/">Công cụ tạo chữ kiểu UltraTextGen</a> biến nó thành hơn 100 kiểu chữ copy-paste.</p>
-    </div>
-  </section>
-
-  <div class="section-divider"></div>
-
-  <div class="counter-tool">
+<div class="counter-tool">
     <div id="platformChecker"></div>
 
     <div class="counter-field">
@@ -211,12 +203,14 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     </div>
   </div>
 
+  <p class="counter-footnote">Mọi thứ được tính ngay trong trình duyệt của bạn — không có gì bạn gõ được tải lên hay lưu lại. Cần văn bản có kiểu chữ nữa? <a href="/vi/">Công cụ tạo chữ kiểu UltraTextGen</a> biến nó thành hơn 100 font copy-paste.</p>
+
   <div class="section-divider"></div>
 
   <section class="editorial-section">
     <h2>Giới hạn cứng và giới hạn mềm</h2>
     <p>Hai thứ rất khác nhau cùng được gọi là "giới hạn ký tự", và vượt quá loại nào thì cái giá phải trả cũng khác.</p>
-    <table class="comparison-table">
+    <div class="comparison-table-wrap"><table class="comparison-table">
       <thead><tr><th>Loại</th><th>Vượt quá thì sao</th><th>Ví dụ</th></tr></thead>
       <tbody>
         <tr>
@@ -230,35 +224,39 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
           <td>Chú thích Instagram sau 125 · Bài đăng LinkedIn sau ~140 trên di động / ~210 trên máy tính · Mô tả YouTube sau ~157</td>
         </tr>
       </tbody>
-    </table>
+    </table></div>
     <p>Riêng ở thị trường Việt Nam, giới hạn 2.000 ký tự của một bài đăng hay nhật ký Zalo là giới hạn người dùng chạm phải thường xuyên nhất — nhất là khi dán cả một đoạn tâm sự dài hoặc thông báo nhóm. Chi tiết ở phần <a href="#gioi-han-zalo">giới hạn ký tự trên Zalo</a> bên dưới.</p>
     <p>Giới hạn mềm mới là thứ phần lớn mọi người thực sự đang viết cho, vậy mà gần như không bộ đếm nào hiển thị nó. Một bài đăng LinkedIn được 3.000 ký tự nhưng chỉ có khoảng 140 ký tự thực sự dùng được: phần còn lại nằm sau một cú chạm mà rất ít người chạm. Vì thế công cụ phía trên vẽ thẳng chỗ bị cắt ra — chọn trong bộ kiểm tra một nơi có rút gọn (Zalo được chọn sẵn không rút gọn, nên khung này chỉ hiện khi bạn chọn LinkedIn, Instagram, YouTube hoặc Facebook) rồi gõ vào, bạn sẽ thấy đúng đoạn chữ xuất hiện trước "xem thêm", phần sau vạch cắt bị làm mờ, cùng với việc chính đoạn mở đầu đó còn trụ được ở những nơi khác hay không.</p>
     <p><strong>Mỗi nơi cắt ở đâu, và trên thiết bị nào:</strong></p>
-    <table class="comparison-table">
-      <thead><tr><th>Nơi đăng</th><th>Cắt ở</th><th>Điều đó có nghĩa gì với đoạn mở đầu</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Nơi đăng</th><th class="num">Điện thoại</th><th class="num">Máy tính</th><th>Điều đó có nghĩa gì với đoạn mở đầu</th></tr></thead>
       <tbody>
         <tr>
           <td>Bài đăng LinkedIn</td>
-          <td>~140 trên điện thoại<br>~210 trên máy tính</td>
+          <td class="num">~140</td>
+          <td class="num">~210</td>
           <td>Viết gọn trong 140 ký tự là trụ được cả hai. Đây là khoảng chênh điện thoại/máy tính lớn nhất trong bảng này.</td>
         </tr>
         <tr>
           <td><a href="/vi/font-ig/">Chú thích Instagram</a></td>
-          <td>~125</td>
+          <td class="num">~125</td>
+          <td class="num">~125</td>
           <td>Chỗ cắt chặt nhất ở đây — chỉ khoảng một câu là đã tới chữ "… thêm".</td>
         </tr>
         <tr>
           <td>Mô tả video YouTube</td>
-          <td>~157</td>
+          <td class="num">~157</td>
+          <td class="num">~157</td>
           <td>Phần hiện dưới tiêu đề trước nút "Hiển thị thêm"; cũng thường là phần công cụ tìm kiếm lấy ra.</td>
         </tr>
         <tr>
           <td><a href="/vi/font-facebook/">Bài đăng Facebook</a></td>
-          <td>~477</td>
+          <td class="num">~477</td>
+          <td class="num">~477</td>
           <td>Chỗ cắt dễ thở nhất — trọn một đoạn ngắn vẫn nằm trước vạch cắt.</td>
         </tr>
       </tbody>
-    </table>
+    </table></div>
     <p>Hai điều cần nói thẳng. Đây là hành vi quan sát được trên giao diện chứ không phải giới hạn nền tảng công bố, nên hãy hiểu chúng là "mức thường xuyên hiển thị được" thay vì ngưỡng chính xác — và các nền tảng còn cắt theo <em>số dòng</em>, nên chỉ vài lần xuống dòng sớm là bài bị rút gọn trước khi chạm tới bất kỳ con số ký tự nào. Nếu đoạn mở đầu của bạn phụ thuộc vào một danh sách gạch đầu dòng, hãy thử luôn trong trình soạn thảo thật.</p>
   </section>
 
@@ -269,51 +267,51 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <p>Chính những giới hạn mà bộ kiểm tra phía trên đang dùng, trình bày dạng bảng tra cứu. Nhảy nhanh tới: <a href="#zalo">Zalo</a> · <a href="#twitter">X/Twitter</a> · <a href="#discord">Discord</a> · <a href="#instagram">Instagram</a> · <a href="#tiktok">TikTok</a> · <a href="#sms">SMS</a> · <a href="#counting-modes">cách mỗi nền tảng đếm</a>.</p>
 
     <h3>Bài đăng &amp; tin nhắn</h3>
-    <table class="comparison-table">
-      <thead><tr><th>Nền tảng</th><th>Giới hạn</th><th>Ghi chú</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Nền tảng</th><th class="num">Giới hạn</th><th>Ghi chú</th></tr></thead>
       <tbody>
-        <tr id="zalo"><td>Bài đăng / nhật ký Zalo</td><td>2.000</td><td>Vượt quá là Zalo báo "Bạn chỉ được nhập tối đa 2000 ký tự"</td></tr>
-        <tr id="twitter"><td>Bài đăng X / Twitter</td><td>280</td><td>Đếm có trọng số: mỗi liên kết = 23, phần lớn emoji/ký hiệu/chữ kiểu = 2 — xem <a href="#counting-modes">cách X đếm</a></td></tr>
-        <tr id="discord"><td>Tin nhắn Discord</td><td>2.000</td><td>4.000 nếu có Nitro; tin dài hơn bị chuyển thành tệp .txt đính kèm</td></tr>
-        <tr id="instagram"><td>Chú thích Instagram</td><td>2.200</td><td>Bị rút gọn bằng "thêm" sau vài dòng đầu</td></tr>
-        <tr id="tiktok"><td>Chú thích TikTok</td><td>2.200</td><td></td></tr>
-        <tr><td>Bài đăng LinkedIn</td><td>3.000</td><td>Nút "xem thêm" rút gọn ở khoảng 200–700 ký tự tùy thiết bị</td></tr>
-        <tr><td>Bài đăng Facebook</td><td>63.206</td><td></td></tr>
-        <tr><td>Mô tả video YouTube</td><td>5.000</td><td></td></tr>
-        <tr><td>Mô tả ghim Pinterest</td><td>500</td><td></td></tr>
-        <tr><td>Tin nhắn Telegram</td><td>4.096</td><td>1.024 cho chú thích ảnh/video</td></tr>
-        <tr><td>Bài đăng Threads</td><td>500</td><td></td></tr>
-        <tr><td>Bài đăng Bluesky</td><td>300</td><td>Đếm theo grapheme (ký tự bạn nhìn thấy), không phải code point</td></tr>
-        <tr><td>Tiêu đề bài đăng Reddit</td><td>300</td><td></td></tr>
+        <tr id="zalo"><td>Bài đăng / nhật ký Zalo</td><td class="num">2.000</td><td>Vượt quá là Zalo báo "Bạn chỉ được nhập tối đa 2000 ký tự"</td></tr>
+        <tr id="twitter"><td>Bài đăng X / Twitter</td><td class="num">280</td><td>Đếm có trọng số: mỗi liên kết = 23, phần lớn emoji/ký hiệu/chữ kiểu = 2 — xem <a href="#counting-modes">cách X đếm</a></td></tr>
+        <tr id="discord"><td>Tin nhắn Discord</td><td class="num">2.000</td><td>4.000 nếu có Nitro; tin dài hơn bị chuyển thành tệp .txt đính kèm</td></tr>
+        <tr id="instagram"><td>Chú thích Instagram</td><td class="num">2.200</td><td>Bị rút gọn bằng "thêm" sau vài dòng đầu</td></tr>
+        <tr id="tiktok"><td>Chú thích TikTok</td><td class="num">2.200</td><td></td></tr>
+        <tr><td>Bài đăng LinkedIn</td><td class="num">3.000</td><td>Nút "xem thêm" rút gọn ở khoảng 200–700 ký tự tùy thiết bị</td></tr>
+        <tr><td>Bài đăng Facebook</td><td class="num">63.206</td><td></td></tr>
+        <tr><td>Mô tả video YouTube</td><td class="num">5.000</td><td></td></tr>
+        <tr><td>Mô tả ghim Pinterest</td><td class="num">500</td><td></td></tr>
+        <tr><td>Tin nhắn Telegram</td><td class="num">4.096</td><td>1.024 cho chú thích ảnh/video</td></tr>
+        <tr><td>Bài đăng Threads</td><td class="num">500</td><td></td></tr>
+        <tr><td>Bài đăng Bluesky</td><td class="num">300</td><td>Đếm theo grapheme (ký tự bạn nhìn thấy), không phải code point</td></tr>
+        <tr><td>Tiêu đề bài đăng Reddit</td><td class="num">300</td><td></td></tr>
       </tbody>
-    </table>
+    </table></div>
 
     <h3>Tiểu sử &amp; hồ sơ</h3>
-    <table class="comparison-table">
-      <thead><tr><th>Ô nhập</th><th>Giới hạn</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Ô nhập</th><th class="num">Giới hạn</th></tr></thead>
       <tbody>
-        <tr><td>Tiểu sử Instagram</td><td>150</td></tr>
-        <tr><td>Tiểu sử TikTok</td><td>80</td></tr>
-        <tr><td>Tiêu đề LinkedIn</td><td>220</td></tr>
-        <tr><td>Giới thiệu WhatsApp</td><td>139</td></tr>
-        <tr><td>Tiểu sử Telegram</td><td>70</td></tr>
-        <tr><td>Trạng thái VK</td><td>140</td></tr>
+        <tr><td>Tiểu sử Instagram</td><td class="num">150</td></tr>
+        <tr><td>Tiểu sử TikTok</td><td class="num">80</td></tr>
+        <tr><td>Tiêu đề LinkedIn</td><td class="num">220</td></tr>
+        <tr><td>Giới thiệu WhatsApp</td><td class="num">139</td></tr>
+        <tr><td>Tiểu sử Telegram</td><td class="num">70</td></tr>
+        <tr><td>Trạng thái VK</td><td class="num">140</td></tr>
       </tbody>
-    </table>
+    </table></div>
 
     <h3>Tên người dùng, tiêu đề &amp; SMS</h3>
-    <table class="comparison-table">
-      <thead><tr><th>Ô nhập</th><th>Giới hạn</th><th>Ghi chú</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>Ô nhập</th><th class="num">Giới hạn</th><th>Ghi chú</th></tr></thead>
       <tbody>
-        <tr><td>Biệt danh Discord</td><td>32</td><td></td></tr>
-        <tr><td>Tên người dùng TikTok</td><td>24</td><td>Chỉ gồm chữ cái, số, gạch dưới và dấu chấm</td></tr>
-        <tr><td>Tên người dùng Instagram</td><td>30</td><td></td></tr>
-        <tr><td>Tiêu đề video YouTube</td><td>100</td><td></td></tr>
-        <tr><td>Thẻ tiêu đề SEO</td><td>~60</td><td>Google cắt theo chiều rộng pixel — coi đây là mốc tham khảo</td></tr>
-        <tr><td>Thẻ mô tả SEO</td><td>~155</td><td>Tương tự — cắt theo chiều rộng pixel</td></tr>
-        <tr id="sms"><td>Tin nhắn SMS</td><td>160 / tin</td><td>Rơi xuống 70 mỗi tin ngay khi xuất hiện một ký tự ngoài GSM-7 (emoji, dấu nháy cong, và mọi chữ tiếng Việt có dấu) — xem <a href="#sms-co-dau">cách đếm SMS</a></td></tr>
+        <tr><td>Biệt danh Discord</td><td class="num">32</td><td></td></tr>
+        <tr><td>Tên người dùng TikTok</td><td class="num">24</td><td>Chỉ gồm chữ cái, số, gạch dưới và dấu chấm</td></tr>
+        <tr><td>Tên người dùng Instagram</td><td class="num">30</td><td></td></tr>
+        <tr><td>Tiêu đề video YouTube</td><td class="num">100</td><td></td></tr>
+        <tr><td>Thẻ tiêu đề SEO</td><td class="num">~60</td><td>Google cắt theo chiều rộng pixel — coi đây là mốc tham khảo</td></tr>
+        <tr><td>Thẻ mô tả SEO</td><td class="num">~155</td><td>Tương tự — cắt theo chiều rộng pixel</td></tr>
+        <tr id="sms"><td>Tin nhắn SMS</td><td class="num">160 / tin</td><td>Rơi xuống 70 mỗi tin ngay khi xuất hiện một ký tự ngoài GSM-7 (emoji, dấu nháy cong, và mọi chữ tiếng Việt có dấu) — xem <a href="#sms-co-dau">cách đếm SMS</a></td></tr>
       </tbody>
-    </table>
+    </table></div>
   </section>
 
   <div class="section-divider"></div>
@@ -321,7 +319,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <section class="editorial-section" id="counting-modes">
     <h2>Vì sao số ký tự của bạn không khớp với nền tảng</h2>
     <p>"Đoạn này bao nhiêu ký tự?" có nhiều hơn một đáp án đúng, vì mỗi nền tảng đếm bằng một đơn vị khác nhau. Cùng một đoạn văn bản có thể có bốn độ dài:</p>
-    <table class="comparison-table">
+    <div class="comparison-table-wrap"><table class="comparison-table">
       <thead><tr><th>Cách đếm</th><th>Đo cái gì</th><th>Ai dùng</th></tr></thead>
       <tbody>
         <tr><td>Grapheme</td><td>Đúng thứ mắt bạn nhìn thấy — một emoji kèm màu da là 1</td><td>Bluesky; gần với cách Instagram xử lý emoji</td></tr>
@@ -329,7 +327,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
         <tr><td>Đơn vị UTF-16</td><td>Cách JavaScript và nhiều ứng dụng lưu chữ — mỗi chữ kiểu (𝗮 𝗯 𝗰) tốn 2 đơn vị</td><td>Ô nhập HTML (<code>maxlength</code>), nhiều game và backend ứng dụng</td></tr>
         <tr><td>Byte UTF-8</td><td>Dung lượng lưu trữ — é là 2, 中 là 3, 𝗯 là 4</td><td>Ô sản phẩm Amazon (tiêu đề 200 byte), tên Steam, cơ sở dữ liệu</td></tr>
       </tbody>
-    </table>
+    </table></div>
     <p>Cả bốn đều hiển thị trực tiếp ở phần số liệu phía trên, nên khi một biểu mẫu báo văn bản của bạn quá dài trong khi Word nói ngược lại, bạn thấy ngay biểu mẫu đó đang đếm bằng đơn vị nào. Một lưu ý riêng cho tiếng Việt: mỗi chữ có dấu như ế hay ộ vẫn là 1 code point, nhưng tốn tới 3 byte UTF-8 — nên những ô giới hạn theo byte sẽ chật hơn nhiều so với con số ký tự bạn thấy. Ngoài ra có hai nền tảng cần luật riêng:</p>
     <p><strong>X / Twitter đếm theo trọng số, không đếm ký tự.</strong> Theo đúng thuật toán X tự công bố (thư viện <code>twitter-text</code>), mỗi liên kết được tính chẵn 23, chữ cái Latinh cơ bản tính 1, và gần như mọi thứ còn lại — chữ CJK, phần lớn emoji, và mọi chữ Unicode kiểu — tính <strong>2</strong>. Một bài đăng viết toàn chữ kiểu vì thế chỉ chứa được 140 chữ hiển thị trong ngân sách 280. Mục "X / Twitter" trong bộ kiểm tra phía trên chạy đúng thuật toán này.</p>
     <p><strong>SMS đếm theo tin, và một ký tự thôi cũng đủ nhân đôi hóa đơn.</strong> Đây chính là chỗ tiếng Việt chịu thiệt nhất — xem phần <a href="#sms-co-dau">tin nhắn SMS có dấu</a> ngay bên dưới.</p>
@@ -454,6 +452,9 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     foldMeta: "Hiện {shown} trong {total} ký tự · {hidden} ký tự nằm sau nút bấm",
     foldRoom: "Còn {n} ký tự mở đầu trước khi bị cắt",
     foldDevices: "Điện thoại cắt ở {m}, máy tính ở {d}.",
+    pastFold: "Vừa — cắt ở {n} ⚠",
+    showAllFits: "Xem tất cả ({n})",
+    showFewerFits: "Thu gọn",
     overBy: "Vượt {n} ký tự — chọn một cách xử lý:",
     trimToFit: "Cắt cho vừa",
     undo: "Hoàn tác",

--- a/zh-tw/zishu-tongji/index.html
+++ b/zh-tw/zishu-tongji/index.html
@@ -48,7 +48,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>字數統計 — 免費線上計算字數與字元數工具 | UltraTextGen</title>
-  <meta name="description" content="免費的線上字數統計工具。輸入或貼上文字即時計算字數、字元數（含空白與不含空白）、句數、段落數與閱讀時間，中文字數計算一個字算一個字元，另附 X（推特）、Instagram、Discord 等 27 種平台字數限制檢查。">
+  <meta name="description" content="免費的線上字數統計工具。輸入或貼上文字即時計算字數、字元數（含空白與不含空白）、句數、段落數與閱讀時間，中文字數計算一個字算一個字元，另附 X（推特）、Instagram、Discord 等 17 個平台、38 個欄位的字數限制檢查。">
   <link rel="canonical" href="https://ultratextgen.com/zh-tw/zishu-tongji/">
 
   <link rel="alternate" hreflang="zh-TW" href="https://ultratextgen.com/zh-tw/zishu-tongji/">
@@ -69,7 +69,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <link rel="alternate" hreflang="x-default" href="https://ultratextgen.com/character-counter/">
 
   <meta property="og:title" content="字數統計 — 免費線上計算字數與字元數工具 | UltraTextGen">
-  <meta property="og:description" content="即時計算字數、字元數（含空白與不含空白）、句數、段落數與閱讀時間。中文一個字算一個字元，另附 X（推特）、Instagram、TikTok 等 27 種平台字數限制檢查。免費、免註冊、純瀏覽器端運算。">
+  <meta property="og:description" content="即時計算字數、字元數（含空白與不含空白）、句數、段落數與閱讀時間。中文一個字算一個字元，另附 X（推特）、Instagram、TikTok 等 17 個平台、38 個欄位的字數限制檢查。免費、免註冊、純瀏覽器端運算。">
   <meta property="og:url" content="https://ultratextgen.com/zh-tw/zishu-tongji/">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://ultratextgen.com/assets/og/zh-tw-zishu-tongji.png">
@@ -79,7 +79,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <meta property="og:image:alt" content="字數統計 — 免費線上計算字數與字元數工具 | UltraTextGen">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="字數統計 — 免費線上計算字數與字元數工具 | UltraTextGen">
-  <meta name="twitter:description" content="即時計算字數、字元數（含空白與不含空白）、句數、段落數與閱讀時間。中文一個字算一個字元，另附 X（推特）、Instagram、TikTok 等 27 種平台字數限制檢查。免費、免註冊、純瀏覽器端運算。">
+  <meta name="twitter:description" content="即時計算字數、字元數（含空白與不含空白）、句數、段落數與閱讀時間。中文一個字算一個字元，另附 X（推特）、Instagram、TikTok 等 17 個平台、38 個欄位的字數限制檢查。免費、免註冊、純瀏覽器端運算。">
   <meta name="twitter:image" content="https://ultratextgen.com/assets/og/zh-tw-zishu-tongji.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -102,7 +102,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   "inLanguage": "zh-TW",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Any",
-  "description": "即時計算字數、字元數（含空白與不含空白）、句數、段落數、行數與閱讀時間的免費字數統計工具。中文以 Unicode 碼位計算，一個中文字算一個字元，另附 27 種平台字數限制檢查，包含 X（推特）的加權計算與 SMS 簡訊分則計算。所有運算都在瀏覽器內完成。",
+  "description": "即時計算字數、字元數（含空白與不含空白）、句數、段落數、行數與閱讀時間的免費字數統計工具。中文以 Unicode 碼位計算，一個中文字算一個字元，另附 17 個平台、38 個欄位的字數限制檢查，包含 X（推特）的加權計算與 SMS 簡訊分則計算。所有運算都在瀏覽器內完成。",
   "offers": {
     "@type": "Offer",
     "price": "0",
@@ -159,19 +159,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <section class="hero"><div class="hero-inner"><div class="hero-card">
   <h1 class="hero-headline">字數統計</h1>
-  <p class="hero-sub">輸入的同時就完成字數統計：字元數（含空白與不含空白）、句數、段落數、行數、閱讀時間即時更新。還可以檢查目前的文字是否符合 X（推特）、Instagram、Threads、TikTok、YouTube、Discord、Telegram、SMS 等 27 種平台的字數限制 — 而且是照每個平台實際的計算方式計算。</p>
+  <p class="hero-sub">即時檢查 17 個平台、38 個欄位的字數限制，超出時一鍵修正。</p>
 </div></div></section>
 
 <main class="container">
-  <section class="editorial-section">
-    <div class="editorial-block">
-      <p>先在方框正上方選擇這段文字要發到哪裡，再輸入或貼上內容：字元數（含空白與不含空白）、句數、段落數、行數、閱讀時間與朗讀時間都會立刻更新，而檢查器會照你選的平台實際的計算方式計算，直接告訴你還剩下幾個字元（或超出幾個字元）。萬一超出，工具不會只丟給你一句「超過了」 — 它會列出可以怎麼縮短、每一種各能省下多少，全部一鍵套用、也能一鍵還原。沒有送出按鈕，輸入的內容也不會上傳 — 每一個數字都在你的瀏覽器裡算完。想把剛剛數好的文字換成特殊字體，<a href="/zh-tw/">UltraTextGen 特殊符號產生器</a>可以一鍵轉換成 100 種以上可複製貼上的樣式。</p>
-    </div>
-  </section>
-
-  <div class="section-divider"></div>
-
-  <div class="counter-tool">
+<div class="counter-tool">
     <div id="platformChecker"></div>
 
     <div class="counter-field">
@@ -211,12 +203,14 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     </div>
   </div>
 
+  <p class="counter-footnote">所有計算都在你的瀏覽器裡完成 — 輸入的內容不會上傳，也不會被儲存。想順便換個字體嗎？<a href="/zh-tw/">UltraTextGen 產生器</a>可以轉換成 100 種以上可複製貼上的字體。</p>
+
   <div class="section-divider"></div>
 
   <section class="editorial-section">
     <h2>硬性限制與軟性限制</h2>
     <p>被稱作「字數限制」的其實有兩種，超過之後的代價完全不同。</p>
-    <table class="comparison-table">
+    <div class="comparison-table-wrap"><table class="comparison-table">
       <thead><tr><th>類型</th><th>超過會怎樣</th><th>例子</th></tr></thead>
       <tbody>
         <tr>
@@ -230,35 +224,39 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
           <td>Instagram 貼文說明 125 字後 · LinkedIn 貼文行動版約 140 字、電腦版約 210 字後 · YouTube 說明約 157 字後</td>
         </tr>
       </tbody>
-    </table>
+    </table></div>
     <p>大多數人真正在對付的其實是軟性限制，卻幾乎沒有字數工具會把它顯示出來。一則 LinkedIn 貼文可以打 3,000 個字元，但真正有用的大約只有前面 140 個，其餘都藏在沒人會點的那一下之後。所以上方的工具直接把收合的位置畫出來 — 打字進去，你會看到「顯示更多」之前實際出現的那段文字，切線之後的部分會變淡，同時也看得到同一個開頭在其他會收合的版位撐不撐得住。</p>
     <p>這裡要特別講清楚：<strong>收合是用畫面上看得到的字數來算的。</strong>中文字在 UTF-8 佔 3 個位元組，但在收合的計算裡，一個字就是一個字。Instagram 的 125 字元收合，中文一樣放得下 125 個字，不會因為位元組而縮水。位元組會卡住你的是「送不送得出去」的硬性限制那一邊，跟收合是兩回事。</p>
     <p><strong>各個版位在哪裡收合，用什麼裝置看：</strong></p>
-    <table class="comparison-table">
-      <thead><tr><th>版位</th><th>收合位置</th><th>對開頭的意義</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>版位</th><th class="num">手機</th><th class="num">電腦</th><th>對開頭的意義</th></tr></thead>
       <tbody>
         <tr>
           <td>LinkedIn 貼文</td>
-          <td>手機約 140<br>電腦約 210</td>
-          <td>寫在 140 個字元以內，兩邊都撐得住。這是表中手機與電腦落差最大的一個版位。</td>
+          <td class="num">約 140</td>
+          <td class="num">約 210</td>
+          <td>寫在 140 個字元以內，兩邊都撐得住 — 這是表中裝置落差最大的一個版位。</td>
         </tr>
         <tr>
           <td><a href="/zh-tw/ig-ziti/">Instagram 貼文說明</a></td>
-          <td>約 125</td>
+          <td class="num">約 125</td>
+          <td class="num">約 125</td>
           <td>表中最緊的收合 — 大概只有一句話，就到「⋯更多」了。</td>
         </tr>
         <tr>
           <td>YouTube 說明</td>
-          <td>約 157</td>
+          <td class="num">約 157</td>
+          <td class="num">約 157</td>
           <td>標題底下、「顯示更多」之前會露出的那一段；搜尋結果抓的通常也是這裡。</td>
         </tr>
         <tr>
           <td>Facebook 貼文</td>
-          <td>約 477</td>
+          <td class="num">約 477</td>
+          <td class="num">約 477</td>
           <td>最寬鬆的收合 — 一個短段落可以整段落在切線之前。</td>
         </tr>
       </tbody>
-    </table>
+    </table></div>
     <p>兩點要老實講。這些是從實際介面觀察到的行為，不是平台公布的限制，所以請把它們當成「穩定會顯示出來的長度」，而不是精確的門檻 — 而且這些版位也會依<em>行數</em>收合，開頭連換三行，可能還沒碰到任何字數就先被截斷了。如果你的開頭靠的是條列，請也到真正的發文框裡試一次。</p>
   </section>
 
@@ -267,7 +265,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <section class="editorial-section" id="counting-modes">
     <h2>為什麼你算的字數和平台算的不一樣</h2>
     <p>「這段有幾個字？」不只有一個正確答案，因為每個系統計算的單位不同。對中文使用者來說最關鍵的一點是：<strong>一個中文字是 1 個碼位、1 個 UTF-16 單位，但換成 UTF-8 是 3 個位元組</strong>。所以用字元數來看明明還有空間，遇到以位元組設限的欄位或系統卻會被擋下來。同一段文字，可以有四種長度：</p>
-    <table class="comparison-table">
+    <div class="comparison-table-wrap"><table class="comparison-table">
       <thead><tr><th>計算方式</th><th>算的是什麼</th><th>中文的情況</th></tr></thead>
       <tbody>
         <tr><td>字素</td><td>眼睛看到的樣子 — 帶膚色的表情符號也算 1</td><td>「字」＝ 1。Bluesky 採用</td></tr>
@@ -275,7 +273,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
         <tr><td>UTF-16 單位</td><td>JavaScript 與許多應用程式儲存文字的方式</td><td>「字」＝ 1，但特殊字體的英數字每個算 2。HTML 表單的 <code>maxlength</code>、遊戲與應用程式後端</td></tr>
         <tr><td>UTF-8 位元組</td><td>儲存大小</td><td><strong>「字」＝ 3 個位元組</strong>。資料庫 <code>VARCHAR</code>、電商商品欄位、Steam 名稱、舊式系統與 CSV 介接</td></tr>
       </tbody>
-    </table>
+    </table></div>
     <p>這個落差在實務上很有感：一個標示「上限 255 位元組」的欄位，中文其實只放得下 85 個字。上方的「字素（看得見的字）」「UTF-16 單位」「UTF-8 位元組」三格會隨著輸入同步更新，當表單說你的文字太長、你自己算卻還沒滿時，可以當場看出它是用哪一種單位在算。至於全形與半形的換算，是中文表單特有的另一個問題，另外寫在<a href="#quanjiao-banjiao">全形與半形字元的計算方式</a>。</p>
     <p>除了這四種之外，還有兩個地方有自己的規則。<strong>X（推特）不是數字元、而是算加權</strong>，中文字每個計 2（詳見<a href="#x-twitter">X（推特）的中文字數</a>）。<strong>SMS 是以「則」計算</strong>，中文不在 GSM-7 字元集內，所以一律以 Unicode 編碼處理，每則降到 70 個字元（被拆開時是 67 個）；只用半形英數字的話則是每則 160 個字元。</p>
   </section>
@@ -313,51 +311,51 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <p>下表就是上方檢查器實際使用的那一份字數限制，供你查閱。快速跳至：<a href="#twitter">X／推特</a> · <a href="#discord">Discord</a> · <a href="#instagram">Instagram</a> · <a href="#tiktok">TikTok</a> · <a href="#sms">SMS</a> · <a href="#counting-modes">各平台的計算方式</a>。</p>
 
     <h3>貼文與訊息</h3>
-    <table class="comparison-table">
-      <thead><tr><th>平台</th><th>上限</th><th>補充</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>平台</th><th class="num">上限</th><th>補充</th></tr></thead>
       <tbody>
-        <tr id="twitter"><td>X（推特）貼文</td><td>280</td><td>加權計算：URL 一律計 23，中文字、表情符號與特殊字體每個計 2，中文貼文實際約 140 字</td></tr>
-        <tr id="discord"><td>Discord 訊息</td><td>2,000</td><td>訂閱 Nitro 為 4,000；更長的訊息會被轉成 .txt 附件</td></tr>
-        <tr id="instagram"><td>Instagram 貼文說明</td><td>2,200</td><td>前幾行之後會收合成「更多」</td></tr>
-        <tr id="tiktok"><td>TikTok 貼文說明</td><td>2,200</td><td></td></tr>
-        <tr><td>LinkedIn 貼文</td><td>3,000</td><td>依裝置不同，約 200–700 個字元後收合成「查看更多」</td></tr>
-        <tr><td>Facebook 貼文</td><td>63,206</td><td></td></tr>
-        <tr><td>YouTube 影片說明</td><td>5,000</td><td></td></tr>
-        <tr><td>Pinterest 圖釘說明</td><td>500</td><td></td></tr>
-        <tr><td>Telegram 訊息</td><td>4,096</td><td>照片／影片說明為 1,024</td></tr>
-        <tr><td>Threads 貼文</td><td>500</td><td></td></tr>
-        <tr><td>Bluesky 貼文</td><td>300</td><td>以字素（看得見的字）計算，不是碼位</td></tr>
-        <tr><td>Reddit 貼文標題</td><td>300</td><td></td></tr>
-        <tr><td>Zalo 貼文／動態</td><td>2,000</td><td></td></tr>
+        <tr id="twitter"><td>X（推特）貼文</td><td class="num">280</td><td>加權計算：URL 一律計 23，中文字、表情符號與特殊字體每個計 2，中文貼文實際約 140 字</td></tr>
+        <tr id="discord"><td>Discord 訊息</td><td class="num">2,000</td><td>訂閱 Nitro 為 4,000；更長的訊息會被轉成 .txt 附件</td></tr>
+        <tr id="instagram"><td>Instagram 貼文說明</td><td class="num">2,200</td><td>前幾行之後會收合成「更多」</td></tr>
+        <tr id="tiktok"><td>TikTok 貼文說明</td><td class="num">2,200</td><td></td></tr>
+        <tr><td>LinkedIn 貼文</td><td class="num">3,000</td><td>依裝置不同，約 200–700 個字元後收合成「查看更多」</td></tr>
+        <tr><td>Facebook 貼文</td><td class="num">63,206</td><td></td></tr>
+        <tr><td>YouTube 影片說明</td><td class="num">5,000</td><td></td></tr>
+        <tr><td>Pinterest 圖釘說明</td><td class="num">500</td><td></td></tr>
+        <tr><td>Telegram 訊息</td><td class="num">4,096</td><td>照片／影片說明為 1,024</td></tr>
+        <tr><td>Threads 貼文</td><td class="num">500</td><td></td></tr>
+        <tr><td>Bluesky 貼文</td><td class="num">300</td><td>以字素（看得見的字）計算，不是碼位</td></tr>
+        <tr><td>Reddit 貼文標題</td><td class="num">300</td><td></td></tr>
+        <tr><td>Zalo 貼文／動態</td><td class="num">2,000</td><td></td></tr>
       </tbody>
-    </table>
+    </table></div>
 
     <h3>個人簡介與檔案</h3>
-    <table class="comparison-table">
-      <thead><tr><th>欄位</th><th>上限</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>欄位</th><th class="num">上限</th></tr></thead>
       <tbody>
-        <tr><td>Instagram 個人簡介</td><td>150</td></tr>
-        <tr><td>TikTok 個人簡介</td><td>80</td></tr>
-        <tr><td>LinkedIn 標題（Headline）</td><td>220</td></tr>
-        <tr><td>WhatsApp 個人狀態</td><td>139</td></tr>
-        <tr><td>Telegram 個人簡介</td><td>70</td></tr>
-        <tr><td>VK 狀態</td><td>140</td></tr>
+        <tr><td>Instagram 個人簡介</td><td class="num">150</td></tr>
+        <tr><td>TikTok 個人簡介</td><td class="num">80</td></tr>
+        <tr><td>LinkedIn 標題（Headline）</td><td class="num">220</td></tr>
+        <tr><td>WhatsApp 個人狀態</td><td class="num">139</td></tr>
+        <tr><td>Telegram 個人簡介</td><td class="num">70</td></tr>
+        <tr><td>VK 狀態</td><td class="num">140</td></tr>
       </tbody>
-    </table>
+    </table></div>
 
     <h3>使用者名稱、標題與 SMS</h3>
-    <table class="comparison-table">
-      <thead><tr><th>欄位</th><th>上限</th><th>補充</th></tr></thead>
+    <div class="comparison-table-wrap"><table class="comparison-table">
+      <thead><tr><th>欄位</th><th class="num">上限</th><th>補充</th></tr></thead>
       <tbody>
-        <tr><td>Discord 暱稱</td><td>32</td><td></td></tr>
-        <tr><td>TikTok 使用者名稱</td><td>24</td><td>只能使用半形英文字母、數字、底線與句點</td></tr>
-        <tr><td>Instagram 使用者名稱</td><td>30</td><td></td></tr>
-        <tr><td>YouTube 影片標題</td><td>100</td><td></td></tr>
-        <tr><td>網頁標題（SEO meta title）</td><td>約 60</td><td>Google 以像素寬度截斷，請當作參考值</td></tr>
-        <tr><td>網頁描述（SEO meta description）</td><td>約 155</td><td>同樣是以像素寬度截斷</td></tr>
-        <tr id="sms"><td>SMS 簡訊</td><td>每則 160</td><td>全部使用 GSM-7 字元時。<strong>中文一律以 Unicode 編碼處理，實際每則只有 70 個字元</strong>（被拆開時為 67）</td></tr>
+        <tr><td>Discord 暱稱</td><td class="num">32</td><td></td></tr>
+        <tr><td>TikTok 使用者名稱</td><td class="num">24</td><td>只能使用半形英文字母、數字、底線與句點</td></tr>
+        <tr><td>Instagram 使用者名稱</td><td class="num">30</td><td></td></tr>
+        <tr><td>YouTube 影片標題</td><td class="num">100</td><td></td></tr>
+        <tr><td>網頁標題（SEO meta title）</td><td class="num">約 60</td><td>Google 以像素寬度截斷，請當作參考值</td></tr>
+        <tr><td>網頁描述（SEO meta description）</td><td class="num">約 155</td><td>同樣是以像素寬度截斷</td></tr>
+        <tr id="sms"><td>SMS 簡訊</td><td class="num">每則 160</td><td>全部使用 GSM-7 字元時。<strong>中文一律以 Unicode 編碼處理，實際每則只有 70 個字元</strong>（被拆開時為 67）</td></tr>
       </tbody>
-    </table>
+    </table></div>
     <p>台灣常用的服務中，<strong>LINE 狀態消息上限為 500 個字元</strong>。LINE 未包含在上方的檢查器中，請直接以「字元數」那一格對照即可。</p>
   </section>
 
@@ -456,6 +454,9 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     foldMeta: "{total} 個字元中顯示了 {shown} 個 · {hidden} 個藏在點擊之後",
     foldRoom: "距離被收合，開頭還剩 {n} 個字元",
     foldDevices: "手機在 {m} 收合，電腦在 {d}。",
+    pastFold: "放得下，但 {n} 字後收合 ⚠",
+    showAllFits: "顯示全部 {n} 個",
+    showFewerFits: "顯示少一點",
     overBy: "超出 {n} 個 — 選一種處理方式：",
     trimToFit: "截斷到剛好符合",
     undo: "還原",


### PR DESCRIPTION
Follow-up to #719, which merged while this work was in flight. These four commits landed on the branch afterwards, so no open PR tracked them — rebased onto current `main` and raised here.

Everything below is a response to the owner's review of the merged page: *"Isn't this part too verbose? ... Should hard and soft limit be baked in UX? Like it shows amber when it hits the soft limit? ... I don't think people want to be educated or reminded. They just want a tool where they could copy-paste and check."*

## The badge was lying by omission

The amber suggestion exposed the tool's central flaw. Measured on the live page:

```
LinkedIn post, 680 characters:
  badge said : Fits ✓ (green)      bar fill : 23% (looks comfortable)
  reality    : 540 characters behind the tap — 79% of the post unread
  fold sat at: 5% along the bar — invisible, unmarked
```

Two states — fits, or over — and **the state that matters most on a feed field was neither of them.** Now three: green fits, **amber past the fold**, red over limit, plus a **tick on the bar** where the feed truncates. The number a writer is actually working against is on the control instead of explained in a paragraph below it.

## The rest of the review, measured

| Problem | Was | Now |
|---|---|---|
| Preamble before you can paste | **141 words** | 21 |
| Fit grid | **38 chips**, 25 red at once | 12 at the boundary + toggle |
| Fold table | both numbers in one cell → 4-line row | `Mobile` / `Desktop` columns |
| `.comparison-table` CSS | **14 lines** — no row rules, zebra, tabular numerals or overflow container | all four, plus `.num` right-align |

The missing overflow container is why wide tables pushed the whole layout sideways on a phone.

Structurally the page was *an article containing a tool*. The reference material is still there — it's why the page can rank — but it no longer stands between the visitor and the textarea.

## The embeddable widget was never updated

`/character-counter/embed/` — the version that renders inside **other people's sites** — was still the pre-critique design: selector below the stats grid, no fix bar, no fold panel, `counterReduce.js` never loaded. It's `noindex`, so no gate or audit was ever going to look at it, and it was a plain character counter: exactly what every competitor already ships.

Backlinks, not translations, are the documented constraint on this page ranking, and an embed is only worth embedding if it does something the alternatives don't. It now leads with the picker and carries the live count, inspect line, fold panel and one-click fixes. The 38-chip grid is deliberately left out — an embed should stay small.

## The gate that was missing

Every validator in this repo checks *structure* — links, headings, FAQ counts, hreflang, images. **None checked whether a number written in prose still matches the code that produces it.** That gap shipped twice in one week with every gate green, because a figure inside a `<td>` or a `<meta>` is invisible to a structural diff by design.

`scripts/check-counter-claims.js` (`npm run check:counter-claims`) asserts both directions against `counterRules.js` itself — aggregate claims ("N platforms", "N fields") and every numeric table cell. Numbers are language-independent, which is what lets one check cover 15 languages without translating anything.

Proven both ways per this repo's own *"adding a validator is not the same as gating on it"* rule: clean on the real tree, exit 1 on falsified input, tested separately for each half. Wired into `validate.yml` **and its final gating condition** — alongside `check:external-refs`, which main added in the same window; the rebase kept both.

**It immediately found more than the two numbers that motivated it: ten pages asserting a stale platform count — and not all said 27. Spanish and Portuguese said *eighteen*.** A grep for the known-bad value would never have surfaced those. Japanese and Traditional Chinese said 27 in their meta, OG *and* JSON-LD while their own new subtitle said 38/17 — the page contradicting itself in the snippet Google prints.

Three blind spots in the checker itself, all found by using it and fixed rather than whitelisted:
- it stripped `<script>` before scanning, so JSON-LD `description` fields — a claim made to machines exactly like a meta tag — were invisible;
- it required the figure adjacent to the noun, which never holds in CJK (`27種類のプラットフォーム`, `27 種平台`), narrowly enough now that an ordinary `4種類の数え方` isn't swept up;
- it flagged Russia's runtime-injected VK limit (15,940) as invalid, because that rule exists in no shared file. Valid figures are now derived **per page**, replaying inline scripts that touch `LIMITS`.

## Two bugs these changes introduced, caught by their own assertions

- **`pastFold` was never passed to the checker's `text` config** — every translated page would have rendered the English amber badge.
- **Grid collapse could hide the destination the user selected** — precisely when it has the most headroom, i.e. when they're least likely to notice. The active row is now pinned in.

Both existed for minutes, because the assertions were written before the code was trusted.

## Localisation

All 14 locale pages brought to the same UX: the three new strings translated so the amber badge and grid toggle don't fall back to English, the verbose intro replaced by a one-line footnote, fold tables split into Mobile/Desktop columns, every table wrapped for mobile.

Verified independently of the agents' own reports: `<h2>` counts unchanged, **no outbound link dropped** (the footnote carries each locale's homepage link, so link sets are byte-identical and the parity gate has nothing to fire on), FAQ text and JSON-LD still in sync, no inline styles, table/wrapper counts matched, and the whole `<main>` re-parsed on all 15 pages.

## Validation

All twelve gates pass, plus both suites — **51 engine and 98 DOM assertions** — re-run against the new base after the rebase, per this repo's rule that merged-in governance binds unshipped work:

`check:counter-claims` · `check:external-refs` · `check:faq-schema` · `check:translation-parity` · `check:locale-mesh` · `check:new-page-images` · `check:locale-parent-gap` · `check:funding-choices` · `check:hreflang` · `check:hreflang-completeness` · `check:new-symbol-peer-links` · `validate_library_pages.py`

## One thing to check before merge

The `.comparison-table` restyle is **site-wide** — it touches every page using that class, not just the counter. It's a strict improvement over 14 lines of bare padding and all gates pass, but I have not visually reviewed other pages that use it. Worth a spot-check on a `guide/` or `library/` page.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjDLiPV7WJBH9XQXM8exbr)_