### PR TITLE
fix(scripts): apply the updates/ pin exclusion to locale entries too

### DIFF
--- a/scripts/check-image-assets.py
+++ b/scripts/check-image-assets.py
@@ -68,6 +68,27 @@ def url_to_slug(url):
     return "homepage" if path == "" else path.replace("/", "-")
 
 
+def is_dated_update(url):
+    """True for a DATED updates entry in ANY locale; False for the hub.
+
+    page_type() returns "localized" for every <lang>/... URL and stops before
+    it can see the content type, so `ptype` is never "updates" for a locale
+    entry and the exclusion below silently missed all of them: 56 locale
+    entries were being reported as missing a Pinterest pin that
+    generate-pinterest.py deliberately never generates. EN was unaffected
+    (`updates/foo` classifies as "updates"), which is why the asymmetry went
+    unnoticed — 0 EN entries flagged against 56 locale ones.
+
+    Tests for a segment AFTER "updates" on purpose: per CLAUDE.md the
+    `updates/` hub IS pin-eligible and only the dated entries beneath it are
+    excluded.
+    """
+    seg = [s for s in url.replace(BASE, "").strip("/").split("/") if s]
+    if seg and seg[0] in LOCALES:
+        seg = seg[1:]
+    return len(seg) >= 2 and seg[0] == "updates"
+
+
 def pin_eligible(url, ptype):
     """Mirror of generate-pinterest.py:classify — hubs stay in, only
     legal/info, embed, and updates (dated status log, not visual pin
@@ -76,7 +97,7 @@ def pin_eligible(url, ptype):
         return False
     if ptype == "embed" or "/embed/" in url:
         return False
-    if ptype == "updates":
+    if ptype == "updates" or is_dated_update(url):
         return False
     return True
 

--- a/scripts/generate-pinterest.py
+++ b/scripts/generate-pinterest.py
@@ -219,6 +219,27 @@ def pin_svg(slug, title, sub, motif, kicker, a=PURPLE, b=BLUE):
 
 
 # ---------------------------------------------------------------- eligibility
+# Locale-aware twin of the `ptype == "updates"` test in classify(). The "Page
+# type" column comes from build-image-seo-status.py:page_type, which returns
+# "localized" for every <lang>/... URL and never reaches the content type — so
+# a locale updates entry reads as "localized" and would be pinned, while its EN
+# original is correctly excluded. Kept as a mirror of
+# check-image-assets.py:is_dated_update; if you change one, change both.
+_UPD_LOCALES = ("ar", "bs", "cs", "da", "de", "es", "fi", "fr", "hi", "hr",
+                "hu", "id", "it", "ja", "ko", "ms", "nl", "no", "pl", "pt",
+                "ro", "ru", "sk", "sr", "sv", "th", "tl", "tr", "vi", "zh-tw")
+
+
+def _is_dated_update(url):
+    """True for a dated updates entry in any locale; False for the hub."""
+    path = url.split("://", 1)[-1]
+    path = path.split("/", 1)[1] if "/" in path else ""
+    seg = [s for s in path.strip("/").split("/") if s]
+    if seg and seg[0] in _UPD_LOCALES:
+        seg = seg[1:]
+    return len(seg) >= 2 and seg[0] == "updates"
+
+
 def classify(row):
     """Return (include: bool, exclusion_reason: str). exclusion_reason is ''
     when the page is included."""
@@ -229,7 +250,7 @@ def classify(row):
                        else "utility page")
     if ptype == "embed" or slug.startswith("embed-") or "/embed/" in row["Page URL"]:
         return False, "embed page"
-    if ptype == "updates":
+    if ptype == "updates" or _is_dated_update(row["Page URL"]):
         return False, "dated status/verification log, not visual pin material"
     # The overview hubs (/category/, /usecase/, /library/, /answers/, /guide/)
     # are kept: each is a strong topical landing page with real keyword + visual


### PR DESCRIPTION
Two files, both Python. No pages added or changed.

## The bug

Per CLAUDE.md, a **dated `updates/` entry is excluded from the Pinterest pin requirement** — "a dated status/verification log isn't visual pin material" — while the `updates/` **hub** stays pin-eligible. Both `check-image-assets.py` and `generate-pinterest.py` implement that exclusion by testing `ptype == "updates"`.

That test only ever matched English.

`page_type()` returns `"localized"` for any `<lang>/…` URL and returns *immediately*, before it can look at the content type. So `ptype` is never `"updates"` for a locale entry, and every dated locale entry fell straight through the exclusion into the pin requirement.

The asymmetry is why it went unnoticed: **0 EN entries flagged, 56 locale ones.** `updates/foo` classifies correctly as `"updates"`, so the English side always looked right.

## The fix

A small `is_dated_update()` helper in each script that strips a leading locale segment before testing for `updates/`, added to the existing eligibility test rather than replacing it. Mirrored into both scripts, because they are already documented as needing to stay in sync about what counts as pin-eligible — a fix in one only would have re-created the drift as a new bug.

It deliberately tests for a segment *after* `updates`, so the hub keeps its pin in every locale.

## Verification

Measured on an identical page tree, `main`'s script vs this branch's:

| | Indexable pages checked | Problems found |
|---|---:|---:|
| `main` | 4,431 | 2,028 |
| this branch | 4,431 | **1,972** |

Exactly **56** removed, every one a dated locale `updates/` entry asking for a pin `generate-pinterest.py` deliberately never generates.

Pin-eligibility truth table, all seven cases passing:

| URL | Expected | Result |
|---|---|---|
| `/updates/` | eligible | PASS |
| `/updates/unicode-18-release-date-confirmed/` | excluded | PASS |
| `/vi/updates/emoji-moi-unicode-18/` | excluded | PASS |
| `/zh-tw/updates/unicode-18-fabu-riqi-queren/` | excluded | PASS |
| `/vi/updates/` | eligible | PASS |
| `/id/printables/huruf-bubble/` | eligible | PASS |
| `/vi/` | eligible | PASS |

`npm run check:workflows` — 10 workflows, 0 errors, 0 warnings.

## Why this is worth landing rather than leaving

`check-image-assets.py` is the informational dashboard, but the same exclusion logic governs what the **gating** `check-new-page-images` reasons about. Until this lands, the 56 phantom failures stay in the report and grow with every new locale `updates/` entry — noise in exactly the check that is supposed to catch a genuinely missing asset.

## Note on the branch

This commit was originally pushed to this branch *after* #745 had already merged, which left it tracked by nothing — the "a commit pushed to a branch whose PR already merged is invisible" case CLAUDE.md calls out. Per that rule the branch has been restarted from `main` with the commit rebased onto it, so this PR is a new PR rather than a revival of #745. The rebase preserved main's own change to the same file (the `--only` help text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zfXS66bnanzQSUMgCWt5N

---
_Generated by [Claude Code](https://claude.ai/code/session_018zfXS66bnanzQSUMgCWt5N)_