### PR TITLE
fix: resolve 2 real GSC 404s (bad th/symbol internal link, zh-TW casing)

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -128,6 +128,17 @@ https://www.ultratextgen.com/*  https://ultratextgen.com/:splat  301!
 /category/popular/            /category/ 301
 /category/popular/index.html  /category/ 301
 
+# Locale casing: the zh-tw directory is lowercase (matches the actual repo
+# path and every href on-site — hreflang="zh-TW" attribute values use the
+# BCP-47 convention, but their href targets are always lowercase /zh-tw/).
+# Cloudflare Pages routing is case-sensitive, so an uppercase-cased request
+# 404s even though the real page exists. Nothing in this repo links the
+# uppercase form; the requests are external (bots/old backlinks guessing the
+# hreflang casing). Redirect rather than leave a real page 404ing on a casing
+# mismatch (GSC 404 cleanup).
+/zh-TW/            /zh-tw/          301
+/zh-TW/library/    /zh-tw/library/  301
+
 # Root asset: /og.png was renamed to a descriptive, convention-aligned asset
 # (see docs/image-seo-fixes.md). Redirect stale crawled/cached references
 # instead of letting them 404 (GSC 404 cleanup).

--- a/th/symbol/khreuangmai-santiphap/index.html
+++ b/th/symbol/khreuangmai-santiphap/index.html
@@ -298,7 +298,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 <section class="editorial-section">
   <span class="article-section-label">สัญลักษณ์ที่เกี่ยวข้อง</span>
   <div class="compare-grid">
-    <a href="/th/symbol/simbol-yin-yang/" class="compare-card variant-muted u-no-underline">
+    <a href="/th/symbol/sanyalak-yin-yang/" class="compare-card variant-muted u-no-underline">
       <h4>☯ หยินหยาง</h4>
       <p>ปรัชญาจีนโบราณเบื้องหลังลวดลายหมุนวน</p>
     </a>


### PR DESCRIPTION
- th/symbol/khreuangmai-santiphap linked its yin-yang peer card to a slug that never existed (/th/symbol/simbol-yin-yang/, an Indonesian slug pattern under the Thai locale prefix). The real page is /th/symbol/sanyalak-yin-yang/, which already links back — fixing the one-directional href, not adding a new peer relation.
- Add 301s for /zh-TW/ and /zh-TW/library/ -> the real lowercase /zh-tw/ paths. Every on-site href already targets lowercase zh-tw (hreflang="zh-TW" attribute values follow BCP-47 convention but their href targets do not); Cloudflare Pages routing is case-sensitive, so external requests using the uppercase casing 404 a real, live page. Redirect rather than leave it 404ing.

The other 9 URLs in the Coverage-Drilldown export are not actionable: 5 (library/youtube-symbols, usecase/social-post-text, usecase/bio-text, category/popular, cdn-cgi/l/email-protection) already got 301s in the 2026-07-31 GSC-404-cleanup pass, predating this export's crawl dates — stale entries that clear on Google's next recrawl. The remaining 4 (upload/*.m3u8 x3, /220, a malformed ">" path) are external bot probes with no corresponding page or link anywhere in this repo.


Claude-Session: https://claude.ai/code/session_01EtQxLk7V2G38zuugR6o6Rc