### PR TITLE
fix(seo): add missing answerCount to all 19 QAPage schema blocks

### DIFF
--- a/answers/discord-allowed-characters/index.html
+++ b/answers/discord-allowed-characters/index.html
@@ -77,6 +77,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   "@type": "QAPage",
   "mainEntity": {
     "@type": "Question",
+    "answerCount": 1,
     "name": "What characters are allowed on Discord?",
     "author": {
       "@type": "Organization",

--- a/answers/do-you-need-nitro-for-discord-fonts/index.html
+++ b/answers/do-you-need-nitro-for-discord-fonts/index.html
@@ -77,6 +77,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   "@type": "QAPage",
   "mainEntity": {
     "@type": "Question",
+    "answerCount": 1,
     "name": "Do you need Nitro to use fonts on Discord?",
     "author": {
       "@type": "Organization",

--- a/answers/how-to-change-minecraft-username/index.html
+++ b/answers/how-to-change-minecraft-username/index.html
@@ -79,6 +79,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   "@type": "QAPage",
   "mainEntity": {
     "@type": "Question",
+    "answerCount": 1,
     "name": "How do you change your Minecraft username?",
     "text": "How do you change your Minecraft username? Is it different on Java and Bedrock?",
     "author": {

--- a/answers/how-to-change-roblox-username/index.html
+++ b/answers/how-to-change-roblox-username/index.html
@@ -79,6 +79,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   "@type": "QAPage",
   "mainEntity": {
     "@type": "Question",
+    "answerCount": 1,
     "name": "How do you change your Roblox username?",
     "text": "How do you change your Roblox username? What does it cost and is there a free option?",
     "author": {

--- a/answers/how-to-change-youtube-channel-name/index.html
+++ b/answers/how-to-change-youtube-channel-name/index.html
@@ -80,6 +80,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   "@type": "QAPage",
   "mainEntity": {
     "@type": "Question",
+    "answerCount": 1,
     "name": "How do you change your YouTube channel name?",
     "author": {
       "@type": "Organization",

--- a/answers/how-to-uncover-redacted-text/index.html
+++ b/answers/how-to-uncover-redacted-text/index.html
@@ -80,6 +80,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   "@type": "QAPage",
   "mainEntity": {
     "@type": "Question",
+    "answerCount": 1,
     "name": "Can you uncover redacted text?",
     "text": "Can blacked-out or redacted text be revealed, decoded, or unredacted?",
     "author": {

--- a/answers/what-font-does-discord-use/index.html
+++ b/answers/what-font-does-discord-use/index.html
@@ -77,6 +77,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   "@type": "QAPage",
   "mainEntity": {
     "@type": "Question",
+    "answerCount": 1,
     "name": "What font does Discord use?",
     "author": {
       "@type": "Organization",

--- a/answers/what-font-does-instagram-use/index.html
+++ b/answers/what-font-does-instagram-use/index.html
@@ -77,6 +77,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   "@type": "QAPage",
   "mainEntity": {
     "@type": "Question",
+    "answerCount": 1,
     "name": "What font does Instagram use?",
     "author": {
       "@type": "Organization",

--- a/answers/what-font-does-tiktok-use/index.html
+++ b/answers/what-font-does-tiktok-use/index.html
@@ -77,6 +77,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   "@type": "QAPage",
   "mainEntity": {
     "@type": "Question",
+    "answerCount": 1,
     "name": "What font does TikTok use?",
     "author": {
       "@type": "Organization",

--- a/answers/what-font-does-twitter-use/index.html
+++ b/answers/what-font-does-twitter-use/index.html
@@ -77,6 +77,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   "@type": "QAPage",
   "mainEntity": {
     "@type": "Question",
+    "answerCount": 1,
     "name": "What font does Twitter/X use?",
     "author": {
       "@type": "Organization",

--- a/answers/what-font-does-youtube-use/index.html
+++ b/answers/what-font-does-youtube-use/index.html
@@ -77,6 +77,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   "@type": "QAPage",
   "mainEntity": {
     "@type": "Question",
+    "answerCount": 1,
     "name": "What font does YouTube use?",
     "author": {
       "@type": "Organization",

--- a/answers/what-is-ascii/index.html
+++ b/answers/what-is-ascii/index.html
@@ -79,6 +79,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   "@type": "QAPage",
   "mainEntity": {
     "@type": "Question",
+    "answerCount": 1,
     "name": "What is ASCII?",
     "author": {
       "@type": "Organization",

--- a/answers/youtube-handle-vs-channel-name/index.html
+++ b/answers/youtube-handle-vs-channel-name/index.html
@@ -80,6 +80,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   "@type": "QAPage",
   "mainEntity": {
     "@type": "Question",
+    "answerCount": 1,
     "name": "What is the difference between a YouTube handle and a channel name?",
     "author": {
       "@type": "Organization",

--- a/id/answers/cara-mengganti-nama-channel-youtube/index.html
+++ b/id/answers/cara-mengganti-nama-channel-youtube/index.html
@@ -82,6 +82,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   "@type": "QAPage",
   "mainEntity": {
     "@type": "Question",
+    "answerCount": 1,
     "name": "Bagaimana cara mengganti nama channel YouTube?",
     "author": {
       "@type": "Organization",

--- a/id/answers/handle-vs-nama-channel-youtube/index.html
+++ b/id/answers/handle-vs-nama-channel-youtube/index.html
@@ -82,6 +82,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   "@type": "QAPage",
   "mainEntity": {
     "@type": "Question",
+    "answerCount": 1,
     "name": "Apa bedanya handle dan nama channel YouTube?",
     "author": {
       "@type": "Organization",

--- a/pt/answers/como-mudar-o-nome-do-canal-do-youtube/index.html
+++ b/pt/answers/como-mudar-o-nome-do-canal-do-youtube/index.html
@@ -82,6 +82,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   "@type": "QAPage",
   "mainEntity": {
     "@type": "Question",
+    "answerCount": 1,
     "name": "Como mudar o nome do canal do YouTube?",
     "author": {
       "@type": "Organization",

--- a/pt/answers/handle-ou-nome-do-canal-do-youtube/index.html
+++ b/pt/answers/handle-ou-nome-do-canal-do-youtube/index.html
@@ -82,6 +82,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   "@type": "QAPage",
   "mainEntity": {
     "@type": "Question",
+    "answerCount": 1,
     "name": "Qual é a diferença entre o handle e o nome do canal do YouTube?",
     "author": {
       "@type": "Organization",

--- a/tr/answers/youtube-handle-mi-kanal-adi-mi/index.html
+++ b/tr/answers/youtube-handle-mi-kanal-adi-mi/index.html
@@ -82,6 +82,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   "@type": "QAPage",
   "mainEntity": {
     "@type": "Question",
+    "answerCount": 1,
     "name": "YouTube handle ile kanal adı arasındaki fark nedir?",
     "author": {
       "@type": "Organization",

--- a/tr/answers/youtube-kanal-adi-nasil-degistirilir/index.html
+++ b/tr/answers/youtube-kanal-adi-nasil-degistirilir/index.html
@@ -82,6 +82,7 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   "@type": "QAPage",
   "mainEntity": {
     "@type": "Question",
+    "answerCount": 1,
     "name": "YouTube kanal adı nasıl değiştirilir?",
     "author": {
       "@type": "Organization",


### PR DESCRIPTION
GSC flagged a structured-data warning on answers/how-to-uncover-redacted-text/ ("Missing field 'answerCount' (in 'mainEntity')") for its QAPage JSON-LD. A site-wide sweep found the same field missing on every QAPage block, not just the reported page: all 13 EN answers/ pages using QAPage, plus the 6 locale (id/tr/pt) translations of the two youtube-handle/channel-name pages.

Every affected page has exactly one accepted Answer under its mainEntity Question, so answerCount: 1 is correct in each case. Mechanical, single-field addition — no visible content, links, or FAQ changed.


Claude-Session: https://claude.ai/code/session_015SgW1AmUaJuZZUYc9txCmz