### PR TITLE
feat(ja): per-letter cursive grid + 空白コピペ retarget; fix 2 unclosed CS…

### DIFF
--- a/ja/hikkitai/index.html
+++ b/ja/hikkitai/index.html
@@ -217,7 +217,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <!-- 筆記体 A-Z -->
   <section class="editorial-section glyph-section">
     <h2>筆記体 A–Z 一覧（大文字・小文字）</h2>
-    <p class="editorial-intro">イニシャルやモノグラム用に1文字ずつ欲しい人向けの、筆記体アルファベット一覧です。行をクリックすると、A–Zをまとめてコピーできます。</p>
+    <p class="editorial-intro">イニシャルやモノグラム用に1文字ずつ欲しい人向けの、筆記体アルファベット一覧です。行をクリックするとA–Zをまとめて、下の1文字ずつの一覧では好きな文字だけをコピーできます。</p>
     <div class="alpha-list">
       <div class="alpha-row">
         <span class="alpha-label">筆記体・太</span>
@@ -228,6 +228,141 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
         <button class="glyph-copy alpha-glyphs" type="button" data-text="𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵 𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏" aria-label="筆記体・細のアルファベットをコピー">𝒜ℬ𝒞𝒟ℰℱ𝒢ℋℐ𝒥𝒦ℒℳ𝒩𝒪𝒫𝒬ℛ𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵 · 𝒶𝒷𝒸𝒹ℯ𝒻ℊ𝒽𝒾𝒿𝓀𝓁𝓂𝓃ℴ𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏</button>
       </div>
     </div>
+
+    <p class="u-mt-15">1文字ずつコピーしたいときはこちら。太い筆記体と細い筆記体を、大文字・小文字セットで並べています。</p>
+      <div class="letter-anchor-grid">
+        <div class="letter-anchor-cell" id="hikkitai-a">
+          <span class="alpha-label">筆記体 A</span>
+          <button class="glyph-copy" type="button" data-text="𝓐𝓪" aria-label="A の筆記体・太（大文字・小文字）をコピー">𝓐 𝓪</button>
+          <button class="glyph-copy" type="button" data-text="𝒜𝒶" aria-label="A の筆記体・細（大文字・小文字）をコピー">𝒜 𝒶</button>
+        </div>
+        <div class="letter-anchor-cell" id="hikkitai-b">
+          <span class="alpha-label">筆記体 B</span>
+          <button class="glyph-copy" type="button" data-text="𝓑𝓫" aria-label="B の筆記体・太（大文字・小文字）をコピー">𝓑 𝓫</button>
+          <button class="glyph-copy" type="button" data-text="ℬ𝒷" aria-label="B の筆記体・細（大文字・小文字）をコピー">ℬ 𝒷</button>
+        </div>
+        <div class="letter-anchor-cell" id="hikkitai-c">
+          <span class="alpha-label">筆記体 C</span>
+          <button class="glyph-copy" type="button" data-text="𝓒𝓬" aria-label="C の筆記体・太（大文字・小文字）をコピー">𝓒 𝓬</button>
+          <button class="glyph-copy" type="button" data-text="𝒞𝒸" aria-label="C の筆記体・細（大文字・小文字）をコピー">𝒞 𝒸</button>
+        </div>
+        <div class="letter-anchor-cell" id="hikkitai-d">
+          <span class="alpha-label">筆記体 D</span>
+          <button class="glyph-copy" type="button" data-text="𝓓𝓭" aria-label="D の筆記体・太（大文字・小文字）をコピー">𝓓 𝓭</button>
+          <button class="glyph-copy" type="button" data-text="𝒟𝒹" aria-label="D の筆記体・細（大文字・小文字）をコピー">𝒟 𝒹</button>
+        </div>
+        <div class="letter-anchor-cell" id="hikkitai-e">
+          <span class="alpha-label">筆記体 E</span>
+          <button class="glyph-copy" type="button" data-text="𝓔𝓮" aria-label="E の筆記体・太（大文字・小文字）をコピー">𝓔 𝓮</button>
+          <button class="glyph-copy" type="button" data-text="ℰℯ" aria-label="E の筆記体・細（大文字・小文字）をコピー">ℰ ℯ</button>
+        </div>
+        <div class="letter-anchor-cell" id="hikkitai-f">
+          <span class="alpha-label">筆記体 F</span>
+          <button class="glyph-copy" type="button" data-text="𝓕𝓯" aria-label="F の筆記体・太（大文字・小文字）をコピー">𝓕 𝓯</button>
+          <button class="glyph-copy" type="button" data-text="ℱ𝒻" aria-label="F の筆記体・細（大文字・小文字）をコピー">ℱ 𝒻</button>
+        </div>
+        <div class="letter-anchor-cell" id="hikkitai-g">
+          <span class="alpha-label">筆記体 G</span>
+          <button class="glyph-copy" type="button" data-text="𝓖𝓰" aria-label="G の筆記体・太（大文字・小文字）をコピー">𝓖 𝓰</button>
+          <button class="glyph-copy" type="button" data-text="𝒢ℊ" aria-label="G の筆記体・細（大文字・小文字）をコピー">𝒢 ℊ</button>
+        </div>
+        <div class="letter-anchor-cell" id="hikkitai-h">
+          <span class="alpha-label">筆記体 H</span>
+          <button class="glyph-copy" type="button" data-text="𝓗𝓱" aria-label="H の筆記体・太（大文字・小文字）をコピー">𝓗 𝓱</button>
+          <button class="glyph-copy" type="button" data-text="ℋ𝒽" aria-label="H の筆記体・細（大文字・小文字）をコピー">ℋ 𝒽</button>
+        </div>
+        <div class="letter-anchor-cell" id="hikkitai-i">
+          <span class="alpha-label">筆記体 I</span>
+          <button class="glyph-copy" type="button" data-text="𝓘𝓲" aria-label="I の筆記体・太（大文字・小文字）をコピー">𝓘 𝓲</button>
+          <button class="glyph-copy" type="button" data-text="ℐ𝒾" aria-label="I の筆記体・細（大文字・小文字）をコピー">ℐ 𝒾</button>
+        </div>
+        <div class="letter-anchor-cell" id="hikkitai-j">
+          <span class="alpha-label">筆記体 J</span>
+          <button class="glyph-copy" type="button" data-text="𝓙𝓳" aria-label="J の筆記体・太（大文字・小文字）をコピー">𝓙 𝓳</button>
+          <button class="glyph-copy" type="button" data-text="𝒥𝒿" aria-label="J の筆記体・細（大文字・小文字）をコピー">𝒥 𝒿</button>
+        </div>
+        <div class="letter-anchor-cell" id="hikkitai-k">
+          <span class="alpha-label">筆記体 K</span>
+          <button class="glyph-copy" type="button" data-text="𝓚𝓴" aria-label="K の筆記体・太（大文字・小文字）をコピー">𝓚 𝓴</button>
+          <button class="glyph-copy" type="button" data-text="𝒦𝓀" aria-label="K の筆記体・細（大文字・小文字）をコピー">𝒦 𝓀</button>
+        </div>
+        <div class="letter-anchor-cell" id="hikkitai-l">
+          <span class="alpha-label">筆記体 L</span>
+          <button class="glyph-copy" type="button" data-text="𝓛𝓵" aria-label="L の筆記体・太（大文字・小文字）をコピー">𝓛 𝓵</button>
+          <button class="glyph-copy" type="button" data-text="ℒ𝓁" aria-label="L の筆記体・細（大文字・小文字）をコピー">ℒ 𝓁</button>
+        </div>
+        <div class="letter-anchor-cell" id="hikkitai-m">
+          <span class="alpha-label">筆記体 M</span>
+          <button class="glyph-copy" type="button" data-text="𝓜𝓶" aria-label="M の筆記体・太（大文字・小文字）をコピー">𝓜 𝓶</button>
+          <button class="glyph-copy" type="button" data-text="ℳ𝓂" aria-label="M の筆記体・細（大文字・小文字）をコピー">ℳ 𝓂</button>
+        </div>
+        <div class="letter-anchor-cell" id="hikkitai-n">
+          <span class="alpha-label">筆記体 N</span>
+          <button class="glyph-copy" type="button" data-text="𝓝𝓷" aria-label="N の筆記体・太（大文字・小文字）をコピー">𝓝 𝓷</button>
+          <button class="glyph-copy" type="button" data-text="𝒩𝓃" aria-label="N の筆記体・細（大文字・小文字）をコピー">𝒩 𝓃</button>
+        </div>
+        <div class="letter-anchor-cell" id="hikkitai-o">
+          <span class="alpha-label">筆記体 O</span>
+          <button class="glyph-copy" type="button" data-text="𝓞𝓸" aria-label="O の筆記体・太（大文字・小文字）をコピー">𝓞 𝓸</button>
+          <button class="glyph-copy" type="button" data-text="𝒪ℴ" aria-label="O の筆記体・細（大文字・小文字）をコピー">𝒪 ℴ</button>
+        </div>
+        <div class="letter-anchor-cell" id="hikkitai-p">
+          <span class="alpha-label">筆記体 P</span>
+          <button class="glyph-copy" type="button" data-text="𝓟𝓹" aria-label="P の筆記体・太（大文字・小文字）をコピー">𝓟 𝓹</button>
+          <button class="glyph-copy" type="button" data-text="𝒫𝓅" aria-label="P の筆記体・細（大文字・小文字）をコピー">𝒫 𝓅</button>
+        </div>
+        <div class="letter-anchor-cell" id="hikkitai-q">
+          <span class="alpha-label">筆記体 Q</span>
+          <button class="glyph-copy" type="button" data-text="𝓠𝓺" aria-label="Q の筆記体・太（大文字・小文字）をコピー">𝓠 𝓺</button>
+          <button class="glyph-copy" type="button" data-text="𝒬𝓆" aria-label="Q の筆記体・細（大文字・小文字）をコピー">𝒬 𝓆</button>
+        </div>
+        <div class="letter-anchor-cell" id="hikkitai-r">
+          <span class="alpha-label">筆記体 R</span>
+          <button class="glyph-copy" type="button" data-text="𝓡𝓻" aria-label="R の筆記体・太（大文字・小文字）をコピー">𝓡 𝓻</button>
+          <button class="glyph-copy" type="button" data-text="ℛ𝓇" aria-label="R の筆記体・細（大文字・小文字）をコピー">ℛ 𝓇</button>
+        </div>
+        <div class="letter-anchor-cell" id="hikkitai-s">
+          <span class="alpha-label">筆記体 S</span>
+          <button class="glyph-copy" type="button" data-text="𝓢𝓼" aria-label="S の筆記体・太（大文字・小文字）をコピー">𝓢 𝓼</button>
+          <button class="glyph-copy" type="button" data-text="𝒮𝓈" aria-label="S の筆記体・細（大文字・小文字）をコピー">𝒮 𝓈</button>
+        </div>
+        <div class="letter-anchor-cell" id="hikkitai-t">
+          <span class="alpha-label">筆記体 T</span>
+          <button class="glyph-copy" type="button" data-text="𝓣𝓽" aria-label="T の筆記体・太（大文字・小文字）をコピー">𝓣 𝓽</button>
+          <button class="glyph-copy" type="button" data-text="𝒯𝓉" aria-label="T の筆記体・細（大文字・小文字）をコピー">𝒯 𝓉</button>
+        </div>
+        <div class="letter-anchor-cell" id="hikkitai-u">
+          <span class="alpha-label">筆記体 U</span>
+          <button class="glyph-copy" type="button" data-text="𝓤𝓾" aria-label="U の筆記体・太（大文字・小文字）をコピー">𝓤 𝓾</button>
+          <button class="glyph-copy" type="button" data-text="𝒰𝓊" aria-label="U の筆記体・細（大文字・小文字）をコピー">𝒰 𝓊</button>
+        </div>
+        <div class="letter-anchor-cell" id="hikkitai-v">
+          <span class="alpha-label">筆記体 V</span>
+          <button class="glyph-copy" type="button" data-text="𝓥𝓿" aria-label="V の筆記体・太（大文字・小文字）をコピー">𝓥 𝓿</button>
+          <button class="glyph-copy" type="button" data-text="𝒱𝓋" aria-label="V の筆記体・細（大文字・小文字）をコピー">𝒱 𝓋</button>
+        </div>
+        <div class="letter-anchor-cell" id="hikkitai-w">
+          <span class="alpha-label">筆記体 W</span>
+          <button class="glyph-copy" type="button" data-text="𝓦𝔀" aria-label="W の筆記体・太（大文字・小文字）をコピー">𝓦 𝔀</button>
+          <button class="glyph-copy" type="button" data-text="𝒲𝓌" aria-label="W の筆記体・細（大文字・小文字）をコピー">𝒲 𝓌</button>
+        </div>
+        <div class="letter-anchor-cell" id="hikkitai-x">
+          <span class="alpha-label">筆記体 X</span>
+          <button class="glyph-copy" type="button" data-text="𝓧𝔁" aria-label="X の筆記体・太（大文字・小文字）をコピー">𝓧 𝔁</button>
+          <button class="glyph-copy" type="button" data-text="𝒳𝓍" aria-label="X の筆記体・細（大文字・小文字）をコピー">𝒳 𝓍</button>
+        </div>
+        <div class="letter-anchor-cell" id="hikkitai-y">
+          <span class="alpha-label">筆記体 Y</span>
+          <button class="glyph-copy" type="button" data-text="𝓨𝔂" aria-label="Y の筆記体・太（大文字・小文字）をコピー">𝓨 𝔂</button>
+          <button class="glyph-copy" type="button" data-text="𝒴𝓎" aria-label="Y の筆記体・細（大文字・小文字）をコピー">𝒴 𝓎</button>
+        </div>
+        <div class="letter-anchor-cell" id="hikkitai-z">
+          <span class="alpha-label">筆記体 Z</span>
+          <button class="glyph-copy" type="button" data-text="𝓩𝔃" aria-label="Z の筆記体・太（大文字・小文字）をコピー">𝓩 𝔃</button>
+          <button class="glyph-copy" type="button" data-text="𝒵𝓏" aria-label="Z の筆記体・細（大文字・小文字）をコピー">𝒵 𝓏</button>
+        </div>
+      </div>
+
     <p class="u-mt-15">補足：数字には筆記体がUnicodeに存在しないため、0–9はそのまま表示されます。また筆記体・細の ℯ・ℊ・ℴ は別のUnicodeブロック由来の文字で、これが正式な形です（誤字ではありません）。</p>
   </section>
 

--- a/ja/kuuhaku-moji/index.html
+++ b/ja/kuuhaku-moji/index.html
@@ -50,8 +50,8 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title>空白文字（見えない文字）— 空白スペースをコピー＆ペースト | UltraTextGen</title>
-<meta name="description" content="フリーフャイア、インスタのプロフィール、空っぽに見えるLINE・WhatsAppメッセージに使う見えない文字・空白文字（ゼロ幅スペース、ハングルフィラー、点字の空白）をコピー。クリックで即コピー — 無料。">
+<title>空白コピペ — 見えない空白文字をコピー（インスタ・ゲーム名）| UltraTextGen</title>
+<meta name="description" content="空白コピペ用の見えない文字を無料で。ゼロ幅スペース、ハングルフィラー、点字の空白をクリックだけでコピーして、インスタのプロフィール改行・空の名前・フリーファイアやモバイルレジェンドのゲーム名に貼り付け。アプリ不要。">
 
 <link rel="canonical" href="https://ultratextgen.com/ja/kuuhaku-moji/">
   <link rel="alternate" hreflang="en" href="https://ultratextgen.com/library/invisible-character/">
@@ -80,13 +80,13 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta property="og:image:type" content="image/png">
-<meta property="og:image:alt" content="空白文字（見えない文字）— 空白スペースをコピー＆ペースト">
+<meta property="og:image:alt" content="空白コピペ — 見えない空白文字をコピー（インスタ・ゲーム名）">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="空白文字（見えない文字）— 空白スペースをコピー＆ペースト">
+<meta name="twitter:title" content="空白コピペ — 見えない空白文字をコピー（インスタ・ゲーム名）">
 <meta name="twitter:description" content="見えない文字・空白文字をコピーして空の名前、インスタのプロフィール、WhatsAppメッセージに使えます。クリックでコピー。">
 <meta name="twitter:image" content="https://ultratextgen.com/assets/og/ja-kuuhaku-moji.png">
-<meta property="og:title" content="空白文字（見えない文字）— 空白スペースをコピー＆ペースト">
-<meta property="og:description" content="フリーフャイア、インスタのプロフィール、空っぽに見えるWhatsAppメッセージに使う見えない文字・空白文字（ゼロ幅スペース、ハングルフィラー、点字の空白）をコピー。無料、アプリ不要。">
+<meta property="og:title" content="空白コピペ — 見えない空白文字をコピー（インスタ・ゲーム名）">
+<meta property="og:description" content="フリーファイア、インスタのプロフィール、空っぽに見えるWhatsAppメッセージに使う見えない文字・空白文字（ゼロ幅スペース、ハングルフィラー、点字の空白）をコピー。無料、アプリ不要。">
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://ultratextgen.com/ja/kuuhaku-moji/">
 <meta property="og:locale" content="ja_JP">
@@ -102,9 +102,9 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 {
   "@context": "https://schema.org",
   "@type": "Article",
-  "headline": "空白文字（見えない文字）— 空白スペースをコピー＆ペースト",
-  "alternateName": ["空白文字", "見えない文字", "空白スペース", "空の名前", "透明な文字", "空白のコピー", "見えないスペース"],
-  "description": "フリーフャイア、インスタのプロフィール、空っぽに見えるLINE・WhatsAppメッセージに使う見えない文字・空白文字（ゼロ幅スペース、ハングルフィラー、点字の空白）をコピー。クリックで即コピー — 無料。",
+  "headline": "空白コピペ — 見えない空白文字をコピー（インスタ・ゲーム名）",
+  "alternateName": ["空白コピペ", "空白文字", "見えない文字", "空白スペース", "空の名前", "透明な文字", "空白のコピー", "空白コピー", "見えないスペース"],
+  "description": "空白コピペ用の見えない文字を無料で。ゼロ幅スペース、ハングルフィラー、点字の空白をクリックだけでコピーして、インスタのプロフィール改行・空の名前・フリーファイアやモバイルレジェンドのゲーム名に貼り付け。アプリ不要。",
   "inLanguage": "ja",
   "author": {
     "@type": "Organization",
@@ -136,8 +136,8 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     },
     {
       "@type": "Question",
-      "name": "フリーフャイアやモバイルレジェンドで見えない名前を作るには？",
-      "acceptedAnswer": { "@type": "Answer", "text": "このページの見えない文字のひとつをクリックし（通常はハングルフィラー U+3164 か点字の空白 U+2800 が一番うまくいきます）、フリーフャイアやモバイルレジェンドの名前変更欄に貼り付けてください。ゲームが複数文字を要求する場合は2〜3回貼り付けます。本物のUnicode文字なので欄は埋まりますが、名前は空に見えます。" }
+      "name": "フリーファイアやモバイルレジェンドで見えない名前を作るには？",
+      "acceptedAnswer": { "@type": "Answer", "text": "このページの見えない文字のひとつをクリックし（通常はハングルフィラー U+3164 か点字の空白 U+2800 が一番うまくいきます）、フリーファイアやモバイルレジェンドの名前変更欄に貼り付けてください。ゲームが複数文字を要求する場合は2〜3回貼り付けます。本物のUnicode文字なので欄は埋まりますが、名前は空に見えます。" }
     },
     {
       "@type": "Question",
@@ -207,8 +207,8 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 <!-- HERO -->
 <section class="hero">
   <div class="hero-inner">
-    <h1 class="hero-headline">空白文字 &amp; 見えない文字</h1>
-    <p class="hero-tagline">Unicodeが用意するすべての空白・見えない文字 — ゼロ幅スペース、フィラー、点字の空白まで。文字をクリックすればすぐにコピーできます。</p>
+    <h1 class="hero-headline">空白コピペ — 空白文字 &amp; 見えない文字</h1>
+    <p class="hero-tagline">Unicodeが用意するすべての空白・見えない文字 — ゼロ幅スペース、フィラー、点字の空白まで。文字をクリックすればそのままコピペできます。</p>
   </div>
 </section>
 <figure class="page-hero-figure" data-uthero aria-hidden="true">
@@ -220,7 +220,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 <!-- INTRO -->
 <section class="editorial-section">
   <div class="editorial-block">
-    <p>見えない文字とは、何もないように見える本物のUnicode文字のことです — 普通なら空欄を受け付けないところにもコピー＆ペーストできます。フリーフャイアやモバイルレジェンドで見えない名前を作ったり、インスタのプロフィールやキャプションに空行を入れたり、空に見えるWhatsAppメッセージを送ったり、ゲームのニックネームにきれいな余白を付けたりするのに使われます。以下のボタンにはすべて本物の見えない文字・空白文字が入っています：見た目は空ですが、ラベルを見れば正確にどの文字をコピーしているかわかります。</p>
+    <p>見えない文字とは、何もないように見える本物のUnicode文字のことです — 普通なら空欄を受け付けないところにもコピー＆ペーストできます。フリーファイアやモバイルレジェンドで見えない名前を作ったり、インスタのプロフィールやキャプションに空行を入れたり、空に見えるWhatsAppメッセージを送ったり、ゲームのニックネームにきれいな余白を付けたりするのに使われます。以下のボタンにはすべて本物の見えない文字・空白文字が入っています：見た目は空ですが、ラベルを見れば正確にどの文字をコピーしているかわかります。</p>
     <p>なぜこの文字ひとつ（U+2800）が空の名前を作る一番確実な方法なのか、詳しく知りたい方は<a href="/ja/symbol/mienai-moji/">見えない文字の専門ページ</a>をご覧ください。</p>
   </div>
 </section>
@@ -422,8 +422,8 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <p class="faq-answer">見えない文字とは、本物のUnicode文字でありながら何も表示されないものです — 目には見えませんが、テキストとしてはきちんとカウントされます。そのため、通常は空欄を許可しないゲームの名前欄・プロフィール・チャットメッセージなどにも入力できます。例としてゼロ幅スペース、ハングルフィラー、点字の空白などがあります。このページのボタンは空に見えますが、ラベルを見れば正確にどの文字をコピーしているかわかります。</p>
   </details>
   <details class="faq-item">
-    <summary class="faq-question">フリーフャイアやモバイルレジェンドで見えない名前を作るには？</summary>
-    <p class="faq-answer">このページの見えない文字のひとつをクリックし（通常はハングルフィラー U+3164 か点字の空白 U+2800 が一番うまくいきます）、フリーフャイアやモバイルレジェンドの名前変更欄に貼り付けてください。ゲームが複数文字を要求する場合は2〜3回貼り付けます。本物のUnicode文字なので欄は埋まりますが、名前は空に見えます。</p>
+    <summary class="faq-question">フリーファイアやモバイルレジェンドで見えない名前を作るには？</summary>
+    <p class="faq-answer">このページの見えない文字のひとつをクリックし（通常はハングルフィラー U+3164 か点字の空白 U+2800 が一番うまくいきます）、フリーファイアやモバイルレジェンドの名前変更欄に貼り付けてください。ゲームが複数文字を要求する場合は2〜3回貼り付けます。本物のUnicode文字なので欄は埋まりますが、名前は空に見えます。</p>
   </details>
   <details class="faq-item">
     <summary class="faq-question">ゲームの名前に一番向いている見えない文字はどれですか？</summary>

--- a/style.css
+++ b/style.css
@@ -8478,6 +8478,7 @@ body.dark-mode .kana-cell-empty { opacity: 0.35; }
 }
 .lib-clear-btn.visible {
   display: inline-flex;
+}
 
 /* Cursive hub A-Z chart (crawlable text glyphs, links to letter guides) */
 .cursive-chart-grid {
@@ -8749,20 +8750,33 @@ body.dark-mode .kana-cell-empty { opacity: 0.35; }
   font-size: 0.85rem;
   color: var(--text-secondary);
   line-height: 1.45;
+}
 
-/* Per-letter sierletters grid (nl/sierlijke-letters). GSC shows 23 distinct
-   single-letter queries ("sierlijke b", "sierletter o", …) landing on that page
-   at pos ~7.9 with almost no clicks — the page ranked for them but only offered
-   whole-alphabet copy rows. Each cell is individually anchored so those queries
-   land on the letter they asked for. Layout mirrors .cursive-letter-grid; no JS
-   of its own — the buttons inside are ordinary .glyph-copy targets. */
-.sierletter-grid {
+/* Per-letter anchored letter grid. Two pages use it, for the same reason:
+   a page ranks for single-letter queries but only offers whole-alphabet copy
+   rows, so the searcher lands on a wall of 26 letters instead of the one they
+   asked for. Each cell is individually anchored so the query can deep-link to
+   its own letter. Layout mirrors .cursive-letter-grid; no JS of its own — the
+   buttons inside are ordinary .glyph-copy targets, picked up by script.js's
+   delegated handler.
+
+   .sierletter-* — nl/sierlijke-letters. GSC showed 23 distinct single-letter
+   queries ("sierlijke b", "sierletter o", …) at pos ~7.9 with almost no clicks.
+   .letter-anchor-* — the generic name, added 2026-08-10 for ja/hikkitai, where
+   a Semrush pull found 39 single-letter cursive queries ("s 筆記体", "筆記体 f",
+   both word orders) worth ~115,850/mo combined against a page whose own intro
+   promised per-letter glyphs but shipped only two whole-alphabet buttons.
+   Prefer .letter-anchor-* for any new page; .sierletter-* is kept so the
+   existing Dutch markup kept working unchanged. */
+.sierletter-grid,
+.letter-anchor-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(104px, 1fr));
   gap: 10px;
   margin: 18px 0;
 }
-.sierletter-cell {
+.sierletter-cell,
+.letter-anchor-cell {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -8773,10 +8787,12 @@ body.dark-mode .kana-cell-empty { opacity: 0.35; }
   background: var(--bg-white);
   scroll-margin-top: 90px;
 }
-.sierletter-cell .alpha-label {
+.sierletter-cell .alpha-label,
+.letter-anchor-cell .alpha-label {
   flex: none;
 }
-.sierletter-cell .glyph-copy {
+.sierletter-cell .glyph-copy,
+.letter-anchor-cell .glyph-copy {
   font-size: 1.5rem;
   line-height: 1.2;
   padding: 2px 6px;


### PR DESCRIPTION
…S rules

Three changes, all driven by a Semrush pull on the Japanese market.

1. ja/hikkitai/ — per-letter cursive A-Z grid (~115,850/mo) 39 single-letter cursive queries ("s 筆記体", "筆記体 f", both word orders; 8,100/mo down to 170/mo each) had nothing to land on: the page's own intro promised per-letter glyphs ("1文字ずつ欲しい人向け") and then shipped only two whole-alphabet copy buttons. Adds 26 anchored cells (#hikkitai-a .. #hikkitai-z), each labelled 筆記体 X with both weights as separate copy targets.

   Not a new mechanism: category/cursive-fonts (the EN parent) already ships a per-letter grid, and nl/sierlijke-letters already ships this exact static no-JS variant, added there for the identical diagnosis. Reuses that pattern; the .sierletter-* CSS gains a generic .letter-anchor-* alias so the Dutch markup keeps working untouched.

   Glyphs are generated from the page's own existing copy buttons rather than hand-typed, so they cannot drift from what the page already ships; all 11 Letterlike-Symbols special cases verified. No new <h2>, no new internal links, no .symbol-tile — the translation-parity fingerprint does not move, verified by running the gate.

2. ja/kuuhaku-moji/ — retargeted onto 空白コピペ (40,500/mo) The page led with 空白文字/見えない文字, terms absent from the entire 7,506-keyword competitor dataset, while omitting コピペ altogether. Title, meta, OG, Twitter, JSON-LD headline/alternateName/description and H1 now lead with 空白コピペ, keeping the old terms as secondary equity.

   Also fixes a real typo found in the file: Free Fire was written フリーフャイア 8 times (フャ is not valid kana; correct is フリーファイア), across meta, OG, JSON-LD, a JSON-LD FAQ Q+A and the visible FAQ Q+A. This was the only page on the site mentioning Free Fire in Japanese and the correct spelling appeared nowhere. JSON-LD and visible FAQ fixed together so they stay in sync.

3. style.css — two rules were missing their closing brace .ig-route-desc and .lib-clear-btn.visible, both live on main, each silently swallowing the rules that followed. The second had been breaking nl/sierlijke-letters in production: rendered pre-fix, its per-letter grid showed 1 column, display:block, no border, no background. That page's whole grid has been shipping unstyled. Found because the new JA grid didn't render either. style.css now parses balanced for the first time.

Verified by rendering both pages headlessly at 1280px and 390px, light and dark: 26 cells, 7 grid columns, display:flex, correct light/dark backgrounds, clipboard genuinely receiving 𝓢𝓼 on click, #hikkitai-r deep-link scrolling into view, the existing generator still rendering, zero page errors. The one mobile overflow found is pre-existing (shared header + horizontally-scrolling category tabs); no letter-anchor element overflows.


Claude-Session: https://claude.ai/code/session_01RM9iLha112sG5RLoG1nbHA