### PR TITLE
fix: scope Pages Functions to `/` only via _routes.json — static requests stop billing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,9 @@ ultratextgen/
 ├── _redirects              # Cloudflare Pages redirect rules — PATH ONLY,
 │                           #   query strings are silently ignored (see below)
 ├── _headers                # Cloudflare Pages response headers
+├── _routes.json            # Pages Functions routing: ONLY `/` invokes the
+│                           #   Function — keeps every other request a free
+│                           #   static asset (see What NOT to Do)
 ├── functions/_middleware.js# Pages Function: owns `/` (English homepage + ?lang=)
 │
 ├── .github/workflows/
@@ -1809,12 +1812,25 @@ Standing protocol:
 - Do not put a query string in a `_redirects` source path. This is Cloudflare
   Pages, not Netlify: Pages matches the **path only** and silently drops the
   query, so `/?lang=fr  /fr/  301` is read as `/  /fr/  301` and 301s the
-  English homepage to French for every visitor and crawler — and because a
-  static redirect short-circuits before Pages Functions, it also bypasses
-  `functions/_middleware.js`, which exists specifically to keep `/` English.
-  That shipped in PR #566 and sat live from 2026-07-15 to 2026-07-26. Query
-  matching belongs in `functions/_middleware.js` (`LANG_REDIRECTS`), which can
-  actually read `url.searchParams`.
+  English homepage to French for every visitor and crawler. That shipped in
+  PR #566 and sat live from 2026-07-15 to 2026-07-26 — during that window
+  `functions/_middleware.js` (which exists specifically to keep `/` English)
+  was not executing, so nothing intercepted the bad rule. Note the ordering:
+  when Functions ARE active on a route (per `_routes.json`), the Function
+  runs *before* `_redirects` — verified on production 2026-08-10, where the
+  middleware's `?lang=` 301s fire on `/` even though `_redirects` also has a
+  `/` rule. Query matching belongs in `functions/_middleware.js`
+  (`LANG_REDIRECTS`), which can actually read `url.searchParams`.
+- Do not widen `_routes.json`'s `include` list, add new files under
+  `functions/`, or delete `_routes.json`, without checking the Functions
+  invocation budget. Every included route bills one Workers-quota invocation
+  per request; with no `_routes.json`, Cloudflare auto-generates one that
+  routes **every** request (CSS, JS, images, all pages) through the root
+  middleware just to run `context.next()`. That was live until 2026-08-10
+  and burned ~100k invocations/day — the entire Workers free daily quota —
+  at ~36k pageviews/day. Static asset requests are free and unlimited only
+  when they do not invoke a Function. Only `/` needs the Function (English
+  homepage + legacy `?lang=` 301s); everything else must stay excluded.
 - Do not edit `sitemap.xml` directly
 - Do not add `var` declarations — use `const`/`let`
 - Do not use `import`/`export` ES module syntax in frontend scripts

--- a/_redirects
+++ b/_redirects
@@ -3,14 +3,16 @@ https://www.ultratextgen.com/*  https://ultratextgen.com/:splat  301!
 
 # Serve the English homepage for the root path.
 #
-# This rule is what actually keeps / on English. It was previously
-# described as a "safety net if the middleware is not deployed", with
-# functions/_middleware.js as the primary fix — but the middleware does
-# not execute on this Pages project at all. Verified on the PR #674
-# preview: with this rule REMOVED (so nothing in _redirects matched /),
-# /?lang=de still returned 200 rather than the 301 the middleware issues
-# from its very first branch. Functions are inert here; this is primary,
-# not a fallback. Do not remove it expecting the middleware to cover /.
+# Fallback layer for /. On current production (verified 2026-08-10)
+# functions/_middleware.js IS executing and owns / — it runs before
+# _redirects on routes /_routes.json sends it, serves the English
+# homepage via /_root, and 301s legacy ?lang= URLs. This rule exists
+# for the state where Functions are inert (as a PR #674 preview test
+# observed on 2026-07-26, when this comment claimed Functions never
+# ran here): if the middleware ever stops executing again, this rewrite
+# is what keeps / on English instead of letting Pages' implicit
+# Accept-Language i18n negotiation serve a locale homepage. Keep both
+# layers; do not remove either expecting the other to cover /.
 /  /index.html  200
 
 # Canonical path: enforce trailing slash on platform root pages

--- a/_routes.json
+++ b/_routes.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "include": ["/"],
+  "exclude": []
+}

--- a/functions/_middleware.js
+++ b/functions/_middleware.js
@@ -1,16 +1,28 @@
-// ⚠️  THIS MIDDLEWARE DOES NOT CURRENTLY RUN.
+// ✅ THIS MIDDLEWARE IS LIVE, and its invocation scope is governed by
+// /_routes.json — only pathname `/` invokes it. Do not add routes to
+// that include list (or new files under functions/) without checking
+// the Functions invocation budget: every included route bills one
+// Workers-quota invocation per request, and before /_routes.json
+// existed (added 2026-08-10) Cloudflare's auto-generated routing sent
+// EVERY request — CSS, JS, images, all locale pages — through this
+// function just to run context.next(), burning ~100k invocations/day
+// (the entire Workers free daily quota) at ~36k pageviews/day.
 //
-// Pages Functions are not executing on this project. Verified on the
-// PR #674 preview deploy (2026-07-26): with every _redirects rule that
-// matched `/` removed, `/?lang=de` still returned 200 instead of the
-// 301 the LANG_REDIRECTS branch below issues before touching anything
-// else. `/` is served by the `/  /index.html  200` rule in _redirects,
-// and the `_root.html` copy this file fetches is unused.
-//
-// The code below is correct and will take effect if Functions are ever
-// enabled (check the Pages project's build config in the Cloudflare
-// dashboard) — but do not rely on it for anything today, and do not
-// delete a _redirects rule on the assumption that it covers you.
+// History, so nobody "re-discovers" either half of it:
+// - A PR #674 preview test (2026-07-26) concluded Pages Functions were
+//   not executing on this project, and this banner used to say so.
+//   That conclusion no longer holds and must not be trusted: verified
+//   against production on 2026-08-10, `/?lang=de` 301s to /de/,
+//   `/?lang=DE` does too (this file's .toLowerCase()), `/?lang=en` and
+//   unknown codes fall through, and `?q=` is carried while `lang` is
+//   dropped — this file's exact fingerprint, which no _redirects rule
+//   can produce (Pages matches _redirects on the path only). What
+//   changed between those two dates was never pinned down; what is
+//   certain is that Functions execute on production today.
+// - The `/  /index.html  200` rule in _redirects is the fallback that
+//   keeps `/` English if Functions are ever inert again (as they were
+//   during that 07-26 test). Keep both layers; do not delete either on
+//   the assumption that the other covers you.
 //
 // Legacy ?lang= query-param URLs → path-based locale homepages.
 //


### PR DESCRIPTION
## Why requests were being counted

With a root-level `functions/_middleware.js` and **no `_routes.json`**, Cloudflare Pages auto-generates a routing manifest that sends **every request** through the Function. Per current Cloudflare docs ([Functions routing](https://developers.cloudflare.com/pages/functions/routing/), [pricing](https://developers.cloudflare.com/pages/functions/pricing/)): *"once you add Functions on a Pages project, all requests by default will invoke your Function"*, those invocations count against the shared Workers free quota (100k/day), and static asset requests are only free/unlimited *"when [they do] not invoke Functions."* So every CSS, JS, image, and locale-page request was a billed invocation that ran `context.next()` and nothing else. The numbers fit exactly: 100,232 invocations ÷ ~36k pageviews ≈ 2.8 requests/pageview, and 1,345,914 CPU-ms ÷ 1.18M requests ≈ 1.1 ms — the profile of a trivial pass-through middleware.

## Reconciling the repo comments with the usage evidence

The repo claimed the middleware "does not run" (PR #674 preview test, 2026-07-26). **That conclusion no longer holds on production.** Verified 2026-08-10 against `ultratextgen.com`:

| Probe | Result | Matches middleware code |
|---|---|---|
| `/?lang=de` | 301 → `/de/` | `LANG_REDIRECTS` branch |
| `/?lang=fr&q=test` | 301 → `/fr/?q=test` | drops `lang`, carries `q` |
| `/?lang=DE` | 301 → `/de/` | `.toLowerCase()` |
| `/?lang=en`, `/?lang=xx` | 200 | en-skip + unknown-code fallthrough |
| `/fr/?lang=de` | 200 | only pathname `/` intercepted |

`_redirects` matches paths only and cannot produce any of this — the Function is live. What changed between 2026-07-26 and now was not pinned down from the repo alone (it isn't in tracked files); what is certain is that Functions execute on production today, which is also what the billing data says.

**This is why Option 1 (delete `functions/`) was rejected: it would have broken live, working `?lang=` redirects.** Option 3 preserves them at ~zero cost.

## Routes before / after

- **Before:** all routes invoke the Function (auto-generated manifest).
- **After:** only pathname `/` invokes it (any query string included — routing is path-based). Everything else — CSS, JS, images, SVG/PNG/JSON, all locale and content pages — is served directly as free static assets, because `_routes.json`'s `include` list is authoritative and anything outside it never reaches the Function.

## Homepage and localization safeguards

- `/` keeps its two independent layers, now correctly documented: the live middleware (serves the English `/_root` copy, immune to Pages' implicit Accept-Language i18n negotiation, and 301s legacy `?lang=`), and the `/  /index.html  200` rewrite in `_redirects` as fallback if Functions ever go inert again.
- Legacy `?lang=` URLs: **live behavior preserved** — the repo previously said this handling was inactive; it is in fact active, and this PR keeps it active (documented in the updated comments).
- `_root.html` + the `cp index.html _root.html` build step are kept — the live middleware depends on them.

## Tests performed

Functional verification with `wrangler pages dev` (same routing engine as production), using a **temporary marker header** (never committed) to make invocation observable:

- **With `_routes.json`:** `/` carries the marker; `/style.css`, `/script.js`, `/fr/`, `/library/emoji-combos/`, `/assets/og/fancy-text-generator-preview.png` do **not** → static routes bypass the Function.
- **Without `_routes.json` (counterfactual):** all of those routes carry the marker → root cause confirmed empirically, not just from docs.
- **16-URL status/location matrix** (`/`, `/?lang=de`, `/?lang=fr&q=test`, `/?q=test`, `/?lang=en|xx|DE`, `/fr/`, `/de/`, `/style.css`, `/script.js`, OG PNG, `/library/emoji-combos/`, `/symbol/euro-sign/`, `/discord`→`/discord/`, `/fr/?lang=de`) matches the production baseline captured before the change, byte-for-byte on status + Location.
- `/` returns **200, `lang="en"`, canonical `https://ultratextgen.com/`** under Accept-Language none/fr/de/id.
- www→non-www 301 verified on production (zone-level, untouched by this change).
- Repo gates: `check:translation-parity`, `check:locale-mesh`, `check:faq-schema`, `check:new-page-images`, `check:locale-parent-gap` (no HTML changed — all pass), `check:workflows` (10 workflows, 0 errors).

## Expected Cloudflare usage reduction

Function invocations should drop from ~100k/day to roughly the daily count of root-path (`/`) requests — a small fraction of homepage pageviews' share of 36k total pageviews. No exact number promised until production traffic is observed. This is a genuine elimination of invocations, not a relocation: the excluded requests are served by Pages' static asset layer, which is free and unlimited on all plans.

## Post-deployment verification

1. Dashboard → Workers & Pages → this Pages project → **Metrics → Functions**: invocation count should collapse within hours of the deploy.
2. Re-run the production probes: `/?lang=de` still 301 → `/de/`; `/` still 200 English under `Accept-Language: fr`.
3. Spot-check a static asset and a locale page return 200.
4. After 24h, compare Function requests vs GA4 pageviews: Function requests should be far **below** pageviews (only root-path hits), where before they exceeded them ~3×.
5. If the dashboard still shows high usage attributed to this project, the residual is coming from something outside this repo (e.g. another Worker on the account) — that would need dashboard-side investigation, not repo changes.

## Rollback

Revert this commit (restores the auto-generated all-routes manifest and old comments). Behavior-wise nothing else changes on rollback — the middleware and `_redirects` are functionally untouched; only comments and routing scope moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RcDQWL8adB6uYTT9SpHJAX

---
_Generated by [Claude Code](https://claude.ai/code/session_01RcDQWL8adB6uYTT9SpHJAX)_