### PR TITLE
fix: remove stale degree-sign redirect rules that formed a live loop

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -160,10 +160,16 @@ https://www.ultratextgen.com/*  https://ultratextgen.com/:splat  301!
 # simbolo-de-grado = copy-paste collection framing). 0010bce41 (2026-07-23)
 # picked signo-de-grado as the closer symbol/-scope match but only touched
 # 2 of the cluster's 18 pages; 016abfdab (2026-07-25) reintroduced the
-# duplicate across the rest. Retired simbolo-de-grado for good this time —
-# deduped hreflang on all 18 cluster members, repointed every internal link.
-/es/symbol/simbolo-de-grado/             /es/symbol/signo-de-grado/  301
-/es/symbol/simbolo-de-grado/index.html   /es/symbol/signo-de-grado/  301
+# duplicate across the rest.
+# CORRECTION 2026-08-16: the simbolo-de-grado -> signo-de-grado rules that
+# lived here were REMOVED. The 2026-08-03 duplicate-claimant merge (see its
+# block near the end of this file) reversed the survivor on Semrush evidence
+# — simbolo-de-grado won, 16,700/mo vs 9,500/mo — but these earlier
+# opposite-direction rules were left behind, and first-match-wins turned the
+# pair into a live redirect LOOP (simbolo -> signo -> simbolo): both URLs
+# served ERR_TOO_MANY_REDIRECTS from 2026-08-03 until this fix. Verified by
+# live curl in both directions before removal. Lesson: reversing a survivor
+# decision must delete the losing direction's rules, not just add new ones.
 
 # Library → Symbol pillar (i18n): single-glyph translated pages shipped under
 # <lang>/library/ instead of <lang>/symbol/ (see docs/unicode-library-workflow.md §7).
@@ -184,8 +190,8 @@ https://www.ultratextgen.com/*  https://ultratextgen.com/:splat  301!
 /es/library/signo-de-euro/index.html        /es/symbol/signo-de-euro/                  301
 /es/library/signo-de-libra/                 /es/symbol/signo-de-libra/                 301
 /es/library/signo-de-libra/index.html       /es/symbol/signo-de-libra/                 301
-/es/library/simbolo-de-grado/               /es/symbol/signo-de-grado/                 301
-/es/library/simbolo-de-grado/index.html     /es/symbol/signo-de-grado/                 301
+/es/library/simbolo-de-grado/               /es/symbol/simbolo-de-grado/               301
+/es/library/simbolo-de-grado/index.html     /es/symbol/simbolo-de-grado/               301
 /es/library/simbolo-de-infinito/            /es/symbol/simbolo-de-infinito/            301
 /es/library/simbolo-de-infinito/index.html  /es/symbol/simbolo-de-infinito/            301
 /id/library/simbol-derajat/                 /id/symbol/simbol-derajat/                 301


### PR DESCRIPTION
`/es/symbol/simbolo-de-grado/` and `/es/symbol/signo-de-grado/` have been 301ing **to each other** since 2026-08-03 — both URLs serve `ERR_TOO_MANY_REDIRECTS` (verified by live curl in both directions), so the ES degree-sign page, the only copy on disk, has been unreachable to users and crawlers for ~2 weeks while still being listed in the sitemap.

## Root cause

`_redirects` is first-match-wins. The 2026-07-23 decision picked `signo-de-grado` as survivor and added `simbolo → signo` rules. The 2026-08-03 duplicate-claimant merge reversed that on Semrush evidence ("símbolo de grado" 16,700/mo + 94 variations vs "signo de grados" 9,500/mo + 54) and added `signo → simbolo` rules — **but never removed the July rules**. The July rule matched first, bounced simbolo to signo; signo's rule bounced it straight back.

## The fix (surgical, `_redirects` only)

- **Removed** the two stale `simbolo → signo` rules; a dated CORRECTION note stays in their comment block per house convention, including the lesson: *reversing a survivor decision must delete the losing direction's rules, not just add new ones.*
- **Repointed** the two `es/library/simbolo-de-grado` rules straight at the survivor instead of chaining through the retired signo URL.

## Verification

First-match-wins simulation over the full fixed rule file:
```
/es/symbol/simbolo-de-grado/   [serves]
/es/symbol/signo-de-grado/  -301->  /es/symbol/simbolo-de-grado/   [serves]
/es/library/simbolo-de-grado/  -301->  /es/symbol/simbolo-de-grado/   [serves]
```

No page-content or sitemap changes needed: only `simbolo-de-grado/index.html` exists on disk, zero internal references to the signo slug remain anywhere in the repo, and the auto-generated sitemap already lists exactly the survivor. The duplicate same-direction `signo → simbolo` rule pairs (from the 2026-08-02 and 2026-08-03 blocks) are deliberately left as-is — harmless and consistent.

Merging this also triggers a Pages deploy, which should activate the already-merged-but-not-yet-serving `pt/letras-para-copiar` and `library/heart-emoji` redirect rules (currently 404ing live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MdXNcbnzE3zJryXGxgzDhS

---
_Generated by [Claude Code](https://claude.ai/code/session_01MdXNcbnzE3zJryXGxgzDhS)_