### PR TITLE
fix(i18n): clear the locale-English backlog's sweepable classes — and separate the debt from the measurement

### DIFF
--- a/ar/answers/what-font-does-pinterest-use/index.html
+++ b/ar/answers/what-font-does-pinterest-use/index.html
@@ -183,7 +183,7 @@
 
 
 <section class="editorial-section">
-  <span class="article-section-label">Quick answer</span>
+  <span class="article-section-label">الإجابة السريعة</span>
   <div class="editorial-block">
     <p>تعتمد واجهة بينتيرست وموقعه وهويته البصرية على <strong>Pinterest Sans</strong>، وهو خط هندسي بلا زوائد (sans-serif) مخصص صممته <a href="https://www.grillitype.com/commissions/pinterest" target="_blank" rel="noopener noreferrer">Grilli Type</a>، دار خطوط سويسرية. يأتي الخط بأربعة أوزان بالإضافة إلى نسخة مخصصة للأحجام الصغيرة تُسمى <strong>Pinterest UI</strong>. خط Pinterest Sans حصري لبينتيرست وغير متاح للتحميل أو الترخيص العام.</p>
     <p>إذا كنت تريد فقط خطًا يبدو قريبًا من هوية بينتيرست لتصميم أو عرض تقديمي: استخدم <strong>Poppins</strong>، وهو خط هندسي مجاني على <a href="https://fonts.google.com/specimen/Poppins" target="_blank" rel="noopener noreferrer">Google Fonts</a> يحمل نفس الدفء المستدير.</p>
@@ -193,7 +193,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">The details</span>
+  <span class="article-section-label">التفاصيل</span>
   <h2>ما هو الخط الذي يستخدمه بينتيرست؟</h2>
 
   <div class="data-table-wrap">
@@ -254,7 +254,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Style your own text</span>
+  <span class="article-section-label">نسّق نصك</span>
   <h2>…لكنك تريد أن تبرز صورك (pins) الخاصة؟</h2>
   <div class="editorial-block">
     <p>إذا وصلت إلى هنا لأنك تريد أن تبدو عناوين صورك ووصفها وأسماء لوحاتك بخط مختلف — وليس لأنك تطابق الهوية التجارية — فمعرفة اسم الخط لن تفيدك. لا يوجد في بينتيرست أي زر تنسيق في أي مكان بالتطبيق.</p>
@@ -275,7 +275,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Keep exploring</span>
+  <span class="article-section-label">تصفح المزيد</span>
   <h2>صفحات ذات صلة</h2>
   <div class="compare-grid">
     <a href="/pinterest/" class="compare-card variant-muted u-no-underline">
@@ -300,7 +300,7 @@
 
 <section class="editorial-section" id="faq">
   <span class="article-section-label">FAQ</span>
-  <h2>Frequently Asked Questions</h2>
+  <h2>الأسئلة الشائعة</h2>
   <details class="faq-item">
     <summary class="faq-question">ما هو الخط الذي يستخدمه بينتيرست؟</summary>
     <p class="faq-answer">تعتمد واجهة بينتيرست وموقعه وهويته البصرية على Pinterest Sans، وهو خط هندسي بلا زوائد مخصص صممته دار الخطوط السويسرية Grilli Type. يأتي بأربعة أوزان بالإضافة إلى نسخة مخصصة للأحجام الصغيرة تُسمى Pinterest UI. الخط حصري لبينتيرست وغير متاح للتحميل أو الترخيص العام.</p>

--- a/ar/answers/what-font-does-whatsapp-use/index.html
+++ b/ar/answers/what-font-does-whatsapp-use/index.html
@@ -167,7 +167,7 @@
 
 
 <section class="editorial-section">
-  <span class="article-section-label">Quick answer</span>
+  <span class="article-section-label">الإجابة السريعة</span>
   <div class="editorial-block">
     <p>شعار WhatsApp مصمم بخط Helvetica Neue، مع تعديل بسيط في العرض والتباعد ليلائم حجم أيقونة التطبيق الصغيرة. أما واجهة المحادثة نفسها فلا تحتوي على أي خط مضمّن أو مخصص إطلاقًا؛ إذ يعتمد التطبيق كليًا على خط النظام الخاص بجهازك: San Francisco على آيفون، وRoboto على أندرويد، وSegoe UI على أجهزة ويندوز المكتبية وWhatsApp Web.</p>
     <p>ولهذا السبب بالتحديد قد تبدو المحادثة نفسها مختلفة قليلًا في شكل الحروف بحسب الجهاز الذي يقرأها — فما تراه على آيفون قد لا يتطابق تمامًا مع ما يظهر على أندرويد أو ويندوز.</p>
@@ -177,7 +177,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">The details</span>
+  <span class="article-section-label">التفاصيل</span>
   <h2>ما هو الخط الذي يستخدمه WhatsApp؟</h2>
 
   <div class="data-table-wrap">
@@ -240,7 +240,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Style your own text</span>
+  <span class="article-section-label">نسّق نصك</span>
   <h2>...لكن هل تريد أن تبرز رسائلك الخاصة؟</h2>
   <div class="editorial-block">
     <p>إذا وصلت إلى هذه الصفحة لأنك تريد أن تبدو رسائلك أو حالتك أو اسم مجموعتك على WhatsApp مختلفة، لا لمطابقة هوية العلامة التجارية، فإن إجابة خط النظام أعلاه لن تفيدك. يدعم WhatsApp فعليًا 4 أنماط تنسيق أصلية عبر رموز كتابة بسيطة: *غامق*، و_مائل_، و~يتوسطه خط~، وخط أحادي المسافة بثلاث علامات اقتباس عكسية. اطّلع على الشرح الكامل في <a href="/guide/whatsapp-text-formatting-explained/">دليل تنسيق النصوص في WhatsApp</a>.</p>
@@ -258,7 +258,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Keep exploring</span>
+  <span class="article-section-label">تصفح المزيد</span>
   <h2>صفحات ذات صلة</h2>
   <div class="compare-grid">
     <a href="/whatsapp/" class="compare-card variant-muted u-no-underline">
@@ -283,7 +283,7 @@
 
 <section class="editorial-section" id="faq">
   <span class="article-section-label">FAQ</span>
-  <h2>Frequently Asked Questions</h2>
+  <h2>الأسئلة الشائعة</h2>
   <details class="faq-item">
     <summary class="faq-question">ما هو الخط الذي يستخدمه WhatsApp؟</summary>
     <p class="faq-answer">شعار WhatsApp مصمم بخط Helvetica Neue مع تعديل بسيط في العرض والتباعد. أما واجهة المحادثة فلا تحتوي على خط خاص بها؛ فهي تعتمد على خط نظام جهازك: San Francisco على آيفون، وRoboto على أندرويد، وSegoe UI على ويندوز المكتبي والويب.</p>

--- a/cs/generator-prezdivek/index.html
+++ b/cs/generator-prezdivek/index.html
@@ -204,7 +204,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 <!-- GENERATOR -->
 <section class="hero"><div class="hero-inner"><div class="hero-card">
   <div class="input-wrapper"><textarea class="main-input" id="mainInput" placeholder="Napiš jméno nebo přezdívku…" maxlength="100">Sanz</textarea><span class="char-count"><span id="charCount">0</span>/100</span></div>
-  <div class="decoration-section"><div class="decoration-label">Přidat ozdoby do výsledku</div><div class="decoration-tabs"><button class="decoration-tab active" data-deco-tab="symbols">Symboly</button><button class="decoration-tab" data-deco-tab="minimal">Minimal</button><button class="decoration-tab" data-deco-tab="emojis">Emoji</button></div><div class="decoration-grid" id="decorationGrid"></div></div>
+  <div class="decoration-section"><div class="decoration-label">Přidat ozdoby do výsledku</div><div class="decoration-tabs"><button class="decoration-tab active" data-deco-tab="symbols">Symboly</button><button class="decoration-tab" data-deco-tab="minimal">Minimalistické</button><button class="decoration-tab" data-deco-tab="emojis">Emoji</button></div><div class="decoration-grid" id="decorationGrid"></div></div>
 </div></div></section>
 
 <main class="container">

--- a/data/translation_identical_strings.json
+++ b/data/translation_identical_strings.json
@@ -14,8 +14,10 @@
       { "string": "Clown Emoji &amp; Kaomoji", "reason": "both nouns are loanwords in German; the ampersand form is identical", "found_on": "de/library/clown-emoji/", "added": "2026-08-15" },
       { "string": "Cupcake", "reason": "loanword, spelled identically in German", "found_on": "de/library/geschenk-emoji/", "added": "2026-08-15" },
       { "string": "Emoji Combos", "reason": "both words are used untranslated in German", "found_on": "de/library/geschenk-emoji/", "added": "2026-08-15" },
+      { "string": "Emojis", "reason": "German pluralises the loanword exactly this way; 16 of 19 German decoration tabs render \"Emojis\"", "found_on": "de/usecase/* decoration tabs", "added": "2026-08-16" },
       { "string": "Joker", "reason": "loanword, spelled identically in German", "found_on": "de/library/clown-emoji/", "added": "2026-08-15" },
       { "string": "Joystick", "reason": "loanword, spelled identically in German", "found_on": "de/library/geist-emoji/", "added": "2026-08-15" },
+      { "string": "Minimal", "reason": "standard German adjective; the site's own German decoration tabs use it on 14 pages against 8 \"Minimalistisch\" — the majority form, not an untranslated one", "found_on": "de/usecase/* decoration tabs", "added": "2026-08-16" },
       { "string": "Muah", "reason": "onomatopoeia, written the same way", "found_on": "de/library/kuss-emoji/", "added": "2026-08-15" },
       { "string": "Namaste &amp; Balance", "reason": "Namaste is a loanword and Balance is the ordinary German noun", "found_on": "de/library/friedens-emoji/", "added": "2026-08-15" },
       { "string": "Peace Out", "reason": "English slang used untranslated in German", "found_on": "de/library/friedens-emoji/", "added": "2026-08-15" },
@@ -27,8 +29,16 @@
       { "string": "Yin Yang", "reason": "transliteration, identical in German", "found_on": "de/library/friedens-emoji/", "added": "2026-08-15" },
       { "string": "Zombie", "reason": "loanword, spelled identically in German", "found_on": "de/library/teufel-emoji/", "added": "2026-08-15" }
     ],
+    "es": [
+      { "string": "Emojis", "reason": "Spanish pluralises the loanword identically; all 25 Spanish decoration tabs render \"Emojis\"", "found_on": "es/usecase/* decoration tabs", "added": "2026-08-16" },
+      { "string": "Minimal", "reason": "used as-is in Spanish; 19 of 26 Spanish decoration tabs render \"Minimal\" against 7 \"Minimalista\"", "found_on": "es/usecase/* decoration tabs", "added": "2026-08-16" }
+    ],
+    "fr": [
+      { "string": "Emojis", "reason": "French pluralises the loanword identically; 10 of 14 French decoration tabs render \"Emojis\"", "found_on": "fr/usecase/* decoration tabs", "added": "2026-08-16" }
+    ],
     "id": [
       { "string": "Font", "reason": "loanword; Indonesian uses 'font' untranslated, as every id page on the site does", "found_on": "id/symbol/* tables", "added": "2026-08-16" },
+      { "string": "Minimal", "reason": "\"minimal\" is ordinary Indonesian; 41 of 43 Indonesian decoration tabs render it, against 2 \"Minimalis\"", "found_on": "id/usecase/* decoration tabs", "added": "2026-08-16" },
       { "string": "Platform", "reason": "loanword; Indonesian spells it 'Platform' — id's own longer header 'Platform / Alat' keeps the word untranslated and translates only 'Tool'", "found_on": "id/symbol/* input-method tables", "added": "2026-08-16" }
     ],
     "it": [
@@ -37,6 +47,7 @@
       { "string": "Cupcake", "reason": "loanword, spelled identically in Italian", "found_on": "it/library/emoji-regalo/", "added": "2026-08-15" },
       { "string": "Font", "reason": "loanword; Italian uses 'font' for a typeface, and the site's Italian pages use it untranslated throughout", "found_on": "it/symbol/* tables", "added": "2026-08-16" },
       { "string": "Goblin", "reason": "loanword, spelled identically in Italian", "found_on": "it/library/emoji-diavolo/", "added": "2026-08-15" },
+      { "string": "Minimal", "reason": "used as-is in Italian design vocabulary; 23 of 26 Italian decoration tabs render \"Minimal\" against 3 \"Minimo\"", "found_on": "it/usecase/* decoration tabs", "added": "2026-08-16" },
       { "string": "Muah", "reason": "onomatopoeia, written the same way", "found_on": "it/library/emoji-bacio/", "added": "2026-08-15" },
       { "string": "XOXO", "reason": "an initialism, not translated", "found_on": "it/library/emoji-bacio/", "added": "2026-08-15" },
       { "string": "Yin Yang", "reason": "transliteration, identical in Italian", "found_on": "it/library/emoji-pace/", "added": "2026-08-15" },
@@ -44,6 +55,9 @@
     ],
     "ja": [
       { "string": "XOXO", "reason": "an initialism, kept in Latin script in Japanese copy", "found_on": "ja/library/kisu-emoji/", "added": "2026-08-15" }
+    ],
+    "ms": [
+      { "string": "Minimal", "reason": "\"minimal\" is ordinary Malay; all 8 Malay decoration tabs render it", "found_on": "ms/usecase/* decoration tabs", "added": "2026-08-16" }
     ],
     "nl": [
       { "string": "126 / 0x7E / 0b1111110 / 0o176 — Tilde", "reason": "a codepoint line; Tilde is also the Dutch word", "found_on": "nl/library/ascii-tabel/", "added": "2026-08-15" },
@@ -71,7 +85,11 @@
       { "string": "Yin Yang", "reason": "transliteration, identical in Polish", "found_on": "pl/library/emoji-pokoju/", "added": "2026-08-15" },
       { "string": "Zombie", "reason": "loanword, spelled identically in Polish", "found_on": "pl/library/symbole-halloween/", "added": "2026-08-15" }
     ],
+    "pt": [
+      { "string": "Emojis", "reason": "Portuguese pluralises the loanword identically; all 21 Portuguese decoration tabs render \"Emojis\"", "found_on": "pt/usecase/* decoration tabs", "added": "2026-08-16" }
+    ],
     "tr": [
+      { "string": "Minimal", "reason": "\"minimal\" is ordinary Turkish; all 23 Turkish decoration tabs render it", "found_on": "tr/usecase/* decoration tabs", "added": "2026-08-16" },
       { "string": "Platform", "reason": "loanword; Turkish spells it 'Platform' — confirmed by tr's own dominant table header 'Platform|Çalışır mı?' (×74 pages), i.e. the site already settled on this form in Turkish", "found_on": "tr/symbol/* input-method tables", "added": "2026-08-16" }
     ]
   }

--- a/data/translation_identical_strings.json
+++ b/data/translation_identical_strings.json
@@ -7,6 +7,9 @@
     "added": "YYYY-MM-DD"
   },
   "entries": {
+    "da": [
+      { "string": "Platform", "reason": "loanword; Danish spells it 'Platform' — the same tables translate every neighbouring header (Værdi, Virker?, Metode, Indtastning, Egenskab) and leave this one, so the form is the locale's own choice", "found_on": "da/symbol/kvadratrodstegn/", "added": "2026-08-16" }
+    ],
     "de": [
       { "string": "Clown Emoji &amp; Kaomoji", "reason": "both nouns are loanwords in German; the ampersand form is identical", "found_on": "de/library/clown-emoji/", "added": "2026-08-15" },
       { "string": "Cupcake", "reason": "loanword, spelled identically in German", "found_on": "de/library/geschenk-emoji/", "added": "2026-08-15" },
@@ -21,13 +24,18 @@
       { "string": "Silent Disco", "reason": "the German term for the concept is the English one", "found_on": "de/library/tanz-emoji/", "added": "2026-08-15" },
       { "string": "Wolf", "reason": "identical noun in German", "found_on": "de/library/anime-symbole/", "added": "2026-08-15" },
       { "string": "XOXO", "reason": "an initialism, not translated", "found_on": "de/library/kuss-emoji/", "added": "2026-08-15" },
-      { "string": "Zombie", "reason": "loanword, spelled identically in German", "found_on": "de/library/teufel-emoji/", "added": "2026-08-15" },
-      { "string": "Yin Yang", "reason": "transliteration, identical in German", "found_on": "de/library/friedens-emoji/", "added": "2026-08-15" }
+      { "string": "Yin Yang", "reason": "transliteration, identical in German", "found_on": "de/library/friedens-emoji/", "added": "2026-08-15" },
+      { "string": "Zombie", "reason": "loanword, spelled identically in German", "found_on": "de/library/teufel-emoji/", "added": "2026-08-15" }
+    ],
+    "id": [
+      { "string": "Font", "reason": "loanword; Indonesian uses 'font' untranslated, as every id page on the site does", "found_on": "id/symbol/* tables", "added": "2026-08-16" },
+      { "string": "Platform", "reason": "loanword; Indonesian spells it 'Platform' — id's own longer header 'Platform / Alat' keeps the word untranslated and translates only 'Tool'", "found_on": "id/symbol/* input-method tables", "added": "2026-08-16" }
     ],
     "it": [
       { "string": "126 / 0x7E / 0b1111110 / 0o176 — Tilde", "reason": "a codepoint line; Tilde is also the Italian word", "found_on": "it/library/tabella-ascii/", "added": "2026-08-15" },
       { "string": "Clown Check", "reason": "an English meme phrase used untranslated in Italian", "found_on": "it/library/emoji-clown/", "added": "2026-08-15" },
       { "string": "Cupcake", "reason": "loanword, spelled identically in Italian", "found_on": "it/library/emoji-regalo/", "added": "2026-08-15" },
+      { "string": "Font", "reason": "loanword; Italian uses 'font' for a typeface, and the site's Italian pages use it untranslated throughout", "found_on": "it/symbol/* tables", "added": "2026-08-16" },
       { "string": "Goblin", "reason": "loanword, spelled identically in Italian", "found_on": "it/library/emoji-diavolo/", "added": "2026-08-15" },
       { "string": "Muah", "reason": "onomatopoeia, written the same way", "found_on": "it/library/emoji-bacio/", "added": "2026-08-15" },
       { "string": "XOXO", "reason": "an initialism, not translated", "found_on": "it/library/emoji-bacio/", "added": "2026-08-15" },
@@ -50,6 +58,7 @@
       { "string": "Muah", "reason": "onomatopoeia, written the same way", "found_on": "nl/library/kus-emoji/", "added": "2026-08-15" },
       { "string": "Namaste &amp; Balance", "reason": "Namaste is a loanword and Balance is used in Dutch", "found_on": "nl/library/vrede-emoji/", "added": "2026-08-15" },
       { "string": "Peace Out", "reason": "English slang used untranslated in Dutch", "found_on": "nl/library/vrede-emoji/", "added": "2026-08-15" },
+      { "string": "Platform", "reason": "loanword; Dutch spells it 'Platform' — confirmed by nl's own dominant table header 'Platform|Werkt het?' (×15 pages)", "found_on": "nl/symbol/* input-method tables", "added": "2026-08-16" },
       { "string": "Pluto", "reason": "planet name, identical in Dutch", "found_on": "nl/library/sterrenbeeld-symbolen/", "added": "2026-08-15" },
       { "string": "Uranus", "reason": "planet name, identical in Dutch", "found_on": "nl/library/sterrenbeeld-symbolen/", "added": "2026-08-15" },
       { "string": "Venus", "reason": "planet name, identical in Dutch", "found_on": "nl/library/sterrenbeeld-symbolen/", "added": "2026-08-15" },
@@ -61,6 +70,9 @@
       { "string": "38 / 0x26 / 0b0100110 / 0o46 — Ampersand", "reason": "a codepoint line; Ampersand is the Polish term too", "found_on": "pl/library/tabela-ascii/", "added": "2026-08-15" },
       { "string": "Yin Yang", "reason": "transliteration, identical in Polish", "found_on": "pl/library/emoji-pokoju/", "added": "2026-08-15" },
       { "string": "Zombie", "reason": "loanword, spelled identically in Polish", "found_on": "pl/library/symbole-halloween/", "added": "2026-08-15" }
+    ],
+    "tr": [
+      { "string": "Platform", "reason": "loanword; Turkish spells it 'Platform' — confirmed by tr's own dominant table header 'Platform|Çalışır mı?' (×74 pages), i.e. the site already settled on this form in Turkish", "found_on": "tr/symbol/* input-method tables", "added": "2026-08-16" }
     ]
   }
 }

--- a/de/library/aesthetische-symbole/index.html
+++ b/de/library/aesthetische-symbole/index.html
@@ -497,11 +497,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Pilze, Blumen, ländliche Cottage-Wärme.</p>
     </a>
     <a href="/de/library/kawaii-suesse-symbole/" class="compare-card variant-muted u-no-underline">
-      <h4>Kawaii / Cute</h4>
+      <h4>Kawaii &amp; Süße Symbole</h4>
       <p>Weich, rund, Baby-Pastell und japanisch-niedlich.</p>
     </a>
     <a href="/de/library/y2k-symbole/" class="compare-card variant-muted u-no-underline">
-      <h4>Y2K / Cyber</h4>
+      <h4>Y2K-Symbole</h4>
       <p>2000er-Nostalgie, Cybercore, Schmetterlinge.</p>
     </a>
     <a href="/library/goth-grunge-symbols/" class="compare-card variant-muted u-no-underline">

--- a/de/symbol/daumenzeichen-emoji/index.html
+++ b/de/symbol/daumenzeichen-emoji/index.html
@@ -240,7 +240,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Verwandte Ressourcen</span>
   <div class="compare-grid">
     <a href="/de/library/hand-symbole/" class="compare-card variant-muted u-no-underline">
-      <h4>Hand Gesture Symbols</h4>
+      <h4>Hand- und Gestensymbole</h4>
       <p>Zeigende Hände, Zustimmungsgesten und jedes bereits kodierte Hand-Zeichen.</p>
     </a>
     <a href="/de/symbol/berstendes-gesicht-emoji/" class="compare-card variant-muted u-no-underline">

--- a/de/symbol/divisionszeichen/index.html
+++ b/de/symbol/divisionszeichen/index.html
@@ -303,7 +303,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Ähnliche Symbole</span>
   <div class="compare-grid">
     <a href="/de/symbol/plus-minus-zeichen/" class="compare-card variant-muted u-no-underline">
-      <h4>Plus-Minus (±)</h4>
+      <h4>Plus-Minus-Zeichen (±)</h4>
       <p>Zwei mögliche Werte in einem Ausdruck.</p>
     </a>
     <a href="/de/symbol/quadratwurzelzeichen/" class="compare-card variant-muted u-no-underline">

--- a/de/symbol/index.html
+++ b/de/symbol/index.html
@@ -268,7 +268,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Ein Interpunktionsvorschlag von 1575 — und warum es nicht dasselbe Zeichen wie ¿ ist.</p>
     </a>
     <a href="/de/symbol/interrobang/" class="compare-card variant-muted u-no-underline">
-      <h4>‽ Interrobang</h4>
+      <h4>Interrobang (‽)</h4>
       <p>Die Verschmelzung von ? und ! eines Werbemanns von 1962 — kurzzeitig eine echte Schreibmaschinentaste.</p>
     </a>
     <a href="/de/symbol/sternchen-symbol/" class="compare-card variant-muted u-no-underline">
@@ -711,7 +711,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Übernahm einen Codepoint-Platz, der ursprünglich für einen zurückgestellten Apple-Core-Vorschlag reserviert war.</p>
     </a>
     <a href="/de/symbol/meteor-emoji/" class="compare-card variant-muted u-no-underline">
-      <h4>🪋 Meteor Emoji</h4>
+      <h4>Meteor Emoji</h4>
       <p>Löst Komets jahrelange Darstellungs-Spaltung zwischen blauem Eis und rotem Feuerball.</p>
     </a>
     <a href="/de/symbol/monarchfalter-emoji/" class="compare-card variant-muted u-no-underline">

--- a/de/symbol/meteor-emoji/index.html
+++ b/de/symbol/meteor-emoji/index.html
@@ -228,7 +228,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Verwandte Ressourcen</span>
   <div class="compare-grid">
     <a href="/de/library/wetter-symbole/" class="compare-card variant-muted u-no-underline">
-      <h4>Weather Symbols</h4>
+      <h4>Wetter Symbole und Emojis</h4>
       <p>Sonne, Regen, Schnee und jedes bereits kodierte Himmels-Zeichen, einschließlich Komet.</p>
     </a>
     <a href="/de/symbol/berstendes-gesicht-emoji/" class="compare-card variant-muted u-no-underline">

--- a/de/symbol/quadratwurzelzeichen/index.html
+++ b/de/symbol/quadratwurzelzeichen/index.html
@@ -306,7 +306,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Ähnliche Symbole</span>
   <div class="compare-grid">
     <a href="/de/symbol/plus-minus-zeichen/" class="compare-card variant-muted u-no-underline">
-      <h4>Plus-Minus (±)</h4>
+      <h4>Plus-Minus-Zeichen (±)</h4>
       <p>Zwei mögliche Werte in einem Ausdruck.</p>
     </a>
     <a href="/de/symbol/divisionszeichen/" class="compare-card variant-muted u-no-underline">

--- a/de/symbol/stern-und-halbmond/index.html
+++ b/de/symbol/stern-und-halbmond/index.html
@@ -256,11 +256,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Verwandte Ressourcen</span>
   <div class="compare-grid">
     <a href="/de/library/religioese-symbole/" class="compare-card variant-muted u-no-underline">
-      <h4>Religious Symbols</h4>
+      <h4>Religiöse &amp; Spirituelle Symbole</h4>
       <p>Glaubenssymbole aller großen Weltreligionen in einer durchstöberbaren Referenz.</p>
     </a>
     <a href="/de/library/islamische-symbole/" class="compare-card variant-muted u-no-underline">
-      <h4>Islamic Symbols</h4>
+      <h4>Islamische Symbole</h4>
       <p>Stern und Halbmond neben der Allah-Kalligrafie, der Moschee, dem Gebet und weiteren mit dem Islam verbundenen Symbolen.</p>
     </a>
     <a href="/de/symbol/davidstern/" class="compare-card variant-muted u-no-underline">

--- a/de/symbol/sternchen-symbol/index.html
+++ b/de/symbol/sternchen-symbol/index.html
@@ -256,7 +256,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Gedankenstriche, Klammern, Anführungszeichen und die alltägliche Interpunktions-Familie, zu der das Sternchen gehört.</p>
     </a>
     <a href="/de/library/tastatur-symbole/" class="compare-card variant-muted u-no-underline">
-      <h4>Keyboard Symbols</h4>
+      <h4>Tastatur-Symbole</h4>
       <p>Sternchen, Et-Zeichen, Raute und die übrigen Zeichen, die über die Reihen einer Standardtastatur verteilt sind.</p>
     </a>
     <a href="/de/symbol/stern-symbol/" class="compare-card variant-muted u-no-underline">

--- a/de/symbol/tilde-zeichen/index.html
+++ b/de/symbol/tilde-zeichen/index.html
@@ -248,7 +248,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Verwandte Ressourcen</span>
   <div class="compare-grid">
     <a href="/de/library/tastatur-symbole/" class="compare-card variant-muted u-no-underline">
-      <h4>Keyboard Symbols</h4>
+      <h4>Tastatur-Symbole</h4>
       <p>Tilde, Backtick, Et-Zeichen und die übrigen Interpunktions- und Sonderzeichen einer Standardtastatur, bereit zum Kopieren.</p>
     </a>
     <a href="/de/library/mathe-symbole/" class="compare-card variant-muted u-no-underline">

--- a/de/symbol/unterstrich/index.html
+++ b/de/symbol/unterstrich/index.html
@@ -236,7 +236,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Verwandte Ressourcen</span>
   <div class="compare-grid">
     <a href="/de/library/tastatur-symbole/" class="compare-card variant-muted u-no-underline">
-      <h4>Keyboard Symbols</h4>
+      <h4>Tastatur-Symbole</h4>
       <p>Unterstrich, Bindestrich, Sternchen und die übrigen Interpunktions- und Sonderzeichen einer Standardtastatur.</p>
     </a>
     <a href="/library/punctuation-symbols/" class="compare-card variant-muted u-no-underline">

--- a/es/answers/what-font-does-pinterest-use/index.html
+++ b/es/answers/what-font-does-pinterest-use/index.html
@@ -183,7 +183,7 @@
 
 
 <section class="editorial-section">
-  <span class="article-section-label">Quick answer</span>
+  <span class="article-section-label">Respuesta corta</span>
   <div class="editorial-block">
     <p>La app, el sitio web y la marca de Pinterest usan <strong>Pinterest Sans</strong>, una tipografía sans-serif geométrica personalizada encargada a <a href="https://www.grillitype.com/commissions/pinterest" target="_blank" rel="noopener noreferrer">Grilli Type</a>, una fundición suiza. Viene en cuatro pesos más un corte específico para tamaños pequeños llamado <strong>Pinterest UI</strong>. Pinterest Sans es propietaria — hecha exclusivamente para Pinterest, no disponible para descarga pública ni licencia.</p>
     <p>Si solo necesitas una fuente que se sienta "al estilo Pinterest" para un gráfico o presentación: diseña con <strong>Poppins</strong>, una sans geométrica gratuita en <a href="https://fonts.google.com/specimen/Poppins" target="_blank" rel="noopener noreferrer">Google Fonts</a> que tiene la misma calidez redondeada.</p>
@@ -193,7 +193,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">The details</span>
+  <span class="article-section-label">En detalle</span>
   <h2>¿Qué Fuente Usa Pinterest?</h2>
 
   <div class="data-table-wrap">
@@ -254,7 +254,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Style your own text</span>
+  <span class="article-section-label">Dale estilo a tu texto</span>
   <h2>…¿pero quieres que tus propios pines destaquen?</h2>
   <div class="editorial-block">
     <p>Si llegaste aquí porque quieres que tus propios títulos de pines, descripciones o nombres de tableros se vean diferentes — no porque estés igualando la marca — saber el nombre de la fuente no te ayudará. Pinterest no tiene ningún botón de formato en ninguna parte de la app.</p>
@@ -275,7 +275,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Keep exploring</span>
+  <span class="article-section-label">Sigue explorando</span>
   <h2>Páginas relacionadas</h2>
   <div class="compare-grid">
     <a href="/pinterest/" class="compare-card variant-muted u-no-underline">
@@ -300,7 +300,7 @@
 
 <section class="editorial-section" id="faq">
   <span class="article-section-label">FAQ</span>
-  <h2>Frequently Asked Questions</h2>
+  <h2>Preguntas Frecuentes</h2>
   <details class="faq-item">
     <summary class="faq-question">¿Qué fuente usa Pinterest?</summary>
     <p class="faq-answer">La app, el sitio web y la marca de Pinterest usan Pinterest Sans, una tipografía sans-serif geométrica personalizada encargada a la fundición suiza Grilli Type. Viene en cuatro pesos más un corte específico para tamaños pequeños llamado Pinterest UI. Pinterest Sans es propietaria — hecha exclusivamente para Pinterest, no disponible para descarga pública ni licencia.</p>

--- a/es/answers/what-font-does-pinterest-use/index.html
+++ b/es/answers/what-font-does-pinterest-use/index.html
@@ -285,7 +285,7 @@
     </a>
     <a href="/es/letras-negritas/" class="compare-card variant-muted u-no-underline">
       <span class="compare-badge">Tool</span>
-      <h4>Bold Text Generator</h4>
+      <h4>Letras negritas</h4>
       <ul><li>Generate clean bold text for any platform.</li></ul>
     </a>
     <a href="/answers/is-fancy-text-bad-for-seo/" class="compare-card variant-muted u-no-underline">

--- a/es/answers/what-font-does-whatsapp-use/index.html
+++ b/es/answers/what-font-does-whatsapp-use/index.html
@@ -263,7 +263,7 @@
   <div class="compare-grid">
     <a href="/es/fuentes-para-whatsapp/" class="compare-card variant-muted u-no-underline">
       <span class="compare-badge">Tool</span>
-      <h4>WhatsApp Font Generator</h4>
+      <h4>Fuentes para WhatsApp: letras para el nombre, la Info y el estado</h4>
       <ul><li>Style your status, group names and messages.</li></ul>
     </a>
     <a href="/guide/whatsapp-text-formatting-explained/" class="compare-card variant-muted u-no-underline">
@@ -273,7 +273,7 @@
     </a>
     <a href="/es/letras-negritas/" class="compare-card variant-muted u-no-underline">
       <span class="compare-badge">Tool</span>
-      <h4>Bold Text Generator</h4>
+      <h4>Letras negritas</h4>
       <ul><li>Generate clean bold text for any platform.</li></ul>
     </a>
   </div>

--- a/es/answers/what-font-does-whatsapp-use/index.html
+++ b/es/answers/what-font-does-whatsapp-use/index.html
@@ -167,7 +167,7 @@
 
 
 <section class="editorial-section">
-  <span class="article-section-label">Quick answer</span>
+  <span class="article-section-label">Respuesta corta</span>
   <div class="editorial-block">
     <p>El logotipo y el nombre de marca de WhatsApp están compuestos en Helvetica Neue, con el ancho y el espaciado ligeramente ajustados para que se vea nítido en el icono de la app. La interfaz de chat, en cambio, no incluye ninguna fuente propia: WhatsApp recurre por completo a la fuente del sistema de cada dispositivo — San Francisco en iPhone, Roboto en Android y Segoe UI en Windows de escritorio y en WhatsApp Web.</p>
     <p>Por eso, una misma conversación puede verse sutilmente distinta según el dispositivo desde el que se lea: la app no fuerza una tipografía única, sino que deja que cada sistema operativo muestre el texto con su propia fuente nativa.</p>
@@ -177,7 +177,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">The details</span>
+  <span class="article-section-label">En detalle</span>
   <h2>¿Qué fuente usa WhatsApp?</h2>
 
   <div class="data-table-wrap">
@@ -240,7 +240,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Style your own text</span>
+  <span class="article-section-label">Dale estilo a tu texto</span>
   <h2>...¿pero quieres que tus propios mensajes destaquen?</h2>
   <div class="editorial-block">
     <p>Si has llegado hasta aquí porque quieres que tus mensajes, tu estado o el nombre de tu grupo se vean diferentes (y no porque busques igualar la marca), la respuesta sobre la fuente del sistema no te sirve de mucho. WhatsApp sí admite 4 estilos nativos mediante símbolos al escribir: *negrita*, _cursiva_, ~tachado~ y ```monoespaciado```. Puedes ver el desglose completo en la <a href="/guide/whatsapp-text-formatting-explained/">guía de formato de texto en WhatsApp</a>.</p>
@@ -258,7 +258,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Keep exploring</span>
+  <span class="article-section-label">Sigue explorando</span>
   <h2>Páginas relacionadas</h2>
   <div class="compare-grid">
     <a href="/es/fuentes-para-whatsapp/" class="compare-card variant-muted u-no-underline">
@@ -283,7 +283,7 @@
 
 <section class="editorial-section" id="faq">
   <span class="article-section-label">FAQ</span>
-  <h2>Frequently Asked Questions</h2>
+  <h2>Preguntas Frecuentes</h2>
   <details class="faq-item">
     <summary class="faq-question">¿Qué fuente usa WhatsApp?</summary>
     <p class="faq-answer">El logotipo de WhatsApp está compuesto en Helvetica Neue, con los anchos y el espaciado ligeramente ajustados. La interfaz de chat, en cambio, no tiene ninguna fuente propia: usa la fuente del sistema de cada dispositivo — San Francisco en iPhone, Roboto en Android y Segoe UI en Windows de escritorio y en WhatsApp Web.</p>

--- a/es/library/jeroglificos-egipcios/index.html
+++ b/es/library/jeroglificos-egipcios/index.html
@@ -4556,7 +4556,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Recursos Relacionados</span>
   <div class="compare-grid">
     <a href="/es/library/caracteres-especiales/" class="compare-card variant-muted u-no-underline">
-      <h4>Special Characters</h4>
+      <h4>Caracteres Especiales</h4>
       <p>Unique Unicode symbols with individual meaning and standalone appeal.</p>
     </a>
     <a href="/es/library/runas-vikingas/" class="compare-card variant-muted u-no-underline">
@@ -4568,11 +4568,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Faith symbols from every major world religion.</p>
     </a>
     <a href="/es/simbolos-aesthetic/" class="compare-card variant-muted u-no-underline">
-      <h4>Aesthetic Symbols</h4>
+      <h4>Símbolos aesthetic</h4>
       <p>Decorative Unicode symbols for bios and captions.</p>
     </a>
     <a href="/es/symbol/simbolo-ankh/" class="compare-card variant-muted u-no-underline">
-      <h4>Ankh Symbol</h4>
+      <h4>Símbolo Ankh</h4>
       <p>El símbolo ankh (☥).</p>
     </a>
   </div>

--- a/es/symbol/index.html
+++ b/es/symbol/index.html
@@ -655,7 +655,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 <section class="mood-explainers" id="cartas-y-ajedrez">
   <span class="article-section-label">Cartas y ajedrez</span>
   <h2>Páginas individuales de cartas y ajedrez</h2>
-  <p class="u-secondary-tight">Sacados de las bibliotecas de <a href="/library/card-suit-symbols/">palos de baraja</a> y <a href="/es/library/simbolos-de-ajedrez/">símbolos de ajedrez</a> para tener su propia página dedicada.</p>
+  <p class="u-secondary-tight">Sacados de las bibliotecas de <a href="/es/library/simbolos-de-cartas/">palos de baraja</a> y <a href="/es/library/simbolos-de-ajedrez/">símbolos de ajedrez</a> para tener su propia página dedicada.</p>
   <div class="compare-grid">
     <a href="/es/symbol/simbolo-de-picas/" class="compare-card variant-muted u-no-underline">
       <h4>♠ ♤ Símbolo de Picas</h4>
@@ -674,7 +674,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 <section class="mood-explainers" id="emoji-borrador">
   <span class="article-section-label">Emoji en borrador</span>
   <h2>Páginas de emoji en borrador de Unicode 18.0</h2>
-  <p class="u-secondary-tight">Todavía sin aprobar — candidatos para Emoji 18.0, previstos junto a Unicode 18.0 en septiembre de 2026. Sacados de las bibliotecas de <a href="/es/library/emojis-de-caras/">emoji de caras</a>, <a href="/library/food-drink-emojis/">emoji de comida y bebida</a>, <a href="/library/weather-symbols/">símbolos del tiempo</a>, <a href="/library/animal-emojis/">emoji de animales</a> y <a href="/library/hand-symbols/">símbolos de manos</a> para tener su propia página dedicada.</p>
+  <p class="u-secondary-tight">Todavía sin aprobar — candidatos para Emoji 18.0, previstos junto a Unicode 18.0 en septiembre de 2026. Sacados de las bibliotecas de <a href="/es/library/emojis-de-caras/">emoji de caras</a>, <a href="/es/library/emojis-de-comida/">emoji de comida y bebida</a>, <a href="/es/library/simbolos-del-clima/">símbolos del tiempo</a>, <a href="/es/library/emojis-de-animales/">emoji de animales</a> y <a href="/es/library/simbolos-de-manos/">símbolos de manos</a> para tener su propia página dedicada.</p>
   <div class="compare-grid">
     <a href="/es/symbol/emoji-de-cara-agrietada/" class="compare-card variant-muted u-no-underline">
       <h4>🫫 Emoji de Cara Agrietada</h4>

--- a/es/symbol/index.html
+++ b/es/symbol/index.html
@@ -455,7 +455,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>El símbolo de copyright © (U+00A9) explicado — su origen legal de 1909, si todavía es necesario, y cómo escribirlo en Windows/Mac.</p>
     </a>
     <a href="/es/symbol/interrobang/" class="compare-card variant-muted u-no-underline">
-      <h4>‽ Interrobang</h4>
+      <h4>Interrobang (‽)</h4>
       <p>La mezcla de ? y ! que ideó un publicista en 1962 — brevemente una tecla real de máquina de escribir.</p>
     </a>
     <a href="/es/symbol/asterisco/" class="compare-card variant-muted u-no-underline">

--- a/fi/lihavoitu-teksti/index.html
+++ b/fi/lihavoitu-teksti/index.html
@@ -396,7 +396,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
           <p>Kalteva korostus lihavoinnin pariksi.</p>
         </a>
         <a href="/fi/kaunokirjoitus/" class="compare-card variant-muted u-no-underline">
-          <h4>Cursive Fonts</h4>
+          <h4>Kaunokirjoitus-generaattori</h4>
           <p>Kursiivisia käsialatyylejä.</p>
         </a>
         <a href="/usecase/linkedin-headline/" class="compare-card variant-muted u-no-underline">

--- a/fr/answers/what-font-does-pinterest-use/index.html
+++ b/fr/answers/what-font-does-pinterest-use/index.html
@@ -285,7 +285,7 @@
     </a>
     <a href="/fr/texte-en-gras/" class="compare-card variant-muted u-no-underline">
       <span class="compare-badge">Tool</span>
-      <h4>Bold Text Generator</h4>
+      <h4>Texte en gras à copier-coller</h4>
       <ul><li>Generate clean bold text for any platform.</li></ul>
     </a>
     <a href="/answers/is-fancy-text-bad-for-seo/" class="compare-card variant-muted u-no-underline">

--- a/fr/answers/what-font-does-pinterest-use/index.html
+++ b/fr/answers/what-font-does-pinterest-use/index.html
@@ -183,7 +183,7 @@
 
 
 <section class="editorial-section">
-  <span class="article-section-label">Quick answer</span>
+  <span class="article-section-label">Réponse courte</span>
   <div class="editorial-block">
     <p>L'app, le site et l'identité de Pinterest reposent sur <strong>Pinterest Sans</strong>, une police sans-serif géométrique personnalisée commandée à <a href="https://www.grillitype.com/commissions/pinterest" target="_blank" rel="noopener noreferrer">Grilli Type</a>, une fonderie suisse. Elle existe en quatre graisses, plus une déclinaison optimisée pour les petites tailles appelée <strong>Pinterest UI</strong>. Pinterest Sans est propriétaire — créée exclusivement pour Pinterest, non disponible au téléchargement ni à la licence publique.</p>
     <p>Si vous avez juste besoin d'une police "à la Pinterest" pour un visuel ou une présentation : utilisez <strong>Poppins</strong>, une sans géométrique gratuite sur <a href="https://fonts.google.com/specimen/Poppins" target="_blank" rel="noopener noreferrer">Google Fonts</a> qui a la même chaleur arrondie.</p>
@@ -193,7 +193,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">The details</span>
+  <span class="article-section-label">En détail</span>
   <h2>Quelle Police Utilise Pinterest ?</h2>
 
   <div class="data-table-wrap">
@@ -254,7 +254,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Style your own text</span>
+  <span class="article-section-label">Stylise ton texte</span>
   <h2>…mais vous voulez que vos propres épingles se démarquent ?</h2>
   <div class="editorial-block">
     <p>Si vous êtes arrivé ici parce que vous voulez que vos propres titres d'épingles, descriptions ou noms de tableaux aient un style différent — pas pour reproduire la marque — connaître le nom de la police ne vous aidera pas. Pinterest n'a aucun bouton de mise en forme nulle part dans l'app.</p>
@@ -275,7 +275,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Keep exploring</span>
+  <span class="article-section-label">À explorer aussi</span>
   <h2>Pages liées</h2>
   <div class="compare-grid">
     <a href="/pinterest/" class="compare-card variant-muted u-no-underline">
@@ -300,7 +300,7 @@
 
 <section class="editorial-section" id="faq">
   <span class="article-section-label">FAQ</span>
-  <h2>Frequently Asked Questions</h2>
+  <h2>Questions Fréquentes</h2>
   <details class="faq-item">
     <summary class="faq-question">Quelle police utilise Pinterest ?</summary>
     <p class="faq-answer">L'app, le site et l'identité de Pinterest reposent sur Pinterest Sans, une police sans-serif géométrique personnalisée commandée à la fonderie suisse Grilli Type. Elle existe en quatre graisses, plus une déclinaison optimisée pour les petites tailles appelée Pinterest UI. Pinterest Sans est propriétaire — créée exclusivement pour Pinterest, non disponible au téléchargement ni à la licence publique.</p>

--- a/fr/answers/what-font-does-whatsapp-use/index.html
+++ b/fr/answers/what-font-does-whatsapp-use/index.html
@@ -167,7 +167,7 @@
 
 
 <section class="editorial-section">
-  <span class="article-section-label">Quick answer</span>
+  <span class="article-section-label">Réponse courte</span>
   <div class="editorial-block">
     <p>Le logo et le wordmark WhatsApp sont composés en Helvetica Neue, avec des largeurs et un espacement légèrement resserrés pour rester lisibles à la taille d'une icône. L'interface de chat, elle, n'embarque aucune police personnalisée : elle s'appuie entièrement sur la police système de l'appareil qui l'affiche — San Francisco sur iPhone, Roboto sur Android, et Segoe UI sur Windows (bureau) et WhatsApp Web.</p>
     <p>C'est pourquoi une même conversation peut avoir un rendu subtilement différent selon l'appareil qui l'affiche : les lettres, l'épaisseur des traits et l'espacement varient d'un système à l'autre, même si le texte est strictement identique.</p>
@@ -177,7 +177,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">The details</span>
+  <span class="article-section-label">En détail</span>
   <h2>Quelle police utilise WhatsApp ?</h2>
 
   <div class="data-table-wrap">
@@ -240,7 +240,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Style your own text</span>
+  <span class="article-section-label">Stylise ton texte</span>
   <h2>...mais vous voulez que vos propres messages se démarquent ?</h2>
   <div class="editorial-block">
     <p>Si vous êtes arrivé ici parce que vous voulez que vos propres messages, votre statut ou le nom de votre groupe aient une apparence différente — et non pour reproduire l'identité visuelle de la marque — la réponse « police système » ne vous sera pas d'une grande aide. WhatsApp prend en charge nativement 4 styles de texte via des symboles de mise en forme : *gras*, _italique_, ~barré~ et ```monospace``` (police à chasse fixe entre triples apostrophes inverses). Retrouvez le détail complet dans notre <a href="/guide/whatsapp-text-formatting-explained/">guide de mise en forme du texte WhatsApp</a>.</p>
@@ -258,7 +258,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Keep exploring</span>
+  <span class="article-section-label">À explorer aussi</span>
   <h2>Pages associées</h2>
   <div class="compare-grid">
     <a href="/whatsapp/" class="compare-card variant-muted u-no-underline">
@@ -283,7 +283,7 @@
 
 <section class="editorial-section" id="faq">
   <span class="article-section-label">FAQ</span>
-  <h2>Frequently Asked Questions</h2>
+  <h2>Questions Fréquentes</h2>
   <details class="faq-item">
     <summary class="faq-question">Quelle police utilise WhatsApp ?</summary>
     <p class="faq-answer">Le logo WhatsApp est composé en Helvetica Neue, avec des largeurs et un espacement légèrement ajustés. L'interface de chat, en revanche, n'intègre aucune police propre : elle utilise la police système de l'appareil — San Francisco sur iPhone, Roboto sur Android, et Segoe UI sur Windows et WhatsApp Web.</p>

--- a/fr/answers/what-font-does-whatsapp-use/index.html
+++ b/fr/answers/what-font-does-whatsapp-use/index.html
@@ -273,7 +273,7 @@
     </a>
     <a href="/fr/texte-en-gras/" class="compare-card variant-muted u-no-underline">
       <span class="compare-badge">Tool</span>
-      <h4>Bold Text Generator</h4>
+      <h4>Texte en gras à copier-coller</h4>
       <ul><li>Generate clean bold text for any platform.</li></ul>
     </a>
   </div>

--- a/fr/library/codes-alt/index.html
+++ b/fr/library/codes-alt/index.html
@@ -635,7 +635,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Codes décimaux et hexadécimaux pour chaque caractère ASCII imprimable.</p>
     </a>
     <a href="/fr/library/caracteres-speciaux/" class="compare-card variant-muted u-no-underline">
-      <h4>Special Characters</h4>
+      <h4>Caractères Spéciaux</h4>
       <p>Une liste principale de caractères Unicode spéciaux à copier.</p>
     </a>
   </div>

--- a/fr/library/codes-alt/index.html
+++ b/fr/library/codes-alt/index.html
@@ -630,8 +630,8 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <h4>Police d'Écriture</h4>
       <p>Toutes les polices Unicode — pour pseudo, bio et légendes.</p>
     </a>
-    <a href="/library/ascii-table/" class="compare-card variant-muted u-no-underline">
-      <h4>ASCII Table</h4>
+    <a href="/fr/library/table-ascii/" class="compare-card variant-muted u-no-underline">
+      <h4>Table ASCII</h4>
       <p>Codes décimaux et hexadécimaux pour chaque caractère ASCII imprimable.</p>
     </a>
     <a href="/fr/library/caracteres-speciaux/" class="compare-card variant-muted u-no-underline">

--- a/fr/symbol/croissant-et-etoile/index.html
+++ b/fr/symbol/croissant-et-etoile/index.html
@@ -256,11 +256,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Ressources liées</span>
   <div class="compare-grid">
     <a href="/fr/library/symboles-religieux/" class="compare-card variant-muted u-no-underline">
-      <h4>Religious Symbols</h4>
+      <h4>Symboles Religieux et Spirituels</h4>
       <p>Les symboles de foi de chaque grande religion mondiale réunis dans une même référence à parcourir (en anglais).</p>
     </a>
     <a href="/fr/library/symboles-islamiques/" class="compare-card variant-muted u-no-underline">
-      <h4>Islamic Symbols</h4>
+      <h4>Symboles Islamiques</h4>
       <p>Le croissant et l'étoile aux côtés de la calligraphie « Allah », de la mosquée, de la prière et des autres symboles liés à l'islam (en anglais).</p>
     </a>
     <a href="/fr/symbol/etoile-de-david/" class="compare-card variant-muted u-no-underline">

--- a/fr/symbol/emoji-microphone/index.html
+++ b/fr/symbol/emoji-microphone/index.html
@@ -244,11 +244,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Chaque emoji d'objet du quotidien — technologie, maison et bureau, dont le microphone — à parcourir dans une même grille (en anglais).</p>
     </a>
     <a href="/fr/library/emoji-combos/" class="compare-card variant-muted u-no-underline">
-      <h4>Emoji Combos</h4>
+      <h4>Combos emoji à copier-coller</h4>
       <p>Des associations d'emoji toutes prêtes pour bios et légendes, y compris sur les thèmes musique et performance (en anglais).</p>
     </a>
     <a href="/fr/library/symboles-musicaux/" class="compare-card variant-muted u-no-underline">
-      <h4>Music Symbols</h4>
+      <h4>Symboles Musicaux</h4>
       <p>La notation musicale Unicode — ♪ ♫ ♬ — la cousine en texte de la famille des emoji de musique (en anglais).</p>
     </a>
   </div>

--- a/fr/symbol/index.html
+++ b/fr/symbol/index.html
@@ -280,7 +280,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Une proposition de ponctuation de 1575 — et pourquoi ce n'est pas le même geste que ¿.</p>
     </a>
     <a href="/fr/symbol/symbole-interrobang/" class="compare-card variant-muted u-no-underline">
-      <h4>‽ Interrobang</h4>
+      <h4>Interrobang (‽)</h4>
       <p>Inventé en 1962 — brièvement une vraie touche de machine à écrire.</p>
     </a>
     <a href="/fr/symbol/symbole-asterisque/" class="compare-card variant-muted u-no-underline">
@@ -397,7 +397,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Le design de Gerald Holtom (1958), tiré du code sémaphore.</p>
     </a>
     <a href="/fr/symbol/symbole-yin-yang/" class="compare-card variant-muted u-no-underline">
-      <h4>☯ Yin Yang</h4>
+      <h4>Symbole yin yang (☯)</h4>
       <p>La philosophie chinoise ancienne derrière la spirale.</p>
     </a>
     <a href="/fr/symbol/symbole-khanda/" class="compare-card variant-muted u-no-underline">

--- a/fr/symbol/symbole-asterisque/index.html
+++ b/fr/symbol/symbole-asterisque/index.html
@@ -256,7 +256,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Tirets, crochets, guillemets et toute la famille de ponctuation courante à laquelle appartient l'astérisque (en anglais).</p>
     </a>
     <a href="/fr/library/symboles-clavier/" class="compare-card variant-muted u-no-underline">
-      <h4>Keyboard Symbols</h4>
+      <h4>Symboles Clavier</h4>
       <p>L'astérisque, l'esperluette, le dièse et le reste des symboles imprimés sur les rangées de ton clavier (en anglais).</p>
     </a>
     <a href="/fr/symbol/symbole-etoile/" class="compare-card variant-muted u-no-underline">

--- a/fr/symbol/symbole-chi/index.html
+++ b/fr/symbol/symbole-chi/index.html
@@ -288,11 +288,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>L'alphabet grec complet, majuscules, minuscules et variantes mathématiques, prêt à copier-coller.</p>
     </a>
     <a href="/fr/library/symboles-mathematiques/" class="compare-card variant-muted u-no-underline">
-      <h4>Math Symbols</h4>
+      <h4>Symboles Mathématiques</h4>
       <p>Le chi-deux, les exposants, et les opérateurs et lettres grecques qui complètent une équation (en anglais).</p>
     </a>
     <a href="/fr/library/symboles-religieux/" class="compare-card variant-muted u-no-underline">
-      <h4>Religious Symbols</h4>
+      <h4>Symboles Religieux et Spirituels</h4>
       <p>Le Chi-Rho, les croix et les autres symboles chrétiens et religieux réunis dans une même référence (en anglais).</p>
     </a>
     <a href="/fr/symbol/symbole-pi/" class="compare-card variant-muted u-no-underline">

--- a/fr/symbol/symbole-inferieur-ou-egal/index.html
+++ b/fr/symbol/symbole-inferieur-ou-egal/index.html
@@ -244,7 +244,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Ressources liées</span>
   <div class="compare-grid">
     <a href="/fr/library/symboles-mathematiques/" class="compare-card variant-muted u-no-underline">
-      <h4>Math Symbols</h4>
+      <h4>Symboles Mathématiques</h4>
       <p>Opérateurs, notation ensembliste et constantes mathématiques réunis dans une même référence à parcourir (en anglais).</p>
     </a>
     <a href="/fr/symbol/symbole-different/" class="compare-card variant-muted u-no-underline">

--- a/fr/symbol/symbole-lambda/index.html
+++ b/fr/symbol/symbole-lambda/index.html
@@ -267,7 +267,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>L'alphabet grec complet — alpha, lambda, pi, sigma, oméga — en majuscules et minuscules, prêt à copier-coller.</p>
     </a>
     <a href="/fr/library/symboles-mathematiques/" class="compare-card variant-muted u-no-underline">
-      <h4>Math Symbols</h4>
+      <h4>Symboles Mathématiques</h4>
       <p>Longueur d'onde, constante cosmologique, et les opérateurs et lettres grecques qui complètent une équation (en anglais).</p>
     </a>
     <a href="/library/pride-lgbtq-symbols/" class="compare-card variant-muted u-no-underline">

--- a/fr/symbol/symbole-peso/index.html
+++ b/fr/symbol/symbole-peso/index.html
@@ -253,7 +253,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Ressources liées</span>
   <div class="compare-grid">
     <a href="/fr/library/symboles-monetaires/" class="compare-card variant-muted u-no-underline">
-      <h4>Currency Symbols</h4>
+      <h4>Symboles Monétaires</h4>
       <p>Parcours tous les symboles monétaires du monde — dollar, euro, livre, yen, roupie et peso — côte à côte dans une même grille (en anglais).</p>
     </a>
     <a href="/fr/symbol/symbole-dollar/" class="compare-card variant-muted u-no-underline">

--- a/fr/symbol/symbole-phi/index.html
+++ b/fr/symbol/symbole-phi/index.html
@@ -249,7 +249,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>L'alphabet grec complet, majuscules, minuscules et variantes mathématiques, prêt à copier-coller.</p>
     </a>
     <a href="/fr/library/symboles-mathematiques/" class="compare-card variant-muted u-no-underline">
-      <h4>Math Symbols</h4>
+      <h4>Symboles Mathématiques</h4>
       <p>Le nombre d'or, la racine carrée, et les opérateurs et lettres grecques qui complètent une équation (en anglais).</p>
     </a>
     <a href="/fr/symbol/symbole-pi/" class="compare-card variant-muted u-no-underline">

--- a/fr/symbol/symbole-pion/index.html
+++ b/fr/symbol/symbole-pion/index.html
@@ -274,7 +274,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Ressources liées</span>
   <div class="compare-grid">
     <a href="/fr/library/symboles-echecs/" class="compare-card variant-muted u-no-underline">
-      <h4>Chess Symbols</h4>
+      <h4>Symboles d'Échecs</h4>
       <p>Le jeu d'échecs Unicode complet — rois, reines, tours, fous, cavaliers et les deux pions — dans une même référence à copier-coller (en anglais).</p>
     </a>
     <a href="/library/card-suit-symbols/" class="compare-card variant-muted u-no-underline">

--- a/fr/symbol/symbole-psi/index.html
+++ b/fr/symbol/symbole-psi/index.html
@@ -262,7 +262,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>L'alphabet grec complet — alpha, lambda, pi, sigma, oméga — en majuscules et minuscules, prêt à copier-coller.</p>
     </a>
     <a href="/fr/library/symboles-mathematiques/" class="compare-card variant-muted u-no-underline">
-      <h4>Math Symbols</h4>
+      <h4>Symboles Mathématiques</h4>
       <p>Fonctions d'onde, opérateurs, et les lettres grecques qui complètent une équation de physique ou de mathématiques (en anglais).</p>
     </a>
     <a href="/fr/symbol/symbole-omega/" class="compare-card variant-muted u-no-underline">

--- a/fr/symbol/symbole-rouble/index.html
+++ b/fr/symbol/symbole-rouble/index.html
@@ -252,7 +252,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Ressources liées</span>
   <div class="compare-grid">
     <a href="/fr/library/symboles-monetaires/" class="compare-card variant-muted u-no-underline">
-      <h4>Currency Symbols</h4>
+      <h4>Symboles Monétaires</h4>
       <p>Un ensemble de symboles monétaires du monde à parcourir, du dollar et de l'euro jusqu'à la roupie, le rouble et le bitcoin (en anglais).</p>
     </a>
     <a href="/fr/symbol/symbole-roupie/" class="compare-card variant-muted u-no-underline">

--- a/fr/symbol/symbole-theta/index.html
+++ b/fr/symbol/symbole-theta/index.html
@@ -253,7 +253,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>L'alphabet grec complet, majuscules, minuscules et variantes mathématiques, prêt à copier-coller.</p>
     </a>
     <a href="/fr/library/symboles-mathematiques/" class="compare-card variant-muted u-no-underline">
-      <h4>Math Symbols</h4>
+      <h4>Symboles Mathématiques</h4>
       <p>Angles, opérateurs, et les lettres grecques qui complètent une équation (en anglais).</p>
     </a>
     <a href="/fr/symbol/symbole-omega/" class="compare-card variant-muted u-no-underline">

--- a/fr/symbol/symbole-tilde/index.html
+++ b/fr/symbol/symbole-tilde/index.html
@@ -248,11 +248,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Ressources liées</span>
   <div class="compare-grid">
     <a href="/fr/library/symboles-clavier/" class="compare-card variant-muted u-no-underline">
-      <h4>Keyboard Symbols</h4>
+      <h4>Symboles Clavier</h4>
       <p>Le tilde, l'accent grave, l'esperluette et le reste des touches de ponctuation d'un clavier standard, prêtes à copier (en anglais).</p>
     </a>
     <a href="/fr/library/symboles-mathematiques/" class="compare-card variant-muted u-no-underline">
-      <h4>Math Symbols</h4>
+      <h4>Symboles Mathématiques</h4>
       <p>Presque-égal, semblable-à, et les opérateurs et relations qui complètent une équation aux côtés du tilde (en anglais).</p>
     </a>
     <a href="/library/accent-marks-diacritics/" class="compare-card variant-muted u-no-underline">

--- a/fr/symbol/tiret-bas/index.html
+++ b/fr/symbol/tiret-bas/index.html
@@ -236,7 +236,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Ressources liées</span>
   <div class="compare-grid">
     <a href="/fr/library/symboles-clavier/" class="compare-card variant-muted u-no-underline">
-      <h4>Keyboard Symbols</h4>
+      <h4>Symboles Clavier</h4>
       <p>Le tiret bas, le trait d'union, l'astérisque et le reste des signes de ponctuation d'un clavier standard, prêts à copier (en anglais).</p>
     </a>
     <a href="/library/punctuation-symbols/" class="compare-card variant-muted u-no-underline">

--- a/fr/usecase/nom-de-contact-aesthetic/index.html
+++ b/fr/usecase/nom-de-contact-aesthetic/index.html
@@ -201,7 +201,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 <!-- GENERATOR -->
 <section class="hero"><div class="hero-inner"><div class="hero-card">
   <div class="input-wrapper"><textarea class="main-input" id="mainInput" placeholder="Tape un nom ou un petit surnom…" maxlength="100">Chéri</textarea><span class="char-count"><span id="charCount">0</span>/100</span></div>
-  <div class="decoration-section"><div class="decoration-label">Ajoute de la déco au résultat</div><button class="surprise-btn" id="surpriseBtn" type="button">🎲 Surprends-moi</button><div class="decoration-tabs"><button class="decoration-tab active" data-deco-tab="symbols">Symboles</button><button class="decoration-tab" data-deco-tab="minimal">Minimal</button><button class="decoration-tab" data-deco-tab="emojis">Emoji</button><button class="decoration-tab" data-deco-tab="contact">Cœurs</button></div><div class="decoration-grid" id="decorationGrid"></div></div>
+  <div class="decoration-section"><div class="decoration-label">Ajoute de la déco au résultat</div><button class="surprise-btn" id="surpriseBtn" type="button">🎲 Surprends-moi</button><div class="decoration-tabs"><button class="decoration-tab active" data-deco-tab="symbols">Symboles</button><button class="decoration-tab" data-deco-tab="minimal">Minimaliste</button><button class="decoration-tab" data-deco-tab="emojis">Emoji</button><button class="decoration-tab" data-deco-tab="contact">Cœurs</button></div><div class="decoration-grid" id="decorationGrid"></div></div>
 </div></div></section>
 
 <main class="container">

--- a/fr/usecase/nom-de-groupe/index.html
+++ b/fr/usecase/nom-de-groupe/index.html
@@ -200,7 +200,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 <!-- GENERATOR -->
 <section class="hero"><div class="hero-inner"><div class="hero-card">
   <div class="input-wrapper"><textarea class="main-input" id="mainInput" placeholder="Tape le nom de ton groupe…" maxlength="100">Le Cercle</textarea><span class="char-count"><span id="charCount">0</span>/100</span></div>
-  <div class="decoration-section"><div class="decoration-label">Ajoute de la déco au résultat</div><button class="surprise-btn" id="surpriseBtn" type="button">🎲 Surprends-moi</button><div class="decoration-tabs"><button class="decoration-tab active" data-deco-tab="symbols">Symboles</button><button class="decoration-tab" data-deco-tab="minimal">Minimal</button><button class="decoration-tab" data-deco-tab="emojis">Emoji</button><button class="decoration-tab" data-deco-tab="group">Groupe</button></div><div class="decoration-grid" id="decorationGrid"></div></div>
+  <div class="decoration-section"><div class="decoration-label">Ajoute de la déco au résultat</div><button class="surprise-btn" id="surpriseBtn" type="button">🎲 Surprends-moi</button><div class="decoration-tabs"><button class="decoration-tab active" data-deco-tab="symbols">Symboles</button><button class="decoration-tab" data-deco-tab="minimal">Minimaliste</button><button class="decoration-tab" data-deco-tab="emojis">Emoji</button><button class="decoration-tab" data-deco-tab="group">Groupe</button></div><div class="decoration-grid" id="decorationGrid"></div></div>
 </div></div></section>
 
 <main class="container">

--- a/fr/usecase/pseudo-stumble-guys/index.html
+++ b/fr/usecase/pseudo-stumble-guys/index.html
@@ -200,7 +200,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 <section class="hero"><div class="hero-inner"><div class="hero-card">
   <div class="input-wrapper"><textarea class="main-input" id="mainInput" placeholder="Tape ton nom ou ton pseudo…" maxlength="100">Titube</textarea><span class="char-count"><span id="charCount">0</span>/100</span></div>
   <div class="decoration-section namecheck-inline"><div class="decoration-label">Vérificateur de pseudo Stumble Guys — en direct</div><div id="sgNameChecker"></div></div>
-  <div class="decoration-section"><div class="decoration-label">Ajoute de la déco au résultat</div><button class="surprise-btn" id="surpriseBtn" type="button">🎲 Surprends-moi</button><div class="decoration-tabs"><button class="decoration-tab active" data-deco-tab="symbols">Symboles</button><button class="decoration-tab" data-deco-tab="minimal">Minimal</button><button class="decoration-tab" data-deco-tab="emojis">Emoji</button><button class="decoration-tab" data-deco-tab="sg">Stumble</button></div><div class="decoration-grid" id="decorationGrid"></div></div>
+  <div class="decoration-section"><div class="decoration-label">Ajoute de la déco au résultat</div><button class="surprise-btn" id="surpriseBtn" type="button">🎲 Surprends-moi</button><div class="decoration-tabs"><button class="decoration-tab active" data-deco-tab="symbols">Symboles</button><button class="decoration-tab" data-deco-tab="minimal">Minimaliste</button><button class="decoration-tab" data-deco-tab="emojis">Emoji</button><button class="decoration-tab" data-deco-tab="sg">Stumble</button></div><div class="decoration-grid" id="decorationGrid"></div></div>
 </div></div></section>
 
 <main class="container">

--- a/id/answers/what-font-does-pinterest-use/index.html
+++ b/id/answers/what-font-does-pinterest-use/index.html
@@ -183,7 +183,7 @@
 
 
 <section class="editorial-section">
-  <span class="article-section-label">Quick answer</span>
+  <span class="article-section-label">Jawaban singkat</span>
   <div class="editorial-block">
     <p>Aplikasi, situs, dan branding Pinterest menggunakan <strong>Pinterest Sans</strong>, font sans-serif geometris kustom yang dipesan dari <a href="https://www.grillitype.com/commissions/pinterest" target="_blank" rel="noopener noreferrer">Grilli Type</a>, foundry asal Swiss. Font ini tersedia dalam empat ketebalan plus versi khusus ukuran kecil bernama <strong>Pinterest UI</strong>. Pinterest Sans bersifat eksklusif — dibuat khusus untuk Pinterest, tidak tersedia untuk diunduh atau dilisensikan ke publik.</p>
     <p>Kalau kamu cuma butuh font yang terasa "seperti Pinterest" untuk desain atau presentasi: gunakan <strong>Poppins</strong>, sans geometris gratis di <a href="https://fonts.google.com/specimen/Poppins" target="_blank" rel="noopener noreferrer">Google Fonts</a> yang punya kehangatan bulat yang sama.</p>
@@ -193,7 +193,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">The details</span>
+  <span class="article-section-label">Rinciannya</span>
   <h2>Font Apa yang Digunakan Pinterest?</h2>
 
   <div class="data-table-wrap">
@@ -254,7 +254,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Style your own text</span>
+  <span class="article-section-label">Gaya teksmu sendiri</span>
   <h2>…tapi kamu mau pin kamu sendiri tampil beda?</h2>
   <div class="editorial-block">
     <p>Kalau kamu ke sini karena mau judul pin, deskripsi, atau nama board kamu sendiri tampil beda — bukan karena mencocokkan brand — mengetahui nama fontnya tidak akan membantu. Pinterest tidak punya tombol format di mana pun di aplikasinya.</p>
@@ -275,7 +275,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Keep exploring</span>
+  <span class="article-section-label">Jelajahi lainnya</span>
   <h2>Halaman terkait</h2>
   <div class="compare-grid">
     <a href="/pinterest/" class="compare-card variant-muted u-no-underline">
@@ -300,7 +300,7 @@
 
 <section class="editorial-section" id="faq">
   <span class="article-section-label">FAQ</span>
-  <h2>Frequently Asked Questions</h2>
+  <h2>Pertanyaan yang Sering Ditanya</h2>
   <details class="faq-item">
     <summary class="faq-question">Font apa yang digunakan Pinterest?</summary>
     <p class="faq-answer">Aplikasi, situs, dan branding Pinterest menggunakan Pinterest Sans, font sans-serif geometris kustom yang dipesan dari foundry asal Swiss, Grilli Type. Font ini tersedia dalam empat ketebalan plus versi khusus ukuran kecil bernama Pinterest UI. Pinterest Sans bersifat eksklusif — dibuat khusus untuk Pinterest, tidak tersedia untuk diunduh atau dilisensikan ke publik.</p>

--- a/id/answers/what-font-does-pinterest-use/index.html
+++ b/id/answers/what-font-does-pinterest-use/index.html
@@ -285,7 +285,7 @@
     </a>
     <a href="/id/tulisan-tebal/" class="compare-card variant-muted u-no-underline">
       <span class="compare-badge">Tool</span>
-      <h4>Bold Text Generator</h4>
+      <h4>Generator Tulisan Tebal &amp; Font Tebal (𝗕𝗼𝗹𝗱)</h4>
       <ul><li>Generate clean bold text for any platform.</li></ul>
     </a>
     <a href="/answers/is-fancy-text-bad-for-seo/" class="compare-card variant-muted u-no-underline">

--- a/id/answers/what-font-does-whatsapp-use/index.html
+++ b/id/answers/what-font-does-whatsapp-use/index.html
@@ -263,7 +263,7 @@
   <div class="compare-grid">
     <a href="/id/font-wa/" class="compare-card variant-muted u-no-underline">
       <span class="compare-badge">Tool</span>
-      <h4>WhatsApp Font Generator</h4>
+      <h4>Font WA — Gaya Tulisan WhatsApp Aesthetic</h4>
       <ul><li>Style your status, group names and messages.</li></ul>
     </a>
     <a href="/guide/whatsapp-text-formatting-explained/" class="compare-card variant-muted u-no-underline">
@@ -273,7 +273,7 @@
     </a>
     <a href="/id/tulisan-tebal/" class="compare-card variant-muted u-no-underline">
       <span class="compare-badge">Tool</span>
-      <h4>Bold Text Generator</h4>
+      <h4>Generator Tulisan Tebal &amp; Font Tebal (𝗕𝗼𝗹𝗱)</h4>
       <ul><li>Generate clean bold text for any platform.</li></ul>
     </a>
   </div>

--- a/id/answers/what-font-does-whatsapp-use/index.html
+++ b/id/answers/what-font-does-whatsapp-use/index.html
@@ -167,7 +167,7 @@
 
 
 <section class="editorial-section">
-  <span class="article-section-label">Quick answer</span>
+  <span class="article-section-label">Jawaban singkat</span>
   <div class="editorial-block">
     <p>Logo dan wordmark WhatsApp disusun menggunakan Helvetica Neue, dengan lebar huruf dan jarak spasi yang sedikit disesuaikan agar tetap terbaca jelas di ukuran kecil. Namun, tampilan chat-nya sendiri sama sekali tidak membawa font khusus — WhatsApp sepenuhnya mengandalkan font sistem bawaan perangkat: San Francisco di iPhone, Roboto di Android, dan Segoe UI di WhatsApp Desktop maupun WhatsApp Web untuk Windows.</p>
     <p>Itulah sebabnya satu percakapan yang sama bisa terlihat sedikit berbeda tergantung perangkat mana yang membacanya — bentuk huruf yang kamu lihat di iPhone tidak akan persis sama dengan yang dilihat teman yang memakai Android atau WhatsApp Web.</p>
@@ -177,7 +177,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">The details</span>
+  <span class="article-section-label">Rinciannya</span>
   <h2>Font Apa yang Digunakan WhatsApp?</h2>
 
   <div class="data-table-wrap">
@@ -240,7 +240,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Style your own text</span>
+  <span class="article-section-label">Gaya teksmu sendiri</span>
   <h2>...Tapi Kamu Ingin Pesanmu Sendiri Tampil Beda?</h2>
   <div class="editorial-block">
     <p>Kalau kamu sampai ke halaman ini karena ingin pesan, status, atau nama grup WhatsApp-mu tampil beda — bukan sekadar ingin tahu soal branding — jawaban soal font sistem di atas tidak banyak membantu. Kabar baiknya, WhatsApp sebenarnya mendukung 4 gaya teks bawaan lewat simbol pengetikan: *tebal*, _miring_, ~coret~, dan ```monospace```. Baca penjelasan lengkapnya di <a href="/guide/whatsapp-text-formatting-explained/">panduan format teks WhatsApp</a>.</p>
@@ -258,7 +258,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Keep exploring</span>
+  <span class="article-section-label">Jelajahi lainnya</span>
   <h2>Halaman Terkait</h2>
   <div class="compare-grid">
     <a href="/id/font-wa/" class="compare-card variant-muted u-no-underline">
@@ -283,7 +283,7 @@
 
 <section class="editorial-section" id="faq">
   <span class="article-section-label">FAQ</span>
-  <h2>Frequently Asked Questions</h2>
+  <h2>Pertanyaan yang Sering Ditanya</h2>
   <details class="faq-item">
     <summary class="faq-question">Font apa yang digunakan WhatsApp?</summary>
     <p class="faq-answer">WhatsApp menggunakan dua pendekatan berbeda. Logo dan wordmark-nya disusun dengan Helvetica Neue, dengan lebar dan jarak huruf yang disesuaikan untuk tampilan ikon aplikasi. Sementara itu, tampilan chat-nya tidak memakai font khusus sama sekali — WhatsApp mengambil font sistem bawaan perangkat, yaitu San Francisco di iPhone, Roboto di Android, dan Segoe UI di WhatsApp Desktop/Web untuk Windows.</p>

--- a/id/library/cat-kaomoji/index.html
+++ b/id/library/cat-kaomoji/index.html
@@ -313,7 +313,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">Halaman Terkait</span>
   <div class="compare-grid">
     <a href="/id/library/kaomoji/" class="compare-card variant-muted u-no-underline">
       <h4>Kaomoji</h4>

--- a/id/library/crying-kaomoji/index.html
+++ b/id/library/crying-kaomoji/index.html
@@ -280,7 +280,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">Halaman Terkait</span>
   <div class="compare-grid">
     <a href="/id/library/kaomoji/" class="compare-card variant-muted u-no-underline">
       <h4>Kaomoji</h4>

--- a/id/library/cute-kaomoji/index.html
+++ b/id/library/cute-kaomoji/index.html
@@ -287,7 +287,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">Halaman Terkait</span>
   <div class="compare-grid">
     <a href="/id/library/kaomoji/" class="compare-card variant-muted u-no-underline">
       <h4>Kaomoji</h4>

--- a/id/library/happy-kaomoji/index.html
+++ b/id/library/happy-kaomoji/index.html
@@ -284,7 +284,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">Halaman Terkait</span>
   <div class="compare-grid">
     <a href="/id/library/kaomoji/" class="compare-card variant-muted u-no-underline">
       <h4>Kaomoji</h4>

--- a/id/library/love-kaomoji/index.html
+++ b/id/library/love-kaomoji/index.html
@@ -299,7 +299,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">Halaman Terkait</span>
   <div class="compare-grid">
     <a href="/id/usecase/nama-kontak-pacar-aesthetic/" class="compare-card variant-muted u-no-underline">
       <h4>Nama Kontak Pacar Aesthetic</h4>

--- a/id/library/sad-kaomoji/index.html
+++ b/id/library/sad-kaomoji/index.html
@@ -297,7 +297,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">Halaman Terkait</span>
   <div class="compare-grid">
     <a href="/id/library/kaomoji/" class="compare-card variant-muted u-no-underline">
       <h4>Kaomoji</h4>

--- a/id/library/shrug-kaomoji/index.html
+++ b/id/library/shrug-kaomoji/index.html
@@ -257,7 +257,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">Halaman Terkait</span>
   <div class="compare-grid">
     <a href="/id/library/kaomoji/" class="compare-card variant-muted u-no-underline">
       <h4>Kaomoji</h4>

--- a/id/library/simbol-facebook/index.html
+++ b/id/library/simbol-facebook/index.html
@@ -499,7 +499,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Ubah huruf biasa jadi font Unicode tebal, miring, dan lainnya untuk Facebook.</p>
     </a>
     <a href="/id/library/simbol-love/" class="compare-card variant-muted u-no-underline">
-      <h4>Heart Symbols</h4>
+      <h4>Simbol Love &amp; Hati</h4>
       <p>Semua emoji hati dan karakter hati Unicode dalam berbagai warna dan gaya.</p>
     </a>
   </div>

--- a/id/library/simbol-fortnite/index.html
+++ b/id/library/simbol-fortnite/index.html
@@ -405,7 +405,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">Halaman Terkait</span>
   <div class="compare-grid">
     <a href="/id/usecase/nama-fortnite-keren/" class="compare-card variant-muted u-no-underline">
       <h4>Nama Fortnite Keren</h4>

--- a/id/library/simbol-minecraft/index.html
+++ b/id/library/simbol-minecraft/index.html
@@ -419,7 +419,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">Halaman Terkait</span>
   <div class="compare-grid">
     <a href="/id/library/simbol-roblox/" class="compare-card variant-muted u-no-underline">
       <h4>Simbol Roblox</h4>

--- a/id/library/simbol-pubg/index.html
+++ b/id/library/simbol-pubg/index.html
@@ -425,7 +425,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">Halaman Terkait</span>
   <div class="compare-grid">
     <a href="/id/usecase/nama-pubg-keren/" class="compare-card variant-muted u-no-underline">
       <h4>Nama PUBG Keren</h4>

--- a/id/symbol/index.html
+++ b/id/symbol/index.html
@@ -626,7 +626,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Karakter kosong Braille U+2800 di balik nama dan bio yang tampak kosong.</p>
     </a>
     <a href="/id/symbol/simbol-black-moon-lilith/" class="compare-card variant-muted u-no-underline">
-      <h4>⚸ Black Moon Lilith</h4>
+      <h4>Simbol Black Moon Lilith</h4>
       <p>Titik apogee orbit Bulan dalam astrologi, bukan benda langit fisik.</p>
     </a>
     <a href="/id/symbol/simbol-sekop/" class="compare-card variant-muted u-no-underline">

--- a/id/usecase/nama-ff-keren/index.html
+++ b/id/usecase/nama-ff-keren/index.html
@@ -376,7 +376,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Username &amp; nama IG aesthetic buat bio Instagram.</p>
     </a>
     <a href="/id/spasi-kosong/" class="compare-card variant-muted u-no-underline">
-      <h4>Invisible Character</h4>
+      <h4>Spasi Kosong &amp; Karakter Kosong</h4>
       <p>Karakter tak terlihat buat nama FF pakai spasi.</p>
     </a>
   </div>

--- a/id/usecase/nama-guild-ff-keren/index.html
+++ b/id/usecase/nama-guild-ff-keren/index.html
@@ -413,11 +413,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Nickname &amp; font aesthetic buat Mobile Legends.</p>
     </a>
     <a href="/id/library/simbol-ff/" class="compare-card variant-muted u-no-underline">
-      <h4>Free Fire Name Symbols</h4>
+      <h4>Simbol FF ꧁꧂</h4>
       <p>Palet lengkap simbol &amp; karakter buat nick FF.</p>
     </a>
     <a href="/id/spasi-kosong/" class="compare-card variant-muted u-no-underline">
-      <h4>Invisible Character</h4>
+      <h4>Spasi Kosong &amp; Karakter Kosong</h4>
       <p>Karakter tak terlihat buat nama pakai spasi.</p>
     </a>
   </div>

--- a/it/answers/what-font-does-pinterest-use/index.html
+++ b/it/answers/what-font-does-pinterest-use/index.html
@@ -285,7 +285,7 @@
     </a>
     <a href="/it/grassetto/" class="compare-card variant-muted u-no-underline">
       <span class="compare-badge">Tool</span>
-      <h4>Bold Text Generator</h4>
+      <h4>Testo in grassetto da copiare</h4>
       <ul><li>Generate clean bold text for any platform.</li></ul>
     </a>
     <a href="/answers/is-fancy-text-bad-for-seo/" class="compare-card variant-muted u-no-underline">

--- a/it/answers/what-font-does-pinterest-use/index.html
+++ b/it/answers/what-font-does-pinterest-use/index.html
@@ -183,7 +183,7 @@
 
 
 <section class="editorial-section">
-  <span class="article-section-label">Quick answer</span>
+  <span class="article-section-label">Risposta breve</span>
   <div class="editorial-block">
     <p>L'app, il sito e il branding di Pinterest usano tutti Pinterest Sans, un sans-serif geometrico creato su commissione da Grilli Type. La famiglia comprende quattro pesi più un taglio ottimizzato per le dimensioni ridotte, chiamato Pinterest UI. È un font proprietario, realizzato esclusivamente per Pinterest: non è scaricabile né disponibile per la licenza pubblica.</p>
     <p>Se cerchi un'alternativa gratuita dall'aspetto simile da usare nelle tue grafiche, la scelta più vicina è Poppins: un sans-serif geometrico disponibile su Google Fonts, con la stessa rotondità morbida che caratterizza Pinterest Sans.</p>
@@ -193,7 +193,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">The details</span>
+  <span class="article-section-label">In dettaglio</span>
   <h2>Che Font Usa Pinterest?</h2>
 
   <div class="data-table-wrap">
@@ -254,7 +254,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Style your own text</span>
+  <span class="article-section-label">Personalizza il tuo testo</span>
   <h2>Come dare uno stile diverso al testo su Pinterest</h2>
   <div class="editorial-block">
     <p>Pinterest non offre un selettore di font nativo per i pin, le descrizioni, i nomi delle bacheche o la bio: qualsiasi testo che scrivi viene mostrato in Pinterest Sans, punto e basta. L'unico modo per far sembrare il tuo testo scritto con un font diverso è usare caratteri Unicode stilizzati, che appaiono come un font a parte ma vengono trattati da Pinterest come normale testo.</p>
@@ -275,7 +275,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Keep exploring</span>
+  <span class="article-section-label">Continua a esplorare</span>
   <h2>Pagine correlate</h2>
   <div class="compare-grid">
     <a href="/pinterest/" class="compare-card variant-muted u-no-underline">
@@ -300,7 +300,7 @@
 
 <section class="editorial-section" id="faq">
   <span class="article-section-label">FAQ</span>
-  <h2>Frequently Asked Questions</h2>
+  <h2>Domande Frequenti</h2>
   <details class="faq-item">
     <summary class="faq-question">Che font usa Pinterest?</summary>
     <p class="faq-answer">Pinterest usa Pinterest Sans, un sans-serif geometrico creato su commissione dalla fonderia svizzera Grilli Type. È disponibile in quattro pesi più un taglio dedicato alle dimensioni ridotte, Pinterest UI, usato nell'interfaccia di app e sito. È un font proprietario e non è disponibile per il download o la licenza pubblica.</p>

--- a/it/answers/what-font-does-whatsapp-use/index.html
+++ b/it/answers/what-font-does-whatsapp-use/index.html
@@ -263,7 +263,7 @@
   <div class="compare-grid">
     <a href="/it/font-whatsapp/" class="compare-card variant-muted u-no-underline">
       <span class="compare-badge">Tool</span>
-      <h4>WhatsApp Font Generator</h4>
+      <h4>Font per WhatsApp</h4>
       <ul><li>Style your status, group names and messages.</li></ul>
     </a>
     <a href="/guide/whatsapp-text-formatting-explained/" class="compare-card variant-muted u-no-underline">
@@ -273,7 +273,7 @@
     </a>
     <a href="/it/grassetto/" class="compare-card variant-muted u-no-underline">
       <span class="compare-badge">Tool</span>
-      <h4>Bold Text Generator</h4>
+      <h4>Testo in grassetto da copiare</h4>
       <ul><li>Generate clean bold text for any platform.</li></ul>
     </a>
   </div>

--- a/it/answers/what-font-does-whatsapp-use/index.html
+++ b/it/answers/what-font-does-whatsapp-use/index.html
@@ -167,7 +167,7 @@
 
 
 <section class="editorial-section">
-  <span class="article-section-label">Quick answer</span>
+  <span class="article-section-label">Risposta breve</span>
   <div class="editorial-block">
     <p>Il logo e il marchio di WhatsApp usano Helvetica Neue, con larghezze e spaziature leggermente adattate. La finestra della chat, invece, non include alcun font personalizzato: si affida interamente al font di sistema del dispositivo — San Francisco su iPhone, Roboto su Android, Segoe UI su Windows desktop e sul Web.</p>
     <p>È proprio per questo che una stessa conversazione può avere un aspetto leggermente diverso a seconda del dispositivo con cui la leggi: ogni piattaforma disegna il testo con il proprio font di sistema, non con un font scelto da WhatsApp.</p>
@@ -177,7 +177,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">The details</span>
+  <span class="article-section-label">In dettaglio</span>
   <h2>Che Font Usa WhatsApp?</h2>
 
   <div class="data-table-wrap">
@@ -240,7 +240,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Style your own text</span>
+  <span class="article-section-label">Personalizza il tuo testo</span>
   <h2>Come dare stile ai tuoi messaggi WhatsApp</h2>
   <div class="editorial-block">
     <p>WhatsApp supporta nativamente quattro stili di testo tramite semplici simboli digitati durante la scrittura: *grassetto*, _corsivo_, ~barrato~ e ```monospace```. Trovi tutti i dettagli nella nostra <a href="/guide/whatsapp-text-formatting-explained/">guida alla formattazione del testo su WhatsApp</a>.</p>
@@ -258,7 +258,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Keep exploring</span>
+  <span class="article-section-label">Continua a esplorare</span>
   <h2>Pagine correlate</h2>
   <div class="compare-grid">
     <a href="/it/font-whatsapp/" class="compare-card variant-muted u-no-underline">
@@ -283,7 +283,7 @@
 
 <section class="editorial-section" id="faq">
   <span class="article-section-label">FAQ</span>
-  <h2>Frequently Asked Questions</h2>
+  <h2>Domande Frequenti</h2>
   <details class="faq-item">
     <summary class="faq-question">Che font usa WhatsApp?</summary>
     <p class="faq-answer">Il logo di WhatsApp è impostato in Helvetica Neue. La chat, però, non ha nessun font proprio: mostra il font di sistema del dispositivo che stai usando — San Francisco su iPhone, Roboto su Android, Segoe UI su Windows desktop e sul Web.</p>

--- a/it/library/codici-alt/index.html
+++ b/it/library/codici-alt/index.html
@@ -568,11 +568,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Asterisco, croce, virgolette basse e i segni oltre la tastiera.</p>
     </a>
     <a href="/it/library/tabella-ascii/" class="compare-card variant-muted u-no-underline">
-      <h4>ASCII Table</h4>
+      <h4>Tabella ASCII</h4>
       <p>Codici decimali ed esadecimali per ogni carattere ASCII stampabile.</p>
     </a>
     <a href="/it/library/caratteri-speciali-simboli/" class="compare-card variant-muted u-no-underline">
-      <h4>Special Characters</h4>
+      <h4>Caratteri Speciali</h4>
       <p>Un elenco principale di caratteri Unicode speciali da copiare.</p>
     </a>
   </div>

--- a/it/library/simboli-discord/index.html
+++ b/it/library/simboli-discord/index.html
@@ -666,7 +666,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Faccine ASCII ed emoticon giapponesi che funzionano su Discord.</p>
     </a>
     <a href="/it/library/simboli-cuore/" class="compare-card variant-muted u-no-underline">
-      <h4>Heart Symbols</h4>
+      <h4>Simboli cuore ♥</h4>
       <p>Ogni emoji cuore e carattere Unicode a forma di cuore.</p>
     </a>
     <a href="/library/sparkle-symbols/" class="compare-card variant-muted u-no-underline">
@@ -674,7 +674,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Stelle, scintille e caratteri decorativi luminosi.</p>
     </a>
     <a href="/it/library/simboli-parentesi/" class="compare-card variant-muted u-no-underline">
-      <h4>Bracket Symbols</h4>
+      <h4>Parentesi graffa e virgolette caporali</h4>
       <p>Tutti i tipi di parentesi e segni di racchiusura Unicode.</p>
     </a>
     <a href="/answers/discord-allowed-characters/" class="compare-card variant-muted u-no-underline">

--- a/it/library/simboli-y2k/index.html
+++ b/it/library/simboli-y2k/index.html
@@ -788,11 +788,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>100+ font Unicode — per nickname, bio e didascalie.</p>
     </a>
     <a href="/it/library/simboli-stella/" class="compare-card variant-muted u-no-underline">
-      <h4>Star Symbol Collection</h4>
+      <h4>Simboli stella da copiare</h4>
       <p>Stelle e scintille in tutti gli stili.</p>
     </a>
     <a href="/it/library/geroglifici-egizi/" class="compare-card variant-muted u-no-underline">
-      <h4>Egyptian Hieroglyphs</h4>
+      <h4>Geroglifici Egizi</h4>
       <p>Tutti i 1.072 caratteri geroglifici Unicode.</p>
     </a>
   </div>

--- a/it/symbol/croce-ortodossa/index.html
+++ b/it/symbol/croce-ortodossa/index.html
@@ -262,7 +262,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Windows (Word / inserimento Unicode)</td><td><code>2626</code> poi <code>Alt+X</code></td></tr>

--- a/it/symbol/emoji-meteora/index.html
+++ b/it/symbol/emoji-meteora/index.html
@@ -228,7 +228,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Risorse Correlate</span>
   <div class="compare-grid">
     <a href="/it/library/simboli-meteo/" class="compare-card variant-muted u-no-underline">
-      <h4>Weather Symbols</h4>
+      <h4>Simboli meteo ed emoji del tempo</h4>
       <p>Sole, pioggia, neve e ogni carattere celeste già codificato, incluso Comet.</p>
     </a>
     <a href="/it/symbol/emoji-volto-incrinato/" class="compare-card variant-muted u-no-underline">

--- a/it/symbol/emoji-microfono/index.html
+++ b/it/symbol/emoji-microfono/index.html
@@ -244,11 +244,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Ogni emoji di oggetto quotidiano già codificata — tech, casa e ufficio — incluso il microfono, sfogliabile in un'unica griglia.</p>
     </a>
     <a href="/it/combinazioni-emoji/" class="compare-card variant-muted u-no-underline">
-      <h4>Emoji Combos</h4>
+      <h4>Combinazioni di emoji da copiare e incollare</h4>
       <p>Abbinamenti di emoji già pronti per bio e didascalie, inclusi temi musicali e di performance.</p>
     </a>
     <a href="/it/library/simboli-musicali/" class="compare-card variant-muted u-no-underline">
-      <h4>Music Symbols</h4>
+      <h4>Simboli Musicali</h4>
       <p>Notazione musicale Unicode — ♪ ♫ ♬ — la cugina testuale della famiglia delle emoji musicali.</p>
     </a>
   </div>

--- a/it/symbol/freccia-destra/index.html
+++ b/it/symbol/freccia-destra/index.html
@@ -252,7 +252,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Codice Alt su Windows</td><td><code>Alt+26</code></td></tr>

--- a/it/symbol/freccia-giu/index.html
+++ b/it/symbol/freccia-giu/index.html
@@ -247,7 +247,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Codice Alt su Windows</td><td><code>Alt+25</code></td></tr>

--- a/it/symbol/freccia-sinistra/index.html
+++ b/it/symbol/freccia-sinistra/index.html
@@ -247,7 +247,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Codice Alt su Windows</td><td><code>Alt+27</code></td></tr>

--- a/it/symbol/freccia-su/index.html
+++ b/it/symbol/freccia-su/index.html
@@ -247,7 +247,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Codice Alt su Windows</td><td><code>Alt+24</code></td></tr>

--- a/it/symbol/index.html
+++ b/it/symbol/index.html
@@ -254,7 +254,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Virgolette dritte vs curve «tipografiche», e perché confonderle rompe il codice.</p>
     </a>
     <a href="/it/symbol/interrobang/" class="compare-card variant-muted u-no-underline">
-      <h4>‽ Interrobang</h4>
+      <h4>Interrobang (‽)</h4>
       <p>La fusione tra ? e ! coniata da un pubblicitario nel 1962 — per un periodo un vero tasto da macchina da scrivere.</p>
     </a>
     <a href="/it/symbol/simbolo-asterisco/" class="compare-card variant-muted u-no-underline">

--- a/it/symbol/linea-verticale/index.html
+++ b/it/symbol/linea-verticale/index.html
@@ -253,7 +253,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Tastiera (Windows e Mac, layout US)</td><td><code>Shift+\</code></td></tr>

--- a/it/symbol/luna-nera-lilith/index.html
+++ b/it/symbol/luna-nera-lilith/index.html
@@ -258,7 +258,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Word / Windows (input Unicode)</td><td>Digita <code>26B8</code>, poi premi <code>Alt+X</code></td></tr>

--- a/it/symbol/punto-interrogativo-inverso/index.html
+++ b/it/symbol/punto-interrogativo-inverso/index.html
@@ -259,7 +259,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Word / Windows (input Unicode)</td><td>Digita <code>2E2E</code>, poi premi <code>Alt+X</code></td></tr>

--- a/it/symbol/simbolo-acquario/index.html
+++ b/it/symbol/simbolo-acquario/index.html
@@ -298,7 +298,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Windows (Word) — codice esadecimale poi Alt+X</td><td>Digita <code>2652</code> poi <code>Alt+X</code> (dà ♒)</td></tr>

--- a/it/symbol/simbolo-alfa/index.html
+++ b/it/symbol/simbolo-alfa/index.html
@@ -333,7 +333,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Word / Windows (input Unicode)</td><td>Digita <code>0391</code> (Α) o <code>03B1</code> (α), poi premi <code>Alt+X</code></td></tr>

--- a/it/symbol/simbolo-anarchia/index.html
+++ b/it/symbol/simbolo-anarchia/index.html
@@ -264,7 +264,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Word / Windows (input Unicode)</td><td>Digita <code>24B6</code>, poi premi <code>Alt+X</code></td></tr>

--- a/it/symbol/simbolo-ankh/index.html
+++ b/it/symbol/simbolo-ankh/index.html
@@ -261,7 +261,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Windows (Word / inserimento Unicode)</td><td><code>2625</code> poi <code>Alt+X</code></td></tr>

--- a/it/symbol/simbolo-ariete/index.html
+++ b/it/symbol/simbolo-ariete/index.html
@@ -298,7 +298,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Windows (Word) — codice esadecimale poi Alt+X</td><td>Digita <code>2648</code> poi <code>Alt+X</code> (dà ♈)</td></tr>

--- a/it/symbol/simbolo-asterisco/index.html
+++ b/it/symbol/simbolo-asterisco/index.html
@@ -256,7 +256,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Trattini, parentesi, virgolette e la famiglia di punteggiatura quotidiana a cui appartiene l'asterisco.</p>
     </a>
     <a href="/it/library/simboli-tastiera/" class="compare-card variant-muted u-no-underline">
-      <h4>Keyboard Symbols</h4>
+      <h4>Simboli Tastiera</h4>
       <p>L'asterisco, la e commerciale, il cancelletto e il resto dei simboli stampati sulle righe della tastiera.</p>
     </a>
     <a href="/it/symbol/simbolo-stella/" class="compare-card variant-muted u-no-underline">

--- a/it/symbol/simbolo-autismo/index.html
+++ b/it/symbol/simbolo-autismo/index.html
@@ -260,7 +260,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Word / Windows (input Unicode)</td><td>Digita <code>221E</code>, poi premi <code>Alt+X</code></td></tr>

--- a/it/symbol/simbolo-bilancia/index.html
+++ b/it/symbol/simbolo-bilancia/index.html
@@ -298,7 +298,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Windows (Word) — codice esadecimale poi Alt+X</td><td>Digita <code>264E</code> poi <code>Alt+X</code> (dà ♎)</td></tr>

--- a/it/symbol/simbolo-cancro/index.html
+++ b/it/symbol/simbolo-cancro/index.html
@@ -298,7 +298,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Windows (Word) — codice esadecimale poi Alt+X</td><td>Digita <code>264B</code> poi <code>Alt+X</code> (dà ♋)</td></tr>

--- a/it/symbol/simbolo-capricorno/index.html
+++ b/it/symbol/simbolo-capricorno/index.html
@@ -298,7 +298,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Windows (Word) — codice esadecimale poi Alt+X</td><td>Digita <code>2651</code> poi <code>Alt+X</code> (dà ♑)</td></tr>

--- a/it/symbol/simbolo-carattere-invisibile/index.html
+++ b/it/symbol/simbolo-carattere-invisibile/index.html
@@ -253,7 +253,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Tastiera italiana</td><td>Nessuna combinazione dedicata — copialo da questa pagina</td></tr>

--- a/it/symbol/simbolo-centesimo/index.html
+++ b/it/symbol/simbolo-centesimo/index.html
@@ -266,7 +266,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Codice Alt su Windows</td><td><code>Alt+0162</code> sul tastierino numerico</td></tr>

--- a/it/symbol/simbolo-chi/index.html
+++ b/it/symbol/simbolo-chi/index.html
@@ -288,11 +288,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>L'intero alfabeto greco in maiuscolo, minuscolo e nelle varianti matematiche, da copiare e incollare.</p>
     </a>
     <a href="/it/library/simboli-matematici/" class="compare-card variant-muted u-no-underline">
-      <h4>Math Symbols</h4>
+      <h4>Simboli Matematici</h4>
       <p>Chi-quadrato, apici e gli operatori e le lettere greche che completano un'equazione.</p>
     </a>
     <a href="/it/library/simboli-religiosi/" class="compare-card variant-muted u-no-underline">
-      <h4>Religious Symbols</h4>
+      <h4>Simboli Religiosi e Spirituali</h4>
       <p>Il Chi-Rho, le croci e altri simboli cristiani e religiosi raccolti in un unico riferimento.</p>
     </a>
     <a href="/it/symbol/simbolo-pi-greco/" class="compare-card variant-muted u-no-underline">

--- a/it/symbol/simbolo-chiocciola/index.html
+++ b/it/symbol/simbolo-chiocciola/index.html
@@ -257,7 +257,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Tastiera (Windows e Mac, layout US)</td><td><code>Shift+2</code></td></tr>

--- a/it/symbol/simbolo-congruente/index.html
+++ b/it/symbol/simbolo-congruente/index.html
@@ -257,7 +257,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Windows (Word)</td><td>Digita <code>2245</code> e poi premi <code>Alt+X</code></td></tr>

--- a/it/symbol/simbolo-copyright/index.html
+++ b/it/symbol/simbolo-copyright/index.html
@@ -253,7 +253,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Codice Alt su Windows</td><td><code>Alt+0169</code></td></tr>

--- a/it/symbol/simbolo-croce/index.html
+++ b/it/symbol/simbolo-croce/index.html
@@ -258,7 +258,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Windows (Word / input Unicode)</td><td>Digita <code>271D</code>, poi premi <code>Alt+X</code></td></tr>

--- a/it/symbol/simbolo-cuore/index.html
+++ b/it/symbol/simbolo-cuore/index.html
@@ -350,7 +350,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Codice Alt su Windows (classico)</td><td><code>Alt+3</code> sul tastierino numerico → ♥</td></tr>

--- a/it/symbol/simbolo-della-pace/index.html
+++ b/it/symbol/simbolo-della-pace/index.html
@@ -253,7 +253,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Windows (Word)</td><td>Digita <code>262E</code>, poi premi <code>Alt+X</code></td></tr>
@@ -327,7 +327,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Simboli collegati</span>
   <div class="compare-grid">
     <a href="/it/symbol/simbolo-yin-yang/" class="compare-card variant-muted u-no-underline">
-      <h4>☯ Yin Yang</h4>
+      <h4>Simbolo yin yang (☯)</h4>
       <p>L'antica filosofia cinese dietro la spirale.</p>
     </a>
     <a href="/it/symbol/simbolo-croce/" class="compare-card variant-muted u-no-underline">

--- a/it/symbol/simbolo-delta/index.html
+++ b/it/symbol/simbolo-delta/index.html
@@ -286,7 +286,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Windows / Word (maiuscola Δ)</td><td>digita <code>0394</code> poi <code>Alt+X</code></td></tr>

--- a/it/symbol/simbolo-di-paragrafo/index.html
+++ b/it/symbol/simbolo-di-paragrafo/index.html
@@ -252,7 +252,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Codice Alt su Windows</td><td><code>Alt+0182</code></td></tr>

--- a/it/symbol/simbolo-di-sezione/index.html
+++ b/it/symbol/simbolo-di-sezione/index.html
@@ -252,7 +252,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Codice Alt su Windows</td><td><code>Alt+0167</code></td></tr>

--- a/it/symbol/simbolo-di-spunta/index.html
+++ b/it/symbol/simbolo-di-spunta/index.html
@@ -317,7 +317,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Windows (Word / input Unicode)</td><td>digita <code>2713</code> (✓) o <code>2714</code> (✔), poi <code>Alt+X</code></td></tr>

--- a/it/symbol/simbolo-diametro/index.html
+++ b/it/symbol/simbolo-diametro/index.html
@@ -314,7 +314,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>AutoCAD</td><td><code>%%C</code> — lo converte automaticamente in ⌀</td></tr>

--- a/it/symbol/simbolo-diverso/index.html
+++ b/it/symbol/simbolo-diverso/index.html
@@ -321,7 +321,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Mac</td><td><code>Option+=</code> (il ≠ compare direttamente)</td></tr>

--- a/it/symbol/simbolo-divisione/index.html
+++ b/it/symbol/simbolo-divisione/index.html
@@ -283,7 +283,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Codice Alt su Windows</td><td><code>Alt+0247</code></td></tr>

--- a/it/symbol/simbolo-dollaro/index.html
+++ b/it/symbol/simbolo-dollaro/index.html
@@ -283,7 +283,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Tastiera italiana</td><td><code>Maiusc+4</code> (tasto dedicato)</td></tr>

--- a/it/symbol/simbolo-e-commerciale/index.html
+++ b/it/symbol/simbolo-e-commerciale/index.html
@@ -253,7 +253,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Tastiera (Windows e Mac, layout US)</td><td><code>Shift+7</code></td></tr>

--- a/it/symbol/simbolo-euro/index.html
+++ b/it/symbol/simbolo-euro/index.html
@@ -263,7 +263,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Codice Alt su Windows</td><td><code>Alt+0128</code> (oppure <code>Ctrl+Alt+E</code> su molti layout europei)</td></tr>

--- a/it/symbol/simbolo-fleur-de-lis/index.html
+++ b/it/symbol/simbolo-fleur-de-lis/index.html
@@ -336,7 +336,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Windows (Word / input Unicode)</td><td>digita <code>269C</code>, poi <code>Alt+X</code></td></tr>

--- a/it/symbol/simbolo-gemelli/index.html
+++ b/it/symbol/simbolo-gemelli/index.html
@@ -298,7 +298,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Windows (Word) — codice esadecimale poi Alt+X</td><td>Digita <code>264A</code> poi <code>Alt+X</code> (dà ♊)</td></tr>

--- a/it/symbol/simbolo-gradi/index.html
+++ b/it/symbol/simbolo-gradi/index.html
@@ -277,7 +277,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Codice Alt su Windows</td><td><code>Alt+0176</code></td></tr>

--- a/it/symbol/simbolo-hamsa/index.html
+++ b/it/symbol/simbolo-hamsa/index.html
@@ -261,7 +261,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Windows (Word / inserimento Unicode)</td><td><code>1FAAC</code> poi <code>Alt+X</code></td></tr>

--- a/it/symbol/simbolo-infinito/index.html
+++ b/it/symbol/simbolo-infinito/index.html
@@ -279,7 +279,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Codice Alt su Windows</td><td><code>Alt+8734</code></td></tr>

--- a/it/symbol/simbolo-khanda/index.html
+++ b/it/symbol/simbolo-khanda/index.html
@@ -265,7 +265,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Windows (Word / inserimento Unicode)</td><td><code>262C</code> (Adi Shakti) oppure <code>1FAAF</code> (emoji khanda), poi <code>Alt+X</code></td></tr>

--- a/it/symbol/simbolo-lambda/index.html
+++ b/it/symbol/simbolo-lambda/index.html
@@ -267,7 +267,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>L'intero alfabeto greco — alfa, lambda, pi, sigma, omega — in maiuscolo e minuscolo, da copiare e incollare.</p>
     </a>
     <a href="/it/library/simboli-matematici/" class="compare-card variant-muted u-no-underline">
-      <h4>Math Symbols</h4>
+      <h4>Simboli Matematici</h4>
       <p>Lunghezza d'onda, costante cosmologica, e gli operatori e le lettere greche che completano un'equazione.</p>
     </a>
     <a href="/library/pride-lgbtq-symbols/" class="compare-card variant-muted u-no-underline">

--- a/it/symbol/simbolo-leone/index.html
+++ b/it/symbol/simbolo-leone/index.html
@@ -298,7 +298,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Windows (Word) — codice esadecimale poi Alt+X</td><td>Digita <code>264C</code> poi <code>Alt+X</code> (dà ♌)</td></tr>

--- a/it/symbol/simbolo-marchio/index.html
+++ b/it/symbol/simbolo-marchio/index.html
@@ -252,7 +252,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Codice Alt su Windows</td><td><code>Alt+0153</code></td></tr>

--- a/it/symbol/simbolo-micro/index.html
+++ b/it/symbol/simbolo-micro/index.html
@@ -259,7 +259,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Codice Alt su Windows (ereditato)</td><td><code>Alt+0181</code> — segno micro (posizione Windows-1252)</td></tr>

--- a/it/symbol/simbolo-minore-o-uguale/index.html
+++ b/it/symbol/simbolo-minore-o-uguale/index.html
@@ -244,7 +244,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Risorse Correlate</span>
   <div class="compare-grid">
     <a href="/it/library/simboli-matematici/" class="compare-card variant-muted u-no-underline">
-      <h4>Math Symbols</h4>
+      <h4>Simboli Matematici</h4>
       <p>Operatori, notazione degli insiemi e costanti matematiche in un unico riferimento sfogliabile.</p>
     </a>
     <a href="/it/symbol/simbolo-diverso/" class="compare-card variant-muted u-no-underline">

--- a/it/symbol/simbolo-moltiplicazione/index.html
+++ b/it/symbol/simbolo-moltiplicazione/index.html
@@ -294,7 +294,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Codice Alt su Windows</td><td><code>Alt+0215</code></td></tr>

--- a/it/symbol/simbolo-ohm/index.html
+++ b/it/symbol/simbolo-ohm/index.html
@@ -261,7 +261,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Word / Windows (segno ohm)</td><td><code>2126</code> poi <code>Alt+X</code></td></tr>

--- a/it/symbol/simbolo-om/index.html
+++ b/it/symbol/simbolo-om/index.html
@@ -260,7 +260,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Word / Windows (inserimento Unicode)</td><td><code>0950</code> poi <code>Alt+X</code></td></tr>

--- a/it/symbol/simbolo-omega/index.html
+++ b/it/symbol/simbolo-omega/index.html
@@ -259,7 +259,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Codice Alt su Windows</td><td><code>Alt+234</code> (dà Ω)</td></tr>

--- a/it/symbol/simbolo-pedone/index.html
+++ b/it/symbol/simbolo-pedone/index.html
@@ -277,8 +277,8 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <h4>Simboli degli Scacchi</h4>
       <p>L'intero set Unicode degli scacchi — re, regine, torri, alfieri, cavalli ed entrambi i pedoni — in un unico riferimento da copiare e incollare.</p>
     </a>
-    <a href="/library/card-suit-symbols/" class="compare-card variant-muted u-no-underline">
-      <h4>Card Suit Symbols</h4>
+    <a href="/it/library/simboli-carte-da-gioco/" class="compare-card variant-muted u-no-underline">
+      <h4>Simboli delle carte da gioco ♠ ♥ ♦ ♣</h4>
       <p>Picche, cuori, quadri e fiori — gli altri glifi da gioco, proprio accanto ai pezzi degli scacchi nel blocco Miscellaneous Symbols di Unicode.</p>
     </a>
     <a href="/library/crown-royalty-symbols/" class="compare-card variant-muted u-no-underline">

--- a/it/symbol/simbolo-pedone/index.html
+++ b/it/symbol/simbolo-pedone/index.html
@@ -274,7 +274,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Risorse Correlate</span>
   <div class="compare-grid">
     <a href="/it/library/simboli-scacchi/" class="compare-card variant-muted u-no-underline">
-      <h4>Chess Symbols</h4>
+      <h4>Simboli degli Scacchi</h4>
       <p>L'intero set Unicode degli scacchi — re, regine, torri, alfieri, cavalli ed entrambi i pedoni — in un unico riferimento da copiare e incollare.</p>
     </a>
     <a href="/library/card-suit-symbols/" class="compare-card variant-muted u-no-underline">

--- a/it/symbol/simbolo-pentagramma/index.html
+++ b/it/symbol/simbolo-pentagramma/index.html
@@ -263,7 +263,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Word / Windows (input Unicode)</td><td>Digita <code>26E4</code>, poi premi <code>Alt+X</code></td></tr>

--- a/it/symbol/simbolo-pesci/index.html
+++ b/it/symbol/simbolo-pesci/index.html
@@ -298,7 +298,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Windows (Word) — codice esadecimale poi Alt+X</td><td>Digita <code>2653</code> poi <code>Alt+X</code> (dà ♓)</td></tr>

--- a/it/symbol/simbolo-phi/index.html
+++ b/it/symbol/simbolo-phi/index.html
@@ -249,7 +249,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>L'intero alfabeto greco in maiuscolo, minuscolo e nelle varianti matematiche, da copiare e incollare.</p>
     </a>
     <a href="/it/library/simboli-matematici/" class="compare-card variant-muted u-no-underline">
-      <h4>Math Symbols</h4>
+      <h4>Simboli Matematici</h4>
       <p>La sezione aurea, la radice quadrata e gli operatori e le lettere greche che completano un'equazione.</p>
     </a>
     <a href="/it/symbol/simbolo-pi-greco/" class="compare-card variant-muted u-no-underline">

--- a/it/symbol/simbolo-pi-greco/index.html
+++ b/it/symbol/simbolo-pi-greco/index.html
@@ -286,7 +286,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Codice Alt su Windows</td><td><code>Alt+227</code> (dà π)</td></tr>

--- a/it/symbol/simbolo-piu-meno/index.html
+++ b/it/symbol/simbolo-piu-meno/index.html
@@ -253,7 +253,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Codice Alt su Windows</td><td><code>Alt+0177</code></td></tr>

--- a/it/symbol/simbolo-psi/index.html
+++ b/it/symbol/simbolo-psi/index.html
@@ -262,7 +262,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>L'intero alfabeto greco in maiuscolo, minuscolo e nelle varianti matematiche, da copiare e incollare.</p>
     </a>
     <a href="/it/library/simboli-matematici/" class="compare-card variant-muted u-no-underline">
-      <h4>Math Symbols</h4>
+      <h4>Simboli Matematici</h4>
       <p>Funzioni d'onda, operatori e le lettere greche che completano un'equazione di fisica o matematica.</p>
     </a>
     <a href="/it/symbol/simbolo-omega/" class="compare-card variant-muted u-no-underline">

--- a/it/symbol/simbolo-rabbia/index.html
+++ b/it/symbol/simbolo-rabbia/index.html
@@ -253,7 +253,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Word / Windows (input Unicode)</td><td>Digita <code>1F4A2</code>, poi premi <code>Alt+X</code></td></tr>

--- a/it/symbol/simbolo-radice-quadrata/index.html
+++ b/it/symbol/simbolo-radice-quadrata/index.html
@@ -291,7 +291,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Codice Alt su Windows</td><td><code>Alt+251</code></td></tr>

--- a/it/symbol/simbolo-riciclo/index.html
+++ b/it/symbol/simbolo-riciclo/index.html
@@ -340,7 +340,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Windows (Word / input Unicode)</td><td>digita <code>267B</code>, poi <code>Alt+X</code></td></tr>

--- a/it/symbol/simbolo-rischio-biologico/index.html
+++ b/it/symbol/simbolo-rischio-biologico/index.html
@@ -260,7 +260,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Word / Windows (input Unicode)</td><td>Digita <code>2623</code>, poi premi <code>Alt+X</code></td></tr>

--- a/it/symbol/simbolo-rupia/index.html
+++ b/it/symbol/simbolo-rupia/index.html
@@ -262,7 +262,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Windows (Word)</td><td>Digita <code>20B9</code> poi premi <code>Alt+X</code></td></tr>

--- a/it/symbol/simbolo-sagittario/index.html
+++ b/it/symbol/simbolo-sagittario/index.html
@@ -298,7 +298,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Windows (Word) — codice esadecimale poi Alt+X</td><td>Digita <code>2650</code> poi <code>Alt+X</code> (dà ♐)</td></tr>

--- a/it/symbol/simbolo-scorpione/index.html
+++ b/it/symbol/simbolo-scorpione/index.html
@@ -298,7 +298,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Windows (Word) — codice esadecimale poi Alt+X</td><td>Digita <code>264F</code> poi <code>Alt+X</code> (dà ♏)</td></tr>

--- a/it/symbol/simbolo-sedia-a-rotelle/index.html
+++ b/it/symbol/simbolo-sedia-a-rotelle/index.html
@@ -298,7 +298,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Piattaforma / strumento</th><th>Input</th></tr>
+        <tr><th>Piattaforma / strumento</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Word / Windows (input Unicode)</td><td>Digita <code>267F</code>, poi premi <code>Alt+X</code></td></tr>

--- a/it/symbol/simbolo-sigma/index.html
+++ b/it/symbol/simbolo-sigma/index.html
@@ -334,7 +334,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Piattaforma / strumento</th><th>Input</th></tr>
+        <tr><th>Piattaforma / strumento</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Word / Windows (input Unicode)</td><td>Digita <code>03A3</code> (Σ) o <code>03C3</code> (σ), poi premi <code>Alt+X</code></td></tr>

--- a/it/symbol/simbolo-stella/index.html
+++ b/it/symbol/simbolo-stella/index.html
@@ -342,7 +342,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Windows (Word / input Unicode)</td><td>digita <code>2605</code> (★) o <code>2606</code> (☆), poi <code>Alt+X</code></td></tr>

--- a/it/symbol/simbolo-sterlina/index.html
+++ b/it/symbol/simbolo-sterlina/index.html
@@ -262,7 +262,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Tastiera italiana</td><td><code>Maiusc+3</code> (tasto dedicato)</td></tr>

--- a/it/symbol/simbolo-stop/index.html
+++ b/it/symbol/simbolo-stop/index.html
@@ -259,7 +259,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Windows (tastiera degli emoji)</td><td><code>Win+.</code> (punto), poi cerca «stop»</td></tr>

--- a/it/symbol/simbolo-theta/index.html
+++ b/it/symbol/simbolo-theta/index.html
@@ -253,7 +253,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>L'intero alfabeto greco in maiuscolo, minuscolo e nelle varianti matematiche, da copiare e incollare.</p>
     </a>
     <a href="/it/library/simboli-matematici/" class="compare-card variant-muted u-no-underline">
-      <h4>Math Symbols</h4>
+      <h4>Simboli Matematici</h4>
       <p>Angoli, operatori e le lettere greche come theta che completano un'equazione.</p>
     </a>
     <a href="/it/symbol/simbolo-omega/" class="compare-card variant-muted u-no-underline">

--- a/it/symbol/simbolo-toro/index.html
+++ b/it/symbol/simbolo-toro/index.html
@@ -298,7 +298,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Windows (Word) — codice esadecimale poi Alt+X</td><td>Digita <code>2649</code> poi <code>Alt+X</code> (dà ♉)</td></tr>

--- a/it/symbol/simbolo-vergine/index.html
+++ b/it/symbol/simbolo-vergine/index.html
@@ -298,7 +298,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Windows (Word) — codice esadecimale poi Alt+X</td><td>Digita <code>264D</code> poi <code>Alt+X</code> (dà ♍)</td></tr>

--- a/it/symbol/simbolo-won/index.html
+++ b/it/symbol/simbolo-won/index.html
@@ -262,7 +262,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Windows (Word)</td><td>Digita <code>20A9</code> poi premi <code>Alt+X</code></td></tr>

--- a/it/symbol/simbolo-yen/index.html
+++ b/it/symbol/simbolo-yen/index.html
@@ -262,7 +262,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Codice Alt su Windows</td><td><code>Alt+0165</code></td></tr>

--- a/it/symbol/simbolo-yin-yang/index.html
+++ b/it/symbol/simbolo-yin-yang/index.html
@@ -253,7 +253,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Windows (Word)</td><td>Digita <code>262F</code>, poi premi <code>Alt+X</code></td></tr>

--- a/it/symbol/stella-di-david/index.html
+++ b/it/symbol/stella-di-david/index.html
@@ -266,7 +266,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Windows (Word / inserimento Unicode)</td><td><code>2721</code> poi <code>Alt+X</code></td></tr>

--- a/it/symbol/stella-e-mezzaluna/index.html
+++ b/it/symbol/stella-e-mezzaluna/index.html
@@ -256,11 +256,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Risorse Correlate</span>
   <div class="compare-grid">
     <a href="/it/library/simboli-religiosi/" class="compare-card variant-muted u-no-underline">
-      <h4>Religious Symbols</h4>
+      <h4>Simboli Religiosi e Spirituali</h4>
       <p>Simboli religiosi di ogni grande fede mondiale in un unico riferimento sfogliabile.</p>
     </a>
     <a href="/it/library/simboli-islamici/" class="compare-card variant-muted u-no-underline">
-      <h4>Islamic Symbols</h4>
+      <h4>Simboli Islamici</h4>
       <p>La stella e mezzaluna insieme alla calligrafia di Allah, la moschea, la preghiera e altri simboli legati all'Islam.</p>
     </a>
     <a href="/it/symbol/stella-di-david/" class="compare-card variant-muted u-no-underline">

--- a/it/symbol/trattino-lungo/index.html
+++ b/it/symbol/trattino-lungo/index.html
@@ -259,7 +259,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="data-table-wrap">
     <table class="data-table">
       <thead>
-        <tr><th>Metodo</th><th>Input</th></tr>
+        <tr><th>Metodo</th><th>Inserimento</th></tr>
       </thead>
       <tbody>
         <tr><td>Codice Alt su Windows</td><td><code>Alt+0151</code> per — (<code>Alt+0150</code> per il trattino medio –)</td></tr>

--- a/ja/answers/what-font-does-pinterest-use/index.html
+++ b/ja/answers/what-font-does-pinterest-use/index.html
@@ -183,7 +183,7 @@
 
 
 <section class="editorial-section">
-  <span class="article-section-label">Quick answer</span>
+  <span class="article-section-label">かんたんな答え</span>
   <div class="editorial-block">
     <p>Pinterestのアプリやウェブサイト、ブランディングで使われているフォントは、スイスのタイプファウンドリーGrilli Typeが手がけた専用書体「Pinterest Sans」です。4種類のウェイトに加え、小さいサイズ向けに最適化された「Pinterest UI」というカットも用意されています。Pinterest専用に作られたプロプライエタリ(非公開)書体で、一般には配布・ライセンス提供されていません。</p>
     <p>Pinterestらしい雰囲気を無料で再現したい場合は、幾何学的でどこか温かみのあるサンセリフ体Poppinsがもっとも近い代替フォントです。</p>
@@ -193,7 +193,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">The details</span>
+  <span class="article-section-label">詳細</span>
   <h2>Pinterestのフォントは何ですか?</h2>
 
   <div class="data-table-wrap">
@@ -254,7 +254,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Style your own text</span>
+  <span class="article-section-label">自分のテキストを装飾</span>
   <h2>自分のPinterestの文字を装飾するには</h2>
   <div class="editorial-block">
     <p>ピンの説明文やボード名、プロフィールには、フォントを直接変更できる機能がありません。見た目のフォントを変えたい場合は、Unicodeの装飾文字を使うのが一般的な方法です。装飾文字は見た目こそ別のフォントのようですが、実際には通常のテキストとして扱われるため、どこにでも貼り付けて使えます。</p>
@@ -275,7 +275,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Keep exploring</span>
+  <span class="article-section-label">関連ページ</span>
   <h2>関連ページ</h2>
   <div class="compare-grid">
     <a href="/pinterest/" class="compare-card variant-muted u-no-underline">
@@ -300,7 +300,7 @@
 
 <section class="editorial-section" id="faq">
   <span class="article-section-label">FAQ</span>
-  <h2>Frequently Asked Questions</h2>
+  <h2>よくある質問</h2>
   <details class="faq-item">
     <summary class="faq-question">Pinterestではどんなフォントが使われていますか?</summary>
     <p class="faq-answer">PinterestではスイスのタイプファウンドリーGrilli Typeが専用に開発した幾何学的サンセリフ体「Pinterest Sans」が使われています。4種類のウェイトと、小さいサイズ向けの「Pinterest UI」カットがあり、Pinterest以外では公式に配布・ライセンス提供されていないプロプライエタリ書体です。</p>

--- a/ja/answers/what-font-does-whatsapp-use/index.html
+++ b/ja/answers/what-font-does-whatsapp-use/index.html
@@ -167,7 +167,7 @@
 
 
 <section class="editorial-section">
-  <span class="article-section-label">Quick answer</span>
+  <span class="article-section-label">かんたんな答え</span>
   <div class="editorial-block">
     <p>WhatsAppのロゴ・ワードマークにはHelvetica Neue(幅や字間を若干調整したもの)が使われています。一方でチャット画面には専用に組み込まれたフォントは存在せず、表示はすべて端末側のシステムフォントに委ねられています。具体的には、iPhoneではSan Francisco、AndroidではRoboto、Windowsデスクトップ版・Web版ではSegoe UIが使われます。</p>
     <p>そのため、同じメッセージでも使っている端末によって文字の見え方が微妙に異なります。これは自分の設定がおかしいのではなく、WhatsAppの仕様によるものです。</p>
@@ -177,7 +177,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">The details</span>
+  <span class="article-section-label">詳細</span>
   <h2>WhatsAppのフォントは何ですか?</h2>
 
   <div class="data-table-wrap">
@@ -240,7 +240,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Style your own text</span>
+  <span class="article-section-label">自分のテキストを装飾</span>
   <h2>自分のWhatsAppメッセージを装飾するには</h2>
   <div class="editorial-block">
     <p>WhatsAppは*太字*、_斜体_、~取り消し線~、```等幅フォント```という4種類のスタイルをネイティブでサポートしています。詳しい入力方法は<a href="/guide/whatsapp-text-formatting-explained/">WhatsAppの文字装飾ガイド</a>で解説しています。</p>
@@ -258,7 +258,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Keep exploring</span>
+  <span class="article-section-label">関連ページ</span>
   <h2>関連ページ</h2>
   <div class="compare-grid">
     <a href="/whatsapp/" class="compare-card variant-muted u-no-underline">
@@ -283,7 +283,7 @@
 
 <section class="editorial-section" id="faq">
   <span class="article-section-label">FAQ</span>
-  <h2>Frequently Asked Questions</h2>
+  <h2>よくある質問</h2>
   <details class="faq-item">
     <summary class="faq-question">WhatsAppではどんなフォントが使われていますか?</summary>
     <p class="faq-answer">WhatsAppのロゴにはHelvetica Neueが使われていますが、チャット画面には専用のフォントは組み込まれておらず、iPhoneではSan Francisco、AndroidではRoboto、Windowsのデスクトップ版・Web版ではSegoe UIといった、それぞれの端末のシステムフォントで表示されます。</p>

--- a/ms/library/ruang-kosong/index.html
+++ b/ms/library/ruang-kosong/index.html
@@ -325,7 +325,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">Halaman Berkaitan</span>
   <div class="compare-grid">
     <a href="/ms/symbol/aksara-tak-nampak/" class="compare-card variant-muted u-no-underline">
       <h4>Aksara Tak Nampak (⠀)</h4>

--- a/ms/symbol/aksara-tak-nampak/index.html
+++ b/ms/symbol/aksara-tak-nampak/index.html
@@ -231,7 +231,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">Halaman Berkaitan</span>
   <div class="compare-grid">
     <a href="/ms/library/ruang-kosong/" class="compare-card variant-muted u-no-underline">
       <h4>Semua Aksara Kosong</h4>

--- a/ms/usecase/nama-ff-hebat/index.html
+++ b/ms/usecase/nama-ff-hebat/index.html
@@ -333,11 +333,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Bold Unicode untuk nama, bio, dan nickname yang terus menonjol.</p>
     </a>
     <a href="/ms/library/ruang-kosong/" class="compare-card variant-muted u-no-underline">
-      <h4>Invisible Character</h4>
+      <h4>Ruang Kosong &amp; Aksara Kosong</h4>
       <p>Aksara tak kelihatan untuk nama FF pakai ruang.</p>
     </a>
     <a href="/ms/usecase/nama-ff-hebat/" class="compare-card variant-muted u-no-underline">
-      <h4>Free Fire Name Generator</h4>
+      <h4>Nama FF Hebat</h4>
       <p>Hub antarabangsa untuk nickname Free Fire bergaya &amp; aesthetic.</p>
     </a>
   </div>

--- a/ms/usecase/nama-ml-hebat/index.html
+++ b/ms/usecase/nama-ml-hebat/index.html
@@ -294,7 +294,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Palet lengkap simbol &amp; aksara untuk nick Mobile Legends.</p>
     </a>
     <a href="/ms/usecase/nama-ml-hebat/" class="compare-card variant-muted u-no-underline">
-      <h4>Nickname Generator</h4>
+      <h4>Nama ML Hebat</h4>
       <p>Hub nama bergaya &amp; aesthetic untuk semua game dan media sosial.</p>
     </a>
   </div>

--- a/nl/answers/what-font-does-pinterest-use/index.html
+++ b/nl/answers/what-font-does-pinterest-use/index.html
@@ -285,7 +285,7 @@
     </a>
     <a href="/nl/vetgedrukte-letters/" class="compare-card variant-muted u-no-underline">
       <span class="compare-badge">Tool</span>
-      <h4>Bold Text Generator</h4>
+      <h4>Vetgedrukte letters om te kopiëren en plakken</h4>
       <ul><li>Generate clean bold text for any platform.</li></ul>
     </a>
     <a href="/answers/is-fancy-text-bad-for-seo/" class="compare-card variant-muted u-no-underline">

--- a/nl/answers/what-font-does-pinterest-use/index.html
+++ b/nl/answers/what-font-does-pinterest-use/index.html
@@ -183,7 +183,7 @@
 
 
 <section class="editorial-section">
-  <span class="article-section-label">Quick answer</span>
+  <span class="article-section-label">Kort antwoord</span>
   <div class="editorial-block">
     <p>Pinterest gebruikt Pinterest Sans, een custom geometrisch schreefloos lettertype dat in opdracht is ontworpen door Grilli Type, een Zwitsers lettertypehuis. Het bestaat uit vier gewichten plus een aparte kleine-maatuitvoering genaamd Pinterest UI, en is volledig eigendom van Pinterest — je kunt het nergens downloaden of licentiëren.</p>
     <p>Wil je zelf iets vergelijkbaars gebruiken? Poppins is de dichtstbijzijnde gratis look-alike: een geometrisch schreefloos lettertype op Google Fonts met dezelfde ronde warmte.</p>
@@ -193,7 +193,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">The details</span>
+  <span class="article-section-label">De details</span>
   <h2>Welk lettertype gebruikt Pinterest?</h2>
 
   <div class="data-table-wrap">
@@ -254,7 +254,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Style your own text</span>
+  <span class="article-section-label">Zelf tekst stylen</span>
   <h2>Zelf tekst stylen voor Pinterest</h2>
   <div class="editorial-block">
     <p>Pinterest heeft geen ingebouwde lettertypekiezer voor pins, beschrijvingen, bordnamen of je bio. De oplossing is gestileerde Unicode-tekens: tekens die eruitzien als een ander lettertype, maar door Pinterest — en door je browser — gewoon als normale tekst worden behandeld.</p>
@@ -275,7 +275,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Keep exploring</span>
+  <span class="article-section-label">Verder kijken</span>
   <h2>Gerelateerde pagina's</h2>
   <div class="compare-grid">
     <a href="/pinterest/" class="compare-card variant-muted u-no-underline">
@@ -300,7 +300,7 @@
 
 <section class="editorial-section" id="faq">
   <span class="article-section-label">FAQ</span>
-  <h2>Frequently Asked Questions</h2>
+  <h2>Veelgestelde Vragen</h2>
   <details class="faq-item">
     <summary class="faq-question">Welk lettertype gebruikt Pinterest?</summary>
     <p class="faq-answer">Pinterest gebruikt Pinterest Sans, een custom geometrisch schreefloos lettertype dat Grilli Type — een Zwitsers lettertypehuis — exclusief voor Pinterest heeft ontworpen. Het is er in vier gewichten plus een kleine-maatuitvoering, Pinterest UI, die specifiek voor de interface wordt gebruikt. Het lettertype is proprietary: het is nergens te downloaden of te licentiëren.</p>

--- a/nl/answers/what-font-does-whatsapp-use/index.html
+++ b/nl/answers/what-font-does-whatsapp-use/index.html
@@ -273,7 +273,7 @@
     </a>
     <a href="/nl/vetgedrukte-letters/" class="compare-card variant-muted u-no-underline">
       <span class="compare-badge">Tool</span>
-      <h4>Bold Text Generator</h4>
+      <h4>Vetgedrukte letters om te kopiëren en plakken</h4>
       <ul><li>Generate clean bold text for any platform.</li></ul>
     </a>
   </div>

--- a/nl/answers/what-font-does-whatsapp-use/index.html
+++ b/nl/answers/what-font-does-whatsapp-use/index.html
@@ -167,7 +167,7 @@
 
 
 <section class="editorial-section">
-  <span class="article-section-label">Quick answer</span>
+  <span class="article-section-label">Kort antwoord</span>
   <div class="editorial-block">
     <p>Het WhatsApp-logo en de merknaam zijn gezet in Helvetica Neue, met licht aangepaste breedtes en spatiëring. De chatinterface zelf gebruikt echter geen los meegeleverd lettertype — WhatsApp vertrouwt daar volledig op het systeemlettertype van je apparaat: San Francisco op iPhone, Roboto op Android en Segoe UI op Windows-desktop en de webversie.</p>
     <p>Dat is precies waarom een gesprek er op de telefoon van een vriend net iets anders uitziet: niet WhatsApp, maar het besturingssysteem bepaalt welk lettertype je chats toont.</p>
@@ -177,7 +177,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">The details</span>
+  <span class="article-section-label">De details</span>
   <h2>Welk lettertype gebruikt WhatsApp?</h2>
 
   <div class="data-table-wrap">
@@ -240,7 +240,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Style your own text</span>
+  <span class="article-section-label">Zelf tekst stylen</span>
   <h2>Zelf tekst stylen in WhatsApp</h2>
   <div class="editorial-block">
     <p>WhatsApp ondersteunt native vier opmaakstijlen via typsymbolen: *vet*, _cursief_, ~doorgehaald~ en ```monospace```. Hoe dat precies werkt, lees je in de <a href="/guide/whatsapp-text-formatting-explained/">WhatsApp-opmaakgids</a>.</p>
@@ -258,7 +258,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Keep exploring</span>
+  <span class="article-section-label">Verder kijken</span>
   <h2>Gerelateerde pagina's</h2>
   <div class="compare-grid">
     <a href="/whatsapp/" class="compare-card variant-muted u-no-underline">
@@ -283,7 +283,7 @@
 
 <section class="editorial-section" id="faq">
   <span class="article-section-label">FAQ</span>
-  <h2>Frequently Asked Questions</h2>
+  <h2>Veelgestelde Vragen</h2>
   <details class="faq-item">
     <summary class="faq-question">Welk lettertype gebruikt WhatsApp?</summary>
     <p class="faq-answer">Het WhatsApp-logo is gezet in Helvetica Neue, met licht aangepaste breedtes en spatiëring. De chatinterface zelf heeft geen eigen meegeleverd lettertype: die gebruikt het systeemlettertype van je apparaat — San Francisco op iPhone, Roboto op Android en Segoe UI op Windows-desktop en de webversie.</p>

--- a/nl/symbol/bitcoin-teken/index.html
+++ b/nl/symbol/bitcoin-teken/index.html
@@ -249,7 +249,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Gerelateerde Bronnen</span>
   <div class="compare-grid">
     <a href="/nl/library/euroteken/" class="compare-card variant-muted u-no-underline">
-      <h4>Currency Symbols</h4>
+      <h4>Euroteken € kopiëren — en typen op je toetsenbord</h4>
       <p>Dollar, euro, pond, yen, roepie en andere wereldvalutatekens in één overzicht (Engelstalige bibliotheek).</p>
     </a>
     <a href="/nl/symbol/euro-symbool/" class="compare-card variant-muted u-no-underline">

--- a/nl/symbol/boogschutter-symbool/index.html
+++ b/nl/symbol/boogschutter-symbool/index.html
@@ -233,7 +233,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Gerelateerde Bronnen</span>
   <div class="compare-grid">
     <a href="/nl/library/sterrenbeeld-symbolen/" class="compare-card variant-muted u-no-underline">
-      <h4>Zodiac Symbols</h4>
+      <h4>Sterrenbeeld- en astrologiesymbolen</h4>
       <p>Westerse sterrenbeeldtekens, planeetsymbolen en Chinese dierenriemdieren in één overzicht (Engelstalige bibliotheek).</p>
     </a>
     <a href="/nl/symbol/tweelingen-symbool/" class="compare-card variant-muted u-no-underline">

--- a/nl/symbol/centteken/index.html
+++ b/nl/symbol/centteken/index.html
@@ -245,7 +245,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Meer dan duizend jaar oud, van het Latijnse libra.</p>
     </a>
     <a href="/nl/library/euroteken/" class="compare-card variant-muted u-no-underline">
-      <h4>All Currency Symbols</h4>
+      <h4>Euroteken € kopiëren — en typen op je toetsenbord</h4>
       <p>Elk wereldvalutateken, per regio gerangschikt (Engelstalige bibliotheek).</p>
     </a>
     <a href="/nl/symbol/dollarteken/" class="compare-card variant-muted u-no-underline">

--- a/nl/symbol/chi-symbool/index.html
+++ b/nl/symbol/chi-symbool/index.html
@@ -292,7 +292,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Chi-kwadraat, superscripts en de operatoren en Griekse letters die een vergelijking compleet maken.</p>
     </a>
     <a href="/nl/library/religieuze-symbolen/" class="compare-card variant-muted u-no-underline">
-      <h4>Religious Symbols</h4>
+      <h4>Religieuze &amp; Spirituele Symbolen</h4>
       <p>Het Chi-Rho, kruizen en andere christelijke en geloofssymbolen in één overzicht (Engelstalige bibliotheek).</p>
     </a>
     <a href="/nl/symbol/pi-symbool/" class="compare-card variant-muted u-no-underline">

--- a/nl/symbol/davidster/index.html
+++ b/nl/symbol/davidster/index.html
@@ -237,7 +237,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Gerelateerde Bronnen</span>
   <div class="compare-grid">
     <a href="/nl/library/religieuze-symbolen/" class="compare-card variant-muted u-no-underline">
-      <h4>Religious Symbols</h4>
+      <h4>Religieuze &amp; Spirituele Symbolen</h4>
       <p>Geloofssymbolen uit elke grote wereldreligie in één overzicht (Engelstalige bibliotheek).</p>
     </a>
     <a href="/nl/symbol/khanda-symbool/" class="compare-card variant-muted u-no-underline">

--- a/nl/symbol/dirhamteken/index.html
+++ b/nl/symbol/dirhamteken/index.html
@@ -238,7 +238,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Gerelateerde Bronnen</span>
   <div class="compare-grid">
     <a href="/nl/library/euroteken/" class="compare-card variant-muted u-no-underline">
-      <h4>Currency Symbols</h4>
+      <h4>Euroteken € kopiëren — en typen op je toetsenbord</h4>
       <p>Elk wereldvalutateken dat je vandaag al kunt kopiëren en plakken (Engelstalige bibliotheek).</p>
     </a>
     <a href="/nl/symbol/omaanse-rial-teken/" class="compare-card variant-muted u-no-underline">

--- a/nl/symbol/dollarteken/index.html
+++ b/nl/symbol/dollarteken/index.html
@@ -257,7 +257,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Het enige gangbare valutateken zonder eigen toetsenbordtoets.</p>
     </a>
     <a href="/nl/library/euroteken/" class="compare-card variant-muted u-no-underline">
-      <h4>All Currency Symbols</h4>
+      <h4>Euroteken € kopiëren — en typen op je toetsenbord</h4>
       <p>Elk wereldvalutateken, per regio gerangschikt (Engelstalige bibliotheek).</p>
     </a>
     <a href="/nl/symbol/dirhamteken/" class="compare-card variant-muted u-no-underline">

--- a/nl/symbol/halvemaan-en-ster/index.html
+++ b/nl/symbol/halvemaan-en-ster/index.html
@@ -256,11 +256,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Gerelateerde Bronnen</span>
   <div class="compare-grid">
     <a href="/nl/library/religieuze-symbolen/" class="compare-card variant-muted u-no-underline">
-      <h4>Religious Symbols</h4>
+      <h4>Religieuze &amp; Spirituele Symbolen</h4>
       <p>Geloofssymbolen uit elke grote wereldreligie in één doorbladerbaar overzicht (Engelstalige bibliotheek).</p>
     </a>
     <a href="/nl/library/islamitische-symbolen/" class="compare-card variant-muted u-no-underline">
-      <h4>Islamic Symbols</h4>
+      <h4>Islamitische Symbolen</h4>
       <p>Halvemaan en ster naast de Allah-kalligrafie, moskee, gebed en andere symbolen die met de islam zijn verbonden (Engelstalige bibliotheek).</p>
     </a>
     <a href="/nl/symbol/davidster/" class="compare-card variant-muted u-no-underline">

--- a/nl/symbol/index.html
+++ b/nl/symbol/index.html
@@ -199,7 +199,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Verbindt bereiken zoals 1939–1945 en de vlucht New York–Londen — langer dan een koppelteken, korter dan een em-streep.</p>
     </a>
     <a href="/nl/symbol/interrobang/" class="compare-card variant-muted u-no-underline">
-      <h4>‽ Interrobang</h4>
+      <h4>Interrobang (‽)</h4>
       <p>‘?’ en ‘!’ in één teken samengesmolten, bedacht in 1962 door reclameman Martin Speckter.</p>
     </a>
     <a href="/nl/symbol/omgekeerd-vraagteken/" class="compare-card variant-muted u-no-underline">
@@ -215,7 +215,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Je Unix-thuismap, ‘ongeveer’, en het combinerende accent boven ñ en ã.</p>
     </a>
     <a href="/nl/symbol/underscore-teken/" class="compare-card variant-muted u-no-underline">
-      <h4>_ Underscore</h4>
+      <h4>Underscore (_)</h4>
       <p>Van typemachinetruc voor onderstrepen tot snake_case — het spatie-veilige teken.</p>
     </a>
     <a href="/nl/symbol/verticale-streep/" class="compare-card variant-muted u-no-underline">

--- a/nl/symbol/khanda-symbool/index.html
+++ b/nl/symbol/khanda-symbool/index.html
@@ -237,7 +237,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Gerelateerde Bronnen</span>
   <div class="compare-grid">
     <a href="/nl/library/religieuze-symbolen/" class="compare-card variant-muted u-no-underline">
-      <h4>Religious Symbols</h4>
+      <h4>Religieuze &amp; Spirituele Symbolen</h4>
       <p>Geloofssymbolen uit elke grote wereldreligie in één overzicht (Engelstalige bibliotheek).</p>
     </a>
     <a href="/nl/symbol/vredesteken/" class="compare-card variant-muted u-no-underline">

--- a/nl/symbol/kreeft-symbool/index.html
+++ b/nl/symbol/kreeft-symbool/index.html
@@ -233,7 +233,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Gerelateerde Bronnen</span>
   <div class="compare-grid">
     <a href="/nl/library/sterrenbeeld-symbolen/" class="compare-card variant-muted u-no-underline">
-      <h4>Zodiac Symbols</h4>
+      <h4>Sterrenbeeld- en astrologiesymbolen</h4>
       <p>Westerse sterrenbeeldtekens, planeetsymbolen en Chinese dierenriemdieren in één overzicht (Engelstalige bibliotheek).</p>
     </a>
     <a href="/nl/symbol/steenbok-symbool/" class="compare-card variant-muted u-no-underline">

--- a/nl/symbol/latijns-kruis/index.html
+++ b/nl/symbol/latijns-kruis/index.html
@@ -265,7 +265,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Kruisjes, X-tekens en het overlijdensteken † om te doorbladeren en te kopiëren.</p>
     </a>
     <a href="/nl/library/religieuze-symbolen/" class="compare-card variant-muted u-no-underline">
-      <h4>Religious Symbols</h4>
+      <h4>Religieuze &amp; Spirituele Symbolen</h4>
       <p>Geloofssymbolen uit elke grote wereldreligie in één overzicht (Engelstalige bibliotheek).</p>
     </a>
     <a href="/nl/symbol/ankh-symbool/" class="compare-card variant-muted u-no-underline">

--- a/nl/symbol/leeuw-symbool/index.html
+++ b/nl/symbol/leeuw-symbool/index.html
@@ -233,7 +233,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Gerelateerde Bronnen</span>
   <div class="compare-grid">
     <a href="/nl/library/sterrenbeeld-symbolen/" class="compare-card variant-muted u-no-underline">
-      <h4>Zodiac Symbols</h4>
+      <h4>Sterrenbeeld- en astrologiesymbolen</h4>
       <p>Westerse sterrenbeeldtekens, planeetsymbolen en Chinese dierenriemdieren in één overzicht (Engelstalige bibliotheek).</p>
     </a>
     <a href="/nl/symbol/waterman-symbool/" class="compare-card variant-muted u-no-underline">

--- a/nl/symbol/maagd-symbool/index.html
+++ b/nl/symbol/maagd-symbool/index.html
@@ -233,7 +233,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Gerelateerde Bronnen</span>
   <div class="compare-grid">
     <a href="/nl/library/sterrenbeeld-symbolen/" class="compare-card variant-muted u-no-underline">
-      <h4>Zodiac Symbols</h4>
+      <h4>Sterrenbeeld- en astrologiesymbolen</h4>
       <p>Westerse sterrenbeeldtekens, planeetsymbolen en Chinese dierenriemdieren in één overzicht (Engelstalige bibliotheek).</p>
     </a>
     <a href="/nl/symbol/vissen-symbool/" class="compare-card variant-muted u-no-underline">

--- a/nl/symbol/microfoon-emoji/index.html
+++ b/nl/symbol/microfoon-emoji/index.html
@@ -244,11 +244,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Elke alledaagse-voorwerp-emoji — tech, huishoudelijk en kantoor — inclusief de microfoon, doorbladerbaar in één raster (Engelstalige bibliotheek).</p>
     </a>
     <a href="/nl/library/emoji-combos/" class="compare-card variant-muted u-no-underline">
-      <h4>Emoji Combos</h4>
+      <h4>Emoji combinaties om te kopiëren en plakken</h4>
       <p>Kant-en-klare emoji-combinaties voor bio's en bijschriften, waaronder muziek- en optreden-thema's (Engelstalige bibliotheek).</p>
     </a>
     <a href="/nl/library/muzieksymbolen/" class="compare-card variant-muted u-no-underline">
-      <h4>Music Symbols</h4>
+      <h4>Muzieksymbolen</h4>
       <p>Unicode-muzieknotatie — ♪ ♫ ♬ — de tekstgebaseerde neef van de muziek-emoji-familie (Engelstalige bibliotheek).</p>
     </a>
   </div>

--- a/nl/symbol/om-symbool/index.html
+++ b/nl/symbol/om-symbool/index.html
@@ -249,7 +249,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Gerelateerde Bronnen</span>
   <div class="compare-grid">
     <a href="/nl/library/religieuze-symbolen/" class="compare-card variant-muted u-no-underline">
-      <h4>Religious Symbols</h4>
+      <h4>Religieuze &amp; Spirituele Symbolen</h4>
       <p>Geloofssymbolen uit elke grote wereldreligie in één overzicht (Engelstalige bibliotheek).</p>
     </a>
     <a href="/nl/symbol/khanda-symbool/" class="compare-card variant-muted u-no-underline">

--- a/nl/symbol/omaanse-rial-teken/index.html
+++ b/nl/symbol/omaanse-rial-teken/index.html
@@ -216,7 +216,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Gerelateerde Bronnen</span>
   <div class="compare-grid">
     <a href="/nl/library/euroteken/" class="compare-card variant-muted u-no-underline">
-      <h4>Currency Symbols</h4>
+      <h4>Euroteken € kopiëren — en typen op je toetsenbord</h4>
       <p>Elk wereldvalutateken dat je vandaag al kunt kopiëren en plakken (Engelstalige bibliotheek).</p>
     </a>
     <a href="/nl/symbol/dirhamteken/" class="compare-card variant-muted u-no-underline">

--- a/nl/symbol/onzichtbaar-teken/index.html
+++ b/nl/symbol/onzichtbaar-teken/index.html
@@ -258,7 +258,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Eeuwen astronomie, hoeken en temperatuurschalen.</p>
     </a>
     <a href="/nl/onzichtbare-tekst/" class="compare-card variant-muted u-no-underline">
-      <h4>All Invisible Characters</h4>
+      <h4>Onzichtbare Tekst &amp; Onzichtbaar Teken</h4>
       <p>Zero-width-spaties, fillers en lege braille (Engelstalige bibliotheek).</p>
     </a>
   </div>

--- a/nl/symbol/pentagram-symbool/index.html
+++ b/nl/symbol/pentagram-symbool/index.html
@@ -261,7 +261,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Pentagrammen, maanfasen, alchemistische tekens en andere symbolen in één doorbladerbaar overzicht (Engelstalige bibliotheek).</p>
     </a>
     <a href="/nl/library/religieuze-symbolen/" class="compare-card variant-muted u-no-underline">
-      <h4>Religious Symbols</h4>
+      <h4>Religieuze &amp; Spirituele Symbolen</h4>
       <p>Geloofs- en spirituele symbolen uit belangrijke wereldtradities, inclusief levende heidense en Wicca-praktijk (Engelstalige bibliotheek).</p>
     </a>
     <a href="/nl/symbol/yin-yang-symbool/" class="compare-card variant-muted u-no-underline">

--- a/nl/symbol/pesoteken/index.html
+++ b/nl/symbol/pesoteken/index.html
@@ -253,7 +253,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Gerelateerde Bronnen</span>
   <div class="compare-grid">
     <a href="/nl/library/euroteken/" class="compare-card variant-muted u-no-underline">
-      <h4>Currency Symbols</h4>
+      <h4>Euroteken € kopiëren — en typen op je toetsenbord</h4>
       <p>Blader door elk wereldvalutateken — dollar, euro, pond, yen, roepie en peso — naast elkaar in één overzicht (Engelstalige bibliotheek).</p>
     </a>
     <a href="/nl/symbol/dollarteken/" class="compare-card variant-muted u-no-underline">

--- a/nl/symbol/pion-symbool/index.html
+++ b/nl/symbol/pion-symbool/index.html
@@ -274,7 +274,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Gerelateerde Bronnen</span>
   <div class="compare-grid">
     <a href="/nl/library/schaaksymbolen/" class="compare-card variant-muted u-no-underline">
-      <h4>Chess Symbols</h4>
+      <h4>Schaaksymbolen</h4>
       <p>De volledige Unicode-schaakset — koningen, koninginnen, torens, lopers, paarden en beide pionnen — in één kopieer-en-plak-overzicht (Engelstalige bibliotheek).</p>
     </a>
     <a href="/nl/symbol/schoppen-symbool/" class="compare-card variant-muted u-no-underline">

--- a/nl/symbol/pondteken/index.html
+++ b/nl/symbol/pondteken/index.html
@@ -242,7 +242,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Gedeeld tussen de Japanse yen en de Chinese yuan.</p>
     </a>
     <a href="/nl/library/euroteken/" class="compare-card variant-muted u-no-underline">
-      <h4>All Currency Symbols</h4>
+      <h4>Euroteken € kopiëren — en typen op je toetsenbord</h4>
       <p>Dollar, euro, pond, yen en andere wereldvalutatekens (Engelstalige bibliotheek).</p>
     </a>
     <a href="/nl/symbol/centteken/" class="compare-card variant-muted u-no-underline">

--- a/nl/symbol/ram-symbool/index.html
+++ b/nl/symbol/ram-symbool/index.html
@@ -233,7 +233,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Gerelateerde Bronnen</span>
   <div class="compare-grid">
     <a href="/nl/library/sterrenbeeld-symbolen/" class="compare-card variant-muted u-no-underline">
-      <h4>Zodiac Symbols</h4>
+      <h4>Sterrenbeeld- en astrologiesymbolen</h4>
       <p>Westerse sterrenbeeldtekens, planeetsymbolen en Chinese dierenriemdieren in één overzicht (Engelstalige bibliotheek).</p>
     </a>
     <a href="/nl/symbol/weegschaal-symbool/" class="compare-card variant-muted u-no-underline">

--- a/nl/symbol/roebelteken/index.html
+++ b/nl/symbol/roebelteken/index.html
@@ -252,7 +252,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Gerelateerde Bronnen</span>
   <div class="compare-grid">
     <a href="/nl/library/euroteken/" class="compare-card variant-muted u-no-underline">
-      <h4>Currency Symbols</h4>
+      <h4>Euroteken € kopiëren — en typen op je toetsenbord</h4>
       <p>Een doorbladerbare set wereldvalutatekens, van dollar en euro tot roepie, roebel en bitcoin (Engelstalige bibliotheek).</p>
     </a>
     <a href="/nl/symbol/roepieteken/" class="compare-card variant-muted u-no-underline">

--- a/nl/symbol/roepieteken/index.html
+++ b/nl/symbol/roepieteken/index.html
@@ -241,7 +241,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Meer dan duizend jaar oud, van het Latijnse libra.</p>
     </a>
     <a href="/nl/library/euroteken/" class="compare-card variant-muted u-no-underline">
-      <h4>All Currency Symbols</h4>
+      <h4>Euroteken € kopiëren — en typen op je toetsenbord</h4>
       <p>Dollar, euro, pond, yen en andere wereldvalutatekens (Engelstalige bibliotheek).</p>
     </a>
     <a href="/nl/symbol/bitcoin-teken/" class="compare-card variant-muted u-no-underline">

--- a/nl/symbol/saudi-riyal-teken/index.html
+++ b/nl/symbol/saudi-riyal-teken/index.html
@@ -224,7 +224,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Gerelateerde Bronnen</span>
   <div class="compare-grid">
     <a href="/nl/library/euroteken/" class="compare-card variant-muted u-no-underline">
-      <h4>Currency Symbols</h4>
+      <h4>Euroteken € kopiëren — en typen op je toetsenbord</h4>
       <p>Elk wereldvalutateken dat je vandaag al kunt kopiëren en plakken (Engelstalige bibliotheek).</p>
     </a>
     <a href="/nl/symbol/dirhamteken/" class="compare-card variant-muted u-no-underline">

--- a/nl/symbol/schorpioen-symbool/index.html
+++ b/nl/symbol/schorpioen-symbool/index.html
@@ -233,7 +233,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Gerelateerde Bronnen</span>
   <div class="compare-grid">
     <a href="/nl/library/sterrenbeeld-symbolen/" class="compare-card variant-muted u-no-underline">
-      <h4>Zodiac Symbols</h4>
+      <h4>Sterrenbeeld- en astrologiesymbolen</h4>
       <p>Westerse sterrenbeeldtekens, planeetsymbolen en Chinese dierenriemdieren in één overzicht (Engelstalige bibliotheek).</p>
     </a>
     <a href="/nl/symbol/stier-symbool/" class="compare-card variant-muted u-no-underline">

--- a/nl/symbol/steenbok-symbool/index.html
+++ b/nl/symbol/steenbok-symbool/index.html
@@ -233,7 +233,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Gerelateerde Bronnen</span>
   <div class="compare-grid">
     <a href="/nl/library/sterrenbeeld-symbolen/" class="compare-card variant-muted u-no-underline">
-      <h4>Zodiac Symbols</h4>
+      <h4>Sterrenbeeld- en astrologiesymbolen</h4>
       <p>Westerse sterrenbeeldtekens, planeetsymbolen en Chinese dierenriemdieren in één overzicht (Engelstalige bibliotheek).</p>
     </a>
     <a href="/nl/symbol/kreeft-symbool/" class="compare-card variant-muted u-no-underline">

--- a/nl/symbol/ster-symbool/index.html
+++ b/nl/symbol/ster-symbool/index.html
@@ -261,7 +261,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Het kaartkleur-hart dat het teken voor liefde werd.</p>
     </a>
     <a href="/nl/library/speciale-tekens/" class="compare-card variant-muted u-no-underline">
-      <h4>Aesthetic Symbols</h4>
+      <h4>Speciale Tekens</h4>
       <p>Sterren, sparkles en decoratieve tekens voor bio's en gebruikersnamen (Engelstalige bibliotheek).</p>
     </a>
     <a href="/nl/symbol/sterretje-teken/" class="compare-card variant-muted u-no-underline">

--- a/nl/symbol/sterretje-teken/index.html
+++ b/nl/symbol/sterretje-teken/index.html
@@ -252,7 +252,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Gerelateerde Bronnen</span>
   <div class="compare-grid">
     <a href="/nl/library/vraagteken/" class="compare-card variant-muted u-no-underline">
-      <h4>Punctuation Symbols</h4>
+      <h4>Vraagteken kopiëren — ? ¿ ‽ en alle bijzondere leestekens</h4>
       <p>Streepjes, haakjes, aanhalingstekens en de familie alledaagse interpunctie waar het sterretje bij hoort (Engelstalige bibliotheek).</p>
     </a>
     <a href="/nl/library/ster-symbolen/" class="compare-card variant-muted u-no-underline">

--- a/nl/symbol/stier-symbool/index.html
+++ b/nl/symbol/stier-symbool/index.html
@@ -233,7 +233,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Gerelateerde Bronnen</span>
   <div class="compare-grid">
     <a href="/nl/library/sterrenbeeld-symbolen/" class="compare-card variant-muted u-no-underline">
-      <h4>Zodiac Symbols</h4>
+      <h4>Sterrenbeeld- en astrologiesymbolen</h4>
       <p>Westerse sterrenbeeldtekens, planeetsymbolen en Chinese dierenriemdieren in één overzicht (Engelstalige bibliotheek).</p>
     </a>
     <a href="/nl/symbol/schorpioen-symbool/" class="compare-card variant-muted u-no-underline">

--- a/nl/symbol/tweelingen-symbool/index.html
+++ b/nl/symbol/tweelingen-symbool/index.html
@@ -233,7 +233,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Gerelateerde Bronnen</span>
   <div class="compare-grid">
     <a href="/nl/library/sterrenbeeld-symbolen/" class="compare-card variant-muted u-no-underline">
-      <h4>Zodiac Symbols</h4>
+      <h4>Sterrenbeeld- en astrologiesymbolen</h4>
       <p>Westerse sterrenbeeldtekens, planeetsymbolen en Chinese dierenriemdieren in één overzicht (Engelstalige bibliotheek).</p>
     </a>
     <a href="/nl/symbol/boogschutter-symbool/" class="compare-card variant-muted u-no-underline">

--- a/nl/symbol/underscore-teken/index.html
+++ b/nl/symbol/underscore-teken/index.html
@@ -240,7 +240,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>De underscore, het koppelteken, het sterretje en de rest van de leestekens op een standaardtoetsenbord.</p>
     </a>
     <a href="/nl/library/vraagteken/" class="compare-card variant-muted u-no-underline">
-      <h4>Punctuation Symbols</h4>
+      <h4>Vraagteken kopiëren — ? ¿ ‽ en alle bijzondere leestekens</h4>
       <p>Streepjes, haakjes, aanhalingstekens en de alledaagse interpunctie van Unicode in één overzicht (Engelstalige bibliotheek).</p>
     </a>
     <a href="/nl/symbol/apenstaartje/" class="compare-card variant-muted u-no-underline">

--- a/nl/symbol/vissen-symbool/index.html
+++ b/nl/symbol/vissen-symbool/index.html
@@ -233,7 +233,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Gerelateerde Bronnen</span>
   <div class="compare-grid">
     <a href="/nl/library/sterrenbeeld-symbolen/" class="compare-card variant-muted u-no-underline">
-      <h4>Zodiac Symbols</h4>
+      <h4>Sterrenbeeld- en astrologiesymbolen</h4>
       <p>Westerse sterrenbeeldtekens, planeetsymbolen en Chinese dierenriemdieren in één overzicht (Engelstalige bibliotheek).</p>
     </a>
     <a href="/nl/symbol/maagd-symbool/" class="compare-card variant-muted u-no-underline">

--- a/nl/symbol/waterman-symbool/index.html
+++ b/nl/symbol/waterman-symbool/index.html
@@ -233,7 +233,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Gerelateerde Bronnen</span>
   <div class="compare-grid">
     <a href="/nl/library/sterrenbeeld-symbolen/" class="compare-card variant-muted u-no-underline">
-      <h4>Zodiac Symbols</h4>
+      <h4>Sterrenbeeld- en astrologiesymbolen</h4>
       <p>Westerse sterrenbeeldtekens, planeetsymbolen en Chinese dierenriemdieren in één overzicht (Engelstalige bibliotheek).</p>
     </a>
     <a href="/nl/symbol/leeuw-symbool/" class="compare-card variant-muted u-no-underline">

--- a/nl/symbol/weegschaal-symbool/index.html
+++ b/nl/symbol/weegschaal-symbool/index.html
@@ -233,7 +233,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Gerelateerde Bronnen</span>
   <div class="compare-grid">
     <a href="/nl/library/sterrenbeeld-symbolen/" class="compare-card variant-muted u-no-underline">
-      <h4>Zodiac Symbols</h4>
+      <h4>Sterrenbeeld- en astrologiesymbolen</h4>
       <p>Westerse sterrenbeeldtekens, planeetsymbolen en Chinese dierenriemdieren in één overzicht (Engelstalige bibliotheek).</p>
     </a>
     <a href="/nl/symbol/ram-symbool/" class="compare-card variant-muted u-no-underline">

--- a/nl/symbol/woede-symbool/index.html
+++ b/nl/symbol/woede-symbool/index.html
@@ -249,7 +249,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Gerelateerde Bronnen</span>
   <div class="compare-grid">
     <a href="/nl/library/emoji-combos/" class="compare-card variant-muted u-no-underline">
-      <h4>Emoji Combos</h4>
+      <h4>Emoji combinaties om te kopiëren en plakken</h4>
       <p>Kant-en-klare esthetische en reactiecombo's, waaronder verschillende opgebouwd rond boze en woedende gezichten (Engelstalige bibliotheek).</p>
     </a>
     <a href="/nl/symbol/stopbord-emoji/" class="compare-card variant-muted u-no-underline">

--- a/nl/symbol/wonteken/index.html
+++ b/nl/symbol/wonteken/index.html
@@ -229,7 +229,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Gerelateerde Bronnen</span>
   <div class="compare-grid">
     <a href="/nl/library/euroteken/" class="compare-card variant-muted u-no-underline">
-      <h4>Currency Symbols</h4>
+      <h4>Euroteken € kopiëren — en typen op je toetsenbord</h4>
       <p>Een doorbladerbare set wereldvalutatekens, van dollar en euro tot roepie en bitcoin (Engelstalige bibliotheek).</p>
     </a>
     <a href="/nl/symbol/yenteken/" class="compare-card variant-muted u-no-underline">

--- a/nl/symbol/yenteken/index.html
+++ b/nl/symbol/yenteken/index.html
@@ -241,7 +241,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Meer dan duizend jaar oud, van het Latijnse libra.</p>
     </a>
     <a href="/nl/library/euroteken/" class="compare-card variant-muted u-no-underline">
-      <h4>All Currency Symbols</h4>
+      <h4>Euroteken € kopiëren — en typen op je toetsenbord</h4>
       <p>Dollar, euro, pond, yen en andere wereldvalutatekens (Engelstalige bibliotheek).</p>
     </a>
     <a href="/nl/symbol/roepieteken/" class="compare-card variant-muted u-no-underline">

--- a/nl/symbol/zwarte-maan-lilith/index.html
+++ b/nl/symbol/zwarte-maan-lilith/index.html
@@ -261,7 +261,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Gerelateerde Bronnen</span>
   <div class="compare-grid">
     <a href="/nl/library/sterrenbeeld-symbolen/" class="compare-card variant-muted u-no-underline">
-      <h4>Zodiac Symbols</h4>
+      <h4>Sterrenbeeld- en astrologiesymbolen</h4>
       <p>De twaalf tekenglyphs waar een Zwarte-Maan-Lilith-plaatsing tegen wordt gelezen (Engelstalige bibliotheek).</p>
     </a>
     <a href="/nl/symbol/davidster/" class="compare-card variant-muted u-no-underline">

--- a/pl/answers/what-font-does-pinterest-use/index.html
+++ b/pl/answers/what-font-does-pinterest-use/index.html
@@ -183,7 +183,7 @@
 
 
 <section class="editorial-section">
-  <span class="article-section-label">Quick answer</span>
+  <span class="article-section-label">Krótka odpowiedź</span>
   <div class="editorial-block">
     <p>Aplikacja, strona i identyfikacja wizualna Pinteresta opierają się na Pinterest Sans — niestandardowym kroju geometrycznym zamówionym u Grilli Type, szwajcarskiej odlewni typograficznej. Krój dostępny jest w czterech grubościach oraz osobnym, mniejszym cięciu o nazwie Pinterest UI. Pinterest Sans jest własnościowy — powstał wyłącznie na potrzeby Pinteresta i nie jest dostępny do publicznego pobrania ani licencjonowania.</p>
     <p>Jeśli potrzebujesz tylko czcionki, która na grafice lub w prezentacji będzie kojarzyć się z Pinterestem, sięgnij po Poppins — darmowy krój geometryczny z Google Fonts o tej samej zaokrąglonej, ciepłej stylistyce.</p>
@@ -193,7 +193,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">The details</span>
+  <span class="article-section-label">Szczegóły</span>
   <h2>Jakiej czcionki używa Pinterest?</h2>
 
   <div class="data-table-wrap">
@@ -254,7 +254,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Style your own text</span>
+  <span class="article-section-label">Ostyluj swój tekst</span>
   <h2>…ale chcesz, żeby wyróżniały się Twoje własne piny?</h2>
   <div class="editorial-block">
     <p>Jeśli trafiłeś tu, bo zależy Ci, by tytuły, opisy lub nazwy tablic Twoich własnych pinów wyglądały inaczej — a nie dlatego, że chcesz dopasować się do marki — sama nazwa czcionki niewiele Ci pomoże. Pinterest nie ma nigdzie w aplikacji przycisku formatowania tekstu.</p>
@@ -275,7 +275,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Keep exploring</span>
+  <span class="article-section-label">Zobacz więcej</span>
   <h2>Powiązane strony</h2>
   <div class="compare-grid">
     <a href="/pinterest/" class="compare-card variant-muted u-no-underline">
@@ -300,7 +300,7 @@
 
 <section class="editorial-section" id="faq">
   <span class="article-section-label">FAQ</span>
-  <h2>Frequently Asked Questions</h2>
+  <h2>Najczęstsze pytania</h2>
   <details class="faq-item">
     <summary class="faq-question">Jakiej czcionki używa Pinterest?</summary>
     <p class="faq-answer">Aplikacja, strona i identyfikacja wizualna Pinteresta opierają się na Pinterest Sans, niestandardowym kroju geometrycznym zamówionym u szwajcarskiej odlewni Grilli Type. Krój dostępny jest w czterech grubościach oraz osobnym cięciu zoptymalizowanym pod interfejs o nazwie Pinterest UI, stworzonym z myślą o czytelności w małych rozmiarach. Pinterest Sans jest własnościowy — powstał wyłącznie na potrzeby Pinteresta i nie jest dostępny do publicznego pobrania ani licencjonowania.</p>

--- a/pl/answers/what-font-does-pinterest-use/index.html
+++ b/pl/answers/what-font-does-pinterest-use/index.html
@@ -285,7 +285,7 @@
     </a>
     <a href="/pl/pogrubiona-czcionka/" class="compare-card variant-muted u-no-underline">
       <span class="compare-badge">Tool</span>
-      <h4>Bold Text Generator</h4>
+      <h4>Generator Pogrubionej Czcionki</h4>
       <ul><li>Generate clean bold text for any platform.</li></ul>
     </a>
     <a href="/answers/is-fancy-text-bad-for-seo/" class="compare-card variant-muted u-no-underline">

--- a/pl/answers/what-font-does-whatsapp-use/index.html
+++ b/pl/answers/what-font-does-whatsapp-use/index.html
@@ -167,7 +167,7 @@
 
 
 <section class="editorial-section">
-  <span class="article-section-label">Quick answer</span>
+  <span class="article-section-label">Krótka odpowiedź</span>
   <div class="editorial-block">
     <p>Logo i logotyp WhatsAppa są złożone w Helvetica Neue. Sam interfejs czatu nie ma natomiast żadnej wbudowanej, autorskiej czcionki — WhatsApp w całości opiera się na czcionce systemowej, jaką ma już Twoje urządzenie: San Francisco na iPhonie, Roboto na Androidzie oraz Segoe UI na komputerze z Windows i w wersji WhatsApp Web.</p>
     <p>Dlatego ta sama rozmowa może wyglądać nieco inaczej w zależności od urządzenia, na którym jest czytana — to nie jedna czcionka WhatsAppa, tylko ta, jaką narzuca dana platforma.</p>
@@ -177,7 +177,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">The details</span>
+  <span class="article-section-label">Szczegóły</span>
   <h2>Jakiej czcionki używa WhatsApp?</h2>
 
   <div class="data-table-wrap">
@@ -240,7 +240,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Style your own text</span>
+  <span class="article-section-label">Ostyluj swój tekst</span>
   <h2>…ale chcesz, żeby wyróżniały się Twoje własne wiadomości?</h2>
   <div class="editorial-block">
     <p>Jeśli trafiłeś tu, bo zależy Ci, by Twoje własne wiadomości, status lub nazwa grupy na WhatsAppie wyglądały inaczej — a nie dlatego, że chcesz dopasować się do marki — powyższa odpowiedź o czcionce systemowej niewiele Ci pomoże. WhatsApp natywnie obsługuje cztery style za pomocą zwykłych symboli wpisywanych z klawiatury: *pogrubienie*, _kursywa_, ~przekreślenie~ oraz ```czcionka o stałej szerokości```. Pełny opis znajdziesz w <a href="/guide/whatsapp-text-formatting-explained/">przewodniku po formatowaniu tekstu w WhatsApp</a>.</p>
@@ -258,7 +258,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Keep exploring</span>
+  <span class="article-section-label">Zobacz więcej</span>
   <h2>Powiązane strony</h2>
   <div class="compare-grid">
     <a href="/pl/czcionki-na-whatsapp/" class="compare-card variant-muted u-no-underline">
@@ -283,7 +283,7 @@
 
 <section class="editorial-section" id="faq">
   <span class="article-section-label">FAQ</span>
-  <h2>Frequently Asked Questions</h2>
+  <h2>Najczęstsze pytania</h2>
   <details class="faq-item">
     <summary class="faq-question">Jakiej czcionki używa WhatsApp?</summary>
     <p class="faq-answer">Logo i logotyp WhatsAppa są złożone w Helvetica Neue, z lekko dostosowaną szerokością i odstępami na potrzeby ikony aplikacji. Sam interfejs czatu nie ma natomiast żadnej wbudowanej, autorskiej czcionki — WhatsApp w całości opiera się na czcionce systemowej Twojego urządzenia: San Francisco na iPhonie, Roboto na Androidzie oraz Segoe UI na komputerze z Windows i w wersji Web.</p>

--- a/pl/answers/what-font-does-whatsapp-use/index.html
+++ b/pl/answers/what-font-does-whatsapp-use/index.html
@@ -263,7 +263,7 @@
   <div class="compare-grid">
     <a href="/pl/czcionki-na-whatsapp/" class="compare-card variant-muted u-no-underline">
       <span class="compare-badge">Tool</span>
-      <h4>WhatsApp Font Generator</h4>
+      <h4>Czcionki na WhatsApp: ładna czcionka na status, opis i wiadomości</h4>
       <ul><li>Style your status, group names and messages.</li></ul>
     </a>
     <a href="/guide/whatsapp-text-formatting-explained/" class="compare-card variant-muted u-no-underline">
@@ -273,7 +273,7 @@
     </a>
     <a href="/pl/pogrubiona-czcionka/" class="compare-card variant-muted u-no-underline">
       <span class="compare-badge">Tool</span>
-      <h4>Bold Text Generator</h4>
+      <h4>Generator Pogrubionej Czcionki</h4>
       <ul><li>Generate clean bold text for any platform.</li></ul>
     </a>
   </div>

--- a/pl/estetyczne-czcionki/index.html
+++ b/pl/estetyczne-czcionki/index.html
@@ -225,7 +225,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
             <button class="decoration-tab active" data-deco-tab="symbols">Symbole</button>
             <button class="decoration-tab" data-deco-tab="frames">Ramki</button>
             <button class="decoration-tab" data-deco-tab="dividers">Separatory</button>
-            <button class="decoration-tab" data-deco-tab="minimal">Minimal</button>
+            <button class="decoration-tab" data-deco-tab="minimal">Minimalne</button>
             <button class="decoration-tab" data-deco-tab="emojis">Emoji</button>
           </div>
           <div class="decoration-grid" id="decorationGrid"></div>

--- a/pl/library/alfabet-grecki/index.html
+++ b/pl/library/alfabet-grecki/index.html
@@ -452,7 +452,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Wszystkie kolekcje symboli i emotek do skopiowania w jednym miejscu.</p>
     </a>
     <a href="/pl/library/symbole-matematyczne/" class="compare-card variant-muted u-no-underline">
-      <h4>Math Symbols</h4>
+      <h4>Symbole Matematyczne</h4>
       <p>Pełna kolekcja symboli matematycznych (po angielsku).</p>
     </a>
   </div>

--- a/pl/library/symbole-estetyczne/index.html
+++ b/pl/library/symbole-estetyczne/index.html
@@ -510,31 +510,31 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <div class="compare-grid">
     <a href="/pl/library/symbole-coquette/" class="compare-card variant-muted is-link">
       <span class="compare-badge">Pinterest</span>
-      <h4>Coquette / Dollette</h4>
+      <h4>Symbole coquette</h4>
       <p class="aesthetic-card-symbols">🎀 ୨୧ ʚɞ 𐙚 ⋆˚࿔</p>
       <p class="aesthetic-card-desc">Miękki róż, wstążki i kokardki, klimat lalki-dziewczynki.</p>
     </a>
     <a href="/pl/library/symbole-cottagecore/" class="compare-card variant-muted is-link">
       <span class="compare-badge">Instagram</span>
-      <h4>Cottagecore</h4>
+      <h4>Symbole cottagecore</h4>
       <p class="aesthetic-card-symbols">🍄 🌿 🐝 🌷 ☾</p>
       <p class="aesthetic-card-desc">Grzyby, kwiaty, ciepło wiejskiej chatki.</p>
     </a>
     <a href="/pl/library/symbole-kawaii-cute/" class="compare-card variant-muted is-link">
       <span class="compare-badge">TikTok</span>
-      <h4>Kawaii / Cute</h4>
+      <h4>Symbole kawaii i cute</h4>
       <p class="aesthetic-card-symbols">♡ ෆ ʚɞ ◕‿◕</p>
       <p class="aesthetic-card-desc">Miękkie, zaokrąglone, pastelowe i japońsko-urocze.</p>
     </a>
     <a href="/pl/library/symbole-y2k/" class="compare-card variant-muted is-link">
       <span class="compare-badge">TikTok</span>
-      <h4>Y2K / Cyber</h4>
+      <h4>Symbole Y2K</h4>
       <p class="aesthetic-card-symbols">♱ ✮ 𓆩 𓆪 🦋 🫧</p>
       <p class="aesthetic-card-desc">Nostalgia lat 2000, cybercore i motyle.</p>
     </a>
     <a href="/pl/library/symbole-goth-grunge/" class="compare-card variant-muted is-link">
       <span class="compare-badge">Bio Discord</span>
-      <h4>Goth / Grunge</h4>
+      <h4>Symbole goth i grunge</h4>
       <p class="aesthetic-card-symbols">♱ † ☠ 🕷 𖤐</p>
       <p class="aesthetic-card-desc">Krzyże, czaszki i mroczna energia mody.</p>
     </a>

--- a/pl/library/symbole-facebook/index.html
+++ b/pl/library/symbole-facebook/index.html
@@ -509,11 +509,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Gwiazdki, iskierki i znaki asterysku do skopiowania.</p>
     </a>
     <a href="/pl/library/symbole-punktowania/" class="compare-card variant-muted u-no-underline">
-      <h4>Bullet Point Symbols</h4>
+      <h4>Symbole Punktowania</h4>
       <p>Znaczniki list, strzałki i ozdobne punktory do postów.</p>
     </a>
     <a href="/pl/library/symbol-ptaszka/" class="compare-card variant-muted u-no-underline">
-      <h4>Checkmark Symbols</h4>
+      <h4>Symbol ptaszka</h4>
       <p>Znaczniki wyboru, krzyżyki i wskaźniki statusu.</p>
     </a>
   </div>

--- a/pl/ozdobniki/index.html
+++ b/pl/ozdobniki/index.html
@@ -187,7 +187,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
           <button class="decoration-tab" data-deco-tab="frames">Ramki</button>
           <button class="decoration-tab" data-deco-tab="dividers">Separatory</button>
           <button class="decoration-tab" data-deco-tab="arrows">Strzałki</button>
-          <button class="decoration-tab" data-deco-tab="minimal">Minimal</button>
+          <button class="decoration-tab" data-deco-tab="minimal">Minimalne</button>
           <button class="decoration-tab" data-deco-tab="emojis">Emoji</button>
         </div>
         <div class="decoration-grid" id="decorationGrid"></div>

--- a/pl/podkreslony-tekst/index.html
+++ b/pl/podkreslony-tekst/index.html
@@ -150,7 +150,7 @@
         <div class="decoration-tabs">
           <button class="decoration-tab active" data-deco-tab="symbols">Symbole</button>
           <button class="decoration-tab" data-deco-tab="frames">Ramki</button>
-          <button class="decoration-tab" data-deco-tab="minimal">Minimal</button>
+          <button class="decoration-tab" data-deco-tab="minimal">Minimalne</button>
         </div>
         <div class="decoration-grid" id="decorationGrid"></div>
       </div>

--- a/pl/symbol/anch/index.html
+++ b/pl/symbol/anch/index.html
@@ -245,7 +245,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Powiązane Zasoby</span>
   <div class="compare-grid">
     <a href="/pl/library/hieroglify-egipskie/" class="compare-card variant-muted u-no-underline">
-      <h4>Egyptian Hieroglyphs</h4>
+      <h4>Hieroglify Egipskie</h4>
       <p>Pełny system pisma hieroglificznego, do którego należy anch (znak S34).</p>
     </a>
     <a href="/pl/symbol/krzyz-lacinski/" class="compare-card variant-muted u-no-underline">

--- a/pl/symbol/czarny-ksiezyc-lilith/index.html
+++ b/pl/symbol/czarny-ksiezyc-lilith/index.html
@@ -261,11 +261,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Powiązane Zasoby</span>
   <div class="compare-grid">
     <a href="/pl/library/symbole-znakow-zodiaku/" class="compare-card variant-muted u-no-underline">
-      <h4>Zodiac Symbols</h4>
+      <h4>Symbole Znaków Zodiaku</h4>
       <p>Dwanaście glifów znaków zodiaku, względem których odczytuje się położenie Czarnego Księżyca Lilith.</p>
     </a>
     <a href="/pl/symbol/gwiazda-dawida/" class="compare-card variant-muted u-no-underline">
-      <h4>Star of David</h4>
+      <h4>Gwiazda Dawida</h4>
       <p>Kolejny symbol, którego prawdziwa historia jest cichsza i późniejsza niż znaczenie, jakie ma dziś.</p>
     </a>
     <a href="/pl/symbol/pentagram/" class="compare-card variant-muted u-no-underline">

--- a/pl/symbol/emoji-meteoru/index.html
+++ b/pl/symbol/emoji-meteoru/index.html
@@ -228,7 +228,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Powiązane Zasoby</span>
   <div class="compare-grid">
     <a href="/pl/library/symbole-pogody/" class="compare-card variant-muted u-no-underline">
-      <h4>Weather Symbols</h4>
+      <h4>Symbole pogody i emoji</h4>
       <p>Słońce, deszcz, śnieg i każdy już zakodowany znak niebieski, w tym Kometa.</p>
     </a>
     <a href="/pl/symbol/pekajaca-twarz/" class="compare-card variant-muted u-no-underline">

--- a/pl/symbol/emoji-mikrofonu/index.html
+++ b/pl/symbol/emoji-mikrofonu/index.html
@@ -244,11 +244,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Każde emoji przedmiotu codziennego użytku — technologia, dom i biuro — w tym mikrofon, przeglądalne w jednej siatce.</p>
     </a>
     <a href="/pl/library/emoji-combos/" class="compare-card variant-muted u-no-underline">
-      <h4>Emoji Combos</h4>
+      <h4>Kombinacje emoji do kopiowania</h4>
       <p>Gotowe zestawienia emoji do bio i podpisów, w tym motywy muzyczne i sceniczne.</p>
     </a>
     <a href="/pl/library/symbole-muzyczne/" class="compare-card variant-muted u-no-underline">
-      <h4>Music Symbols</h4>
+      <h4>Symbole Muzyczne</h4>
       <p>Notacja muzyczna Unicode — ♪ ♫ ♬ — tekstowy kuzyn rodziny emoji muzycznych.</p>
     </a>
   </div>

--- a/pl/symbol/gwiazda-dawida/index.html
+++ b/pl/symbol/gwiazda-dawida/index.html
@@ -237,7 +237,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Powiązane Zasoby</span>
   <div class="compare-grid">
     <a href="/pl/library/symbole-religijne/" class="compare-card variant-muted u-no-underline">
-      <h4>Religious Symbols</h4>
+      <h4>Symbole Religijne i Duchowe</h4>
       <p>Symbole wiary z każdej większej światowej religii w jednym miejscu.</p>
     </a>
     <a href="/pl/symbol/khanda/" class="compare-card variant-muted u-no-underline">

--- a/pl/symbol/gwiazda-i-polksiezyc/index.html
+++ b/pl/symbol/gwiazda-i-polksiezyc/index.html
@@ -256,11 +256,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Powiązane Zasoby</span>
   <div class="compare-grid">
     <a href="/pl/library/symbole-religijne/" class="compare-card variant-muted u-no-underline">
-      <h4>Religious Symbols</h4>
+      <h4>Symbole Religijne i Duchowe</h4>
       <p>Symbole wiary z każdej większej światowej religii w jednym przeglądalnym zestawie.</p>
     </a>
     <a href="/pl/library/symbole-islamskie/" class="compare-card variant-muted u-no-underline">
-      <h4>Islamic Symbols</h4>
+      <h4>Symbole Islamskie</h4>
       <p>Gwiazda i półksiężyc obok kaligrafii Allah, meczetu, modlitwy i innych symboli związanych z islamem.</p>
     </a>
     <a href="/pl/symbol/gwiazda-dawida/" class="compare-card variant-muted u-no-underline">

--- a/pl/symbol/hamsa/index.html
+++ b/pl/symbol/hamsa/index.html
@@ -245,7 +245,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Kolejny symbol z realną, udokumentowaną historią projektu, opisaną bez stawania po żadnej ze stron.</p>
     </a>
     <a href="/pl/symbol/gwiazda-dawida/" class="compare-card variant-muted u-no-underline">
-      <h4>Star of David</h4>
+      <h4>Gwiazda Dawida</h4>
       <p>Zaskakująco niedawna droga wspólnego, starożytnego motywu do bycia symbolem jednej wiary.</p>
     </a>
     <a href="/pl/symbol/anch/" class="compare-card variant-muted u-no-underline">

--- a/pl/symbol/index.html
+++ b/pl/symbol/index.html
@@ -234,7 +234,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Operator „razy”, inny znak niż litera x.</p>
     </a>
     <a href="/pl/symbol/yin-yang/" class="compare-card variant-muted u-no-underline">
-      <h4>☯ Yin Yang</h4>
+      <h4>Symbol Yin Yang (☯)</h4>
       <p>Taijitu z czasów dynastii Song, XI–XII wiek.</p>
     </a>
     <a href="/pl/symbol/symbol-gwiazdy/" class="compare-card variant-muted u-no-underline">
@@ -550,7 +550,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Znak wyzwolenia gejowskiego i rachunek lambda Churcha.</p>
     </a>
     <a href="/pl/symbol/interrobang/" class="compare-card variant-muted u-no-underline">
-      <h4>‽ Interrobang</h4>
+      <h4>Interrobang (‽)</h4>
       <p>Wymyślony w 1962 roku, przez chwilę prawdziwy klawisz.</p>
     </a>
     <a href="/pl/symbol/polpauza/" class="compare-card variant-muted u-no-underline">

--- a/pl/symbol/khanda/index.html
+++ b/pl/symbol/khanda/index.html
@@ -237,15 +237,15 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Powiązane Zasoby</span>
   <div class="compare-grid">
     <a href="/pl/library/symbole-religijne/" class="compare-card variant-muted u-no-underline">
-      <h4>Religious Symbols</h4>
+      <h4>Symbole Religijne i Duchowe</h4>
       <p>Symbole wiary z każdej większej światowej religii w jednym miejscu.</p>
     </a>
     <a href="/pl/symbol/symbol-pokoju/" class="compare-card variant-muted u-no-underline">
-      <h4>Peace Symbol</h4>
+      <h4>Symbol Pokoju (☮)</h4>
       <p>Symbol pokoju oraz gołębie, gesty i symbole natury o podobnym znaczeniu.</p>
     </a>
     <a href="/pl/symbol/yin-yang/" class="compare-card variant-muted u-no-underline">
-      <h4>Yin Yang Symbol</h4>
+      <h4>Symbol Yin Yang (☯)</h4>
       <p>Symbol yin-yang oraz powiązane znaki równowagi i harmonii.</p>
     </a>
     <a href="/pl/symbol/krzyz-lacinski/" class="compare-card variant-muted u-no-underline">

--- a/pl/symbol/krzyz-lacinski/index.html
+++ b/pl/symbol/krzyz-lacinski/index.html
@@ -253,7 +253,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Powiązane Zasoby</span>
   <div class="compare-grid">
     <a href="/pl/symbol/symbol-pokoju/" class="compare-card variant-muted u-no-underline">
-      <h4>Peace Symbol (☮)</h4>
+      <h4>Symbol Pokoju (☮)</h4>
       <p>Projekt Geralda Holtoma z 1958 roku i powiązane symbole dobrej woli.</p>
     </a>
     <a href="/pl/symbol/khanda/" class="compare-card variant-muted u-no-underline">
@@ -261,7 +261,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Sikhijski emblemat, z tej samej biblioteki symboli religijnych.</p>
     </a>
     <a href="/pl/library/symbole-religijne/" class="compare-card variant-muted u-no-underline">
-      <h4>Religious Symbols</h4>
+      <h4>Symbole Religijne i Duchowe</h4>
       <p>Symbole wiary z każdej większej światowej religii w jednym miejscu.</p>
     </a>
     <a href="/pl/symbol/krzyz-prawoslawny/" class="compare-card variant-muted u-no-underline">

--- a/pl/symbol/krzyz-prawoslawny/index.html
+++ b/pl/symbol/krzyz-prawoslawny/index.html
@@ -245,11 +245,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Symbole wiary i duchowości z głównych światowych tradycji, w tym krzyże, półksiężyce i gwiazdy.</p>
     </a>
     <a href="/pl/symbol/krzyz-lacinski/" class="compare-card variant-muted u-no-underline">
-      <h4>Cross Symbol</h4>
+      <h4>Symbol Krzyża</h4>
       <p>Zwykły krzyż łaciński chrześcijaństwa — i sztylet oraz znak ✕, z którymi bywa mylony.</p>
     </a>
     <a href="/pl/symbol/gwiazda-dawida/" class="compare-card variant-muted u-no-underline">
-      <h4>Star of David</h4>
+      <h4>Gwiazda Dawida</h4>
       <p>Kolejny symbol z realną, udokumentowaną historią, opisaną bez stawania po żadnej ze stron.</p>
     </a>
   </div>

--- a/pl/symbol/pauza/index.html
+++ b/pl/symbol/pauza/index.html
@@ -261,7 +261,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Powiązane Zasoby</span>
   <div class="compare-grid">
     <a href="/pl/symbol/polpauza/" class="compare-card variant-muted u-no-underline">
-      <h4>En Dash</h4>
+      <h4>Półpauza (–)</h4>
       <p>Krótsza od pauzy półpauza — kreska, którą polska typografia stosuje jako właściwy myślnik zdaniowy.</p>
     </a>
     <a href="/pl/symbol/znak-akapitu/" class="compare-card variant-muted u-no-underline">

--- a/pl/symbol/pentagram/index.html
+++ b/pl/symbol/pentagram/index.html
@@ -261,7 +261,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Pentagramy, fazy księżyca, znaki alchemiczne i inne symbole w jednym przeglądalnym zestawie.</p>
     </a>
     <a href="/pl/library/symbole-religijne/" class="compare-card variant-muted u-no-underline">
-      <h4>Religious Symbols</h4>
+      <h4>Symbole Religijne i Duchowe</h4>
       <p>Symbole wiary i duchowości z głównych światowych tradycji, w tym żywej praktyki pogańskiej i wiccańskiej.</p>
     </a>
     <a href="/pl/symbol/symbol-autyzmu/" class="compare-card variant-muted u-no-underline">

--- a/pl/symbol/symbol-anarchii/index.html
+++ b/pl/symbol/symbol-anarchii/index.html
@@ -261,7 +261,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Znaki punkowe, gotyckie i alternatywnej estetyki, do których świetnie pasuje okrągłe A.</p>
     </a>
     <a href="/pl/symbol/symbol-pokoju/" class="compare-card variant-muted u-no-underline">
-      <h4>Peace Symbol</h4>
+      <h4>Symbol Pokoju (☮)</h4>
       <p>Kolejny symbol protestu z realną, precyzyjnie udokumentowaną historią jednego projektanta.</p>
     </a>
     <a href="/library/pride-lgbtq-symbols/" class="compare-card variant-muted u-no-underline">

--- a/pl/symbol/symbol-barana/index.html
+++ b/pl/symbol/symbol-barana/index.html
@@ -233,7 +233,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Powiązane Zasoby</span>
   <div class="compare-grid">
     <a href="/pl/library/symbole-znakow-zodiaku/" class="compare-card variant-muted u-no-underline">
-      <h4>Zodiac Symbols</h4>
+      <h4>Symbole Znaków Zodiaku</h4>
       <p>Znaki zachodniego zodiaku, symbole planet i chińskie zwierzęta zodiakalne w jednym miejscu.</p>
     </a>
     <a href="/pl/symbol/symbol-wagi/" class="compare-card variant-muted u-no-underline">
@@ -241,7 +241,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Astrologiczne przeciwieństwo Barana, leżące dokładnie po drugiej stronie koła zodiaku.</p>
     </a>
     <a href="/pl/symbol/symbol-lwa/" class="compare-card variant-muted u-no-underline">
-      <h4>Leo Symbol</h4>
+      <h4>Symbol Lwa</h4>
       <p>Kolejny znak Ognia, z mitem o Lwie Nemejskim stojącym za jego glifem.</p>
     </a>
   </div>

--- a/pl/symbol/symbol-blizniat/index.html
+++ b/pl/symbol/symbol-blizniat/index.html
@@ -233,7 +233,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Powiązane Zasoby</span>
   <div class="compare-grid">
     <a href="/pl/library/symbole-znakow-zodiaku/" class="compare-card variant-muted u-no-underline">
-      <h4>Zodiac Symbols</h4>
+      <h4>Symbole Znaków Zodiaku</h4>
       <p>Znaki zachodniego zodiaku, symbole planet i chińskie zwierzęta zodiakalne w jednym miejscu.</p>
     </a>
     <a href="/pl/symbol/symbol-strzelca/" class="compare-card variant-muted u-no-underline">
@@ -241,7 +241,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Astrologiczne przeciwieństwo Bliźniąt, leżące dokładnie po drugiej stronie koła zodiaku.</p>
     </a>
     <a href="/pl/symbol/symbol-lwa/" class="compare-card variant-muted u-no-underline">
-      <h4>Leo Symbol</h4>
+      <h4>Symbol Lwa</h4>
       <p>Kolejny indywidualny znak zodiaku, z mitem o Lwie Nemejskim za jego glifem.</p>
     </a>
     <a href="/pl/symbol/symbol-panny/" class="compare-card variant-muted u-no-underline">

--- a/pl/symbol/symbol-byka/index.html
+++ b/pl/symbol/symbol-byka/index.html
@@ -233,7 +233,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Powiązane Zasoby</span>
   <div class="compare-grid">
     <a href="/pl/library/symbole-znakow-zodiaku/" class="compare-card variant-muted u-no-underline">
-      <h4>Zodiac Symbols</h4>
+      <h4>Symbole Znaków Zodiaku</h4>
       <p>Znaki zachodniego zodiaku, symbole planet i chińskie zwierzęta zodiakalne w jednym miejscu.</p>
     </a>
     <a href="/pl/symbol/symbol-skorpiona/" class="compare-card variant-muted u-no-underline">

--- a/pl/symbol/symbol-chi/index.html
+++ b/pl/symbol/symbol-chi/index.html
@@ -292,7 +292,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Chi-kwadrat, górne indeksy oraz operatory i litery greckie wypełniające równanie.</p>
     </a>
     <a href="/pl/library/symbole-religijne/" class="compare-card variant-muted u-no-underline">
-      <h4>Religious Symbols</h4>
+      <h4>Symbole Religijne i Duchowe</h4>
       <p>Chi-Rho, krzyże i inne symbole chrześcijańskie oraz wiary zebrane w jednym miejscu.</p>
     </a>
     <a href="/pl/symbol/symbol-pi/" class="compare-card variant-muted u-no-underline">

--- a/pl/symbol/symbol-gwiazdy/index.html
+++ b/pl/symbol/symbol-gwiazdy/index.html
@@ -257,7 +257,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Cała kolekcja gwiazdek, iskierek i gwiazdek ocen do skopiowania w jednym miejscu.</p>
     </a>
     <a href="/pl/symbol/symbol-serca/" class="compare-card variant-muted u-no-underline">
-      <h4>Heart Symbol (♥)</h4>
+      <h4>Symbol Serca</h4>
       <p>Karciany symbol serca, który stał się znakiem miłości.</p>
     </a>
     <a href="/pl/library/symbole-serca/" class="compare-card variant-muted u-no-underline">

--- a/pl/symbol/symbol-koziorozca/index.html
+++ b/pl/symbol/symbol-koziorozca/index.html
@@ -233,7 +233,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Powiązane Zasoby</span>
   <div class="compare-grid">
     <a href="/pl/library/symbole-znakow-zodiaku/" class="compare-card variant-muted u-no-underline">
-      <h4>Zodiac Symbols</h4>
+      <h4>Symbole Znaków Zodiaku</h4>
       <p>Znaki zachodniego zodiaku, symbole planet i chińskie zwierzęta zodiakalne w jednym miejscu.</p>
     </a>
     <a href="/pl/symbol/symbol-raka/" class="compare-card variant-muted u-no-underline">
@@ -241,7 +241,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Astrologiczne przeciwieństwo Koziorożca, leżące dokładnie po drugiej stronie koła zodiaku.</p>
     </a>
     <a href="/pl/symbol/symbol-byka/" class="compare-card variant-muted u-no-underline">
-      <h4>Taurus Symbol</h4>
+      <h4>Symbol Byka</h4>
       <p>Kolejny znak Ziemi i prawdopodobnie najstarszy nieprzerwanie obserwowany gwiazdozbiór w zodiaku.</p>
     </a>
   </div>

--- a/pl/symbol/symbol-lwa/index.html
+++ b/pl/symbol/symbol-lwa/index.html
@@ -233,7 +233,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Powiązane Zasoby</span>
   <div class="compare-grid">
     <a href="/pl/library/symbole-znakow-zodiaku/" class="compare-card variant-muted u-no-underline">
-      <h4>Zodiac Symbols</h4>
+      <h4>Symbole Znaków Zodiaku</h4>
       <p>Znaki zachodniego zodiaku, symbole planet i chińskie zwierzęta zodiakalne w jednym miejscu.</p>
     </a>
     <a href="/pl/symbol/symbol-wodnika/" class="compare-card variant-muted u-no-underline">

--- a/pl/symbol/symbol-niepelnosprawnosci/index.html
+++ b/pl/symbol/symbol-niepelnosprawnosci/index.html
@@ -245,7 +245,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Laska Eskulapa, krzyże medyczne, znaki aptek i symbole zdrowia oraz ratownictwa w jednym miejscu.</p>
     </a>
     <a href="/pl/symbol/symbol-autyzmu/" class="compare-card variant-muted u-no-underline">
-      <h4>Autism Symbol</h4>
+      <h4>Symbol Autyzmu</h4>
       <p>Kolejny symbol związany z dostępnością, wokół którego toczy się realna, wciąż nierozstrzygnięta dyskusja społeczności.</p>
     </a>
     <a href="/library/traffic-road-sign-symbols/" class="compare-card variant-muted u-no-underline">

--- a/pl/symbol/symbol-om/index.html
+++ b/pl/symbol/symbol-om/index.html
@@ -249,15 +249,15 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Powiązane Zasoby</span>
   <div class="compare-grid">
     <a href="/pl/library/symbole-religijne/" class="compare-card variant-muted u-no-underline">
-      <h4>Religious Symbols</h4>
+      <h4>Symbole Religijne i Duchowe</h4>
       <p>Symbole wiary z każdej większej światowej religii w jednym miejscu.</p>
     </a>
     <a href="/pl/symbol/khanda/" class="compare-card variant-muted u-no-underline">
-      <h4>Khanda Symbol</h4>
+      <h4>Symbol Khanda</h4>
       <p>Sikhijski emblemat, którego własna strona już pokazuje Om jako powiązany dharmiczny glif.</p>
     </a>
     <a href="/pl/symbol/hamsa/" class="compare-card variant-muted u-no-underline">
-      <h4>Hamsa Symbol</h4>
+      <h4>Symbol Hamsa</h4>
       <p>Kolejny symbol wspólny dla wielu tradycji, opisany jako udokumentowana historia, bez stawania po żadnej ze stron.</p>
     </a>
   </div>

--- a/pl/symbol/symbol-omega/index.html
+++ b/pl/symbol/symbol-omega/index.html
@@ -241,7 +241,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Litera stojąca za memem „sigma male” — i dlaczego wyprzedza ją pod względem popularności 🗿.</p>
     </a>
     <a href="/pl/symbol/znak-mikro/" class="compare-card variant-muted u-no-underline">
-      <h4>Micro Sign</h4>
+      <h4>Znak Mikro (µ)</h4>
       <p>Ta sama pomyłka co oma z omegą — identyczna z grecką literą mu na ekranie, a jednak pod spodem to inny znak.</p>
     </a>
     <a href="/pl/symbol/symbol-alfa/" class="compare-card variant-muted u-no-underline">

--- a/pl/symbol/symbol-panny/index.html
+++ b/pl/symbol/symbol-panny/index.html
@@ -233,7 +233,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Powiązane Zasoby</span>
   <div class="compare-grid">
     <a href="/pl/library/symbole-znakow-zodiaku/" class="compare-card variant-muted u-no-underline">
-      <h4>Zodiac Symbols</h4>
+      <h4>Symbole Znaków Zodiaku</h4>
       <p>Znaki zachodniego zodiaku, symbole planet i chińskie zwierzęta zodiakalne w jednym miejscu.</p>
     </a>
     <a href="/pl/symbol/symbol-ryb/" class="compare-card variant-muted u-no-underline">

--- a/pl/symbol/symbol-pika/index.html
+++ b/pl/symbol/symbol-pika/index.html
@@ -264,7 +264,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Powiązane Zasoby</span>
   <div class="compare-grid">
     <a href="/pl/library/symbole-kart/" class="compare-card variant-muted u-no-underline">
-      <h4>Card Suit Symbols</h4>
+      <h4>Symbole kolorów kart ♠ ♥ ♦ ♣</h4>
       <p>Wszystkie cztery kolory kart — pik, kier, karo i trefl — w formach pełnych i konturowych do przeglądania i kopiowania.</p>
     </a>
     <a href="/library/dice-domino-symbols/" class="compare-card variant-muted u-no-underline">

--- a/pl/symbol/symbol-piona/index.html
+++ b/pl/symbol/symbol-piona/index.html
@@ -274,7 +274,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Powiązane Zasoby</span>
   <div class="compare-grid">
     <a href="/pl/library/symbole-szachowe/" class="compare-card variant-muted u-no-underline">
-      <h4>Chess Symbols</h4>
+      <h4>Symbole Szachowe</h4>
       <p>Pełny unicode'owy komplet szachowy — króle, hetmany, wieże, gońce, skoczki i oba piony — w jednym miejscu do skopiowania.</p>
     </a>
     <a href="/pl/symbol/symbol-pika/" class="compare-card variant-muted u-no-underline">

--- a/pl/symbol/symbol-raka/index.html
+++ b/pl/symbol/symbol-raka/index.html
@@ -233,15 +233,15 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Powiązane Zasoby</span>
   <div class="compare-grid">
     <a href="/pl/library/symbole-znakow-zodiaku/" class="compare-card variant-muted u-no-underline">
-      <h4>Zodiac Symbols</h4>
+      <h4>Symbole Znaków Zodiaku</h4>
       <p>Znaki zachodniego zodiaku, symbole planet i chińskie zwierzęta zodiakalne w jednym miejscu.</p>
     </a>
     <a href="/pl/symbol/symbol-koziorozca/" class="compare-card variant-muted u-no-underline">
-      <h4>Capricorn Symbol</h4>
+      <h4>Symbol Koziorożca</h4>
       <p>Astrologiczne przeciwieństwo Raka, leżące dokładnie po drugiej stronie koła zodiaku.</p>
     </a>
     <a href="/pl/symbol/symbol-lwa/" class="compare-card variant-muted u-no-underline">
-      <h4>Leo Symbol</h4>
+      <h4>Symbol Lwa</h4>
       <p>Jedyny znak zodiaku rządzony przez Słońce — odpowiednik rządzonego przez Księżyc Raka.</p>
     </a>
   </div>

--- a/pl/symbol/symbol-recyklingu/index.html
+++ b/pl/symbol/symbol-recyklingu/index.html
@@ -253,7 +253,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Znaki recyklingu, ekoetykiety i symbole natury w jednym miejscu — ta strona jest dedykowaną odnogą tego huba.</p>
     </a>
     <a href="/pl/symbol/zagrozenie-biologiczne/" class="compare-card variant-muted u-no-underline">
-      <h4>Biohazard Symbol</h4>
+      <h4>Symbol Zagrożenia Biologicznego</h4>
       <p>Kolejny nowoczesny piktogram z udokumentowanym firmowym rodowodem — zaprojektowany w Dow Chemical w 1966 roku tak, by być celowo „zapadającym w pamięć, ale pozbawionym znaczenia”.</p>
     </a>
     <a href="/pl/symbol/symbol-niepelnosprawnosci/" class="compare-card variant-muted u-no-underline">

--- a/pl/symbol/symbol-ryb/index.html
+++ b/pl/symbol/symbol-ryb/index.html
@@ -233,7 +233,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Powiązane Zasoby</span>
   <div class="compare-grid">
     <a href="/pl/library/symbole-znakow-zodiaku/" class="compare-card variant-muted u-no-underline">
-      <h4>Zodiac Symbols</h4>
+      <h4>Symbole Znaków Zodiaku</h4>
       <p>Znaki zachodniego zodiaku, symbole planet i chińskie zwierzęta zodiakalne w jednym miejscu.</p>
     </a>
     <a href="/pl/symbol/symbol-panny/" class="compare-card variant-muted u-no-underline">

--- a/pl/symbol/symbol-serca/index.html
+++ b/pl/symbol/symbol-serca/index.html
@@ -261,7 +261,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Każdy znak serca i kolorowe emoji serca w jednym miejscu.</p>
     </a>
     <a href="/pl/library/symbole-kart/" class="compare-card variant-muted u-no-underline">
-      <h4>Card Suit Symbols</h4>
+      <h4>Symbole kolorów kart ♠ ♥ ♦ ♣</h4>
       <p>♥ ♦ ♣ ♠ — cztery kolory kart, z których wywodzi się serce.</p>
     </a>
     <a href="/pl/symbol/kolory-serc-na-snapchacie/" class="compare-card variant-muted u-no-underline">

--- a/pl/symbol/symbol-skorpiona/index.html
+++ b/pl/symbol/symbol-skorpiona/index.html
@@ -233,7 +233,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Powiązane Zasoby</span>
   <div class="compare-grid">
     <a href="/pl/library/symbole-znakow-zodiaku/" class="compare-card variant-muted u-no-underline">
-      <h4>Zodiac Symbols</h4>
+      <h4>Symbole Znaków Zodiaku</h4>
       <p>Znaki zachodniego zodiaku, symbole planet i chińskie zwierzęta zodiakalne w jednym miejscu.</p>
     </a>
     <a href="/pl/symbol/symbol-byka/" class="compare-card variant-muted u-no-underline">

--- a/pl/symbol/symbol-strzelca/index.html
+++ b/pl/symbol/symbol-strzelca/index.html
@@ -233,15 +233,15 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Powiązane Zasoby</span>
   <div class="compare-grid">
     <a href="/pl/library/symbole-znakow-zodiaku/" class="compare-card variant-muted u-no-underline">
-      <h4>Zodiac Symbols</h4>
+      <h4>Symbole Znaków Zodiaku</h4>
       <p>Znaki zachodniego zodiaku, symbole planet i chińskie zwierzęta zodiakalne w jednym miejscu.</p>
     </a>
     <a href="/pl/symbol/symbol-blizniat/" class="compare-card variant-muted u-no-underline">
-      <h4>Gemini Symbol</h4>
+      <h4>Symbol Bliźniąt</h4>
       <p>Astrologiczne przeciwieństwo Strzelca, leżące dokładnie po drugiej stronie koła zodiaku.</p>
     </a>
     <a href="/pl/symbol/symbol-wodnika/" class="compare-card variant-muted u-no-underline">
-      <h4>Aquarius Symbol</h4>
+      <h4>Symbol Wodnika</h4>
       <p>Wodnik, który mimo nazwy jest znakiem Powietrza, a nie Wody.</p>
     </a>
     <a href="/pl/symbol/symbol-wagi/" class="compare-card variant-muted u-no-underline">

--- a/pl/symbol/symbol-wagi/index.html
+++ b/pl/symbol/symbol-wagi/index.html
@@ -233,11 +233,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Powiązane Zasoby</span>
   <div class="compare-grid">
     <a href="/pl/library/symbole-znakow-zodiaku/" class="compare-card variant-muted u-no-underline">
-      <h4>Zodiac Symbols</h4>
+      <h4>Symbole Znaków Zodiaku</h4>
       <p>Znaki zachodniego zodiaku, symbole planet i chińskie zwierzęta zodiakalne w jednym miejscu.</p>
     </a>
     <a href="/pl/symbol/symbol-barana/" class="compare-card variant-muted u-no-underline">
-      <h4>Aries Symbol</h4>
+      <h4>Symbol Barana</h4>
       <p>Astrologiczne przeciwieństwo Wagi, leżące dokładnie po drugiej stronie koła zodiaku.</p>
     </a>
     <a href="/pl/symbol/symbol-strzelca/" class="compare-card variant-muted u-no-underline">

--- a/pl/symbol/symbol-wodnika/index.html
+++ b/pl/symbol/symbol-wodnika/index.html
@@ -233,11 +233,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Powiązane Zasoby</span>
   <div class="compare-grid">
     <a href="/pl/library/symbole-znakow-zodiaku/" class="compare-card variant-muted u-no-underline">
-      <h4>Zodiac Symbols</h4>
+      <h4>Symbole Znaków Zodiaku</h4>
       <p>Znaki zachodniego zodiaku, symbole planet i chińskie zwierzęta zodiakalne w jednym miejscu.</p>
     </a>
     <a href="/pl/symbol/symbol-lwa/" class="compare-card variant-muted u-no-underline">
-      <h4>Leo Symbol</h4>
+      <h4>Symbol Lwa</h4>
       <p>Astrologiczne przeciwieństwo Wodnika, leżące dokładnie po drugiej stronie koła zodiaku.</p>
     </a>
     <a href="/pl/symbol/symbol-wagi/" class="compare-card variant-muted u-no-underline">

--- a/pl/symbol/symbol-zlosci/index.html
+++ b/pl/symbol/symbol-zlosci/index.html
@@ -249,11 +249,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Powiązane Zasoby</span>
   <div class="compare-grid">
     <a href="/pl/library/emoji-combos/" class="compare-card variant-muted u-no-underline">
-      <h4>Emoji Combos</h4>
+      <h4>Kombinacje emoji do kopiowania</h4>
       <p>Gotowe zestawy emoji na różne klimaty i reakcje, w tym kilka zbudowanych wokół złości i wściekłości.</p>
     </a>
     <a href="/pl/symbol/znak-stop/" class="compare-card variant-muted u-no-underline">
-      <h4>Stop Sign Symbol</h4>
+      <h4>Symbol Znaku Stop</h4>
       <p>Kolejne emoji, którego całe znaczenie opiera się na rozpoznawalnym kształcie ze świata realnego, a nie na twarzy.</p>
     </a>
     <a href="/pl/usecase/zalgo-text/" class="compare-card variant-muted u-no-underline">

--- a/pl/symbol/znak-bitcoina/index.html
+++ b/pl/symbol/znak-bitcoina/index.html
@@ -249,7 +249,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Powiązane Zasoby</span>
   <div class="compare-grid">
     <a href="/pl/library/symbole-walut/" class="compare-card variant-muted u-no-underline">
-      <h4>Currency Symbols</h4>
+      <h4>Symbole Walut</h4>
       <p>Dolar, euro, funt, jen, rupia i inne światowe znaki walut w jednym miejscu.</p>
     </a>
     <a href="/pl/symbol/znak-euro/" class="compare-card variant-muted u-no-underline">
@@ -257,7 +257,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Kolejny znak waluty zaprojektowany na zamówienie we współczesnej erze, w 1996 roku.</p>
     </a>
     <a href="/pl/symbol/znak-rupii/" class="compare-card variant-muted u-no-underline">
-      <h4>Rupee Sign</h4>
+      <h4>Znak Rupii Indyjskiej (₹)</h4>
       <p>Niedawny, celowo stworzony znak waluty — wybrany w konkursie publicznym w 2010 roku.</p>
     </a>
   </div>

--- a/pl/symbol/znak-centa/index.html
+++ b/pl/symbol/znak-centa/index.html
@@ -241,11 +241,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Symbol euro zaprojektowany celowo w 1996 roku, plus symbole innych walut świata.</p>
     </a>
     <a href="/pl/symbol/znak-funta/" class="compare-card variant-muted u-no-underline">
-      <h4>Pound Sign (£)</h4>
+      <h4>Znak Funta (£)</h4>
       <p>Symbol funta liczący sobie ponad tysiąc lat, wywodzący się z łacińskiego libra.</p>
     </a>
     <a href="/pl/library/symbole-walut/" class="compare-card variant-muted u-no-underline">
-      <h4>All Currency Symbols</h4>
+      <h4>Symbole Walut</h4>
       <p>Wszystkie światowe symbole walut, uporządkowane według regionu.</p>
     </a>
     <a href="/pl/symbol/znak-dolara/" class="compare-card variant-muted u-no-underline">

--- a/pl/symbol/znak-dirhama/index.html
+++ b/pl/symbol/znak-dirhama/index.html
@@ -238,7 +238,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Powiązane Zasoby</span>
   <div class="compare-grid">
     <a href="/pl/library/symbole-walut/" class="compare-card variant-muted u-no-underline">
-      <h4>Currency Symbols</h4>
+      <h4>Symbole Walut</h4>
       <p>Każdy światowy symbol waluty, który możesz już dziś skopiować i wkleić.</p>
     </a>
     <a href="/pl/symbol/znak-riala-omanskiego/" class="compare-card variant-muted u-no-underline">

--- a/pl/symbol/znak-oma/index.html
+++ b/pl/symbol/znak-oma/index.html
@@ -256,7 +256,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Przeglądalny zestaw glifów schematów — uziemienia, źródła, przełączniki i jednostki, którymi się je opisuje.</p>
     </a>
     <a href="/pl/symbol/znak-mikro/" class="compare-card variant-muted u-no-underline">
-      <h4>Micro Sign</h4>
+      <h4>Znak Mikro (µ)</h4>
       <p>Dokładnie ta sama unikodowa osobliwość co znak oma: µ to dawny znak normalizujący się do greckiej litery mu — kolejny przedrostek SI (µF, µA), który wygląda jak grecka litera, choć pod spodem nią nie jest.</p>
     </a>
     <a href="/pl/symbol/symbol-celsjusza/" class="compare-card variant-muted u-no-underline">

--- a/pl/symbol/znak-peso/index.html
+++ b/pl/symbol/znak-peso/index.html
@@ -253,15 +253,15 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Powiązane Zasoby</span>
   <div class="compare-grid">
     <a href="/pl/library/symbole-walut/" class="compare-card variant-muted u-no-underline">
-      <h4>Currency Symbols</h4>
+      <h4>Symbole Walut</h4>
       <p>Przeglądaj każdy światowy symbol waluty — dolar, euro, funt, jen, rupię i peso — obok siebie w jednej siatce.</p>
     </a>
     <a href="/pl/symbol/znak-dolara/" class="compare-card variant-muted u-no-underline">
-      <h4>Dollar Sign ($)</h4>
+      <h4>Znak Dolara ($)</h4>
       <p>Znak, którego naprawdę używa niemal każde peso: tylko peso filipińskie ma własny ₱, a meksykańskie, argentyńskie i kolumbijskie zapisuje się $.</p>
     </a>
     <a href="/pl/symbol/znak-rupii/" class="compare-card variant-muted u-no-underline">
-      <h4>Rupee Sign (₹)</h4>
+      <h4>Znak Rupii Indyjskiej (₹)</h4>
       <p>Indyjskie ₹ — podobnie jak ₱, nowoczesny znak waluty formalnie ustanowiony dla pieniądza jednego kraju, zbudowany przez przekreślenie litery równoległymi kreskami.</p>
     </a>
   </div>

--- a/pl/symbol/znak-riala-omanskiego/index.html
+++ b/pl/symbol/znak-riala-omanskiego/index.html
@@ -216,7 +216,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Powiązane Zasoby</span>
   <div class="compare-grid">
     <a href="/pl/library/symbole-walut/" class="compare-card variant-muted u-no-underline">
-      <h4>Currency Symbols</h4>
+      <h4>Symbole Walut</h4>
       <p>Każdy światowy symbol waluty, który możesz już dziś skopiować i wkleić.</p>
     </a>
     <a href="/pl/symbol/znak-dirhama/" class="compare-card variant-muted u-no-underline">

--- a/pl/symbol/znak-riala-saudyjskiego/index.html
+++ b/pl/symbol/znak-riala-saudyjskiego/index.html
@@ -224,7 +224,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">Powiązane Zasoby</span>
   <div class="compare-grid">
     <a href="/pl/library/symbole-walut/" class="compare-card variant-muted u-no-underline">
-      <h4>Currency Symbols</h4>
+      <h4>Symbole Walut</h4>
       <p>Każdy światowy symbol waluty, który możesz już dziś skopiować i wkleić.</p>
     </a>
     <a href="/pl/symbol/znak-dirhama/" class="compare-card variant-muted u-no-underline">

--- a/pl/symbol/znak-rubla/index.html
+++ b/pl/symbol/znak-rubla/index.html
@@ -256,11 +256,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Symbol euro i symbole innych popularnych walut świata do skopiowania.</p>
     </a>
     <a href="/pl/symbol/znak-rupii/" class="compare-card variant-muted u-no-underline">
-      <h4>Rupee Sign</h4>
+      <h4>Znak Rupii Indyjskiej (₹)</h4>
       <p>Najbliższy kuzyn rubla: indyjskie ₹ też wybrano w publicznym konkursie projektowym, zaledwie trzy lata wcześniej, w 2010 roku.</p>
     </a>
     <a href="/pl/symbol/znak-dolara/" class="compare-card variant-muted u-no-underline">
-      <h4>Dollar Sign</h4>
+      <h4>Znak Dolara ($)</h4>
       <p>Odwrotna historia — znak $ liczy sobie wieki i ma sporne pochodzenie, podczas gdy narodziny rubla z 2013 roku są w pełni udokumentowane.</p>
     </a>
   </div>

--- a/pl/symbol/znak-stop/index.html
+++ b/pl/symbol/znak-stop/index.html
@@ -253,7 +253,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Szerszy zestaw znaków ostrzegawczych, promieniotwórczości i zagrożenia biologicznego, obok których zwykle pojawia się znak stop.</p>
     </a>
     <a href="/pl/symbol/zagrozenie-biologiczne/" class="compare-card variant-muted u-no-underline">
-      <h4>Biohazard Symbol</h4>
+      <h4>Symbol Zagrożenia Biologicznego</h4>
       <p>Kolejny znak, w którym ostrzeżeniem jest sam kształt — zaprojektowany w 1966 roku tak, by był pozbawiony znaczenia, dopóki go nie poznasz, a potem niezapomniany.</p>
     </a>
     <a href="/pl/symbol/symbol-niepelnosprawnosci/" class="compare-card variant-muted u-no-underline">

--- a/pl/symbol/znak-wona/index.html
+++ b/pl/symbol/znak-wona/index.html
@@ -233,11 +233,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Symbol euro i symbole innych popularnych walut świata do skopiowania.</p>
     </a>
     <a href="/pl/symbol/znak-jena/" class="compare-card variant-muted u-no-underline">
-      <h4>Yen Sign</h4>
+      <h4>Znak Jena (¥)</h4>
       <p>Wschodnioazjatycki kuzyn wona — ta sama etymologia „okrągłego” i glif ¥, z którym bywa mylony.</p>
     </a>
     <a href="/pl/symbol/znak-dolara/" class="compare-card variant-muted u-no-underline">
-      <h4>Dollar Sign</h4>
+      <h4>Znak Dolara ($)</h4>
       <p>Hiszpańsko-amerykański dolar w srebrze, który zapoczątkował wona, jena i juana, jest też walutą najczęściej wiązaną z pochodzeniem znaku $.</p>
     </a>
   </div>

--- a/pl/usecase/nazwy-do-kontaktu/index.html
+++ b/pl/usecase/nazwy-do-kontaktu/index.html
@@ -205,7 +205,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 <!-- GENERATOR -->
 <section class="hero"><div class="hero-inner"><div class="hero-card">
   <div class="input-wrapper"><textarea class="main-input" id="mainInput" placeholder="Wpisz imię lub pieszczotliwe przezwisko…" maxlength="100">Skarbie</textarea><span class="char-count"><span id="charCount">0</span>/100</span></div>
-  <div class="decoration-section"><div class="decoration-label">Dodaj ozdobniki do wyniku</div><button class="surprise-btn" id="surpriseBtn" type="button">🎲 Losuj nazwę</button><div class="decoration-tabs"><button class="decoration-tab active" data-deco-tab="symbols">Symbole</button><button class="decoration-tab" data-deco-tab="minimal">Minimal</button><button class="decoration-tab" data-deco-tab="emojis">Emoji</button><button class="decoration-tab" data-deco-tab="contact">Serca</button></div><div class="decoration-grid" id="decorationGrid"></div></div>
+  <div class="decoration-section"><div class="decoration-label">Dodaj ozdobniki do wyniku</div><button class="surprise-btn" id="surpriseBtn" type="button">🎲 Losuj nazwę</button><div class="decoration-tabs"><button class="decoration-tab active" data-deco-tab="symbols">Symbole</button><button class="decoration-tab" data-deco-tab="minimal">Minimalne</button><button class="decoration-tab" data-deco-tab="emojis">Emoji</button><button class="decoration-tab" data-deco-tab="contact">Serca</button></div><div class="decoration-grid" id="decorationGrid"></div></div>
 </div></div></section>
 
 <main class="container">

--- a/pl/usecase/nazwy-do-robloxa/index.html
+++ b/pl/usecase/nazwy-do-robloxa/index.html
@@ -200,7 +200,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 <section class="hero"><div class="hero-inner"><div class="hero-card">
   <div class="input-wrapper"><textarea class="main-input" id="mainInput" placeholder="Wpisz swój nick…" maxlength="100">Nova</textarea><span class="char-count"><span id="charCount">0</span>/100</span></div>
   <div class="decoration-section namecheck-inline"><div class="decoration-label">Sprawdź Nazwę Roblox — na bieżąco, w trakcie pisania</div><div id="robloxNameChecker"></div></div>
-  <div class="decoration-section"><div class="decoration-label">Dodaj ozdobniki do wyniku</div><button class="surprise-btn" id="surpriseBtn" type="button">🎲 Losuj nazwę</button><div class="decoration-tabs"><button class="decoration-tab active" data-deco-tab="symbols">Symbole</button><button class="decoration-tab" data-deco-tab="minimal">Minimal</button><button class="decoration-tab" data-deco-tab="emojis">Emoji</button><button class="decoration-tab" data-deco-tab="roblox">Roblox</button></div><div class="decoration-grid" id="decorationGrid"></div></div>
+  <div class="decoration-section"><div class="decoration-label">Dodaj ozdobniki do wyniku</div><button class="surprise-btn" id="surpriseBtn" type="button">🎲 Losuj nazwę</button><div class="decoration-tabs"><button class="decoration-tab active" data-deco-tab="symbols">Symbole</button><button class="decoration-tab" data-deco-tab="minimal">Minimalne</button><button class="decoration-tab" data-deco-tab="emojis">Emoji</button><button class="decoration-tab" data-deco-tab="roblox">Roblox</button></div><div class="decoration-grid" id="decorationGrid"></div></div>
 </div></div></section>
 
 <main class="container">

--- a/pl/usecase/nazwy-do-stumble-guys/index.html
+++ b/pl/usecase/nazwy-do-stumble-guys/index.html
@@ -204,7 +204,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 <section class="hero"><div class="hero-inner"><div class="hero-card">
   <div class="input-wrapper"><textarea class="main-input" id="mainInput" placeholder="Wpisz swój nick lub pseudonim…" maxlength="100">Chwiejny</textarea><span class="char-count"><span id="charCount">0</span>/100</span></div>
   <div class="decoration-section namecheck-inline"><div class="decoration-label">Sprawdź Nazwę Stumble Guys — na bieżąco, w trakcie pisania</div><div id="sgNameChecker"></div></div>
-  <div class="decoration-section"><div class="decoration-label">Dodaj ozdobniki do wyniku</div><button class="surprise-btn" id="surpriseBtn" type="button">🎲 Losuj nazwę</button><div class="decoration-tabs"><button class="decoration-tab active" data-deco-tab="symbols">Symbole</button><button class="decoration-tab" data-deco-tab="minimal">Minimal</button><button class="decoration-tab" data-deco-tab="emojis">Emoji</button><button class="decoration-tab" data-deco-tab="sg">Stumble</button></div><div class="decoration-grid" id="decorationGrid"></div></div>
+  <div class="decoration-section"><div class="decoration-label">Dodaj ozdobniki do wyniku</div><button class="surprise-btn" id="surpriseBtn" type="button">🎲 Losuj nazwę</button><div class="decoration-tabs"><button class="decoration-tab active" data-deco-tab="symbols">Symbole</button><button class="decoration-tab" data-deco-tab="minimal">Minimalne</button><button class="decoration-tab" data-deco-tab="emojis">Emoji</button><button class="decoration-tab" data-deco-tab="sg">Stumble</button></div><div class="decoration-grid" id="decorationGrid"></div></div>
 </div></div></section>
 
 <main class="container">

--- a/pl/usecase/nazwy-grupy/index.html
+++ b/pl/usecase/nazwy-grupy/index.html
@@ -204,7 +204,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 <!-- GENERATOR -->
 <section class="hero"><div class="hero-inner"><div class="hero-card">
   <div class="input-wrapper"><textarea class="main-input" id="mainInput" placeholder="Wpisz nazwę swojej grupy…" maxlength="100">Nasza Ekipa</textarea><span class="char-count"><span id="charCount">0</span>/100</span></div>
-  <div class="decoration-section"><div class="decoration-label">Dodaj ozdobniki do wyniku</div><button class="surprise-btn" id="surpriseBtn" type="button">🎲 Losuj nazwę</button><div class="decoration-tabs"><button class="decoration-tab active" data-deco-tab="symbols">Symbole</button><button class="decoration-tab" data-deco-tab="minimal">Minimal</button><button class="decoration-tab" data-deco-tab="emojis">Emoji</button><button class="decoration-tab" data-deco-tab="group">Grupa</button></div><div class="decoration-grid" id="decorationGrid"></div></div>
+  <div class="decoration-section"><div class="decoration-label">Dodaj ozdobniki do wyniku</div><button class="surprise-btn" id="surpriseBtn" type="button">🎲 Losuj nazwę</button><div class="decoration-tabs"><button class="decoration-tab active" data-deco-tab="symbols">Symbole</button><button class="decoration-tab" data-deco-tab="minimal">Minimalne</button><button class="decoration-tab" data-deco-tab="emojis">Emoji</button><button class="decoration-tab" data-deco-tab="group">Grupa</button></div><div class="decoration-grid" id="decorationGrid"></div></div>
 </div></div></section>
 
 <main class="container">

--- a/pt/answers/what-font-does-pinterest-use/index.html
+++ b/pt/answers/what-font-does-pinterest-use/index.html
@@ -285,7 +285,7 @@
     </a>
     <a href="/pt/letras-negrito/" class="compare-card variant-muted u-no-underline">
       <span class="compare-badge">Tool</span>
-      <h4>Bold Text Generator</h4>
+      <h4>Gerador de Letras em Negrito</h4>
       <ul><li>Generate clean bold text for any platform.</li></ul>
     </a>
     <a href="/answers/is-fancy-text-bad-for-seo/" class="compare-card variant-muted u-no-underline">

--- a/pt/answers/what-font-does-pinterest-use/index.html
+++ b/pt/answers/what-font-does-pinterest-use/index.html
@@ -183,7 +183,7 @@
 
 
 <section class="editorial-section">
-  <span class="article-section-label">Quick answer</span>
+  <span class="article-section-label">Resposta curta</span>
   <div class="editorial-block">
     <p>A fonte oficial do Pinterest chama-se Pinterest Sans, uma tipografia geométrica exclusiva encomendada à Grilli Type, uma fundição tipográfica suíça. Está disponível em quatro pesos, mais um corte otimizado para tamanhos pequenos chamado Pinterest UI, e é proprietária — foi criada apenas para o Pinterest e não pode ser descarregada nem licenciada publicamente.</p>
     <p>Se procura uma alternativa gratuita com um ar semelhante para usar nos seus pins, a Poppins é a escolha mais próxima — outra fonte sans-serif geométrica, disponível no Google Fonts, com o mesmo calor arredondado.</p>
@@ -193,7 +193,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">The details</span>
+  <span class="article-section-label">Em detalhe</span>
   <h2>Que Fonte Usa o Pinterest?</h2>
 
   <div class="data-table-wrap">
@@ -254,7 +254,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Style your own text</span>
+  <span class="article-section-label">Estilize seu texto</span>
   <h2>Quer estilizar o seu texto no Pinterest?</h2>
   <div class="editorial-block">
     <p>O Pinterest não tem um seletor de fontes nativo para pins, descrições, nomes de boards ou biografia — a única forma de mudar o aspeto do texto é usar carateres Unicode estilizados, que parecem outra fonte mas são tratados como texto comum.</p>
@@ -275,7 +275,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Keep exploring</span>
+  <span class="article-section-label">Continue explorando</span>
   <h2>Páginas relacionadas</h2>
   <div class="compare-grid">
     <a href="/pinterest/" class="compare-card variant-muted u-no-underline">
@@ -300,7 +300,7 @@
 
 <section class="editorial-section" id="faq">
   <span class="article-section-label">FAQ</span>
-  <h2>Frequently Asked Questions</h2>
+  <h2>Perguntas Frequentes</h2>
   <details class="faq-item">
     <summary class="faq-question">Que fonte usa o Pinterest?</summary>
     <p class="faq-answer">O Pinterest usa a Pinterest Sans, uma fonte sans-serif geométrica exclusiva, criada pela fundição suíça Grilli Type. É proprietária e não está disponível para download ou licenciamento público.</p>

--- a/pt/answers/what-font-does-whatsapp-use/index.html
+++ b/pt/answers/what-font-does-whatsapp-use/index.html
@@ -263,7 +263,7 @@
   <div class="compare-grid">
     <a href="/pt/fontes-para-whatsapp/" class="compare-card variant-muted u-no-underline">
       <span class="compare-badge">Tool</span>
-      <h4>WhatsApp Font Generator</h4>
+      <h4>Fontes para WhatsApp: letras diferentes pra recado, nome e status</h4>
       <ul><li>Style your status, group names and messages.</li></ul>
     </a>
     <a href="/guide/whatsapp-text-formatting-explained/" class="compare-card variant-muted u-no-underline">
@@ -273,7 +273,7 @@
     </a>
     <a href="/pt/letras-negrito/" class="compare-card variant-muted u-no-underline">
       <span class="compare-badge">Tool</span>
-      <h4>Bold Text Generator</h4>
+      <h4>Gerador de Letras em Negrito</h4>
       <ul><li>Generate clean bold text for any platform.</li></ul>
     </a>
   </div>

--- a/pt/answers/what-font-does-whatsapp-use/index.html
+++ b/pt/answers/what-font-does-whatsapp-use/index.html
@@ -167,7 +167,7 @@
 
 
 <section class="editorial-section">
-  <span class="article-section-label">Quick answer</span>
+  <span class="article-section-label">Resposta curta</span>
   <div class="editorial-block">
     <p>O logótipo e o nome do WhatsApp são compostos em Helvetica Neue, com ligeiros ajustes na largura e no espaçamento dos carateres. Mas a interface de conversação não inclui nenhuma fonte própria — depende inteiramente da fonte do sistema do dispositivo onde está instalada: San Francisco no iPhone, Roboto no Android e Segoe UI no Windows e na versão Web para computador.</p>
     <p>É exatamente por isso que uma conversa no WhatsApp tem um aspeto ligeiramente diferente consoante o dispositivo em que é vista — não existe uma única fonte «oficial» do chat, apenas a fonte que o sistema operativo de cada pessoa já usa.</p>
@@ -177,7 +177,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">The details</span>
+  <span class="article-section-label">Em detalhe</span>
   <h2>Que Fonte Usa o WhatsApp?</h2>
 
   <div class="data-table-wrap">
@@ -240,7 +240,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Style your own text</span>
+  <span class="article-section-label">Estilize seu texto</span>
   <h2>Quer estilizar o seu texto no WhatsApp?</h2>
   <div class="editorial-block">
     <p>O WhatsApp suporta nativamente quatro estilos de texto através de símbolos digitados: *negrito*, _itálico_, ~rasurado~ e ```monoespaçado```. Para saber exatamente como usar cada um, veja o nosso <a href="/guide/whatsapp-text-formatting-explained/">guia de formatação de texto no WhatsApp</a>.</p>
@@ -258,7 +258,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Keep exploring</span>
+  <span class="article-section-label">Continue explorando</span>
   <h2>Páginas relacionadas</h2>
   <div class="compare-grid">
     <a href="/pt/fontes-para-whatsapp/" class="compare-card variant-muted u-no-underline">
@@ -283,7 +283,7 @@
 
 <section class="editorial-section" id="faq">
   <span class="article-section-label">FAQ</span>
-  <h2>Frequently Asked Questions</h2>
+  <h2>Perguntas Frequentes</h2>
   <details class="faq-item">
     <summary class="faq-question">Que fonte usa o WhatsApp?</summary>
     <p class="faq-answer">O logótipo do WhatsApp é composto em Helvetica Neue. No entanto, a interface de conversação não usa nenhuma fonte própria — mostra sempre a fonte do sistema do dispositivo: San Francisco no iPhone, Roboto no Android e Segoe UI no Windows e na Web.</p>

--- a/pt/library/codigos-alt/index.html
+++ b/pt/library/codigos-alt/index.html
@@ -484,7 +484,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">Páginas relacionadas</span>
   <div class="compare-grid">
     <a href="/pt/library/tabela-ascii/" class="compare-card variant-muted u-no-underline">
       <h4>Tabela ASCII</h4>

--- a/pt/library/simbolos-copyright-marca-registrada/index.html
+++ b/pt/library/simbolos-copyright-marca-registrada/index.html
@@ -303,7 +303,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">Páginas relacionadas</span>
   <div class="compare-grid">
     <a href="/pt/library/codigos-alt/" class="compare-card variant-muted u-no-underline">
       <h4>Códigos Alt</h4>

--- a/pt/library/simbolos-de-natal/index.html
+++ b/pt/library/simbolos-de-natal/index.html
@@ -404,7 +404,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">Páginas relacionadas</span>
   <div class="compare-grid">
     <a href="/pt/library/simbolos-de-estrela/" class="compare-card variant-muted u-no-underline">
       <h4>Símbolos de Estrela</h4>

--- a/pt/library/simbolos-de-xadrez/index.html
+++ b/pt/library/simbolos-de-xadrez/index.html
@@ -561,7 +561,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">Páginas relacionadas</span>
   <div class="compare-grid">
     <a href="/pt/library/naipes-de-baralho/" class="compare-card variant-muted u-no-underline">
       <h4>Naipes de Baralho</h4>

--- a/pt/library/tabela-ascii/index.html
+++ b/pt/library/tabela-ascii/index.html
@@ -463,7 +463,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">Páginas relacionadas</span>
   <div class="compare-grid">
     <a href="/ascii-converter/" class="compare-card variant-muted u-no-underline">
       <h4>Conversor ASCII</h4>

--- a/pt/symbol/index.html
+++ b/pt/symbol/index.html
@@ -329,7 +329,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Uma abreviação de escriba medieval que virou o ñ — e o atalho da pasta home no Unix.</p>
     </a>
     <a href="/pt/symbol/interrobang/" class="compare-card variant-muted u-no-underline">
-      <h4>‽ Interrobang</h4>
+      <h4>Interrobang (‽)</h4>
       <p>Criado em 1962 — e, por um tempo, uma tecla real de máquina de escrever.</p>
     </a>
     <a href="/pt/symbol/travessao-curto/" class="compare-card variant-muted u-no-underline">
@@ -383,7 +383,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>O design de Gerald Holtom (1958), tirado do código de semáforo.</p>
     </a>
     <a href="/pt/symbol/simbolo-yin-yang/" class="compare-card variant-muted u-no-underline">
-      <h4>☯ Yin Yang</h4>
+      <h4>Símbolo Yin Yang (☯)</h4>
       <p>A antiga filosofia chinesa por trás da espiral.</p>
     </a>
     <a href="/pt/symbol/simbolo-khanda/" class="compare-card variant-muted u-no-underline">

--- a/ru/answers/what-font-does-pinterest-use/index.html
+++ b/ru/answers/what-font-does-pinterest-use/index.html
@@ -183,7 +183,7 @@
 
 
 <section class="editorial-section">
-  <span class="article-section-label">Quick answer</span>
+  <span class="article-section-label">Короткий ответ</span>
   <div class="editorial-block">
     <p>Приложение, сайт и весь фирменный стиль Pinterest используют Pinterest Sans — геометрический рубленый шрифт, созданный на заказ швейцарской шрифтовой студией Grilli Type. Семейство включает четыре начертания и отдельную уменьшенную по кеглю версию для интерфейса под названием Pinterest UI. Шрифт проприетарный: скачать его или лицензировать для собственных проектов нельзя.</p>
     <p>Если нужен похожий по духу бесплатный шрифт, ближе всего к Pinterest Sans подходит Poppins — геометрический шрифт с той же округлой теплотой, доступный в Google Fonts.</p>
@@ -193,7 +193,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">The details</span>
+  <span class="article-section-label">Подробности</span>
   <h2>Какой шрифт использует Pinterest?</h2>
 
   <div class="data-table-wrap">
@@ -254,7 +254,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Style your own text</span>
+  <span class="article-section-label">Оформите свой текст</span>
   <h2>Как оформить собственный текст в стиле Pinterest</h2>
   <div class="editorial-block">
     <p>Встроенного выбора шрифта для пинов, описаний, названий досок или био в Pinterest нет — весь текст набирается стандартным системным шрифтом. Обходной путь — вставить уже стилизованный текст на основе символов Unicode: внешне он выглядит как другой шрифт, а технически остаётся обычным текстом, который принимает любое текстовое поле.</p>
@@ -275,7 +275,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Keep exploring</span>
+  <span class="article-section-label">Смотрите также</span>
   <h2>Похожие материалы</h2>
   <div class="compare-grid">
     <a href="/pinterest/" class="compare-card variant-muted u-no-underline">
@@ -300,7 +300,7 @@
 
 <section class="editorial-section" id="faq">
   <span class="article-section-label">FAQ</span>
-  <h2>Frequently Asked Questions</h2>
+  <h2>Частые Вопросы</h2>
   <details class="faq-item">
     <summary class="faq-question">Какой шрифт использует Pinterest?</summary>
     <p class="faq-answer">Pinterest использует Pinterest Sans — фирменный геометрический шрифт, созданный на заказ швейцарской шрифтовой студией Grilli Type. В интерфейсе применяется его уменьшенная по кеглю версия, Pinterest UI, а в логотипе и маркетинговых материалах — более тяжёлые начертания того же семейства.</p>

--- a/ru/answers/what-font-does-pinterest-use/index.html
+++ b/ru/answers/what-font-does-pinterest-use/index.html
@@ -285,7 +285,7 @@
     </a>
     <a href="/ru/zhirnyy-shrift/" class="compare-card variant-muted u-no-underline">
       <span class="compare-badge">Tool</span>
-      <h4>Bold Text Generator</h4>
+      <h4>Генератор жирного шрифта</h4>
       <ul><li>Generate clean bold text for any platform.</li></ul>
     </a>
     <a href="/answers/is-fancy-text-bad-for-seo/" class="compare-card variant-muted u-no-underline">

--- a/ru/answers/what-font-does-whatsapp-use/index.html
+++ b/ru/answers/what-font-does-whatsapp-use/index.html
@@ -167,7 +167,7 @@
 
 
 <section class="editorial-section">
-  <span class="article-section-label">Quick answer</span>
+  <span class="article-section-label">Короткий ответ</span>
   <div class="editorial-block">
     <p>Логотип и надпись WhatsApp набраны в Helvetica Neue с немного скорректированной шириной и межбуквенным расстоянием. А вот сам чат-интерфейс не использует ни одного встроенного шрифта — приложение полностью полагается на системный шрифт устройства: San Francisco на iPhone, Roboto на Android и Segoe UI в десктопной и веб-версии для Windows.</p>
     <p>Именно поэтому одна и та же переписка выглядит немного по-разному в зависимости от устройства собеседника — это не сбой и не ошибка синхронизации, а особенность того, как WhatsApp сознательно передаёт отрисовку текста операционной системе.</p>
@@ -177,7 +177,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">The details</span>
+  <span class="article-section-label">Подробности</span>
   <h2>Какой шрифт использует WhatsApp?</h2>
 
   <div class="data-table-wrap">
@@ -240,7 +240,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Style your own text</span>
+  <span class="article-section-label">Оформите свой текст</span>
   <h2>Как отформатировать и стилизовать собственный текст в WhatsApp</h2>
   <div class="editorial-block">
     <p>WhatsApp напрямую поддерживает четыре стиля прямо в тексте сообщения — ничего скачивать не нужно, достаточно окружить текст символами: *жирный*, _курсив_, ~зачёркнутый~ и ```моноширинный```. Подробный разбор всех вариантов — в <a href="/guide/whatsapp-text-formatting-explained/">руководстве по форматированию текста в WhatsApp</a>.</p>
@@ -258,7 +258,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Keep exploring</span>
+  <span class="article-section-label">Смотрите также</span>
   <h2>Похожие материалы</h2>
   <div class="compare-grid">
     <a href="/whatsapp/" class="compare-card variant-muted u-no-underline">
@@ -283,7 +283,7 @@
 
 <section class="editorial-section" id="faq">
   <span class="article-section-label">FAQ</span>
-  <h2>Frequently Asked Questions</h2>
+  <h2>Частые Вопросы</h2>
   <details class="faq-item">
     <summary class="faq-question">Какой шрифт использует WhatsApp?</summary>
     <p class="faq-answer">Логотип WhatsApp набран в Helvetica Neue. Сам чат-интерфейс собственного шрифта не имеет — он использует системный шрифт устройства: San Francisco на iPhone, Roboto на Android и Segoe UI в десктопной и веб-версии для Windows.</p>

--- a/ru/answers/what-font-does-whatsapp-use/index.html
+++ b/ru/answers/what-font-does-whatsapp-use/index.html
@@ -273,7 +273,7 @@
     </a>
     <a href="/ru/zhirnyy-shrift/" class="compare-card variant-muted u-no-underline">
       <span class="compare-badge">Tool</span>
-      <h4>Bold Text Generator</h4>
+      <h4>Генератор жирного шрифта</h4>
       <ul><li>Generate clean bold text for any platform.</li></ul>
     </a>
   </div>

--- a/scripts/fix-locale-template-strings.js
+++ b/scripts/fix-locale-template-strings.js
@@ -150,6 +150,72 @@ const CTA = {
         btn: '開啟 UltraTextGen →' }
 };
 
+// ── Pass 4: section kickers (added 2026-08-16) ───────────────────────────────
+//
+// `<span class="article-section-label">` is the small kicker above a section's
+// <h2>. On 77 pages it is still English while everything under it — including
+// that very <h2> — is fully translated, so this is the same page-furniture class
+// as the three passes above, not content debt.
+//
+// Two provenance tiers, kept visibly separate because they carry different
+// confidence:
+//
+//   HARVESTED — the locale's own dominant existing form, counted across its
+//   already-correct pages. "Quick answer" was unanimous in 11 of 12 locales
+//   (pt 3/4). "Related Resources" resolves to each locale's dominant
+//   related-pages kicker; note `id` uses `Halaman Terkait` (×170) rather than
+//   the generator's `Sumber Terkait` (×30) — same settle-on-the-majority rule
+//   pass 1 used for the German breadcrumb.
+//
+//   SUPPLIED — `The details`, `Keep exploring` and `Style your own text` are
+//   the template's generic defaults. Better-authored pages replace them with
+//   bespoke labels, so there is nothing to harvest and these are written here.
+//   They are short UI kickers, and each sits directly above an already-
+//   translated <h2> that fixes the register (nl "Style your own text" sits on
+//   "Zelf tekst stylen voor Pinterest").
+//
+// Stop rule unchanged: a locale absent from a table keeps the English string.
+const SECTION_LABEL = {
+  // harvested                    supplied ───────────────────────────────────
+  ar: { 'Quick answer': 'الإجابة السريعة',  'Related Resources': null,
+        'The details': 'التفاصيل', 'Keep exploring': 'تصفح المزيد', 'Style your own text': 'نسّق نصك' },
+  es: { 'Quick answer': 'Respuesta corta',  'Related Resources': null,
+        'The details': 'En detalle', 'Keep exploring': 'Sigue explorando', 'Style your own text': 'Dale estilo a tu texto' },
+  fr: { 'Quick answer': 'Réponse courte',   'Related Resources': null,
+        'The details': 'En détail', 'Keep exploring': 'À explorer aussi', 'Style your own text': 'Stylise ton texte' },
+  id: { 'Quick answer': 'Jawaban singkat',  'Related Resources': 'Halaman Terkait',
+        'The details': 'Rinciannya', 'Keep exploring': 'Jelajahi lainnya', 'Style your own text': 'Gaya teksmu sendiri' },
+  it: { 'Quick answer': 'Risposta breve',   'Related Resources': null,
+        'The details': 'In dettaglio', 'Keep exploring': 'Continua a esplorare', 'Style your own text': 'Personalizza il tuo testo' },
+  ja: { 'Quick answer': 'かんたんな答え',    'Related Resources': null,
+        'The details': '詳細', 'Keep exploring': '関連ページ', 'Style your own text': '自分のテキストを装飾' },
+  ms: { 'Quick answer': null,               'Related Resources': 'Halaman Berkaitan',
+        'The details': null, 'Keep exploring': null, 'Style your own text': null },
+  nl: { 'Quick answer': 'Kort antwoord',    'Related Resources': null,
+        'The details': 'De details', 'Keep exploring': 'Verder kijken', 'Style your own text': 'Zelf tekst stylen' },
+  pl: { 'Quick answer': 'Krótka odpowiedź', 'Related Resources': null,
+        'The details': 'Szczegóły', 'Keep exploring': 'Zobacz więcej', 'Style your own text': 'Ostyluj swój tekst' },
+  pt: { 'Quick answer': 'Resposta curta',   'Related Resources': 'Páginas relacionadas',
+        'The details': 'Em detalhe', 'Keep exploring': 'Continue explorando', 'Style your own text': 'Estilize seu texto' },
+  ru: { 'Quick answer': 'Короткий ответ',   'Related Resources': null,
+        'The details': 'Подробности', 'Keep exploring': 'Смотрите также', 'Style your own text': 'Оформите свой текст' },
+  th: { 'Quick answer': 'คำตอบสั้นๆ',        'Related Resources': 'หน้าที่เกี่ยวข้อง',
+        'The details': 'รายละเอียด', 'Keep exploring': 'สำรวจต่อ', 'Style your own text': 'จัดสไตล์ข้อความของคุณ' },
+  tr: { 'Quick answer': 'Kısa cevap',       'Related Resources': null,
+        'The details': 'Ayrıntılar', 'Keep exploring': 'Keşfetmeye devam', 'Style your own text': 'Kendi metnini biçimlendir' },
+  'zh-tw': { 'Quick answer': null,          'Related Resources': '相關頁面',
+        'The details': null, 'Keep exploring': null, 'Style your own text': null }
+};
+
+// The FAQ <h2>. Harvested dominant form per locale; `fr`/`nl`/`ru` legitimately
+// use the loanword "FAQ" as their own dominant heading and are recorded as such.
+const FAQ_H2 = {
+  ar: 'الأسئلة الشائعة', es: 'Preguntas Frecuentes', fr: 'Questions Fréquentes',
+  id: 'Pertanyaan yang Sering Ditanya', it: 'Domande Frequenti', ja: 'よくある質問',
+  nl: 'Veelgestelde Vragen', pl: 'Najczęstsze pytania', pt: 'Perguntas Frequentes',
+  ru: 'Частые Вопросы', th: 'คำถามที่พบบ่อย', tr: 'Sıkça Sorulan Sorular'
+};
+
 const args = process.argv.slice(2);
 const write = args.includes('--write');
 const localeArg = args.includes('--locale') ? args[args.indexOf('--locale') + 1] : null;
@@ -175,15 +241,17 @@ function walk(dir, acc = []) {
 }
 
 const esc = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-const counts = { breadcrumb: 0, langSwitcher: 0, cta: 0, files: 0 };
+const counts = { breadcrumb: 0, langSwitcher: 0, cta: 0, kicker: 0, faqH2: 0, files: 0 };
 const perLocale = {};
 
 for (const loc of locales) {
   const bc = BREADCRUMB[loc];
   const ls = LANG_SWITCHER[loc];
   const cta = CTA[loc];
-  if (!bc && !ls && !cta) continue; // stop rule: unknown locale is left alone
-  const stat = { breadcrumb: 0, langSwitcher: 0, cta: 0, files: 0 };
+  const kick = SECTION_LABEL[loc];
+  const faqH2 = FAQ_H2[loc];
+  if (!bc && !ls && !cta && !kick && !faqH2) continue; // stop rule: unknown locale is left alone
+  const stat = { breadcrumb: 0, langSwitcher: 0, cta: 0, kicker: 0, faqH2: 0, files: 0 };
 
   for (const file of walk(path.join(ROOT, loc))) {
     const before = fs.readFileSync(file, 'utf8');
@@ -228,6 +296,24 @@ for (const loc of locales) {
       );
     }
 
+    if (kick) {
+      // Scoped to the kicker element itself, so these short words can never be
+      // rewritten anywhere else on the page.
+      for (const [en, native] of Object.entries(kick)) {
+        if (!native) continue; // stop rule, per string not just per locale
+        const re = new RegExp(
+          `(<span class="article-section-label">)\\s*${esc(en)}\\s*(</span>)`, 'g'
+        );
+        const n = (html.match(re) || []).length;
+        if (n) { html = html.replace(re, `$1${native}$2`); stat.kicker += n; }
+      }
+    }
+    if (faqH2) {
+      const re = /(<h2>)\s*Frequently Asked Questions\s*(<\/h2>)/g;
+      const n = (html.match(re) || []).length;
+      if (n) { html = html.replace(re, `$1${faqH2}$2`); stat.faqH2 += n; }
+    }
+
     if (html !== before) {
       stat.files++;
       if (write) fs.writeFileSync(file, html, 'utf8');
@@ -239,24 +325,28 @@ for (const loc of locales) {
     counts.breadcrumb += stat.breadcrumb;
     counts.langSwitcher += stat.langSwitcher;
     counts.cta += stat.cta;
+    counts.kicker += stat.kicker;
+    counts.faqH2 += stat.faqH2;
     counts.files += stat.files;
   }
 }
 
 console.log(write ? 'Applying locale template-string fixes' : 'Dry run — no files written');
 console.log('');
-console.log(`${'locale'.padEnd(8)}${'files'.padStart(7)}${'breadcrumb'.padStart(12)}${'lang-sw'.padStart(9)}${'CTA'.padStart(6)}`);
+console.log(`${'locale'.padEnd(8)}${'files'.padStart(7)}${'breadcrumb'.padStart(12)}${'lang-sw'.padStart(9)}${'CTA'.padStart(6)}${'kicker'.padStart(8)}${'faqH2'.padStart(7)}`);
 for (const [loc, s] of Object.entries(perLocale).sort((a, b) => b[1].files - a[1].files)) {
   console.log(
     `${loc.padEnd(8)}${String(s.files).padStart(7)}${String(s.breadcrumb).padStart(12)}` +
-      `${String(s.langSwitcher).padStart(9)}${String(s.cta).padStart(6)}`
+      `${String(s.langSwitcher).padStart(9)}${String(s.cta).padStart(6)}` +
+      `${String(s.kicker).padStart(8)}${String(s.faqH2).padStart(7)}`
   );
 }
 console.log('');
 console.log(
   `${counts.files} file(s): ${counts.breadcrumb} breadcrumb label(s), ` +
-    `${counts.langSwitcher} language-switcher label(s), ${counts.cta} CTA card(s)`
+    `${counts.langSwitcher} language-switcher label(s), ${counts.cta} CTA card(s), ` +
+    `${counts.kicker} section kicker(s), ${counts.faqH2} FAQ heading(s)`
 );
-const skipped = locales.filter((l) => !BREADCRUMB[l] && !LANG_SWITCHER[l] && !CTA[l]);
+const skipped = locales.filter((l) => !BREADCRUMB[l] && !LANG_SWITCHER[l] && !CTA[l] && !SECTION_LABEL[l] && !FAQ_H2[l]);
 if (skipped.length) console.log(`Left in English (no confident form): ${skipped.join(', ')}`);
 if (!write) console.log('\nRe-run with --write to apply.');

--- a/scripts/lib/locale-translation-audit.js
+++ b/scripts/lib/locale-translation-audit.js
@@ -85,6 +85,10 @@ const IDENTIFIER_RULES = [
   [/U\+[0-9A-Fa-f]{4}/, 'unicode-codepoint'],
   // literal CSS/LaTeX the reader copies: content: "\007C", \sqrt{x}, \surd
   [/content:\s*"|\\|\{|\}|&#/, 'code-literal'],
+  // A bare CSS property reference — "CSS content" is the name of the `content`
+  // property, cited the same way as `content: "\\007C"` a row below it. The
+  // existing code-literal rule only fires when the colon is present.
+  [/^CSS [a-z-]+$/, 'css-property'],
   // key names are not localised on the keyboard itself
   [/\b(?:Option|Alt|Ctrl|Cmd|Shift|Fn)\s*\+/, 'keyboard-shortcut'],
   [/&(?:amp;)?[a-zA-Z]{2,6};/, 'html-entity'],
@@ -222,6 +226,82 @@ function copySlotStrings(html) {
  * throws more identical-name coincidences than a half-translated 20-tile one.
  */
 let placeCache = null;
+/**
+ * True when every word in a cell is a brand/acronym rather than ordinary English.
+ *
+ * The column this reads also carries USAGE CONTEXTS — "Documents, emails, bios",
+ * "Recommended form", "Mobile keyboard" — which every locale genuinely translates.
+ * Harvesting those as proper names would silently exempt real defects, so the
+ * shape test is what separates `Windows (Word)` from `Recommended form`. Both
+ * were in the first raw harvest; only the first should be exempt.
+ */
+function isProperNounPhrase(v) {
+  const words = v.replace(/[(),/]/g, ' ').split(/\s+/).filter(Boolean);
+  if (!words.length) return false;
+  return words.every(
+    (w) =>
+      /^[A-Z0-9][A-Za-z0-9.+#-]*$/.test(w) || // Mac, Windows, HTML, AutoCAD, Word
+      /^i[A-Z]/.test(w) ||                    // iOS, iPhone
+      /^[a-z]{1,3}$/.test(w)                  // short joiners: "on", "or"
+  );
+}
+
+let platformCache = null;
+/**
+ * Platform / tool names cited in the input-method tables — "Windows (Word)",
+ * "Mac", "iOS / Android", "HTML", "CSS content".
+ *
+ * Harvested from the ENGLISH pages' own tables, exactly like unicodeBlockNames
+ * above and for the same reason: the site is the authority on what it cites,
+ * and a harvested list maintains itself as pages change.
+ *
+ * These are product names and code identifiers. Every locale on this site
+ * already cites them untranslated inside otherwise-translated tables — the
+ * Italian page that says `<th>Metodo</th>` still says `<td>Mac</td>` — which is
+ * the same citation pattern the Unicode block names follow.
+ *
+ * They enter `properNames`, NOT `IDENTIFIER_RULES`, so the exemption stays
+ * SLOT-SCOPED: exempt in a cited `<td>`, still a real defect in a heading or a
+ * card title. That distinction is load-bearing and is regression-tested against
+ * the `Currency Symbols` pair described above.
+ *
+ * Scoped to the first column of a two-column table whose header pair is one of
+ * the known input-method shapes, so ordinary content cells cannot leak in.
+ */
+function platformToolNames(root = ROOT) {
+  if (platformCache) return platformCache;
+  const out = new Set();
+  // ONLY the input-method tables. `Property|Value` is deliberately excluded: its
+  // first column holds row LABELS ("Category", "Formal name", "Introduced in")
+  // which every locale genuinely translates, and harvesting those would silently
+  // exempt real defects. Caught by reading what a first, wider pattern matched.
+  const HEADERS = /<tr><th>(?:Method|Platform|Platform \/ Tool)<\/th><th>(?:Input|Works\?|Method)<\/th><\/tr>/i;
+  const walkEn = (dir) => {
+    for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+      const p = path.join(dir, e.name);
+      if (e.isDirectory()) {
+        if (e.name.startsWith('.') || e.name === 'node_modules') continue;
+        if (dir === root && /^[a-z]{2}(-[a-z]{2})?$/.test(e.name) && e.name !== 'js') continue;
+        walkEn(p);
+      } else if (e.name === 'index.html') {
+        const html = fs.readFileSync(p, 'utf8');
+        for (const tbl of html.match(/<table[^>]*>[\s\S]*?<\/table>/gi) || []) {
+          if (!HEADERS.test(tbl)) continue;
+          const re = /<tr><td>([\s\S]*?)<\/td>/gi;
+          let m;
+          while ((m = re.exec(tbl)) !== null) {
+            const v = stripTags(m[1]);
+            if (v && v.length <= 24 && !/[.!?]/.test(v) && isProperNounPhrase(v)) out.add(v);
+          }
+        }
+      }
+    }
+  };
+  try { walkEn(root); } catch { /* best effort */ }
+  platformCache = out;
+  return out;
+}
+
 function placeNames(root = ROOT) {
   if (placeCache) return placeCache;
   const out = new Set(['Africa', 'Asia', 'Oceania', 'Europe', 'Americas', 'Antarctica']);
@@ -319,7 +399,11 @@ function auditPair(localeHtml, parentHtml, locale, { root = ROOT } = {}) {
   const en = translatableStrings(parentHtml);
   const loc = translatableStrings(localeHtml);
   const ledger = loadLedger().get(locale) || new Set();
-  const properNames = new Set([...unicodeBlockNames(root), ...placeNames(root)]);
+  const properNames = new Set([
+    ...unicodeBlockNames(root),
+    ...placeNames(root),
+    ...platformToolNames(root)
+  ]);
   const copySlots = copySlotStrings(localeHtml);
   const survivors = [];
   const ledgered = [];
@@ -391,6 +475,7 @@ module.exports = {
   identifierClass,
   unicodeBlockNames,
   placeNames,
+  platformToolNames,
   copySlotStrings,
   auditLocalePage,
   translatableStrings,

--- a/th/answers/what-font-does-pinterest-use/index.html
+++ b/th/answers/what-font-does-pinterest-use/index.html
@@ -183,7 +183,7 @@
 
 
 <section class="editorial-section">
-  <span class="article-section-label">Quick answer</span>
+  <span class="article-section-label">คำตอบสั้นๆ</span>
   <div class="editorial-block">
     <p>ฟอนต์ที่ Pinterest ใช้ทั้งในแอป เว็บไซต์ และงานแบรนดิ้งคือ Pinterest Sans ฟอนต์ซานเซอริฟแนวเรขาคณิตที่ Pinterest ว่าจ้าง Grilli Type ให้ออกแบบขึ้นเป็นการเฉพาะ ตระกูลฟอนต์นี้มีให้เลือกใช้ 4 น้ำหนัก บวกกับฟอนต์ตัวเล็กพิเศษสำหรับหน้าจอที่เรียกว่า Pinterest UI ฟอนต์นี้เป็นกรรมสิทธิ์เฉพาะของ Pinterest เท่านั้น ไม่เปิดให้ดาวน์โหลดหรือขอใช้งานสาธารณะ</p>
     <p>หากต้องการฟอนต์ที่ให้ความรู้สึกใกล้เคียงกันและดาวน์โหลดได้ฟรี ตัวเลือกที่ใกล้เคียงที่สุดคือ Poppins ฟอนต์ซานเซอริฟแนวเรขาคณิตบน Google Fonts ที่ให้ความอบอุ่นโค้งมนคล้ายกัน</p>
@@ -193,7 +193,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">The details</span>
+  <span class="article-section-label">รายละเอียด</span>
   <h2>Pinterest ใช้ฟอนต์อะไร?</h2>
 
   <div class="data-table-wrap">
@@ -254,7 +254,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Style your own text</span>
+  <span class="article-section-label">จัดสไตล์ข้อความของคุณ</span>
   <h2>จัดสไตล์ข้อความสำหรับ Pinterest ของคุณเอง</h2>
   <div class="editorial-block">
     <p>Pinterest ไม่มีตัวเลือกฟอนต์ในตัวสำหรับคำอธิบายพิน ชื่อบอร์ด หรือประวัติส่วนตัว ทางลัดที่คนส่วนใหญ่ใช้คือการวางตัวอักษร Unicode ที่ผ่านการจัดสไตล์มาแล้ว ซึ่งจะแสดงผลราวกับเป็นฟอนต์อื่น ทั้งที่ระบบยังมองว่าเป็นข้อความธรรมดา</p>
@@ -275,7 +275,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Keep exploring</span>
+  <span class="article-section-label">สำรวจต่อ</span>
   <h2>หน้าที่เกี่ยวข้อง</h2>
   <div class="compare-grid">
     <a href="/pinterest/" class="compare-card variant-muted u-no-underline">
@@ -300,7 +300,7 @@
 
 <section class="editorial-section" id="faq">
   <span class="article-section-label">FAQ</span>
-  <h2>Frequently Asked Questions</h2>
+  <h2>คำถามที่พบบ่อย</h2>
   <details class="faq-item">
     <summary class="faq-question">Pinterest ใช้ฟอนต์อะไร?</summary>
     <p class="faq-answer">Pinterest ใช้ฟอนต์ชื่อ Pinterest Sans ซึ่งเป็นฟอนต์ซานเซอริฟแนวเรขาคณิตที่ Grilli Type ออกแบบขึ้นเฉพาะสำหรับ Pinterest มีให้ใช้ 4 น้ำหนัก บวกกับฟอนต์ตัวเล็กพิเศษ Pinterest UI สำหรับแสดงผลบนหน้าจอ และเป็นฟอนต์กรรมสิทธิ์ที่ไม่เปิดให้ดาวน์โหลดใช้งานทั่วไป</p>

--- a/th/answers/what-font-does-whatsapp-use/index.html
+++ b/th/answers/what-font-does-whatsapp-use/index.html
@@ -167,7 +167,7 @@
 
 
 <section class="editorial-section">
-  <span class="article-section-label">Quick answer</span>
+  <span class="article-section-label">คำตอบสั้นๆ</span>
   <div class="editorial-block">
     <p>โลโก้และชื่อแบรนด์ WhatsApp ใช้ฟอนต์ Helvetica Neue โดยปรับความกว้างและระยะห่างตัวอักษรเล็กน้อยจากต้นฉบับ แต่หน้าจอแชทเองไม่ได้ฝังฟอนต์เฉพาะทางไว้เลย แอปปล่อยให้ระบบปฏิบัติการของแต่ละอุปกรณ์เลือกฟอนต์มาตรฐานของตัวเองมาแสดงผลแทน — San Francisco บน iPhone, Roboto บน Android และ Segoe UI บนเดสก์ท็อป Windows และเว็บ</p>
     <p>นี่คือเหตุผลที่ข้อความสนทนาเดียวกันอาจดูมีรายละเอียดแตกต่างกันเล็กน้อย ขึ้นอยู่กับว่าคุณหรือคู่สนทนากำลังเปิด WhatsApp อยู่บนอุปกรณ์ชนิดไหน</p>
@@ -177,7 +177,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">The details</span>
+  <span class="article-section-label">รายละเอียด</span>
   <h2>WhatsApp ใช้ฟอนต์อะไร?</h2>
 
   <div class="data-table-wrap">
@@ -240,7 +240,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Style your own text</span>
+  <span class="article-section-label">จัดสไตล์ข้อความของคุณ</span>
   <h2>จัดสไตล์ข้อความแชท WhatsApp ของคุณ</h2>
   <div class="editorial-block">
     <p>WhatsApp รองรับการจัดสไตล์ในตัว 4 แบบผ่านสัญลักษณ์พิมพ์ง่าย ๆ ได้แก่ *ตัวหนา*, _ตัวเอียง_, ~ขีดฆ่า~ และ ```ตัวพิมพ์ดีด``` ดูรายละเอียดเพิ่มเติมได้ใน <a href="/guide/whatsapp-text-formatting-explained/">คู่มือจัดรูปแบบข้อความ WhatsApp</a> ของเรา</p>
@@ -258,7 +258,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Keep exploring</span>
+  <span class="article-section-label">สำรวจต่อ</span>
   <h2>หน้าที่เกี่ยวข้อง</h2>
   <div class="compare-grid">
     <a href="/whatsapp/" class="compare-card variant-muted u-no-underline">
@@ -283,7 +283,7 @@
 
 <section class="editorial-section" id="faq">
   <span class="article-section-label">FAQ</span>
-  <h2>Frequently Asked Questions</h2>
+  <h2>คำถามที่พบบ่อย</h2>
   <details class="faq-item">
     <summary class="faq-question">WhatsApp ใช้ฟอนต์อะไร?</summary>
     <p class="faq-answer">โลโก้ WhatsApp ใช้ Helvetica Neue แต่หน้าจอแชทไม่มีฟอนต์เฉพาะของตัวเองเลย แอปจะใช้ฟอนต์มาตรฐานของแต่ละอุปกรณ์แทน ได้แก่ San Francisco บน iPhone, Roboto บน Android และ Segoe UI บนเดสก์ท็อป Windows และเว็บ</p>

--- a/th/library/cat-kaomoji/index.html
+++ b/th/library/cat-kaomoji/index.html
@@ -313,7 +313,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">หน้าที่เกี่ยวข้อง</span>
   <div class="compare-grid">
     <a href="/th/library/kaomoji/" class="compare-card variant-muted u-no-underline">
       <h4>คาโอโมจิ</h4>

--- a/th/library/cute-kaomoji/index.html
+++ b/th/library/cute-kaomoji/index.html
@@ -287,7 +287,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">หน้าที่เกี่ยวข้อง</span>
   <div class="compare-grid">
     <a href="/th/library/kaomoji/" class="compare-card variant-muted u-no-underline">
       <h4>คาโอโมจิ</h4>

--- a/th/library/heart-symbols/index.html
+++ b/th/library/heart-symbols/index.html
@@ -610,7 +610,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>คลังอักขระพิเศษ สัญลักษณ์ และเครื่องหมายยูนิโค้ดที่คัดลอกได้ทันที</p>
     </a>
     <a href="/th/library/star-symbols/" class="compare-card variant-muted u-no-underline">
-      <h4>Star Symbol Collection</h4>
+      <h4>รวมสัญลักษณ์ดาว</h4>
       <p>Star emojis and sparkle characters in various Unicode styles and sizes.</p>
     </a>
     <a href="/library/card-suit-symbols/" class="compare-card variant-muted u-no-underline">

--- a/th/library/love-kaomoji/index.html
+++ b/th/library/love-kaomoji/index.html
@@ -299,7 +299,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">หน้าที่เกี่ยวข้อง</span>
   <div class="compare-grid">
     <a href="/usecase/aesthetic-contact-names/" class="compare-card variant-muted u-no-underline">
       <h4>Aesthetic Contact Names</h4>

--- a/th/usecase/free-fire-name-generator/index.html
+++ b/th/usecase/free-fire-name-generator/index.html
@@ -330,11 +330,11 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>แท็กสควอดสั้นๆ กรอบ ꧁꧂ และไอเดียชื่อกิลด์เท่ๆ</p>
     </a>
     <a href="/th/usecase/mobile-legends-name-generator/" class="compare-card variant-muted u-no-underline">
-      <h4>Nickname Generator</h4>
+      <h4>ชื่อ Mobile Legends เท่ๆ — นิกเนม สัญลักษณ์ และเช็กชื่อ MLBB</h4>
       <p>พิมพ์ชื่อเพื่อรับนิกเนมเท่ๆ น่ารัก พร้อมไอเดียสำเร็จรูป</p>
     </a>
     <a href="/th/khokhwam-long-hon/" class="compare-card variant-muted u-no-underline">
-      <h4>Invisible Character</h4>
+      <h4>ข้อความล่องหน &amp; ตัวอักษรล่องหน</h4>
       <p>อักขระว่างสำหรับชื่อฟีฟายแบบมีเว้นวรรค</p>
     </a>
     <a href="/th/library/special-characters/" class="compare-card variant-muted u-no-underline">

--- a/tr/answers/what-font-does-pinterest-use/index.html
+++ b/tr/answers/what-font-does-pinterest-use/index.html
@@ -183,7 +183,7 @@
 
 
 <section class="editorial-section">
-  <span class="article-section-label">Quick answer</span>
+  <span class="article-section-label">Kısa cevap</span>
   <div class="editorial-block">
     <p>Pinterest'in uygulaması, web sitesi ve marka kimliği; İsviçreli yazı tipi tasarım stüdyosu Grilli Type tarafından özel olarak tasarlanan geometrik bir sans-serif olan Pinterest Sans'ı kullanır. Dört ağırlıkla ve Pinterest UI adı verilen küçük boyutlara özel bir kesimle birlikte gelir; bu yazı tipi tamamen Pinterest'e özeldir ve herkese açık olarak indirilemez veya lisanslanamaz.</p>
     <p>Pinterest'e yakın, ücretsiz bir alternatif arıyorsanız Poppins iyi bir seçimdir.</p>
@@ -193,7 +193,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">The details</span>
+  <span class="article-section-label">Ayrıntılar</span>
   <h2>Pinterest Hangi Yazı Tipini Kullanıyor?</h2>
 
   <div class="data-table-wrap">
@@ -254,7 +254,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Style your own text</span>
+  <span class="article-section-label">Kendi metnini biçimlendir</span>
   <h2>Kendi Pinterest Metninizi Nasıl Stilize Edersiniz</h2>
   <div class="editorial-block">
     <p>Pinterest; pin açıklamaları, pano adları veya biyografiniz için yerleşik bir yazı tipi seçici sunmaz. Yaygın çözüm, farklı bir yazı tipiymiş gibi görünen ama aslında sıradan metin olarak işlenen Unicode stilize karakterler kullanmaktır.</p>
@@ -275,7 +275,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Keep exploring</span>
+  <span class="article-section-label">Keşfetmeye devam</span>
   <h2>İlgili Sayfalar</h2>
   <div class="compare-grid">
     <a href="/pinterest/" class="compare-card variant-muted u-no-underline">
@@ -300,7 +300,7 @@
 
 <section class="editorial-section" id="faq">
   <span class="article-section-label">FAQ</span>
-  <h2>Frequently Asked Questions</h2>
+  <h2>Sıkça Sorulan Sorular</h2>
   <details class="faq-item">
     <summary class="faq-question">Pinterest hangi yazı tipini kullanıyor?</summary>
     <p class="faq-answer">Pinterest, uygulamasında, web sitesinde ve marka kimliğinde Pinterest Sans adlı özel bir yazı tipi kullanır. Bu geometrik sans-serif, İsviçreli yazı tipi tasarım stüdyosu Grilli Type tarafından Pinterest için özel olarak tasarlanmıştır; dört ağırlığın yanı sıra arayüzde kullanılan küçük boyutlu Pinterest UI kesimini de içerir. Yazı tipi tamamen Pinterest'e özeldir ve herkese açık olarak indirilemez veya satın alınamaz.</p>

--- a/tr/answers/what-font-does-pinterest-use/index.html
+++ b/tr/answers/what-font-does-pinterest-use/index.html
@@ -285,7 +285,7 @@
     </a>
     <a href="/tr/kalin-yazi/" class="compare-card variant-muted u-no-underline">
       <span class="compare-badge">Tool</span>
-      <h4>Bold Text Generator</h4>
+      <h4>Kalın yazı yazma — kopyala yapıştır</h4>
       <ul><li>Generate clean bold text for any platform.</li></ul>
     </a>
     <a href="/answers/is-fancy-text-bad-for-seo/" class="compare-card variant-muted u-no-underline">

--- a/tr/answers/what-font-does-whatsapp-use/index.html
+++ b/tr/answers/what-font-does-whatsapp-use/index.html
@@ -167,7 +167,7 @@
 
 
 <section class="editorial-section">
-  <span class="article-section-label">Quick answer</span>
+  <span class="article-section-label">Kısa cevap</span>
   <div class="editorial-block">
     <p>WhatsApp'ın logosu ve marka yazısı Helvetica Neue ile tasarlanmıştır. Ancak sohbet arayüzünün kendine ait, gömülü bir yazı tipi yoktur — WhatsApp tamamen kullandığınız cihazın sistem yazı tipine güvenir: iPhone'da San Francisco, Android'de Roboto, Windows masaüstü ve WhatsApp Web'de ise Segoe UI.</p>
     <p>Bu yüzden aynı sohbeti farklı cihazlarda açtığınızda metnin görünümü ince farklarla değişir — her platform kendi yerel sistem yazı tipini devreye sokar.</p>
@@ -177,7 +177,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">The details</span>
+  <span class="article-section-label">Ayrıntılar</span>
   <h2>WhatsApp Hangi Yazı Tipini Kullanıyor?</h2>
 
   <div class="data-table-wrap">
@@ -240,7 +240,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Style your own text</span>
+  <span class="article-section-label">Kendi metnini biçimlendir</span>
   <h2>Kendi WhatsApp Metninizi Nasıl Stilize Edersiniz</h2>
   <div class="editorial-block">
     <p>WhatsApp; yazarken kullanabileceğiniz *kalın*, _italik_, ~üstü çizili~ ve ```sabit genişlikli``` olmak üzere dört stili doğrudan destekler. Bu biçimlendirme seçeneklerinin tamamını <a href="/guide/whatsapp-text-formatting-explained/">WhatsApp metin biçimlendirme rehberimizde</a> bulabilirsiniz.</p>
@@ -258,7 +258,7 @@
 <div class="section-divider"></div>
 
 <section class="editorial-section">
-  <span class="article-section-label">Keep exploring</span>
+  <span class="article-section-label">Keşfetmeye devam</span>
   <h2>İlgili Sayfalar</h2>
   <div class="compare-grid">
     <a href="/tr/whatsapp-yazi-tipi/" class="compare-card variant-muted u-no-underline">
@@ -283,7 +283,7 @@
 
 <section class="editorial-section" id="faq">
   <span class="article-section-label">FAQ</span>
-  <h2>Frequently Asked Questions</h2>
+  <h2>Sıkça Sorulan Sorular</h2>
   <details class="faq-item">
     <summary class="faq-question">WhatsApp hangi yazı tipini kullanıyor?</summary>
     <p class="faq-answer">WhatsApp'ın logosu ve marka yazısı Helvetica Neue ile tasarlanmıştır. Ancak sohbet arayüzünde WhatsApp'a ait gömülü bir yazı tipi yoktur; uygulama tamamen kullandığınız cihazın sistem yazı tipine güvenir: iPhone'da San Francisco, Android'de Roboto, Windows masaüstü ve WhatsApp Web'de ise Segoe UI.</p>

--- a/tr/answers/what-font-does-whatsapp-use/index.html
+++ b/tr/answers/what-font-does-whatsapp-use/index.html
@@ -263,7 +263,7 @@
   <div class="compare-grid">
     <a href="/tr/whatsapp-yazi-tipi/" class="compare-card variant-muted u-no-underline">
       <span class="compare-badge">Tool</span>
-      <h4>WhatsApp Font Generator</h4>
+      <h4>WhatsApp yazı tipi — mesaj ve durum için şekilli yazı</h4>
       <ul><li>Style your status, group names and messages.</li></ul>
     </a>
     <a href="/guide/whatsapp-text-formatting-explained/" class="compare-card variant-muted u-no-underline">
@@ -273,7 +273,7 @@
     </a>
     <a href="/tr/kalin-yazi/" class="compare-card variant-muted u-no-underline">
       <span class="compare-badge">Tool</span>
-      <h4>Bold Text Generator</h4>
+      <h4>Kalın yazı yazma — kopyala yapıştır</h4>
       <ul><li>Generate clean bold text for any platform.</li></ul>
     </a>
   </div>

--- a/tr/library/discord-sembolleri/index.html
+++ b/tr/library/discord-sembolleri/index.html
@@ -620,7 +620,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
           <p>Sembolleri otomatik olarak kelimenin etrafına sar.</p>
         </a>
         <a href="/tr/library/kalp-sembolleri/" class="compare-card variant-muted u-no-underline">
-          <h4>Heart Symbols</h4>
+          <h4>Kalp sembolleri — kopyala yapıştır</h4>
           <p>Her kalp emojisi ve Unicode kalp karakteri.</p>
         </a>
         <a href="/answers/discord-allowed-characters/" class="compare-card variant-muted u-no-underline">

--- a/tr/symbol/baris-isareti/index.html
+++ b/tr/symbol/baris-isareti/index.html
@@ -333,7 +333,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <span class="article-section-label">İlgili Semboller</span>
   <div class="compare-grid">
     <a href="/tr/symbol/yin-yang-sembolu/" class="compare-card variant-muted u-no-underline">
-      <h4>☯ Yin Yang</h4>
+      <h4>Yin Yang Sembolü (☯)</h4>
       <p>Girdabın ardındaki antik Çin felsefesi.</p>
     </a>
     <a href="/tr/symbol/anarsi-sembolu/" class="compare-card variant-muted u-no-underline">

--- a/tr/symbol/index.html
+++ b/tr/symbol/index.html
@@ -394,7 +394,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Gerald Holtom'un 1958 tasarımı, semafor kodundan türetildi.</p>
     </a>
     <a href="/tr/symbol/yin-yang-sembolu/" class="compare-card variant-muted u-no-underline">
-      <h4>☯ Yin Yang</h4>
+      <h4>Yin Yang Sembolü (☯)</h4>
       <p>Sarmalın arkasındaki kadim Çin felsefesi.</p>
     </a>
     <a href="/tr/symbol/khanda-sembolu/" class="compare-card variant-muted u-no-underline">

--- a/vi/symbol/em-dash/index.html
+++ b/vi/symbol/em-dash/index.html
@@ -269,7 +269,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Dấu ngoặc kép, dấu gạch ngang, dấu ngoặc và các dấu câu thông thường khác trong Unicode.</p>
     </a>
     <a href="/vi/symbol/pilcrow/" class="compare-card variant-muted u-no-underline">
-      <h4>Pilcrow (¶)</h4>
+      <h4>Ký Hiệu Pilcrow (¶)</h4>
       <p>Dấu đoạn văn — một ký hiệu kiểu chữ biên tập khác với lịch sử in ấn lâu đời.</p>
     </a>
     <a href="/vi/symbol/en-dash/" class="compare-card variant-muted u-no-underline">

--- a/vi/symbol/index.html
+++ b/vi/symbol/index.html
@@ -274,7 +274,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Một đề xuất dấu câu năm 1575 — và vì sao nó khác với ¿.</p>
     </a>
     <a href="/vi/symbol/interrobang/" class="compare-card variant-muted u-no-underline">
-      <h4>‽ Interrobang</h4>
+      <h4>Interrobang (‽)</h4>
       <p>Sự kết hợp năm 1962 của một người làm quảng cáo giữa ? và ! — từng có cả phím máy chữ riêng.</p>
     </a>
     <a href="/vi/symbol/asterisk-symbol/" class="compare-card variant-muted u-no-underline">
@@ -518,7 +518,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Dấu «gân nổi» trong manga trở thành cả một emoji nguyên vẹn.</p>
     </a>
     <a href="/vi/symbol/black-moon-lilith/" class="compare-card variant-muted u-no-underline">
-      <h4>⚸ Black Moon Lilith</h4>
+      <h4>Ký Hiệu Black Moon Lilith</h4>
       <p>Một điểm quỹ đạo, không phải một thiên thể — và không phải cùng thứ với tiểu hành tinh Lilith.</p>
     </a>
     <a href="/vi/symbol/fleur-de-lis-symbol/" class="compare-card variant-muted u-no-underline">

--- a/vi/symbol/interrobang/index.html
+++ b/vi/symbol/interrobang/index.html
@@ -256,7 +256,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
       <p>Một dấu câu khác với câu chuyện sống động và một họ hình ảnh giống nhau mà mọi người liên tục nhầm lẫn.</p>
     </a>
     <a href="/vi/symbol/pilcrow/" class="compare-card variant-muted u-no-underline">
-      <h4>Pilcrow (¶)</h4>
+      <h4>Ký Hiệu Pilcrow (¶)</h4>
       <p>Dấu đoạn văn — một ký hiệu kiểu chữ biên tập với lịch sử in ấn lâu đời của riêng nó.</p>
     </a>
   </div>

--- a/zh-tw/symbol/alpha-symbol/index.html
+++ b/zh-tw/symbol/alpha-symbol/index.html
@@ -238,7 +238,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">相關頁面</span>
   <div class="compare-grid">
     <a href="/zh-tw/symbol/omega-symbol/" class="compare-card variant-muted u-no-underline">
       <h4>歐米加符號（Ω）</h4>

--- a/zh-tw/symbol/bitcoin-symbol/index.html
+++ b/zh-tw/symbol/bitcoin-symbol/index.html
@@ -234,7 +234,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">相關頁面</span>
   <div class="compare-grid">
     <a href="/zh-tw/symbol/euro-sign/" class="compare-card variant-muted u-no-underline">
       <h4>歐元符號（€）</h4>

--- a/zh-tw/symbol/celsius-symbol/index.html
+++ b/zh-tw/symbol/celsius-symbol/index.html
@@ -234,7 +234,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">相關頁面</span>
   <div class="compare-grid">
     <a href="/zh-tw/symbol/degree-symbol/" class="compare-card variant-muted u-no-underline">
       <h4>度數符號（°）</h4>

--- a/zh-tw/symbol/cent-sign/index.html
+++ b/zh-tw/symbol/cent-sign/index.html
@@ -234,7 +234,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">相關頁面</span>
   <div class="compare-grid">
     <a href="/zh-tw/symbol/pound-sign/" class="compare-card variant-muted u-no-underline">
       <h4>英鎊符號（£）</h4>

--- a/zh-tw/symbol/checkmark-symbol/index.html
+++ b/zh-tw/symbol/checkmark-symbol/index.html
@@ -246,7 +246,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">相關頁面</span>
   <div class="compare-grid">
     <a href="/zh-tw/symbol/square-root/" class="compare-card variant-muted u-no-underline">
       <h4>平方根符號（√）</h4>

--- a/zh-tw/symbol/copyright-symbol/index.html
+++ b/zh-tw/symbol/copyright-symbol/index.html
@@ -234,7 +234,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">相關頁面</span>
   <div class="compare-grid">
     <a href="/zh-tw/symbol/trademark-symbol/" class="compare-card variant-muted u-no-underline">
       <h4>商標符號（™）</h4>

--- a/zh-tw/symbol/degree-symbol/index.html
+++ b/zh-tw/symbol/degree-symbol/index.html
@@ -240,7 +240,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">相關頁面</span>
   <div class="compare-grid">
     <a href="/zh-tw/symbol/celsius-symbol/" class="compare-card variant-muted u-no-underline">
       <h4>攝氏度符號（℃）</h4>

--- a/zh-tw/symbol/delta-symbol/index.html
+++ b/zh-tw/symbol/delta-symbol/index.html
@@ -238,7 +238,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">相關頁面</span>
   <div class="compare-grid">
     <a href="/zh-tw/symbol/omega-symbol/" class="compare-card variant-muted u-no-underline">
       <h4>歐米加符號（Ω）</h4>

--- a/zh-tw/symbol/diameter-symbol/index.html
+++ b/zh-tw/symbol/diameter-symbol/index.html
@@ -238,7 +238,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">相關頁面</span>
   <div class="compare-grid">
     <a href="/zh-tw/symbol/degree-symbol/" class="compare-card variant-muted u-no-underline">
       <h4>度數符號（°）</h4>

--- a/zh-tw/symbol/division-sign/index.html
+++ b/zh-tw/symbol/division-sign/index.html
@@ -238,7 +238,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">相關頁面</span>
   <div class="compare-grid">
     <a href="/zh-tw/symbol/multiplication-sign/" class="compare-card variant-muted u-no-underline">
       <h4>乘號（×）</h4>

--- a/zh-tw/symbol/dun-hao/index.html
+++ b/zh-tw/symbol/dun-hao/index.html
@@ -254,7 +254,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">相關頁面</span>
   <div class="compare-grid">
     <a href="/zh-tw/symbol/shan-jie-hao/" class="compare-card variant-muted u-no-underline">
       <h4>刪節號（……）</h4>

--- a/zh-tw/symbol/euro-sign/index.html
+++ b/zh-tw/symbol/euro-sign/index.html
@@ -236,7 +236,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">相關頁面</span>
   <div class="compare-grid">
     <a href="/zh-tw/symbol/pound-sign/" class="compare-card variant-muted u-no-underline">
       <h4>英鎊符號（£）</h4>

--- a/zh-tw/symbol/fahrenheit-symbol/index.html
+++ b/zh-tw/symbol/fahrenheit-symbol/index.html
@@ -234,7 +234,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">相關頁面</span>
   <div class="compare-grid">
     <a href="/zh-tw/symbol/celsius-symbol/" class="compare-card variant-muted u-no-underline">
       <h4>攝氏度符號（℃）</h4>

--- a/zh-tw/symbol/infinity/index.html
+++ b/zh-tw/symbol/infinity/index.html
@@ -234,7 +234,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">相關頁面</span>
   <div class="compare-grid">
     <a href="/zh-tw/usecase/ciqing-ziti/" class="compare-card variant-muted u-no-underline">
       <h4>刺青字體產生器</h4>

--- a/zh-tw/symbol/invisible-character/index.html
+++ b/zh-tw/symbol/invisible-character/index.html
@@ -231,7 +231,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">相關頁面</span>
   <div class="compare-grid">
     <a href="/zh-tw/library/kongbai-fuhao/" class="compare-card variant-muted u-no-underline">
       <h4>所有空白符號</h4>

--- a/zh-tw/symbol/lambda-symbol/index.html
+++ b/zh-tw/symbol/lambda-symbol/index.html
@@ -238,7 +238,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">相關頁面</span>
   <div class="compare-grid">
     <a href="/zh-tw/symbol/omega-symbol/" class="compare-card variant-muted u-no-underline">
       <h4>歐米加符號（Ω）</h4>

--- a/zh-tw/symbol/micro-sign/index.html
+++ b/zh-tw/symbol/micro-sign/index.html
@@ -234,7 +234,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">相關頁面</span>
   <div class="compare-grid">
     <a href="/zh-tw/symbol/omega-symbol/" class="compare-card variant-muted u-no-underline">
       <h4>歐米加符號（Ω）</h4>

--- a/zh-tw/symbol/multiplication-sign/index.html
+++ b/zh-tw/symbol/multiplication-sign/index.html
@@ -238,7 +238,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">相關頁面</span>
   <div class="compare-grid">
     <a href="/zh-tw/symbol/division-sign/" class="compare-card variant-muted u-no-underline">
       <h4>除號（÷）</h4>

--- a/zh-tw/symbol/not-equal-sign/index.html
+++ b/zh-tw/symbol/not-equal-sign/index.html
@@ -238,7 +238,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">相關頁面</span>
   <div class="compare-grid">
     <a href="/zh-tw/symbol/multiplication-sign/" class="compare-card variant-muted u-no-underline">
       <h4>乘號（×）</h4>

--- a/zh-tw/symbol/ohm-symbol/index.html
+++ b/zh-tw/symbol/ohm-symbol/index.html
@@ -244,7 +244,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">相關頁面</span>
   <div class="compare-grid">
     <a href="/zh-tw/symbol/omega-symbol/" class="compare-card variant-muted u-no-underline">
       <h4>歐米加符號（Ω／ω）</h4>

--- a/zh-tw/symbol/omega-symbol/index.html
+++ b/zh-tw/symbol/omega-symbol/index.html
@@ -238,7 +238,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">相關頁面</span>
   <div class="compare-grid">
     <a href="/zh-tw/symbol/alpha-symbol/" class="compare-card variant-muted u-no-underline">
       <h4>阿爾法符號（α）</h4>

--- a/zh-tw/symbol/peso-sign/index.html
+++ b/zh-tw/symbol/peso-sign/index.html
@@ -234,7 +234,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">相關頁面</span>
   <div class="compare-grid">
     <a href="/zh-tw/symbol/euro-sign/" class="compare-card variant-muted u-no-underline">
       <h4>歐元符號（€）</h4>

--- a/zh-tw/symbol/phi-symbol/index.html
+++ b/zh-tw/symbol/phi-symbol/index.html
@@ -238,7 +238,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">相關頁面</span>
   <div class="compare-grid">
     <a href="/zh-tw/symbol/omega-symbol/" class="compare-card variant-muted u-no-underline">
       <h4>歐米加符號（Ω）</h4>

--- a/zh-tw/symbol/plus-minus/index.html
+++ b/zh-tw/symbol/plus-minus/index.html
@@ -238,7 +238,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">相關頁面</span>
   <div class="compare-grid">
     <a href="/zh-tw/symbol/multiplication-sign/" class="compare-card variant-muted u-no-underline">
       <h4>乘號（×）</h4>

--- a/zh-tw/symbol/pound-sign/index.html
+++ b/zh-tw/symbol/pound-sign/index.html
@@ -235,7 +235,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">相關頁面</span>
   <div class="compare-grid">
     <a href="/zh-tw/symbol/euro-sign/" class="compare-card variant-muted u-no-underline">
       <h4>歐元符號（€）</h4>

--- a/zh-tw/symbol/section-sign/index.html
+++ b/zh-tw/symbol/section-sign/index.html
@@ -230,7 +230,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">相關頁面</span>
   <div class="compare-grid">
     <a href="/zh-tw/symbol/copyright-symbol/" class="compare-card variant-muted u-no-underline">
       <h4>版權符號（©）</h4>

--- a/zh-tw/symbol/shan-jie-hao/index.html
+++ b/zh-tw/symbol/shan-jie-hao/index.html
@@ -248,7 +248,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">相關頁面</span>
   <div class="compare-grid">
     <a href="/zh-tw/symbol/dun-hao/" class="compare-card variant-muted u-no-underline">
       <h4>頓號（、）</h4>

--- a/zh-tw/symbol/sigma-symbol/index.html
+++ b/zh-tw/symbol/sigma-symbol/index.html
@@ -238,7 +238,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">相關頁面</span>
   <div class="compare-grid">
     <a href="/zh-tw/symbol/omega-symbol/" class="compare-card variant-muted u-no-underline">
       <h4>歐米加符號（Ω）</h4>

--- a/zh-tw/symbol/square-root/index.html
+++ b/zh-tw/symbol/square-root/index.html
@@ -219,7 +219,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">相關頁面</span>
   <div class="compare-grid">
     <a href="/zh-tw/symbol/checkmark-symbol/" class="compare-card variant-muted u-no-underline">
       <h4>打勾符號（✓ ✔）</h4>

--- a/zh-tw/symbol/theta-symbol/index.html
+++ b/zh-tw/symbol/theta-symbol/index.html
@@ -238,7 +238,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">相關頁面</span>
   <div class="compare-grid">
     <a href="/zh-tw/symbol/omega-symbol/" class="compare-card variant-muted u-no-underline">
       <h4>歐米加符號（Ω）</h4>

--- a/zh-tw/symbol/trademark-symbol/index.html
+++ b/zh-tw/symbol/trademark-symbol/index.html
@@ -234,7 +234,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">相關頁面</span>
   <div class="compare-grid">
     <a href="/zh-tw/symbol/copyright-symbol/" class="compare-card variant-muted u-no-underline">
       <h4>版權符號（©）</h4>

--- a/zh-tw/symbol/won-sign/index.html
+++ b/zh-tw/symbol/won-sign/index.html
@@ -234,7 +234,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">相關頁面</span>
   <div class="compare-grid">
     <a href="/zh-tw/symbol/yen-sign/" class="compare-card variant-muted u-no-underline">
       <h4>日幣符號（¥）</h4>

--- a/zh-tw/symbol/yen-sign/index.html
+++ b/zh-tw/symbol/yen-sign/index.html
@@ -234,7 +234,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 
 <!-- RELATED -->
 <section class="editorial-section">
-  <span class="article-section-label">Related Resources</span>
+  <span class="article-section-label">相關頁面</span>
   <div class="compare-grid">
     <a href="/zh-tw/symbol/euro-sign/" class="compare-card variant-muted u-no-underline">
       <h4>歐元符號（€）</h4>

--- a/zh-tw/usecase/ciqing-ziti/index.html
+++ b/zh-tw/usecase/ciqing-ziti/index.html
@@ -264,7 +264,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     <h2>更多字體風格</h2>
     <div class="compare-grid">
       <a href="/zh-tw/shufa-ziti/" class="compare-card variant-muted u-no-underline">
-        <h4>Cursive Fonts</h4>
+        <h4>書法字體產生器</h4>
         <p>完整花體字家族——名字和字句刺青的經典選擇。</p>
       </a>
       <a href="/category/gothic-fonts/" class="compare-card variant-muted u-no-underline">


### PR DESCRIPTION
## What this does

Works the locale-English backlog surfaced by `npm run audit:locale-translation` down from **3,542 → 2,678 string instances** and **1,339 → 889 pages**, across four commits.

The more useful outcome than the counts: **the audit's headline number mixes two different things**, and they need separating before anyone treats it as a work estimate.

## The correction that shaped this PR

The work was framed as "fix the ~400 pages carrying the English CTA paragraph." That number was wrong — it came from CLAUDE.md's record of the audit's **first** run on 2026-08-15, and a prior pass had already driven it to zero. Verified directly rather than assumed: the English CTA appears on **0** locale pages, and `aria-label="Breadcrumb"` (the other historical leader, 527 pages) is also at 0. Both were closed by `scripts/fix-locale-template-strings.js`, which already existed.

## What was actually still broken

**1. Section kickers (149 + 24 FAQ headings, 77 files).** The `<span class="article-section-label">` above a heading was English while everything beneath it — including that very heading — was translated. Fixed by extending the existing script with a fourth pass, not by writing a new one. Values are kept in two visibly separate provenance tiers, *harvested* (from each locale's own correct pages, unanimous or near-unanimous) vs *supplied* (the three generic template defaults, which have nothing to harvest). The stop rule applies per string, so `ms` and `zh-tw` take only their harvested value rather than being guessed at.

**2. Related-card titles (229 across 168 files).** A card's `<h4>` is written once at page-creation time from the English source, so a Dutch page linking its own Dutch euro page still titled the card "All Currency Symbols". Rewritten from the **target locale page's own `<h1>`** — the same source `sync_symbol_spoke_links.py` already uses for card copy, so nothing is invented and nothing is translated here.

> A first attempt rewrote **8,623 cards across 2,768 files** by rewriting *every* card rather than only the ones the audit flags as English, replacing correct locale titles with verbose target H1s. It was reverted before it went anywhere. The constraint that makes this safe is the intersection of *audit-flagged* **and** *same-locale link target*.

**3. Italian `<th>Input</th>` → `<th>Inserimento</th>` (71 files).** Every sibling locale translates that column (`Entrada` / `Saisie` / `Eingabe` / `Invoer` / `Girdi` / `Indtastning`); Italian alone did not.

**4. Decoration tabs — 11 pages, not 94.** Harvesting every `<button data-deco-tab>` label per locale showed five of seven tabs (`symbols`, `frames`, `arrows`, `flags`, `dividers`) have **zero** English survivors in any locale. `Minimal` on 94 pages was mostly not debt: it is the settled native form in de/es/id/it/ms/tr (id 41 of 43, tr 23 of 23, it 23 of 26). Only three locales have a clear native dominant *and* English stragglers against it — cs `Minimalistické` 7 vs 1, fr `Minimaliste` 23 vs 3, pl `Minimalne` 14 vs 7 — so 11 pages were fixed.

**5. Cited product/tool names are identifiers, not debt.** The audit already scopes proper names *by slot* — exempt where cited (`<td>`, `<p>`, `<li>`), still a defect in a heading or `aria-label`. It had no rule for AutoCAD, Discord, LaTeX, WhatsApp, Windows, iOS / Android, so a table cell citing them counted as untranslated. `platformToolNames()` now harvests them from the site's own English pages, gated behind an `isProperNounPhrase()` shape test (two earlier harvests over-collected prose like "Documents, emails, bios" exactly that way). CSS literals join the identifier rules.

**6. Mesh debt on touched pages (7 links, 3 files).** `check:locale-mesh` is scoped by changed file, so touching a page pulls its standing English-hub links into scope. Fixed with the sanctioned fixer, scoped. Two of the seven rewrites then unlocked card titles the earlier pass had correctly declined to touch (their link target was English at the time).

## Ledger entries — 16, each with the locale's own evidence

`data/translation_identical_strings.json` grows by 16 byte-identical translations. Every reason cites **that locale's own dominant form on this site**, not a claim about the language: tr `Platform|Çalışır mı?` ×74, nl `Platform|Werkt het?` ×15, id `Platform / Alat` ×6 (translating only "Tool"), es `Emojis` 25 of 25, pt 21 of 21.

**Deliberately not ledgered:** da/no/sv/tl, where the *only* occurrence of the string on the whole site is the flagged page itself. "Minimal" is a real word in all four, but the evidence would be the defect vouching for itself, and the ledger's own rule is that an entry names independent evidence. They stay reported.

## Verification

Per CLAUDE.md's "adding a validator script is not the same as gating on it", the rule change to `scripts/lib/locale-translation-audit.js` was checked against the regression pair CLAUDE.md names by hand: `Currency Symbols` stays **exempt** as a cited Unicode block name in a `<td>` on `symbol/bitcoin-symbol`, and stays a **defect** as a related-card `<h4>` on the 14 other pages. 4/4 assertions pass — a string-level exemption would have silently cleared those 14.

All ten gates green on the final commit:

`check:locale-translation` · `check:translation-parity` · `check:locale-mesh` · `check:faq-schema` · `check:locale-parent-gap` · `check:new-page-images` · `check:hreflang-completeness` · `check:funding-choices` · `check:workflows` · `validate_library_pages.py`

`check:locale-translation` reports 96 pre-existing survivors on pages this branch touched and **introduced 0** — reported, not silenced, per its own design.

## Deliberately left open

- Per-locale verification still needed before any ledger entry: `Kaomoji Generator` (35), `Interrobang (‽)` (33), `Ankh` (28), `Zalgo` (26), `Logo font` (24), `Bitcoin` (16). Breadth across locales is suggestive but is not verification.
- Card titles pointing at English pages that have **no** locale sibling — the locale-native linking rule permits those, and no rewrite can fix them.
- Minority-but-correct variants (de `Minimalistisch`, it `Minimo`). Both forms are right; normalising them is a copy decision, not a translation fix.
- `LOCALE_UI_STRINGS['id'].related` in the generator says `Sumber Terkait` while the site's settled form is `Halaman Terkait` (170 vs 30), so new `id` pages will drift. Not changed here because that file is edited on another branch and duplicating the edit risks a conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWmX9CTqeQM6DurnQvUpBz

---
_Generated by [Claude Code](https://claude.ai/code/session_01WWmX9CTqeQM6DurnQvUpBz)_