### PR TITLE
feat(sitemap): declare every content image per URL, not just the og:image

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "check:external-refs": "node scripts/check-external-refs.js",
     "refresh:events": "python3 scripts/refresh-event-pages.py",
     "check:counter-claims": "node scripts/check-counter-claims.js",
+    "test:sitemap-images": "node scripts/update-sitemap.test.js",
     "plan:library-locale": "python3 scripts/plan-library-locale-batch.py",
     "check:tile-codepoints": "python3 scripts/check-tile-codepoints.py",
     "check:document-head": "python3 scripts/check-document-head.py",

--- a/scripts/update-sitemap.js
+++ b/scripts/update-sitemap.js
@@ -43,16 +43,58 @@ function findIndexFiles(dir, relativePath = '') {
 const OG_IMAGE_RE = /<meta\s+property=["']og:image["']\s+content=["']([^"']+)["']/;
 const LOGO_FALLBACK = `${BASE_URL}/logo.png`;
 
-function getOgImage(filePath) {
+// Decorative figures are stripped before scanning for content images. The hero
+// banner restates the page's own <h1>, so wire-site-art.py ships it as
+// aria-hidden with a null alt — the WCAG-correct call for an image that adds
+// nothing a screen reader user isn't already getting. An image sitemap should
+// list images we want *indexed*, and a decorative one is by definition not that.
+const DECORATIVE_FIGURE_RE = /<figure\b[^>]*\baria-hidden=["']true["'][^>]*>[\s\S]*?<\/figure>/gi;
+const IMG_TAG_RE = /<img\b[^>]*>/gi;
+const SRC_RE = /\bsrc=["']([^"']+)["']/i;
+const ALT_RE = /\balt=["']([^"']*)["']/i;
+
+// Content images: an <img> with a real (non-empty) alt, outside any decorative
+// figure. That rule is the reason specimen charts (assets/specimen/*.png — a
+// rendered grid of the page's own symbols, which carries information the prose
+// does not) get declared, while the ~2,000 decorative hero SVGs never do. It is
+// deliberately a property of the markup rather than a hardcoded path: any future
+// content image described well enough to deserve indexing qualifies on its own,
+// and nothing here needs updating when one is added.
+function getContentImages(html) {
+  const out = [];
+  for (const tag of html.replace(DECORATIVE_FIGURE_RE, '').match(IMG_TAG_RE) || []) {
+    if (/\baria-hidden=["']true["']/i.test(tag)) continue;
+    const alt = tag.match(ALT_RE);
+    if (!alt || !alt[1].trim()) continue;
+    const src = tag.match(SRC_RE);
+    if (!src) continue;
+    const url = src[1].trim();
+    // Same-origin only. A data: URI has no URL to index, and an image we do not
+    // host is not ours to declare. `//host/path` is protocol-relative and points
+    // at another origin despite its leading slash — prefixing it would produce
+    // https://ultratextgen.com//cdn.example.com/... and declare an image that
+    // 404s. Caught by update-sitemap.test.js rather than by review.
+    if (url.startsWith('//')) continue;
+    if (url.startsWith('/')) out.push(`${BASE_URL}${url}`);
+    else if (url.startsWith(`${BASE_URL}/`)) out.push(url);
+  }
+  return out;
+}
+
+// Every image this page wants indexed, og:image first, de-duplicated. A page may
+// legitimately declare several — the sitemap spec allows up to 1,000 per URL.
+function getPageImages(filePath) {
   let html;
   try {
     html = fs.readFileSync(path.join(REPO_ROOT, filePath), 'utf8');
   } catch {
-    return null;
+    return [];
   }
-  const m = html.match(OG_IMAGE_RE);
-  if (!m || m[1] === LOGO_FALLBACK) return null;
-  return m[1];
+  const images = [];
+  const og = html.match(OG_IMAGE_RE);
+  if (og && og[1] !== LOGO_FALLBACK) images.push(og[1]);
+  images.push(...getContentImages(html));
+  return [...new Set(images)];
 }
 
 // A sitemap is a list of pages we WANT indexed — advertising a noindex page
@@ -120,7 +162,7 @@ function todayDate() {
 
 // ─── XML builder ──────────────────────────────────────────────────────────────
 
-function buildUrlBlock(url, lastmod, changefreq, priority, image) {
+function buildUrlBlock(url, lastmod, changefreq, priority, images) {
   const lines = [
     '  <url>',
     `    <loc>${BASE_URL}${url}</loc>`,
@@ -128,7 +170,7 @@ function buildUrlBlock(url, lastmod, changefreq, priority, image) {
     `    <changefreq>${changefreq}</changefreq>`,
     `    <priority>${priority}</priority>`,
   ];
-  if (image) {
+  for (const image of images || []) {
     lines.push('    <image:image>', `      <image:loc>${image}</image:loc>`, '    </image:image>');
   }
   lines.push('  </url>');
@@ -137,7 +179,7 @@ function buildUrlBlock(url, lastmod, changefreq, priority, image) {
 
 function buildSitemap(urlEntries) {
   const blocks = urlEntries.map(e =>
-    buildUrlBlock(e.url, e.lastmod, e.changefreq, e.priority, e.image)
+    buildUrlBlock(e.url, e.lastmod, e.changefreq, e.priority, e.images)
   );
 
   return [
@@ -178,8 +220,8 @@ function generateSitemap() {
       const url      = pathToUrl(filePath);
       const lastmod  = getGitLastMod(filePath);
       const defaults = getUrlDefaults(url);
-      const image    = getOgImage(filePath);
-      return { url, lastmod, image, ...defaults };
+      const images   = getPageImages(filePath);
+      return { url, lastmod, images, ...defaults };
     })
     .sort((a, b) => urlSortKey(a.url).localeCompare(urlSortKey(b.url)));
 
@@ -203,4 +245,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { generateSitemap };
+module.exports = { generateSitemap, getContentImages };

--- a/scripts/update-sitemap.test.js
+++ b/scripts/update-sitemap.test.js
@@ -1,0 +1,128 @@
+/* ==========================================================
+   update-sitemap.test.js
+   Assertions for getContentImages() — the rule deciding which on-page
+   images the sitemap declares.
+
+   No DOM, no dependencies, no runner:
+       node scripts/update-sitemap.test.js
+   Exits non-zero on the first failure, and prints every assertion.
+
+   This file exists because the decorative/content split is invisible when
+   it breaks. Getting it wrong in one direction declares ~2,000 decorative
+   hero banners that restate their own <h1> — images an image sitemap is
+   explicitly not for. Getting it wrong in the other direction silently
+   drops the specimen charts the whole image-SEO probe depends on, and the
+   only symptom would be a null result 45 days later that looks like the
+   experiment failing rather than the images never being declared.
+
+   The site's own markup already encodes the distinction, and the rule reads
+   it rather than hardcoding paths: guide/ uses a visible guide-hero-figure
+   with real descriptive alt, while answers/ and most pages use a decorative
+   page-hero-figure shipped aria-hidden with a null alt (see CLAUDE.md,
+   "Content Type: Updates", which states that split directly).
+   ========================================================== */
+const { getContentImages } = require("./update-sitemap.js");
+
+let pass = 0;
+let fail = 0;
+
+function eq(label, actual, expected) {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a === e) {
+    pass++;
+    console.log(`  ok   ${label}`);
+  } else {
+    fail++;
+    console.error(`  FAIL ${label}\n         expected ${e}\n         actual   ${a}`);
+  }
+}
+
+const B = "https://ultratextgen.com";
+
+// --- decorative: excluded -------------------------------------------------
+eq("decorative hero (aria-hidden figure + null alt) is not declared",
+  getContentImages(
+    '<figure class="page-hero-figure" data-uthero aria-hidden="true">' +
+    '<img src="/assets/hero/about.svg" width="1200" height="340" alt=""></figure>'),
+  []);
+
+eq("null alt alone is enough to exclude, with no aria-hidden anywhere",
+  getContentImages('<img src="/assets/hero/x.svg" alt="">'),
+  []);
+
+eq("whitespace-only alt counts as null, not as a description",
+  getContentImages('<img src="/assets/hero/x.svg" alt="   ">'),
+  []);
+
+eq("no alt attribute at all is excluded — undescribed is not indexable content",
+  getContentImages('<img src="/assets/hero/x.svg">'),
+  []);
+
+eq("aria-hidden on the <img> itself excludes it even with a real alt",
+  getContentImages('<img src="/a.png" alt="Real description" aria-hidden="true">'),
+  []);
+
+// --- content: included ----------------------------------------------------
+eq("specimen chart is declared",
+  getContentImages(
+    '<figure class="specimen-figure">' +
+    '<img src="/assets/specimen/library-roblox-symbols.png" width="1200" height="1076" ' +
+    'loading="lazy" decoding="async" alt="Roblox Symbols"></figure>'),
+  [`${B}/assets/specimen/library-roblox-symbols.png`]);
+
+eq("visible guide hero (no aria-hidden, descriptive alt) is declared",
+  getContentImages(
+    '<figure class="guide-hero-figure">' +
+    '<img src="/guide/assets/bio-formatting-without-spam.svg" alt="A cluttered bio card ' +
+    'next to a clean one."></figure>'),
+  [`${B}/guide/assets/bio-formatting-without-spam.svg`]);
+
+eq("a non-Latin alt is a real description",
+  getContentImages('<img src="/assets/specimen/ko.png" alt="화살표 기호">'),
+  [`${B}/assets/specimen/ko.png`]);
+
+eq("an already-absolute same-origin src is kept as-is, not double-prefixed",
+  getContentImages(`<img src="${B}/assets/specimen/x.png" alt="Described">`),
+  [`${B}/assets/specimen/x.png`]);
+
+// --- origin and URL-shape rules ------------------------------------------
+eq("a third-party image is never declared — not ours to claim",
+  getContentImages('<img src="https://example.com/a.png" alt="Described">'),
+  []);
+
+eq("a data: URI is skipped — there is no URL for Google Images to index",
+  getContentImages('<img src="data:image/png;base64,iVBOR" alt="Described">'),
+  []);
+
+eq("a protocol-relative URL is skipped rather than mangled into a path",
+  getContentImages('<img src="//cdn.example.com/a.png" alt="Described">'),
+  []);
+
+// --- mixed pages ----------------------------------------------------------
+eq("a page with both keeps only the content image, in document order",
+  getContentImages(
+    '<figure class="page-hero-figure" aria-hidden="true">' +
+    '<img src="/assets/hero/library-roblox-symbols.svg" alt=""></figure>' +
+    '<p>copy</p>' +
+    '<figure class="specimen-figure">' +
+    '<img src="/assets/specimen/library-roblox-symbols.png" alt="Roblox Symbols"></figure>'),
+  [`${B}/assets/specimen/library-roblox-symbols.png`]);
+
+eq("two decorative figures do not swallow a content image sitting between them",
+  getContentImages(
+    '<figure aria-hidden="true"><img src="/a.svg" alt=""></figure>' +
+    '<img src="/mid.png" alt="Between">' +
+    '<figure aria-hidden="true"><img src="/b.svg" alt=""></figure>'),
+  [`${B}/mid.png`]);
+
+eq("single-quoted attributes parse the same as double-quoted",
+  getContentImages("<img src='/assets/specimen/x.png' alt='Described'>"),
+  [`${B}/assets/specimen/x.png`]);
+
+eq("a page with no images yields none",
+  getContentImages("<p>no images here</p>"),
+  []);
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -14,7 +14,7 @@
 
   <url>
     <loc>https://ultratextgen.com/about/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
     <image:image>
@@ -34,7 +34,7 @@
 
   <url>
     <loc>https://ultratextgen.com/answers/can-you-search-fancy-text/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -74,7 +74,7 @@
 
   <url>
     <loc>https://ultratextgen.com/answers/discord-allowed-characters/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -94,7 +94,7 @@
 
   <url>
     <loc>https://ultratextgen.com/answers/do-fancy-fonts-work-on-iphone/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -104,7 +104,7 @@
 
   <url>
     <loc>https://ultratextgen.com/answers/do-fancy-fonts-work-with-arabic/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -124,7 +124,7 @@
 
   <url>
     <loc>https://ultratextgen.com/answers/do-you-need-nitro-for-discord-fonts/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -154,7 +154,7 @@
 
   <url>
     <loc>https://ultratextgen.com/answers/fancy-text-with-n-and-accented-letters/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -294,7 +294,7 @@
 
   <url>
     <loc>https://ultratextgen.com/answers/how-to-type-kaomoji/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -324,7 +324,7 @@
 
   <url>
     <loc>https://ultratextgen.com/answers/is-fancy-text-bad-for-accessibility/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -334,7 +334,7 @@
 
   <url>
     <loc>https://ultratextgen.com/answers/is-fancy-text-bad-for-seo/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -414,7 +414,7 @@
 
   <url>
     <loc>https://ultratextgen.com/answers/what-does-o7-mean/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -424,7 +424,7 @@
 
   <url>
     <loc>https://ultratextgen.com/answers/what-does-owo-mean/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -434,7 +434,7 @@
 
   <url>
     <loc>https://ultratextgen.com/answers/what-does-uwu-mean/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -444,7 +444,7 @@
 
   <url>
     <loc>https://ultratextgen.com/answers/what-does-xd-mean/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -454,7 +454,7 @@
 
   <url>
     <loc>https://ultratextgen.com/answers/what-font-does-discord-use/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -574,7 +574,7 @@
 
   <url>
     <loc>https://ultratextgen.com/answers/what-is-ascii/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -584,7 +584,7 @@
 
   <url>
     <loc>https://ultratextgen.com/answers/what-is-kaomoji/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -614,7 +614,7 @@
 
   <url>
     <loc>https://ultratextgen.com/answers/why-fancy-text-looks-different-on-iphone-vs-android/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -654,7 +654,7 @@
 
   <url>
     <loc>https://ultratextgen.com/answers/why-wont-discord-accept-fancy-username/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -790,6 +790,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/ar-guide-amaken-khutut-discord.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/ar-guide-amaken-khutut-discord.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -799,6 +802,9 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/ar-guide-ism-discord-amin.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/ar-guide-ism-discord-amin.svg</image:loc>
     </image:image>
   </url>
 
@@ -810,11 +816,14 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/ar-guide-tanseeq-nusus-discord.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/ar-guide-tanseeq-nusus-discord.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/ar/khat-snapchat/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -824,7 +833,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ar/library/</loc>
-    <lastmod>2026-08-10</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -884,7 +893,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ar/library/bullet-point-symbols/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -894,7 +903,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ar/library/chess-symbols/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -934,7 +943,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ar/library/discord-symbols/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -979,6 +988,16 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/ar-library-facebook-symbols.png</image:loc>
+    </image:image>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/ar/library/fire-emoji/</loc>
+    <lastmod>2026-08-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/og/ar-library-fire-emoji.png</image:loc>
     </image:image>
   </url>
 
@@ -1034,7 +1053,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ar/library/islamic-symbols/</loc>
-    <lastmod>2026-08-02</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -1084,7 +1103,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ar/library/music-symbols/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -1103,8 +1122,18 @@
   </url>
 
   <url>
+    <loc>https://ultratextgen.com/ar/library/pubg-symbols/</loc>
+    <lastmod>2026-08-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/og/ar-library-pubg-symbols.png</image:loc>
+    </image:image>
+  </url>
+
+  <url>
     <loc>https://ultratextgen.com/ar/library/religious-symbols/</loc>
-    <lastmod>2026-08-02</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -1114,7 +1143,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ar/library/roblox-symbols/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -1143,6 +1172,16 @@
   </url>
 
   <url>
+    <loc>https://ultratextgen.com/ar/library/text-art/</loc>
+    <lastmod>2026-08-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/og/ar-library-text-art.png</image:loc>
+    </image:image>
+  </url>
+
+  <url>
     <loc>https://ultratextgen.com/ar/library/vertical-line-symbols/</loc>
     <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
@@ -1153,8 +1192,18 @@
   </url>
 
   <url>
+    <loc>https://ultratextgen.com/ar/library/whatsapp-symbols/</loc>
+    <lastmod>2026-08-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/og/ar-library-whatsapp-symbols.png</image:loc>
+    </image:image>
+  </url>
+
+  <url>
     <loc>https://ultratextgen.com/ar/library/y2k-symbols/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -2244,7 +2293,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ar/symbol/squared-cubed/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -2344,7 +2393,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ar/usecase/khat-bio/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -2354,7 +2403,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ar/usecase/mutarjim-emoji/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -2384,7 +2433,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ascii-art-generator/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
     <image:image>
@@ -2394,7 +2443,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ascii-converter/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
     <image:image>
@@ -2460,6 +2509,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/bs-guide-gdje-rade-fontovi-na-discordu.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/bs-guide-gdje-rade-fontovi-na-discordu.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -2470,6 +2522,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/bs-guide-oblikovanje-teksta-na-discordu.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/bs-guide-oblikovanje-teksta-na-discordu.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -2479,6 +2534,9 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/bs-guide-siguran-nadimak-na-discordu.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/bs-guide-siguran-nadimak-na-discordu.svg</image:loc>
     </image:image>
   </url>
 
@@ -2564,7 +2622,7 @@
 
   <url>
     <loc>https://ultratextgen.com/category/bold-fonts/bold-italic/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -2574,7 +2632,7 @@
 
   <url>
     <loc>https://ultratextgen.com/category/bubble-fonts/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
     <image:image>
@@ -2584,7 +2642,7 @@
 
   <url>
     <loc>https://ultratextgen.com/category/bubble-fonts/circle/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -2594,7 +2652,7 @@
 
   <url>
     <loc>https://ultratextgen.com/category/case-converter/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
     <image:image>
@@ -2634,7 +2692,7 @@
 
   <url>
     <loc>https://ultratextgen.com/category/emoji-letter-fonts/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
     <image:image>
@@ -2644,7 +2702,7 @@
 
   <url>
     <loc>https://ultratextgen.com/category/faux-fonts/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
     <image:image>
@@ -2654,7 +2712,7 @@
 
   <url>
     <loc>https://ultratextgen.com/category/fullwidth-fonts/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
     <image:image>
@@ -2684,7 +2742,7 @@
 
   <url>
     <loc>https://ultratextgen.com/category/novelty-fonts/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
     <image:image>
@@ -2694,7 +2752,7 @@
 
   <url>
     <loc>https://ultratextgen.com/category/old-english-fonts/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
     <image:image>
@@ -2704,7 +2762,7 @@
 
   <url>
     <loc>https://ultratextgen.com/category/small-caps/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
     <image:image>
@@ -2734,7 +2792,7 @@
 
   <url>
     <loc>https://ultratextgen.com/category/subscript/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
     <image:image>
@@ -2754,7 +2812,7 @@
 
   <url>
     <loc>https://ultratextgen.com/category/text-decorator/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
     <image:image>
@@ -2804,7 +2862,7 @@
 
   <url>
     <loc>https://ultratextgen.com/contact/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
     <image:image>
@@ -2860,6 +2918,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/cs-guide-bezpecny-nick-na-discordu.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/cs-guide-bezpecny-nick-na-discordu.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -2870,6 +2931,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/cs-guide-formatovani-textu-na-discordu.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/cs-guide-formatovani-textu-na-discordu.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -2879,6 +2943,9 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/cs-guide-kde-funguje-pismo-na-discordu.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/cs-guide-kde-funguje-pismo-na-discordu.svg</image:loc>
     </image:image>
   </url>
 
@@ -2944,7 +3011,7 @@
 
   <url>
     <loc>https://ultratextgen.com/cs/usecase/pismo-pro-bio/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -2990,6 +3057,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/da-guide-discord-tekstformatering-forklaret.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/da-guide-discord-tekstformatering-forklaret.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -3000,6 +3070,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/da-guide-hvor-virker-skrifttyper-i-discord.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/da-guide-hvor-virker-skrifttyper-i-discord.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -3009,6 +3082,9 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/da-guide-sikkert-discord-navn.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/da-guide-sikkert-discord-navn.svg</image:loc>
     </image:image>
   </url>
 
@@ -3194,7 +3270,7 @@
 
   <url>
     <loc>https://ultratextgen.com/de/gross-und-kleinschreibung/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -3220,6 +3296,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/de-guide-discord-namen-sicher-gestalten.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/de-guide-discord-namen-sicher-gestalten.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -3230,6 +3309,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/de-guide-discord-textformatierung-erklaert.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/de-guide-discord-textformatierung-erklaert.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -3239,6 +3321,9 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/de-guide-wo-funktionieren-schriftarten-in-discord.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/de-guide-wo-funktionieren-schriftarten-in-discord.svg</image:loc>
     </image:image>
   </url>
 
@@ -3314,7 +3399,7 @@
 
   <url>
     <loc>https://ultratextgen.com/de/library/akzente-diakritische-zeichen/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -3344,7 +3429,7 @@
 
   <url>
     <loc>https://ultratextgen.com/de/library/aufzaehlungszeichen/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -3414,7 +3499,7 @@
 
   <url>
     <loc>https://ultratextgen.com/de/library/discord-symbole/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -3444,7 +3529,7 @@
 
   <url>
     <loc>https://ultratextgen.com/de/library/facebook-symbole/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -3554,7 +3639,7 @@
 
   <url>
     <loc>https://ultratextgen.com/de/library/islamische-symbole/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -3674,7 +3759,7 @@
 
   <url>
     <loc>https://ultratextgen.com/de/library/musik-symbole/</loc>
-    <lastmod>2026-08-11</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -3694,7 +3779,7 @@
 
   <url>
     <loc>https://ultratextgen.com/de/library/rahmenzeichen/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -3704,7 +3789,7 @@
 
   <url>
     <loc>https://ultratextgen.com/de/library/religioese-symbole/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -3714,7 +3799,7 @@
 
   <url>
     <loc>https://ultratextgen.com/de/library/roblox-symbole/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -3724,7 +3809,7 @@
 
   <url>
     <loc>https://ultratextgen.com/de/library/schach-symbole/</loc>
-    <lastmod>2026-08-05</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -3734,7 +3819,7 @@
 
   <url>
     <loc>https://ultratextgen.com/de/library/solidaritaetsschleifen/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -3854,7 +3939,7 @@
 
   <url>
     <loc>https://ultratextgen.com/de/library/y2k-symbole/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -3914,7 +3999,7 @@
 
   <url>
     <loc>https://ultratextgen.com/de/schriftarten-fuer-telegram/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -4654,7 +4739,7 @@
 
   <url>
     <loc>https://ultratextgen.com/de/symbol/quadrat-und-kubikzeichen/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -5044,7 +5129,7 @@
 
   <url>
     <loc>https://ultratextgen.com/de/tiefgestellt/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -5074,7 +5159,7 @@
 
   <url>
     <loc>https://ultratextgen.com/de/updates/naher-osten-waehrungssymbole-unicode-18/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -5114,7 +5199,7 @@
 
   <url>
     <loc>https://ultratextgen.com/de/updates/vae-dirham-symbol-unicode-18/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -5144,7 +5229,7 @@
 
   <url>
     <loc>https://ultratextgen.com/de/usecase/emoji-buchstaben/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -5154,7 +5239,7 @@
 
   <url>
     <loc>https://ultratextgen.com/de/usecase/emoji-uebersetzer/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -5264,7 +5349,7 @@
 
   <url>
     <loc>https://ultratextgen.com/de/zum-ausdrucken/name-ausmalen/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -5274,7 +5359,7 @@
 
   <url>
     <loc>https://ultratextgen.com/de/zum-ausdrucken/namen-schreiben/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -5324,7 +5409,7 @@
 
   <url>
     <loc>https://ultratextgen.com/embed/</loc>
-    <lastmod>2026-07-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
     <image:image>
@@ -5334,7 +5419,7 @@
 
   <url>
     <loc>https://ultratextgen.com/embed/bio-font-generator/</loc>
-    <lastmod>2026-07-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -5354,7 +5439,7 @@
 
   <url>
     <loc>https://ultratextgen.com/embed/linkedin-headline-generator/</loc>
-    <lastmod>2026-07-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -5364,7 +5449,7 @@
 
   <url>
     <loc>https://ultratextgen.com/embed/name-checker/</loc>
-    <lastmod>2026-07-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -5374,7 +5459,7 @@
 
   <url>
     <loc>https://ultratextgen.com/embed/nickname-generator/</loc>
-    <lastmod>2026-07-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -5384,7 +5469,7 @@
 
   <url>
     <loc>https://ultratextgen.com/embed/zalgo-text-generator/</loc>
-    <lastmod>2026-07-24</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -5524,7 +5609,7 @@
 
   <url>
     <loc>https://ultratextgen.com/es/conversor-ascii/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -5614,7 +5699,7 @@
 
   <url>
     <loc>https://ultratextgen.com/es/fuentes-para-telegram/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -5660,6 +5745,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/es-guide-donde-funcionan-las-fuentes-en-discord.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/es-guide-donde-funcionan-las-fuentes-en-discord.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -5670,6 +5758,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/es-guide-formato-texto-discord-explicado.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/es-guide-formato-texto-discord-explicado.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -5679,6 +5770,9 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/es-guide-nombre-discord-sin-riesgos.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/es-guide-nombre-discord-sin-riesgos.svg</image:loc>
     </image:image>
   </url>
 
@@ -6354,7 +6448,7 @@
 
   <url>
     <loc>https://ultratextgen.com/es/library/arte-de-texto/</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -6944,7 +7038,7 @@
 
   <url>
     <loc>https://ultratextgen.com/es/library/emoji-fuego/</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -7874,7 +7968,7 @@
 
   <url>
     <loc>https://ultratextgen.com/es/library/happy-kaomoji/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -8114,7 +8208,7 @@
 
   <url>
     <loc>https://ultratextgen.com/es/library/shrug-kaomoji/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -8224,7 +8318,7 @@
 
   <url>
     <loc>https://ultratextgen.com/es/library/simbolos-de-ajedrez/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -8364,7 +8458,7 @@
 
   <url>
     <loc>https://ultratextgen.com/es/library/simbolos-de-musica/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -8484,7 +8578,7 @@
 
   <url>
     <loc>https://ultratextgen.com/es/library/simbolos-de-vineta/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -8514,7 +8608,7 @@
 
   <url>
     <loc>https://ultratextgen.com/es/library/simbolos-discord/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -8604,7 +8698,7 @@
 
   <url>
     <loc>https://ultratextgen.com/es/library/simbolos-islamicos/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -8694,7 +8788,7 @@
 
   <url>
     <loc>https://ultratextgen.com/es/library/simbolos-para-instagram/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -8734,7 +8828,7 @@
 
   <url>
     <loc>https://ultratextgen.com/es/library/simbolos-pubg/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -8744,7 +8838,7 @@
 
   <url>
     <loc>https://ultratextgen.com/es/library/simbolos-religiosos/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -8754,7 +8848,7 @@
 
   <url>
     <loc>https://ultratextgen.com/es/library/simbolos-roblox/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -8784,7 +8878,7 @@
 
   <url>
     <loc>https://ultratextgen.com/es/library/simbolos-whatsapp/</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -8804,7 +8898,7 @@
 
   <url>
     <loc>https://ultratextgen.com/es/library/simbolos-y2k/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -8834,7 +8928,7 @@
 
   <url>
     <loc>https://ultratextgen.com/es/mayusculas-y-minusculas/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -10044,7 +10138,7 @@
 
   <url>
     <loc>https://ultratextgen.com/es/updates/simbolo-dirham-emiratos-unicode-18/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -10054,7 +10148,7 @@
 
   <url>
     <loc>https://ultratextgen.com/es/updates/simbolos-moneda-oriente-medio-unicode-18/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -10104,7 +10198,7 @@
 
   <url>
     <loc>https://ultratextgen.com/es/usecase/letras-para-bio/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -10114,7 +10208,7 @@
 
   <url>
     <loc>https://ultratextgen.com/es/usecase/letras-para-tatuajes/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -10214,7 +10308,7 @@
 
   <url>
     <loc>https://ultratextgen.com/es/usecase/traductor-de-emojis/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -10480,6 +10574,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/fi-guide-discord-tekstin-muotoilu-selitetty.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/fi-guide-discord-tekstin-muotoilu-selitetty.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -10490,6 +10587,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/fi-guide-missa-discord-fontit-toimivat.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/fi-guide-missa-discord-fontit-toimivat.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -10499,6 +10599,9 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/fi-guide-turvallinen-discord-nimimerkki.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/fi-guide-turvallinen-discord-nimimerkki.svg</image:loc>
     </image:image>
   </url>
 
@@ -10780,6 +10883,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/fr-guide-formatage-texte-discord-explique.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/fr-guide-formatage-texte-discord-explique.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -10790,6 +10896,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/fr-guide-ou-fonctionnent-les-polices-discord.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/fr-guide-ou-fonctionnent-les-polices-discord.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -10799,6 +10908,9 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/fr-guide-pseudo-discord-sans-risque.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/fr-guide-pseudo-discord-sans-risque.svg</image:loc>
     </image:image>
   </url>
 
@@ -10854,7 +10966,7 @@
 
   <url>
     <loc>https://ultratextgen.com/fr/imprimables/prenom-a-tracer/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -11094,7 +11206,7 @@
 
   <url>
     <loc>https://ultratextgen.com/fr/library/symboles-discord/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -11114,7 +11226,7 @@
 
   <url>
     <loc>https://ultratextgen.com/fr/library/symboles-echecs/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -11194,7 +11306,7 @@
 
   <url>
     <loc>https://ultratextgen.com/fr/library/symboles-islamiques/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -11244,7 +11356,7 @@
 
   <url>
     <loc>https://ultratextgen.com/fr/library/symboles-musicaux/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -11254,7 +11366,7 @@
 
   <url>
     <loc>https://ultratextgen.com/fr/library/symboles-puces/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -11264,7 +11376,7 @@
 
   <url>
     <loc>https://ultratextgen.com/fr/library/symboles-religieux/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -11274,7 +11386,7 @@
 
   <url>
     <loc>https://ultratextgen.com/fr/library/symboles-roblox/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -11304,7 +11416,7 @@
 
   <url>
     <loc>https://ultratextgen.com/fr/library/symboles-y2k/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -11320,11 +11432,14 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/fr-library-symboles.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/specimen/fr-library-symboles.png</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/fr/majuscules-et-minuscules/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -11394,7 +11509,7 @@
 
   <url>
     <loc>https://ultratextgen.com/fr/police-tiktok/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -11704,7 +11819,7 @@
 
   <url>
     <loc>https://ultratextgen.com/fr/symbol/symbole-carre-cube/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -12674,7 +12789,7 @@
 
   <url>
     <loc>https://ultratextgen.com/fr/usecase/traducteur-emoji/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -12684,7 +12799,7 @@
 
   <url>
     <loc>https://ultratextgen.com/fr/usecase/vertical-text/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -12710,25 +12825,34 @@
     <image:image>
       <image:loc>https://ultratextgen.com/guide/assets/og/index.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/guide/assets/index.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/guide/bio-formatting-without-spam/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/guide/assets/og/bio-formatting-without-spam.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/guide/assets/bio-formatting-without-spam.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/guide/boxes-vs-mojibake-vs-question-marks/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/guide/assets/og/boxes-vs-mojibake-vs-question-marks.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/guide/assets/boxes-vs-mojibake-vs-question-marks.svg</image:loc>
     </image:image>
   </url>
 
@@ -12740,6 +12864,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/guide/assets/og/branding-with-fonts-for-social-media.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/guide/assets/branding-with-fonts-for-social-media.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -12750,15 +12877,21 @@
     <image:image>
       <image:loc>https://ultratextgen.com/guide/assets/og/comments-that-stand-out.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/guide/assets/comments-that-stand-out.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/guide/discord-colored-text-guide/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/guide/assets/og/discord-colored-text-guide.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/guide/assets/discord-colored-text-guide.svg</image:loc>
     </image:image>
   </url>
 
@@ -12770,6 +12903,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/guide/assets/og/discord-safe-name-styling.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/guide/assets/discord-safe-name-styling.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -12779,6 +12915,9 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/guide/assets/og/discord-text-formatting-explained.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/guide/assets/discord-text-formatting-explained.svg</image:loc>
     </image:image>
   </url>
 
@@ -12790,41 +12929,53 @@
     <image:image>
       <image:loc>https://ultratextgen.com/guide/assets/og/discord-where-fonts-work.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/guide/assets/discord-where-fonts-work.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/guide/dividers-separators-guide/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/guide/assets/og/dividers-separators-guide.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/guide/assets/dividers-separators-guide.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/guide/emoticon-vs-emoji-vs-kaomoji/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/guide/assets/og/emoticon-vs-emoji-vs-kaomoji.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/guide/assets/emoticon-vs-emoji-vs-kaomoji.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/guide/fancy-fonts-accessibility-guide/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/guide/assets/og/fancy-fonts-accessibility-guide.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/guide/assets/fancy-fonts-accessibility-guide.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/guide/fancy-fonts-and-accents/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -12834,21 +12985,27 @@
 
   <url>
     <loc>https://ultratextgen.com/guide/font-personality-and-brand/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/guide/assets/og/font-personality-and-brand.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/guide/assets/font-personality-and-brand.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/guide/fonts-and-search-visibility/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/guide/assets/og/fonts-and-search-visibility.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/guide/assets/fonts-and-search-visibility.svg</image:loc>
     </image:image>
   </url>
 
@@ -12860,105 +13017,138 @@
     <image:image>
       <image:loc>https://ultratextgen.com/guide/assets/og/game-username-allowed-symbols.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/guide/assets/game-username-allowed-symbols.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/guide/how-unicode-fonts-work/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/guide/assets/og/how-unicode-fonts-work.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/guide/assets/how-unicode-fonts-work.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/guide/instagram-bio-line-breaks/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/guide/assets/og/instagram-bio-line-breaks.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/guide/assets/instagram-bio-line-breaks.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/guide/instagram-font-ideas/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/fancy-text-generator-preview.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/guide/assets/branding-with-fonts-for-social-media.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/guide/instagram-fonts-shadowban-myth/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/guide/assets/og/instagram-fonts-shadowban-myth.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/guide/assets/instagram-fonts-shadowban-myth.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/guide/linkedin-bold-text-reach/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/guide/assets/og/linkedin-bold-text-reach.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/guide/assets/linkedin-bold-text-reach.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/guide/linkedin-comment-styling/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/guide/assets/og/linkedin-comment-styling.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/guide/assets/linkedin-comment-styling.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/guide/linkedin-comments-guide/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/guide/assets/og/linkedin-comments-guide.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/guide/assets/linkedin-comments-guide.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/guide/linkedin-fonts-recruiters-ats/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/guide/assets/og/linkedin-fonts-recruiters-ats.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/guide/assets/linkedin-fonts-recruiters-ats.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/guide/personal-branding-through-typography/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/guide/assets/og/personal-branding-through-typography.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/guide/assets/personal-branding-through-typography.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/guide/stop-the-scroll-with-font-variation/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/guide/assets/og/stop-the-scroll-with-font-variation.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/guide/assets/stop-the-scroll-with-font-variation.svg</image:loc>
     </image:image>
   </url>
 
@@ -12970,6 +13160,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/guide/assets/og/style-linkedin-hooks-to-stand-out.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/guide/assets/style-linkedin-hooks-to-stand-out.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -12980,41 +13173,53 @@
     <image:image>
       <image:loc>https://ultratextgen.com/guide/assets/og/the-rhetoric-of-fonts.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/guide/assets/the-rhetoric-of-fonts.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/guide/tiktok-font-changed/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/guide/assets/og/tiktok-font-changed.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/guide/assets/tiktok-font-changed.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/guide/unicode-symbol-approval-process/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/guide/assets/og/unicode-symbol-approval-process.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/guide/assets/unicode-symbol-approval-process.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/guide/vertical-text-guide/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/guide/assets/og/vertical-text-guide.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/guide/assets/vertical-text-guide.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/guide/whatsapp-text-formatting-explained/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -13024,11 +13229,14 @@
 
   <url>
     <loc>https://ultratextgen.com/guide/why-fonts-show-as-boxes/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/guide/assets/og/why-fonts-show-as-boxes.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/guide/assets/why-fonts-show-as-boxes.svg</image:loc>
     </image:image>
   </url>
 
@@ -13060,6 +13268,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/hi-guide-discord-font-kahan-kaam-karte-hain.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/hi-guide-discord-font-kahan-kaam-karte-hain.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -13069,6 +13280,9 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/hi-guide-discord-safe-naam-styling.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/hi-guide-discord-safe-naam-styling.svg</image:loc>
     </image:image>
   </url>
 
@@ -13080,11 +13294,14 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/hi-guide-discord-text-formatting-samjhein.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/hi-guide-discord-text-formatting-samjhein.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/hi/usecase/emoji-anuvadak/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -13124,7 +13341,7 @@
 
   <url>
     <loc>https://ultratextgen.com/hiragana-chart/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
     <image:image>
@@ -13200,6 +13417,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/hr-guide-gdje-rade-fontovi-na-discordu.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/hr-guide-gdje-rade-fontovi-na-discordu.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -13210,6 +13430,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/hr-guide-oblikovanje-teksta-na-discordu.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/hr-guide-oblikovanje-teksta-na-discordu.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -13219,6 +13442,9 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/hr-guide-siguran-nadimak-na-discordu.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/hr-guide-siguran-nadimak-na-discordu.svg</image:loc>
     </image:image>
   </url>
 
@@ -13350,6 +13576,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/hu-guide-biztonsagos-discord-becenev.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/hu-guide-biztonsagos-discord-becenev.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -13360,6 +13589,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/hu-guide-discord-szovegformazas.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/hu-guide-discord-szovegformazas.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -13369,6 +13601,9 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/hu-guide-hol-mukodnek-a-discord-fontok.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/hu-guide-hol-mukodnek-a-discord-fontok.svg</image:loc>
     </image:image>
   </url>
 
@@ -13464,7 +13699,7 @@
 
   <url>
     <loc>https://ultratextgen.com/id/category/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -13484,7 +13719,7 @@
 
   <url>
     <loc>https://ultratextgen.com/id/font-bubble/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -13580,6 +13815,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/id-guide-di-mana-font-discord-bekerja.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/id-guide-di-mana-font-discord-bekerja.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -13589,6 +13827,9 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/id-guide-format-teks-discord-dijelaskan.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/id-guide-format-teks-discord-dijelaskan.svg</image:loc>
     </image:image>
   </url>
 
@@ -13600,11 +13841,14 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/id-guide-nama-discord-aman.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/id-guide-nama-discord-aman.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/id/huruf-besar-kecil/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -13854,7 +14098,7 @@
 
   <url>
     <loc>https://ultratextgen.com/id/library/happy-kaomoji/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -13914,7 +14158,7 @@
 
   <url>
     <loc>https://ultratextgen.com/id/library/shrug-kaomoji/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -13930,6 +14174,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/id-library-simbol-aesthetic.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/specimen/id-library-simbol-aesthetic.png</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -13939,6 +14186,9 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/id-library-simbol-bintang.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/specimen/id-library-simbol-bintang.png</image:loc>
     </image:image>
   </url>
 
@@ -13954,7 +14204,7 @@
 
   <url>
     <loc>https://ultratextgen.com/id/library/simbol-catur/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -14004,7 +14254,7 @@
 
   <url>
     <loc>https://ultratextgen.com/id/library/simbol-discord/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -14104,7 +14354,7 @@
 
   <url>
     <loc>https://ultratextgen.com/id/library/simbol-instagram/</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -14114,7 +14364,7 @@
 
   <url>
     <loc>https://ultratextgen.com/id/library/simbol-islami/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -14144,7 +14394,7 @@
 
   <url>
     <loc>https://ultratextgen.com/id/library/simbol-keagamaan/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -14179,6 +14429,9 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/id-library-simbol-love.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/specimen/id-library-simbol-love.png</image:loc>
     </image:image>
   </url>
 
@@ -14234,7 +14487,7 @@
 
   <url>
     <loc>https://ultratextgen.com/id/library/simbol-musik/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -14284,7 +14537,7 @@
 
   <url>
     <loc>https://ultratextgen.com/id/library/simbol-poin/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -14294,7 +14547,7 @@
 
   <url>
     <loc>https://ultratextgen.com/id/library/simbol-pubg/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -14304,7 +14557,7 @@
 
   <url>
     <loc>https://ultratextgen.com/id/library/simbol-roblox/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -14344,7 +14597,7 @@
 
   <url>
     <loc>https://ultratextgen.com/id/library/simbol-whatsapp/</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -14364,7 +14617,7 @@
 
   <url>
     <loc>https://ultratextgen.com/id/library/simbol-y2k/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -15150,6 +15403,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/id-symbol-simbol-kutip.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/specimen/id-symbol-simbol-kutip.png</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -15794,7 +16050,7 @@
 
   <url>
     <loc>https://ultratextgen.com/id/usecase/font-tato/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -16024,7 +16280,7 @@
 
   <url>
     <loc>https://ultratextgen.com/id/usecase/penerjemah-emoji/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -16034,7 +16290,7 @@
 
   <url>
     <loc>https://ultratextgen.com/id/usecase/vertical-text/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -16134,7 +16390,7 @@
 
   <url>
     <loc>https://ultratextgen.com/it/category/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -16204,7 +16460,7 @@
 
   <url>
     <loc>https://ultratextgen.com/it/da-stampare/nome-da-colorare/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -16214,7 +16470,7 @@
 
   <url>
     <loc>https://ultratextgen.com/it/da-stampare/tracciare-il-nome/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -16340,6 +16596,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/it-guide-dove-funzionano-i-font-discord.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/it-guide-dove-funzionano-i-font-discord.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -16350,6 +16609,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/it-guide-formattazione-testo-discord-spiegata.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/it-guide-formattazione-testo-discord-spiegata.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -16359,6 +16621,9 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/it-guide-nome-discord-senza-rischi.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/it-guide-nome-discord-senza-rischi.svg</image:loc>
     </image:image>
   </url>
 
@@ -16514,7 +16779,7 @@
 
   <url>
     <loc>https://ultratextgen.com/it/library/simboli-discord/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -16604,7 +16869,7 @@
 
   <url>
     <loc>https://ultratextgen.com/it/library/simboli-islamici/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -16644,7 +16909,7 @@
 
   <url>
     <loc>https://ultratextgen.com/it/library/simboli-musicali/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -16684,7 +16949,7 @@
 
   <url>
     <loc>https://ultratextgen.com/it/library/simboli-punto-elenco/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -16694,7 +16959,7 @@
 
   <url>
     <loc>https://ultratextgen.com/it/library/simboli-religiosi/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -16704,7 +16969,7 @@
 
   <url>
     <loc>https://ultratextgen.com/it/library/simboli-roblox/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -16714,7 +16979,7 @@
 
   <url>
     <loc>https://ultratextgen.com/it/library/simboli-scacchi/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -16764,7 +17029,7 @@
 
   <url>
     <loc>https://ultratextgen.com/it/library/simboli-y2k/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -16804,7 +17069,7 @@
 
   <url>
     <loc>https://ultratextgen.com/it/maiuscole-e-minuscole/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -18034,7 +18299,7 @@
 
   <url>
     <loc>https://ultratextgen.com/it/updates/simboli-valuta-medio-oriente-unicode-18/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -18044,7 +18309,7 @@
 
   <url>
     <loc>https://ultratextgen.com/it/updates/simbolo-dirham-unicode-18/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -18114,7 +18379,7 @@
 
   <url>
     <loc>https://ultratextgen.com/it/usecase/traduttore-emoji/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -18124,7 +18389,7 @@
 
   <url>
     <loc>https://ultratextgen.com/it/usecase/vertical-text/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -18224,7 +18489,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ja/gal-moji/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -18250,6 +18515,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/ja-guide-discord-anzen-namae.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/ja-guide-discord-anzen-namae.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -18260,6 +18528,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/ja-guide-discord-font-doko.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/ja-guide-discord-font-doko.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -18269,6 +18540,9 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/ja-guide-discord-moji-soshoku.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/ja-guide-discord-moji-soshoku.svg</image:loc>
     </image:image>
   </url>
 
@@ -18364,7 +18638,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ja/library/bullet-point-symbols/</loc>
-    <lastmod>2026-07-30</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -18394,7 +18668,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ja/library/chess-symbols/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -18434,7 +18708,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ja/library/discord-symbols/</loc>
-    <lastmod>2026-07-26</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -18494,7 +18768,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ja/library/happy-kaomoji/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -18584,7 +18858,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ja/library/islamic-symbols/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -18684,7 +18958,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ja/library/music-symbols/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -18724,7 +18998,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ja/library/religious-symbols/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -18734,7 +19008,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ja/library/roblox-symbols/</loc>
-    <lastmod>2026-08-11</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -18764,7 +19038,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ja/library/shrug-kaomoji/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -18864,7 +19138,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ja/library/y2k-symbols/</loc>
-    <lastmod>2026-07-26</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -19854,7 +20128,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ja/symbol/squared-cubed/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -20004,7 +20278,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ja/usecase/bio-font/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -20024,7 +20298,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ja/usecase/vertical-text/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -20034,7 +20308,7 @@
 
   <url>
     <loc>https://ultratextgen.com/kaomoji-dictionary/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
     <image:image>
@@ -20044,7 +20318,7 @@
 
   <url>
     <loc>https://ultratextgen.com/kaomoji-generator/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
     <image:image>
@@ -20054,7 +20328,7 @@
 
   <url>
     <loc>https://ultratextgen.com/katakana-chart/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
     <image:image>
@@ -20140,6 +20414,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/ko-guide-discord-nikneim-anjeon.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/ko-guide-discord-nikneim-anjeon.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -20150,6 +20427,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/ko-guide-discord-ponteu-jiwon.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/ko-guide-discord-ponteu-jiwon.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -20159,6 +20439,9 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/ko-guide-discord-tekseuteu-seosik.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/ko-guide-discord-tekseuteu-seosik.svg</image:loc>
     </image:image>
   </url>
 
@@ -20214,7 +20497,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ko/library/bulkkot-imoji/</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -20274,7 +20557,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ko/library/chess-gihou/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -20294,7 +20577,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ko/library/discord-giho/</loc>
-    <lastmod>2026-07-26</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -20324,7 +20607,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ko/library/eumak-giho/</loc>
-    <lastmod>2026-08-05</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -20334,7 +20617,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ko/library/facebook-giho/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -20349,6 +20632,9 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/ko-library-gamseong-giho.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/specimen/ko-library-gamseong-giho.png</image:loc>
     </image:image>
   </url>
 
@@ -20490,6 +20776,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/ko-library-hwasalpyo-giho.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/specimen/ko-library-hwasalpyo-giho.png</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -20524,7 +20813,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ko/library/islam-gihou/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -20534,7 +20823,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ko/library/jeom-giho/</loc>
-    <lastmod>2026-08-05</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -20544,7 +20833,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ko/library/jonggyo-gihou/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -20604,7 +20893,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ko/library/roblox-giho/</loc>
-    <lastmod>2026-08-11</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -20734,7 +21023,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ko/library/y2k-giho/</loc>
-    <lastmod>2026-07-26</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -21904,7 +22193,7 @@
 
   <url>
     <loc>https://ultratextgen.com/learn/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
     <image:image>
@@ -21914,121 +22203,157 @@
 
   <url>
     <loc>https://ultratextgen.com/learn/coloring-and-fine-motor/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/learn-coloring-and-fine-motor.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/learn-coloring-and-fine-motor.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/learn/dot-to-dots/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/learn-dot-to-dots.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/learn-dot-to-dots.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/learn/handwriting/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/learn-handwriting.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/learn-handwriting.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/learn/handwriting/cursive-when-and-how/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/learn-handwriting-cursive-when-and-how.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/learn-handwriting-cursive-when-and-how.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/learn/handwriting/first-letters-uppercase/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/learn-handwriting-first-letters-uppercase.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/learn-handwriting-first-letters-uppercase.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/learn/handwriting/from-tracing-to-writing/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/learn-handwriting-from-tracing-to-writing.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/learn-handwriting-from-tracing-to-writing.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/learn/handwriting/how-much-practice/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/learn-handwriting-how-much-practice.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/learn-handwriting-how-much-practice.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/learn/handwriting/lowercase-and-reversals/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/learn-handwriting-lowercase-and-reversals.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/learn-handwriting-lowercase-and-reversals.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/learn/handwriting/name-writing/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/learn-handwriting-name-writing.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/learn-handwriting-name-writing.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/learn/handwriting/pre-writing-strokes/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/learn-handwriting-pre-writing-strokes.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/learn-handwriting-pre-writing-strokes.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/learn/handwriting/stroke-order-and-start-dots/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/learn-handwriting-stroke-order-and-start-dots.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/learn-handwriting-stroke-order-and-start-dots.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/learn/handwriting/when-to-start-handwriting/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/learn-handwriting-when-to-start-handwriting.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/learn-handwriting-when-to-start-handwriting.svg</image:loc>
     </image:image>
   </url>
 
@@ -22079,6 +22404,9 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/library-aesthetic-symbols.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/specimen/library-aesthetic-symbols.png</image:loc>
     </image:image>
   </url>
 
@@ -22274,7 +22602,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/benzema-emoji-combos/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -22324,7 +22652,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/box-drawing-symbols/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -22374,7 +22702,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/bullet-point-symbols/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -22394,7 +22722,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/cameroon-emoji-combos/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -22474,7 +22802,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/chefs-kiss-emoji/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -22484,7 +22812,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/chess-symbols/</loc>
-    <lastmod>2026-08-02</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -22524,7 +22852,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/choking-emoji/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -22764,7 +23092,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/dark-academia-symbols/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -22774,7 +23102,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/dash-hyphen-symbols/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -22784,7 +23112,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/de-bruyne-emoji-combos/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -22814,7 +23142,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/di-maria-emoji-combos/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -22834,11 +23162,14 @@
 
   <url>
     <loc>https://ultratextgen.com/library/discord-symbols/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/library-discord-symbols.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/specimen/library-discord-symbols.png</image:loc>
     </image:image>
   </url>
 
@@ -22990,6 +23321,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/library-emoji-combos.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/specimen/library-emoji-combos.png</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -23114,7 +23448,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/fire-emoji/</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -23144,7 +23478,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/foden-emoji-combos/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -23164,7 +23498,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/football-ascii-art/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -23184,7 +23518,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/football-kaomoji/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -23194,7 +23528,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/football-reaction-emojis/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -23214,7 +23548,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/football-trophy-emoji/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -23224,7 +23558,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/football-username-ideas/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -23324,7 +23658,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/gavi-emoji-combos/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -23334,7 +23668,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/gender-symbols/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -23474,7 +23808,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/guess-soccer-team-by-emoji/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -23484,7 +23818,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/haaland-emoji-combos/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -23594,7 +23928,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/high-five-emoji/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -23654,7 +23988,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/instagram-symbols/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -23714,7 +24048,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/islamic-symbols/</loc>
-    <lastmod>2026-08-02</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -23764,7 +24098,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/japanese-symbols/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -23784,7 +24118,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/kane-emoji-combos/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -23844,7 +24178,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/kvaratskhelia-emoji-combos/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -23894,7 +24228,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/lautaro-martinez-emoji-combos/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -23914,7 +24248,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/lewandowski-emoji-combos/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -23954,7 +24288,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/loading-text-symbols/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -23984,7 +24318,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/mbappe-emoji-combos/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -23994,7 +24328,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/media-control-symbols/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -24070,6 +24404,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/library-ml-name-symbols.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/specimen/library-ml-name-symbols.png</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -24084,7 +24421,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/modric-emoji-combos/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -24124,7 +24461,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/movie-night-emojis/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -24144,7 +24481,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/musiala-emoji-combos/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -24154,7 +24491,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/music-kaomoji/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -24164,7 +24501,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/music-symbols/</loc>
-    <lastmod>2026-08-02</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -24194,7 +24531,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/netherlands-emoji-combos/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -24244,7 +24581,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/nkunku-emoji-combos/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -24294,7 +24631,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/osimhen-emoji-combos/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -24344,7 +24681,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/pedri-emoji-combos/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -24444,7 +24781,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/pubg-symbols/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -24474,7 +24811,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/rashford-emoji-combos/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -24494,7 +24831,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/religious-symbols/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -24504,11 +24841,14 @@
 
   <url>
     <loc>https://ultratextgen.com/library/roblox-symbols/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/library-roblox-symbols.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/specimen/library-roblox-symbols.png</image:loc>
     </image:image>
   </url>
 
@@ -24534,7 +24874,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/rodri-emoji-combos/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -24544,7 +24884,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/rodrygo-emoji-combos/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -24584,7 +24924,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/saka-emoji-combos/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -24714,7 +25054,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/shrug-kaomoji/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -24784,7 +25124,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/sleepy-kaomoji/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -24824,7 +25164,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/soccer-emoji-copy-paste/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -24834,7 +25174,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/son-emoji-combos/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -24844,7 +25184,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/south-africa-emoji-combos/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -24914,7 +25254,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/star-ascii-art/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -24954,7 +25294,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/steam-symbols/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -24964,7 +25304,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/suarez-emoji-combos/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -25024,7 +25364,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/text-art/</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -25039,6 +25379,9 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/library-text-faces-kaomoji.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/specimen/library-text-faces-kaomoji.png</image:loc>
     </image:image>
   </url>
 
@@ -25094,7 +25437,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/tiktok-symbols/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -25164,7 +25507,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/turkey-emoji-combos/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -25234,7 +25577,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/vinicius-emoji-combos/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -25304,7 +25647,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/whatsapp-symbols/</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -25334,7 +25677,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/wirtz-emoji-combos/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -25354,7 +25697,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/world-cup-emoji-combos/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -25374,7 +25717,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/y2k-symbols/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -25384,7 +25727,7 @@
 
   <url>
     <loc>https://ultratextgen.com/library/yamal-emoji-combos/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -25404,7 +25747,7 @@
 
   <url>
     <loc>https://ultratextgen.com/linkedin/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
     <image:image>
@@ -25490,6 +25833,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/ms-guide-di-mana-font-discord-berfungsi.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/ms-guide-di-mana-font-discord-berfungsi.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -25499,6 +25845,9 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/ms-guide-format-teks-discord-dijelaskan.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/ms-guide-format-teks-discord-dijelaskan.svg</image:loc>
     </image:image>
   </url>
 
@@ -25510,11 +25859,14 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/ms-guide-nama-discord-selamat.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/ms-guide-nama-discord-selamat.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/ms/huruf-besar-kecil/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -25534,7 +25886,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ms/library/simbol-discord/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -25554,7 +25906,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ms/library/simbol-roblox/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -25564,7 +25916,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ms/library/simbol-y2k/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -25760,6 +26112,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/nl-guide-discord-naam-veilig-stylen.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/nl-guide-discord-naam-veilig-stylen.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -25770,6 +26125,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/nl-guide-discord-tekstopmaak-uitgelegd.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/nl-guide-discord-tekstopmaak-uitgelegd.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -25779,6 +26137,9 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/nl-guide-waar-lettertypes-werken-in-discord.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/nl-guide-waar-lettertypes-werken-in-discord.svg</image:loc>
     </image:image>
   </url>
 
@@ -25823,8 +26184,18 @@
   </url>
 
   <url>
+    <loc>https://ultratextgen.com/nl/library/ascii-kunst/</loc>
+    <lastmod>2026-08-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/og/nl-library-ascii-kunst.png</image:loc>
+    </image:image>
+  </url>
+
+  <url>
     <loc>https://ultratextgen.com/nl/library/discord-symbolen/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -25893,6 +26264,16 @@
   </url>
 
   <url>
+    <loc>https://ultratextgen.com/nl/library/instagram-bio-symbolen/</loc>
+    <lastmod>2026-08-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/og/nl-library-instagram-bio-symbolen.png</image:loc>
+    </image:image>
+  </url>
+
+  <url>
     <loc>https://ultratextgen.com/nl/library/iphone-emoji/</loc>
     <lastmod>2026-08-10</lastmod>
     <changefreq>monthly</changefreq>
@@ -25904,7 +26285,7 @@
 
   <url>
     <loc>https://ultratextgen.com/nl/library/islamitische-symbolen/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -25934,7 +26315,7 @@
 
   <url>
     <loc>https://ultratextgen.com/nl/library/muzieksymbolen/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -25944,7 +26325,7 @@
 
   <url>
     <loc>https://ultratextgen.com/nl/library/opsommingstekens/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -25964,7 +26345,7 @@
 
   <url>
     <loc>https://ultratextgen.com/nl/library/religieuze-symbolen/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -25974,7 +26355,7 @@
 
   <url>
     <loc>https://ultratextgen.com/nl/library/roblox-symbolen/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -25984,7 +26365,7 @@
 
   <url>
     <loc>https://ultratextgen.com/nl/library/schaaksymbolen/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -26023,6 +26404,16 @@
   </url>
 
   <url>
+    <loc>https://ultratextgen.com/nl/library/tiktok-symbolen/</loc>
+    <lastmod>2026-08-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/og/nl-library-tiktok-symbolen.png</image:loc>
+    </image:image>
+  </url>
+
+  <url>
     <loc>https://ultratextgen.com/nl/library/vinkje/</loc>
     <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
@@ -26043,6 +26434,16 @@
   </url>
 
   <url>
+    <loc>https://ultratextgen.com/nl/library/whatsapp-symbolen/</loc>
+    <lastmod>2026-08-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/og/nl-library-whatsapp-symbolen.png</image:loc>
+    </image:image>
+  </url>
+
+  <url>
     <loc>https://ultratextgen.com/nl/library/wiskunde-symbolen/</loc>
     <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
@@ -26054,7 +26455,7 @@
 
   <url>
     <loc>https://ultratextgen.com/nl/library/y2k-symbolen/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -26544,7 +26945,7 @@
 
   <url>
     <loc>https://ultratextgen.com/nl/symbol/kwadraat-en-derdemacht/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -27184,7 +27585,7 @@
 
   <url>
     <loc>https://ultratextgen.com/nl/updates/dirham-symbool-unicode-18/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -27224,7 +27625,7 @@
 
   <url>
     <loc>https://ultratextgen.com/nl/updates/valutasymbolen-midden-oosten-unicode-18/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -27264,7 +27665,7 @@
 
   <url>
     <loc>https://ultratextgen.com/nl/usecase/vertical-text/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -27330,6 +27731,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/no-guide-discord-tekstformatering-forklart.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/no-guide-discord-tekstformatering-forklart.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -27340,6 +27744,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/no-guide-hvor-fungerer-skrifter-i-discord.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/no-guide-hvor-fungerer-skrifter-i-discord.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -27349,6 +27756,9 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/no-guide-trygt-discord-navn.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/no-guide-trygt-discord-navn.svg</image:loc>
     </image:image>
   </url>
 
@@ -27434,7 +27844,7 @@
 
   <url>
     <loc>https://ultratextgen.com/no/library/korssymboler/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -27534,7 +27944,7 @@
 
   <url>
     <loc>https://ultratextgen.com/pinterest/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
     <image:image>
@@ -27594,7 +28004,7 @@
 
   <url>
     <loc>https://ultratextgen.com/pl/category/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -27724,7 +28134,7 @@
 
   <url>
     <loc>https://ultratextgen.com/pl/do-druku/banery-z-literami/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -27744,7 +28154,7 @@
 
   <url>
     <loc>https://ultratextgen.com/pl/do-druku/pisanie-imienia/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -27754,7 +28164,7 @@
 
   <url>
     <loc>https://ultratextgen.com/pl/do-druku/pokoloruj-imie/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -27790,6 +28200,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/pl-guide-bezpieczna-nazwa-na-discordzie.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/pl-guide-bezpieczna-nazwa-na-discordzie.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -27800,6 +28213,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/pl-guide-formatowanie-tekstu-na-discordzie.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/pl-guide-formatowanie-tekstu-na-discordzie.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -27809,6 +28225,9 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/pl-guide-gdzie-dzialaja-czcionki-na-discordzie.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/pl-guide-gdzie-dzialaja-czcionki-na-discordzie.svg</image:loc>
     </image:image>
   </url>
 
@@ -27984,7 +28403,7 @@
 
   <url>
     <loc>https://ultratextgen.com/pl/library/symbole-discord/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -28054,7 +28473,7 @@
 
   <url>
     <loc>https://ultratextgen.com/pl/library/symbole-islamskie/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -28104,7 +28523,7 @@
 
   <url>
     <loc>https://ultratextgen.com/pl/library/symbole-muzyczne/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -28124,7 +28543,7 @@
 
   <url>
     <loc>https://ultratextgen.com/pl/library/symbole-punktowania/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -28134,7 +28553,7 @@
 
   <url>
     <loc>https://ultratextgen.com/pl/library/symbole-religijne/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -28144,7 +28563,7 @@
 
   <url>
     <loc>https://ultratextgen.com/pl/library/symbole-roblox/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -28174,7 +28593,7 @@
 
   <url>
     <loc>https://ultratextgen.com/pl/library/symbole-szachowe/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -28214,7 +28633,7 @@
 
   <url>
     <loc>https://ultratextgen.com/pl/library/symbole-y2k/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -28534,7 +28953,7 @@
 
   <url>
     <loc>https://ultratextgen.com/pl/symbol/kwadrat-i-szescian/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -29494,7 +29913,7 @@
 
   <url>
     <loc>https://ultratextgen.com/pl/usecase/tlumacz-emoji/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -29504,7 +29923,7 @@
 
   <url>
     <loc>https://ultratextgen.com/pl/usecase/vertical-text/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -29524,7 +29943,7 @@
 
   <url>
     <loc>https://ultratextgen.com/pl/wielkie-i-male-litery/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -29914,7 +30333,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/banner-maker/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -29924,7 +30343,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/best-friend-in-cursive/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -30314,7 +30733,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/bubble-letters/letter-a/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -30324,7 +30743,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/bubble-letters/letter-b/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -30334,7 +30753,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/bubble-letters/letter-c/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -30344,7 +30763,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/bubble-letters/letter-d/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -30354,7 +30773,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/bubble-letters/letter-e/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -30364,7 +30783,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/bubble-letters/letter-f/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -30374,7 +30793,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/bubble-letters/letter-g/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -30384,7 +30803,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/bubble-letters/letter-h/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -30394,7 +30813,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/bubble-letters/letter-i/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -30404,7 +30823,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/bubble-letters/letter-j/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -30414,7 +30833,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/bubble-letters/letter-k/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -30424,7 +30843,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/bubble-letters/letter-l/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -30434,7 +30853,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/bubble-letters/letter-m/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -30444,7 +30863,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/bubble-letters/letter-n/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -30454,7 +30873,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/bubble-letters/letter-o/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -30464,7 +30883,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/bubble-letters/letter-p/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -30474,7 +30893,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/bubble-letters/letter-q/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -30484,7 +30903,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/bubble-letters/letter-r/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -30494,7 +30913,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/bubble-letters/letter-s/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -30504,7 +30923,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/bubble-letters/letter-t/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -30514,7 +30933,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/bubble-letters/letter-u/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -30524,7 +30943,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/bubble-letters/letter-v/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -30534,7 +30953,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/bubble-letters/letter-w/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -30544,7 +30963,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/bubble-letters/letter-x/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -30554,7 +30973,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/bubble-letters/letter-y/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -30564,7 +30983,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/bubble-letters/letter-z/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -30944,7 +31363,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/coloring-page-maker/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -30974,267 +31393,345 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/cursive-alphabet/letter-a/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/printables-cursive-alphabet-letter-a.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/printables-cursive-alphabet-letter-a.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/printables/cursive-alphabet/letter-b/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/printables-cursive-alphabet-letter-b.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/printables-cursive-alphabet-letter-b.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/printables/cursive-alphabet/letter-c/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/printables-cursive-alphabet-letter-c.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/printables-cursive-alphabet-letter-c.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/printables/cursive-alphabet/letter-d/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/printables-cursive-alphabet-letter-d.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/printables-cursive-alphabet-letter-d.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/printables/cursive-alphabet/letter-e/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/printables-cursive-alphabet-letter-e.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/printables-cursive-alphabet-letter-e.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/printables/cursive-alphabet/letter-f/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/printables-cursive-alphabet-letter-f.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/printables-cursive-alphabet-letter-f.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/printables/cursive-alphabet/letter-g/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/printables-cursive-alphabet-letter-g.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/printables-cursive-alphabet-letter-g.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/printables/cursive-alphabet/letter-h/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/printables-cursive-alphabet-letter-h.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/printables-cursive-alphabet-letter-h.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/printables/cursive-alphabet/letter-i/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/printables-cursive-alphabet-letter-i.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/printables-cursive-alphabet-letter-i.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/printables/cursive-alphabet/letter-j/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/printables-cursive-alphabet-letter-j.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/printables-cursive-alphabet-letter-j.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/printables/cursive-alphabet/letter-k/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/printables-cursive-alphabet-letter-k.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/printables-cursive-alphabet-letter-k.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/printables/cursive-alphabet/letter-l/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/printables-cursive-alphabet-letter-l.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/printables-cursive-alphabet-letter-l.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/printables/cursive-alphabet/letter-m/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/printables-cursive-alphabet-letter-m.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/printables-cursive-alphabet-letter-m.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/printables/cursive-alphabet/letter-n/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/printables-cursive-alphabet-letter-n.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/printables-cursive-alphabet-letter-n.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/printables/cursive-alphabet/letter-o/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/printables-cursive-alphabet-letter-o.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/printables-cursive-alphabet-letter-o.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/printables/cursive-alphabet/letter-p/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/printables-cursive-alphabet-letter-p.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/printables-cursive-alphabet-letter-p.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/printables/cursive-alphabet/letter-q/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/printables-cursive-alphabet-letter-q.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/printables-cursive-alphabet-letter-q.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/printables/cursive-alphabet/letter-r/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/printables-cursive-alphabet-letter-r.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/printables-cursive-alphabet-letter-r.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/printables/cursive-alphabet/letter-s/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/printables-cursive-alphabet-letter-s.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/printables-cursive-alphabet-letter-s.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/printables/cursive-alphabet/letter-t/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/printables-cursive-alphabet-letter-t.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/printables-cursive-alphabet-letter-t.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/printables/cursive-alphabet/letter-u/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/printables-cursive-alphabet-letter-u.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/printables-cursive-alphabet-letter-u.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/printables/cursive-alphabet/letter-v/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/printables-cursive-alphabet-letter-v.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/printables-cursive-alphabet-letter-v.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/printables/cursive-alphabet/letter-w/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/printables-cursive-alphabet-letter-w.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/printables-cursive-alphabet-letter-w.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/printables/cursive-alphabet/letter-x/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/printables-cursive-alphabet-letter-x.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/printables-cursive-alphabet-letter-x.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/printables/cursive-alphabet/letter-y/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/printables-cursive-alphabet-letter-y.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/printables-cursive-alphabet-letter-y.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/printables/cursive-alphabet/letter-z/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/printables-cursive-alphabet-letter-z.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/printables-cursive-alphabet-letter-z.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/printables/dad-in-cursive/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -31254,7 +31751,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/dot-to-dot-alphabet/letter-a/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -31264,7 +31761,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/dot-to-dot-alphabet/letter-b/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -31274,7 +31771,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/dot-to-dot-alphabet/letter-c/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -31284,7 +31781,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/dot-to-dot-alphabet/letter-d/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -31294,7 +31791,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/dot-to-dot-alphabet/letter-e/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -31304,7 +31801,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/dot-to-dot-alphabet/letter-f/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -31314,7 +31811,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/dot-to-dot-alphabet/letter-g/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -31324,7 +31821,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/dot-to-dot-alphabet/letter-h/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -31334,7 +31831,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/dot-to-dot-alphabet/letter-i/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -31344,7 +31841,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/dot-to-dot-alphabet/letter-j/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -31354,7 +31851,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/dot-to-dot-alphabet/letter-k/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -31364,7 +31861,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/dot-to-dot-alphabet/letter-l/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -31374,7 +31871,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/dot-to-dot-alphabet/letter-m/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -31384,7 +31881,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/dot-to-dot-alphabet/letter-n/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -31394,7 +31891,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/dot-to-dot-alphabet/letter-o/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -31404,7 +31901,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/dot-to-dot-alphabet/letter-p/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -31414,7 +31911,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/dot-to-dot-alphabet/letter-q/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -31424,7 +31921,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/dot-to-dot-alphabet/letter-r/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -31434,7 +31931,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/dot-to-dot-alphabet/letter-s/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -31444,7 +31941,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/dot-to-dot-alphabet/letter-t/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -31454,7 +31951,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/dot-to-dot-alphabet/letter-u/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -31464,7 +31961,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/dot-to-dot-alphabet/letter-v/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -31474,7 +31971,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/dot-to-dot-alphabet/letter-w/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -31484,7 +31981,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/dot-to-dot-alphabet/letter-x/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -31494,7 +31991,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/dot-to-dot-alphabet/letter-y/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -31504,7 +32001,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/dot-to-dot-alphabet/letter-z/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -31514,7 +32011,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/dot-to-dot-name/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -31524,7 +32021,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/family-in-cursive/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -31564,7 +32061,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/love-in-cursive/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -31574,7 +32071,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/mom-in-cursive/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -31594,7 +32091,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/name-puzzle-maker/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -31604,7 +32101,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/name-tracing/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -31614,7 +32111,7 @@
 
   <url>
     <loc>https://ultratextgen.com/printables/sight-word-tracing/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -31634,7 +32131,7 @@
 
   <url>
     <loc>https://ultratextgen.com/privacy/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
     <image:image>
@@ -31794,7 +32291,7 @@
 
   <url>
     <loc>https://ultratextgen.com/pt/fontes-para-telegram/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -31850,6 +32347,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/pt-guide-formatacao-de-texto-no-discord.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/pt-guide-formatacao-de-texto-no-discord.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -31860,6 +32360,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/pt-guide-nome-discord-sem-risco.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/pt-guide-nome-discord-sem-risco.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -31869,6 +32372,9 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/pt-guide-onde-as-fontes-funcionam-no-discord.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/pt-guide-onde-as-fontes-funcionam-no-discord.svg</image:loc>
     </image:image>
   </url>
 
@@ -31964,7 +32470,7 @@
 
   <url>
     <loc>https://ultratextgen.com/pt/letras-diferentes/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -32284,7 +32790,7 @@
 
   <url>
     <loc>https://ultratextgen.com/pt/library/simbolos-de-marcadores/</loc>
-    <lastmod>2026-08-06</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -32314,7 +32820,7 @@
 
   <url>
     <loc>https://ultratextgen.com/pt/library/simbolos-de-xadrez/</loc>
-    <lastmod>2026-08-05</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -32324,7 +32830,7 @@
 
   <url>
     <loc>https://ultratextgen.com/pt/library/simbolos-discord/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -32364,7 +32870,7 @@
 
   <url>
     <loc>https://ultratextgen.com/pt/library/simbolos-islamicos/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -32404,7 +32910,7 @@
 
   <url>
     <loc>https://ultratextgen.com/pt/library/simbolos-musicais/</loc>
-    <lastmod>2026-08-06</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -32424,7 +32930,7 @@
 
   <url>
     <loc>https://ultratextgen.com/pt/library/simbolos-religiosos/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -32434,7 +32940,7 @@
 
   <url>
     <loc>https://ultratextgen.com/pt/library/simbolos-roblox/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -32464,7 +32970,7 @@
 
   <url>
     <loc>https://ultratextgen.com/pt/library/simbolos-y2k/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -32480,6 +32986,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/pt-library-simbolos.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/specimen/pt-library-simbolos.png</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -32494,7 +33003,7 @@
 
   <url>
     <loc>https://ultratextgen.com/pt/library/vinicius-emoji-combos/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -32504,7 +33013,7 @@
 
   <url>
     <loc>https://ultratextgen.com/pt/maiusculas-e-minusculas/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -32744,7 +33253,7 @@
 
   <url>
     <loc>https://ultratextgen.com/pt/symbol/quadrado-e-cubo/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -33694,7 +34203,7 @@
 
   <url>
     <loc>https://ultratextgen.com/pt/usecase/letras-para-tatuagem/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -33784,7 +34293,7 @@
 
   <url>
     <loc>https://ultratextgen.com/pt/usecase/tradutor-de-emojis/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -33870,6 +34379,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/ro-guide-formatare-text-discord-explicat.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/ro-guide-formatare-text-discord-explicat.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -33880,6 +34392,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/ro-guide-nume-discord-fara-riscuri.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/ro-guide-nume-discord-fara-riscuri.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -33889,6 +34404,9 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/ro-guide-unde-functioneaza-fonturile-discord.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/ro-guide-unde-functioneaza-fonturile-discord.svg</image:loc>
     </image:image>
   </url>
 
@@ -33944,7 +34462,7 @@
 
   <url>
     <loc>https://ultratextgen.com/roblox/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
     <image:image>
@@ -33964,7 +34482,7 @@
 
   <url>
     <loc>https://ultratextgen.com/roblox/old-roblox-font/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -34080,6 +34598,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/ru-guide-bezopasnyy-nik-discord.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/ru-guide-bezopasnyy-nik-discord.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -34090,6 +34611,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/ru-guide-formatirovanie-teksta-discord.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/ru-guide-formatirovanie-teksta-discord.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -34099,6 +34623,9 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/ru-guide-gde-rabotayut-shrifty-discord.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/ru-guide-gde-rabotayut-shrifty-discord.svg</image:loc>
     </image:image>
   </url>
 
@@ -34214,7 +34741,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ru/library/islamskie-simvoly/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -34264,7 +34791,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ru/library/markery-spiska/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -34294,7 +34821,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ru/library/muzykalnye-simvoly/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -34304,7 +34831,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ru/library/religioznye-simvoly/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -34334,7 +34861,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ru/library/shakhmatnye-simvoly/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -34354,7 +34881,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ru/library/simvoly-discord/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -34384,7 +34911,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ru/library/simvoly-roblox/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -34424,7 +34951,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ru/library/simvoly-y2k/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -34534,7 +35061,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ru/shrift-dlya-telegram/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -34814,7 +35341,7 @@
 
   <url>
     <loc>https://ultratextgen.com/ru/symbol/kvadrat-i-kub/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -35720,6 +36247,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/sk-guide-bezpecny-nick-na-discorde.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/sk-guide-bezpecny-nick-na-discorde.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -35730,6 +36260,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/sk-guide-formatovanie-textu-na-discorde.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/sk-guide-formatovanie-textu-na-discorde.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -35739,6 +36272,9 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/sk-guide-kde-funguje-pismo-na-discorde.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/sk-guide-kde-funguje-pismo-na-discorde.svg</image:loc>
     </image:image>
   </url>
 
@@ -35804,7 +36340,7 @@
 
   <url>
     <loc>https://ultratextgen.com/snapchat/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
     <image:image>
@@ -35870,6 +36406,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/sr-guide-bezbedan-nadimak-na-discordu.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/sr-guide-bezbedan-nadimak-na-discordu.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -35880,6 +36419,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/sr-guide-formatiranje-teksta-na-discordu.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/sr-guide-formatiranje-teksta-na-discordu.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -35889,6 +36431,9 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/sr-guide-gde-fontovi-rade-na-discordu.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/sr-guide-gde-fontovi-rade-na-discordu.svg</image:loc>
     </image:image>
   </url>
 
@@ -35950,6 +36495,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/sv-guide-discord-namn-utan-risk.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/sv-guide-discord-namn-utan-risk.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -35960,6 +36508,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/sv-guide-discord-textformatering-forklarad.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/sv-guide-discord-textformatering-forklarad.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -35969,6 +36520,9 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/sv-guide-var-typsnitt-fungerar-i-discord.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/sv-guide-var-typsnitt-fungerar-i-discord.svg</image:loc>
     </image:image>
   </url>
 
@@ -36004,7 +36558,7 @@
 
   <url>
     <loc>https://ultratextgen.com/sv/library/discord-symboler/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -36044,7 +36598,7 @@
 
   <url>
     <loc>https://ultratextgen.com/sv/library/konssymboler/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -36074,7 +36628,7 @@
 
   <url>
     <loc>https://ultratextgen.com/sv/library/roblox-symboler/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -36104,7 +36658,7 @@
 
   <url>
     <loc>https://ultratextgen.com/sv/library/y2k-symboler/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -36114,7 +36668,7 @@
 
   <url>
     <loc>https://ultratextgen.com/sv/updates/dirham-symbol-unicode-18/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -36134,7 +36688,7 @@
 
   <url>
     <loc>https://ultratextgen.com/sv/updates/valutasymboler-mellanostern-unicode-18/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -37104,7 +37658,7 @@
 
   <url>
     <loc>https://ultratextgen.com/symbol/squared-cubed/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -37284,7 +37838,7 @@
 
   <url>
     <loc>https://ultratextgen.com/telegram/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
     <image:image>
@@ -37294,7 +37848,7 @@
 
   <url>
     <loc>https://ultratextgen.com/terms/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
     <image:image>
@@ -37370,6 +37924,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/th-guide-discord-font-thamngan-thinai.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/th-guide-discord-font-thamngan-thinai.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -37380,6 +37937,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/th-guide-discord-rupbaep-khokhwam.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/th-guide-discord-rupbaep-khokhwam.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -37389,6 +37949,9 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/th-guide-discord-tang-chue-plodphai.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/th-guide-discord-tang-chue-plodphai.svg</image:loc>
     </image:image>
   </url>
 
@@ -37454,7 +38017,7 @@
 
   <url>
     <loc>https://ultratextgen.com/th/library/bullet-point-symbols/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -37474,7 +38037,7 @@
 
   <url>
     <loc>https://ultratextgen.com/th/library/chess-symbols/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -37504,7 +38067,7 @@
 
   <url>
     <loc>https://ultratextgen.com/th/library/discord-symbols/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -37584,7 +38147,7 @@
 
   <url>
     <loc>https://ultratextgen.com/th/library/islamic-symbols/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -37634,7 +38197,7 @@
 
   <url>
     <loc>https://ultratextgen.com/th/library/music-symbols/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -37644,7 +38207,7 @@
 
   <url>
     <loc>https://ultratextgen.com/th/library/religious-symbols/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -37654,7 +38217,7 @@
 
   <url>
     <loc>https://ultratextgen.com/th/library/roblox-symbols/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -37684,7 +38247,7 @@
 
   <url>
     <loc>https://ultratextgen.com/th/library/y2k-symbols/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -38754,7 +39317,7 @@
 
   <url>
     <loc>https://ultratextgen.com/th/symbol/squared-cubed/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -38804,7 +39367,7 @@
 
   <url>
     <loc>https://ultratextgen.com/th/usecase/bio-font-ig/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -38834,7 +39397,7 @@
 
   <url>
     <loc>https://ultratextgen.com/threads/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
     <image:image>
@@ -38890,6 +39453,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/tl-guide-discord-name-na-safe.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/tl-guide-discord-name-na-safe.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -38899,6 +39465,9 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/tl-guide-discord-text-formatting-paliwanag.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/tl-guide-discord-text-formatting-paliwanag.svg</image:loc>
     </image:image>
   </url>
 
@@ -38910,11 +39479,14 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/tl-guide-saan-gumagana-ang-font-sa-discord.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/tl-guide-saan-gumagana-ang-font-sa-discord.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
     <loc>https://ultratextgen.com/tl/usecase/bio-font/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -39034,7 +39606,7 @@
 
   <url>
     <loc>https://ultratextgen.com/tr/buyuk-kucuk-harf/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -39110,6 +39682,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/tr-guide-discord-fontlari-nerede-calisir.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/tr-guide-discord-fontlari-nerede-calisir.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -39120,6 +39695,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/tr-guide-discord-metin-bicimlendirme.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/tr-guide-discord-metin-bicimlendirme.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -39129,6 +39707,9 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/tr-guide-guvenli-discord-ismi.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/tr-guide-guvenli-discord-ismi.svg</image:loc>
     </image:image>
   </url>
 
@@ -39214,7 +39795,7 @@
 
   <url>
     <loc>https://ultratextgen.com/tr/library/ates-emoji/</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -39234,7 +39815,7 @@
 
   <url>
     <loc>https://ultratextgen.com/tr/library/coquette-sembolleri/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -39274,7 +39855,7 @@
 
   <url>
     <loc>https://ultratextgen.com/tr/library/dini-semboller/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -39284,7 +39865,7 @@
 
   <url>
     <loc>https://ultratextgen.com/tr/library/discord-sembolleri/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -39344,7 +39925,7 @@
 
   <url>
     <loc>https://ultratextgen.com/tr/library/facebook-sembolleri/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -39394,7 +39975,7 @@
 
   <url>
     <loc>https://ultratextgen.com/tr/library/islami-semboller/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -39474,7 +40055,7 @@
 
   <url>
     <loc>https://ultratextgen.com/tr/library/madde-imi-sembolleri/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -39494,7 +40075,7 @@
 
   <url>
     <loc>https://ultratextgen.com/tr/library/muzik-sembolleri/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -39554,7 +40135,7 @@
 
   <url>
     <loc>https://ultratextgen.com/tr/library/pubg-sembolleri/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -39564,7 +40145,7 @@
 
   <url>
     <loc>https://ultratextgen.com/tr/library/roblox-sembolleri/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -39574,7 +40155,7 @@
 
   <url>
     <loc>https://ultratextgen.com/tr/library/satranc-sembolleri/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -39589,6 +40170,9 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/tr-library-semboller.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/specimen/tr-library-semboller.png</image:loc>
     </image:image>
   </url>
 
@@ -39634,7 +40218,7 @@
 
   <url>
     <loc>https://ultratextgen.com/tr/library/y2k-sembolleri/</loc>
-    <lastmod>2026-07-26</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -40214,7 +40798,7 @@
 
   <url>
     <loc>https://ultratextgen.com/tr/symbol/kare-kup-isaretleri/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -40834,7 +41418,7 @@
 
   <url>
     <loc>https://ultratextgen.com/tr/updates/dirhem-sembolu-unicode-18/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -40844,7 +41428,7 @@
 
   <url>
     <loc>https://ultratextgen.com/tr/updates/orta-dogu-para-birimi-sembolleri-unicode-18/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -40894,7 +41478,7 @@
 
   <url>
     <loc>https://ultratextgen.com/tr/usecase/biyografi-yazi-tipi/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -40924,7 +41508,7 @@
 
   <url>
     <loc>https://ultratextgen.com/tr/usecase/emoji-ceviri/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -40934,7 +41518,7 @@
 
   <url>
     <loc>https://ultratextgen.com/tr/usecase/emoji-harfler/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -41004,7 +41588,7 @@
 
   <url>
     <loc>https://ultratextgen.com/tr/usecase/valorant-nick/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -41014,7 +41598,7 @@
 
   <url>
     <loc>https://ultratextgen.com/tr/usecase/vertical-text/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -41064,7 +41648,7 @@
 
   <url>
     <loc>https://ultratextgen.com/updates/forza-horizon-6-gamertag-rules/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -41084,7 +41668,7 @@
 
   <url>
     <loc>https://ultratextgen.com/updates/middle-east-currency-symbols-scorecard/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -41104,7 +41688,7 @@
 
   <url>
     <loc>https://ultratextgen.com/updates/uae-dirham-symbol-unicode-18/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -41114,7 +41698,7 @@
 
   <url>
     <loc>https://ultratextgen.com/updates/unicode-17-new-emoji-rollout/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -41154,7 +41738,7 @@
 
   <url>
     <loc>https://ultratextgen.com/updates/whatsapp-usernames-rollout/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -41314,7 +41898,7 @@
 
   <url>
     <loc>https://ultratextgen.com/usecase/emoji-letters/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -41324,7 +41908,7 @@
 
   <url>
     <loc>https://ultratextgen.com/usecase/emoji-to-text/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -41334,7 +41918,7 @@
 
   <url>
     <loc>https://ultratextgen.com/usecase/football-font/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -41444,7 +42028,7 @@
 
   <url>
     <loc>https://ultratextgen.com/usecase/old-english-translator/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -41454,7 +42038,7 @@
 
   <url>
     <loc>https://ultratextgen.com/usecase/pirate-translator/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -41484,7 +42068,7 @@
 
   <url>
     <loc>https://ultratextgen.com/usecase/repeat-text/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -41524,7 +42108,7 @@
 
   <url>
     <loc>https://ultratextgen.com/usecase/tattoo-fonts/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -41534,7 +42118,7 @@
 
   <url>
     <loc>https://ultratextgen.com/usecase/text-to-emoji/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -41574,7 +42158,7 @@
 
   <url>
     <loc>https://ultratextgen.com/usecase/zalgo-text/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -41644,7 +42228,7 @@
 
   <url>
     <loc>https://ultratextgen.com/vi/chu-hoa-chu-thuong/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -41810,6 +42394,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/vi-guide-dat-ten-discord-an-toan.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/vi-guide-dat-ten-discord-an-toan.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -41820,6 +42407,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/vi-guide-dinh-dang-chu-discord.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/vi-guide-dinh-dang-chu-discord.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -41829,6 +42419,9 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/vi-guide-font-discord-dung-o-dau.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/vi-guide-font-discord-dung-o-dau.svg</image:loc>
     </image:image>
   </url>
 
@@ -41864,7 +42457,7 @@
 
   <url>
     <loc>https://ultratextgen.com/vi/ki-tu-discord/</loc>
-    <lastmod>2026-07-26</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -41874,7 +42467,7 @@
 
   <url>
     <loc>https://ultratextgen.com/vi/ki-tu-facebook/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -41904,7 +42497,7 @@
 
   <url>
     <loc>https://ultratextgen.com/vi/ki-tu-roblox/</loc>
-    <lastmod>2026-07-26</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -41924,7 +42517,7 @@
 
   <url>
     <loc>https://ultratextgen.com/vi/ki-tu-y2k/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -41954,7 +42547,7 @@
 
   <url>
     <loc>https://ultratextgen.com/vi/library/bullet-point-symbols/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -42044,7 +42637,7 @@
 
   <url>
     <loc>https://ultratextgen.com/vi/library/ky-hieu-am-nhac/</loc>
-    <lastmod>2026-08-06</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -42054,7 +42647,7 @@
 
   <url>
     <loc>https://ultratextgen.com/vi/library/ky-hieu-co-vua/</loc>
-    <lastmod>2026-08-06</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -42074,7 +42667,7 @@
 
   <url>
     <loc>https://ultratextgen.com/vi/library/ky-hieu-hoi-giao/</loc>
-    <lastmod>2026-08-06</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -42094,7 +42687,7 @@
 
   <url>
     <loc>https://ultratextgen.com/vi/library/ky-hieu-ton-giao/</loc>
-    <lastmod>2026-08-06</lastmod>
+    <lastmod>2026-08-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -43084,7 +43677,7 @@
 
   <url>
     <loc>https://ultratextgen.com/vi/symbol/squared-cubed/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -43294,7 +43887,7 @@
 
   <url>
     <loc>https://ultratextgen.com/vi/usecase/dich-emoji/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -43374,7 +43967,7 @@
 
   <url>
     <loc>https://ultratextgen.com/whatsapp/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
     <image:image>
@@ -43434,7 +44027,7 @@
 
   <url>
     <loc>https://ultratextgen.com/zh-tw/da-xiao-xie-zhuanhuan/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -43460,6 +44053,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/zh-tw-guide-discord-anquan-nicheng.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/zh-tw-guide-discord-anquan-nicheng.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -43470,6 +44066,9 @@
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/zh-tw-guide-discord-wenzi-geshi.png</image:loc>
     </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/zh-tw-guide-discord-wenzi-geshi.svg</image:loc>
+    </image:image>
   </url>
 
   <url>
@@ -43479,6 +44078,9 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/zh-tw-guide-discord-ziti-nali-nengyong.png</image:loc>
+    </image:image>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/hero/zh-tw-guide-discord-ziti-nali-nengyong.svg</image:loc>
     </image:image>
   </url>
 
@@ -43573,6 +44175,16 @@
   </url>
 
   <url>
+    <loc>https://ultratextgen.com/zh-tw/library/discord-fuhao/</loc>
+    <lastmod>2026-08-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/og/zh-tw-library-discord-fuhao.png</image:loc>
+    </image:image>
+  </url>
+
+  <url>
     <loc>https://ultratextgen.com/zh-tw/library/divider-kaomoji/</loc>
     <lastmod>2026-08-12</lastmod>
     <changefreq>monthly</changefreq>
@@ -43593,6 +44205,16 @@
   </url>
 
   <url>
+    <loc>https://ultratextgen.com/zh-tw/library/guojixiangqi-fuhao/</loc>
+    <lastmod>2026-08-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/og/zh-tw-library-guojixiangqi-fuhao.png</image:loc>
+    </image:image>
+  </url>
+
+  <url>
     <loc>https://ultratextgen.com/zh-tw/library/guoqi-emoji/</loc>
     <lastmod>2026-08-11</lastmod>
     <changefreq>monthly</changefreq>
@@ -43604,7 +44226,7 @@
 
   <url>
     <loc>https://ultratextgen.com/zh-tw/library/happy-kaomoji/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -43713,6 +44335,16 @@
   </url>
 
   <url>
+    <loc>https://ultratextgen.com/zh-tw/library/roblox-fuhao/</loc>
+    <lastmod>2026-08-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/og/zh-tw-library-roblox-fuhao.png</image:loc>
+    </image:image>
+  </url>
+
+  <url>
     <loc>https://ultratextgen.com/zh-tw/library/sad-kaomoji/</loc>
     <lastmod>2026-08-10</lastmod>
     <changefreq>monthly</changefreq>
@@ -43724,7 +44356,7 @@
 
   <url>
     <loc>https://ultratextgen.com/zh-tw/library/shrug-kaomoji/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -43763,6 +44395,16 @@
   </url>
 
   <url>
+    <loc>https://ultratextgen.com/zh-tw/library/xiangmu-fuhao/</loc>
+    <lastmod>2026-08-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/og/zh-tw-library-xiangmu-fuhao.png</image:loc>
+    </image:image>
+  </url>
+
+  <url>
     <loc>https://ultratextgen.com/zh-tw/library/xila-zimu-fuhao/</loc>
     <lastmod>2026-08-07</lastmod>
     <changefreq>monthly</changefreq>
@@ -43789,6 +44431,46 @@
     <priority>0.7</priority>
     <image:image>
       <image:loc>https://ultratextgen.com/assets/og/zh-tw-library-xingzuo-fuhao.png</image:loc>
+    </image:image>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/zh-tw/library/y2k-fuhao/</loc>
+    <lastmod>2026-08-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/og/zh-tw-library-y2k-fuhao.png</image:loc>
+    </image:image>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/zh-tw/library/yinyue-fuhao/</loc>
+    <lastmod>2026-08-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/og/zh-tw-library-yinyue-fuhao.png</image:loc>
+    </image:image>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/zh-tw/library/yisilan-fuhao/</loc>
+    <lastmod>2026-08-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/og/zh-tw-library-yisilan-fuhao.png</image:loc>
+    </image:image>
+  </url>
+
+  <url>
+    <loc>https://ultratextgen.com/zh-tw/library/zongjiao-fuhao/</loc>
+    <lastmod>2026-08-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://ultratextgen.com/assets/og/zh-tw-library-zongjiao-fuhao.png</image:loc>
     </image:image>
   </url>
 


### PR DESCRIPTION
Follow-up to #742, which merged the specimen-art probe. This is a **new PR** because #742 is already merged — commits pushed onto that branch afterwards were untracked by any open PR.

## The gap

The generator emitted exactly **one `<image:image>` per URL** — the `og:image`. So the 15 specimen charts shipped in `35c5a386b` were on-page and crawlable but never declared.

Verified against the live sitemap before changing anything:

| Live `sitemap.xml` (fetched 2026-08-14) | |
|---|---|
| URLs | 4,438 |
| `<image:loc>` entries | 4,438 — exactly one per URL |
| `assets/specimen` references | **0** |

That matters for the probe specifically. Its readout on 2026-09-26 asks whether a page's own symbols rendered as an image outrank a brand card. A null result would have been ambiguous between *"the thesis is wrong"* and *"the images were never declared."* Declaring them removes the second reading.

## The rule

A property of the **markup**, not a path list: an `<img>` with a real `alt`, outside any `aria-hidden` figure.

Deliberate — nothing needs updating when a future content image is added, and no hardcoded `specimen` special case can drift.

It also turns out to match a distinction the site already documents. `CLAUDE.md` describes the decorative `page-hero-figure` (shipped `aria-hidden` with a null alt, because it restates the page's own `<h1>`) against the visible `guide-hero-figure` that guides use.

## Result

4,438 URLs now carry **4,612 images**:

- 15 specimen charts
- 159 guide hero illustrations that already had real descriptive alt
- `about/` and `answers/` stay at one image each (decorative heroes correctly excluded)
- **0** declared files missing on disk

## Tests

`scripts/update-sitemap.test.js` — 16 cases covering the split in both directions, in the repo's existing zero-dependency idiom (`npm run test:sitemap-images`).

It earned itself immediately: it caught that a protocol-relative `//cdn.example.com/a.png` was being prefixed into `https://ultratextgen.com//cdn.example.com/a.png` — a declared image that would 404. Getting this rule wrong is silent in **both** directions, which is exactly the failure mode this repo keeps hitting.

## Validation

Rebased onto current `main` (resolved `package.json` to keep main's three new script entries alongside `test:sitemap-images`; regenerated `sitemap.xml` against the new base rather than merging the stale one).

`npm run check:ci-gates` — **all 15 gating checks pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014PpY1gYHP3XSWsCdPSt2qb)_