### PR TITLE
fix(da,no): retarget da/ head term to seje skrifttyper; translate no/…

### DIFF
--- a/da/index.html
+++ b/da/index.html
@@ -48,8 +48,8 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<title data-i18n="meta.title">Skrifttyper – 88 Unicode-skrifttyper (kopiér og indsæt)</title>
-<meta name="description" data-i18n-content="meta.description" content="Skrifttyper der gør almindelig tekst om til sej tekst: 88 Unicode-skrifttyper med fed skrift, kursiv/script, håndskrift, gotisk, bobler, små bogstaver, aesthetic, på hovedet og Zalgo. Kopiér til Instagram-bio, TikTok, Discord, LinkedIn og WhatsApp. Gratis, hurtigt og uden konto.">
+<title data-i18n="meta.title">Seje Skrifttyper – 88 Unicode-skrifttyper (kopiér og indsæt)</title>
+<meta name="description" data-i18n-content="meta.description" content="Seje skrifttyper der gør almindelig tekst om til sej tekst: 88 Unicode-skrifttyper med fed skrift, kursiv/script, håndskrift, gotisk, bobler, små bogstaver, aesthetic, på hovedet og Zalgo. Kopiér til Instagram-bio, TikTok, Discord, LinkedIn og WhatsApp. Gratis, hurtigt og uden konto.">
 
 <link rel="canonical" href="https://ultratextgen.com/da/">
 
@@ -89,19 +89,19 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 <meta name="robots" content="index, follow">
 
 <meta property="og:site_name" content="UltraTextGen">
-<meta property="og:title" content="Skrifttyper – 88 Unicode-skrifttyper (kopiér og indsæt)">
-<meta property="og:description" content="Skrifttyper der gør tekst om til seje Unicode-stilarter til Instagram, TikTok, Discord, LinkedIn og WhatsApp. Fed skrift, kursiv/script og symboler du kan kopiere direkte.">
+<meta property="og:title" content="Seje Skrifttyper – 88 Unicode-skrifttyper (kopiér og indsæt)">
+<meta property="og:description" content="Seje skrifttyper der gør tekst om til seje Unicode-stilarter til Instagram, TikTok, Discord, LinkedIn og WhatsApp. Fed skrift, kursiv/script og symboler du kan kopiere direkte.">
 <meta property="og:url" content="https://ultratextgen.com/da/">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://ultratextgen.com/assets/og/fancy-text-generator-preview.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta property="og:image:type" content="image/png">
-<meta property="og:image:alt" content="Skrifttyper – 88 Unicode-skrifttyper (kopiér og indsæt)">
+<meta property="og:image:alt" content="Seje Skrifttyper – 88 Unicode-skrifttyper (kopiér og indsæt)">
 
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Skrifttyper – 88 Unicode-skrifttyper (kopiér og indsæt)">
-<meta name="twitter:description" content="Skrifttyper der gør tekst om til seje Unicode-stilarter til Instagram, TikTok, Discord, LinkedIn og WhatsApp. Fed skrift, kursiv/script og symboler du kan kopiere direkte.">
+<meta name="twitter:title" content="Seje Skrifttyper – 88 Unicode-skrifttyper (kopiér og indsæt)">
+<meta name="twitter:description" content="Seje skrifttyper der gør tekst om til seje Unicode-stilarter til Instagram, TikTok, Discord, LinkedIn og WhatsApp. Fed skrift, kursiv/script og symboler du kan kopiere direkte.">
 <meta name="twitter:image" content="https://ultratextgen.com/assets/og/fancy-text-generator-preview.png">
 
 <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -355,7 +355,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <section class="hero">
     <div class="hero-inner">
       <div class="hero-card">
-        <h1 class="hero-headline" data-i18n="hero.title">Skrifttyper til kopiér og indsæt</h1>
+        <h1 class="hero-headline" data-i18n="hero.title">Seje skrifttyper til kopiér og indsæt</h1>
         <p class="hero-tagline" data-i18n="hero.subtitle">Skriv én gang, og få 88 seje skrifttyper du kan kopiere og indsætte med det samme: kursiv/script, fed skrift, håndskrift, fine bogstaver, Instagram-skrifttyper, TikTok-tekst, Discord-navne og WhatsApp-status.</p>
         <div class="input-wrapper">
           <textarea class="main-input" id="mainInput" placeholder="Skriv din tekst her..." data-i18n-placeholder="ui.placeholder" maxlength="500" autofocus=""></textarea>

--- a/locales/da.json
+++ b/locales/da.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "title": "Skrifttyper – 88 Unicode-skrifttyper (kopiér og indsæt)",
-    "description": "Skrifttyper der gør almindelig tekst om til sej tekst: 88 Unicode-skrifttyper med fed skrift, kursiv/script, håndskrift, gotisk, bobler, små bogstaver, aesthetic, på hovedet og Zalgo. Kopiér til Instagram-bio, TikTok, Discord, LinkedIn og WhatsApp. Gratis, hurtigt og uden konto."
+    "title": "Seje Skrifttyper – 88 Unicode-skrifttyper (kopiér og indsæt)",
+    "description": "Seje skrifttyper der gør almindelig tekst om til sej tekst: 88 Unicode-skrifttyper med fed skrift, kursiv/script, håndskrift, gotisk, bobler, små bogstaver, aesthetic, på hovedet og Zalgo. Kopiér til Instagram-bio, TikTok, Discord, LinkedIn og WhatsApp. Gratis, hurtigt og uden konto."
   },
   "hero": {
-    "title": "Skrifttyper til kopiér og indsæt",
+    "title": "Seje skrifttyper til kopiér og indsæt",
     "subtitle": "Skriv én gang, og få 88 seje skrifttyper du kan kopiere og indsætte med det samme: kursiv/script, fed skrift, håndskrift, fine bogstaver, Instagram-skrifttyper, TikTok-tekst, Discord-navne og WhatsApp-status."
   },
   "decorations": {

--- a/no/index.html
+++ b/no/index.html
@@ -410,51 +410,51 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
   <!-- Intro / topical anchor -->
   <section class="editorial-section" aria-labelledby="intro-heading">
-    <h2 id="intro-heading">What this fancy text generator actually does</h2>
+    <h2 id="intro-heading">Hva denne tekstgeneratoren faktisk gjør</h2>
     <p>
-      UltraTextGen is a free Unicode font generator. You type plain text, it swaps each letter for a styled character that lives inside the Unicode standard, and you copy the result wherever you want it: an Instagram bio, a TikTok caption, a Discord display name, a LinkedIn headline, a Roblox profile, a WhatsApp status, even an email subject line. Because the styled letters <em>are</em> the text — not a font file your phone has to load, and not Markdown that gets stripped — they survive copy-paste into apps that don’t allow formatting.
+      UltraTextGen er en gratis Unicode-skriftgenerator. Du skriver vanlig tekst, og hver bokstav byttes ut med et stylet tegn som allerede finnes i Unicode-standarden — du kopierer resultatet dit du vil ha det: en Instagram-bio, en TikTok-bildetekst, et Discord-visningsnavn, en LinkedIn-overskrift, en Roblox-profil, en WhatsApp-status, til og med en e-post-emnelinje. Fordi de stylede bokstavene <em>er</em> teksten — ikke en fontfil telefonen din må laste inn, og ikke Markdown som blir fjernet — overlever de copy-paste i apper som ikke tillater formatering.
     </p>
     <p>
-      Type <code>hello</code> and you get:
-      𝗵𝗲𝗹𝗹𝗼 (bold),
-      𝘩𝘦𝘭𝘭𝘰 (italic),
-      𝒽ℯ𝓁𝓁ℴ (cursive script),
-      𝔥𝔢𝔩𝔩𝔬 (gothic),
-      🅗🅔🅛🅛🅞 (bubble),
-      ʰᵉˡˡᵒ (tiny / superscript),
+      Skriv <code>hello</code>, og du får:
+      𝗵𝗲𝗹𝗹𝗼 (fet),
+      𝘩𝘦𝘭𝘭𝘰 (kursiv),
+      𝒽ℯ𝓁𝓁ℴ (håndskrift),
+      𝔥𝔢𝔩𝔩𝔬 (gotisk),
+      🅗🅔🅛🅛🅞 (boble),
+      ʰᵉˡˡᵒ (liten / hevet skrift),
       ʜᴇʟʟᴏ (small caps),
-      ⓗⓔⓛⓛⓞ (circled),
+      ⓗⓔⓛⓛⓞ (innringet),
       ｈｅｌｌｏ (fullwidth),
-      h̶e̶l̶l̶o̶ (strikethrough),
-      h̳e̳l̳l̳o̳ (underline),
-      oʅʅǝɥ (upside-down),
-      ollǝɥ (mirror),
+      h̶e̶l̶l̶o̶ (gjennomstreket),
+      h̳e̳l̳l̳o̳ (understreket),
+      oʅʅǝɥ (opp ned),
+      ollǝɥ (speilvendt),
       h̷̢̛e̴̜͝l̸̼͝l̷͔͠o̵̗͝ (Zalgo / glitch),
-      and roughly 50 more — including aesthetic spaced styles like <strong>𝓱 𝓮 𝓵 𝓵 𝓸</strong> people use for Pinterest pins and Y2K-style usernames.
+      og rundt 50 til — inkludert luftige aesthetic-stiler som <strong>𝓱 𝓮 𝓵 𝓵 𝓸</strong> folk bruker til Pinterest-pins og Y2K-aktige brukernavn.
     </p>
-    <h3>Where these fonts actually work (and where they don’t)</h3>
+    <h3>Hvor disse skriftene faktisk fungerer (og hvor de ikke gjør det)</h3>
     <p>
-      Compatibility varies because Unicode rendering depends on the device font, not the website. Here’s what we’ve tested:
+      Kompatibilitet varierer fordi Unicode-visning avhenger av enhetens font, ikke nettsiden. Her er hva vi har testet:
     </p>
     <ul class="compat-list">
-      <li><strong>Instagram</strong> — bio, post caption, comments, story stickers: works in every style. Username field: works only with Latin-script styles (bold, italic, cursive, bubble); won’t accept Zalgo or fullwidth.</li>
-      <li><strong>TikTok</strong> — bio, caption, comments, video description: works in all core styles. The "nickname" field is more permissive than Instagram’s username.</li>
-      <li><strong>Discord</strong> — server nickname, display name, messages, “About me”: Unicode fonts work without Nitro. Markdown bold (<code>**text**</code>) only renders inside messages; Unicode bold renders <em>everywhere</em>, including your nickname.</li>
-      <li><strong>LinkedIn</strong> — headline, About section, post body: bold, italic and small caps render reliably. Avoid Zalgo and heavily decorated styles on a professional profile — they trigger recruiter filters and screen-reader issues.</li>
-      <li><strong>WhatsApp</strong> — status, group names, broadcasts: all Unicode fonts work. WhatsApp’s own <code>*bold*</code>, <code>_italic_</code> and <code>~strike~</code> only render inside chat messages, so Unicode is the only option for status and group names.</li>
-      <li><strong>X (Twitter)</strong> — display name, bio, tweets: works everywhere. Some Zalgo styles get visually clipped on mobile.</li>
-      <li><strong>Snapchat, Pinterest, Telegram, Signal, iMessage</strong> — bios, captions, messages: all work.</li>
-      <li><strong>Roblox, Steam, Minecraft, Fortnite</strong> — display names usually accept bold/italic/gothic. Each platform’s name filter rejects different characters — try a different style if one is blocked.</li>
-      <li><strong>Email subject lines</strong> (Gmail, Outlook, Apple Mail) — render Unicode fonts as written. This is the one place where there is no rich-text alternative.</li>
-      <li><strong>Won’t work:</strong> Microsoft Word, Google Docs body text styling (use the built-in toolbar instead), printed documents with non-Unicode fonts, and anywhere the recipient’s device is missing the glyph (rare on phones made after 2018).</li>
+      <li><strong>Instagram</strong> — bio, bildetekst, kommentarer, story-klistremerker: fungerer i alle stiler. Brukernavnfeltet: fungerer bare med latinske stiler (fet, kursiv, håndskrift, boble); godtar ikke Zalgo eller fullwidth.</li>
+      <li><strong>TikTok</strong> — bio, bildetekst, kommentarer, videobeskrivelse: fungerer i alle kjernestiler. «Kallenavn»-feltet er mer tillatende enn Instagrams brukernavnfelt.</li>
+      <li><strong>Discord</strong> — serverkallenavn, visningsnavn, meldinger, «Om meg»: Unicode-skrifter fungerer uten Nitro. Markdown-fet (<code>**tekst**</code>) vises bare inne i meldinger; Unicode-fet vises <em>overalt</em>, også i kallenavnet ditt.</li>
+      <li><strong>LinkedIn</strong> — overskrift, Om-seksjon, innleggstekst: fet, kursiv og small caps vises pålitelig. Unngå Zalgo og sterkt dekorerte stiler på en profesjonell profil — de utløser rekrutteringsfiltre og skjermleser-problemer.</li>
+      <li><strong>WhatsApp</strong> — status, gruppenavn, kringkastinger: alle Unicode-skrifter fungerer. WhatsApps egne <code>*fet*</code>, <code>_kursiv_</code> og <code>~gjennomstreket~</code> vises bare inne i chat-meldinger, så Unicode er eneste alternativ for status og gruppenavn.</li>
+      <li><strong>X (Twitter)</strong> — visningsnavn, bio, tweets: fungerer overalt. Enkelte Zalgo-stiler blir visuelt klippet på mobil.</li>
+      <li><strong>Snapchat, Pinterest, Telegram, Signal, iMessage</strong> — bioer, bildetekster, meldinger: alt fungerer.</li>
+      <li><strong>Roblox, Steam, Minecraft, Fortnite</strong> — visningsnavn godtar vanligvis fet/kursiv/gotisk. Hver plattforms navnefilter avviser ulike tegn — prøv en annen stil hvis én blir blokkert.</li>
+      <li><strong>E-post-emnelinjer</strong> (Gmail, Outlook, Apple Mail) — viser Unicode-skrifter som skrevet. Dette er det ene stedet hvor det ikke finnes noe riktekst-alternativ.</li>
+      <li><strong>Fungerer ikke:</strong> Microsoft Word, Google Docs’ brødtekst-styling (bruk verktøylinjen i stedet), utskrevne dokumenter med ikke-Unicode-skrifter, og steder der mottakerens enhet mangler tegnet (sjeldent på telefoner fra 2018 eller nyere).</li>
     </ul>
-    <h3>Why Unicode fonts ≠ regular fonts</h3>
+    <h3>Hvorfor Unicode-skrifter ≠ vanlige skrifttyper</h3>
     <p>
-      A regular font (Helvetica, Arial, the LinkedIn Sans typeface, etc.) is a file that lives on your device and tells the screen how to draw a letter. If the website doesn’t load that font, the letter still says "A" — it just gets drawn in a default font instead. Unicode “fonts” aren’t fonts at all in that sense. They’re separate characters in the Unicode standard — A, 𝐀, 𝘈, 𝓐, 𝔄, 𝕬, Ⓐ are all different characters with different code points. That’s why they travel: you’re not styling the letter A, you’re using a different letter entirely that happens to look styled.
+      En vanlig skrifttype (Helvetica, Arial, LinkedIn Sans-fonten osv.) er en fil som ligger på enheten din og forteller skjermen hvordan en bokstav skal tegnes. Hvis nettsiden ikke laster inn den fonten, står bokstaven fortsatt som «A» — den tegnes bare med en standardfont i stedet. Unicode-«skrifter» er ikke skrifttyper i det hele tatt i den forstand. De er egne tegn i Unicode-standarden — A, 𝐀, 𝘈, 𝓐, 𝔄, 𝕬, Ⓐ er alle forskjellige tegn med forskjellige kodepunkter. Derfor overlever de: du stiler ikke bokstaven A, du bruker en helt annen bokstav som tilfeldigvis ser stylet ut.
     </p>
-    <h3>What’s in the library</h3>
+    <h3>Hva som finnes i stilbiblioteket</h3>
     <p>
-      About 65 styles across twelve families: <strong>bold</strong> (sans, serif, italic-bold), <strong>italic</strong>, <strong>cursive / script</strong> (regular and bold), <strong>gothic / fraktur</strong>, <strong>bubble</strong> (filled, light, tiles, curly, angle, spaced, and more — 12 variants), <strong>strikethrough</strong> (slash, tilde, short, long), <strong>underline</strong>, <strong>monospace / fullwidth</strong>, <strong>small caps and superscript</strong>, <strong>aesthetic / spaced</strong>, <strong>upside-down + mirror + backwards</strong>, <strong>Zalgo (glitch)</strong>, and a ten-style <strong>text decorator</strong> that auto-brackets each word with symbols. Stack two styles together with one click, or wrap the whole result in a frame, divider, arrow, emoji or flag.
+      Rundt 65 stiler fordelt på tolv familier: <strong>fet</strong> (grotesk, antikva, kursiv-fet), <strong>kursiv</strong>, <strong>håndskrift / script</strong> (vanlig og fet), <strong>gotisk / fraktur</strong>, <strong>boble</strong> (fylt, lett, fliser, buet, vinklet, luftig og flere — 12 varianter), <strong>gjennomstreket</strong> (skråstrek, tilde, kort, lang), <strong>understreket</strong>, <strong>monospace / fullwidth</strong>, <strong>small caps og hevet skrift</strong>, <strong>aesthetic / luftig</strong>, <strong>opp ned + speilvendt + baklengs</strong>, <strong>Zalgo (glitch)</strong>, og en ti-stils <strong>tekstdekoratør</strong> som automatisk rammer inn hvert ord med symboler. Kombiner to stiler med ett klikk, eller ramm inn hele resultatet med en ramme, skillelinje, pil, emoji eller flagg.
     </p>
   </section>
 


### PR DESCRIPTION
… editorial section

da/index.html + locales/da.json: title/og:title/twitter:title/meta description/og:description/twitter:description/og:image:alt/H1 all retargeted from the bare, intent-split "Skrifttyper" onto "Seje Skrifttyper" -- the exact qualified phrase already in the page's own hero tagline, converting at GSC position 6-8 vs the bare term's position 41-56 on its own three highest-impression queries. Same shape as the tr/sekilli-yazi precedent. No structural change (no added/removed links, FAQ, or h2s) -- wording only.

no/index.html: translated the "What this fancy text generator actually does" editorial section (H2 + 2 intro paragraphs + platform compatibility list + "why Unicode fonts != regular fonts" + "what's in the library") from English into Norwegian -- previously untranslated English prose sitting inside an otherwise-Norwegian page. Vocabulary matches terms already established elsewhere on the same page (kursiv, handskrift, fet skrift, gotisk, boble, small caps). Kept the "hello" example word and its exact original Unicode glyphs unchanged rather than generating new transforms for a translated word -- verified against renderer.js's actual flipMap/script tables that a hand-typed Norwegian example risked introducing wrong codepoints (e.g. upside-down "i" is U+1D09 per flipMap, not the U+0131 initially guessed).