### PR TITLE
fix(sitemap): advance lastmod only when the content actually changed

### DIFF
--- a/.github/workflows/update-sitemap.yml
+++ b/.github/workflows/update-sitemap.yml
@@ -29,6 +29,10 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add sitemap.xml
+          # The cache must be committed alongside the sitemap. The generator
+          # writes it every run; if only sitemap.xml is staged, the cache is
+          # silently discarded and every later run compares against a frozen
+          # snapshot instead of the previous run's state.
+          git add sitemap.xml data/sitemap-lastmod-cache.json
           git diff --cached --quiet || git commit -m "chore: regenerate sitemap.xml [skip ci]"
           git push

--- a/data/sitemap-lastmod-cache.json
+++ b/data/sitemap-lastmod-cache.json
@@ -1,0 +1,18306 @@
+{
+ "/": {
+  "hash": "b5cceac83c3adfc9",
+  "lastmod": "2026-08-04"
+ },
+ "/about/": {
+  "hash": "f45f40ce7302b0a2",
+  "lastmod": "2026-07-25"
+ },
+ "/answers/": {
+  "hash": "ce29aa8465f4100f",
+  "lastmod": "2026-08-07"
+ },
+ "/answers/can-you-search-fancy-text/": {
+  "hash": "abc9e54063aa9783",
+  "lastmod": "2026-07-25"
+ },
+ "/answers/change-font-size-on-facebook/": {
+  "hash": "31c3b81ec160750b",
+  "lastmod": "2026-07-26"
+ },
+ "/answers/christmas-card-what-to-write/": {
+  "hash": "dc0887271a93cc00",
+  "lastmod": "2026-07-26"
+ },
+ "/answers/cny-greetings-what-to-say/": {
+  "hash": "c026647623110248",
+  "lastmod": "2026-07-26"
+ },
+ "/answers/discord-allowed-characters/": {
+  "hash": "87d94896c5ec2dd0",
+  "lastmod": "2026-07-25"
+ },
+ "/answers/diwali-wishes-what-to-say/": {
+  "hash": "8bebed026c80e39f",
+  "lastmod": "2026-07-26"
+ },
+ "/answers/do-fancy-fonts-work-on-iphone/": {
+  "hash": "2a8becaaf42ef57c",
+  "lastmod": "2026-07-25"
+ },
+ "/answers/do-fancy-fonts-work-with-arabic/": {
+  "hash": "630bb8febc9cf8e8",
+  "lastmod": "2026-07-25"
+ },
+ "/answers/do-fancy-fonts-work-with-vietnamese/": {
+  "hash": "2a9ccb059be5aa3e",
+  "lastmod": "2026-07-26"
+ },
+ "/answers/do-you-need-nitro-for-discord-fonts/": {
+  "hash": "86aa95512a466d26",
+  "lastmod": "2026-07-25"
+ },
+ "/answers/does-zalgo-work-on-roblox/": {
+  "hash": "3117eafdfae7198b",
+  "lastmod": "2026-07-26"
+ },
+ "/answers/eid-mubarak-meaning-and-reply/": {
+  "hash": "db43a92133d1bf4d",
+  "lastmod": "2026-07-26"
+ },
+ "/answers/fancy-text-with-n-and-accented-letters/": {
+  "hash": "d082c9fa3bf96365",
+  "lastmod": "2026-07-25"
+ },
+ "/answers/fathers-day-messages-what-to-write/": {
+  "hash": "89ba1a2dd4dbddba",
+  "lastmod": "2026-07-26"
+ },
+ "/answers/halloween-messages-what-to-write/": {
+  "hash": "264e0035a4107e2b",
+  "lastmod": "2026-07-31"
+ },
+ "/answers/happy-new-year-wishes-what-to-write/": {
+  "hash": "bf4163446390331a",
+  "lastmod": "2026-07-26"
+ },
+ "/answers/how-to-change-discord-username/": {
+  "hash": "c9dc5c085b243cf3",
+  "lastmod": "2026-07-26"
+ },
+ "/answers/how-to-change-instagram-username/": {
+  "hash": "9907117db55efc6d",
+  "lastmod": "2026-07-26"
+ },
+ "/answers/how-to-change-minecraft-username/": {
+  "hash": "114fcd6d6a6f8889",
+  "lastmod": "2026-07-31"
+ },
+ "/answers/how-to-change-roblox-username/": {
+  "hash": "242b0399585837ac",
+  "lastmod": "2026-07-26"
+ },
+ "/answers/how-to-change-tiktok-username/": {
+  "hash": "4151f46e5e85625c",
+  "lastmod": "2026-07-26"
+ },
+ "/answers/how-to-change-youtube-channel-name/": {
+  "hash": "907c92d20f8779e0",
+  "lastmod": "2026-08-05"
+ },
+ "/answers/how-to-make-a-blank-name/": {
+  "hash": "dfc4eb554a5eb7c4",
+  "lastmod": "2026-08-07"
+ },
+ "/answers/how-to-make-big-text-in-discord/": {
+  "hash": "62e0239c21f279af",
+  "lastmod": "2026-07-26"
+ },
+ "/answers/how-to-make-bold-text-in-discord/": {
+  "hash": "0b97a6e5e7fc2a25",
+  "lastmod": "2026-08-12"
+ },
+ "/answers/how-to-remove-zalgo-text/": {
+  "hash": "46205d8cd4367ffc",
+  "lastmod": "2026-07-26"
+ },
+ "/answers/how-to-type-kaomoji/": {
+  "hash": "d23bd7c15fda4c52",
+  "lastmod": "2026-07-25"
+ },
+ "/answers/how-to-uncover-redacted-text/": {
+  "hash": "35d2ac6af4398e80",
+  "lastmod": "2026-07-26"
+ },
+ "/answers/how-to-underline-in-discord/": {
+  "hash": "8e1e5c8a62801bad",
+  "lastmod": "2026-07-26"
+ },
+ "/answers/is-fancy-text-bad-for-accessibility/": {
+  "hash": "999e5b9f20bbecc8",
+  "lastmod": "2026-08-15"
+ },
+ "/answers/is-fancy-text-bad-for-seo/": {
+  "hash": "230d70277656d93f",
+  "lastmod": "2026-07-25"
+ },
+ "/answers/is-linkedin-bold-text-safe/": {
+  "hash": "b09ca5a6b29f9aab",
+  "lastmod": "2026-08-15"
+ },
+ "/answers/is-zalgo-text-safe/": {
+  "hash": "c23dbc5c0b02b8d8",
+  "lastmod": "2026-07-26"
+ },
+ "/answers/merry-christmas-in-different-languages/": {
+  "hash": "17e47d601927ea2f",
+  "lastmod": "2026-07-26"
+ },
+ "/answers/mothers-day-messages-what-to-write/": {
+  "hash": "d58bbc964212d59d",
+  "lastmod": "2026-07-26"
+ },
+ "/answers/teacher-appreciation-card-what-to-write/": {
+  "hash": "9d3c87f8bbb1f158",
+  "lastmod": "2026-08-13"
+ },
+ "/answers/valentines-day-messages-what-to-write/": {
+  "hash": "ee112a225a6b1fb1",
+  "lastmod": "2026-07-31"
+ },
+ "/answers/what-are-discord-display-name-styles/": {
+  "hash": "c8c4f05c3d2591ec",
+  "lastmod": "2026-08-02"
+ },
+ "/answers/what-does-o7-mean/": {
+  "hash": "a07087a9df8e99dc",
+  "lastmod": "2026-07-25"
+ },
+ "/answers/what-does-owo-mean/": {
+  "hash": "defe99aa6ebae794",
+  "lastmod": "2026-07-25"
+ },
+ "/answers/what-does-uwu-mean/": {
+  "hash": "648924f65da9d5f7",
+  "lastmod": "2026-07-25"
+ },
+ "/answers/what-does-xd-mean/": {
+  "hash": "6940332ecba653d4",
+  "lastmod": "2026-07-25"
+ },
+ "/answers/what-font-does-discord-use/": {
+  "hash": "842068a539b48f44",
+  "lastmod": "2026-07-25"
+ },
+ "/answers/what-font-does-facebook-use/": {
+  "hash": "71cc9c59c207ba03",
+  "lastmod": "2026-07-26"
+ },
+ "/answers/what-font-does-instagram-use/": {
+  "hash": "d3e28546cbd4bfa2",
+  "lastmod": "2026-07-26"
+ },
+ "/answers/what-font-does-linkedin-use/": {
+  "hash": "560ee9b057b615e6",
+  "lastmod": "2026-07-26"
+ },
+ "/answers/what-font-does-pinterest-use/": {
+  "hash": "32a6e92b1d9fa0a2",
+  "lastmod": "2026-08-07"
+ },
+ "/answers/what-font-does-roblox-use/": {
+  "hash": "653de472daf75f56",
+  "lastmod": "2026-07-26"
+ },
+ "/answers/what-font-does-snapchat-use/": {
+  "hash": "fe81bd129504dc87",
+  "lastmod": "2026-07-26"
+ },
+ "/answers/what-font-does-tiktok-use/": {
+  "hash": "06355e38ea10ef26",
+  "lastmod": "2026-07-26"
+ },
+ "/answers/what-font-does-twitter-use/": {
+  "hash": "2f2c8a60715bf1e9",
+  "lastmod": "2026-07-26"
+ },
+ "/answers/what-font-does-whatsapp-use/": {
+  "hash": "c2fa12211c054a32",
+  "lastmod": "2026-08-07"
+ },
+ "/answers/what-font-does-youtube-use/": {
+  "hash": "1919cd56d7b46020",
+  "lastmod": "2026-07-26"
+ },
+ "/answers/what-is-a-tiktok-handle/": {
+  "hash": "cc3f8634f98a5e5a",
+  "lastmod": "2026-07-26"
+ },
+ "/answers/what-is-ascii/": {
+  "hash": "64946de236330c8d",
+  "lastmod": "2026-07-25"
+ },
+ "/answers/what-is-kaomoji/": {
+  "hash": "65ad55268d18dff0",
+  "lastmod": "2026-07-25"
+ },
+ "/answers/where-do-fancy-fonts-work-username-vs-display-name/": {
+  "hash": "6a348ce058b7a558",
+  "lastmod": "2026-08-07"
+ },
+ "/answers/why-does-copied-fancy-text-lose-formatting/": {
+  "hash": "2b5923c2a9b17069",
+  "lastmod": "2026-07-26"
+ },
+ "/answers/why-fancy-text-looks-different-on-iphone-vs-android/": {
+  "hash": "82833f0cb5faace4",
+  "lastmod": "2026-07-25"
+ },
+ "/answers/why-fancy-text-removes-accents/": {
+  "hash": "b64e6d41b50064fe",
+  "lastmod": "2026-08-15"
+ },
+ "/answers/why-is-my-name-showing-as-boxes/": {
+  "hash": "91870f1bf2bf6a55",
+  "lastmod": "2026-08-07"
+ },
+ "/answers/why-was-my-game-name-rejected/": {
+  "hash": "a9efadd8b1fd2008",
+  "lastmod": "2026-08-07"
+ },
+ "/answers/why-wont-discord-accept-fancy-username/": {
+  "hash": "d65de949f0530c4c",
+  "lastmod": "2026-07-25"
+ },
+ "/answers/why-wont-instagram-accept-my-fancy-username/": {
+  "hash": "22ade81617054182",
+  "lastmod": "2026-07-26"
+ },
+ "/answers/youtube-handle-vs-channel-name/": {
+  "hash": "ff1eda925d719d16",
+  "lastmod": "2026-08-05"
+ },
+ "/ar/": {
+  "hash": "8bcc501dcd8dce04",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/addad-al-huruf-wal-kalimat/": {
+  "hash": "965481de47435f83",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/answers/": {
+  "hash": "5cee054b17a4f2b1",
+  "lastmod": "2026-08-07"
+ },
+ "/ar/answers/insha-ism-farigh/": {
+  "hash": "57e194bd83815584",
+  "lastmod": "2026-08-07"
+ },
+ "/ar/answers/ism-mustakhdim-am-ism-zahir/": {
+  "hash": "831235120f38d5a5",
+  "lastmod": "2026-08-07"
+ },
+ "/ar/answers/sabab-rafd-ism-allaeba/": {
+  "hash": "235240e005b8658f",
+  "lastmod": "2026-08-07"
+ },
+ "/ar/answers/what-font-does-pinterest-use/": {
+  "hash": "c9619e4ca30fd570",
+  "lastmod": "2026-08-16"
+ },
+ "/ar/answers/what-font-does-whatsapp-use/": {
+  "hash": "a3305c45b279f53d",
+  "lastmod": "2026-08-16"
+ },
+ "/ar/answers/zuhoor-alism-murabbaat/": {
+  "hash": "d9f663d08aca9d97",
+  "lastmod": "2026-08-07"
+ },
+ "/ar/guide/": {
+  "hash": "459d54c71b60e2b4",
+  "lastmod": "2026-08-11"
+ },
+ "/ar/guide/amaken-khutut-discord/": {
+  "hash": "c07d4b72066a23e2",
+  "lastmod": "2026-07-26"
+ },
+ "/ar/guide/ism-discord-amin/": {
+  "hash": "1e1f7f35653cac5c",
+  "lastmod": "2026-07-26"
+ },
+ "/ar/guide/tanseeq-nusus-discord/": {
+  "hash": "9346a635fc9fc94e",
+  "lastmod": "2026-07-26"
+ },
+ "/ar/khat-snapchat/": {
+  "hash": "f6f89ed2e9ee7621",
+  "lastmod": "2026-07-25"
+ },
+ "/ar/library/": {
+  "hash": "c52c79ab0cc2987a",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/library/aesthetic-symbols/": {
+  "hash": "2c7724b1eb3882ae",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/library/alamat-sah/": {
+  "hash": "87d06bb9c7051755",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/library/alt-codes/": {
+  "hash": "03bb2ba40509e169",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/library/animal-emojis/": {
+  "hash": "84a388572f5fccda",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/library/arrow-symbols/": {
+  "hash": "2dd0d73ac90afbd9",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/library/bracket-symbols/": {
+  "hash": "eb6685b41e85d919",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/library/bullet-point-symbols/": {
+  "hash": "763b842314dd7559",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/library/chess-symbols/": {
+  "hash": "c0cbc1ea10a873ce",
+  "lastmod": "2026-08-13"
+ },
+ "/ar/library/cross-x-symbols/": {
+  "hash": "af8de3841c7baed8",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/library/crown-royalty-symbols/": {
+  "hash": "27d750a1c689e58e",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/library/currency-symbols/": {
+  "hash": "6bed42160be3e384",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/library/discord-symbols/": {
+  "hash": "587e991449c6e66f",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/library/emoji-alsalam/": {
+  "hash": "7b1b2f55595c787f",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/library/emoji-combos/": {
+  "hash": "cbb62498ba5110ef",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/library/emoji-flags/": {
+  "hash": "39b39d6018f31b5d",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/library/evil-eye-hamsa-symbols/": {
+  "hash": "f12100d8995a9381",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/library/facebook-symbols/": {
+  "hash": "84dff9fc625ece9b",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/library/fire-emoji/": {
+  "hash": "2b944767c8d2b351",
+  "lastmod": "2026-08-16"
+ },
+ "/ar/library/flower-symbols/": {
+  "hash": "651f5bb5e0b5863b",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/library/fraction-symbols/": {
+  "hash": "258b09c178690f8c",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/library/greek-letter-symbols/": {
+  "hash": "0577871080f8f766",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/library/heart-symbols/": {
+  "hash": "2f7a29851c225bd9",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/library/iphone-emojis/": {
+  "hash": "ff78fe84c3c7c4df",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/library/islamic-symbols/": {
+  "hash": "72f66c1aeda35216",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/library/japanese-symbols/": {
+  "hash": "316e472c81196e22",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/library/kaomoji/": {
+  "hash": "003366c410582c80",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/library/kawaii-cute-symbols/": {
+  "hash": "c7ae3d76ce609fe4",
+  "lastmod": "2026-08-07"
+ },
+ "/ar/library/math-symbols/": {
+  "hash": "00d307fb95a389c1",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/library/music-symbols/": {
+  "hash": "83db0df7c854db48",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/library/number-symbols/": {
+  "hash": "af69965ad776cde9",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/library/pubg-symbols/": {
+  "hash": "5524ad37c8dd0a43",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/library/religious-symbols/": {
+  "hash": "0991000bedad5732",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/library/roblox-symbols/": {
+  "hash": "35707312b6e639fc",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/library/rumuz-alkibord/": {
+  "hash": "3ac5924d5769452f",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/library/rumuz-tibbiya/": {
+  "hash": "c91155978e398e92",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/library/special-characters/": {
+  "hash": "cc4c2340d54f56d5",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/library/star-symbols/": {
+  "hash": "da0df870bb35a10b",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/library/text-art/": {
+  "hash": "4b6a236266a594a5",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/library/vertical-line-symbols/": {
+  "hash": "cec92d116e1b586c",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/library/whatsapp-symbols/": {
+  "hash": "777696064bc7c6ae",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/library/y2k-symbols/": {
+  "hash": "eb87c93989bab116",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/library/zodiac-symbols/": {
+  "hash": "bc716b30c989cb1c",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/nas-ghayr-marii/": {
+  "hash": "bfb3619c505dac09",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/": {
+  "hash": "e6cd181ee52f39d8",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/degree-symbol/": {
+  "hash": "ea2f4125be42001b",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/division-sign/": {
+  "hash": "e17664cd82724f1b",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/infinity/": {
+  "hash": "8c9b0795dbad9945",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/multiplication-sign/": {
+  "hash": "72fe46d821b27d9d",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-alama-tijariya/": {
+  "hash": "858a1587296a012e",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-alaqtibas/": {
+  "hash": "1cbfebef15e73823",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-alatf/": {
+  "hash": "0bb4a294367b2f2c",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-albastoni/": {
+  "hash": "76283c9adabdf7ee",
+  "lastmod": "2026-08-05"
+ },
+ "/ar/symbol/ramz-albaydaq/": {
+  "hash": "4b5d263ef9e3573a",
+  "lastmod": "2026-08-05"
+ },
+ "/ar/symbol/ramz-albintaghram/": {
+  "hash": "eecc89fb50f5c9eb",
+  "lastmod": "2026-08-13"
+ },
+ "/ar/symbol/ramz-alfa/": {
+  "hash": "835c75d6fcec72e8",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-alfaqra/": {
+  "hash": "5cf16849eda5173b",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-alfawdawiya/": {
+  "hash": "b763b1a31f2f301f",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-alghadab/": {
+  "hash": "bd812efbd3554f84",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-alhamsa/": {
+  "hash": "76687cfb3de2ac5f",
+  "lastmod": "2026-08-06"
+ },
+ "/ar/symbol/ramz-alhilal-walnajma/": {
+  "hash": "cb3aa226c4250fac",
+  "lastmod": "2026-08-05"
+ },
+ "/ar/symbol/ramz-alibham/": {
+  "hash": "524721730c16747c",
+  "lastmod": "2026-08-05"
+ },
+ "/ar/symbol/ramz-aljumjuma-waledmaan/": {
+  "hash": "ccabb6131bca2312",
+  "lastmod": "2026-08-05"
+ },
+ "/ar/symbol/ramz-alkhanda/": {
+  "hash": "9212582bf9b24d0a",
+  "lastmod": "2026-08-06"
+ },
+ "/ar/symbol/ramz-alkhat-alamoodi/": {
+  "hash": "1e02a12c54ef7890",
+  "lastmod": "2026-08-13"
+ },
+ "/ar/symbol/ramz-alkhatar-alhayawi/": {
+  "hash": "15386edf908a3231",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-alkursi-almutaharrik/": {
+  "hash": "fc5ebd9ff24606a9",
+  "lastmod": "2026-08-13"
+ },
+ "/ar/symbol/ramz-almikhalal/": {
+  "hash": "8cab2c368dede5ce",
+  "lastmod": "2026-08-05"
+ },
+ "/ar/symbol/ramz-almikro/": {
+  "hash": "650c9aec9a2533fa",
+  "lastmod": "2026-08-06"
+ },
+ "/ar/symbol/ramz-almikrufun/": {
+  "hash": "f65abafceb8a06b6",
+  "lastmod": "2026-07-26"
+ },
+ "/ar/symbol/ramz-alnadarat-alshamsiya/": {
+  "hash": "0632d5c9cac31e02",
+  "lastmod": "2026-08-05"
+ },
+ "/ar/symbol/ramz-alnajma/": {
+  "hash": "7e854dd65f365a12",
+  "lastmod": "2026-08-06"
+ },
+ "/ar/symbol/ramz-alnayzak/": {
+  "hash": "02b6a884ecbddf21",
+  "lastmod": "2026-08-05"
+ },
+ "/ar/symbol/ramz-alqalb/": {
+  "hash": "9a2c4f93f71ca48d",
+  "lastmod": "2026-08-06"
+ },
+ "/ar/symbol/ramz-alqism/": {
+  "hash": "58a5523abbe90cf6",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-alsah/": {
+  "hash": "3d7db400109358e0",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-alsalam/": {
+  "hash": "f66df92f0a3739af",
+  "lastmod": "2026-08-13"
+ },
+ "/ar/symbol/ramz-alsalib-alorthodhoksi/": {
+  "hash": "9a5af75816c5ffd6",
+  "lastmod": "2026-07-26"
+ },
+ "/ar/symbol/ramz-alsalib/": {
+  "hash": "73fbcab182c8bf7d",
+  "lastmod": "2026-08-06"
+ },
+ "/ar/symbol/ramz-altawahhud/": {
+  "hash": "71b0911bf731693f",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-alwajh-almutasaddi/": {
+  "hash": "ffe259c63cbd961d",
+  "lastmod": "2026-08-05"
+ },
+ "/ar/symbol/ramz-alwan-qulub-snapchat/": {
+  "hash": "77786eb023016060",
+  "lastmod": "2026-08-13"
+ },
+ "/ar/symbol/ramz-asghar-akbar/": {
+  "hash": "b60c860ff430b5ae",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-asghar-yusawi/": {
+  "hash": "1e491b64feb2e45a",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-at/": {
+  "hash": "97fbaca449f7b1d6",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-awm/": {
+  "hash": "351e85baab1946ae",
+  "lastmod": "2026-07-26"
+ },
+ "/ar/symbol/ramz-bay/": {
+  "hash": "a9f7d4e94fab426c",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-bitkoin/": {
+  "hash": "0312da2fa3ea023d",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-bizo/": {
+  "hash": "43aa42d07ece3c28",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-bsay/": {
+  "hash": "e028e88d0aefd824",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-burj-adhraa/": {
+  "hash": "88f523c90f4589e4",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-burj-aldalw/": {
+  "hash": "51b1f698f9630d11",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-burj-alhamal/": {
+  "hash": "8a55c75a5afc053b",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-burj-aqrab/": {
+  "hash": "e41f79eafad176c0",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-burj-asad/": {
+  "hash": "9f23927e9c1ed63b",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-burj-hoot/": {
+  "hash": "8ce2fe6246bcd1a1",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-burj-jady/": {
+  "hash": "2ec8079a8ada4838",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-burj-jawza/": {
+  "hash": "82557219454be158",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-burj-mizan/": {
+  "hash": "9182aacbd9bd409d",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-burj-qaws/": {
+  "hash": "2541542ff0f1da99",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-burj-saratan/": {
+  "hash": "aac71ff86dc05492",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-burj-thawr/": {
+  "hash": "e9960f7e739db384",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-delta/": {
+  "hash": "d3dd7e214b0b8441",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-dirham/": {
+  "hash": "60be48272012989b",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-dolar/": {
+  "hash": "3a79b165bf713d64",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-fahrenheit/": {
+  "hash": "da0f8cddbcb41ae8",
+  "lastmod": "2026-08-13"
+ },
+ "/ar/symbol/ramz-farashat-almalik/": {
+  "hash": "0f8de46c74f4f21e",
+  "lastmod": "2026-07-26"
+ },
+ "/ar/symbol/ramz-fay/": {
+  "hash": "32ff69df72d55053",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-harf-ghayr-marii/": {
+  "hash": "65e50ac943a4b487",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-huqooq-nashr/": {
+  "hash": "657058d1ae0551c8",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-iadat-altadwir/": {
+  "hash": "6b7183159f5bd157",
+  "lastmod": "2026-08-05"
+ },
+ "/ar/symbol/ramz-interrobang/": {
+  "hash": "e034d7dabbce7edf",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-istifham-makous/": {
+  "hash": "c881104e43ad04a8",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-junayh-istarlini/": {
+  "hash": "65d12ddcbb904b4d",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-khay/": {
+  "hash": "3e8bd48b542c00b5",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-la-yusawi/": {
+  "hash": "99f6d002111533ad",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-lambda/": {
+  "hash": "fc2cd8cf8a3ce4cb",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-lilith/": {
+  "hash": "1f2d2618a2f04633",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-miftah-alhayah/": {
+  "hash": "39f0f0c91f68a261",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-najma/": {
+  "hash": "8fef6c73b8e2c63e",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-najmat-dawud/": {
+  "hash": "13be061bd0dff2e3",
+  "lastmod": "2026-08-13"
+ },
+ "/ar/symbol/ramz-ohm/": {
+  "hash": "8a4ccf673a6f83e1",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-omega/": {
+  "hash": "f22dc24b4d35c5cc",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-qif/": {
+  "hash": "6447e52fb962d706",
+  "lastmod": "2026-08-06"
+ },
+ "/ar/symbol/ramz-qutr/": {
+  "hash": "e94cf1af7a981810",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-rial-omani/": {
+  "hash": "c82c4d163349aa74",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-riyal-saudi/": {
+  "hash": "e4aefb5ae4d61faf",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-rubiya-hindiya/": {
+  "hash": "ea69012c7332005a",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-rubl/": {
+  "hash": "f0b05916c1e1ee50",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-sahm-aala/": {
+  "hash": "63f16269f76a79ea",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-sahm-asfal/": {
+  "hash": "9192d7d63b152533",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-sahm-yamin/": {
+  "hash": "93c0c02e657d6ceb",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-sahm-yasar/": {
+  "hash": "33f975ba00ff3afb",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-sant/": {
+  "hash": "f711e004f85b2790",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-selsius/": {
+  "hash": "70883a77a386281b",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-shart-tahti/": {
+  "hash": "c11699469699fd6c",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-sharta-qasira/": {
+  "hash": "0c41fbf3d3218a32",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-sharta-tawila/": {
+  "hash": "d1d48ea74bdac675",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-sigma/": {
+  "hash": "6086d27f2448734e",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-taqweem/": {
+  "hash": "e78c67678f417044",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-tatabuq/": {
+  "hash": "468ffa06d0341c83",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-theta/": {
+  "hash": "6a98fad348b96a40",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-tilda/": {
+  "hash": "95086d6ed106334c",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-won/": {
+  "hash": "6c36ce8ecaace764",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-yen/": {
+  "hash": "0c0e02ac017a5cd2",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-yin-yang/": {
+  "hash": "9c8d575efffa1122",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-yuro/": {
+  "hash": "7f64e70b19dbd55e",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/ramz-zahrat-alzanbaq/": {
+  "hash": "6ffaa119140049ea",
+  "lastmod": "2026-08-05"
+ },
+ "/ar/symbol/ramz-zaid-naqis/": {
+  "hash": "0cbb6b8beb716c2e",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/square-root/": {
+  "hash": "f150b52ffa666ff5",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/symbol/squared-cubed/": {
+  "hash": "302ee54a558a6bf4",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/updates/middle-east-currency-symbols-scorecard/": {
+  "hash": "f243c6297a692d67",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/updates/uae-dirham-symbol-unicode-18/": {
+  "hash": "b4a7710b69683f01",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/updates/unicode-18-beta-review-opens/": {
+  "hash": "94bcb9a62f15d168",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/updates/unicode-18-most-anticipated-emoji/": {
+  "hash": "dc2f5047afa84e0d",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/updates/unicode-18-release-date-confirmed/": {
+  "hash": "d12309ea8f0b0dc8",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/usecase/": {
+  "hash": "bba2b074bf6632e6",
+  "lastmod": "2026-08-05"
+ },
+ "/ar/usecase/asmaa-free-fire/": {
+  "hash": "187f50527f083b2a",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/usecase/asmaa-mobile-legends/": {
+  "hash": "151aabf9983456da",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/usecase/asmaa-pubg/": {
+  "hash": "35de47039a63b4e2",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/usecase/khat-bio/": {
+  "hash": "05e64b881504cccb",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/usecase/mutarjim-emoji/": {
+  "hash": "79694916b14faa5d",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/usecase/vertical-text/": {
+  "hash": "c00bec958129b513",
+  "lastmod": "2026-08-15"
+ },
+ "/ar/zakhrafa/": {
+  "hash": "a443c81fbb074a55",
+  "lastmod": "2026-08-15"
+ },
+ "/ascii-art-generator/": {
+  "hash": "976aeb546bbddcea",
+  "lastmod": "2026-07-25"
+ },
+ "/ascii-converter/": {
+  "hash": "c7462d5760089700",
+  "lastmod": "2026-07-25"
+ },
+ "/bs/": {
+  "hash": "1db67de599c7a80a",
+  "lastmod": "2026-08-15"
+ },
+ "/bs/fontovi-za-discord/": {
+  "hash": "710e47d7d3808ddd",
+  "lastmod": "2026-08-15"
+ },
+ "/bs/fontovi-za-instagram/": {
+  "hash": "495ad7e45978ad20",
+  "lastmod": "2026-08-15"
+ },
+ "/bs/goticka-slova/": {
+  "hash": "a482b5945ca2a27f",
+  "lastmod": "2026-08-15"
+ },
+ "/bs/guide/": {
+  "hash": "52f55d3d1acdf15f",
+  "lastmod": "2026-08-15"
+ },
+ "/bs/guide/gdje-rade-fontovi-na-discordu/": {
+  "hash": "82539f2329024f5c",
+  "lastmod": "2026-08-15"
+ },
+ "/bs/guide/oblikovanje-teksta-na-discordu/": {
+  "hash": "f4d7eb31a7e0101a",
+  "lastmod": "2026-08-15"
+ },
+ "/bs/guide/siguran-nadimak-na-discordu/": {
+  "hash": "e3d4070e1d3210da",
+  "lastmod": "2026-08-15"
+ },
+ "/bs/kurziv/": {
+  "hash": "85df964bca5a8a4b",
+  "lastmod": "2026-08-15"
+ },
+ "/bs/mala-slova/": {
+  "hash": "9bc83076426dbc45",
+  "lastmod": "2026-08-15"
+ },
+ "/bs/podebljana-slova/": {
+  "hash": "360c024b8b02a6ef",
+  "lastmod": "2026-08-15"
+ },
+ "/calligraphy/": {
+  "hash": "aa6f1fc60fcffa26",
+  "lastmod": "2026-08-11"
+ },
+ "/category/": {
+  "hash": "f2106e0952848703",
+  "lastmod": "2026-08-13"
+ },
+ "/category/aesthetic-fonts/": {
+  "hash": "97c36eae11060477",
+  "lastmod": "2026-08-11"
+ },
+ "/category/ancient-fonts/": {
+  "hash": "ea4d00c31146e9b7",
+  "lastmod": "2026-08-15"
+ },
+ "/category/bold-fonts/": {
+  "hash": "7f66b7c8aa05ec9d",
+  "lastmod": "2026-07-31"
+ },
+ "/category/bold-fonts/bold-italic/": {
+  "hash": "353e8e7e2f2cde19",
+  "lastmod": "2026-07-25"
+ },
+ "/category/bubble-fonts/": {
+  "hash": "438288f9ae5c0e16",
+  "lastmod": "2026-07-25"
+ },
+ "/category/bubble-fonts/circle/": {
+  "hash": "0dffa5a452234a31",
+  "lastmod": "2026-07-25"
+ },
+ "/category/case-converter/": {
+  "hash": "d36d8b3f29f15007",
+  "lastmod": "2026-07-25"
+ },
+ "/category/classified/": {
+  "hash": "d62fa2106f50b2b8",
+  "lastmod": "2026-07-26"
+ },
+ "/category/cursive-fonts/": {
+  "hash": "afbe455c5d4f8f81",
+  "lastmod": "2026-08-16"
+ },
+ "/category/cute-fonts/": {
+  "hash": "bfca6526495a2e71",
+  "lastmod": "2026-08-03"
+ },
+ "/category/emoji-letter-fonts/": {
+  "hash": "67083197042083b2",
+  "lastmod": "2026-08-15"
+ },
+ "/category/faux-fonts/": {
+  "hash": "8bf02e5e978e9b8d",
+  "lastmod": "2026-08-15"
+ },
+ "/category/fullwidth-fonts/": {
+  "hash": "da66acda62978b75",
+  "lastmod": "2026-08-15"
+ },
+ "/category/gothic-fonts/": {
+  "hash": "c2a2bf9c6cc3994f",
+  "lastmod": "2026-08-11"
+ },
+ "/category/italic-fonts/": {
+  "hash": "818675a2b8e1dace",
+  "lastmod": "2026-08-03"
+ },
+ "/category/novelty-fonts/": {
+  "hash": "c2bf3767b5f368b0",
+  "lastmod": "2026-08-15"
+ },
+ "/category/old-english-fonts/": {
+  "hash": "cbc8f3e3f7847aab",
+  "lastmod": "2026-07-25"
+ },
+ "/category/small-caps/": {
+  "hash": "a462f7422d17a096",
+  "lastmod": "2026-07-25"
+ },
+ "/category/small-text/": {
+  "hash": "ffb03ea4db810460",
+  "lastmod": "2026-07-31"
+ },
+ "/category/strikethrough-text/": {
+  "hash": "043d5af5747bd33c",
+  "lastmod": "2026-08-11"
+ },
+ "/category/subscript/": {
+  "hash": "9715950a5bf686cd",
+  "lastmod": "2026-07-25"
+ },
+ "/category/superscript/": {
+  "hash": "4de84cd3f18e2d0d",
+  "lastmod": "2026-07-31"
+ },
+ "/category/text-decorator/": {
+  "hash": "599aabc73356a892",
+  "lastmod": "2026-07-25"
+ },
+ "/category/underline-text/": {
+  "hash": "aa5a181bf6314c95",
+  "lastmod": "2026-08-11"
+ },
+ "/category/upside-down-text/": {
+  "hash": "5c769efc95184f70",
+  "lastmod": "2026-07-31"
+ },
+ "/character-counter/": {
+  "hash": "567e0e430bd6dbf4",
+  "lastmod": "2026-08-13"
+ },
+ "/character-counter/characters-to-words/": {
+  "hash": "b9b56c90e5df0008",
+  "lastmod": "2026-08-06"
+ },
+ "/contact/": {
+  "hash": "840316448e9cf60e",
+  "lastmod": "2026-07-25"
+ },
+ "/cs/": {
+  "hash": "4194f0cf890b9a10",
+  "lastmod": "2026-08-15"
+ },
+ "/cs/generator-prezdivek/": {
+  "hash": "3086cba61aad3cf5",
+  "lastmod": "2026-08-16"
+ },
+ "/cs/goticke-pismo/": {
+  "hash": "e5cb178b4a35e37f",
+  "lastmod": "2026-08-15"
+ },
+ "/cs/guide/": {
+  "hash": "1daccd414a0ebdfe",
+  "lastmod": "2026-08-11"
+ },
+ "/cs/guide/bezpecny-nick-na-discordu/": {
+  "hash": "9007cbab7423e2d6",
+  "lastmod": "2026-07-26"
+ },
+ "/cs/guide/formatovani-textu-na-discordu/": {
+  "hash": "8fc1cec30732afc1",
+  "lastmod": "2026-07-26"
+ },
+ "/cs/guide/kde-funguje-pismo-na-discordu/": {
+  "hash": "042322bbe7ac5115",
+  "lastmod": "2026-07-26"
+ },
+ "/cs/kurziva/": {
+  "hash": "6c8e6a8b1034a438",
+  "lastmod": "2026-08-15"
+ },
+ "/cs/male-pismo/": {
+  "hash": "2c5310c8afe48df1",
+  "lastmod": "2026-08-15"
+ },
+ "/cs/pismo-pro-discord/": {
+  "hash": "ace0df6eb9c84ff2",
+  "lastmod": "2026-08-15"
+ },
+ "/cs/pismo-pro-instagram/": {
+  "hash": "667bdcbc68c10c47",
+  "lastmod": "2026-08-15"
+ },
+ "/cs/specialni-znaky/": {
+  "hash": "1ce2ea4f46ffdf73",
+  "lastmod": "2026-08-15"
+ },
+ "/cs/tucne-pismo/": {
+  "hash": "902a161f01dff65d",
+  "lastmod": "2026-08-15"
+ },
+ "/cs/usecase/pismo-pro-bio/": {
+  "hash": "12ff30ce95522c8c",
+  "lastmod": "2026-08-15"
+ },
+ "/curved-text/": {
+  "hash": "ea78a1e313912c7b",
+  "lastmod": "2026-08-13"
+ },
+ "/da/": {
+  "hash": "04819ec2bca9fd00",
+  "lastmod": "2026-08-16"
+ },
+ "/da/guide/": {
+  "hash": "d4afcd96007f4c29",
+  "lastmod": "2026-08-15"
+ },
+ "/da/guide/discord-tekstformatering-forklaret/": {
+  "hash": "8f2b1c4a0d90efbe",
+  "lastmod": "2026-08-15"
+ },
+ "/da/guide/hvor-virker-skrifttyper-i-discord/": {
+  "hash": "1eaa9d17041d3c76",
+  "lastmod": "2026-08-15"
+ },
+ "/da/guide/sikkert-discord-navn/": {
+  "hash": "0677933ae3b18241",
+  "lastmod": "2026-08-15"
+ },
+ "/da/library/": {
+  "hash": "db4816cd3423cc58",
+  "lastmod": "2026-08-15"
+ },
+ "/da/library/flueben-symboler/": {
+  "hash": "d8d015b76e1277e9",
+  "lastmod": "2026-08-15"
+ },
+ "/da/library/graeske-bogstaver/": {
+  "hash": "f96180624edaedcf",
+  "lastmod": "2026-08-15"
+ },
+ "/da/library/hjerte-symboler/": {
+  "hash": "2a629aad02a77edb",
+  "lastmod": "2026-08-15"
+ },
+ "/da/library/matematiske-symboler/": {
+  "hash": "223c7980598e5469",
+  "lastmod": "2026-08-15"
+ },
+ "/da/library/pil-symboler/": {
+  "hash": "d632f10ba239fd29",
+  "lastmod": "2026-08-15"
+ },
+ "/da/library/valuta-symboler/": {
+  "hash": "98f73899565defb3",
+  "lastmod": "2026-08-15"
+ },
+ "/da/symbol/": {
+  "hash": "ed440484cdca3062",
+  "lastmod": "2026-08-05"
+ },
+ "/da/symbol/gradtegn/": {
+  "hash": "f5cb4f896566f8d7",
+  "lastmod": "2026-08-15"
+ },
+ "/da/symbol/kvadratrodstegn/": {
+  "hash": "989cb3d667d6684d",
+  "lastmod": "2026-08-15"
+ },
+ "/de/": {
+  "hash": "a5d7375734dd6378",
+  "lastmod": "2026-08-15"
+ },
+ "/de/aesthetic-schrift/": {
+  "hash": "986238e3ecfc2829",
+  "lastmod": "2026-08-15"
+ },
+ "/de/altdeutsche-schrift/": {
+  "hash": "f912719fb9ef9035",
+  "lastmod": "2026-08-15"
+ },
+ "/de/answers/leeren-namen-erstellen/": {
+  "hash": "d740f410e576af09",
+  "lastmod": "2026-08-15"
+ },
+ "/de/category/": {
+  "hash": "f41322bff8cf7524",
+  "lastmod": "2026-08-15"
+ },
+ "/de/discord-schriftart/": {
+  "hash": "716a4f65499c48ec",
+  "lastmod": "2026-08-15"
+ },
+ "/de/durchgestrichener-text/": {
+  "hash": "1d33be86c122e26c",
+  "lastmod": "2026-08-15"
+ },
+ "/de/fette-schrift/": {
+  "hash": "0136cc144f0024b8",
+  "lastmod": "2026-08-15"
+ },
+ "/de/gross-und-kleinschreibung/": {
+  "hash": "ceee0f6b01d82ca4",
+  "lastmod": "2026-08-15"
+ },
+ "/de/guide/": {
+  "hash": "1924705b1d17a6b1",
+  "lastmod": "2026-08-15"
+ },
+ "/de/guide/discord-namen-sicher-gestalten/": {
+  "hash": "4421c7cb780b9252",
+  "lastmod": "2026-08-15"
+ },
+ "/de/guide/discord-textformatierung-erklaert/": {
+  "hash": "6d6eee6ba7d5e030",
+  "lastmod": "2026-08-15"
+ },
+ "/de/guide/wo-funktionieren-schriftarten-in-discord/": {
+  "hash": "515fe4c72b65dcbc",
+  "lastmod": "2026-07-26"
+ },
+ "/de/hochgestellt/": {
+  "hash": "fb6b4a7daa39b93c",
+  "lastmod": "2026-08-15"
+ },
+ "/de/kleine-schrift/": {
+  "hash": "782bb8be68e9912f",
+  "lastmod": "2026-08-15"
+ },
+ "/de/kopfueber-text/": {
+  "hash": "8f34d3c38860b47f",
+  "lastmod": "2026-08-15"
+ },
+ "/de/kursive-schrift/": {
+  "hash": "c5ec0153ae7e9759",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/": {
+  "hash": "832d52220c6b74d6",
+  "lastmod": "2026-08-10"
+ },
+ "/de/library/aegyptische-hieroglyphen/": {
+  "hash": "47f0b8e409b1118b",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/aesthetische-symbole/": {
+  "hash": "4cc681c8b12f3684",
+  "lastmod": "2026-08-16"
+ },
+ "/de/library/akzente-diakritische-zeichen/": {
+  "hash": "fceb9ec3a31a6c2d",
+  "lastmod": "2026-07-25"
+ },
+ "/de/library/alt-codes/": {
+  "hash": "c942609319112663",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/anime-symbole/": {
+  "hash": "1433d77284a35dec",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/ascii-tabelle/": {
+  "hash": "3673dc9376990557",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/aufzaehlungszeichen/": {
+  "hash": "48f9759b0e6ce3a4",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/augen-emoji/": {
+  "hash": "f9d562b51887be40",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/backslash-zeichen/": {
+  "hash": "eedc96c694603f52",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/blumen-symbole/": {
+  "hash": "af06f6536df92178",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/braille-symbole/": {
+  "hash": "22b4c0315037d452",
+  "lastmod": "2026-08-12"
+ },
+ "/de/library/cat-kaomoji/": {
+  "hash": "d879cc7c61cb901e",
+  "lastmod": "2026-08-10"
+ },
+ "/de/library/clown-emoji/": {
+  "hash": "e535ebe6bbb4d97f",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/copyright-marken-symbole/": {
+  "hash": "6f11eb43648cae76",
+  "lastmod": "2026-08-12"
+ },
+ "/de/library/cute-kaomoji/": {
+  "hash": "21dadce19b27fbfb",
+  "lastmod": "2026-08-10"
+ },
+ "/de/library/discord-symbole/": {
+  "hash": "81edbc75b64a9466",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/emoji-combos/": {
+  "hash": "3cadd327e3d68b22",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/emoji-flags/": {
+  "hash": "b2bd8f12323fd455",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/facebook-symbole/": {
+  "hash": "3ec59dcfe6e9ec9d",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/friedens-emoji/": {
+  "hash": "36dadcbe934e01f9",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/fussball-symbole/": {
+  "hash": "a677dd934c33d7ad",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/geist-emoji/": {
+  "hash": "15f6d4cceab32813",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/geld-emojis/": {
+  "hash": "cbbb0fbd46593e5e",
+  "lastmod": "2026-08-16"
+ },
+ "/de/library/geometrische-symbole/": {
+  "hash": "a9c855dfe87f1950",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/geschenk-emoji/": {
+  "hash": "6f3d0fae6863d4e6",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/geschlechter-symbole/": {
+  "hash": "76af73aa26e1d4ef",
+  "lastmod": "2026-08-05"
+ },
+ "/de/library/gesichts-emojis/": {
+  "hash": "065ac7ce535bc477",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/griechische-symbole/": {
+  "hash": "d10f5db9328dbe15",
+  "lastmod": "2026-08-07"
+ },
+ "/de/library/haekchen-symbole/": {
+  "hash": "17d64e10961b2e5b",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/halloween-symbole/": {
+  "hash": "2b3b819a74246fa0",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/hand-symbole/": {
+  "hash": "99cbcf275106ce1b",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/herz-symbole/": {
+  "hash": "0933f5bdb636bd30",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/html-entities/": {
+  "hash": "24b5bcd21a2eecdc",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/instagram-symbole/": {
+  "hash": "92ce005b9a6bd29b",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/iphone-emojis/": {
+  "hash": "5c7df7511318ca41",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/islamische-symbole/": {
+  "hash": "d1cd7b861da6f911",
+  "lastmod": "2026-08-13"
+ },
+ "/de/library/japanische-symbole/": {
+  "hash": "253e3c20bde7f464",
+  "lastmod": "2026-08-05"
+ },
+ "/de/library/kaomoji/": {
+  "hash": "1c39959df10609f7",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/kawaii-suesse-symbole/": {
+  "hash": "de29b9a88f2ab291",
+  "lastmod": "2026-08-07"
+ },
+ "/de/library/klammer-symbole/": {
+  "hash": "75c6a3c7addaedda",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/kreuz-x-symbole/": {
+  "hash": "f06990357a2cae13",
+  "lastmod": "2026-08-16"
+ },
+ "/de/library/krone-emoji/": {
+  "hash": "ea8b6d00d713e40f",
+  "lastmod": "2026-08-16"
+ },
+ "/de/library/kronen-symbol/": {
+  "hash": "a7e51824df98cb3b",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/kuss-emoji/": {
+  "hash": "ada25c585c6ae215",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/lenny-face/": {
+  "hash": "473d1efd60d7a8ab",
+  "lastmod": "2026-08-12"
+ },
+ "/de/library/love-kaomoji/": {
+  "hash": "a32a98f049fe4ce0",
+  "lastmod": "2026-08-10"
+ },
+ "/de/library/mathe-symbole/": {
+  "hash": "79eacdf444051830",
+  "lastmod": "2026-08-13"
+ },
+ "/de/library/medizinische-symbole/": {
+  "hash": "ef20b881678af4ae",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/musik-symbole/": {
+  "hash": "bdec5f54bc870d6d",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/pfeil-symbole/": {
+  "hash": "6b0fed87190267d7",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/rahmenzeichen/": {
+  "hash": "a7d508319bacec2f",
+  "lastmod": "2026-07-25"
+ },
+ "/de/library/religioese-symbole/": {
+  "hash": "c10c25e396ffa1be",
+  "lastmod": "2026-08-13"
+ },
+ "/de/library/roblox-symbole/": {
+  "hash": "f76aedd5f854cc81",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/schach-symbole/": {
+  "hash": "82a049868b0b5fc0",
+  "lastmod": "2026-08-13"
+ },
+ "/de/library/solidaritaetsschleifen/": {
+  "hash": "7e196b9a8f89d9cb",
+  "lastmod": "2026-07-25"
+ },
+ "/de/library/spielkarten-symbole/": {
+  "hash": "859dba6976295526",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/stern-symbole/": {
+  "hash": "323596d517a99d09",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/sternzeichen-symbole/": {
+  "hash": "5cfcdeb966051c11",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/symbole-zum-kopieren/": {
+  "hash": "aee28ebbe2654805",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/tanz-emoji/": {
+  "hash": "a769face1de7ba89",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/tastatur-symbole/": {
+  "hash": "7867cfd19defecbe",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/teufel-emoji/": {
+  "hash": "9854eff039d8116a",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/totenkopf-emoji/": {
+  "hash": "6218b5ecc2fbe68f",
+  "lastmod": "2026-08-16"
+ },
+ "/de/library/trauriges-emoji/": {
+  "hash": "a22271cc2a7972a5",
+  "lastmod": "2026-08-16"
+ },
+ "/de/library/waehrungssymbole/": {
+  "hash": "02c86938b6834bf3",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/warnsymbole/": {
+  "hash": "e7171c134909b181",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/weihnachtssymbole/": {
+  "hash": "496c9334750c9d73",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/weinendes-emoji/": {
+  "hash": "4828316fcdc7c12c",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/wetter-symbole/": {
+  "hash": "04599d3e453c2c10",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/whatsapp-symbole/": {
+  "hash": "05dd5f2285fea6f9",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/y2k-symbole/": {
+  "hash": "156ba5e2656d24b0",
+  "lastmod": "2026-08-15"
+ },
+ "/de/library/zahlen-symbole/": {
+  "hash": "7b1a38ce6b5123ef",
+  "lastmod": "2026-08-15"
+ },
+ "/de/schreibschrift/": {
+  "hash": "56c1a6ccd2c57481",
+  "lastmod": "2026-08-15"
+ },
+ "/de/schriftarten-fuer-facebook/": {
+  "hash": "8fec20a759971fae",
+  "lastmod": "2026-08-15"
+ },
+ "/de/schriftarten-fuer-instagram/": {
+  "hash": "e343d079c774cf34",
+  "lastmod": "2026-08-15"
+ },
+ "/de/schriftarten-fuer-snapchat/": {
+  "hash": "deff67e517e6c029",
+  "lastmod": "2026-08-15"
+ },
+ "/de/schriftarten-fuer-telegram/": {
+  "hash": "33627db6a4b706f0",
+  "lastmod": "2026-08-15"
+ },
+ "/de/schriftarten-fuer-tiktok/": {
+  "hash": "96adb9572f0e66d9",
+  "lastmod": "2026-08-15"
+ },
+ "/de/schriftarten-fuer-whatsapp/": {
+  "hash": "bea346343ab3b8ba",
+  "lastmod": "2026-08-15"
+ },
+ "/de/symbol/": {
+  "hash": "03d6c8991e5b6182",
+  "lastmod": "2026-08-16"
+ },
+ "/de/symbol/absatzzeichen/": {
+  "hash": "34aec989987228e7",
+  "lastmod": "2026-08-06"
+ },
+ "/de/symbol/alpha-symbol/": {
+  "hash": "2a32f65e8bba014f",
+  "lastmod": "2026-08-15"
+ },
+ "/de/symbol/anarchie-symbol/": {
+  "hash": "61a5620fd58b6d9b",
+  "lastmod": "2026-08-05"
+ },
+ "/de/symbol/anfuehrungszeichen/": {
+  "hash": "e4ff1a18dd70e26a",
+  "lastmod": "2026-08-05"
+ },
+ "/de/symbol/ankh-symbol/": {
+  "hash": "ef64b10edf2da7ec",
+  "lastmod": "2026-08-06"
+ },
+ "/de/symbol/at-zeichen/": {
+  "hash": "6699b0b736a5b472",
+  "lastmod": "2026-08-06"
+ },
+ "/de/symbol/autismus-symbol/": {
+  "hash": "d11522c303c047d9",
+  "lastmod": "2026-08-06"
+ },
+ "/de/symbol/bauer-symbol/": {
+  "hash": "2ef7d36905c1854b",
+  "lastmod": "2026-08-05"
+ },
+ "/de/symbol/berstendes-gesicht-emoji/": {
+  "hash": "8b5f27a72a99b1c1",
+  "lastmod": "2026-08-05"
+ },
+ "/de/symbol/biohazard-symbol/": {
+  "hash": "f3d95bebf23e9b56",
+  "lastmod": "2026-08-06"
+ },
+ "/de/symbol/bitcoin-symbol/": {
+  "hash": "c4c22e753a6e3d42",
+  "lastmod": "2026-08-05"
+ },
+ "/de/symbol/celsius-zeichen/": {
+  "hash": "47e199c3fca12c6c",
+  "lastmod": "2026-08-13"
+ },
+ "/de/symbol/cent-zeichen/": {
+  "hash": "2d4de375b2dee4ad",
+  "lastmod": "2026-08-05"
+ },
+ "/de/symbol/chi-symbol/": {
+  "hash": "cbab1aab12ae3a36",
+  "lastmod": "2026-08-06"
+ },
+ "/de/symbol/copyright-zeichen/": {
+  "hash": "1bccd9448bb70485",
+  "lastmod": "2026-08-05"
+ },
+ "/de/symbol/daumenzeichen-emoji/": {
+  "hash": "8154b63e9c3f5481",
+  "lastmod": "2026-08-16"
+ },
+ "/de/symbol/davidstern/": {
+  "hash": "dbdd72e64aeef0e6",
+  "lastmod": "2026-08-06"
+ },
+ "/de/symbol/delta-symbol/": {
+  "hash": "e95dafb4ee094a81",
+  "lastmod": "2026-08-15"
+ },
+ "/de/symbol/dirham-zeichen/": {
+  "hash": "a6f020d57f873f8d",
+  "lastmod": "2026-08-06"
+ },
+ "/de/symbol/divisionszeichen/": {
+  "hash": "653d14f7479ef144",
+  "lastmod": "2026-08-16"
+ },
+ "/de/symbol/dollar-zeichen/": {
+  "hash": "e568c3f4af812cb6",
+  "lastmod": "2026-08-06"
+ },
+ "/de/symbol/durchmesserzeichen/": {
+  "hash": "8a1606d7b26728b1",
+  "lastmod": "2026-08-06"
+ },
+ "/de/symbol/essiggurke-emoji/": {
+  "hash": "1e75dd1a257e98ad",
+  "lastmod": "2026-08-05"
+ },
+ "/de/symbol/et-zeichen/": {
+  "hash": "1fe584c211408704",
+  "lastmod": "2026-08-06"
+ },
+ "/de/symbol/euro-zeichen/": {
+  "hash": "223a569905b6bdd1",
+  "lastmod": "2026-08-06"
+ },
+ "/de/symbol/fahrenheit-zeichen/": {
+  "hash": "980bcb31e8c71b79",
+  "lastmod": "2026-08-13"
+ },
+ "/de/symbol/fische-symbol/": {
+  "hash": "67c2a097492d9e46",
+  "lastmod": "2026-08-15"
+ },
+ "/de/symbol/fleur-de-lis-symbol/": {
+  "hash": "49fd180ad555daab",
+  "lastmod": "2026-08-15"
+ },
+ "/de/symbol/friedenszeichen/": {
+  "hash": "387e2fc728c64ad7",
+  "lastmod": "2026-08-06"
+ },
+ "/de/symbol/geviertstrich/": {
+  "hash": "9efae648345a1639",
+  "lastmod": "2026-08-06"
+ },
+ "/de/symbol/grad-zeichen/": {
+  "hash": "6f5a65e398717cd5",
+  "lastmod": "2026-08-06"
+ },
+ "/de/symbol/haekchen-symbol/": {
+  "hash": "0a0c9408553ac963",
+  "lastmod": "2026-08-11"
+ },
+ "/de/symbol/halbgeviertstrich/": {
+  "hash": "62c14832eea89221",
+  "lastmod": "2026-08-05"
+ },
+ "/de/symbol/hamsa-symbol/": {
+  "hash": "9d583b4a3d430566",
+  "lastmod": "2026-08-06"
+ },
+ "/de/symbol/herz-symbol/": {
+  "hash": "2e5934b1ce50214d",
+  "lastmod": "2026-08-06"
+ },
+ "/de/symbol/interrobang/": {
+  "hash": "3fbe7de523ae1b01",
+  "lastmod": "2026-08-05"
+ },
+ "/de/symbol/jungfrau-symbol/": {
+  "hash": "614d873120814c9c",
+  "lastmod": "2026-08-15"
+ },
+ "/de/symbol/kalender-emoji/": {
+  "hash": "b00bb9631a6f5c97",
+  "lastmod": "2026-08-05"
+ },
+ "/de/symbol/khanda-symbol/": {
+  "hash": "b0b9144062dc154e",
+  "lastmod": "2026-08-06"
+ },
+ "/de/symbol/kleiner-gleich-zeichen/": {
+  "hash": "ed01d0605a1ce349",
+  "lastmod": "2026-08-05"
+ },
+ "/de/symbol/kleiner-und-groesser-zeichen/": {
+  "hash": "df31ebd9658a70f0",
+  "lastmod": "2026-08-06"
+ },
+ "/de/symbol/kongruenzzeichen/": {
+  "hash": "9f0eacc32efda2d0",
+  "lastmod": "2026-08-06"
+ },
+ "/de/symbol/krebs-symbol/": {
+  "hash": "e2ee87a699576412",
+  "lastmod": "2026-08-15"
+ },
+ "/de/symbol/kreuz-symbol/": {
+  "hash": "271f7f1cd941fc9a",
+  "lastmod": "2026-08-06"
+ },
+ "/de/symbol/lambda-symbol/": {
+  "hash": "8fba7ecd62da71db",
+  "lastmod": "2026-08-05"
+ },
+ "/de/symbol/loewe-symbol/": {
+  "hash": "8062063fdc80da3f",
+  "lastmod": "2026-08-15"
+ },
+ "/de/symbol/markenzeichen/": {
+  "hash": "36a292e000b4efc8",
+  "lastmod": "2026-08-05"
+ },
+ "/de/symbol/meteor-emoji/": {
+  "hash": "03e2152db805c987",
+  "lastmod": "2026-08-16"
+ },
+ "/de/symbol/mikrofon-emoji/": {
+  "hash": "ff5afe475c0978f2",
+  "lastmod": "2026-08-05"
+ },
+ "/de/symbol/mikrozeichen/": {
+  "hash": "f4272b2ff7bdd2ec",
+  "lastmod": "2026-08-06"
+ },
+ "/de/symbol/monarchfalter-emoji/": {
+  "hash": "8d4a6820f08a8bf2",
+  "lastmod": "2026-08-05"
+ },
+ "/de/symbol/multiplikationszeichen/": {
+  "hash": "d7db7b22f870a46e",
+  "lastmod": "2026-08-06"
+ },
+ "/de/symbol/ohm-zeichen/": {
+  "hash": "2b7476fea95d513f",
+  "lastmod": "2026-08-13"
+ },
+ "/de/symbol/om-symbol/": {
+  "hash": "d87992d7da374d3d",
+  "lastmod": "2026-08-05"
+ },
+ "/de/symbol/omani-rial-zeichen/": {
+  "hash": "928cd319946f8ffa",
+  "lastmod": "2026-08-06"
+ },
+ "/de/symbol/omega-symbol/": {
+  "hash": "8905488f0fcb1b4d",
+  "lastmod": "2026-08-06"
+ },
+ "/de/symbol/orthodoxes-kreuz/": {
+  "hash": "59a6e8cd6d159803",
+  "lastmod": "2026-08-06"
+ },
+ "/de/symbol/paragraphenzeichen/": {
+  "hash": "9f36d85b0456a004",
+  "lastmod": "2026-08-06"
+ },
+ "/de/symbol/pentagramm-symbol/": {
+  "hash": "61494a32342f308f",
+  "lastmod": "2026-08-06"
+ },
+ "/de/symbol/peso-zeichen/": {
+  "hash": "1d515a13e66b9270",
+  "lastmod": "2026-08-05"
+ },
+ "/de/symbol/pfeil-nach-links/": {
+  "hash": "a49ea731c22a7732",
+  "lastmod": "2026-08-05"
+ },
+ "/de/symbol/pfeil-nach-oben/": {
+  "hash": "21edaaa2eb7fae0f",
+  "lastmod": "2026-08-05"
+ },
+ "/de/symbol/pfeil-nach-rechts/": {
+  "hash": "68a6f13905914b6f",
+  "lastmod": "2026-08-05"
+ },
+ "/de/symbol/pfeil-nach-unten/": {
+  "hash": "8fc396f314181303",
+  "lastmod": "2026-08-05"
+ },
+ "/de/symbol/pfund-zeichen/": {
+  "hash": "68a62349a7db8bb8",
+  "lastmod": "2026-08-06"
+ },
+ "/de/symbol/phi-symbol/": {
+  "hash": "d678a39798ed1e5c",
+  "lastmod": "2026-08-05"
+ },
+ "/de/symbol/pi-symbol/": {
+  "hash": "e5f6411f5377e3a1",
+  "lastmod": "2026-08-15"
+ },
+ "/de/symbol/pik-symbol/": {
+  "hash": "db770ca63d358095",
+  "lastmod": "2026-08-05"
+ },
+ "/de/symbol/plus-minus-zeichen/": {
+  "hash": "85dcc1fbd356d142",
+  "lastmod": "2026-08-06"
+ },
+ "/de/symbol/psi-symbol/": {
+  "hash": "20c5db303cc9401e",
+  "lastmod": "2026-08-05"
+ },
+ "/de/symbol/quadrat-und-kubikzeichen/": {
+  "hash": "95e1651ac9ca497f",
+  "lastmod": "2026-07-25"
+ },
+ "/de/symbol/quadratwurzelzeichen/": {
+  "hash": "8902f121fb63dacf",
+  "lastmod": "2026-08-16"
+ },
+ "/de/symbol/recycling-symbol/": {
+  "hash": "7db03f309eae0c4a",
+  "lastmod": "2026-08-15"
+ },
+ "/de/symbol/rollstuhl-symbol/": {
+  "hash": "8d9f0c531d9fcf2b",
+  "lastmod": "2026-08-15"
+ },
+ "/de/symbol/rubel-zeichen/": {
+  "hash": "b6a9f25aebc4ce15",
+  "lastmod": "2026-08-05"
+ },
+ "/de/symbol/rufiyaa-zeichen/": {
+  "hash": "e5d77e1ffe9388de",
+  "lastmod": "2026-08-05"
+ },
+ "/de/symbol/rupien-zeichen/": {
+  "hash": "fa18919265723ff7",
+  "lastmod": "2026-08-06"
+ },
+ "/de/symbol/saudi-rial-zeichen/": {
+  "hash": "9c0bcd39d5e36360",
+  "lastmod": "2026-08-06"
+ },
+ "/de/symbol/schmelzendes-gesicht-emoji/": {
+  "hash": "756b3ba49f4375ba",
+  "lastmod": "2026-08-05"
+ },
+ "/de/symbol/schuetze-symbol/": {
+  "hash": "1c82398fa12c9a12",
+  "lastmod": "2026-08-15"
+ },
+ "/de/symbol/schwarzer-mond-lilith/": {
+  "hash": "8cdc67d6cef1414b",
+  "lastmod": "2026-08-06"
+ },
+ "/de/symbol/senkrechter-strich/": {
+  "hash": "88e21a9d20b5da71",
+  "lastmod": "2026-08-06"
+ },
+ "/de/symbol/sigma-symbol/": {
+  "hash": "f2561f5843e04f10",
+  "lastmod": "2026-08-15"
+ },
+ "/de/symbol/skorpion-symbol/": {
+  "hash": "e2e4aa2c477e7110",
+  "lastmod": "2026-08-15"
+ },
+ "/de/symbol/snapchat-herzfarben/": {
+  "hash": "dcbf92ca0f8bae50",
+  "lastmod": "2026-08-13"
+ },
+ "/de/symbol/sonnenbrille-symbol/": {
+  "hash": "2fa2618d4a40885a",
+  "lastmod": "2026-08-05"
+ },
+ "/de/symbol/steinbock-symbol/": {
+  "hash": "203a0ce8711fd386",
+  "lastmod": "2026-08-15"
+ },
+ "/de/symbol/stern-symbol/": {
+  "hash": "a65772dee7a696db",
+  "lastmod": "2026-08-06"
+ },
+ "/de/symbol/stern-und-halbmond/": {
+  "hash": "122c9aff355efd62",
+  "lastmod": "2026-08-16"
+ },
+ "/de/symbol/sternchen-symbol/": {
+  "hash": "b7aa2ed7f638097b",
+  "lastmod": "2026-08-16"
+ },
+ "/de/symbol/stier-symbol/": {
+  "hash": "2164a1d85dc40912",
+  "lastmod": "2026-08-15"
+ },
+ "/de/symbol/stopp-symbol/": {
+  "hash": "ec9f6ebf07579235",
+  "lastmod": "2026-08-15"
+ },
+ "/de/symbol/theta-symbol/": {
+  "hash": "b24453a013586ed3",
+  "lastmod": "2026-08-05"
+ },
+ "/de/symbol/tilde-zeichen/": {
+  "hash": "4f90b4224df7a9d6",
+  "lastmod": "2026-08-16"
+ },
+ "/de/symbol/totenkopf-symbol/": {
+  "hash": "d1c891fad944f039",
+  "lastmod": "2026-08-11"
+ },
+ "/de/symbol/umgekehrtes-fragezeichen/": {
+  "hash": "e01682e81b29c278",
+  "lastmod": "2026-08-06"
+ },
+ "/de/symbol/unendlichkeitszeichen/": {
+  "hash": "fb55ead2962e9b22",
+  "lastmod": "2026-08-06"
+ },
+ "/de/symbol/ungleichzeichen/": {
+  "hash": "25dd2a4989923408",
+  "lastmod": "2026-08-06"
+ },
+ "/de/symbol/unsichtbares-schriftzeichen/": {
+  "hash": "bc042774a04fb3c8",
+  "lastmod": "2026-08-15"
+ },
+ "/de/symbol/unterstrich/": {
+  "hash": "0b645ce6e52b2722",
+  "lastmod": "2026-08-16"
+ },
+ "/de/symbol/verzerrtes-gesicht-emoji/": {
+  "hash": "d147aaeb461514be",
+  "lastmod": "2026-08-05"
+ },
+ "/de/symbol/waage-symbol/": {
+  "hash": "aba85b9d782fc66b",
+  "lastmod": "2026-08-15"
+ },
+ "/de/symbol/wassermann-symbol/": {
+  "hash": "0dcf2d0b91b373d6",
+  "lastmod": "2026-08-15"
+ },
+ "/de/symbol/widder-symbol/": {
+  "hash": "6844480d3c1da16b",
+  "lastmod": "2026-08-15"
+ },
+ "/de/symbol/won-zeichen/": {
+  "hash": "3d6e27d28af0796c",
+  "lastmod": "2026-08-05"
+ },
+ "/de/symbol/wut-symbol/": {
+  "hash": "9ec5da53813608e8",
+  "lastmod": "2026-08-06"
+ },
+ "/de/symbol/yen-zeichen/": {
+  "hash": "9afc82a896177b1d",
+  "lastmod": "2026-08-06"
+ },
+ "/de/symbol/yin-yang-symbol/": {
+  "hash": "853eece5e8f50786",
+  "lastmod": "2026-08-05"
+ },
+ "/de/symbol/zwillinge-symbol/": {
+  "hash": "068a3afcdfc88a5b",
+  "lastmod": "2026-08-15"
+ },
+ "/de/tiefgestellt/": {
+  "hash": "d96663fccb0e5d13",
+  "lastmod": "2026-08-15"
+ },
+ "/de/unsichtbares-zeichen/": {
+  "hash": "b8ce763656612a8a",
+  "lastmod": "2026-08-15"
+ },
+ "/de/unterstrichener-text/": {
+  "hash": "568cf4ccb802feb1",
+  "lastmod": "2026-08-15"
+ },
+ "/de/updates/naher-osten-waehrungssymbole-unicode-18/": {
+  "hash": "fbd47d72d43188ce",
+  "lastmod": "2026-08-15"
+ },
+ "/de/updates/unicode-18-beta-startet/": {
+  "hash": "09765a6395643840",
+  "lastmod": "2026-08-15"
+ },
+ "/de/updates/unicode-18-emoji-abstimmung/": {
+  "hash": "79fc930a3da36082",
+  "lastmod": "2026-08-15"
+ },
+ "/de/updates/unicode-18-erscheinungsdatum-bestaetigt/": {
+  "hash": "8a6f407a6d241b59",
+  "lastmod": "2026-08-15"
+ },
+ "/de/updates/vae-dirham-symbol-unicode-18/": {
+  "hash": "ea9edcb14ef1b942",
+  "lastmod": "2026-08-15"
+ },
+ "/de/usecase/": {
+  "hash": "2348638b8f25837f",
+  "lastmod": "2026-08-15"
+ },
+ "/de/usecase/bio-schriftart/": {
+  "hash": "22da0b0d5536aaab",
+  "lastmod": "2026-08-15"
+ },
+ "/de/usecase/emoji-buchstaben/": {
+  "hash": "6fb75f27bd3dd8f8",
+  "lastmod": "2026-08-15"
+ },
+ "/de/usecase/emoji-uebersetzer/": {
+  "hash": "0fa939d97ad96527",
+  "lastmod": "2026-08-15"
+ },
+ "/de/usecase/gruppennamen/": {
+  "hash": "a039bf7401710e6c",
+  "lastmod": "2026-08-15"
+ },
+ "/de/usecase/kontaktname-aesthetic/": {
+  "hash": "84c5666b1dd3e802",
+  "lastmod": "2026-08-15"
+ },
+ "/de/usecase/stumble-guys-namensgenerator/": {
+  "hash": "6b78122404ca3297",
+  "lastmod": "2026-08-15"
+ },
+ "/de/usecase/tattoo-schrift/": {
+  "hash": "c54852b9afb7ef7e",
+  "lastmod": "2026-08-15"
+ },
+ "/de/usecase/vertical-text/": {
+  "hash": "bb29ae356b618c8c",
+  "lastmod": "2026-08-15"
+ },
+ "/de/usecase/zalgo-text/": {
+  "hash": "a59b83cb4015b9d9",
+  "lastmod": "2026-08-15"
+ },
+ "/de/woerter-zeichen-zaehlen/": {
+  "hash": "385e6a49d164dc3c",
+  "lastmod": "2026-08-15"
+ },
+ "/de/zum-ausdrucken/": {
+  "hash": "def345c8df399606",
+  "lastmod": "2026-08-15"
+ },
+ "/de/zum-ausdrucken/alphabet-ausmalbilder/": {
+  "hash": "ae3b22abd78acb59",
+  "lastmod": "2026-08-15"
+ },
+ "/de/zum-ausdrucken/blasenbuchstaben/": {
+  "hash": "299ca8b5d0d28b46",
+  "lastmod": "2026-08-15"
+ },
+ "/de/zum-ausdrucken/name-ausmalen/": {
+  "hash": "d979b6a365202942",
+  "lastmod": "2026-08-15"
+ },
+ "/de/zum-ausdrucken/namen-schreiben/": {
+  "hash": "4507b4059f7eef8a",
+  "lastmod": "2026-08-15"
+ },
+ "/de/zum-ausdrucken/schreibschrift/": {
+  "hash": "5a4aa59b3a31fac2",
+  "lastmod": "2026-08-15"
+ },
+ "/de/zum-ausdrucken/schreibuebungen/": {
+  "hash": "2ab29f7994987bcf",
+  "lastmod": "2026-08-15"
+ },
+ "/de/zum-ausdrucken/spanisches-alphabet/": {
+  "hash": "455f1ed99cdec6f9",
+  "lastmod": "2026-08-15"
+ },
+ "/discord/": {
+  "hash": "39694f3de858f3ff",
+  "lastmod": "2026-08-06"
+ },
+ "/embed/": {
+  "hash": "4a1dbd1f3cfe2c3b",
+  "lastmod": "2026-07-24"
+ },
+ "/embed/bio-font-generator/": {
+  "hash": "47bcc45afd0577fb",
+  "lastmod": "2026-07-24"
+ },
+ "/embed/character-counter/": {
+  "hash": "414dea93402ae9fb",
+  "lastmod": "2026-08-07"
+ },
+ "/embed/linkedin-headline-generator/": {
+  "hash": "878ebfa1e2ea5372",
+  "lastmod": "2026-07-24"
+ },
+ "/embed/name-checker/": {
+  "hash": "39ba220179f8edcf",
+  "lastmod": "2026-07-24"
+ },
+ "/embed/nickname-generator/": {
+  "hash": "d84e014a0431b41d",
+  "lastmod": "2026-07-24"
+ },
+ "/embed/zalgo-text-generator/": {
+  "hash": "2ccbb6af357cc673",
+  "lastmod": "2026-07-24"
+ },
+ "/es/": {
+  "hash": "4d982aad855ca17f",
+  "lastmod": "2026-08-12"
+ },
+ "/es/answers/": {
+  "hash": "cb868c2fb4fd5155",
+  "lastmod": "2026-08-07"
+ },
+ "/es/answers/como-hacer-un-nombre-en-blanco/": {
+  "hash": "b4b3e151b9c48fe7",
+  "lastmod": "2026-08-15"
+ },
+ "/es/answers/nombre-de-usuario-o-nombre-en-pantalla/": {
+  "hash": "3e7c030e43e53466",
+  "lastmod": "2026-08-15"
+ },
+ "/es/answers/por-que-mi-nombre-sale-como-cuadros/": {
+  "hash": "aa1ba04046896fbc",
+  "lastmod": "2026-08-15"
+ },
+ "/es/answers/por-que-rechazaron-mi-nombre-en-el-juego/": {
+  "hash": "646607685b4e87af",
+  "lastmod": "2026-08-15"
+ },
+ "/es/answers/que-escribir-en-halloween/": {
+  "hash": "f98b0c32540eaa8b",
+  "lastmod": "2026-08-15"
+ },
+ "/es/answers/que-escribir-en-una-tarjeta-de-navidad/": {
+  "hash": "0065d6aba126b7b3",
+  "lastmod": "2026-08-15"
+ },
+ "/es/answers/que-escribir-en-una-tarjeta-de-san-valentin/": {
+  "hash": "a57ca22116070e71",
+  "lastmod": "2026-08-15"
+ },
+ "/es/answers/what-font-does-pinterest-use/": {
+  "hash": "c917a219361b69af",
+  "lastmod": "2026-08-16"
+ },
+ "/es/answers/what-font-does-whatsapp-use/": {
+  "hash": "e911cd1b84ea8b60",
+  "lastmod": "2026-08-16"
+ },
+ "/es/category/": {
+  "hash": "c4cb686bf50c80ab",
+  "lastmod": "2026-08-15"
+ },
+ "/es/contador-de-palabras-y-caracteres/": {
+  "hash": "08eba208c25af408",
+  "lastmod": "2026-08-15"
+ },
+ "/es/conversor-ascii/": {
+  "hash": "28b66ee3e59b5ed1",
+  "lastmod": "2026-08-15"
+ },
+ "/es/decorador-de-texto/": {
+  "hash": "ef06caaafc90dde7",
+  "lastmod": "2026-08-13"
+ },
+ "/es/events/halloween/": {
+  "hash": "b95f5e9f794def00",
+  "lastmod": "2026-08-15"
+ },
+ "/es/events/navidad/": {
+  "hash": "cc5e7f38fd823792",
+  "lastmod": "2026-08-15"
+ },
+ "/es/events/san-valentin/": {
+  "hash": "78356dc3b22797c5",
+  "lastmod": "2026-08-15"
+ },
+ "/es/fuentes-de-letras/": {
+  "hash": "8bfee8809db14c90",
+  "lastmod": "2026-08-15"
+ },
+ "/es/fuentes-para-discord/": {
+  "hash": "2dbfc4a05e022775",
+  "lastmod": "2026-08-15"
+ },
+ "/es/fuentes-para-instagram/": {
+  "hash": "1c451d6c81492f78",
+  "lastmod": "2026-08-05"
+ },
+ "/es/fuentes-para-roblox/": {
+  "hash": "49d8f972099c3e97",
+  "lastmod": "2026-08-15"
+ },
+ "/es/fuentes-para-telegram/": {
+  "hash": "24d682924a3fb69a",
+  "lastmod": "2026-08-15"
+ },
+ "/es/fuentes-para-tiktok/": {
+  "hash": "75c77c66ea48d581",
+  "lastmod": "2026-08-15"
+ },
+ "/es/fuentes-para-whatsapp/": {
+  "hash": "80fcd41c5272bc2f",
+  "lastmod": "2026-08-15"
+ },
+ "/es/guide/": {
+  "hash": "1ff08c9ae2f1f6f6",
+  "lastmod": "2026-08-11"
+ },
+ "/es/guide/donde-funcionan-las-fuentes-en-discord/": {
+  "hash": "6ff8720ddd9a622b",
+  "lastmod": "2026-07-26"
+ },
+ "/es/guide/formato-texto-discord-explicado/": {
+  "hash": "9d27f3d831d280a8",
+  "lastmod": "2026-07-26"
+ },
+ "/es/guide/nombre-discord-sin-riesgos/": {
+  "hash": "d77d2a8656ed416e",
+  "lastmod": "2026-07-26"
+ },
+ "/es/imprimibles/": {
+  "hash": "8ae021aef81e72da",
+  "lastmod": "2026-08-13"
+ },
+ "/es/imprimibles/abecedario-espanol/": {
+  "hash": "aaa0c38777805712",
+  "lastmod": "2026-08-12"
+ },
+ "/es/imprimibles/abecedario-para-colorear/": {
+  "hash": "7413a68220deea5f",
+  "lastmod": "2026-08-13"
+ },
+ "/es/imprimibles/abecedario-para-colorear/letra-a/": {
+  "hash": "6398626c9c950516",
+  "lastmod": "2026-08-13"
+ },
+ "/es/imprimibles/abecedario-para-colorear/letra-b/": {
+  "hash": "21e5d055878887b1",
+  "lastmod": "2026-08-13"
+ },
+ "/es/imprimibles/abecedario-para-colorear/letra-c/": {
+  "hash": "0fafc0ccaf0ce452",
+  "lastmod": "2026-08-13"
+ },
+ "/es/imprimibles/abecedario-para-colorear/letra-d/": {
+  "hash": "a235c4af1e0871fc",
+  "lastmod": "2026-08-13"
+ },
+ "/es/imprimibles/abecedario-para-colorear/letra-e/": {
+  "hash": "37632e12076abe80",
+  "lastmod": "2026-08-13"
+ },
+ "/es/imprimibles/abecedario-para-colorear/letra-enye/": {
+  "hash": "47b07eb508b6a1e5",
+  "lastmod": "2026-08-13"
+ },
+ "/es/imprimibles/abecedario-para-colorear/letra-f/": {
+  "hash": "c2ddb31f9dae3005",
+  "lastmod": "2026-08-13"
+ },
+ "/es/imprimibles/abecedario-para-colorear/letra-g/": {
+  "hash": "3fff4f899ed27ca6",
+  "lastmod": "2026-08-13"
+ },
+ "/es/imprimibles/abecedario-para-colorear/letra-h/": {
+  "hash": "bb791d78d5c23314",
+  "lastmod": "2026-08-13"
+ },
+ "/es/imprimibles/abecedario-para-colorear/letra-i/": {
+  "hash": "58cd58b7a44c7d0f",
+  "lastmod": "2026-08-13"
+ },
+ "/es/imprimibles/abecedario-para-colorear/letra-j/": {
+  "hash": "687eb6e6ef09b613",
+  "lastmod": "2026-08-13"
+ },
+ "/es/imprimibles/abecedario-para-colorear/letra-k/": {
+  "hash": "27466e71c73b71d1",
+  "lastmod": "2026-08-13"
+ },
+ "/es/imprimibles/abecedario-para-colorear/letra-l/": {
+  "hash": "7e407b23896ade4f",
+  "lastmod": "2026-08-13"
+ },
+ "/es/imprimibles/abecedario-para-colorear/letra-m/": {
+  "hash": "d6d07f842dcedc3e",
+  "lastmod": "2026-08-13"
+ },
+ "/es/imprimibles/abecedario-para-colorear/letra-n/": {
+  "hash": "240cbfee9b5eed75",
+  "lastmod": "2026-08-13"
+ },
+ "/es/imprimibles/abecedario-para-colorear/letra-o/": {
+  "hash": "5ae528c04f51684f",
+  "lastmod": "2026-08-13"
+ },
+ "/es/imprimibles/abecedario-para-colorear/letra-p/": {
+  "hash": "78e512a1f90993bf",
+  "lastmod": "2026-08-13"
+ },
+ "/es/imprimibles/abecedario-para-colorear/letra-q/": {
+  "hash": "e699dbfefc7bcbe4",
+  "lastmod": "2026-08-13"
+ },
+ "/es/imprimibles/abecedario-para-colorear/letra-r/": {
+  "hash": "30a8b958384353f3",
+  "lastmod": "2026-08-13"
+ },
+ "/es/imprimibles/abecedario-para-colorear/letra-s/": {
+  "hash": "573213f948ee2f6b",
+  "lastmod": "2026-08-13"
+ },
+ "/es/imprimibles/abecedario-para-colorear/letra-t/": {
+  "hash": "989682d735c066e2",
+  "lastmod": "2026-08-13"
+ },
+ "/es/imprimibles/abecedario-para-colorear/letra-u/": {
+  "hash": "49d6f1d1b4617cfd",
+  "lastmod": "2026-08-13"
+ },
+ "/es/imprimibles/abecedario-para-colorear/letra-v/": {
+  "hash": "5ad385ad30588a79",
+  "lastmod": "2026-08-13"
+ },
+ "/es/imprimibles/abecedario-para-colorear/letra-w/": {
+  "hash": "5770a1697236c40a",
+  "lastmod": "2026-08-13"
+ },
+ "/es/imprimibles/abecedario-para-colorear/letra-x/": {
+  "hash": "819393804a005810",
+  "lastmod": "2026-08-13"
+ },
+ "/es/imprimibles/abecedario-para-colorear/letra-y/": {
+  "hash": "92a649e007ba1882",
+  "lastmod": "2026-08-13"
+ },
+ "/es/imprimibles/abecedario-para-colorear/letra-z/": {
+  "hash": "2f3d83123f6eaa32",
+  "lastmod": "2026-08-13"
+ },
+ "/es/imprimibles/abecedario-para-colorear/numero-0/": {
+  "hash": "25cd4aa0560c6f8c",
+  "lastmod": "2026-08-13"
+ },
+ "/es/imprimibles/abecedario-para-colorear/numero-1/": {
+  "hash": "493b90bc9e93fbb2",
+  "lastmod": "2026-08-13"
+ },
+ "/es/imprimibles/abecedario-para-colorear/numero-2/": {
+  "hash": "2a4fc5310032f2b0",
+  "lastmod": "2026-08-13"
+ },
+ "/es/imprimibles/abecedario-para-colorear/numero-3/": {
+  "hash": "87ba8b05efdf462d",
+  "lastmod": "2026-08-13"
+ },
+ "/es/imprimibles/abecedario-para-colorear/numero-4/": {
+  "hash": "a6e479e40ade4e97",
+  "lastmod": "2026-08-13"
+ },
+ "/es/imprimibles/abecedario-para-colorear/numero-5/": {
+  "hash": "4848866caf5b80a4",
+  "lastmod": "2026-08-13"
+ },
+ "/es/imprimibles/abecedario-para-colorear/numero-6/": {
+  "hash": "5ba8cc963140564b",
+  "lastmod": "2026-08-13"
+ },
+ "/es/imprimibles/abecedario-para-colorear/numero-7/": {
+  "hash": "07a486133f9292a5",
+  "lastmod": "2026-08-13"
+ },
+ "/es/imprimibles/abecedario-para-colorear/numero-8/": {
+  "hash": "058d87a08700e810",
+  "lastmod": "2026-08-13"
+ },
+ "/es/imprimibles/abecedario-para-colorear/numero-9/": {
+  "hash": "a44dfeb0ecddba48",
+  "lastmod": "2026-08-13"
+ },
+ "/es/imprimibles/alfabeto-cursiva/": {
+  "hash": "1fcc496d1d46169e",
+  "lastmod": "2026-08-12"
+ },
+ "/es/imprimibles/caligrafia/": {
+  "hash": "d87ff98ce893d862",
+  "lastmod": "2026-08-12"
+ },
+ "/es/imprimibles/ejercicios-de-caligrafia/": {
+  "hash": "bb393077c7dab443",
+  "lastmod": "2026-08-13"
+ },
+ "/es/imprimibles/letras-burbuja/": {
+  "hash": "ce26ac6714eb2116",
+  "lastmod": "2026-08-13"
+ },
+ "/es/imprimibles/letras-graffiti/": {
+  "hash": "4dc3351e89a92613",
+  "lastmod": "2026-08-13"
+ },
+ "/es/imprimibles/letras-punteadas/": {
+  "hash": "d257e80ef97f2042",
+  "lastmod": "2026-08-13"
+ },
+ "/es/imprimibles/letras-punto-de-cruz/": {
+  "hash": "c59e480fd18c091b",
+  "lastmod": "2026-08-12"
+ },
+ "/es/imprimibles/moldes-de-letras/": {
+  "hash": "fcad5c6f45d763b7",
+  "lastmod": "2026-08-13"
+ },
+ "/es/imprimibles/monograma/": {
+  "hash": "e7a2d86e70f74370",
+  "lastmod": "2026-08-12"
+ },
+ "/es/imprimibles/nombre-para-trazar/": {
+  "hash": "bb623b0b52fc49b8",
+  "lastmod": "2026-08-12"
+ },
+ "/es/letra-cursiva/": {
+  "hash": "8f3c4e37a3580319",
+  "lastmod": "2026-08-15"
+ },
+ "/es/letra-tachada/": {
+  "hash": "00fc2c834d8ec243",
+  "lastmod": "2026-08-15"
+ },
+ "/es/letras-aesthetic/": {
+  "hash": "c3d7be4e479560bc",
+  "lastmod": "2026-08-15"
+ },
+ "/es/letras-bonitas/": {
+  "hash": "066a0c249ab710fb",
+  "lastmod": "2026-08-15"
+ },
+ "/es/letras-en-otros-idiomas/": {
+  "hash": "1435cd75e1cd5f62",
+  "lastmod": "2026-08-15"
+ },
+ "/es/letras-goticas/": {
+  "hash": "6a5eb2d93a3e94b0",
+  "lastmod": "2026-08-15"
+ },
+ "/es/letras-griegas/": {
+  "hash": "b5524c8e2b738c8a",
+  "lastmod": "2026-08-15"
+ },
+ "/es/letras-italicas/": {
+  "hash": "1c72dcc3cb98f5a4",
+  "lastmod": "2026-08-15"
+ },
+ "/es/letras-negritas/": {
+  "hash": "8bbacea6accc953c",
+  "lastmod": "2026-08-05"
+ },
+ "/es/letras-para-facebook/": {
+  "hash": "27ccf82e2c76937c",
+  "lastmod": "2026-08-15"
+ },
+ "/es/letras-raras/": {
+  "hash": "1d904cb7219673fe",
+  "lastmod": "2026-07-26"
+ },
+ "/es/library/": {
+  "hash": "5b4dd7a789746349",
+  "lastmod": "2026-08-10"
+ },
+ "/es/library/adivina-el-futbolista-por-emojis/": {
+  "hash": "19d7ee86b4addfe4",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/arte-ascii-calavera/": {
+  "hash": "4d4a0752f0e9e169",
+  "lastmod": "2026-08-12"
+ },
+ "/es/library/arte-ascii-gato/": {
+  "hash": "67117f3faf2e2c31",
+  "lastmod": "2026-08-12"
+ },
+ "/es/library/arte-ascii-perro/": {
+  "hash": "45c9f151e8f6b330",
+  "lastmod": "2026-08-12"
+ },
+ "/es/library/arte-de-texto-memes/": {
+  "hash": "099fd752b8f585a0",
+  "lastmod": "2026-08-12"
+ },
+ "/es/library/arte-de-texto/": {
+  "hash": "c814e48c36d3c9e4",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/barra-vertical-simbolo/": {
+  "hash": "45a39ef9e2a46076",
+  "lastmod": "2026-08-12"
+ },
+ "/es/library/bordes-aesthetic/": {
+  "hash": "4f017ac72bc80bb6",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/caracteres-especiales/": {
+  "hash": "5eeac012916118af",
+  "lastmod": "2026-08-07"
+ },
+ "/es/library/caritas-felices/": {
+  "hash": "f2ba16e1a3ebb259",
+  "lastmod": "2026-08-16"
+ },
+ "/es/library/cat-kaomoji/": {
+  "hash": "7e09e9e383ed6d11",
+  "lastmod": "2026-08-10"
+ },
+ "/es/library/codigos-alt/": {
+  "hash": "ca8b1f766b3445e1",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/crying-kaomoji/": {
+  "hash": "d78131586b0aac56",
+  "lastmod": "2026-08-10"
+ },
+ "/es/library/cute-kaomoji/": {
+  "hash": "161a5e2ffa0adf63",
+  "lastmod": "2026-08-10"
+ },
+ "/es/library/dongers/": {
+  "hash": "1756475c05460f47",
+  "lastmod": "2026-08-12"
+ },
+ "/es/library/emoji-alemania/": {
+  "hash": "0944f917838acfa2",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-angel/": {
+  "hash": "ffe3394c7388d005",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-aplausos/": {
+  "hash": "3770a01f6e77788a",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-apreton-de-manos/": {
+  "hash": "5a734853938f6e25",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-arabia-saudita/": {
+  "hash": "cc21cb3b93c6cae2",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-argentina/": {
+  "hash": "aab5513213ad8738",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-asustado/": {
+  "hash": "b11e967317ecdeba",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-aureola/": {
+  "hash": "3bfb421aa97f3cea",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-australia/": {
+  "hash": "8d879c156a92d1aa",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-austria/": {
+  "hash": "134f26928cd54209",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-avergonzado/": {
+  "hash": "9dee44eb17328587",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-bailando/": {
+  "hash": "8d4930fcaf5eb07c",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-bellingham/": {
+  "hash": "a0dbba3662d59a43",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-berenjena/": {
+  "hash": "dbe9dd7d46e9d907",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-beso/": {
+  "hash": "f3fb5c5d349042f8",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-brasil/": {
+  "hash": "7ea0841ba626adbd",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-caballito-de-mar/": {
+  "hash": "4d597abe50afe866",
+  "lastmod": "2026-08-16"
+ },
+ "/es/library/emoji-caca/": {
+  "hash": "3f1e9d2919c83661",
+  "lastmod": "2026-08-16"
+ },
+ "/es/library/emoji-calavera/": {
+  "hash": "2d4ce4a71c7fd069",
+  "lastmod": "2026-08-16"
+ },
+ "/es/library/emoji-canada/": {
+  "hash": "34210d296457d959",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-cansado/": {
+  "hash": "55ffd19cb3912507",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-check/": {
+  "hash": "187f3550e8611081",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-chile/": {
+  "hash": "4728c5f1fc5a2667",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-china/": {
+  "hash": "c7a5bb2eca0152b1",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-cohete/": {
+  "hash": "a86f18b597dbfafb",
+  "lastmod": "2026-08-16"
+ },
+ "/es/library/emoji-colombia/": {
+  "hash": "c79d216d7b75f0c2",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-combos/": {
+  "hash": "64d3ddc98660fa5f",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-confundido/": {
+  "hash": "c3a858f2e70c5aef",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-corea-del-sur/": {
+  "hash": "6a735c2efaaef0c6",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-corona/": {
+  "hash": "2c45fba1714dab36",
+  "lastmod": "2026-08-16"
+ },
+ "/es/library/emoji-costa-rica/": {
+  "hash": "985c60bb4e075713",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-cringe/": {
+  "hash": "642a5ccb2cbccd30",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-croacia/": {
+  "hash": "d8e6bb2da0f3c63b",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-dedo-medio/": {
+  "hash": "c3738227e4b91740",
+  "lastmod": "2026-08-16"
+ },
+ "/es/library/emoji-diablo/": {
+  "hash": "937a04d9bc570853",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-dinamarca/": {
+  "hash": "56f7ca9818aae12b",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-ecuador/": {
+  "hash": "b34016ef2387c893",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-egipto/": {
+  "hash": "6194c5b286ac331e",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-enfermo/": {
+  "hash": "88822c517a46d5db",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-enojado/": {
+  "hash": "cfbb6f97bfd60369",
+  "lastmod": "2026-08-16"
+ },
+ "/es/library/emoji-escocia/": {
+  "hash": "406ae36f09a08b09",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-espana/": {
+  "hash": "05e87664b9aecd3e",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-estados-unidos/": {
+  "hash": "131899a4330920e5",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-estrella/": {
+  "hash": "175d919c2118513f",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-facepalm/": {
+  "hash": "2a9d0afc4e0ffeef",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-fantasma/": {
+  "hash": "688dd2b2e3ca877a",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-flags/": {
+  "hash": "f8d288f41c464e64",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-francia/": {
+  "hash": "3cccd22c37ebd5bc",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-freaky/": {
+  "hash": "6fa6d7c73d3b6b5a",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-fuego/": {
+  "hash": "bbd9b1aa3c2aecaf",
+  "lastmod": "2026-08-16"
+ },
+ "/es/library/emoji-futbol/": {
+  "hash": "c6a32f8c7db9c81b",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-gafas-de-sol/": {
+  "hash": "f41681d538a5e311",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-gales/": {
+  "hash": "24065423d3fe0ada",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-ghana/": {
+  "hash": "e9264dfbfbfd557d",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-goat/": {
+  "hash": "31b5238021fbe026",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-gol/": {
+  "hash": "694b5dc6aa7c977e",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-grecia/": {
+  "hash": "b441e2d7e15bb4b1",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-griezmann/": {
+  "hash": "8365dc991c58d762",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-guino/": {
+  "hash": "e9bdbe0367555735",
+  "lastmod": "2026-08-16"
+ },
+ "/es/library/emoji-honduras/": {
+  "hash": "11aaf1655202082e",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-india/": {
+  "hash": "d37bb692c6d8510c",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-inglaterra/": {
+  "hash": "8aae1562b9e85d38",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-irlanda/": {
+  "hash": "e93ab054a68f7a19",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-italia/": {
+  "hash": "d3ec33eeeb47895c",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-jamaica/": {
+  "hash": "d8eac2424c9b4136",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-japon/": {
+  "hash": "3c591beff138eb5d",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-lengua/": {
+  "hash": "78c791841801e7b0",
+  "lastmod": "2026-08-16"
+ },
+ "/es/library/emoji-llorando/": {
+  "hash": "ae93461d0fda2cb4",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-manos-rezando/": {
+  "hash": "953965ecf58a0a85",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-marruecos/": {
+  "hash": "b841fa8b2b156ae2",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-messi/": {
+  "hash": "f27cb2f6a09bc2ab",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-mexico/": {
+  "hash": "7c98ce19696c75ef",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-moai/": {
+  "hash": "1debbcda55e08db9",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-molesto/": {
+  "hash": "2c4ace0d0eab80c5",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-mordiendose-el-labio/": {
+  "hash": "ff757f6b6ea59951",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-musculo/": {
+  "hash": "b41ef327733b8185",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-nerd/": {
+  "hash": "4fcdb7f78404a6df",
+  "lastmod": "2026-08-16"
+ },
+ "/es/library/emoji-neymar/": {
+  "hash": "539bc9c7d6713c2b",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-nigeria/": {
+  "hash": "b1a0a4b46504eb28",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-noruega/": {
+  "hash": "43446eb36e295049",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-nueva-zelanda/": {
+  "hash": "0d02bcce523e1ee8",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-ojos-en-blanco/": {
+  "hash": "facde1333131e725",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-ojos/": {
+  "hash": "cc6d8c083f276ba3",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-paraguay/": {
+  "hash": "2082f82e9187f944",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-payaso/": {
+  "hash": "cb6cb92826fc49b2",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-paz/": {
+  "hash": "c3d03b3707fe1db0",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-pensando/": {
+  "hash": "868fc820144a79f5",
+  "lastmod": "2026-08-16"
+ },
+ "/es/library/emoji-peru/": {
+  "hash": "43ce72e7b375e1e7",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-polonia/": {
+  "hash": "f3847ea93c8150a8",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-portugal/": {
+  "hash": "554ba39af63125dd",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-pulgar-arriba/": {
+  "hash": "ab1d4827a6f95a5a",
+  "lastmod": "2026-08-16"
+ },
+ "/es/library/emoji-qatar/": {
+  "hash": "e72bfd98208a973c",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-regalo/": {
+  "hash": "6d0a3b008d60158e",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-riendo/": {
+  "hash": "31cabe3dca17e3d8",
+  "lastmod": "2026-08-16"
+ },
+ "/es/library/emoji-ronaldo/": {
+  "hash": "f5f5908639f1c81e",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-salah/": {
+  "hash": "6777d1d62f1f8f52",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-saludo-militar/": {
+  "hash": "d1f88f78c2c1c613",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-senegal/": {
+  "hash": "859f618e88d01f22",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-serbia/": {
+  "hash": "1e92e7fd39c72202",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-side-eye/": {
+  "hash": "3d525bcaae81d911",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-smirk/": {
+  "hash": "27b5fd244d572ed7",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-sonrojado/": {
+  "hash": "aca3b9e1f07e47fb",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-sorprendido/": {
+  "hash": "f2474f772a12cade",
+  "lastmod": "2026-08-16"
+ },
+ "/es/library/emoji-suecia/": {
+  "hash": "f74e366b7a148f54",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-suiza/": {
+  "hash": "c9f39096689e14ed",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-suplicando/": {
+  "hash": "56e228331df6f764",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-suspiro/": {
+  "hash": "a4e49e727db94cca",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-tarjeta-roja/": {
+  "hash": "cbf39fb66bfe8470",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-triste/": {
+  "hash": "dce1bc6c90f61d0d",
+  "lastmod": "2026-08-16"
+ },
+ "/es/library/emoji-ucrania/": {
+  "hash": "5cdf3036975a9f6c",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-uruguay/": {
+  "hash": "91ecb91e98fa922e",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-vaquero/": {
+  "hash": "cf85b39abc113768",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emoji-venezuela/": {
+  "hash": "eba2e73fb21c842d",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emojis-accion-de-gracias/": {
+  "hash": "4a6d9ff5c076689f",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emojis-brainrot/": {
+  "hash": "e481fdaf790d4706",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emojis-de-amistad/": {
+  "hash": "b28d17454cea775f",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emojis-de-animales/": {
+  "hash": "bad48911b6679c7d",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emojis-de-arte/": {
+  "hash": "c6480dd4b5ee227e",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emojis-de-belleza/": {
+  "hash": "928b9824ec17b67b",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emojis-de-boda/": {
+  "hash": "d09a94331ca92088",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emojis-de-caras/": {
+  "hash": "30bce82224ddfb4f",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emojis-de-comida/": {
+  "hash": "bf13f8bc8ef6c372",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emojis-de-deportes/": {
+  "hash": "93b29df611fb7d0e",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emojis-de-dinero/": {
+  "hash": "888ad57afbad31df",
+  "lastmod": "2026-08-16"
+ },
+ "/es/library/emojis-de-escuela/": {
+  "hash": "c868a37e0e54f849",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emojis-de-estaciones/": {
+  "hash": "e6176333dad14fc2",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emojis-de-fantasia/": {
+  "hash": "711b7248d426c7d7",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emojis-de-fiesta/": {
+  "hash": "09037e3a6134e372",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emojis-de-herramientas/": {
+  "hash": "e8f7a93c68c16a6a",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emojis-de-joyas/": {
+  "hash": "f34908c1e88194dd",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emojis-de-moda/": {
+  "hash": "7700db0e0177562e",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emojis-de-naturaleza/": {
+  "hash": "52630ebe09f73d48",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emojis-de-objetos/": {
+  "hash": "59ce53b46444e93a",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emojis-de-pascua/": {
+  "hash": "b374051d7120f4b0",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emojis-de-profesiones/": {
+  "hash": "c71ad65c17af8d7b",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emojis-de-viaje/": {
+  "hash": "576a143be5520681",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emojis-graciosos/": {
+  "hash": "448c45501c911762",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emojis-iphone/": {
+  "hash": "57292faadf428ae0",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emojis-lenguaje-corporal/": {
+  "hash": "565bfc518f8ddfbd",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emojis-para-mensajes/": {
+  "hash": "d6f4abc58122b162",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/emojis-preppy/": {
+  "hash": "1d12dceb076cef81",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/entidades-html/": {
+  "hash": "bc105eb33658a05d",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/happy-kaomoji/": {
+  "hash": "8707898f7ebed49d",
+  "lastmod": "2026-07-25"
+ },
+ "/es/library/jeroglificos-egipcios/": {
+  "hash": "d69bd9f0f2c0c877",
+  "lastmod": "2026-08-16"
+ },
+ "/es/library/kaomoji-abrazo/": {
+  "hash": "66f89d15b229183b",
+  "lastmod": "2026-08-12"
+ },
+ "/es/library/kaomoji-conejo/": {
+  "hash": "05ad7a25f01cf111",
+  "lastmod": "2026-08-12"
+ },
+ "/es/library/kaomoji-corazon/": {
+  "hash": "e883fa4693c9a059",
+  "lastmod": "2026-08-12"
+ },
+ "/es/library/kaomoji-emocionado/": {
+  "hash": "7a4b03fbc45dbb34",
+  "lastmod": "2026-08-12"
+ },
+ "/es/library/kaomoji-enojado/": {
+  "hash": "95e40bbe811b3604",
+  "lastmod": "2026-08-12"
+ },
+ "/es/library/kaomoji-estrella/": {
+  "hash": "f1d1926ca242d634",
+  "lastmod": "2026-08-12"
+ },
+ "/es/library/kaomoji-guino/": {
+  "hash": "3f53f4f4a100504c",
+  "lastmod": "2026-08-12"
+ },
+ "/es/library/kaomoji-oso/": {
+  "hash": "c03663fa513b768f",
+  "lastmod": "2026-08-12"
+ },
+ "/es/library/kaomoji-perro/": {
+  "hash": "b90393bfd493ea5a",
+  "lastmod": "2026-08-12"
+ },
+ "/es/library/kaomoji-pulgar-arriba/": {
+  "hash": "0f45a5115f299beb",
+  "lastmod": "2026-08-12"
+ },
+ "/es/library/kaomoji-riendo/": {
+  "hash": "e7d285283e97603a",
+  "lastmod": "2026-08-12"
+ },
+ "/es/library/kaomoji-saludo/": {
+  "hash": "e2c308eab8a9230f",
+  "lastmod": "2026-08-12"
+ },
+ "/es/library/kaomoji-sonrojado/": {
+  "hash": "9925c79b1998d464",
+  "lastmod": "2026-08-12"
+ },
+ "/es/library/kaomoji-sorprendido/": {
+  "hash": "452e8a2253f0ea0c",
+  "lastmod": "2026-08-12"
+ },
+ "/es/library/kaomoji/": {
+  "hash": "c9ce41cc5aabdea9",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/lenny-face/": {
+  "hash": "c1e2198d0d703e6d",
+  "lastmod": "2026-08-12"
+ },
+ "/es/library/love-kaomoji/": {
+  "hash": "cb9ef551e094b685",
+  "lastmod": "2026-08-10"
+ },
+ "/es/library/parentesis-corchetes-y-llaves/": {
+  "hash": "e7059bf149eb44b0",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/runas-vikingas/": {
+  "hash": "cf9ff71c03cdb7f8",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/sad-kaomoji/": {
+  "hash": "ef2587913f18c9b8",
+  "lastmod": "2026-08-10"
+ },
+ "/es/library/separadores-de-texto/": {
+  "hash": "7d660aab4cdb8db7",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/separadores-kaomoji/": {
+  "hash": "ddc94fd9f6717dd4",
+  "lastmod": "2026-08-12"
+ },
+ "/es/library/shrug-kaomoji/": {
+  "hash": "b3e7d07d8dbee3d8",
+  "lastmod": "2026-07-25"
+ },
+ "/es/library/significado-de-los-emojis/": {
+  "hash": "e1b06064eca43260",
+  "lastmod": "2026-08-16"
+ },
+ "/es/library/simbolo-slash/": {
+  "hash": "52413645db2a555f",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolo-x/": {
+  "hash": "0c52d4cdc5893db8",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-anime/": {
+  "hash": "75a9be37ed3161b9",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-braille/": {
+  "hash": "8a7e65de63d766bc",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-chinos/": {
+  "hash": "cc1dea8bb4c8002f",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-copyright/": {
+  "hash": "c511edf49b1ed669",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-coquette/": {
+  "hash": "d9b252cbbd5ee673",
+  "lastmod": "2026-08-13"
+ },
+ "/es/library/simbolos-coreanos/": {
+  "hash": "5af61c5a5c94fc2b",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-cottagecore/": {
+  "hash": "960ec46b77fad0fb",
+  "lastmod": "2026-08-13"
+ },
+ "/es/library/simbolos-de-ajedrez/": {
+  "hash": "8b3b79b5936cf3fb",
+  "lastmod": "2026-08-13"
+ },
+ "/es/library/simbolos-de-brillo/": {
+  "hash": "16dd3db9d5ca00ab",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-de-cartas/": {
+  "hash": "33ac70a752457007",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-de-corona/": {
+  "hash": "040aeef54f132a31",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-de-email/": {
+  "hash": "ee816c1dac61ea84",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-de-flor/": {
+  "hash": "90dc1fb499faf630",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-de-fracciones/": {
+  "hash": "9ca87ae84f0bf6f3",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-de-futbol/": {
+  "hash": "e594c3b9a8d20a2c",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-de-genero/": {
+  "hash": "7410df117b53290d",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-de-lavado/": {
+  "hash": "130ec2bc5785e2a6",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-de-lazos/": {
+  "hash": "51b987b833501d86",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-de-luna/": {
+  "hash": "c25aaf7b2aa8eb27",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-de-manos/": {
+  "hash": "663da77bc54425f2",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-de-moneda/": {
+  "hash": "99ce2f1c3a22c66a",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-de-musica/": {
+  "hash": "8babef901b5b9e33",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-de-navidad/": {
+  "hash": "43aa196d30d5dcb0",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-de-numero/": {
+  "hash": "67c548607a773ffc",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-de-peligro/": {
+  "hash": "0a7a821bdcd115f5",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-de-puntuacion/": {
+  "hash": "4b50724fdcff93e2",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-de-reciclaje/": {
+  "hash": "1831eaaf8ef649b6",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-de-reloj/": {
+  "hash": "da4c726939ebbca5",
+  "lastmod": "2026-08-12"
+ },
+ "/es/library/simbolos-de-teclado/": {
+  "hash": "48ba78a41f9ba1e7",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-de-transito/": {
+  "hash": "a9ad6a26c5a613af",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-de-transporte/": {
+  "hash": "e3f9ff777dd91b34",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-de-unidades/": {
+  "hash": "c24cfc9785ad119e",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-de-verificacion/": {
+  "hash": "aff710445946b998",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-de-vineta/": {
+  "hash": "6efe986d78e1ea1b",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-del-clima/": {
+  "hash": "ca8ed690b72e14f0",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-del-zodiaco/": {
+  "hash": "05c7d89212a6d685",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-discord/": {
+  "hash": "f8892821a2b96fad",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-dreamcore-weirdcore/": {
+  "hash": "b34c90c7ab36d1b0",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-electricos/": {
+  "hash": "b86cef33d8779c4c",
+  "lastmod": "2026-08-12"
+ },
+ "/es/library/simbolos-facebook/": {
+  "hash": "875ca4f5a233909b",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-fairycore/": {
+  "hash": "ced12576e1345c35",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-geometricos/": {
+  "hash": "63cae9c0c70c14ae",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-goth-grunge/": {
+  "hash": "04cc99fa09a02461",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-halloween/": {
+  "hash": "45359acdf0d485c4",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-ipa/": {
+  "hash": "1f86408c229d2386",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-islamicos/": {
+  "hash": "ccd6636844d2e6d6",
+  "lastmod": "2026-08-14"
+ },
+ "/es/library/simbolos-japoneses/": {
+  "hash": "351cee38dffe61b9",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-kawaii-cute/": {
+  "hash": "3b40dc03ce6f5f9f",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-latex/": {
+  "hash": "025df8c306a40fc8",
+  "lastmod": "2026-08-16"
+ },
+ "/es/library/simbolos-lgbt/": {
+  "hash": "18628ef02296e988",
+  "lastmod": "2026-08-12"
+ },
+ "/es/library/simbolos-matematicos/": {
+  "hash": "0ebc283115613db0",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-medicos/": {
+  "hash": "75d30a200b285c50",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-minecraft/": {
+  "hash": "202fb70314419a7d",
+  "lastmod": "2026-08-12"
+ },
+ "/es/library/simbolos-para-fortnite/": {
+  "hash": "f0edac5cc5e9f199",
+  "lastmod": "2026-08-07"
+ },
+ "/es/library/simbolos-para-instagram/": {
+  "hash": "25c58dd21040b798",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-para-linkedin/": {
+  "hash": "bec9f1b2e9a8970b",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-para-nombres-mobile-legends/": {
+  "hash": "d974cefd04ca1d9d",
+  "lastmod": "2026-08-12"
+ },
+ "/es/library/simbolos-para-twitter/": {
+  "hash": "c2e418da5b1f7b9c",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-pubg/": {
+  "hash": "e856b4f5f4be15bd",
+  "lastmod": "2026-08-14"
+ },
+ "/es/library/simbolos-religiosos/": {
+  "hash": "278e4f447df9177f",
+  "lastmod": "2026-08-13"
+ },
+ "/es/library/simbolos-roblox/": {
+  "hash": "e5e2e97ec3491f65",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-snapchat/": {
+  "hash": "1b834057bf68326c",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-therian/": {
+  "hash": "0ca295af8e8f5050",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-whatsapp/": {
+  "hash": "9a20c83276e92bda",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-witchy-occult/": {
+  "hash": "7e9642e3eb99d58b",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/simbolos-y2k/": {
+  "hash": "e3b60897c6be7919",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/tabla-ascii/": {
+  "hash": "bba06e5fa71549e4",
+  "lastmod": "2026-08-15"
+ },
+ "/es/library/table-flip-kaomoji/": {
+  "hash": "bfbf156b6ea4dfd8",
+  "lastmod": "2026-08-12"
+ },
+ "/es/mayusculas-y-minusculas/": {
+  "hash": "e0896d62fb1d3a65",
+  "lastmod": "2026-08-15"
+ },
+ "/es/simbolos-aesthetic/": {
+  "hash": "805aabb2ee146dd1",
+  "lastmod": "2026-08-02"
+ },
+ "/es/simbolos-de-corazon/": {
+  "hash": "7639ca4c9411cdaf",
+  "lastmod": "2026-08-13"
+ },
+ "/es/simbolos-de-estrella/": {
+  "hash": "b171779070622654",
+  "lastmod": "2026-08-15"
+ },
+ "/es/simbolos-de-flechas/": {
+  "hash": "c332078110f3b007",
+  "lastmod": "2026-08-15"
+ },
+ "/es/simbolos-para-free-fire/": {
+  "hash": "7d126575e6d136cb",
+  "lastmod": "2026-08-13"
+ },
+ "/es/simbolos-para-nombres/": {
+  "hash": "d600998478a9ac85",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/": {
+  "hash": "299b4829f835cc0c",
+  "lastmod": "2026-08-16"
+ },
+ "/es/symbol/arroba/": {
+  "hash": "02d758070becd590",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/asterisco/": {
+  "hash": "3c781eb349ceeb3e",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/calavera-y-huesos-cruzados/": {
+  "hash": "f0fab0fe35009cc7",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/calderon/": {
+  "hash": "41fb5bbb6c518e2a",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/caracter-invisible/": {
+  "hash": "5d6cebe357928489",
+  "lastmod": "2026-08-13"
+ },
+ "/es/symbol/colores-de-corazones-de-snapchat/": {
+  "hash": "3ad6544b15921ffc",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/comillas/": {
+  "hash": "7db107d00ddf3c94",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/cruz-ortodoxa/": {
+  "hash": "5b93179379eea599",
+  "lastmod": "2026-08-06"
+ },
+ "/es/symbol/cuadrado-y-cubo/": {
+  "hash": "60c013875f8cdbcb",
+  "lastmod": "2026-08-03"
+ },
+ "/es/symbol/emoji-de-calendario/": {
+  "hash": "c75dbf7877aa9ca0",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/emoji-de-cara-agrietada/": {
+  "hash": "df47b9b9220ecc72",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/emoji-de-cara-derretida/": {
+  "hash": "6d206836cb4d7e8b",
+  "lastmod": "2026-08-05"
+ },
+ "/es/symbol/emoji-de-cara-distorsionada/": {
+  "hash": "719a385825fc0920",
+  "lastmod": "2026-08-05"
+ },
+ "/es/symbol/emoji-de-gafas-de-sol/": {
+  "hash": "6f3d04f99cdde0f2",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/emoji-de-mariposa-monarca/": {
+  "hash": "b18ac0241c61dfaf",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/emoji-de-meteoro/": {
+  "hash": "98dc23f8cc87fc1a",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/emoji-de-microfono/": {
+  "hash": "ff8507dc850b387d",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/emoji-de-pepinillo/": {
+  "hash": "bc26c5dca3e3222e",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/emoji-de-senal-de-pulgar/": {
+  "hash": "bb62e0ea76f66a66",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/estrella-de-david/": {
+  "hash": "c7f6a20102d07654",
+  "lastmod": "2026-08-06"
+ },
+ "/es/symbol/flecha-abajo/": {
+  "hash": "612a1f69e720b73e",
+  "lastmod": "2026-08-13"
+ },
+ "/es/symbol/flecha-arriba/": {
+  "hash": "93ffc4fd1397167f",
+  "lastmod": "2026-08-13"
+ },
+ "/es/symbol/flecha-derecha/": {
+  "hash": "db49617de4aad89e",
+  "lastmod": "2026-08-13"
+ },
+ "/es/symbol/flecha-izquierda/": {
+  "hash": "ba6660e4efefcd61",
+  "lastmod": "2026-08-13"
+ },
+ "/es/symbol/guion-bajo/": {
+  "hash": "157a09eef8d3b479",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/guion-medio/": {
+  "hash": "54b94b607befeeb1",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/interrobang/": {
+  "hash": "14262d716b2e186c",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/interrogacion-reflexa/": {
+  "hash": "2b478427f3616238",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/linea-vertical/": {
+  "hash": "dea4051d419acdec",
+  "lastmod": "2026-08-13"
+ },
+ "/es/symbol/luna-negra-lilith/": {
+  "hash": "7e4c5162240e86bf",
+  "lastmod": "2026-08-06"
+ },
+ "/es/symbol/media-luna-y-estrella/": {
+  "hash": "c2d22d82acdf469a",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/raya/": {
+  "hash": "33cb5159b0c15f55",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/senal-de-stop/": {
+  "hash": "02e3f9c2266a5e6a",
+  "lastmod": "2026-08-06"
+ },
+ "/es/symbol/signo-de-centavo/": {
+  "hash": "38ab452916ea9b9a",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/signo-de-dirham/": {
+  "hash": "7be25379abc18ad9",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/signo-de-division/": {
+  "hash": "5ebd9ea81995878b",
+  "lastmod": "2026-08-13"
+ },
+ "/es/symbol/signo-de-dolar/": {
+  "hash": "ebe8ae1450a6cb26",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/signo-de-euro/": {
+  "hash": "b5bae090de76f453",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/signo-de-libra/": {
+  "hash": "0f80c10a4dc14b24",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/signo-de-mas-menos/": {
+  "hash": "54f81721a10c4d57",
+  "lastmod": "2026-08-13"
+ },
+ "/es/symbol/signo-de-menor-o-igual-que/": {
+  "hash": "e8ceff5099b7595d",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/signo-de-micro/": {
+  "hash": "a9741e8dc2f43d04",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/signo-de-multiplicacion/": {
+  "hash": "e61a26e8328713cd",
+  "lastmod": "2026-08-13"
+ },
+ "/es/symbol/signo-de-peso/": {
+  "hash": "7099286558b57122",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/signo-de-rial-omani/": {
+  "hash": "219af44488843784",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/signo-de-rial-saudi/": {
+  "hash": "8065a8720d9e9dbd",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/signo-de-rublo/": {
+  "hash": "9830c2f0d3599450",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/signo-de-rufiyaa/": {
+  "hash": "4b3524ee8e040d8c",
+  "lastmod": "2026-08-05"
+ },
+ "/es/symbol/signo-de-rupia-india/": {
+  "hash": "45a03e382b48cb52",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/signo-de-seccion/": {
+  "hash": "2fdc7580419f81d9",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/signo-de-won/": {
+  "hash": "4ea86d5f2be42e65",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/signo-de-yen/": {
+  "hash": "2cf416eb62eb1eb0",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/signo-zodiacal-libra/": {
+  "hash": "0ce4d396a645c3b4",
+  "lastmod": "2026-08-06"
+ },
+ "/es/symbol/signos-de-menor-y-mayor/": {
+  "hash": "4bcfce0ce0ecdd1e",
+  "lastmod": "2026-08-13"
+ },
+ "/es/symbol/simbolo-alfa/": {
+  "hash": "6fbe91203b643e2b",
+  "lastmod": "2026-08-13"
+ },
+ "/es/symbol/simbolo-ampersand/": {
+  "hash": "b6755aba21f472cf",
+  "lastmod": "2026-08-13"
+ },
+ "/es/symbol/simbolo-ankh/": {
+  "hash": "db4e7bc278ed7f9c",
+  "lastmod": "2026-08-06"
+ },
+ "/es/symbol/simbolo-chi/": {
+  "hash": "1a7f8352fc51774b",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/simbolo-congruente/": {
+  "hash": "cd49bcb73d07229f",
+  "lastmod": "2026-08-06"
+ },
+ "/es/symbol/simbolo-de-acuario/": {
+  "hash": "ce322e0f923347ee",
+  "lastmod": "2026-08-06"
+ },
+ "/es/symbol/simbolo-de-anarquia/": {
+  "hash": "aa0aa89fbbd716e3",
+  "lastmod": "2026-08-06"
+ },
+ "/es/symbol/simbolo-de-aries/": {
+  "hash": "bcafc26a937668dc",
+  "lastmod": "2026-08-06"
+ },
+ "/es/symbol/simbolo-de-autismo/": {
+  "hash": "2a95a9b6a1778d69",
+  "lastmod": "2026-08-06"
+ },
+ "/es/symbol/simbolo-de-bitcoin/": {
+  "hash": "6f1692157b69a420",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/simbolo-de-cancer/": {
+  "hash": "79a6c8c52be59f5b",
+  "lastmod": "2026-08-06"
+ },
+ "/es/symbol/simbolo-de-capricornio/": {
+  "hash": "9556dd27f4f0f64f",
+  "lastmod": "2026-08-06"
+ },
+ "/es/symbol/simbolo-de-copyright/": {
+  "hash": "fb45e4b573963fc7",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/simbolo-de-corazon/": {
+  "hash": "27298338085c28fd",
+  "lastmod": "2026-08-06"
+ },
+ "/es/symbol/simbolo-de-diametro/": {
+  "hash": "2d48281c9bd1728b",
+  "lastmod": "2026-08-05"
+ },
+ "/es/symbol/simbolo-de-diferente/": {
+  "hash": "a27cf4902f321b55",
+  "lastmod": "2026-08-06"
+ },
+ "/es/symbol/simbolo-de-enojo/": {
+  "hash": "c1338d30757204d9",
+  "lastmod": "2026-08-13"
+ },
+ "/es/symbol/simbolo-de-escorpio/": {
+  "hash": "1524ddd2c519839f",
+  "lastmod": "2026-08-06"
+ },
+ "/es/symbol/simbolo-de-estrella/": {
+  "hash": "6553e0f288573eb0",
+  "lastmod": "2026-08-06"
+ },
+ "/es/symbol/simbolo-de-geminis/": {
+  "hash": "299bd3a3439fcd83",
+  "lastmod": "2026-08-06"
+ },
+ "/es/symbol/simbolo-de-grado/": {
+  "hash": "6b23ffd1acd2e77b",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/simbolo-de-grados-celsius/": {
+  "hash": "93bfa938a53b0d09",
+  "lastmod": "2026-08-13"
+ },
+ "/es/symbol/simbolo-de-grados-fahrenheit/": {
+  "hash": "56db317d2580049c",
+  "lastmod": "2026-08-13"
+ },
+ "/es/symbol/simbolo-de-infinito/": {
+  "hash": "642a60cb636ebe58",
+  "lastmod": "2026-08-13"
+ },
+ "/es/symbol/simbolo-de-la-cruz/": {
+  "hash": "0317051efa395d7d",
+  "lastmod": "2026-08-06"
+ },
+ "/es/symbol/simbolo-de-la-flor-de-lis/": {
+  "hash": "642b3d7e37c5edf0",
+  "lastmod": "2026-08-06"
+ },
+ "/es/symbol/simbolo-de-la-paz/": {
+  "hash": "1000aad0e3847475",
+  "lastmod": "2026-08-13"
+ },
+ "/es/symbol/simbolo-de-leo/": {
+  "hash": "534f93869c0dca22",
+  "lastmod": "2026-08-06"
+ },
+ "/es/symbol/simbolo-de-marca-comercial/": {
+  "hash": "fd5a1b4ad4d2a9f6",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/simbolo-de-ohmio/": {
+  "hash": "547c36d599e8274a",
+  "lastmod": "2026-08-13"
+ },
+ "/es/symbol/simbolo-de-peligro-biologico/": {
+  "hash": "6894e9826fbe7c07",
+  "lastmod": "2026-08-06"
+ },
+ "/es/symbol/simbolo-de-peon/": {
+  "hash": "e8065f34fe4186ec",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/simbolo-de-picas/": {
+  "hash": "f186d37524f75d81",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/simbolo-de-piscis/": {
+  "hash": "3854b3d04cf9a8b5",
+  "lastmod": "2026-08-06"
+ },
+ "/es/symbol/simbolo-de-raiz-cuadrada/": {
+  "hash": "07ed784d0a71764c",
+  "lastmod": "2026-08-13"
+ },
+ "/es/symbol/simbolo-de-reciclaje/": {
+  "hash": "1fb991665a8beb86",
+  "lastmod": "2026-08-06"
+ },
+ "/es/symbol/simbolo-de-sagitario/": {
+  "hash": "2d37ab9d55915f06",
+  "lastmod": "2026-08-06"
+ },
+ "/es/symbol/simbolo-de-silla-de-ruedas/": {
+  "hash": "cf89d26c64da9690",
+  "lastmod": "2026-08-06"
+ },
+ "/es/symbol/simbolo-de-tauro/": {
+  "hash": "0e29e5bf752bfdf5",
+  "lastmod": "2026-08-06"
+ },
+ "/es/symbol/simbolo-de-verificacion/": {
+  "hash": "c40649cc8fc8b207",
+  "lastmod": "2026-08-11"
+ },
+ "/es/symbol/simbolo-de-virgo/": {
+  "hash": "01a20a417f29a075",
+  "lastmod": "2026-08-06"
+ },
+ "/es/symbol/simbolo-del-pentagrama/": {
+  "hash": "79e1118349c709f7",
+  "lastmod": "2026-08-06"
+ },
+ "/es/symbol/simbolo-delta/": {
+  "hash": "155848c64c93b33f",
+  "lastmod": "2026-08-06"
+ },
+ "/es/symbol/simbolo-hamsa/": {
+  "hash": "1d1b21cb936a9c47",
+  "lastmod": "2026-08-06"
+ },
+ "/es/symbol/simbolo-khanda/": {
+  "hash": "8b0c3490d0fd6be4",
+  "lastmod": "2026-08-06"
+ },
+ "/es/symbol/simbolo-lambda/": {
+  "hash": "76712c8afd6d24ad",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/simbolo-om/": {
+  "hash": "fc7dc1d357e80703",
+  "lastmod": "2026-08-06"
+ },
+ "/es/symbol/simbolo-omega/": {
+  "hash": "d33ccf19d1dc35a9",
+  "lastmod": "2026-08-13"
+ },
+ "/es/symbol/simbolo-phi/": {
+  "hash": "e6b2f3ffa96331e7",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/simbolo-pi/": {
+  "hash": "8709555a14e22532",
+  "lastmod": "2026-08-06"
+ },
+ "/es/symbol/simbolo-psi/": {
+  "hash": "2fd2b561b1a16b81",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/simbolo-sigma/": {
+  "hash": "94d0c31637ad3dcf",
+  "lastmod": "2026-08-06"
+ },
+ "/es/symbol/simbolo-theta/": {
+  "hash": "edfefa240ab96f07",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/virgulilla/": {
+  "hash": "16c2bad5d3c73000",
+  "lastmod": "2026-08-15"
+ },
+ "/es/symbol/yin-yang/": {
+  "hash": "6637eedcdcf64ff0",
+  "lastmod": "2026-08-13"
+ },
+ "/es/texto-al-reves/": {
+  "hash": "810b095e6d288074",
+  "lastmod": "2026-08-15"
+ },
+ "/es/texto-invisible/": {
+  "hash": "efbda35c80a2427b",
+  "lastmod": "2026-08-15"
+ },
+ "/es/texto-pequeno/": {
+  "hash": "3347c53787a701d3",
+  "lastmod": "2026-08-15"
+ },
+ "/es/texto-subrayado/": {
+  "hash": "e0684f3e59e53f0e",
+  "lastmod": "2026-08-15"
+ },
+ "/es/updates/simbolo-dirham-emiratos-unicode-18/": {
+  "hash": "1d254af2c47cd82e",
+  "lastmod": "2026-08-15"
+ },
+ "/es/updates/simbolos-moneda-oriente-medio-unicode-18/": {
+  "hash": "288c93ef12c7e9f4",
+  "lastmod": "2026-08-15"
+ },
+ "/es/updates/unicode-18-beta-comienza-revision/": {
+  "hash": "b00b9c8399d0fe1c",
+  "lastmod": "2026-08-15"
+ },
+ "/es/updates/unicode-18-fecha-lanzamiento-confirmada/": {
+  "hash": "f9daeae8768b8108",
+  "lastmod": "2026-08-15"
+ },
+ "/es/updates/unicode-18-nuevos-emojis-votacion/": {
+  "hash": "1ea958c94442e951",
+  "lastmod": "2026-08-15"
+ },
+ "/es/usecase/": {
+  "hash": "f1149e52a3683e0f",
+  "lastmod": "2026-08-15"
+ },
+ "/es/usecase/letras-para-bio/": {
+  "hash": "ea59bbe179716603",
+  "lastmod": "2026-08-15"
+ },
+ "/es/usecase/letras-para-tatuajes/": {
+  "hash": "64ca588cd6d60f09",
+  "lastmod": "2026-08-15"
+ },
+ "/es/usecase/nombre-de-usuario/": {
+  "hash": "9b89f88aca96a258",
+  "lastmod": "2026-08-15"
+ },
+ "/es/usecase/nombres-aesthetic/": {
+  "hash": "97efa92f3f769312",
+  "lastmod": "2026-08-15"
+ },
+ "/es/usecase/nombres-de-contacto-aesthetic/": {
+  "hash": "d2dc45d946dc5e38",
+  "lastmod": "2026-08-15"
+ },
+ "/es/usecase/nombres-para-free-fire/": {
+  "hash": "9732a10e2db18361",
+  "lastmod": "2026-08-15"
+ },
+ "/es/usecase/nombres-para-grupos/": {
+  "hash": "b62f633936c17d8c",
+  "lastmod": "2026-08-15"
+ },
+ "/es/usecase/nombres-para-mobile-legends/": {
+  "hash": "f10515d5a84ed496",
+  "lastmod": "2026-08-15"
+ },
+ "/es/usecase/nombres-para-roblox/": {
+  "hash": "b529dc6b5d5b99f9",
+  "lastmod": "2026-08-15"
+ },
+ "/es/usecase/nombres-para-stumble-guys/": {
+  "hash": "d1b0f95f52fd2d89",
+  "lastmod": "2026-08-15"
+ },
+ "/es/usecase/tag-de-clan-free-fire/": {
+  "hash": "bd6abedbf0bae498",
+  "lastmod": "2026-08-15"
+ },
+ "/es/usecase/traductor-de-emojis/": {
+  "hash": "7877501eecae2391",
+  "lastmod": "2026-08-15"
+ },
+ "/es/usecase/vertical-text/": {
+  "hash": "a740cc01575b7b02",
+  "lastmod": "2026-08-15"
+ },
+ "/es/usecase/zalgo-text/": {
+  "hash": "d842d12c6c6bf233",
+  "lastmod": "2026-08-15"
+ },
+ "/events/": {
+  "hash": "90e7f308d7f85ed6",
+  "lastmod": "2026-08-13"
+ },
+ "/events/chinese-new-year/": {
+  "hash": "ed14b03f7581ef96",
+  "lastmod": "2026-07-31"
+ },
+ "/events/christmas/": {
+  "hash": "ed2b8398c43d7f8d",
+  "lastmod": "2026-07-31"
+ },
+ "/events/diwali/": {
+  "hash": "1b654f088ab05e6f",
+  "lastmod": "2026-07-31"
+ },
+ "/events/easter/": {
+  "hash": "8e47ce99d9cda75b",
+  "lastmod": "2026-07-31"
+ },
+ "/events/eid-mubarak/": {
+  "hash": "98d8370dffc062f9",
+  "lastmod": "2026-07-31"
+ },
+ "/events/fathers-day/": {
+  "hash": "f72780022b0dbe32",
+  "lastmod": "2026-07-31"
+ },
+ "/events/graduation/": {
+  "hash": "e3a8c1d183e0daf7",
+  "lastmod": "2026-07-31"
+ },
+ "/events/halloween/": {
+  "hash": "cab34c78bc7657fa",
+  "lastmod": "2026-07-31"
+ },
+ "/events/july-4th/": {
+  "hash": "01394cd0cba59b2b",
+  "lastmod": "2026-07-31"
+ },
+ "/events/mothers-day/": {
+  "hash": "527ab027d00fa2fa",
+  "lastmod": "2026-07-31"
+ },
+ "/events/new-year/": {
+  "hash": "f3e008a62d77aeef",
+  "lastmod": "2026-07-31"
+ },
+ "/events/ramadan/": {
+  "hash": "11290411b852a4b3",
+  "lastmod": "2026-07-31"
+ },
+ "/events/st-patricks-day/": {
+  "hash": "b8d01a7700314acd",
+  "lastmod": "2026-07-31"
+ },
+ "/events/teacher-appreciation/": {
+  "hash": "6b0e09b0bf726649",
+  "lastmod": "2026-08-13"
+ },
+ "/events/thanksgiving/": {
+  "hash": "6a169bccc673ee9a",
+  "lastmod": "2026-07-31"
+ },
+ "/events/valentines-day/": {
+  "hash": "fe3b6fb53052ec5a",
+  "lastmod": "2026-08-01"
+ },
+ "/facebook/": {
+  "hash": "36e5f794a078422d",
+  "lastmod": "2026-07-26"
+ },
+ "/fancy-letters/": {
+  "hash": "31a6d32f30d9446b",
+  "lastmod": "2026-08-11"
+ },
+ "/fi/": {
+  "hash": "b8fa00459180ee43",
+  "lastmod": "2026-08-15"
+ },
+ "/fi/discord-fontit/": {
+  "hash": "4ed7c2701abcea46",
+  "lastmod": "2026-08-15"
+ },
+ "/fi/goottilaiset-kirjaimet/": {
+  "hash": "217b081047d0bc41",
+  "lastmod": "2026-08-15"
+ },
+ "/fi/guide/": {
+  "hash": "50974d7fd11b7d55",
+  "lastmod": "2026-08-11"
+ },
+ "/fi/guide/discord-tekstin-muotoilu-selitetty/": {
+  "hash": "c03020f93ecb7027",
+  "lastmod": "2026-07-26"
+ },
+ "/fi/guide/missa-discord-fontit-toimivat/": {
+  "hash": "725bd1445ca142ce",
+  "lastmod": "2026-07-26"
+ },
+ "/fi/guide/turvallinen-discord-nimimerkki/": {
+  "hash": "8c357a1ac83f4b51",
+  "lastmod": "2026-07-26"
+ },
+ "/fi/instagram-fontit/": {
+  "hash": "c51299796caca021",
+  "lastmod": "2026-08-15"
+ },
+ "/fi/kaunokirjoitus/": {
+  "hash": "f676af5cc6c1206a",
+  "lastmod": "2026-08-16"
+ },
+ "/fi/kursivoitu-teksti/": {
+  "hash": "4ba5176b5fbaed0b",
+  "lastmod": "2026-08-15"
+ },
+ "/fi/library/horoskooppimerkit/": {
+  "hash": "204678cb0b0a6a5b",
+  "lastmod": "2026-08-15"
+ },
+ "/fi/lihavoitu-teksti/": {
+  "hash": "b9bb959a00310eab",
+  "lastmod": "2026-08-16"
+ },
+ "/fi/merkkilaskuri/": {
+  "hash": "a62b88127c0d1e9f",
+  "lastmod": "2026-08-15"
+ },
+ "/fi/pieni-teksti/": {
+  "hash": "cfdbcbd947964d6f",
+  "lastmod": "2026-08-15"
+ },
+ "/fi/symbol/asteen-merkki/": {
+  "hash": "e50a3626b53d340a",
+  "lastmod": "2026-08-13"
+ },
+ "/fi/symbol/euron-merkki/": {
+  "hash": "f169d078a84b23c1",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/": {
+  "hash": "2b70ce55e3ec0f65",
+  "lastmod": "2026-08-11"
+ },
+ "/fr/answers/": {
+  "hash": "ff943ba3cb3325fe",
+  "lastmod": "2026-08-07"
+ },
+ "/fr/answers/comment-faire-un-pseudo-vide/": {
+  "hash": "647f110b6222f56e",
+  "lastmod": "2026-08-07"
+ },
+ "/fr/answers/nom-utilisateur-ou-nom-affiche/": {
+  "hash": "7a1891c004563a23",
+  "lastmod": "2026-08-07"
+ },
+ "/fr/answers/what-font-does-pinterest-use/": {
+  "hash": "422639d948ee4670",
+  "lastmod": "2026-08-16"
+ },
+ "/fr/answers/what-font-does-whatsapp-use/": {
+  "hash": "6f7085de51e0a831",
+  "lastmod": "2026-08-16"
+ },
+ "/fr/belle-ecriture/": {
+  "hash": "6dba1c75f9acb745",
+  "lastmod": "2026-08-07"
+ },
+ "/fr/calligraphie/": {
+  "hash": "a54a8ed4a09a76d5",
+  "lastmod": "2026-08-11"
+ },
+ "/fr/category/": {
+  "hash": "9675b460859a85b4",
+  "lastmod": "2026-08-15"
+ },
+ "/fr/changeur-de-police/": {
+  "hash": "50de24e606e421c6",
+  "lastmod": "2026-08-07"
+ },
+ "/fr/compteur-de-mots-et-de-caracteres/": {
+  "hash": "e382872a150d15a0",
+  "lastmod": "2026-08-15"
+ },
+ "/fr/ecriture-aesthetic/": {
+  "hash": "f28c03f734bc436c",
+  "lastmod": "2026-08-11"
+ },
+ "/fr/ecriture-cursive/": {
+  "hash": "489ad3bc0222acb4",
+  "lastmod": "2026-08-15"
+ },
+ "/fr/ecriture-facebook/": {
+  "hash": "a28b4869ad10dfb8",
+  "lastmod": "2026-08-07"
+ },
+ "/fr/ecriture-gothique/": {
+  "hash": "8893e93ccb6e3f6d",
+  "lastmod": "2026-08-11"
+ },
+ "/fr/ecriture-italique/": {
+  "hash": "1e39b71c828e3cf5",
+  "lastmod": "2026-08-07"
+ },
+ "/fr/ecriture-speciale/": {
+  "hash": "509c8d7323032033",
+  "lastmod": "2026-08-11"
+ },
+ "/fr/guide/": {
+  "hash": "5ca5043a072f2330",
+  "lastmod": "2026-08-11"
+ },
+ "/fr/guide/formatage-texte-discord-explique/": {
+  "hash": "dd1464cb24ebdb4c",
+  "lastmod": "2026-07-26"
+ },
+ "/fr/guide/ou-fonctionnent-les-polices-discord/": {
+  "hash": "3fffcf0dc4d121b2",
+  "lastmod": "2026-07-26"
+ },
+ "/fr/guide/pseudo-discord-sans-risque/": {
+  "hash": "c88f74b2d5d2e0b8",
+  "lastmod": "2026-07-26"
+ },
+ "/fr/imprimables/": {
+  "hash": "5815ab838c9fd7e5",
+  "lastmod": "2026-08-12"
+ },
+ "/fr/imprimables/alphabet-cursif/": {
+  "hash": "d756ce8d220b43f0",
+  "lastmod": "2026-08-12"
+ },
+ "/fr/imprimables/alphabet-espagnol/": {
+  "hash": "0114803ee497dd7e",
+  "lastmod": "2026-08-12"
+ },
+ "/fr/imprimables/coloriage-alphabet/": {
+  "hash": "6d5d367c993d9864",
+  "lastmod": "2026-08-12"
+ },
+ "/fr/imprimables/lettres-bulles/": {
+  "hash": "1df6ba4f04cdb10e",
+  "lastmod": "2026-08-12"
+ },
+ "/fr/imprimables/prenom-a-tracer/": {
+  "hash": "9f3c58fdb0222630",
+  "lastmod": "2026-07-25"
+ },
+ "/fr/library/": {
+  "hash": "ba75a56e49fa8a6b",
+  "lastmod": "2026-08-10"
+ },
+ "/fr/library/alphabet-grec/": {
+  "hash": "e6e56c457ce65920",
+  "lastmod": "2026-08-15"
+ },
+ "/fr/library/caracteres-speciaux/": {
+  "hash": "848be13736ba22b2",
+  "lastmod": "2026-08-07"
+ },
+ "/fr/library/cat-kaomoji/": {
+  "hash": "700cd9e770f31234",
+  "lastmod": "2026-08-10"
+ },
+ "/fr/library/codes-alt/": {
+  "hash": "ea491cd5b78dc6e1",
+  "lastmod": "2026-08-16"
+ },
+ "/fr/library/cute-kaomoji/": {
+  "hash": "bf12eb435b47740b",
+  "lastmod": "2026-08-10"
+ },
+ "/fr/library/emoji-clin-doeil/": {
+  "hash": "02f54afbcf12e63b",
+  "lastmod": "2026-08-16"
+ },
+ "/fr/library/emoji-colere/": {
+  "hash": "b74ac81294100ff7",
+  "lastmod": "2026-08-16"
+ },
+ "/fr/library/emoji-combos/": {
+  "hash": "97d4b9382af89f55",
+  "lastmod": "2026-08-07"
+ },
+ "/fr/library/emoji-couronne/": {
+  "hash": "876d33d94052d869",
+  "lastmod": "2026-08-16"
+ },
+ "/fr/library/emoji-drapeaux/": {
+  "hash": "06810550f6fb4bbf",
+  "lastmod": "2026-08-15"
+ },
+ "/fr/library/emoji-feu/": {
+  "hash": "927f50d1c369fb0a",
+  "lastmod": "2026-08-16"
+ },
+ "/fr/library/emoji-heureux/": {
+  "hash": "022885ca853ce5df",
+  "lastmod": "2026-08-16"
+ },
+ "/fr/library/emoji-iphone/": {
+  "hash": "9944b211d04b1d18",
+  "lastmod": "2026-08-15"
+ },
+ "/fr/library/emoji-tete-de-mort/": {
+  "hash": "4e0ac79b69b0c69a",
+  "lastmod": "2026-08-16"
+ },
+ "/fr/library/emoji-triste/": {
+  "hash": "14a5cbe0bc0b9cf6",
+  "lastmod": "2026-08-16"
+ },
+ "/fr/library/emojis-animaux/": {
+  "hash": "e6f256607b772670",
+  "lastmod": "2026-08-15"
+ },
+ "/fr/library/emojis-argent/": {
+  "hash": "94452b40a33a16b3",
+  "lastmod": "2026-08-16"
+ },
+ "/fr/library/emojis-sport/": {
+  "hash": "b59968131a10aba4",
+  "lastmod": "2026-08-15"
+ },
+ "/fr/library/emojis-visages/": {
+  "hash": "bc9b2a069c3df6bc",
+  "lastmod": "2026-08-15"
+ },
+ "/fr/library/hieroglyphes-egyptiens/": {
+  "hash": "bb0caf3631a982d4",
+  "lastmod": "2026-08-15"
+ },
+ "/fr/library/kaomoji/": {
+  "hash": "ce61d2c1bc5b2999",
+  "lastmod": "2026-08-02"
+ },
+ "/fr/library/love-kaomoji/": {
+  "hash": "e097a6e2c31d888b",
+  "lastmod": "2026-08-10"
+ },
+ "/fr/library/symbole-coche/": {
+  "hash": "0477ad00cd9a4fbd",
+  "lastmod": "2026-08-15"
+ },
+ "/fr/library/symbole-couronne/": {
+  "hash": "ec06e2e73ef6deb6",
+  "lastmod": "2026-08-15"
+ },
+ "/fr/library/symboles-astrologiques/": {
+  "hash": "9ae1111cf1c19b9d",
+  "lastmod": "2026-08-15"
+ },
+ "/fr/library/symboles-clavier/": {
+  "hash": "1744ceb345e7bd11",
+  "lastmod": "2026-08-15"
+ },
+ "/fr/library/symboles-coeur/": {
+  "hash": "f6af8a488d051e4c",
+  "lastmod": "2026-08-15"
+ },
+ "/fr/library/symboles-coquette/": {
+  "hash": "a5803d013e96ede4",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/library/symboles-cottagecore/": {
+  "hash": "f8a1980b13156099",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/library/symboles-croix/": {
+  "hash": "62271c2075d6718c",
+  "lastmod": "2026-08-15"
+ },
+ "/fr/library/symboles-discord/": {
+  "hash": "a9d7e6083f642f66",
+  "lastmod": "2026-08-14"
+ },
+ "/fr/library/symboles-dreamcore-weirdcore/": {
+  "hash": "0f8a4f342cf6c13e",
+  "lastmod": "2026-08-11"
+ },
+ "/fr/library/symboles-echecs/": {
+  "hash": "de05970f07d3dbff",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/library/symboles-etoiles/": {
+  "hash": "ed0cf3e81b8265c9",
+  "lastmod": "2026-08-15"
+ },
+ "/fr/library/symboles-facebook/": {
+  "hash": "4cf1f83fd7182410",
+  "lastmod": "2026-08-15"
+ },
+ "/fr/library/symboles-fairycore/": {
+  "hash": "47174520aec7e7c0",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/library/symboles-fleches/": {
+  "hash": "1bf0426aa4bcb576",
+  "lastmod": "2026-08-15"
+ },
+ "/fr/library/symboles-fleurs/": {
+  "hash": "d37cbc74fc7647df",
+  "lastmod": "2026-08-15"
+ },
+ "/fr/library/symboles-fortnite/": {
+  "hash": "54e6aeb94be81aa0",
+  "lastmod": "2026-08-07"
+ },
+ "/fr/library/symboles-goth-grunge/": {
+  "hash": "8aa7e05fc003178c",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/library/symboles-islamiques/": {
+  "hash": "22f9d2d4b2ace184",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/library/symboles-kawaii-cute/": {
+  "hash": "74bfaffd6b883cd8",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/library/symboles-linkedin/": {
+  "hash": "adf32709b431c05b",
+  "lastmod": "2026-08-15"
+ },
+ "/fr/library/symboles-mathematiques/": {
+  "hash": "b032c9f89fc699dd",
+  "lastmod": "2026-08-15"
+ },
+ "/fr/library/symboles-monetaires/": {
+  "hash": "9461ab76705810c1",
+  "lastmod": "2026-08-07"
+ },
+ "/fr/library/symboles-musicaux/": {
+  "hash": "d6bb5f1eedc64631",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/library/symboles-puces/": {
+  "hash": "51cef54a3a1183cb",
+  "lastmod": "2026-08-15"
+ },
+ "/fr/library/symboles-religieux/": {
+  "hash": "0865f08dd6ea97f7",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/library/symboles-roblox/": {
+  "hash": "a086dd48c0eab7c5",
+  "lastmod": "2026-08-14"
+ },
+ "/fr/library/symboles-therian/": {
+  "hash": "a654c33ce7eda803",
+  "lastmod": "2026-08-05"
+ },
+ "/fr/library/symboles-witchy-occult/": {
+  "hash": "bceb7f7271fe829f",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/library/symboles-y2k/": {
+  "hash": "61048f5f29c2a816",
+  "lastmod": "2026-08-14"
+ },
+ "/fr/library/symboles/": {
+  "hash": "a83e650297d483f0",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/library/table-ascii/": {
+  "hash": "4e4d2c68bc156ca4",
+  "lastmod": "2026-08-15"
+ },
+ "/fr/library/text-art/": {
+  "hash": "ac6c36101ca6f416",
+  "lastmod": "2026-08-15"
+ },
+ "/fr/majuscules-et-minuscules/": {
+  "hash": "cf1677fe5a7fc65e",
+  "lastmod": "2026-08-15"
+ },
+ "/fr/petite-ecriture/": {
+  "hash": "e24141ebe7ef3184",
+  "lastmod": "2026-08-07"
+ },
+ "/fr/police-d-ecriture/": {
+  "hash": "11d0a1e022fcfe6c",
+  "lastmod": "2026-08-07"
+ },
+ "/fr/police-discord/": {
+  "hash": "a6b0632538f45b37",
+  "lastmod": "2026-08-05"
+ },
+ "/fr/police-instagram/": {
+  "hash": "d93926726a0eef23",
+  "lastmod": "2026-08-07"
+ },
+ "/fr/police-linkedin/": {
+  "hash": "b92f02be33acfecb",
+  "lastmod": "2026-08-07"
+ },
+ "/fr/police-snapchat/": {
+  "hash": "555a20fd28af253f",
+  "lastmod": "2026-08-11"
+ },
+ "/fr/police-tiktok/": {
+  "hash": "b61a9d2c98a73b59",
+  "lastmod": "2026-07-25"
+ },
+ "/fr/pseudo-style/": {
+  "hash": "909eccac5d4118a9",
+  "lastmod": "2026-08-05"
+ },
+ "/fr/symbol/": {
+  "hash": "5c9ac1f57b91dcd0",
+  "lastmod": "2026-08-16"
+ },
+ "/fr/symbol/barre-verticale/": {
+  "hash": "aa723fe858510f85",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/symbol/caractere-invisible/": {
+  "hash": "3fb7767740789711",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/symbol/couleurs-des-coeurs-snapchat/": {
+  "hash": "fe23f80e8934f3a9",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/symbol/croissant-et-etoile/": {
+  "hash": "2b2564cccd1b4764",
+  "lastmod": "2026-08-16"
+ },
+ "/fr/symbol/croix-orthodoxe/": {
+  "hash": "4cf71ae386f88910",
+  "lastmod": "2026-08-06"
+ },
+ "/fr/symbol/emoji-calendrier/": {
+  "hash": "978eb389cd150cc8",
+  "lastmod": "2026-08-05"
+ },
+ "/fr/symbol/emoji-cornichon/": {
+  "hash": "839cf0993ac8d8d9",
+  "lastmod": "2026-08-05"
+ },
+ "/fr/symbol/emoji-lunettes-de-soleil/": {
+  "hash": "d60063f2d9be8d30",
+  "lastmod": "2026-08-05"
+ },
+ "/fr/symbol/emoji-meteore/": {
+  "hash": "5c809ed055e7bf0b",
+  "lastmod": "2026-08-05"
+ },
+ "/fr/symbol/emoji-microphone/": {
+  "hash": "5932a6c2114cdc75",
+  "lastmod": "2026-08-16"
+ },
+ "/fr/symbol/emoji-papillon-monarque/": {
+  "hash": "db95e2a424da59d1",
+  "lastmod": "2026-08-05"
+ },
+ "/fr/symbol/emoji-signe-du-pouce/": {
+  "hash": "4e9d308e36603a08",
+  "lastmod": "2026-08-05"
+ },
+ "/fr/symbol/emoji-visage-distordu/": {
+  "hash": "7b17bb76122f3e34",
+  "lastmod": "2026-08-05"
+ },
+ "/fr/symbol/emoji-visage-fissure/": {
+  "hash": "31afb7ca0509349e",
+  "lastmod": "2026-08-05"
+ },
+ "/fr/symbol/emoji-visage-qui-fond/": {
+  "hash": "2d8fba10de274e23",
+  "lastmod": "2026-08-05"
+ },
+ "/fr/symbol/etoile-de-david/": {
+  "hash": "9ba7520bb47598b8",
+  "lastmod": "2026-08-06"
+ },
+ "/fr/symbol/point-interrogation-inverse/": {
+  "hash": "6d07ed5763c2d397",
+  "lastmod": "2026-08-06"
+ },
+ "/fr/symbol/symbole-alpha/": {
+  "hash": "5ce4136c16e5d75f",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/symbol/symbole-anarchie/": {
+  "hash": "5f64a1a91183141e",
+  "lastmod": "2026-08-06"
+ },
+ "/fr/symbol/symbole-ankh/": {
+  "hash": "55ffd37148e0fbb9",
+  "lastmod": "2026-08-06"
+ },
+ "/fr/symbol/symbole-arobase/": {
+  "hash": "73bf8ac0f4580ff9",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/symbol/symbole-asterisque/": {
+  "hash": "a793c799bd66ca8e",
+  "lastmod": "2026-08-16"
+ },
+ "/fr/symbol/symbole-autisme/": {
+  "hash": "6a9781eef3ebfca6",
+  "lastmod": "2026-08-06"
+ },
+ "/fr/symbol/symbole-balance/": {
+  "hash": "cbec11caac49dd97",
+  "lastmod": "2026-08-06"
+ },
+ "/fr/symbol/symbole-belier/": {
+  "hash": "bd1e7f106b45fa67",
+  "lastmod": "2026-08-06"
+ },
+ "/fr/symbol/symbole-bitcoin/": {
+  "hash": "b5c45d8bef942041",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/symbol/symbole-cancer/": {
+  "hash": "2d8169c670d2ec14",
+  "lastmod": "2026-08-06"
+ },
+ "/fr/symbol/symbole-capricorne/": {
+  "hash": "e3e87ba0712ebd32",
+  "lastmod": "2026-08-06"
+ },
+ "/fr/symbol/symbole-carre-cube/": {
+  "hash": "4c946f92212f8ec1",
+  "lastmod": "2026-07-25"
+ },
+ "/fr/symbol/symbole-celsius/": {
+  "hash": "43e722806bf4a90d",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/symbol/symbole-cent/": {
+  "hash": "aef6c8e36bf48076",
+  "lastmod": "2026-08-05"
+ },
+ "/fr/symbol/symbole-chi/": {
+  "hash": "25891c7a79b499ae",
+  "lastmod": "2026-08-16"
+ },
+ "/fr/symbol/symbole-coche/": {
+  "hash": "a388df53875885f6",
+  "lastmod": "2026-08-11"
+ },
+ "/fr/symbol/symbole-coeur/": {
+  "hash": "80ae1471460121f3",
+  "lastmod": "2026-08-06"
+ },
+ "/fr/symbol/symbole-colere/": {
+  "hash": "39d3ca2df297d3dc",
+  "lastmod": "2026-08-06"
+ },
+ "/fr/symbol/symbole-congruent/": {
+  "hash": "0a57ff0ae0aef150",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/symbol/symbole-copyright/": {
+  "hash": "98c1745bfd94160a",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/symbol/symbole-croix/": {
+  "hash": "5208ce7b188c67df",
+  "lastmod": "2026-08-06"
+ },
+ "/fr/symbol/symbole-danger-biologique/": {
+  "hash": "4a97801f14b53c6a",
+  "lastmod": "2026-08-06"
+ },
+ "/fr/symbol/symbole-degre/": {
+  "hash": "ba02050951c536a4",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/symbol/symbole-delta/": {
+  "hash": "16a247957f07bd84",
+  "lastmod": "2026-08-06"
+ },
+ "/fr/symbol/symbole-diametre/": {
+  "hash": "13ee7dabe81938d8",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/symbol/symbole-different/": {
+  "hash": "0107772f5275cf43",
+  "lastmod": "2026-08-06"
+ },
+ "/fr/symbol/symbole-dirham/": {
+  "hash": "6891e53c1bd54458",
+  "lastmod": "2026-08-06"
+ },
+ "/fr/symbol/symbole-division/": {
+  "hash": "b7d8e79c1a74207a",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/symbol/symbole-dollar/": {
+  "hash": "d4de39e5e334ff6e",
+  "lastmod": "2026-08-06"
+ },
+ "/fr/symbol/symbole-esperluette/": {
+  "hash": "11c9c02bd7b50f01",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/symbol/symbole-etoile/": {
+  "hash": "498fc889ebb281f7",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/symbol/symbole-euro/": {
+  "hash": "a1bdc7c65ab4b9fb",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/symbol/symbole-fahrenheit/": {
+  "hash": "f55923ac650dafc0",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/symbol/symbole-fleche-bas/": {
+  "hash": "bf99fcb0e3dfdaa5",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/symbol/symbole-fleche-droite/": {
+  "hash": "1abab8b88a8704e6",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/symbol/symbole-fleche-gauche/": {
+  "hash": "0d87912a9938f370",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/symbol/symbole-fleche-haut/": {
+  "hash": "2e1ce04dc7cc67f6",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/symbol/symbole-fleur-de-lys/": {
+  "hash": "f889e415efe4fe71",
+  "lastmod": "2026-08-06"
+ },
+ "/fr/symbol/symbole-gemeaux/": {
+  "hash": "4073bfad1a865746",
+  "lastmod": "2026-08-06"
+ },
+ "/fr/symbol/symbole-guillemet/": {
+  "hash": "688b73fb37fe72b1",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/symbol/symbole-hamsa/": {
+  "hash": "e90087e4fdc863a7",
+  "lastmod": "2026-08-06"
+ },
+ "/fr/symbol/symbole-handicap/": {
+  "hash": "8e1562b9ea2dd35d",
+  "lastmod": "2026-08-06"
+ },
+ "/fr/symbol/symbole-inferieur-ou-egal/": {
+  "hash": "8b161f5f1cf23c82",
+  "lastmod": "2026-08-16"
+ },
+ "/fr/symbol/symbole-inferieur-superieur/": {
+  "hash": "59a0a65b3aa15190",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/symbol/symbole-infini/": {
+  "hash": "516f773e97ef812e",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/symbol/symbole-interrobang/": {
+  "hash": "1c88c28ab28d620f",
+  "lastmod": "2026-08-05"
+ },
+ "/fr/symbol/symbole-khanda/": {
+  "hash": "0485a9a04d49c31f",
+  "lastmod": "2026-08-06"
+ },
+ "/fr/symbol/symbole-lambda/": {
+  "hash": "0b9c64f97d2e01a9",
+  "lastmod": "2026-08-16"
+ },
+ "/fr/symbol/symbole-lilith/": {
+  "hash": "45b155fa395ea514",
+  "lastmod": "2026-08-06"
+ },
+ "/fr/symbol/symbole-lion/": {
+  "hash": "476c504b74ea98b3",
+  "lastmod": "2026-08-06"
+ },
+ "/fr/symbol/symbole-livre-sterling/": {
+  "hash": "00eaa3559dc3a04e",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/symbol/symbole-marque-deposee/": {
+  "hash": "26a9f246251cf456",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/symbol/symbole-micro/": {
+  "hash": "96063816dcea69ab",
+  "lastmod": "2026-08-06"
+ },
+ "/fr/symbol/symbole-multiplication/": {
+  "hash": "aae0b553b7e4f758",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/symbol/symbole-ohm/": {
+  "hash": "3c74c42d935a1596",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/symbol/symbole-om/": {
+  "hash": "3a8ea71d3a3892cd",
+  "lastmod": "2026-08-06"
+ },
+ "/fr/symbol/symbole-omega/": {
+  "hash": "140bda0f17f75038",
+  "lastmod": "2026-08-06"
+ },
+ "/fr/symbol/symbole-paix/": {
+  "hash": "a17ce8011209de13",
+  "lastmod": "2026-08-15"
+ },
+ "/fr/symbol/symbole-paragraphe/": {
+  "hash": "86c274b1c2d2713a",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/symbol/symbole-pentagramme/": {
+  "hash": "8448513b03e072a0",
+  "lastmod": "2026-08-06"
+ },
+ "/fr/symbol/symbole-peso/": {
+  "hash": "e2438a60bdbcae08",
+  "lastmod": "2026-08-16"
+ },
+ "/fr/symbol/symbole-phi/": {
+  "hash": "05997239ad4f902e",
+  "lastmod": "2026-08-16"
+ },
+ "/fr/symbol/symbole-pi/": {
+  "hash": "9617b673467920ea",
+  "lastmod": "2026-08-06"
+ },
+ "/fr/symbol/symbole-pied-de-mouche/": {
+  "hash": "5207fbbe9546c1e1",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/symbol/symbole-pion/": {
+  "hash": "b55ecc0267446bd2",
+  "lastmod": "2026-08-16"
+ },
+ "/fr/symbol/symbole-pique/": {
+  "hash": "adcb7bf6048c0721",
+  "lastmod": "2026-08-05"
+ },
+ "/fr/symbol/symbole-plus-ou-moins/": {
+  "hash": "d8c2268d0ce7ff57",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/symbol/symbole-poissons/": {
+  "hash": "9f27d7576393acc7",
+  "lastmod": "2026-08-06"
+ },
+ "/fr/symbol/symbole-psi/": {
+  "hash": "ef9ac883591cc4ea",
+  "lastmod": "2026-08-16"
+ },
+ "/fr/symbol/symbole-racine-carree/": {
+  "hash": "ee076fbd018a04aa",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/symbol/symbole-recyclage/": {
+  "hash": "446da60ab31a2333",
+  "lastmod": "2026-08-06"
+ },
+ "/fr/symbol/symbole-rial-omanais/": {
+  "hash": "ab6ce59388e5c85a",
+  "lastmod": "2026-08-06"
+ },
+ "/fr/symbol/symbole-riyal-saoudien/": {
+  "hash": "e7b419f599fd5f60",
+  "lastmod": "2026-08-06"
+ },
+ "/fr/symbol/symbole-rouble/": {
+  "hash": "f44b884ec15b0587",
+  "lastmod": "2026-08-16"
+ },
+ "/fr/symbol/symbole-roupie/": {
+  "hash": "316702c83d73b291",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/symbol/symbole-rufiyaa/": {
+  "hash": "4c79acdbc44c87b3",
+  "lastmod": "2026-08-05"
+ },
+ "/fr/symbol/symbole-sagittaire/": {
+  "hash": "3c55869955a6f2d7",
+  "lastmod": "2026-08-06"
+ },
+ "/fr/symbol/symbole-scorpion/": {
+  "hash": "48bcf4062f3e8fe0",
+  "lastmod": "2026-08-06"
+ },
+ "/fr/symbol/symbole-sigma/": {
+  "hash": "6d5701ca2668e1a3",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/symbol/symbole-stop/": {
+  "hash": "814cea7ce63bacc3",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/symbol/symbole-taureau/": {
+  "hash": "a2cf9ddd8ad4b58d",
+  "lastmod": "2026-08-06"
+ },
+ "/fr/symbol/symbole-theta/": {
+  "hash": "1c3fe1ac1cca3999",
+  "lastmod": "2026-08-16"
+ },
+ "/fr/symbol/symbole-tilde/": {
+  "hash": "3e3a1e1ffb1aeab4",
+  "lastmod": "2026-08-16"
+ },
+ "/fr/symbol/symbole-verseau/": {
+  "hash": "033e1c6183521f5c",
+  "lastmod": "2026-08-06"
+ },
+ "/fr/symbol/symbole-vierge/": {
+  "hash": "18ef1ba528ebec9c",
+  "lastmod": "2026-08-06"
+ },
+ "/fr/symbol/symbole-won/": {
+  "hash": "b25d1590a6acca04",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/symbol/symbole-yen/": {
+  "hash": "126989dc869b4d13",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/symbol/symbole-yin-yang/": {
+  "hash": "5c1a85b71c44f601",
+  "lastmod": "2026-08-13"
+ },
+ "/fr/symbol/tete-de-mort/": {
+  "hash": "cf917be633a70f53",
+  "lastmod": "2026-08-11"
+ },
+ "/fr/symbol/tiret-bas/": {
+  "hash": "bd65297505d0251b",
+  "lastmod": "2026-08-16"
+ },
+ "/fr/symbol/tiret-cadratin/": {
+  "hash": "5e86db0910e27609",
+  "lastmod": "2026-08-06"
+ },
+ "/fr/symbol/tiret-demi-cadratin/": {
+  "hash": "1ed895a2a5ce831e",
+  "lastmod": "2026-08-05"
+ },
+ "/fr/texte-barre/": {
+  "hash": "64d0fba0cf67804a",
+  "lastmod": "2026-08-15"
+ },
+ "/fr/texte-courbe/": {
+  "hash": "223f8dc94ab3150a",
+  "lastmod": "2026-08-15"
+ },
+ "/fr/texte-en-gras/": {
+  "hash": "dfe01f7959f97d28",
+  "lastmod": "2026-08-07"
+ },
+ "/fr/texte-invisible/": {
+  "hash": "b96121cf1c9b13b0",
+  "lastmod": "2026-08-15"
+ },
+ "/fr/texte-souligne/": {
+  "hash": "f16ca6cfc6114f65",
+  "lastmod": "2026-08-15"
+ },
+ "/fr/updates/unicode-18-date-de-sortie-confirmee/": {
+  "hash": "64dc282246d3467a",
+  "lastmod": "2026-08-15"
+ },
+ "/fr/updates/unicode-18-nouveaux-emojis-vote/": {
+  "hash": "f060aa47e5c6fb94",
+  "lastmod": "2026-08-12"
+ },
+ "/fr/usecase/": {
+  "hash": "27e82429cfadd63e",
+  "lastmod": "2026-08-15"
+ },
+ "/fr/usecase/ecriture-bio/": {
+  "hash": "2297f62e1e4e172b",
+  "lastmod": "2026-08-15"
+ },
+ "/fr/usecase/ecriture-tatouage/": {
+  "hash": "e2f615bc11db8d7e",
+  "lastmod": "2026-08-07"
+ },
+ "/fr/usecase/guilde-free-fire/": {
+  "hash": "323ad9ac9137a87a",
+  "lastmod": "2026-08-01"
+ },
+ "/fr/usecase/nom-de-contact-aesthetic/": {
+  "hash": "94c92ec1cb76d13b",
+  "lastmod": "2026-08-16"
+ },
+ "/fr/usecase/nom-de-groupe/": {
+  "hash": "f89935eb3b26375a",
+  "lastmod": "2026-08-16"
+ },
+ "/fr/usecase/pseudo-fortnite/": {
+  "hash": "9e94a7b112b0c961",
+  "lastmod": "2026-07-31"
+ },
+ "/fr/usecase/pseudo-free-fire/": {
+  "hash": "d58ef2d4612f78dc",
+  "lastmod": "2026-08-07"
+ },
+ "/fr/usecase/pseudo-stumble-guys/": {
+  "hash": "2b39183b7fa00c63",
+  "lastmod": "2026-08-16"
+ },
+ "/fr/usecase/traducteur-emoji/": {
+  "hash": "a20dd55921c038d0",
+  "lastmod": "2026-08-15"
+ },
+ "/fr/usecase/vertical-text/": {
+  "hash": "12e9b7c36c5baba0",
+  "lastmod": "2026-08-15"
+ },
+ "/fr/usecase/zalgo-text/": {
+  "hash": "1d7166e5396aacd3",
+  "lastmod": "2026-08-15"
+ },
+ "/guide/": {
+  "hash": "80c108736ac6784a",
+  "lastmod": "2026-08-11"
+ },
+ "/guide/bio-formatting-without-spam/": {
+  "hash": "a8d48408c71ba84f",
+  "lastmod": "2026-07-25"
+ },
+ "/guide/boxes-vs-mojibake-vs-question-marks/": {
+  "hash": "f98cd0bd4ed5df73",
+  "lastmod": "2026-07-25"
+ },
+ "/guide/branding-with-fonts-for-social-media/": {
+  "hash": "c5638a917614e0fd",
+  "lastmod": "2026-08-13"
+ },
+ "/guide/comments-that-stand-out/": {
+  "hash": "19d12d5bec22f3b8",
+  "lastmod": "2026-08-05"
+ },
+ "/guide/discord-colored-text-guide/": {
+  "hash": "36389f4f0032ca2b",
+  "lastmod": "2026-07-25"
+ },
+ "/guide/discord-safe-name-styling/": {
+  "hash": "3fe619fa457b184c",
+  "lastmod": "2026-07-26"
+ },
+ "/guide/discord-text-formatting-explained/": {
+  "hash": "dcacb7342df003e5",
+  "lastmod": "2026-08-12"
+ },
+ "/guide/discord-where-fonts-work/": {
+  "hash": "bff4ac7dff15b18f",
+  "lastmod": "2026-07-26"
+ },
+ "/guide/dividers-separators-guide/": {
+  "hash": "2ccc3447dbb9944d",
+  "lastmod": "2026-07-25"
+ },
+ "/guide/emoticon-vs-emoji-vs-kaomoji/": {
+  "hash": "6bb2f1a9a7133351",
+  "lastmod": "2026-07-25"
+ },
+ "/guide/fancy-fonts-accessibility-guide/": {
+  "hash": "6fe98afd89ac2f28",
+  "lastmod": "2026-08-15"
+ },
+ "/guide/fancy-fonts-and-accents/": {
+  "hash": "cf3d2c5082040a63",
+  "lastmod": "2026-07-25"
+ },
+ "/guide/font-personality-and-brand/": {
+  "hash": "cb69cf652b581cd0",
+  "lastmod": "2026-07-25"
+ },
+ "/guide/fonts-and-search-visibility/": {
+  "hash": "c1553d3494f584b0",
+  "lastmod": "2026-07-25"
+ },
+ "/guide/game-username-allowed-symbols/": {
+  "hash": "17fd9d78b5d27fcc",
+  "lastmod": "2026-08-02"
+ },
+ "/guide/how-unicode-fonts-work/": {
+  "hash": "0dc9658402f0d5c6",
+  "lastmod": "2026-07-25"
+ },
+ "/guide/instagram-bio-line-breaks/": {
+  "hash": "9cf0f281d9c65f3b",
+  "lastmod": "2026-07-25"
+ },
+ "/guide/instagram-font-ideas/": {
+  "hash": "460f5618f617e726",
+  "lastmod": "2026-07-25"
+ },
+ "/guide/instagram-fonts-shadowban-myth/": {
+  "hash": "9aaec25c28107724",
+  "lastmod": "2026-07-25"
+ },
+ "/guide/linkedin-bold-text-reach/": {
+  "hash": "73f9ea4afe19d8a9",
+  "lastmod": "2026-07-25"
+ },
+ "/guide/linkedin-comment-styling/": {
+  "hash": "06a4c17328a23803",
+  "lastmod": "2026-07-25"
+ },
+ "/guide/linkedin-comments-guide/": {
+  "hash": "f1c117d26edee406",
+  "lastmod": "2026-07-25"
+ },
+ "/guide/linkedin-fonts-recruiters-ats/": {
+  "hash": "35beca27d4376a64",
+  "lastmod": "2026-07-25"
+ },
+ "/guide/personal-branding-through-typography/": {
+  "hash": "0542e126243cfc0f",
+  "lastmod": "2026-07-25"
+ },
+ "/guide/stop-the-scroll-with-font-variation/": {
+  "hash": "9f1e73b950ac923c",
+  "lastmod": "2026-07-25"
+ },
+ "/guide/style-linkedin-hooks-to-stand-out/": {
+  "hash": "0f439bade3810add",
+  "lastmod": "2026-08-07"
+ },
+ "/guide/the-rhetoric-of-fonts/": {
+  "hash": "20a5ec46219d476f",
+  "lastmod": "2026-07-26"
+ },
+ "/guide/tiktok-font-changed/": {
+  "hash": "878ebd652532fd29",
+  "lastmod": "2026-07-25"
+ },
+ "/guide/unicode-symbol-approval-process/": {
+  "hash": "3151cb7f312e3068",
+  "lastmod": "2026-07-25"
+ },
+ "/guide/vertical-text-guide/": {
+  "hash": "9d93a342fb600724",
+  "lastmod": "2026-07-25"
+ },
+ "/guide/whatsapp-text-formatting-explained/": {
+  "hash": "88b56caffe6713df",
+  "lastmod": "2026-07-25"
+ },
+ "/guide/why-fonts-show-as-boxes/": {
+  "hash": "4cc07615163fa3a9",
+  "lastmod": "2026-07-25"
+ },
+ "/hi/": {
+  "hash": "f52955cb922511ed",
+  "lastmod": "2026-08-15"
+ },
+ "/hi/guide/": {
+  "hash": "a2369bd14b149e9c",
+  "lastmod": "2026-08-15"
+ },
+ "/hi/guide/discord-font-kahan-kaam-karte-hain/": {
+  "hash": "04b1c7dae6e2da34",
+  "lastmod": "2026-08-15"
+ },
+ "/hi/guide/discord-safe-naam-styling/": {
+  "hash": "5ef66d1c6f556c92",
+  "lastmod": "2026-08-15"
+ },
+ "/hi/guide/discord-text-formatting-samjhein/": {
+  "hash": "1039d8637a739840",
+  "lastmod": "2026-08-15"
+ },
+ "/hi/usecase/emoji-anuvadak/": {
+  "hash": "28b7688490030962",
+  "lastmod": "2026-08-15"
+ },
+ "/hi/usecase/free-fire-naam-stylish/": {
+  "hash": "f60d1616d372258d",
+  "lastmod": "2026-08-15"
+ },
+ "/hi/usecase/pubg-bgmi-naam-stylish/": {
+  "hash": "8131a597c4cf34ab",
+  "lastmod": "2026-08-15"
+ },
+ "/hi/usecase/stylish-naam-generator/": {
+  "hash": "915e2e3dc03a8f5d",
+  "lastmod": "2026-08-15"
+ },
+ "/hiragana-chart/": {
+  "hash": "352ec2ed78307d9b",
+  "lastmod": "2026-07-25"
+ },
+ "/hr/": {
+  "hash": "b48bc83967a0e826",
+  "lastmod": "2026-08-15"
+ },
+ "/hr/fontovi-za-discord/": {
+  "hash": "76783c1caf036de6",
+  "lastmod": "2026-08-15"
+ },
+ "/hr/fontovi-za-instagram/": {
+  "hash": "23bc155ee22c8586",
+  "lastmod": "2026-08-15"
+ },
+ "/hr/generator-nadimaka/": {
+  "hash": "66b58a0d1b42d3cd",
+  "lastmod": "2026-08-15"
+ },
+ "/hr/goticka-slova/": {
+  "hash": "b249ed60e2b5ac75",
+  "lastmod": "2026-08-15"
+ },
+ "/hr/guide/": {
+  "hash": "df1b8dbd37b6e50c",
+  "lastmod": "2026-08-11"
+ },
+ "/hr/guide/gdje-rade-fontovi-na-discordu/": {
+  "hash": "28b34714f2d80fd2",
+  "lastmod": "2026-07-26"
+ },
+ "/hr/guide/oblikovanje-teksta-na-discordu/": {
+  "hash": "ea05936e38ba9f9e",
+  "lastmod": "2026-07-26"
+ },
+ "/hr/guide/siguran-nadimak-na-discordu/": {
+  "hash": "faf7f3019d6f8906",
+  "lastmod": "2026-07-26"
+ },
+ "/hr/kurziv/": {
+  "hash": "ee6d53f29f887474",
+  "lastmod": "2026-08-15"
+ },
+ "/hr/mala-slova/": {
+  "hash": "3be70a95ec6b9802",
+  "lastmod": "2026-08-15"
+ },
+ "/hr/podebljana-slova/": {
+  "hash": "647a8e7846cae77a",
+  "lastmod": "2026-08-15"
+ },
+ "/hr/posebni-znakovi/": {
+  "hash": "8e0c822c98cfa51d",
+  "lastmod": "2026-08-15"
+ },
+ "/hu/": {
+  "hash": "969885b5309ffdd7",
+  "lastmod": "2026-08-15"
+ },
+ "/hu/apro-betuk/": {
+  "hash": "b298e16b6fd02b81",
+  "lastmod": "2026-08-15"
+ },
+ "/hu/becenev-generator/": {
+  "hash": "5b4a79e7e6dc6ac9",
+  "lastmod": "2026-08-15"
+ },
+ "/hu/discord-betutipusok/": {
+  "hash": "1877abd24c3869b5",
+  "lastmod": "2026-08-15"
+ },
+ "/hu/dolt-szoveg/": {
+  "hash": "06c589020ffce40e",
+  "lastmod": "2026-08-15"
+ },
+ "/hu/felkover-szoveg/": {
+  "hash": "a4a51b7c05c5df45",
+  "lastmod": "2026-08-15"
+ },
+ "/hu/gotikus-betuk/": {
+  "hash": "8ed40568e255e46b",
+  "lastmod": "2026-08-15"
+ },
+ "/hu/guide/": {
+  "hash": "73413c8229b452d3",
+  "lastmod": "2026-08-15"
+ },
+ "/hu/guide/biztonsagos-discord-becenev/": {
+  "hash": "00db88cd578f6895",
+  "lastmod": "2026-08-15"
+ },
+ "/hu/guide/discord-szovegformazas/": {
+  "hash": "4577d5f57a0e9a47",
+  "lastmod": "2026-08-15"
+ },
+ "/hu/guide/hol-mukodnek-a-discord-fontok/": {
+  "hash": "f9dd3b80024f88d2",
+  "lastmod": "2026-08-15"
+ },
+ "/hu/instagram-betutipusok/": {
+  "hash": "ee105fb10e06c157",
+  "lastmod": "2026-08-15"
+ },
+ "/hu/kulonleges-karakterek/": {
+  "hash": "caba52c6696a06f4",
+  "lastmod": "2026-08-15"
+ },
+ "/id/": {
+  "hash": "d9546ca57a6cf1ed",
+  "lastmod": "2026-08-15"
+ },
+ "/id/answers/": {
+  "hash": "c1eec6d23110f2d9",
+  "lastmod": "2026-08-15"
+ },
+ "/id/answers/cara-membuat-nama-kosong/": {
+  "hash": "7d4a3b37a4a169cc",
+  "lastmod": "2026-08-15"
+ },
+ "/id/answers/cara-mengganti-nama-channel-youtube/": {
+  "hash": "430182613ff7d237",
+  "lastmod": "2026-08-15"
+ },
+ "/id/answers/handle-vs-nama-channel-youtube/": {
+  "hash": "fd417141dfae7176",
+  "lastmod": "2026-08-15"
+ },
+ "/id/answers/what-font-does-pinterest-use/": {
+  "hash": "292abb6ebff4d606",
+  "lastmod": "2026-08-16"
+ },
+ "/id/answers/what-font-does-whatsapp-use/": {
+  "hash": "deb234cedbec15c7",
+  "lastmod": "2026-08-16"
+ },
+ "/id/category/": {
+  "hash": "b540bce62850daf5",
+  "lastmod": "2026-08-16"
+ },
+ "/id/font-angka/": {
+  "hash": "1c5eead09800839b",
+  "lastmod": "2026-08-16"
+ },
+ "/id/font-bubble/": {
+  "hash": "2133c00dc06807bc",
+  "lastmod": "2026-08-16"
+ },
+ "/id/font-discord/": {
+  "hash": "34d50ff9734d07c3",
+  "lastmod": "2026-08-16"
+ },
+ "/id/font-facebook/": {
+  "hash": "96bdadcf06ad35f4",
+  "lastmod": "2026-08-15"
+ },
+ "/id/font-ig/": {
+  "hash": "f9487b99da8f5600",
+  "lastmod": "2026-08-16"
+ },
+ "/id/font-lucu/": {
+  "hash": "5754648bc63aec56",
+  "lastmod": "2026-08-15"
+ },
+ "/id/font-snapchat/": {
+  "hash": "99acb37ac9b8a3e7",
+  "lastmod": "2026-08-16"
+ },
+ "/id/font-tiktok/": {
+  "hash": "9a59822fe2a2e6a5",
+  "lastmod": "2026-08-16"
+ },
+ "/id/font-wa/": {
+  "hash": "fdd8399fa99c823e",
+  "lastmod": "2026-08-16"
+ },
+ "/id/guide/": {
+  "hash": "75521e28c5837f90",
+  "lastmod": "2026-08-15"
+ },
+ "/id/guide/di-mana-font-discord-bekerja/": {
+  "hash": "d727cd4b5cc0b84d",
+  "lastmod": "2026-08-15"
+ },
+ "/id/guide/format-teks-discord-dijelaskan/": {
+  "hash": "677e2679dd209f81",
+  "lastmod": "2026-07-26"
+ },
+ "/id/guide/nama-discord-aman/": {
+  "hash": "009a0d185a0bef89",
+  "lastmod": "2026-08-15"
+ },
+ "/id/huruf-besar-kecil/": {
+  "hash": "26bea2df7dade224",
+  "lastmod": "2026-08-16"
+ },
+ "/id/huruf-kecil-diatas/": {
+  "hash": "c580f231c07909e4",
+  "lastmod": "2026-08-15"
+ },
+ "/id/huruf-keren-a-sampai-z/": {
+  "hash": "a2412092b910b536",
+  "lastmod": "2026-08-15"
+ },
+ "/id/library/": {
+  "hash": "7fb4b5ca7fdcc4c9",
+  "lastmod": "2026-08-15"
+ },
+ "/id/library/cat-kaomoji/": {
+  "hash": "c275fc12ac69d0bd",
+  "lastmod": "2026-08-16"
+ },
+ "/id/library/crying-kaomoji/": {
+  "hash": "c2a48c0eab423932",
+  "lastmod": "2026-08-16"
+ },
+ "/id/library/cute-kaomoji/": {
+  "hash": "e221c11d0a642247",
+  "lastmod": "2026-08-16"
+ },
+ "/id/library/emoji-bendera/": {
+  "hash": "2067c8bbceb5ada4",
+  "lastmod": "2026-08-15"
+ },
+ "/id/library/emoji-bintang/": {
+  "hash": "6fc44ff0d90a26ac",
+  "lastmod": "2026-08-12"
+ },
+ "/id/library/emoji-cium/": {
+  "hash": "7c5def39d7b88faf",
+  "lastmod": "2026-08-15"
+ },
+ "/id/library/emoji-combos/": {
+  "hash": "adbb8e3042005725",
+  "lastmod": "2026-08-15"
+ },
+ "/id/library/emoji-damai/": {
+  "hash": "642ddb4e41fd1638",
+  "lastmod": "2026-08-15"
+ },
+ "/id/library/emoji-hewan/": {
+  "hash": "3777a0c9233f3082",
+  "lastmod": "2026-08-15"
+ },
+ "/id/library/emoji-iphone/": {
+  "hash": "1133f8b123bac5db",
+  "lastmod": "2026-08-10"
+ },
+ "/id/library/emoji-kaget/": {
+  "hash": "409dd7644b84e3e6",
+  "lastmod": "2026-08-16"
+ },
+ "/id/library/emoji-kesal/": {
+  "hash": "c79a86db39501f59",
+  "lastmod": "2026-08-12"
+ },
+ "/id/library/emoji-ketawa/": {
+  "hash": "eb185a94290717ee",
+  "lastmod": "2026-08-16"
+ },
+ "/id/library/emoji-mahkota/": {
+  "hash": "521fad095ec2f093",
+  "lastmod": "2026-08-16"
+ },
+ "/id/library/emoji-malaikat/": {
+  "hash": "65af741a2cb93d1b",
+  "lastmod": "2026-08-12"
+ },
+ "/id/library/emoji-marah/": {
+  "hash": "ff14876759b18657",
+  "lastmod": "2026-08-16"
+ },
+ "/id/library/emoji-nangis/": {
+  "hash": "faf18614e09d63da",
+  "lastmod": "2026-08-15"
+ },
+ "/id/library/emoji-sedih/": {
+  "hash": "0a551c6b1f3c06ae",
+  "lastmod": "2026-08-16"
+ },
+ "/id/library/emoji-senang/": {
+  "hash": "64b2595bad740dda",
+  "lastmod": "2026-08-16"
+ },
+ "/id/library/emoji-tengkorak/": {
+  "hash": "14783042634ae95f",
+  "lastmod": "2026-08-16"
+ },
+ "/id/library/emoji-wajah/": {
+  "hash": "2e0b3b1704d8b148",
+  "lastmod": "2026-08-15"
+ },
+ "/id/library/happy-kaomoji/": {
+  "hash": "a6dc4f699a238a5d",
+  "lastmod": "2026-08-16"
+ },
+ "/id/library/kaomoji/": {
+  "hash": "276e9d4fd2fc4c30",
+  "lastmod": "2026-08-15"
+ },
+ "/id/library/karakter-spesial/": {
+  "hash": "cfcf0c7988abe520",
+  "lastmod": "2026-08-07"
+ },
+ "/id/library/kode-alt/": {
+  "hash": "e190f306b2b28355",
+  "lastmod": "2026-08-16"
+ },
+ "/id/library/love-kaomoji/": {
+  "hash": "6db1ceed5f3afa23",
+  "lastmod": "2026-08-16"
+ },
+ "/id/library/sad-kaomoji/": {
+  "hash": "700197d458b478c3",
+  "lastmod": "2026-08-16"
+ },
+ "/id/library/shrug-kaomoji/": {
+  "hash": "a4d0b66759451867",
+  "lastmod": "2026-08-16"
+ },
+ "/id/library/simbol-aesthetic/": {
+  "hash": "8085b6066a510c3e",
+  "lastmod": "2026-08-15"
+ },
+ "/id/library/simbol-bintang/": {
+  "hash": "278313ad171f7ca4",
+  "lastmod": "2026-08-15"
+ },
+ "/id/library/simbol-bunga/": {
+  "hash": "0e0ce8f86affdebe",
+  "lastmod": "2026-08-15"
+ },
+ "/id/library/simbol-catur/": {
+  "hash": "77e4aca5933fdc72",
+  "lastmod": "2026-08-13"
+ },
+ "/id/library/simbol-centang/": {
+  "hash": "9f221db3f69a18cc",
+  "lastmod": "2026-08-15"
+ },
+ "/id/library/simbol-coquette/": {
+  "hash": "e99495fef038842b",
+  "lastmod": "2026-08-15"
+ },
+ "/id/library/simbol-cottagecore/": {
+  "hash": "e90990e3e5a7187b",
+  "lastmod": "2026-08-15"
+ },
+ "/id/library/simbol-cuaca/": {
+  "hash": "9c52e80dcbb6248b",
+  "lastmod": "2026-08-12"
+ },
+ "/id/library/simbol-discord/": {
+  "hash": "cc463603c545a086",
+  "lastmod": "2026-08-15"
+ },
+ "/id/library/simbol-dreamcore-weirdcore/": {
+  "hash": "12b5de6f44b8997c",
+  "lastmod": "2026-08-15"
+ },
+ "/id/library/simbol-facebook/": {
+  "hash": "d5f3728af8157437",
+  "lastmod": "2026-08-16"
+ },
+ "/id/library/simbol-fairycore/": {
+  "hash": "568be27ca1628736",
+  "lastmod": "2026-08-15"
+ },
+ "/id/library/simbol-ff/": {
+  "hash": "ba8c8611c1ac0168",
+  "lastmod": "2026-08-15"
+ },
+ "/id/library/simbol-fortnite/": {
+  "hash": "e3f98c012915281c",
+  "lastmod": "2026-08-16"
+ },
+ "/id/library/simbol-garis/": {
+  "hash": "f6d18a32f48dc9a1",
+  "lastmod": "2026-08-15"
+ },
+ "/id/library/simbol-gender/": {
+  "hash": "ea733fb076e82b57",
+  "lastmod": "2026-08-15"
+ },
+ "/id/library/simbol-geometri/": {
+  "hash": "fcfc81c26d9d25c3",
+  "lastmod": "2026-08-15"
+ },
+ "/id/library/simbol-goth-grunge/": {
+  "hash": "5fb34414573bc086",
+  "lastmod": "2026-08-15"
+ },
+ "/id/library/simbol-instagram/": {
+  "hash": "6136abb705205030",
+  "lastmod": "2026-08-15"
+ },
+ "/id/library/simbol-islami/": {
+  "hash": "2fc548f7aab78dd7",
+  "lastmod": "2026-08-13"
+ },
+ "/id/library/simbol-jepang/": {
+  "hash": "b0fa29e1c90948e2",
+  "lastmod": "2026-08-15"
+ },
+ "/id/library/simbol-kawaii-cute/": {
+  "hash": "f8c5c712f6bd0ea5",
+  "lastmod": "2026-08-15"
+ },
+ "/id/library/simbol-keagamaan/": {
+  "hash": "23369c847fdfbdf3",
+  "lastmod": "2026-08-13"
+ },
+ "/id/library/simbol-korea/": {
+  "hash": "5319b877dd82cef0",
+  "lastmod": "2026-08-12"
+ },
+ "/id/library/simbol-kurung/": {
+  "hash": "ade66b2ac529d88a",
+  "lastmod": "2026-08-15"
+ },
+ "/id/library/simbol-love/": {
+  "hash": "7809b533190b60bf",
+  "lastmod": "2026-08-15"
+ },
+ "/id/library/simbol-mata-uang/": {
+  "hash": "147e1cb3e79598d9",
+  "lastmod": "2026-08-07"
+ },
+ "/id/library/simbol-matematika/": {
+  "hash": "59e3570b378a8bc4",
+  "lastmod": "2026-08-15"
+ },
+ "/id/library/simbol-medis/": {
+  "hash": "2f3e319906f069d1",
+  "lastmod": "2026-08-15"
+ },
+ "/id/library/simbol-minecraft/": {
+  "hash": "99ca4bd3c5313703",
+  "lastmod": "2026-08-16"
+ },
+ "/id/library/simbol-ml/": {
+  "hash": "0d0258cbf109ea95",
+  "lastmod": "2026-08-12"
+ },
+ "/id/library/simbol-musik/": {
+  "hash": "1e7c0c0a32281f19",
+  "lastmod": "2026-08-15"
+ },
+ "/id/library/simbol-natal/": {
+  "hash": "74441320260794d6",
+  "lastmod": "2026-08-15"
+ },
+ "/id/library/simbol-nickname/": {
+  "hash": "bdd4673788937d92",
+  "lastmod": "2026-08-15"
+ },
+ "/id/library/simbol-panah/": {
+  "hash": "1e2a73ae647749d9",
+  "lastmod": "2026-08-15"
+ },
+ "/id/library/simbol-pecahan/": {
+  "hash": "289e4db802998f33",
+  "lastmod": "2026-08-15"
+ },
+ "/id/library/simbol-poin/": {
+  "hash": "f8481df1a5378225",
+  "lastmod": "2026-08-15"
+ },
+ "/id/library/simbol-pubg/": {
+  "hash": "f57d308e4ac72d1d",
+  "lastmod": "2026-08-16"
+ },
+ "/id/library/simbol-roblox/": {
+  "hash": "9dabc5d276ce7a3c",
+  "lastmod": "2026-08-15"
+ },
+ "/id/library/simbol-salib/": {
+  "hash": "b18d129c977477e7",
+  "lastmod": "2026-08-15"
+ },
+ "/id/library/simbol-tanda-baca/": {
+  "hash": "1785f9504df5d527",
+  "lastmod": "2026-08-07"
+ },
+ "/id/library/simbol-therian/": {
+  "hash": "d975dd855fd063d3",
+  "lastmod": "2026-08-15"
+ },
+ "/id/library/simbol-whatsapp/": {
+  "hash": "24462e1e79b129e8",
+  "lastmod": "2026-08-15"
+ },
+ "/id/library/simbol-witchy-occult/": {
+  "hash": "f725a7aa492aa19e",
+  "lastmod": "2026-08-15"
+ },
+ "/id/library/simbol-y2k/": {
+  "hash": "d27c7c56143e4f68",
+  "lastmod": "2026-08-15"
+ },
+ "/id/library/simbol-yunani/": {
+  "hash": "79033662daeb667f",
+  "lastmod": "2026-08-15"
+ },
+ "/id/library/simbol-zodiak/": {
+  "hash": "ec75a8a90603be20",
+  "lastmod": "2026-08-15"
+ },
+ "/id/penghitung-kata-dan-karakter/": {
+  "hash": "5759d62d397b4751",
+  "lastmod": "2026-08-15"
+ },
+ "/id/printables/": {
+  "hash": "e41d8cea3bd68a32",
+  "lastmod": "2026-08-15"
+ },
+ "/id/printables/alfabet-spanyol/": {
+  "hash": "d5b5271a714d2978",
+  "lastmod": "2026-08-15"
+ },
+ "/id/printables/grafiti-nama/": {
+  "hash": "ae7e3c4867d10a21",
+  "lastmod": "2026-08-15"
+ },
+ "/id/printables/huruf-balok/": {
+  "hash": "e2c97ef057aaf5ce",
+  "lastmod": "2026-08-15"
+ },
+ "/id/printables/huruf-bubble/": {
+  "hash": "1662a5a293e3e5ab",
+  "lastmod": "2026-08-15"
+ },
+ "/id/printables/huruf-kaligrafi/": {
+  "hash": "53210f6adc0447a5",
+  "lastmod": "2026-08-15"
+ },
+ "/id/printables/huruf-sambung/": {
+  "hash": "fd7a6017ed55cb04",
+  "lastmod": "2026-08-15"
+ },
+ "/id/printables/huruf-titik-titik/": {
+  "hash": "c83c66809c53bdff",
+  "lastmod": "2026-08-15"
+ },
+ "/id/printables/kristik-huruf/": {
+  "hash": "42fae7dcd7885b6c",
+  "lastmod": "2026-08-15"
+ },
+ "/id/printables/menebalkan-huruf/": {
+  "hash": "768beb814ce55b62",
+  "lastmod": "2026-08-15"
+ },
+ "/id/printables/mewarnai-huruf/": {
+  "hash": "e3e4ece48cd09096",
+  "lastmod": "2026-08-15"
+ },
+ "/id/printables/tulisan-selamat-ulang-tahun/": {
+  "hash": "60ef6e0d9da2986a",
+  "lastmod": "2026-08-15"
+ },
+ "/id/spasi-kosong/": {
+  "hash": "20d8ca1df47674a9",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/": {
+  "hash": "b1500835d5a03402",
+  "lastmod": "2026-08-16"
+ },
+ "/id/symbol/arti-hati-snapchat/": {
+  "hash": "fc9a9adb5308fc26",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/bintang-daud/": {
+  "hash": "32127ba0157f70e8",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/emoji-acar/": {
+  "hash": "c229f1fad02722d4",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/emoji-kacamata-hitam/": {
+  "hash": "43c8470c8b3aa694",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/emoji-kalender/": {
+  "hash": "3fdffcfec6bac84e",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/emoji-kupu-kupu-monarch/": {
+  "hash": "ea831f1edb68db4c",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/emoji-meteor/": {
+  "hash": "860def31cf9d619a",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/emoji-tanda-jempol/": {
+  "hash": "b60f30581f5769ed",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/emoji-tanda-stop/": {
+  "hash": "6643bff1700de63f",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/emoji-wajah-meleleh/": {
+  "hash": "c1203a2cc47d8d00",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/emoji-wajah-retak/": {
+  "hash": "d572462de7df91d1",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/emoji-wajah-terdistorsi/": {
+  "hash": "87e4e2c6be351533",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/garis-bawah/": {
+  "hash": "f3a54f4994ff52c2",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/garis-vertikal/": {
+  "hash": "0dc7a07b6adff7d8",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/karakter-tak-terlihat/": {
+  "hash": "c7cdf7c064f5c24b",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/mikrofon-emoji/": {
+  "hash": "8e48491cc105d45c",
+  "lastmod": "2026-08-05"
+ },
+ "/id/symbol/panah-atas/": {
+  "hash": "8c8a961b1c4f1497",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/panah-bawah/": {
+  "hash": "d896faa596354050",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/panah-kanan/": {
+  "hash": "e323cdac307c60f8",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/panah-kiri/": {
+  "hash": "d3af6d1656bfeb0d",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/salib-latin/": {
+  "hash": "cc731e38f0a0c0b9",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/salib-ortodoks/": {
+  "hash": "be0c7f1c01ca62bf",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-akar-kuadrat/": {
+  "hash": "60c759bc8ed6028c",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-alfa/": {
+  "hash": "8ae5691be4d849dc",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-ampersand/": {
+  "hash": "78f277c93e1dd34f",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-anarki/": {
+  "hash": "43ef16ee475ba690",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-ankh/": {
+  "hash": "564b399edefb40bb",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-aquarius/": {
+  "hash": "c1622cb3784a03ff",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-aries/": {
+  "hash": "5d280140f84d24d2",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-asterisk/": {
+  "hash": "4764948c7253e2ee",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-at/": {
+  "hash": "e611c748ad7731fc",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-autisme/": {
+  "hash": "1afec7b61a8b43c7",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-bintang-lima/": {
+  "hash": "1eeb54a665ce9d19",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-biohazard/": {
+  "hash": "ee52bc184a0af290",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-bitcoin/": {
+  "hash": "1aca9a9b4c5c2421",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-black-moon-lilith/": {
+  "hash": "2a485551abfe5ce1",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-bulan-bintang/": {
+  "hash": "d90808033dc1b678",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-celsius/": {
+  "hash": "1da7d96b13ce07a3",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-chi/": {
+  "hash": "3817b43fd6b872cb",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-damai/": {
+  "hash": "eb64be074b189310",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-daur-ulang/": {
+  "hash": "965f5e9692f0e897",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-delta/": {
+  "hash": "e74932e7144c30cb",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-derajat/": {
+  "hash": "ac56b2550bd6530a",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-diameter/": {
+  "hash": "aba6a566f9742725",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-dirham/": {
+  "hash": "736da291f3ad212f",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-dolar/": {
+  "hash": "faab313203b59847",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-euro/": {
+  "hash": "3e120ee6bdb7649c",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-fahrenheit/": {
+  "hash": "7a10cb2290150299",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-fleur-de-lis/": {
+  "hash": "93209f96e646d287",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-gemini/": {
+  "hash": "1eba0b8cd76ea371",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-hak-cipta/": {
+  "hash": "0e84210f8d9b946e",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-hamsa/": {
+  "hash": "bd8406ef98767776",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-hati/": {
+  "hash": "cf320c158f81b646",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-interrobang/": {
+  "hash": "2041091193680822",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-khanda/": {
+  "hash": "464685b9e7cede32",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-kongruen/": {
+  "hash": "6c5f66fe4821cf47",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-kuadrat-kubik/": {
+  "hash": "2362e2df6993bc7d",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-kurang-dari-lebih-dari/": {
+  "hash": "bd773c71ec7eee73",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-kurang-dari-sama-dengan/": {
+  "hash": "5c2a69bee9e018ca",
+  "lastmod": "2026-08-06"
+ },
+ "/id/symbol/simbol-kursi-roda/": {
+  "hash": "ced65b5e4029dd51",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-kutip/": {
+  "hash": "7de17255d6ec836e",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-lambda/": {
+  "hash": "77cb223db94d1ef1",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-marah/": {
+  "hash": "4171cd95dd6778ea",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-merek-dagang/": {
+  "hash": "3caed644fbd5a5cf",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-mikro/": {
+  "hash": "492e68df744f3a9a",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-ohm/": {
+  "hash": "c8af20d801fce655",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-om/": {
+  "hash": "e9584fbc992fecdf",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-omega/": {
+  "hash": "43250754aec7363a",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-pentagram/": {
+  "hash": "307e034e3fd7121e",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-peso/": {
+  "hash": "9c72dfd721e1ce34",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-phi/": {
+  "hash": "22277794b5fe7e80",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-pi/": {
+  "hash": "4e724c8c12035d43",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-pion/": {
+  "hash": "edf7713b290d957b",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-plus-minus/": {
+  "hash": "0a248f60e4f2eccf",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-poundsterling/": {
+  "hash": "b26e3f64ab8a2742",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-psi/": {
+  "hash": "e50f543ac042849c",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-rial-oman/": {
+  "hash": "761e97ddc46d3209",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-riyal-saudi/": {
+  "hash": "107400add8e4a3c1",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-rubel/": {
+  "hash": "c22fb2c2c2d1315d",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-rufiyaa/": {
+  "hash": "c5c108974c5492b8",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-rupee-india/": {
+  "hash": "d0f4c698e67b3fe7",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-section/": {
+  "hash": "50c1e1d063e23cf8",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-sekop/": {
+  "hash": "a379cd7e90411da0",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-sen/": {
+  "hash": "a81a67fcf39ed4c2",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-sigma/": {
+  "hash": "488da5578668dd3a",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-tak-hingga/": {
+  "hash": "939e536879bf17a6",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-tengkorak-tulang-silang/": {
+  "hash": "3fdd3be8c102f5f0",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-theta/": {
+  "hash": "b424e93e40b55aa2",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-tidak-sama-dengan/": {
+  "hash": "d3f2225b59f3535e",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-tilde/": {
+  "hash": "6e3eec9196cd796e",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-won/": {
+  "hash": "50060eac678fb372",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-yen/": {
+  "hash": "7eeed309d1772201",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-yin-yang/": {
+  "hash": "f32f5164e1878467",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-zodiak-cancer/": {
+  "hash": "8027825692035cba",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-zodiak-capricorn/": {
+  "hash": "6411e4f75a6466f1",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-zodiak-leo/": {
+  "hash": "f77391de9046f640",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-zodiak-libra/": {
+  "hash": "4c54e7744f3c6b14",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-zodiak-pisces/": {
+  "hash": "51f768eada56e2a5",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-zodiak-sagittarius/": {
+  "hash": "7ce7a31e9951e541",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-zodiak-scorpio/": {
+  "hash": "6d8482dcf9df7520",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-zodiak-taurus/": {
+  "hash": "36d20d709d99e6d0",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/simbol-zodiak-virgo/": {
+  "hash": "217991dad671f68c",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/tanda-bagi/": {
+  "hash": "0da136e2bcd6c672",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/tanda-centang/": {
+  "hash": "c39c602667f94cf7",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/tanda-kali/": {
+  "hash": "37e6e049fe0afb0e",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/tanda-paragraf/": {
+  "hash": "65ea2c62792269cd",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/tanda-pisah-em/": {
+  "hash": "255c19fa29dee6a7",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/tanda-pisah-en/": {
+  "hash": "4460ce73f8065663",
+  "lastmod": "2026-08-15"
+ },
+ "/id/symbol/tanda-tanya-terbalik/": {
+  "hash": "7103fad0a53fef21",
+  "lastmod": "2026-08-15"
+ },
+ "/id/tulisan-aesthetic/": {
+  "hash": "2ca471925b0ff176",
+  "lastmod": "2026-08-16"
+ },
+ "/id/tulisan-coret/": {
+  "hash": "8767b9a78b035353",
+  "lastmod": "2026-08-16"
+ },
+ "/id/tulisan-cuping/": {
+  "hash": "9bbe87ab037b4fbe",
+  "lastmod": "2026-08-15"
+ },
+ "/id/tulisan-garis-bawah/": {
+  "hash": "5e1c50a0423eac90",
+  "lastmod": "2026-08-16"
+ },
+ "/id/tulisan-gotik/": {
+  "hash": "f8df9f437ea6ccc2",
+  "lastmod": "2026-08-16"
+ },
+ "/id/tulisan-kecil/": {
+  "hash": "28dec984de9821b0",
+  "lastmod": "2026-08-16"
+ },
+ "/id/tulisan-miring/": {
+  "hash": "66580c5767cdb0d1",
+  "lastmod": "2026-08-16"
+ },
+ "/id/tulisan-sambung/": {
+  "hash": "3cd1258adcc0f7bc",
+  "lastmod": "2026-08-16"
+ },
+ "/id/tulisan-tebal/": {
+  "hash": "dae25897b4c42be9",
+  "lastmod": "2026-08-16"
+ },
+ "/id/tulisan-terbalik/": {
+  "hash": "f0439dc322b5725b",
+  "lastmod": "2026-08-16"
+ },
+ "/id/updates/tanggal-rilis-unicode-18-dipastikan/": {
+  "hash": "5b50867d6aaaf493",
+  "lastmod": "2026-08-15"
+ },
+ "/id/updates/unicode-18-emoji-baru-voting/": {
+  "hash": "6c9af546ab75c837",
+  "lastmod": "2026-08-15"
+ },
+ "/id/usecase/": {
+  "hash": "f9563224e9e3d2ae",
+  "lastmod": "2026-08-16"
+ },
+ "/id/usecase/bio-ig-aesthetic/": {
+  "hash": "b33f92188e9b928e",
+  "lastmod": "2026-08-15"
+ },
+ "/id/usecase/bio-tiktok-aesthetic/": {
+  "hash": "d9fda43f0bf6d7e9",
+  "lastmod": "2026-08-15"
+ },
+ "/id/usecase/bio-wa-aesthetic/": {
+  "hash": "1089357122e02a37",
+  "lastmod": "2026-08-15"
+ },
+ "/id/usecase/font-tato/": {
+  "hash": "ec6a375cd38d799b",
+  "lastmod": "2026-08-15"
+ },
+ "/id/usecase/nama-coc-keren/": {
+  "hash": "8955a220a5e4df4d",
+  "lastmod": "2026-08-15"
+ },
+ "/id/usecase/nama-couple-ff-aesthetic/": {
+  "hash": "0fbb405f555817f7",
+  "lastmod": "2026-08-15"
+ },
+ "/id/usecase/nama-discord-keren/": {
+  "hash": "6f7871c0a37f5003",
+  "lastmod": "2026-08-15"
+ },
+ "/id/usecase/nama-ff-keren-cewek/": {
+  "hash": "7bb28ac0dcb49c00",
+  "lastmod": "2026-08-15"
+ },
+ "/id/usecase/nama-ff-keren-cowok/": {
+  "hash": "9cb55a12190ea76c",
+  "lastmod": "2026-08-15"
+ },
+ "/id/usecase/nama-ff-keren/": {
+  "hash": "cea8621244e71102",
+  "lastmod": "2026-08-16"
+ },
+ "/id/usecase/nama-fortnite-keren/": {
+  "hash": "06d0bef6b3a009de",
+  "lastmod": "2026-08-15"
+ },
+ "/id/usecase/nama-grup-keren/": {
+  "hash": "8b0bf25f851e3351",
+  "lastmod": "2026-08-15"
+ },
+ "/id/usecase/nama-guild-ff-keren/": {
+  "hash": "3c513724bf2b247b",
+  "lastmod": "2026-08-16"
+ },
+ "/id/usecase/nama-ig-aesthetic/": {
+  "hash": "eb36bf7b76d1d730",
+  "lastmod": "2026-08-15"
+ },
+ "/id/usecase/nama-keren/": {
+  "hash": "9847eedce26cbfc0",
+  "lastmod": "2026-08-15"
+ },
+ "/id/usecase/nama-kontak-pacar-aesthetic/": {
+  "hash": "ec4cabf98e349d4b",
+  "lastmod": "2026-08-15"
+ },
+ "/id/usecase/nama-ml-keren-cowok/": {
+  "hash": "76f1f710ce821490",
+  "lastmod": "2026-08-15"
+ },
+ "/id/usecase/nama-ml-keren-girl/": {
+  "hash": "4addfad8c02ef849",
+  "lastmod": "2026-08-15"
+ },
+ "/id/usecase/nama-ml-keren/": {
+  "hash": "f7e8a8dc36cfe74b",
+  "lastmod": "2026-08-15"
+ },
+ "/id/usecase/nama-panggilan/": {
+  "hash": "f38cf1caa6e07b36",
+  "lastmod": "2026-08-15"
+ },
+ "/id/usecase/nama-pubg-keren/": {
+  "hash": "72cb524d1e76d144",
+  "lastmod": "2026-08-15"
+ },
+ "/id/usecase/nama-roblox-keren/": {
+  "hash": "982b61b8fa423fcc",
+  "lastmod": "2026-08-15"
+ },
+ "/id/usecase/nama-squad-ml-keren/": {
+  "hash": "62930beaad579952",
+  "lastmod": "2026-08-15"
+ },
+ "/id/usecase/nama-stumble-guys-keren/": {
+  "hash": "730aef2c6b859db3",
+  "lastmod": "2026-08-15"
+ },
+ "/id/usecase/nama-tiktok-keren/": {
+  "hash": "f882c739067cdd9c",
+  "lastmod": "2026-08-15"
+ },
+ "/id/usecase/nama-valorant-keren/": {
+  "hash": "3154d9925da0210c",
+  "lastmod": "2026-08-15"
+ },
+ "/id/usecase/penerjemah-emoji/": {
+  "hash": "602fdfc9763a0170",
+  "lastmod": "2026-08-15"
+ },
+ "/id/usecase/vertical-text/": {
+  "hash": "559e8558ac7cc16e",
+  "lastmod": "2026-08-15"
+ },
+ "/id/usecase/zalgo-text/": {
+  "hash": "faba41a588e85cb7",
+  "lastmod": "2026-08-15"
+ },
+ "/instagram/": {
+  "hash": "93013a368da9e82c",
+  "lastmod": "2026-08-03"
+ },
+ "/it/": {
+  "hash": "e0be29536c4b92bb",
+  "lastmod": "2026-08-15"
+ },
+ "/it/answers/": {
+  "hash": "16fd58cd5466648c",
+  "lastmod": "2026-08-15"
+ },
+ "/it/answers/come-creare-un-nickname-vuoto/": {
+  "hash": "9e177db9161f8f3d",
+  "lastmod": "2026-08-15"
+ },
+ "/it/answers/perche-il-mio-nome-appare-come-quadratini/": {
+  "hash": "d4b5ff890ff6c93f",
+  "lastmod": "2026-08-15"
+ },
+ "/it/answers/what-font-does-pinterest-use/": {
+  "hash": "805d0622d5a29875",
+  "lastmod": "2026-08-16"
+ },
+ "/it/answers/what-font-does-whatsapp-use/": {
+  "hash": "639785b0cc542c07",
+  "lastmod": "2026-08-16"
+ },
+ "/it/caratteri-speciali/": {
+  "hash": "1d9eea60ae4865ad",
+  "lastmod": "2026-08-15"
+ },
+ "/it/category/": {
+  "hash": "85ead930b8c2a52b",
+  "lastmod": "2026-08-15"
+ },
+ "/it/combinazioni-emoji/": {
+  "hash": "23fdbd5953913b25",
+  "lastmod": "2026-08-07"
+ },
+ "/it/contatore-di-parole-e-caratteri/": {
+  "hash": "cfe93728b6879351",
+  "lastmod": "2026-08-15"
+ },
+ "/it/convertitore-di-caratteri/": {
+  "hash": "c3258d9ff2c9520d",
+  "lastmod": "2026-08-15"
+ },
+ "/it/da-stampare/": {
+  "hash": "abafc227ec4d0b37",
+  "lastmod": "2026-08-12"
+ },
+ "/it/da-stampare/alfabeto-corsivo/": {
+  "hash": "ad742b10a4080bd0",
+  "lastmod": "2026-08-12"
+ },
+ "/it/da-stampare/alfabeto-spagnolo/": {
+  "hash": "084949622774f32e",
+  "lastmod": "2026-08-12"
+ },
+ "/it/da-stampare/nome-da-colorare/": {
+  "hash": "ab2373970cb5efe5",
+  "lastmod": "2026-07-25"
+ },
+ "/it/da-stampare/tracciare-il-nome/": {
+  "hash": "289ceda396fe56e0",
+  "lastmod": "2026-07-25"
+ },
+ "/it/font-copia-e-incolla/": {
+  "hash": "dc2d5e552c5b34af",
+  "lastmod": "2026-08-15"
+ },
+ "/it/font-facebook/": {
+  "hash": "e40a8a318b8e89c4",
+  "lastmod": "2026-08-15"
+ },
+ "/it/font-instagram/": {
+  "hash": "d380b33a48c8d0f8",
+  "lastmod": "2026-08-15"
+ },
+ "/it/font-snapchat/": {
+  "hash": "3b539eeb5f195ab6",
+  "lastmod": "2026-08-11"
+ },
+ "/it/font-telegram/": {
+  "hash": "6b6cc89c69b0aacf",
+  "lastmod": "2026-08-15"
+ },
+ "/it/font-tiktok/": {
+  "hash": "fd727143ea643476",
+  "lastmod": "2026-08-15"
+ },
+ "/it/font-whatsapp/": {
+  "hash": "3a20ea212fec4cc2",
+  "lastmod": "2026-08-15"
+ },
+ "/it/generatore-di-font/": {
+  "hash": "54c7f96c11ab5171",
+  "lastmod": "2026-08-15"
+ },
+ "/it/gotico/": {
+  "hash": "649e9c5bd3deba62",
+  "lastmod": "2026-08-15"
+ },
+ "/it/grassetto/": {
+  "hash": "3a4c85bcb72e2091",
+  "lastmod": "2026-08-15"
+ },
+ "/it/guide/": {
+  "hash": "bac57990075660a9",
+  "lastmod": "2026-08-15"
+ },
+ "/it/guide/dove-funzionano-i-font-discord/": {
+  "hash": "6924949b9d0500d4",
+  "lastmod": "2026-08-15"
+ },
+ "/it/guide/formattazione-testo-discord-spiegata/": {
+  "hash": "f316d6748e32241b",
+  "lastmod": "2026-08-15"
+ },
+ "/it/guide/nome-discord-senza-rischi/": {
+  "hash": "81df1847be13c36e",
+  "lastmod": "2026-08-15"
+ },
+ "/it/lettere-in-corsivo/": {
+  "hash": "905aa544c0c8ac6a",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/": {
+  "hash": "cbc384352a4d41f5",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/caratteri-speciali-simboli/": {
+  "hash": "b186db458c2dfb84",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/codici-alt/": {
+  "hash": "718daee6adae54d1",
+  "lastmod": "2026-08-16"
+ },
+ "/it/library/emoji-bacio/": {
+  "hash": "e1e18d85b978b965",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/emoji-bandiere/": {
+  "hash": "e003d389a2b4e900",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/emoji-clown/": {
+  "hash": "616f76f2c607a7a2",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/emoji-corona/": {
+  "hash": "f46d5aa4415df12f",
+  "lastmod": "2026-08-16"
+ },
+ "/it/library/emoji-diavolo/": {
+  "hash": "06bfcd21233a0535",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/emoji-faccine/": {
+  "hash": "ceb67f324abb08fa",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/emoji-iphone/": {
+  "hash": "fcffa04b8fa32330",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/emoji-occhi/": {
+  "hash": "252c78af986f00ce",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/emoji-pace/": {
+  "hash": "015c62ea1b95f18b",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/emoji-pianto/": {
+  "hash": "923d84bad980c13c",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/emoji-regalo/": {
+  "hash": "fd809fafb366b704",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/emoji-teschio/": {
+  "hash": "32954554667d85f9",
+  "lastmod": "2026-08-16"
+ },
+ "/it/library/emoji-triste/": {
+  "hash": "82979d0791d47daa",
+  "lastmod": "2026-08-16"
+ },
+ "/it/library/geroglifici-egizi/": {
+  "hash": "3cacb73608ea0a6e",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/kaomoji/": {
+  "hash": "de208b5572b359c2",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/simboli-carte-da-gioco/": {
+  "hash": "56534d6b402e392b",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/simboli-coquette/": {
+  "hash": "9b1fe5967e939cfc",
+  "lastmod": "2026-08-13"
+ },
+ "/it/library/simboli-cottagecore/": {
+  "hash": "fa699f4d53557dc4",
+  "lastmod": "2026-08-13"
+ },
+ "/it/library/simboli-cuore/": {
+  "hash": "cebe3ba078eee529",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/simboli-discord/": {
+  "hash": "622997df27826d21",
+  "lastmod": "2026-08-16"
+ },
+ "/it/library/simboli-dreamcore-weirdcore/": {
+  "hash": "b0a1eb13073b894c",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/simboli-euro/": {
+  "hash": "e06022e2828e632e",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/simboli-facebook/": {
+  "hash": "2f26d245720459b4",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/simboli-fairycore/": {
+  "hash": "54710c521e11c62b",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/simboli-freccia/": {
+  "hash": "6f31313502ba6018",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/simboli-geometrici/": {
+  "hash": "75dacaf6f25b20b9",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/simboli-goth-grunge/": {
+  "hash": "df10e0f9694d2455",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/simboli-greci/": {
+  "hash": "4f34aedc47aa1804",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/simboli-halloween/": {
+  "hash": "a438cb2bbaf48742",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/simboli-instagram/": {
+  "hash": "6522f866dfacf462",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/simboli-islamici/": {
+  "hash": "47a05ddf09007277",
+  "lastmod": "2026-08-16"
+ },
+ "/it/library/simboli-kawaii-cute/": {
+  "hash": "83ebb4268cc8b78f",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/simboli-luna/": {
+  "hash": "3761e64c439d2e94",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/simboli-matematici/": {
+  "hash": "1f07087591e18622",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/simboli-meteo/": {
+  "hash": "dbc302021eacedfa",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/simboli-musicali/": {
+  "hash": "7401df1cc1d7e7db",
+  "lastmod": "2026-08-13"
+ },
+ "/it/library/simboli-natale/": {
+  "hash": "fa8e2fc6d0636663",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/simboli-parentesi/": {
+  "hash": "a81af45cbc0b9226",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/simboli-pericolo/": {
+  "hash": "5c3ff92f8f3d889f",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/simboli-punteggiatura/": {
+  "hash": "295cf51b827398f4",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/simboli-punto-elenco/": {
+  "hash": "4c20c2f7dd00a8a1",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/simboli-religiosi/": {
+  "hash": "18b4d898d96e1ffa",
+  "lastmod": "2026-08-13"
+ },
+ "/it/library/simboli-roblox/": {
+  "hash": "754b6ed986943068",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/simboli-scacchi/": {
+  "hash": "caa92d27141c5a46",
+  "lastmod": "2026-08-13"
+ },
+ "/it/library/simboli-stella/": {
+  "hash": "110de218efc79774",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/simboli-tastiera/": {
+  "hash": "5af4a481b6d1be77",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/simboli-therian/": {
+  "hash": "136f43e064c0050a",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/simboli-whatsapp/": {
+  "hash": "063cdad1a1495524",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/simboli-witchy-occult/": {
+  "hash": "3fbdb454f63124ab",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/simboli-y2k/": {
+  "hash": "8684e57fa978808f",
+  "lastmod": "2026-08-16"
+ },
+ "/it/library/simboli-zodiaco/": {
+  "hash": "90e6109f2f0b6f7c",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/simboli/": {
+  "hash": "bc8af95e71e36701",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/simbolo-spunta/": {
+  "hash": "47a573bcf862e0be",
+  "lastmod": "2026-08-15"
+ },
+ "/it/library/tabella-ascii/": {
+  "hash": "d1347e52948866a6",
+  "lastmod": "2026-08-15"
+ },
+ "/it/maiuscole-e-minuscole/": {
+  "hash": "15d5dd509e6fec8e",
+  "lastmod": "2026-08-15"
+ },
+ "/it/nickname/": {
+  "hash": "894fc023d73bebac",
+  "lastmod": "2026-08-15"
+ },
+ "/it/scritte-3d/": {
+  "hash": "2ad5207888312a1c",
+  "lastmod": "2026-08-15"
+ },
+ "/it/scritte-aesthetic/": {
+  "hash": "56a86a655554be89",
+  "lastmod": "2026-08-15"
+ },
+ "/it/scritte-belle/": {
+  "hash": "925ddd703fbf1e18",
+  "lastmod": "2026-08-15"
+ },
+ "/it/scritte-particolari/": {
+  "hash": "d5b2748df0a5de6a",
+  "lastmod": "2026-08-15"
+ },
+ "/it/symbol/": {
+  "hash": "9a352eedd2b0f207",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/colori-dei-cuori-su-snapchat/": {
+  "hash": "947caea60f378e40",
+  "lastmod": "2026-08-13"
+ },
+ "/it/symbol/croce-ortodossa/": {
+  "hash": "1eb46ae1da6fcbf0",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/emoji-calendario/": {
+  "hash": "89c1715c8baa0425",
+  "lastmod": "2026-08-05"
+ },
+ "/it/symbol/emoji-cetriolino/": {
+  "hash": "ef3f52389362a22c",
+  "lastmod": "2026-08-05"
+ },
+ "/it/symbol/emoji-faccina-che-si-scioglie/": {
+  "hash": "83291962c2efbf10",
+  "lastmod": "2026-08-15"
+ },
+ "/it/symbol/emoji-faccina-distorta/": {
+  "hash": "26384457b5991c5b",
+  "lastmod": "2026-08-15"
+ },
+ "/it/symbol/emoji-farfalla-monarca/": {
+  "hash": "155b62fe8cebbc68",
+  "lastmod": "2026-08-05"
+ },
+ "/it/symbol/emoji-meteora/": {
+  "hash": "fb29487759a94bbc",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/emoji-microfono/": {
+  "hash": "b4351a81b2ff10c2",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/emoji-pollice-direzionale/": {
+  "hash": "1b468859cc8b30c6",
+  "lastmod": "2026-08-05"
+ },
+ "/it/symbol/emoji-volto-incrinato/": {
+  "hash": "9849b8a9831f4d1c",
+  "lastmod": "2026-08-05"
+ },
+ "/it/symbol/freccia-destra/": {
+  "hash": "405e49924a1fd4fa",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/freccia-giu/": {
+  "hash": "a8f6c487ecb6a8d2",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/freccia-sinistra/": {
+  "hash": "d282aa4540e75bac",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/freccia-su/": {
+  "hash": "1f296e49eb7b22b5",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/interrobang/": {
+  "hash": "68037b47c3b028ec",
+  "lastmod": "2026-08-05"
+ },
+ "/it/symbol/linea-verticale/": {
+  "hash": "e73abc8338a9927d",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/luna-nera-lilith/": {
+  "hash": "e8e114ba6bdc4897",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/punto-interrogativo-inverso/": {
+  "hash": "89ee72322280e08c",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simboli-minore-maggiore/": {
+  "hash": "210f9fd5aec3a254",
+  "lastmod": "2026-08-15"
+ },
+ "/it/symbol/simbolo-acquario/": {
+  "hash": "cc9e622830415e20",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-alfa/": {
+  "hash": "81e99974ef5a4fc3",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-anarchia/": {
+  "hash": "9384761764ef478f",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-ankh/": {
+  "hash": "039cb82b1415a904",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-ariete/": {
+  "hash": "311e9ac1669acb1c",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-asterisco/": {
+  "hash": "42a8d16d3303fdc2",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-autismo/": {
+  "hash": "4f0eb8b075d8b0fa",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-bilancia/": {
+  "hash": "fe110b5fce57fb4a",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-bitcoin/": {
+  "hash": "f3cd5c1b64c61d74",
+  "lastmod": "2026-08-15"
+ },
+ "/it/symbol/simbolo-cancro/": {
+  "hash": "9c54dfe46cd4f010",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-capricorno/": {
+  "hash": "973b7c1707f7cda6",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-carattere-invisibile/": {
+  "hash": "4273e83e29e83dae",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-celsius/": {
+  "hash": "d36c59b9a153059c",
+  "lastmod": "2026-08-15"
+ },
+ "/it/symbol/simbolo-centesimo/": {
+  "hash": "0bef1716473f3595",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-chi/": {
+  "hash": "ec337fe5a5265179",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-chiocciola/": {
+  "hash": "63d529738d233be8",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-congruente/": {
+  "hash": "580ac5953c192a86",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-copyright/": {
+  "hash": "646e300945de5639",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-croce/": {
+  "hash": "40f7e31739b5e484",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-cuore/": {
+  "hash": "6a461a09e2ce8af5",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-della-pace/": {
+  "hash": "9ab60bda76ed9370",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-delta/": {
+  "hash": "ad9a679e353eb4c9",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-di-paragrafo/": {
+  "hash": "0c5f83194bb27298",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-di-sezione/": {
+  "hash": "7c1687a87f0b8021",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-di-spunta/": {
+  "hash": "022d46ff101849e6",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-diametro/": {
+  "hash": "8a5560c9d3f1a275",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-dirham/": {
+  "hash": "af6dc8cda9d0b4c4",
+  "lastmod": "2026-08-06"
+ },
+ "/it/symbol/simbolo-diverso/": {
+  "hash": "a395899b9883e269",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-divisione/": {
+  "hash": "edb393719a0075bc",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-dollaro/": {
+  "hash": "70186791fe4e589f",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-e-commerciale/": {
+  "hash": "2035e42f1fe49d5d",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-euro/": {
+  "hash": "bac9e949e234232f",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-fahrenheit/": {
+  "hash": "a87147b792c49ddf",
+  "lastmod": "2026-08-15"
+ },
+ "/it/symbol/simbolo-fleur-de-lis/": {
+  "hash": "a934fa6e7b0a6b09",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-gemelli/": {
+  "hash": "dfd597ef09b86477",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-gradi/": {
+  "hash": "8379584e880d55e9",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-hamsa/": {
+  "hash": "05845e59d137be08",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-infinito/": {
+  "hash": "e622504f3e74e88b",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-khanda/": {
+  "hash": "e9ca86b88bcc9108",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-lambda/": {
+  "hash": "e057f948c5a96505",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-leone/": {
+  "hash": "3a58dacd29df56f5",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-marchio/": {
+  "hash": "3a2e509518d231c9",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-micro/": {
+  "hash": "9de916a4b6f1ba45",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-minore-o-uguale/": {
+  "hash": "ce76dddde14ac580",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-moltiplicazione/": {
+  "hash": "cc4d61375247fc60",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-occhiali-da-sole/": {
+  "hash": "0ed70656b35a28b0",
+  "lastmod": "2026-08-05"
+ },
+ "/it/symbol/simbolo-ohm/": {
+  "hash": "e95cdf2f3e4c72f6",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-om/": {
+  "hash": "67049a485766db33",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-omega/": {
+  "hash": "f76ad3911785de26",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-pedone/": {
+  "hash": "e18441b49ec7236e",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-pentagramma/": {
+  "hash": "f812289668df4a77",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-pesci/": {
+  "hash": "e93ddae651960b26",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-peso/": {
+  "hash": "8e66cce501e26cee",
+  "lastmod": "2026-08-05"
+ },
+ "/it/symbol/simbolo-phi/": {
+  "hash": "5adaa02226f0a183",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-pi-greco/": {
+  "hash": "e8a1d5d450d56cc4",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-picche/": {
+  "hash": "23c95c25a4cb3571",
+  "lastmod": "2026-08-05"
+ },
+ "/it/symbol/simbolo-piu-meno/": {
+  "hash": "6a7ced8b6021a04b",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-psi/": {
+  "hash": "6f12538f59bdff02",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-quadrato-cubo/": {
+  "hash": "17fb60ae41c8b8bd",
+  "lastmod": "2026-08-15"
+ },
+ "/it/symbol/simbolo-rabbia/": {
+  "hash": "99a19df1808b83ca",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-radice-quadrata/": {
+  "hash": "faf2b2d3c6bab268",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-rial-omanita/": {
+  "hash": "db7ad83646d464ec",
+  "lastmod": "2026-08-06"
+ },
+ "/it/symbol/simbolo-riciclo/": {
+  "hash": "5c46fb44932f80b1",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-rischio-biologico/": {
+  "hash": "3922992e08a007df",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-riyal-saudita/": {
+  "hash": "b6ff3e07e859b0f3",
+  "lastmod": "2026-08-06"
+ },
+ "/it/symbol/simbolo-rublo/": {
+  "hash": "8c6b74a063f6812b",
+  "lastmod": "2026-08-05"
+ },
+ "/it/symbol/simbolo-rufiyaa/": {
+  "hash": "050263eb42ef8cf7",
+  "lastmod": "2026-08-15"
+ },
+ "/it/symbol/simbolo-rupia/": {
+  "hash": "fcd65c7c91c4475d",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-sagittario/": {
+  "hash": "53e0fc6ef80340c8",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-scorpione/": {
+  "hash": "613c9b6e5d5f8ca7",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-sedia-a-rotelle/": {
+  "hash": "dcdf488de2c575b6",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-sigma/": {
+  "hash": "8708f6ea4bf652b5",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-stella/": {
+  "hash": "0c2fd8872371ce60",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-sterlina/": {
+  "hash": "f9e42072900e01bb",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-stop/": {
+  "hash": "2113899841e282b1",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-theta/": {
+  "hash": "68ec5e7ce6d8f075",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-tilde/": {
+  "hash": "2f1f8117138734d3",
+  "lastmod": "2026-08-11"
+ },
+ "/it/symbol/simbolo-toro/": {
+  "hash": "7c154c27aa1846fd",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-trattino-basso/": {
+  "hash": "a43d20b7edf31364",
+  "lastmod": "2026-08-11"
+ },
+ "/it/symbol/simbolo-vergine/": {
+  "hash": "6eb8802db65f941b",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-virgolette/": {
+  "hash": "8827112854a766cc",
+  "lastmod": "2026-08-15"
+ },
+ "/it/symbol/simbolo-won/": {
+  "hash": "d282d38761ad99c9",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-yen/": {
+  "hash": "db82848fc99c1a92",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/simbolo-yin-yang/": {
+  "hash": "fae3ef3cccf1e45e",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/stella-di-david/": {
+  "hash": "b46cfd9e0c25bdcc",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/stella-e-mezzaluna/": {
+  "hash": "18913ba250f50a40",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/teschio-e-tibie-incrociate/": {
+  "hash": "f0d2513321fd7688",
+  "lastmod": "2026-08-11"
+ },
+ "/it/symbol/trattino-lungo/": {
+  "hash": "970bcc192002f774",
+  "lastmod": "2026-08-16"
+ },
+ "/it/symbol/trattino-medio/": {
+  "hash": "4ce66709b1966628",
+  "lastmod": "2026-08-05"
+ },
+ "/it/testo-barrato/": {
+  "hash": "2a3f9126ff1056a4",
+  "lastmod": "2026-08-15"
+ },
+ "/it/testo-capovolto/": {
+  "hash": "ff3391e30d119dd8",
+  "lastmod": "2026-08-15"
+ },
+ "/it/testo-invisibile/": {
+  "hash": "d2700e54acea0198",
+  "lastmod": "2026-08-15"
+ },
+ "/it/testo-piccolo/": {
+  "hash": "697093fa61c625fd",
+  "lastmod": "2026-08-15"
+ },
+ "/it/testo-sottolineato/": {
+  "hash": "a6a007ae88546eae",
+  "lastmod": "2026-08-15"
+ },
+ "/it/updates/data-di-uscita-unicode-18-confermata/": {
+  "hash": "90f8e1afa9ea7b47",
+  "lastmod": "2026-08-15"
+ },
+ "/it/updates/revisione-beta-unicode-18/": {
+  "hash": "8149fd2d6c947595",
+  "lastmod": "2026-08-15"
+ },
+ "/it/updates/simboli-valuta-medio-oriente-unicode-18/": {
+  "hash": "7b5528b674a10cda",
+  "lastmod": "2026-08-15"
+ },
+ "/it/updates/simbolo-dirham-unicode-18/": {
+  "hash": "6db6b0a2edf90a47",
+  "lastmod": "2026-08-15"
+ },
+ "/it/usecase/": {
+  "hash": "fa6a0c2d50fd74e6",
+  "lastmod": "2026-08-15"
+ },
+ "/it/usecase/font-per-bio/": {
+  "hash": "71b8e6d39c2141c8",
+  "lastmod": "2026-08-15"
+ },
+ "/it/usecase/font-tatuaggi/": {
+  "hash": "8f4fbdb9de3c04f0",
+  "lastmod": "2026-08-15"
+ },
+ "/it/usecase/nomi-per-contatti-aesthetic/": {
+  "hash": "78367ea41625500d",
+  "lastmod": "2026-08-15"
+ },
+ "/it/usecase/nomi-per-gruppi/": {
+  "hash": "1df4c5b7c0da4437",
+  "lastmod": "2026-08-15"
+ },
+ "/it/usecase/nomi-stumble-guys/": {
+  "hash": "cc0363d43c350b10",
+  "lastmod": "2026-08-15"
+ },
+ "/it/usecase/traduttore-emoji/": {
+  "hash": "71dca3677c6275f8",
+  "lastmod": "2026-08-15"
+ },
+ "/it/usecase/vertical-text/": {
+  "hash": "7eced048119687ec",
+  "lastmod": "2026-08-15"
+ },
+ "/it/usecase/zalgo-text/": {
+  "hash": "31cad52ce42d1f74",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/": {
+  "hash": "d8760700a650436e",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/answers/": {
+  "hash": "b8c161fd9856d9e7",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/answers/game-namae-kyohi-riyuu/": {
+  "hash": "f03e5bf8e83e7f48",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/answers/kuuhaku-namae-tsukurikata/": {
+  "hash": "151cacb7c6f4d21e",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/answers/namae-shikaku-hyouji-riyuu/": {
+  "hash": "ef33021072ed9f05",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/answers/what-font-does-pinterest-use/": {
+  "hash": "6050c3c03d7d9577",
+  "lastmod": "2026-08-16"
+ },
+ "/ja/answers/what-font-does-whatsapp-use/": {
+  "hash": "8bf71e6fb3b234bc",
+  "lastmod": "2026-08-16"
+ },
+ "/ja/answers/yuuzaamei-matawa-hyoujimei/": {
+  "hash": "a733f2ab659af3b4",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/gal-moji/": {
+  "hash": "ebce57e80984e31e",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/guide/": {
+  "hash": "e04cd8034f46357d",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/guide/discord-anzen-namae/": {
+  "hash": "28e8112aa1fd10d1",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/guide/discord-font-doko/": {
+  "hash": "adc645bf846968eb",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/guide/discord-moji-soshoku/": {
+  "hash": "99d25f5212d2ca6a",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/hankaku-zenkaku/": {
+  "hash": "df68a83c3ae17e4f",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/hikkitai/": {
+  "hash": "af08d208876e3b0d",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/insta-font/": {
+  "hash": "f25e1dd917cedd7e",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/kawaii-moji/": {
+  "hash": "4c9348c9e5af6f3c",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/kuuhaku-moji/": {
+  "hash": "1ed60bd0c578c92c",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/": {
+  "hash": "c40510134ba3ee8e",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/aesthetic-symbols/": {
+  "hash": "8289ece625bccb7e",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/alt-codes/": {
+  "hash": "a73ea68848a4ba64",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/angry-kaomoji/": {
+  "hash": "4b1b0acd1f43263a",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/arrow-symbols/": {
+  "hash": "4e565bd5485d1420",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/ascii-hyou/": {
+  "hash": "a17dbd39b3178bbd",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/bullet-point-symbols/": {
+  "hash": "0677280caec3274d",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/bunsuu-kigou/": {
+  "hash": "ae77f025f65c9501",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/cat-kaomoji/": {
+  "hash": "285d69305e8d610f",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/checkmark-kigou/": {
+  "hash": "f74b4a0fe57557fd",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/chess-symbols/": {
+  "hash": "29afacdc78c5f82d",
+  "lastmod": "2026-08-13"
+ },
+ "/ja/library/crying-kaomoji/": {
+  "hash": "5096ce9502353622",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/currency-symbols/": {
+  "hash": "788c89e89b5a38b3",
+  "lastmod": "2026-08-07"
+ },
+ "/ja/library/cute-kaomoji/": {
+  "hash": "68ccf65a604b14ce",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/dansu-emoji/": {
+  "hash": "9562915910833753",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/discord-symbols/": {
+  "hash": "bc6aceb31c02906a",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/divider-kaomoji/": {
+  "hash": "37d33c436e13f293",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/dokuro-emoji/": {
+  "hash": "e8d967837d607dbb",
+  "lastmod": "2026-08-16"
+ },
+ "/ja/library/emoji-combos/": {
+  "hash": "9e2013580978a693",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/greek-letter-symbols/": {
+  "hash": "f82962f01e671010",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/hana-kigou/": {
+  "hash": "2e3ee53b76f8f1a2",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/happy-kaomoji/": {
+  "hash": "c262177919055602",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/heart-ascii-art/": {
+  "hash": "1782be18baf5b500",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/heart-kaomoji/": {
+  "hash": "8a7297da6886cc53",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/heart-symbols/": {
+  "hash": "88e1f9ee851e61b5",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/hieroglyph/": {
+  "hash": "9d6d27a2df68bc9a",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/hoshi-kaomoji/": {
+  "hash": "dac3c58ebd1b9f27",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/html-tokushu-moji/": {
+  "hash": "1f67c38eb648d283",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/hug-kaomoji/": {
+  "hash": "6f72f24b3953a209",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/iphone-emoji/": {
+  "hash": "96819bbb4c30302b",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/islamic-symbols/": {
+  "hash": "1f166af28e701161",
+  "lastmod": "2026-08-16"
+ },
+ "/ja/library/japanese-symbols/": {
+  "hash": "47447ce52cd09d54",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/kanashii-emoji/": {
+  "hash": "fdbd81c46aa213bd",
+  "lastmod": "2026-08-16"
+ },
+ "/ja/library/kao-emoji/": {
+  "hash": "4e8b07032a28bf86",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/kaomoji/": {
+  "hash": "7044458f2ed122e8",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/kawaii-cute-symbols/": {
+  "hash": "26ee2fda2feb53a6",
+  "lastmod": "2026-08-11"
+ },
+ "/ja/library/keyboard-kigou/": {
+  "hash": "eebc1f85220108c6",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/kisu-emoji/": {
+  "hash": "4b0d5c780b6cdc58",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/kokki-emoji/": {
+  "hash": "965302294050bac4",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/love-kaomoji/": {
+  "hash": "f44ec91ed0f4cce7",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/math-symbols/": {
+  "hash": "85db6f38e9351d24",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/me-emoji/": {
+  "hash": "3ee706a548792dcb",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/music-symbols/": {
+  "hash": "d3015c433e776996",
+  "lastmod": "2026-08-13"
+ },
+ "/ja/library/naku-emoji/": {
+  "hash": "e9226f9fd2a51ad8",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/neko-ascii-art/": {
+  "hash": "3dc35afdd72351a4",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/odoroki-kaomoji/": {
+  "hash": "03c6784c0613b3f4",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/oukan-emoji/": {
+  "hash": "662f0f6a8022aa99",
+  "lastmod": "2026-08-16"
+ },
+ "/ja/library/piero-emoji/": {
+  "hash": "3b6092951758a5b7",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/purezento-emoji/": {
+  "hash": "cbffcd03228e7e60",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/religious-symbols/": {
+  "hash": "a569db26e0a9363b",
+  "lastmod": "2026-08-13"
+ },
+ "/ja/library/ribon-kigou/": {
+  "hash": "f55c1830944e4a12",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/roblox-symbols/": {
+  "hash": "e1e1b4bb1a5b8be1",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/sad-kaomoji/": {
+  "hash": "b09a8e750423d43f",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/seiza-kigou/": {
+  "hash": "d977fed5bfe0a5d7",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/shirome-emoji/": {
+  "hash": "6d5c3aba5c67b652",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/shrug-kaomoji/": {
+  "hash": "2ba94b39318f8679",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/sparkle-symbols/": {
+  "hash": "87e9194c5f117323",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/special-characters/": {
+  "hash": "2b12c04a2f207ea4",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/star-symbols/": {
+  "hash": "250374e418111037",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/suuji-kigou/": {
+  "hash": "350d6f8c03414c42",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/te-emoji/": {
+  "hash": "7c4a5313bd855569",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/te-wo-furu-kaomoji/": {
+  "hash": "946ec999f0d74b2a",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/tere-kaomoji/": {
+  "hash": "591a65aa5c615301",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/trump-kigou/": {
+  "hash": "982af6adab14ee05",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/tsuki-kigou/": {
+  "hash": "2a7110c2ff82e4be",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/warai-kaomoji/": {
+  "hash": "74139aa185a852dd",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/wink-kaomoji/": {
+  "hash": "8e6b0a0a89cf4919",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/y2k-symbols/": {
+  "hash": "f127ae75d7f9e70e",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/library/zukei-kigou/": {
+  "hash": "c3de646a28ed2b10",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/mojisu-kaunto/": {
+  "hash": "19c8e0a3c737e6ef",
+  "lastmod": "2026-08-12"
+ },
+ "/ja/namae-kawaii/": {
+  "hash": "82850f87529a5174",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/oshare-moji/": {
+  "hash": "ef16018befaf8b9d",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/": {
+  "hash": "2d9a49936d7e10d3",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/anakii-kigou/": {
+  "hash": "fe92ae1325956210",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/andaabaa/": {
+  "hash": "7a64139be85180dc",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/anku-kigou/": {
+  "hash": "7fa659928d6f4102",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/anpasando-kigou/": {
+  "hash": "73ff854b457b5a35",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/arufa-kigou/": {
+  "hash": "12822d1d406d85da",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/asutarisuku-kigou/": {
+  "hash": "f0ee05f79f7bfc37",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/atto-maaku/": {
+  "hash": "b919dc6ffa36d046",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/baiohazaado-kigou/": {
+  "hash": "7aafece53ab7e489",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/bittokoin-kigou/": {
+  "hash": "269620059dbbe324",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/burakkumuun-ririsu-kigou/": {
+  "hash": "865a0d24c3dfc99e",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/chekkumaaku-kigou/": {
+  "hash": "8800b54bcf0247f4",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/chiruda/": {
+  "hash": "814a537693de3ca6",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/chokkei-kigou/": {
+  "hash": "bb3cd5ff29383754",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/chosakuken-kigou/": {
+  "hash": "adb1e9adb264049f",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/dabide-no-hoshi/": {
+  "hash": "ccf509ceb7c6fe03",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/danraku-kigou/": {
+  "hash": "b40085ec89abd8d8",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/degree-symbol/": {
+  "hash": "fb843a1db61204da",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/deruta-kigou/": {
+  "hash": "0aa7df1008a9da89",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/dirihamu-kigou/": {
+  "hash": "1b0005b138630ea2",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/division-sign/": {
+  "hash": "7aadc3a64603a173",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/dokuro-maaku/": {
+  "hash": "ee4b4e76b26c514c",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/doru-kigou/": {
+  "hash": "42bd9fd3b8114509",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/emu-dasshu/": {
+  "hash": "1cbdc42d57593187",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/en-dasshu/": {
+  "hash": "fc4742d4607764d1",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/en-kigou/": {
+  "hash": "5b2fab3df5e352c1",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/fai-kigou/": {
+  "hash": "11e193838fc8d61b",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/furuurudorisu-kigou/": {
+  "hash": "eddf0ced6bdfdf95",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/futagoza-kigou/": {
+  "hash": "db74d3594bbf31d8",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/futougou/": {
+  "hash": "22574972d8b2e17e",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/gobousei-kigou/": {
+  "hash": "7abd2706854aead6",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/goudou-kigou/": {
+  "hash": "d863cb2b449be37d",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/haato-kigou/": {
+  "hash": "a3a09863bb3edcbd",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/hamusa-kigou/": {
+  "hash": "b77bb476b1671ffd",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/hanten-gimonfu/": {
+  "hash": "f0a208ddd6a9ecda",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/heiwa-kigou/": {
+  "hash": "c01059fac21f5461",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/hibiware-kao-emoji/": {
+  "hash": "6f240edd474aeab8",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/hidari-yajirushi/": {
+  "hash": "bba95a1976f5d59e",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/hoshi-kigou/": {
+  "hash": "4a4861e2c9c4c358",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/hoshi-to-mikazuki-kigou/": {
+  "hash": "0f68e89e15e9d93f",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/ika-kigou/": {
+  "hash": "9526fce905e693c2",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/ikari-maaku/": {
+  "hash": "c4f3a83116a524cb",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/infinity/": {
+  "hash": "5c26ad5a5f38d07c",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/interobangu/": {
+  "hash": "9d03096c076d7f51",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/inyou-maaku/": {
+  "hash": "f708afed9e9b9c5f",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/inyoufu/": {
+  "hash": "3f0b90844a053ea1",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/iteza-kigou/": {
+  "hash": "2ca6c745984e7f7d",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/jiheishou-kigou/": {
+  "hash": "812371e075d802fb",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/juujika-kigou/": {
+  "hash": "55117392bf6059da",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/kai-kigou/": {
+  "hash": "8b31522759920770",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/kandaa-kigou/": {
+  "hash": "7ec278a13ae37e3c",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/kaniza-kigou/": {
+  "hash": "ad5cd79dff2f4c72",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/karendaa-emoji/": {
+  "hash": "e6e6a12067138aba",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/kashi-kigou/": {
+  "hash": "3f84e0520b25f94c",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/kurumaisu-maaku/": {
+  "hash": "172a5ac420120379",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/maiku-emoji/": {
+  "hash": "0cc3e6bffe68ad6e",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/maikuro-kigou/": {
+  "hash": "f195fef283497dd0",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/mienai-moji/": {
+  "hash": "3b0cc79203745c7e",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/migi-yajirushi/": {
+  "hash": "66eeac6ad989064f",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/mizugameza-kigou/": {
+  "hash": "a557a4b94a3e4c04",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/multiplication-sign/": {
+  "hash": "9760defc52f475b4",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/ohitsujiza-kigou/": {
+  "hash": "504c681790aa4329",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/omaanriaru-kigou/": {
+  "hash": "b1e9514185fd7113",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/omega-kigou/": {
+  "hash": "24bd8880038da052",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/ookabamadara-emoji/": {
+  "hash": "01bde6df22a27d38",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/otomeza-kigou/": {
+  "hash": "422b2fa31d64418a",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/oushiza-kigou/": {
+  "hash": "7af3d9f4e13a8daf",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/oyayubi-sain-emoji/": {
+  "hash": "ae945b44ed2ad869",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/pai-kigou/": {
+  "hash": "74101963f72be335",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/peso-kigou/": {
+  "hash": "03bd84522ab78dce",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/pikurusu-emoji/": {
+  "hash": "adc683c9ea25de9f",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/pondo-kigou/": {
+  "hash": "153252bfcdea94fe",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/poon-kigou/": {
+  "hash": "af65addf8376ab1b",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/purasumainasu-kigou/": {
+  "hash": "50b3b2e054b19727",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/pusai-kigou/": {
+  "hash": "b87b3eb5ef69ed35",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/ramuda-kigou/": {
+  "hash": "ca282e59cfdb72d4",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/risaikuru-maaku/": {
+  "hash": "92a524deef0e735b",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/rupii-kigou/": {
+  "hash": "e8c36dd0993e950a",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/ruuburu-kigou/": {
+  "hash": "80cda937ae106631",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/ryuusei-emoji/": {
+  "hash": "c76e0ab1df1b3266",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/sangurasu-emoji/": {
+  "hash": "1e14c397bd144aea",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/sasoriza-kigou/": {
+  "hash": "e57b9a37690ba894",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/saujiriyaru-kigou/": {
+  "hash": "32aca7b756608289",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/seikyoukai-juujika/": {
+  "hash": "75598ac73ca0cde9",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/seion-oomu/": {
+  "hash": "57d01a1f7509fe1b",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/sekushon-kigou/": {
+  "hash": "e5d957c3e8a826b6",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/sento-kigou/": {
+  "hash": "62cbc185a84109e4",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/sesshi-kigou/": {
+  "hash": "36efcd57925230d7",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/shiguma-kigou/": {
+  "hash": "18ffa7ddfeed771a",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/shiita-kigou/": {
+  "hash": "91b501d9996ac2c3",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/shishiza-kigou/": {
+  "hash": "6d88799c2765657a",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/shita-yajirushi/": {
+  "hash": "cf631030ea63310a",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/shouhyou-kigou/": {
+  "hash": "8e2b2a4793175b9c",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/shounari-dainari-kigou/": {
+  "hash": "a4385edf00334c8a",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/square-root/": {
+  "hash": "4bdcf05e9edabcfd",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/squared-cubed/": {
+  "hash": "a5631323966e4cf7",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/sunappuchatto-haato-no-iro/": {
+  "hash": "5b29be4648e572fb",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/supeedo-kigou/": {
+  "hash": "b666a754263c9d20",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/sutoppu-hyoushiki/": {
+  "hash": "a97926462013bb31",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/tatebou/": {
+  "hash": "ea66cb288ce38e4c",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/teikou-kigou/": {
+  "hash": "fcfb854c9b79b481",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/tenbinza-kigou/": {
+  "hash": "1db6159ab23e8782",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/ue-yajirushi/": {
+  "hash": "445ea762beb5a610",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/uoza-kigou/": {
+  "hash": "3388a73023bf2b17",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/won-kigou/": {
+  "hash": "b6655aea063bb823",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/yagiza-kigou/": {
+  "hash": "20be3ca5e42633a6",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/symbol/yuuro-kigou/": {
+  "hash": "1f5a80532eda8932",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/tiktok-font/": {
+  "hash": "11c7d06ce6030980",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/updates/unicode-18-most-anticipated-emoji/": {
+  "hash": "08cf1acc5ec4efad",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/updates/unicode-18-release-date-confirmed/": {
+  "hash": "fd3275aaa138bd16",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/usecase/bio-font/": {
+  "hash": "3ed491afae7440f9",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/usecase/renrakusaki-aesthetic/": {
+  "hash": "67f229c73d39ca1b",
+  "lastmod": "2026-08-15"
+ },
+ "/ja/usecase/vertical-text/": {
+  "hash": "f8b742d4eea3e6d0",
+  "lastmod": "2026-08-15"
+ },
+ "/kaomoji-dictionary/": {
+  "hash": "5aae14609034fbf8",
+  "lastmod": "2026-07-25"
+ },
+ "/kaomoji-generator/": {
+  "hash": "ce4468f5d98290f0",
+  "lastmod": "2026-07-25"
+ },
+ "/katakana-chart/": {
+  "hash": "a2325eecfdc1a73a",
+  "lastmod": "2026-07-25"
+ },
+ "/ko/": {
+  "hash": "dc1509910a80bfa3",
+  "lastmod": "2026-08-04"
+ },
+ "/ko/answers/bin-ireum-mandeulgi/": {
+  "hash": "48597e1a15385550",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/bin-kan-munja/": {
+  "hash": "bb8d5375721003d5",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/font-byeonhwan/": {
+  "hash": "47d9b0620b10fec0",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/gamseong-moji/": {
+  "hash": "285a5bfdff45779a",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/geuljasu-segi/": {
+  "hash": "cf8068afc2d29c68",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/guide/": {
+  "hash": "bb735b35f0c6f195",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/guide/discord-nikneim-anjeon/": {
+  "hash": "c7404c7b51b2c033",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/guide/discord-ponteu-jiwon/": {
+  "hash": "faef7b0610f77c7c",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/guide/discord-tekseuteu-seosik/": {
+  "hash": "a597068bbbefe422",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/insta-font/": {
+  "hash": "6127405338cd0e94",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/ireum-kkumigi/": {
+  "hash": "72fda182fb433f2a",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/jeongak-bangak/": {
+  "hash": "a5a97f01b9608c4f",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/": {
+  "hash": "cdf5c6546c1a44cc",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/alt-kodeu/": {
+  "hash": "8e36716cfbc79504",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/bukkeureoun-imotikon/": {
+  "hash": "c808dbe7d395d08b",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/bulkkot-imoji/": {
+  "hash": "fcf835b622543fb2",
+  "lastmod": "2026-08-16"
+ },
+ "/ko/library/bunsu-giho/": {
+  "hash": "43d8e0e2788e2739",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/byeol-giho/": {
+  "hash": "4f42455e1ebf501e",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/byeol-imotikon/": {
+  "hash": "7874278bb87e92c1",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/byeoljari-giho/": {
+  "hash": "15fc112adee5eef7",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/chekeu-giho/": {
+  "hash": "8683f1de3bd4952b",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/chess-gihou/": {
+  "hash": "e5089fec73ccf1b9",
+  "lastmod": "2026-08-13"
+ },
+ "/ko/library/danwi-giho/": {
+  "hash": "bb5afb55890a9330",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/discord-giho/": {
+  "hash": "0eb63104a048feb3",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/dohyeong-giho/": {
+  "hash": "4a7dc168ef611732",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/eomji-imoji/": {
+  "hash": "e08c9b22f6e85b84",
+  "lastmod": "2026-08-16"
+ },
+ "/ko/library/eumak-giho/": {
+  "hash": "933b3aa0a136530b",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/facebook-giho/": {
+  "hash": "f7d311285a91819c",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/gamseong-giho/": {
+  "hash": "d3b5d9beb039d21f",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/geurisa-munja/": {
+  "hash": "3697a9c6bc7d3db0",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/gido-imoji/": {
+  "hash": "bbaf9c08f35b535e",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/goyangi-ascii-art/": {
+  "hash": "f3f69606b1cf585a",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/goyangi-imotikon/": {
+  "hash": "b5eecc11c6e7b961",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/gubunseon-giho/": {
+  "hash": "d14ded56e5b54cf0",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/gukgi-imoji/": {
+  "hash": "1d8be6703cad9422",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/gwalho-giho/": {
+  "hash": "a1d68dbc36424284",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/gwiyeoun-imotikon/": {
+  "hash": "46cda89114e82ebc",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/gyocha-giho/": {
+  "hash": "6cced749f66fd701",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/haegol-imoji/": {
+  "hash": "164bde12c11d6bf7",
+  "lastmod": "2026-08-16"
+ },
+ "/ko/library/hateu-giho/": {
+  "hash": "e418f63a64a4a82f",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/hwanan-imotikon/": {
+  "hash": "a056a4f5c90a35dd",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/hwapye-giho/": {
+  "hash": "f703849161c1fe79",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/hwasalpyo-giho/": {
+  "hash": "3a79fc5a0e771276",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/ilboneo-giho/": {
+  "hash": "04d5dcf26aa71da4",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/imoji-johap/": {
+  "hash": "9c2131766c2916aa",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/imotikon/": {
+  "hash": "26548508b2afda00",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/islam-gihou/": {
+  "hash": "e00e45b2fe82664a",
+  "lastmod": "2026-08-13"
+ },
+ "/ko/library/jeom-giho/": {
+  "hash": "4d1decac49d47272",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/jonggyo-gihou/": {
+  "hash": "1a9cc0e76f671a83",
+  "lastmod": "2026-08-13"
+ },
+ "/ko/library/kawaii-gwiyeoun-gihou/": {
+  "hash": "056cf5e1e47517bf",
+  "lastmod": "2026-08-07"
+ },
+ "/ko/library/kkot-giho/": {
+  "hash": "ca3d66ebf43bb2be",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/moai-imoji/": {
+  "hash": "3a334cf273b45d49",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/munjangbuho-giho/": {
+  "hash": "3b099fb3a7e09ebb",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/nalssi-giho/": {
+  "hash": "71cdd67f1a2e3ade",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/roblox-giho/": {
+  "hash": "940fafbf84377a22",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/saenggak-imoji/": {
+  "hash": "bde05abf71561e79",
+  "lastmod": "2026-08-16"
+ },
+ "/ko/library/sarang-imotikon/": {
+  "hash": "7a2e1e1d7cbb52cf",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/seongbyeol-giho/": {
+  "hash": "77cf97c0a6b33329",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/seulpeun-imotikon/": {
+  "hash": "5d4144afdedebb21",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/suhak-giho/": {
+  "hash": "26d8a24f837f91bf",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/sutja-giho/": {
+  "hash": "d575bbe53b29606b",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/teuksu-munja/": {
+  "hash": "975d570c85233655",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/teureompeu-kadeu-giho/": {
+  "hash": "1cb29911c386c282",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/uneun-imotikon/": {
+  "hash": "d63e8d1dd9efe75b",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/unneun-imotikon/": {
+  "hash": "083ae48d1dcc563b",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/wanggwan-imoji/": {
+  "hash": "86efa8b2f73be691",
+  "lastmod": "2026-08-16"
+ },
+ "/ko/library/wingkeu-imotikon/": {
+  "hash": "56502880eafa4cc5",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/y2k-giho/": {
+  "hash": "ec17d249a2598cf0",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/library/yeppeun-teduri/": {
+  "hash": "275edeed6032d447",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/pilgichae-byeonhwan/": {
+  "hash": "78fa615af0024cc3",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/": {
+  "hash": "2993d64e15b7fc2c",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/aempeosaendeu-giho/": {
+  "hash": "ce81ddc0a172b29b",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/aet-giho/": {
+  "hash": "8e0ff3214d8270cb",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/alpa-giho/": {
+  "hash": "de463ab10976f4f4",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/anaki-giho/": {
+  "hash": "f16f87026fee9b24",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/angkeu-giho/": {
+  "hash": "0f0d19f669d05e03",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/araejjok-hwasalpyo-giho/": {
+  "hash": "ada7611f871b5899",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/baiohajeodeu-giho/": {
+  "hash": "48bc79b31dd7c1bf",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/beullaekmun-rilliseu-giho/": {
+  "hash": "79af9ff12812eae4",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/biteukoin-giho/": {
+  "hash": "976122c230480aaf",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/budeungho-giho/": {
+  "hash": "a45354cbe5a07e2e",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/bunno-giho/": {
+  "hash": "420440d316e823fb",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/byeol-pyosi-giho/": {
+  "hash": "354f74ecc03d3e51",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/byeolpyo-giho/": {
+  "hash": "fb413ec00925f53c",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/chekeu-pyosi-giho/": {
+  "hash": "93cb667bf4206c9f",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/cheonchingjari-giho/": {
+  "hash": "bbc261a9bd66f691",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/cheonyeojari-giho/": {
+  "hash": "9d3a5d205c427453",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/cheseu-pon-giho/": {
+  "hash": "a8a8af26f06b8c9d",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/choseungdal-byeol-giho/": {
+  "hash": "b829a498301954e5",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/dalleo-giho/": {
+  "hash": "d475e8faeb571453",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/dallyeok-imoji/": {
+  "hash": "693b2842b2af7260",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/danrak-giho/": {
+  "hash": "3ede5b867182ac0a",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/dawidui-byeol-giho/": {
+  "hash": "df0d8cf83062dfdc",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/delta-giho/": {
+  "hash": "d75b28b92e3cce8e",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/direuham-giho/": {
+  "hash": "caab13025e92dc26",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/do-giho/": {
+  "hash": "4fab8a8b43d90477",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/em-daesi-giho/": {
+  "hash": "9159a01d13a2defd",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/en-daesi-giho/": {
+  "hash": "ffd2b455b2ca0d1a",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/eomji-bangyang-imoji/": {
+  "hash": "a5daa826cd3c529a",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/eondeoba-giho/": {
+  "hash": "56ff6bc0c25459da",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/eumyang-giho/": {
+  "hash": "9c2ce6c4a9df85f1",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/gagam-giho/": {
+  "hash": "c804cd87d5e7ebab",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/gatji-anta-giho/": {
+  "hash": "59aa6ffe8d121cac",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/gejari-giho/": {
+  "hash": "995eee567b7af19a",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/geokkuro-mureumpyo-giho/": {
+  "hash": "d7472e1efd9be9ee",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/geumgan-eolgul-imoji/": {
+  "hash": "25ab0801d0d8d8e6",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/gophagi-giho/": {
+  "hash": "468e18c4e04bf49f",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/gungsujari-giho/": {
+  "hash": "4eee4a25180dd5f1",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/haegol-ppyeo-giho/": {
+  "hash": "c542d54ef0fc1013",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/hamsa-giho/": {
+  "hash": "988ed5e8557d8c62",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/hapdong-giho/": {
+  "hash": "78a18824721b8639",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/hateu-pyosi-giho/": {
+  "hash": "69159ed5e2734e07",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/hwangeumbi-giho/": {
+  "hash": "e85207e5997b5d79",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/hwangsojari-giho/": {
+  "hash": "f596407b36e1d284",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/hwassi-giho/": {
+  "hash": "0495de15ed040c96",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/hwilcheeo-giho/": {
+  "hash": "48d798417c58f8f3",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/inteorobaeng-giho/": {
+  "hash": "04a393da24c03fe3",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/jaehwalyong-giho/": {
+  "hash": "723314069339d00a",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/jakgeona-gatda-giho/": {
+  "hash": "075ffb2625146bb9",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/japye-giho/": {
+  "hash": "4f70262fc2fd0766",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/jegop-sejegop-giho/": {
+  "hash": "5c40c1be3c9a0fe6",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/jeohang-om-giho/": {
+  "hash": "7b87082ddebdc1dc",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/jeojakgwon-giho/": {
+  "hash": "86269bec7f3a612e",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/jeol-giho/": {
+  "hash": "75b2803c167e49bf",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/jeonggyohoe-sipjiga-giho/": {
+  "hash": "8d62faed0f894a53",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/jeongji-pyoji-giho/": {
+  "hash": "85e636a5fe4e95df",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/jeonkaljari-giho/": {
+  "hash": "23f15258d0a7399c",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/jireum-giho/": {
+  "hash": "428bbc15d6965633",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/kai-giho/": {
+  "hash": "72fece975bc0f8c7",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/kanda-giho/": {
+  "hash": "a3e9ea28fa64f137",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/maikeu-imoji/": {
+  "hash": "369d882ab305d023",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/maikeuro-giho/": {
+  "hash": "741305a3e32014ab",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/monakeu-nabi-imoji/": {
+  "hash": "d597b218e2ca8d82",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/muhandae-giho/": {
+  "hash": "189eab5673a9960d",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/mulbyeongjari-giho/": {
+  "hash": "65397575d9f55ae0",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/mulgogijari-giho/": {
+  "hash": "e3437e507106f06a",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/nanugi-giho/": {
+  "hash": "6fe06fb61786dcdc",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/oenjjok-hwasalpyo-giho/": {
+  "hash": "8ec1ba7887d4c4b5",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/om-giho/": {
+  "hash": "025b8ed94b2d3464",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/oman-rial-giho/": {
+  "hash": "7cdb4ae5857319df",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/omega-giho/": {
+  "hash": "7b6ebd6e2a930eeb",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/oreunjjok-hwasalpyo-giho/": {
+  "hash": "f8dcebb2c922470c",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/pai-giho/": {
+  "hash": "5d437c849d040dcc",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/paundeu-giho/": {
+  "hash": "44f06018e17142fd",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/pentageuraem-giho/": {
+  "hash": "76909cba6d09f461",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/peso-giho/": {
+  "hash": "f29a43951788dce0",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/peulleoreudeuriseu-giho/": {
+  "hash": "8b727e60c2000ec4",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/peusai-giho/": {
+  "hash": "476b0b7a84ed6e79",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/pikeul-imoji/": {
+  "hash": "e06f7217c41d6c4b",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/pyeonghwa-giho/": {
+  "hash": "84261f9181892140",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/ramda-giho/": {
+  "hash": "07a17cf5b41f9700",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/rubeul-giho/": {
+  "hash": "3d9d7f649f7517c7",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/rupi-giho/": {
+  "hash": "56b8f4c336ce715a",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/ruteu-giho/": {
+  "hash": "bd31447019d07099",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/sajajari-giho/": {
+  "hash": "1edbf37b4f476ca1",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/sangpyo-giho/": {
+  "hash": "fccfe4b44b662bd3",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/saudi-riyal-giho/": {
+  "hash": "e61345ad27da89d6",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/senteu-giho/": {
+  "hash": "6c14a51d529bf089",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/seongeulraseu-imoji/": {
+  "hash": "596c676c6ed85d54",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/seopssi-giho/": {
+  "hash": "11e88ac71fa19b10",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/seta-giho/": {
+  "hash": "44089cc217c49095",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/seunaepchaet-hateu-giho/": {
+  "hash": "13232e427a308512",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/sigma-giho/": {
+  "hash": "74c80b7c2f38d434",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/sipjiga-giho/": {
+  "hash": "211a8180e5d4a55e",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/speideu-giho/": {
+  "hash": "f81c3bde60d9d3a4",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/ssangdungi-jari-giho/": {
+  "hash": "eb8e11e79e06dbc6",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/sujik-seon-giho/": {
+  "hash": "0aac13ff7585a087",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/tildeu-giho/": {
+  "hash": "7f2ef1c9dd4f0091",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/ttaompyo-giho/": {
+  "hash": "76896fef96ada8e5",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/tumyeong-munja-giho/": {
+  "hash": "374acba80d4b4bca",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/wijjok-hwasalpyo-giho/": {
+  "hash": "f278df1520bee8cc",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/won-giho/": {
+  "hash": "00e636a578ddca41",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/yangjari-giho/": {
+  "hash": "388c53a32baacfb9",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/yen-giho/": {
+  "hash": "35131270b090bb7b",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/yeomsojari-giho/": {
+  "hash": "04f2553c2609a796",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/yuro-giho/": {
+  "hash": "697d56c8f529cc50",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/symbol/yuseong-imoji/": {
+  "hash": "b11e56d6f7f4996e",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/tiktok-font/": {
+  "hash": "e489230d357a1d29",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/updates/dirham-giho-unicode-18/": {
+  "hash": "818c5c1b83bb8c82",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/updates/jungdong-hwapye-giho-unicode-18/": {
+  "hash": "a6de8f8c98f5f3af",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/updates/unicode-18-beta-sijak/": {
+  "hash": "a3f89d21c31aa7d0",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/updates/unicode-18-chulsi-il-hwakjeong/": {
+  "hash": "5d4f927e0ef8f2e8",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/updates/unicode-18-imoji-tupyo/": {
+  "hash": "4104cc9d6228df35",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/usecase/vertical-text/": {
+  "hash": "aab86136faf052af",
+  "lastmod": "2026-08-15"
+ },
+ "/ko/yeppeun-geulssi/": {
+  "hash": "927e1eef0d96f87d",
+  "lastmod": "2026-08-15"
+ },
+ "/learn/": {
+  "hash": "16201ee1971da2e0",
+  "lastmod": "2026-07-25"
+ },
+ "/learn/coloring-and-fine-motor/": {
+  "hash": "03aaa2e1544ff2c6",
+  "lastmod": "2026-07-25"
+ },
+ "/learn/dot-to-dots/": {
+  "hash": "764f986fecaf0497",
+  "lastmod": "2026-07-25"
+ },
+ "/learn/handwriting/": {
+  "hash": "216c8940a70d5a7e",
+  "lastmod": "2026-07-25"
+ },
+ "/learn/handwriting/cursive-when-and-how/": {
+  "hash": "b011da71665ccb9e",
+  "lastmod": "2026-07-25"
+ },
+ "/learn/handwriting/first-letters-uppercase/": {
+  "hash": "97a336dde16a5e10",
+  "lastmod": "2026-07-25"
+ },
+ "/learn/handwriting/from-tracing-to-writing/": {
+  "hash": "cc9fa1177cbded23",
+  "lastmod": "2026-07-25"
+ },
+ "/learn/handwriting/how-much-practice/": {
+  "hash": "fcc2eb67c1fa7c09",
+  "lastmod": "2026-07-25"
+ },
+ "/learn/handwriting/lowercase-and-reversals/": {
+  "hash": "db9efb618d89d324",
+  "lastmod": "2026-07-25"
+ },
+ "/learn/handwriting/name-writing/": {
+  "hash": "8439bb4edf415f14",
+  "lastmod": "2026-07-25"
+ },
+ "/learn/handwriting/pre-writing-strokes/": {
+  "hash": "356cab78f6289fec",
+  "lastmod": "2026-07-25"
+ },
+ "/learn/handwriting/stroke-order-and-start-dots/": {
+  "hash": "016ac3ba56186473",
+  "lastmod": "2026-07-25"
+ },
+ "/learn/handwriting/when-to-start-handwriting/": {
+  "hash": "3cab7cd92efa94e6",
+  "lastmod": "2026-07-25"
+ },
+ "/library/": {
+  "hash": "0d615c1de3fe8c6c",
+  "lastmod": "2026-08-13"
+ },
+ "/library/accent-marks-diacritics/": {
+  "hash": "237ccbfe2c696349",
+  "lastmod": "2026-08-13"
+ },
+ "/library/achievement-symbols/": {
+  "hash": "fc9f5f029c83cc21",
+  "lastmod": "2026-08-13"
+ },
+ "/library/aesthetic-borders-frames/": {
+  "hash": "5a88104789c23508",
+  "lastmod": "2026-08-15"
+ },
+ "/library/aesthetic-symbols/": {
+  "hash": "7b1b3b7d0765c8d9",
+  "lastmod": "2026-08-13"
+ },
+ "/library/algeria-emoji-combos/": {
+  "hash": "7be8b6192b878072",
+  "lastmod": "2026-08-13"
+ },
+ "/library/alt-codes/": {
+  "hash": "c8f6e114280ca36d",
+  "lastmod": "2026-07-30"
+ },
+ "/library/angel-emoji/": {
+  "hash": "e5ae3e29ea93acad",
+  "lastmod": "2026-08-12"
+ },
+ "/library/angry-emoji/": {
+  "hash": "c87c4ef816296ec3",
+  "lastmod": "2026-08-16"
+ },
+ "/library/angry-kaomoji/": {
+  "hash": "ab5f5f1bd032287b",
+  "lastmod": "2026-08-12"
+ },
+ "/library/animal-emojis/": {
+  "hash": "b0de26f232ea0718",
+  "lastmod": "2026-08-15"
+ },
+ "/library/anime-symbols/": {
+  "hash": "848820880188c77c",
+  "lastmod": "2026-08-15"
+ },
+ "/library/annoyed-emoji/": {
+  "hash": "d457258a829a7192",
+  "lastmod": "2026-08-12"
+ },
+ "/library/argentina-emoji-combos/": {
+  "hash": "163534a3e8961f1a",
+  "lastmod": "2026-08-12"
+ },
+ "/library/arrow-symbols/": {
+  "hash": "c081ffbecc453352",
+  "lastmod": "2026-08-13"
+ },
+ "/library/art-stationery-emojis/": {
+  "hash": "37806513debb203c",
+  "lastmod": "2026-08-12"
+ },
+ "/library/ascii-table/": {
+  "hash": "90c507c4b1416463",
+  "lastmod": "2026-08-15"
+ },
+ "/library/australia-emoji-combos/": {
+  "hash": "2abd4319d2d4c7e8",
+  "lastmod": "2026-08-12"
+ },
+ "/library/austria-emoji-combos/": {
+  "hash": "c36392869f5a3b89",
+  "lastmod": "2026-08-13"
+ },
+ "/library/awareness-ribbons/": {
+  "hash": "4e512a6bf2bfe2b1",
+  "lastmod": "2026-08-13"
+ },
+ "/library/bear-kaomoji/": {
+  "hash": "440857ec8dacb2bd",
+  "lastmod": "2026-08-12"
+ },
+ "/library/beauty-nails-emojis/": {
+  "hash": "09b578a74a8c5326",
+  "lastmod": "2026-08-12"
+ },
+ "/library/belgium-emoji-combos/": {
+  "hash": "1451954c03c5bab8",
+  "lastmod": "2026-08-13"
+ },
+ "/library/bellingham-emoji-combos/": {
+  "hash": "b98195009bba91bd",
+  "lastmod": "2026-08-12"
+ },
+ "/library/benzema-emoji-combos/": {
+  "hash": "9fa9f54af36b979a",
+  "lastmod": "2026-07-25"
+ },
+ "/library/blush-emoji/": {
+  "hash": "dcb41680df74bc00",
+  "lastmod": "2026-08-12"
+ },
+ "/library/blushing-kaomoji/": {
+  "hash": "f08ebea309d27022",
+  "lastmod": "2026-08-12"
+ },
+ "/library/body-language-emojis/": {
+  "hash": "e48a9d24b3ccb981",
+  "lastmod": "2026-08-13"
+ },
+ "/library/bow-ribbon-symbols/": {
+  "hash": "a0c710c654503811",
+  "lastmod": "2026-08-15"
+ },
+ "/library/box-drawing-symbols/": {
+  "hash": "2d94bdd8e3d6f6c5",
+  "lastmod": "2026-07-25"
+ },
+ "/library/bracket-symbols/": {
+  "hash": "b33361041bc812cc",
+  "lastmod": "2026-08-15"
+ },
+ "/library/braille-pattern-symbols/": {
+  "hash": "224f3f0c6e2f037f",
+  "lastmod": "2026-08-12"
+ },
+ "/library/brainrot-slang-emojis/": {
+  "hash": "f755100d1b4484f2",
+  "lastmod": "2026-08-12"
+ },
+ "/library/brazil-emoji-combos/": {
+  "hash": "5611102d06161c19",
+  "lastmod": "2026-08-13"
+ },
+ "/library/bullet-point-symbols/": {
+  "hash": "08309b5b54836544",
+  "lastmod": "2026-08-14"
+ },
+ "/library/bunny-kaomoji/": {
+  "hash": "136a5ce4e88ae2e3",
+  "lastmod": "2026-08-12"
+ },
+ "/library/cameroon-emoji-combos/": {
+  "hash": "1b53ac51a7b3c970",
+  "lastmod": "2026-07-25"
+ },
+ "/library/canada-emoji-combos/": {
+  "hash": "19304bdfa7ab91ee",
+  "lastmod": "2026-08-13"
+ },
+ "/library/card-emoji-soccer/": {
+  "hash": "e6b96edc479e0966",
+  "lastmod": "2026-08-12"
+ },
+ "/library/card-suit-symbols/": {
+  "hash": "19d56f60ccbc89ea",
+  "lastmod": "2026-08-15"
+ },
+ "/library/cat-ascii-art/": {
+  "hash": "18a249f378132dc4",
+  "lastmod": "2026-08-12"
+ },
+ "/library/cat-kaomoji/": {
+  "hash": "e8199a5dba80648c",
+  "lastmod": "2026-08-10"
+ },
+ "/library/check-mark-emoji/": {
+  "hash": "c0300cc384b7c3eb",
+  "lastmod": "2026-08-12"
+ },
+ "/library/checkmark-symbols/": {
+  "hash": "ae76437e6cd3f034",
+  "lastmod": "2026-08-15"
+ },
+ "/library/chefs-kiss-emoji/": {
+  "hash": "f0a0b0da71d86988",
+  "lastmod": "2026-07-25"
+ },
+ "/library/chess-symbols/": {
+  "hash": "4d0e76e165dfe6d3",
+  "lastmod": "2026-08-13"
+ },
+ "/library/chile-emoji-combos/": {
+  "hash": "aee2876a1b0c8de5",
+  "lastmod": "2026-08-13"
+ },
+ "/library/china-emoji-combos/": {
+  "hash": "6488da61ccb5f4aa",
+  "lastmod": "2026-08-13"
+ },
+ "/library/chinese-symbols/": {
+  "hash": "68b98f12b71ec436",
+  "lastmod": "2026-08-12"
+ },
+ "/library/choking-emoji/": {
+  "hash": "d65feb356dd79035",
+  "lastmod": "2026-07-25"
+ },
+ "/library/christmas-symbols/": {
+  "hash": "e483aea86eae642c",
+  "lastmod": "2026-08-15"
+ },
+ "/library/clap-emoji/": {
+  "hash": "ee7d6b589ad74f83",
+  "lastmod": "2026-08-12"
+ },
+ "/library/clock-time-symbols/": {
+  "hash": "03c582386afe007d",
+  "lastmod": "2026-08-12"
+ },
+ "/library/clothing-fashion-emojis/": {
+  "hash": "f8497cd81ad3c305",
+  "lastmod": "2026-08-12"
+ },
+ "/library/clown-emoji/": {
+  "hash": "1f84274632209144",
+  "lastmod": "2026-08-15"
+ },
+ "/library/colombia-emoji-combos/": {
+  "hash": "ee6fa1b802085b7a",
+  "lastmod": "2026-08-13"
+ },
+ "/library/color-emoji-combos/": {
+  "hash": "a1bdea8bbf54bed4",
+  "lastmod": "2026-08-07"
+ },
+ "/library/confused-emoji/": {
+  "hash": "a256ac856e210459",
+  "lastmod": "2026-08-12"
+ },
+ "/library/copyright-trademark-symbols/": {
+  "hash": "d897f28e5f0a59e9",
+  "lastmod": "2026-08-12"
+ },
+ "/library/coquette-symbols/": {
+  "hash": "e99b52a91e9f830c",
+  "lastmod": "2026-08-13"
+ },
+ "/library/costa-rica-emoji-combos/": {
+  "hash": "5fd2debb4a008f64",
+  "lastmod": "2026-08-13"
+ },
+ "/library/cottagecore-symbols/": {
+  "hash": "387817120c0bdd00",
+  "lastmod": "2026-08-13"
+ },
+ "/library/cowboy-emoji/": {
+  "hash": "fd19f11556868a73",
+  "lastmod": "2026-08-12"
+ },
+ "/library/cringe-emoji/": {
+  "hash": "b8306f47d6741616",
+  "lastmod": "2026-08-12"
+ },
+ "/library/croatia-emoji-combos/": {
+  "hash": "a4adef9d4cea8e60",
+  "lastmod": "2026-08-13"
+ },
+ "/library/cross-x-symbols/": {
+  "hash": "3019cc98e95fd71e",
+  "lastmod": "2026-08-15"
+ },
+ "/library/crown-emoji/": {
+  "hash": "fdd851c80731772b",
+  "lastmod": "2026-08-16"
+ },
+ "/library/crown-royalty-symbols/": {
+  "hash": "b39b25e68a0c7167",
+  "lastmod": "2026-08-15"
+ },
+ "/library/crying-emoji/": {
+  "hash": "e6c838549eeac12a",
+  "lastmod": "2026-08-15"
+ },
+ "/library/crying-kaomoji/": {
+  "hash": "f7307a697c2546f4",
+  "lastmod": "2026-08-10"
+ },
+ "/library/currency-symbols/": {
+  "hash": "886accc3c78e25be",
+  "lastmod": "2026-08-15"
+ },
+ "/library/cute-kaomoji/": {
+  "hash": "60d9e2ce7f67e4c5",
+  "lastmod": "2026-08-10"
+ },
+ "/library/dancing-emoji/": {
+  "hash": "fec8a63803036ac3",
+  "lastmod": "2026-08-15"
+ },
+ "/library/dark-academia-symbols/": {
+  "hash": "3a6106d266a23b4a",
+  "lastmod": "2026-07-25"
+ },
+ "/library/dash-hyphen-symbols/": {
+  "hash": "d4fd00adde63b238",
+  "lastmod": "2026-07-25"
+ },
+ "/library/de-bruyne-emoji-combos/": {
+  "hash": "1a788c5b4d475fb8",
+  "lastmod": "2026-07-25"
+ },
+ "/library/denmark-emoji-combos/": {
+  "hash": "c4490161b4807fa1",
+  "lastmod": "2026-08-12"
+ },
+ "/library/devil-emoji/": {
+  "hash": "2b750bfcd0fd71e9",
+  "lastmod": "2026-08-15"
+ },
+ "/library/di-maria-emoji-combos/": {
+  "hash": "6b970905fc7a45da",
+  "lastmod": "2026-07-25"
+ },
+ "/library/dice-domino-symbols/": {
+  "hash": "996f05d17c3a6ed6",
+  "lastmod": "2026-08-13"
+ },
+ "/library/discord-symbols/": {
+  "hash": "a3e734bc90d8917a",
+  "lastmod": "2026-08-14"
+ },
+ "/library/divider-kaomoji/": {
+  "hash": "d6ac00b650a877d6",
+  "lastmod": "2026-08-12"
+ },
+ "/library/diwali-symbols/": {
+  "hash": "bc4ab348b87a5670",
+  "lastmod": "2026-07-31"
+ },
+ "/library/dog-ascii-art/": {
+  "hash": "cdb941a8db1ad0ad",
+  "lastmod": "2026-08-12"
+ },
+ "/library/dog-kaomoji/": {
+  "hash": "b95aa62e2278b4f5",
+  "lastmod": "2026-08-12"
+ },
+ "/library/dongers/": {
+  "hash": "cc274053df4207b5",
+  "lastmod": "2026-08-12"
+ },
+ "/library/dreamcore-weirdcore-symbols/": {
+  "hash": "5eb3d8b3e3a4112f",
+  "lastmod": "2026-08-11"
+ },
+ "/library/easter-symbols/": {
+  "hash": "d4b734a00b6be1f9",
+  "lastmod": "2026-08-12"
+ },
+ "/library/ecuador-emoji-combos/": {
+  "hash": "a3c014b20826a899",
+  "lastmod": "2026-08-13"
+ },
+ "/library/eggplant-emoji/": {
+  "hash": "e76703dc63d6ce94",
+  "lastmod": "2026-08-12"
+ },
+ "/library/egypt-emoji-combos/": {
+  "hash": "5fe171b9a3b0b2c4",
+  "lastmod": "2026-08-13"
+ },
+ "/library/egyptian-hieroglyphs/": {
+  "hash": "f418300d824ca336",
+  "lastmod": "2026-08-13"
+ },
+ "/library/electrical-circuit-symbols/": {
+  "hash": "ec34843e0463392b",
+  "lastmod": "2026-08-12"
+ },
+ "/library/email-symbols/": {
+  "hash": "81073abeedadb5dd",
+  "lastmod": "2026-08-13"
+ },
+ "/library/embarrassed-emoji/": {
+  "hash": "219d72c5cef4ebc1",
+  "lastmod": "2026-08-12"
+ },
+ "/library/emoji-combos/": {
+  "hash": "21e9164854dcb342",
+  "lastmod": "2026-08-12"
+ },
+ "/library/emoji-flags/": {
+  "hash": "9073bf2ac9a337f0",
+  "lastmod": "2026-08-13"
+ },
+ "/library/emoji-meanings-guide/": {
+  "hash": "7a92eb920d95fee1",
+  "lastmod": "2026-08-16"
+ },
+ "/library/england-emoji-combos/": {
+  "hash": "85c24c9eedec2abc",
+  "lastmod": "2026-08-12"
+ },
+ "/library/evil-eye-hamsa-symbols/": {
+  "hash": "ad92ae170cc1ef20",
+  "lastmod": "2026-08-01"
+ },
+ "/library/excited-kaomoji/": {
+  "hash": "819f4c97b2c773a7",
+  "lastmod": "2026-08-12"
+ },
+ "/library/eye-roll-emoji/": {
+  "hash": "29025b2852ee727d",
+  "lastmod": "2026-08-15"
+ },
+ "/library/eyes-emoji/": {
+  "hash": "a3c3dd9313b45241",
+  "lastmod": "2026-08-15"
+ },
+ "/library/face-emojis/": {
+  "hash": "10cdb0cced079456",
+  "lastmod": "2026-08-13"
+ },
+ "/library/facebook-symbols/": {
+  "hash": "caf65f13d4396a9e",
+  "lastmod": "2026-08-15"
+ },
+ "/library/facepalm-emoji/": {
+  "hash": "7403e50c4609503d",
+  "lastmod": "2026-08-12"
+ },
+ "/library/fairycore-symbols/": {
+  "hash": "769c13d93d32d5a5",
+  "lastmod": "2026-08-11"
+ },
+ "/library/fantasy-mythical-emojis/": {
+  "hash": "ab2eb1776c39b39e",
+  "lastmod": "2026-08-12"
+ },
+ "/library/fire-emoji/": {
+  "hash": "db72416d3e853e7e",
+  "lastmod": "2026-08-16"
+ },
+ "/library/flower-kaomoji/": {
+  "hash": "01702ec7e9015750",
+  "lastmod": "2026-07-31"
+ },
+ "/library/flower-symbols/": {
+  "hash": "7c84e6dd6d6d8e2d",
+  "lastmod": "2026-08-15"
+ },
+ "/library/foden-emoji-combos/": {
+  "hash": "df21e7aa6d1bbb71",
+  "lastmod": "2026-07-25"
+ },
+ "/library/food-drink-emojis/": {
+  "hash": "7a2c793d3f7ba069",
+  "lastmod": "2026-08-15"
+ },
+ "/library/football-ascii-art/": {
+  "hash": "e2bb61ef387206b5",
+  "lastmod": "2026-07-25"
+ },
+ "/library/football-emoji-copy-paste/": {
+  "hash": "7b7df3ab3933a091",
+  "lastmod": "2026-08-12"
+ },
+ "/library/football-kaomoji/": {
+  "hash": "d258d98e17a4f2b2",
+  "lastmod": "2026-07-25"
+ },
+ "/library/football-reaction-emojis/": {
+  "hash": "e635d6d03755a405",
+  "lastmod": "2026-07-25"
+ },
+ "/library/football-symbols/": {
+  "hash": "e415ae2b979d2eaf",
+  "lastmod": "2026-08-12"
+ },
+ "/library/football-trophy-emoji/": {
+  "hash": "6b4f952fa8dec9e0",
+  "lastmod": "2026-07-25"
+ },
+ "/library/football-username-ideas/": {
+  "hash": "f9ffaa0ed7377ac1",
+  "lastmod": "2026-07-25"
+ },
+ "/library/fortnite-symbols/": {
+  "hash": "d53533bc6692585b",
+  "lastmod": "2026-08-07"
+ },
+ "/library/fourth-of-july-symbols/": {
+  "hash": "ceb8588495810587",
+  "lastmod": "2026-07-31"
+ },
+ "/library/fraction-symbols/": {
+  "hash": "1b0c6b1b0ecea754",
+  "lastmod": "2026-08-15"
+ },
+ "/library/france-emoji-combos/": {
+  "hash": "4232ce5fe43da043",
+  "lastmod": "2026-08-13"
+ },
+ "/library/freaky-emoji/": {
+  "hash": "5553e0203de88429",
+  "lastmod": "2026-08-12"
+ },
+ "/library/free-fire-name-symbols/": {
+  "hash": "5a77905797f1055a",
+  "lastmod": "2026-08-10"
+ },
+ "/library/friendship-emojis/": {
+  "hash": "ec54fb1a14f1cc0d",
+  "lastmod": "2026-08-12"
+ },
+ "/library/funny-emoji-combos/": {
+  "hash": "85c4fd6ab940e613",
+  "lastmod": "2026-08-12"
+ },
+ "/library/gaming-aesthetic-symbols/": {
+  "hash": "48a608c979ee1b4e",
+  "lastmod": "2026-08-15"
+ },
+ "/library/gavi-emoji-combos/": {
+  "hash": "c2906d6aa94927ed",
+  "lastmod": "2026-07-25"
+ },
+ "/library/gender-symbols/": {
+  "hash": "111eb431d60f5543",
+  "lastmod": "2026-07-25"
+ },
+ "/library/geometric-symbols/": {
+  "hash": "cbb84c916f26c016",
+  "lastmod": "2026-08-15"
+ },
+ "/library/germany-emoji-combos/": {
+  "hash": "190a24f45d1e730d",
+  "lastmod": "2026-08-13"
+ },
+ "/library/ghana-emoji-combos/": {
+  "hash": "016a003f6e0a55ea",
+  "lastmod": "2026-08-12"
+ },
+ "/library/ghost-emoji/": {
+  "hash": "4bc0eac75a0ca494",
+  "lastmod": "2026-08-15"
+ },
+ "/library/gift-emoji/": {
+  "hash": "d07c1ac6fb513093",
+  "lastmod": "2026-08-15"
+ },
+ "/library/goal-emoji-combos/": {
+  "hash": "81019907ca09f29f",
+  "lastmod": "2026-08-12"
+ },
+ "/library/goat-emoji-combos/": {
+  "hash": "a7674ab6620cd603",
+  "lastmod": "2026-08-12"
+ },
+ "/library/goth-grunge-symbols/": {
+  "hash": "24bb9bec802869c2",
+  "lastmod": "2026-08-13"
+ },
+ "/library/greece-emoji-combos/": {
+  "hash": "887167eeea910d15",
+  "lastmod": "2026-08-12"
+ },
+ "/library/greek-letter-symbols/": {
+  "hash": "491463a2470458d3",
+  "lastmod": "2026-08-13"
+ },
+ "/library/greeting-message-emojis/": {
+  "hash": "474791a776582fca",
+  "lastmod": "2026-08-12"
+ },
+ "/library/griezmann-emoji-combos/": {
+  "hash": "68745c4f9442d8a1",
+  "lastmod": "2026-08-12"
+ },
+ "/library/guess-soccer-player-by-emoji/": {
+  "hash": "ec18797612e11b71",
+  "lastmod": "2026-08-12"
+ },
+ "/library/guess-soccer-team-by-emoji/": {
+  "hash": "94e2ba3b8f9969a6",
+  "lastmod": "2026-07-25"
+ },
+ "/library/haaland-emoji-combos/": {
+  "hash": "6df724f5a6bf1db4",
+  "lastmod": "2026-07-25"
+ },
+ "/library/halloween-symbols/": {
+  "hash": "048828a2ae37f3c6",
+  "lastmod": "2026-08-15"
+ },
+ "/library/halo-emoji/": {
+  "hash": "f8743b47dad62708",
+  "lastmod": "2026-08-12"
+ },
+ "/library/hand-symbols/": {
+  "hash": "2bad6481b2644123",
+  "lastmod": "2026-08-15"
+ },
+ "/library/handshake-emoji/": {
+  "hash": "3fa3c8cfdeb47e02",
+  "lastmod": "2026-08-12"
+ },
+ "/library/happy-emoji/": {
+  "hash": "3fe0b16b4941444a",
+  "lastmod": "2026-08-16"
+ },
+ "/library/happy-kaomoji/": {
+  "hash": "afce239fc7594ac1",
+  "lastmod": "2026-07-31"
+ },
+ "/library/hazard-warning-symbols/": {
+  "hash": "afd2359c83ce0c30",
+  "lastmod": "2026-08-15"
+ },
+ "/library/heart-ascii-art/": {
+  "hash": "d67d71db8fb80f14",
+  "lastmod": "2026-08-10"
+ },
+ "/library/heart-kaomoji/": {
+  "hash": "324190f1e91938b2",
+  "lastmod": "2026-08-12"
+ },
+ "/library/heart-symbols/": {
+  "hash": "9f0dffc63d066335",
+  "lastmod": "2026-08-13"
+ },
+ "/library/high-five-emoji/": {
+  "hash": "e9a833dcba4e1cbd",
+  "lastmod": "2026-07-25"
+ },
+ "/library/hindi-symbols/": {
+  "hash": "f1c0ccdf21da6704",
+  "lastmod": "2026-07-31"
+ },
+ "/library/honduras-emoji-combos/": {
+  "hash": "6c04372e23b4508a",
+  "lastmod": "2026-08-13"
+ },
+ "/library/html-entities/": {
+  "hash": "c394986b62a9a282",
+  "lastmod": "2026-08-12"
+ },
+ "/library/hug-kaomoji/": {
+  "hash": "74b7c44ba65bbae5",
+  "lastmod": "2026-08-12"
+ },
+ "/library/india-emoji-combos/": {
+  "hash": "71a6a7a93570cc2e",
+  "lastmod": "2026-08-12"
+ },
+ "/library/instagram-symbols/": {
+  "hash": "2c52008789a367a5",
+  "lastmod": "2026-08-15"
+ },
+ "/library/invisible-character/": {
+  "hash": "807dc1c00aef9787",
+  "lastmod": "2026-08-07"
+ },
+ "/library/ipa-phonetic-symbols/": {
+  "hash": "47422ce546b8cb2d",
+  "lastmod": "2026-08-12"
+ },
+ "/library/iphone-emojis/": {
+  "hash": "f8edb80d5c973120",
+  "lastmod": "2026-08-13"
+ },
+ "/library/iran-emoji-combos/": {
+  "hash": "52844df3384524f2",
+  "lastmod": "2026-08-13"
+ },
+ "/library/ireland-emoji-combos/": {
+  "hash": "eeb2431e806c8ecd",
+  "lastmod": "2026-08-12"
+ },
+ "/library/islamic-symbols/": {
+  "hash": "f2876b71a79a663a",
+  "lastmod": "2026-08-13"
+ },
+ "/library/italy-emoji-combos/": {
+  "hash": "26ff154b8095d8b0",
+  "lastmod": "2026-08-13"
+ },
+ "/library/ivory-coast-emoji-combos/": {
+  "hash": "67735ef4352f11dd",
+  "lastmod": "2026-08-13"
+ },
+ "/library/jamaica-emoji-combos/": {
+  "hash": "1d909add199cc0aa",
+  "lastmod": "2026-08-13"
+ },
+ "/library/japan-emoji-combos/": {
+  "hash": "88757329557764fa",
+  "lastmod": "2026-08-12"
+ },
+ "/library/japanese-symbols/": {
+  "hash": "9d8976de515306c9",
+  "lastmod": "2026-07-25"
+ },
+ "/library/jewelry-gem-emojis/": {
+  "hash": "914074ebabf7f1e1",
+  "lastmod": "2026-08-12"
+ },
+ "/library/kane-emoji-combos/": {
+  "hash": "79d7ef7ac87d3ece",
+  "lastmod": "2026-07-25"
+ },
+ "/library/kawaii-cute-symbols/": {
+  "hash": "73e27ffc53878203",
+  "lastmod": "2026-08-13"
+ },
+ "/library/keyboard-symbols/": {
+  "hash": "76e9ff750c326ce6",
+  "lastmod": "2026-08-15"
+ },
+ "/library/kiss-emoji/": {
+  "hash": "a559d68e702ad3fc",
+  "lastmod": "2026-08-15"
+ },
+ "/library/kiss-kaomoji/": {
+  "hash": "b37eab6e3cbfc62d",
+  "lastmod": "2026-07-31"
+ },
+ "/library/korean-symbols/": {
+  "hash": "ef82e8df74b1cef1",
+  "lastmod": "2026-08-12"
+ },
+ "/library/kvaratskhelia-emoji-combos/": {
+  "hash": "1fc876f239831ff9",
+  "lastmod": "2026-07-25"
+ },
+ "/library/latex-symbols/": {
+  "hash": "96f1c34881c7aecd",
+  "lastmod": "2026-08-16"
+ },
+ "/library/laughing-emoji/": {
+  "hash": "3c6c8cf026cb2e4e",
+  "lastmod": "2026-08-16"
+ },
+ "/library/laughing-kaomoji/": {
+  "hash": "b63e44d3c0d45eaa",
+  "lastmod": "2026-08-12"
+ },
+ "/library/laundry-care-symbols/": {
+  "hash": "1555a43820fd2d5e",
+  "lastmod": "2026-08-12"
+ },
+ "/library/lautaro-martinez-emoji-combos/": {
+  "hash": "c180c1ce50053296",
+  "lastmod": "2026-07-25"
+ },
+ "/library/lenny-face/": {
+  "hash": "3a8aef5839d93d42",
+  "lastmod": "2026-08-12"
+ },
+ "/library/lewandowski-emoji-combos/": {
+  "hash": "f6a2e2b929af6224",
+  "lastmod": "2026-07-25"
+ },
+ "/library/line-divider-symbols/": {
+  "hash": "2b1f9180e3e314df",
+  "lastmod": "2026-08-13"
+ },
+ "/library/linkedin-symbol-library/": {
+  "hash": "8d43f1c6d57b1595",
+  "lastmod": "2026-08-12"
+ },
+ "/library/lip-bite-emoji/": {
+  "hash": "5b4969c9da42f2b6",
+  "lastmod": "2026-08-12"
+ },
+ "/library/loading-text-symbols/": {
+  "hash": "cd944b857c6cff37",
+  "lastmod": "2026-07-25"
+ },
+ "/library/love-kaomoji/": {
+  "hash": "5c02b5a29c11a582",
+  "lastmod": "2026-08-10"
+ },
+ "/library/math-symbols/": {
+  "hash": "2a27a2f549eafe23",
+  "lastmod": "2026-08-13"
+ },
+ "/library/mbappe-emoji-combos/": {
+  "hash": "f1eba3e17ca86857",
+  "lastmod": "2026-07-25"
+ },
+ "/library/media-control-symbols/": {
+  "hash": "b82880b14fe89438",
+  "lastmod": "2026-07-25"
+ },
+ "/library/medical-symbols/": {
+  "hash": "e7086152d74f6353",
+  "lastmod": "2026-08-15"
+ },
+ "/library/meme-text-art/": {
+  "hash": "ba2d58237dd86e83",
+  "lastmod": "2026-08-12"
+ },
+ "/library/messi-emoji-combos/": {
+  "hash": "90c7be5184045438",
+  "lastmod": "2026-08-12"
+ },
+ "/library/mexico-emoji-combos/": {
+  "hash": "0a25f280ecd74c9e",
+  "lastmod": "2026-08-13"
+ },
+ "/library/middle-finger-emoji/": {
+  "hash": "cbb4379d4bd8b1bd",
+  "lastmod": "2026-08-16"
+ },
+ "/library/minecraft-symbols/": {
+  "hash": "aa9ea130c8a23c88",
+  "lastmod": "2026-08-12"
+ },
+ "/library/ml-name-symbols/": {
+  "hash": "caf9b628f6d92b59",
+  "lastmod": "2026-08-12"
+ },
+ "/library/moai-emoji/": {
+  "hash": "13d189b260802234",
+  "lastmod": "2026-08-12"
+ },
+ "/library/modric-emoji-combos/": {
+  "hash": "6e7a0ccad9ec7ac2",
+  "lastmod": "2026-07-25"
+ },
+ "/library/money-emojis/": {
+  "hash": "72ac2e13a0743892",
+  "lastmod": "2026-08-16"
+ },
+ "/library/moon-celestial-symbols/": {
+  "hash": "e501d36d86c4baa2",
+  "lastmod": "2026-08-15"
+ },
+ "/library/morocco-emoji-combos/": {
+  "hash": "7ad09cd260d550b3",
+  "lastmod": "2026-08-12"
+ },
+ "/library/movie-night-emojis/": {
+  "hash": "b2b87525e47b94ac",
+  "lastmod": "2026-07-25"
+ },
+ "/library/muscle-emoji/": {
+  "hash": "967425ef1e53735a",
+  "lastmod": "2026-08-12"
+ },
+ "/library/musiala-emoji-combos/": {
+  "hash": "cd02d635bd39fccb",
+  "lastmod": "2026-07-25"
+ },
+ "/library/music-kaomoji/": {
+  "hash": "4df524cdbac3d5fc",
+  "lastmod": "2026-07-25"
+ },
+ "/library/music-symbols/": {
+  "hash": "16edc6a20e5a5aa5",
+  "lastmod": "2026-08-13"
+ },
+ "/library/nature-emojis/": {
+  "hash": "9ca335807261a6d7",
+  "lastmod": "2026-08-12"
+ },
+ "/library/nerd-emoji/": {
+  "hash": "6e5c25768739dea9",
+  "lastmod": "2026-08-16"
+ },
+ "/library/netherlands-emoji-combos/": {
+  "hash": "a2797306f659aec4",
+  "lastmod": "2026-07-25"
+ },
+ "/library/new-zealand-emoji-combos/": {
+  "hash": "529d8d3a549ce483",
+  "lastmod": "2026-08-13"
+ },
+ "/library/neymar-emoji-combos/": {
+  "hash": "8598c02ca85a7063",
+  "lastmod": "2026-08-13"
+ },
+ "/library/nickname-symbols/": {
+  "hash": "a4061695958a8f1d",
+  "lastmod": "2026-08-15"
+ },
+ "/library/nigeria-emoji-combos/": {
+  "hash": "4384832bf96211db",
+  "lastmod": "2026-08-13"
+ },
+ "/library/nkunku-emoji-combos/": {
+  "hash": "a3126ba06ac81eeb",
+  "lastmod": "2026-07-25"
+ },
+ "/library/norse-viking-runes/": {
+  "hash": "acd1d54997fa187f",
+  "lastmod": "2026-08-15"
+ },
+ "/library/norway-emoji-combos/": {
+  "hash": "89d633e2fdc8a072",
+  "lastmod": "2026-08-13"
+ },
+ "/library/number-symbols/": {
+  "hash": "ff00b0e138cf6b8f",
+  "lastmod": "2026-08-13"
+ },
+ "/library/object-emojis/": {
+  "hash": "26f618f9f50e14a7",
+  "lastmod": "2026-08-12"
+ },
+ "/library/osimhen-emoji-combos/": {
+  "hash": "a2e05a57d9393865",
+  "lastmod": "2026-07-25"
+ },
+ "/library/panama-emoji-combos/": {
+  "hash": "c4e4ba10c0fd54b1",
+  "lastmod": "2026-08-13"
+ },
+ "/library/paraguay-emoji-combos/": {
+  "hash": "31d44b56078c9b54",
+  "lastmod": "2026-08-13"
+ },
+ "/library/party-celebration-emojis/": {
+  "hash": "eba9f16d12fd9090",
+  "lastmod": "2026-08-15"
+ },
+ "/library/peace-emoji/": {
+  "hash": "3b82ae3e7be00e57",
+  "lastmod": "2026-08-15"
+ },
+ "/library/pedri-emoji-combos/": {
+  "hash": "ff4b65e12c36e98d",
+  "lastmod": "2026-07-25"
+ },
+ "/library/people-profession-emojis/": {
+  "hash": "a956a1a353459153",
+  "lastmod": "2026-08-13"
+ },
+ "/library/peru-emoji-combos/": {
+  "hash": "85b212b9dd55e461",
+  "lastmod": "2026-08-13"
+ },
+ "/library/pleading-emoji/": {
+  "hash": "baf5fc4305763d7b",
+  "lastmod": "2026-08-12"
+ },
+ "/library/poland-emoji-combos/": {
+  "hash": "3f41cdf94631df2b",
+  "lastmod": "2026-08-13"
+ },
+ "/library/poop-emoji/": {
+  "hash": "d773cd6b5f4207ce",
+  "lastmod": "2026-08-16"
+ },
+ "/library/portugal-emoji-combos/": {
+  "hash": "2450a5df793792c2",
+  "lastmod": "2026-08-13"
+ },
+ "/library/praying-hands-emoji/": {
+  "hash": "d6b1f7319b743c65",
+  "lastmod": "2026-08-12"
+ },
+ "/library/preppy-emoji-combos/": {
+  "hash": "ed2836c091f2fff2",
+  "lastmod": "2026-08-12"
+ },
+ "/library/pride-lgbtq-symbols/": {
+  "hash": "d19120879d2d8e78",
+  "lastmod": "2026-08-12"
+ },
+ "/library/pubg-symbols/": {
+  "hash": "0d91bbd5ec6b3a5c",
+  "lastmod": "2026-08-14"
+ },
+ "/library/punctuation-symbols/": {
+  "hash": "2c129282153d8427",
+  "lastmod": "2026-08-13"
+ },
+ "/library/qatar-emoji-combos/": {
+  "hash": "282b149624f1f7ee",
+  "lastmod": "2026-08-13"
+ },
+ "/library/rashford-emoji-combos/": {
+  "hash": "e2cce2434afd61cc",
+  "lastmod": "2026-07-25"
+ },
+ "/library/recycle-environment-symbols/": {
+  "hash": "a2819c0cf91d7162",
+  "lastmod": "2026-08-12"
+ },
+ "/library/religious-symbols/": {
+  "hash": "ac2bc9a94ff0bc3f",
+  "lastmod": "2026-08-14"
+ },
+ "/library/roblox-symbols/": {
+  "hash": "df0973155e471f81",
+  "lastmod": "2026-08-14"
+ },
+ "/library/roblox-text-art/": {
+  "hash": "c73c6f88e0d570ac",
+  "lastmod": "2026-08-10"
+ },
+ "/library/rocket-emoji/": {
+  "hash": "2dd5a8750ee65c74",
+  "lastmod": "2026-08-16"
+ },
+ "/library/rodri-emoji-combos/": {
+  "hash": "b3ff57d870f87e2a",
+  "lastmod": "2026-07-25"
+ },
+ "/library/rodrygo-emoji-combos/": {
+  "hash": "50228366ea1b8837",
+  "lastmod": "2026-07-25"
+ },
+ "/library/ronaldo-emoji-combos/": {
+  "hash": "42da168bc087c673",
+  "lastmod": "2026-08-13"
+ },
+ "/library/sad-emoji/": {
+  "hash": "fa4e8e7cfdf02f1e",
+  "lastmod": "2026-08-16"
+ },
+ "/library/sad-kaomoji/": {
+  "hash": "278e2bf394e2cafe",
+  "lastmod": "2026-08-10"
+ },
+ "/library/saka-emoji-combos/": {
+  "hash": "3d3da3683baefb8e",
+  "lastmod": "2026-07-25"
+ },
+ "/library/salah-emoji-combos/": {
+  "hash": "bb5feff3dd7e7070",
+  "lastmod": "2026-08-13"
+ },
+ "/library/salute-emoji/": {
+  "hash": "82a051cf5ef7f42a",
+  "lastmod": "2026-08-12"
+ },
+ "/library/saudi-arabia-emoji-combos/": {
+  "hash": "bbe975030b677d2a",
+  "lastmod": "2026-08-13"
+ },
+ "/library/scared-emoji/": {
+  "hash": "966de78cec9b4a82",
+  "lastmod": "2026-08-12"
+ },
+ "/library/school-education-emojis/": {
+  "hash": "fcef1122c2e59cc0",
+  "lastmod": "2026-08-12"
+ },
+ "/library/scotland-emoji-combos/": {
+  "hash": "2b6eee5a8eeb739d",
+  "lastmod": "2026-08-13"
+ },
+ "/library/seahorse-emoji/": {
+  "hash": "3ad6fbf68313e90e",
+  "lastmod": "2026-08-16"
+ },
+ "/library/seasonal-emoji-combos/": {
+  "hash": "9a880843d9b3da72",
+  "lastmod": "2026-08-12"
+ },
+ "/library/senegal-emoji-combos/": {
+  "hash": "e4295aa2db04c685",
+  "lastmod": "2026-08-12"
+ },
+ "/library/serbia-emoji-combos/": {
+  "hash": "0c4fa7cdfbd1fbc2",
+  "lastmod": "2026-08-13"
+ },
+ "/library/shocked-emoji/": {
+  "hash": "752f1e1c83a0c59e",
+  "lastmod": "2026-08-16"
+ },
+ "/library/shocked-kaomoji/": {
+  "hash": "b9269e9a168d15a0",
+  "lastmod": "2026-08-12"
+ },
+ "/library/shrug-kaomoji/": {
+  "hash": "d4fe23923ba9becf",
+  "lastmod": "2026-07-25"
+ },
+ "/library/sick-emoji/": {
+  "hash": "888bdeba195e2b00",
+  "lastmod": "2026-08-12"
+ },
+ "/library/side-eye-emoji/": {
+  "hash": "8b31a51153e6763e",
+  "lastmod": "2026-08-12"
+ },
+ "/library/sigh-emoji/": {
+  "hash": "1cd17f5030621a02",
+  "lastmod": "2026-08-12"
+ },
+ "/library/skull-ascii-art/": {
+  "hash": "6e12117ae668080c",
+  "lastmod": "2026-08-12"
+ },
+ "/library/skull-emoji/": {
+  "hash": "aa2edacf990b9de7",
+  "lastmod": "2026-08-16"
+ },
+ "/library/slash-backslash-symbols/": {
+  "hash": "ca0952b50da35245",
+  "lastmod": "2026-08-12"
+ },
+ "/library/sleepy-kaomoji/": {
+  "hash": "cbcd079a721b51a2",
+  "lastmod": "2026-07-25"
+ },
+ "/library/smiley-face-guide/": {
+  "hash": "b88ace90ed0feda6",
+  "lastmod": "2026-08-13"
+ },
+ "/library/smirk-emoji/": {
+  "hash": "9012c0310ccb4ffb",
+  "lastmod": "2026-08-12"
+ },
+ "/library/snapchat-symbols/": {
+  "hash": "037b5f5644296948",
+  "lastmod": "2026-08-13"
+ },
+ "/library/soccer-emoji-copy-paste/": {
+  "hash": "a1bc4a9bf95308e8",
+  "lastmod": "2026-07-25"
+ },
+ "/library/son-emoji-combos/": {
+  "hash": "cc72ad8b0f047b4e",
+  "lastmod": "2026-07-25"
+ },
+ "/library/south-africa-emoji-combos/": {
+  "hash": "00641fae9c8d0d77",
+  "lastmod": "2026-07-25"
+ },
+ "/library/south-korea-emoji-combos/": {
+  "hash": "6e5d4462438d6013",
+  "lastmod": "2026-08-13"
+ },
+ "/library/spain-emoji-combos/": {
+  "hash": "9ef535277c15c6c7",
+  "lastmod": "2026-08-13"
+ },
+ "/library/sparkle-kaomoji/": {
+  "hash": "baf08d7b8ba337e9",
+  "lastmod": "2026-07-31"
+ },
+ "/library/sparkle-symbols/": {
+  "hash": "43aa48278ce69e78",
+  "lastmod": "2026-08-13"
+ },
+ "/library/special-characters/": {
+  "hash": "e0d59f1b0ab84a53",
+  "lastmod": "2026-08-13"
+ },
+ "/library/sports-emojis/": {
+  "hash": "f27b69dc3be8014b",
+  "lastmod": "2026-08-15"
+ },
+ "/library/star-ascii-art/": {
+  "hash": "ad34e606a0d774d2",
+  "lastmod": "2026-07-25"
+ },
+ "/library/star-emoji/": {
+  "hash": "605cffc951a9c3f6",
+  "lastmod": "2026-08-12"
+ },
+ "/library/star-kaomoji/": {
+  "hash": "0b754e7cce3a931d",
+  "lastmod": "2026-08-12"
+ },
+ "/library/star-symbols/": {
+  "hash": "0a899bc3c2a049d0",
+  "lastmod": "2026-08-01"
+ },
+ "/library/steam-symbols/": {
+  "hash": "0140da8c7ebdffe4",
+  "lastmod": "2026-07-25"
+ },
+ "/library/suarez-emoji-combos/": {
+  "hash": "89d51145e8e463f8",
+  "lastmod": "2026-07-25"
+ },
+ "/library/sunglasses-emoji/": {
+  "hash": "248e73aa23b3b003",
+  "lastmod": "2026-08-12"
+ },
+ "/library/sweden-emoji-combos/": {
+  "hash": "0b7b8ba794510f49",
+  "lastmod": "2026-08-13"
+ },
+ "/library/switzerland-emoji-combos/": {
+  "hash": "5abd8ea78bb9891f",
+  "lastmod": "2026-08-12"
+ },
+ "/library/table-flip-kaomoji/": {
+  "hash": "4acdc205af4b221e",
+  "lastmod": "2026-08-12"
+ },
+ "/library/tech-status-symbols/": {
+  "hash": "4c896c4920e84cf0",
+  "lastmod": "2026-08-13"
+ },
+ "/library/text-art/": {
+  "hash": "93cb1341ab5a0181",
+  "lastmod": "2026-08-15"
+ },
+ "/library/text-faces-kaomoji/": {
+  "hash": "7c0a7a225e66e312",
+  "lastmod": "2026-08-13"
+ },
+ "/library/thanksgiving-symbols/": {
+  "hash": "b07edce590423de2",
+  "lastmod": "2026-08-12"
+ },
+ "/library/therian-symbols/": {
+  "hash": "2de631dec9fef9a6",
+  "lastmod": "2026-07-30"
+ },
+ "/library/thinking-emoji/": {
+  "hash": "3a8a64250d244b03",
+  "lastmod": "2026-08-16"
+ },
+ "/library/thumbs-up-emoji/": {
+  "hash": "0fed7c58003d8fa4",
+  "lastmod": "2026-08-16"
+ },
+ "/library/thumbs-up-kaomoji/": {
+  "hash": "ed7e201d5c66d171",
+  "lastmod": "2026-08-12"
+ },
+ "/library/tiktok-symbols/": {
+  "hash": "3298c7641c33fdd9",
+  "lastmod": "2026-08-14"
+ },
+ "/library/tired-emoji/": {
+  "hash": "89a5166024e6191b",
+  "lastmod": "2026-08-12"
+ },
+ "/library/tongue-emoji/": {
+  "hash": "b07a1e199ac47997",
+  "lastmod": "2026-08-16"
+ },
+ "/library/traffic-road-sign-symbols/": {
+  "hash": "aca303308fcf7794",
+  "lastmod": "2026-08-13"
+ },
+ "/library/transport-symbols/": {
+  "hash": "f5c5d58d817dcf83",
+  "lastmod": "2026-08-13"
+ },
+ "/library/travel-vacation-emojis/": {
+  "hash": "533e53de6ed37558",
+  "lastmod": "2026-08-12"
+ },
+ "/library/tunisia-emoji-combos/": {
+  "hash": "ec859d7606df1336",
+  "lastmod": "2026-08-13"
+ },
+ "/library/turkey-emoji-combos/": {
+  "hash": "fb8762157247b0af",
+  "lastmod": "2026-07-25"
+ },
+ "/library/ukraine-emoji-combos/": {
+  "hash": "740826ad2eab38e0",
+  "lastmod": "2026-08-12"
+ },
+ "/library/unit-measurement-symbols/": {
+  "hash": "700bdebe2ed2d4b2",
+  "lastmod": "2026-08-12"
+ },
+ "/library/uruguay-emoji-combos/": {
+  "hash": "e635bcc795b35a85",
+  "lastmod": "2026-08-13"
+ },
+ "/library/usa-emoji-combos/": {
+  "hash": "50a4a89c9b1d3a35",
+  "lastmod": "2026-08-12"
+ },
+ "/library/venezuela-emoji-combos/": {
+  "hash": "f64a4fa17431f71b",
+  "lastmod": "2026-08-13"
+ },
+ "/library/vertical-line-symbols/": {
+  "hash": "dce6052b7ef3bc80",
+  "lastmod": "2026-08-12"
+ },
+ "/library/vinicius-emoji-combos/": {
+  "hash": "dc41d06e7bcdfc56",
+  "lastmod": "2026-07-25"
+ },
+ "/library/vrchat-symbols/": {
+  "hash": "390e98fffd58dd99",
+  "lastmod": "2026-08-05"
+ },
+ "/library/wales-emoji-combos/": {
+  "hash": "2dccc6e2013a65d7",
+  "lastmod": "2026-08-13"
+ },
+ "/library/wave-kaomoji/": {
+  "hash": "e45c7972e30195b8",
+  "lastmod": "2026-08-12"
+ },
+ "/library/weapon-tool-emojis/": {
+  "hash": "b88dcb205ef9b95a",
+  "lastmod": "2026-08-12"
+ },
+ "/library/weather-symbols/": {
+  "hash": "15645554c525ae7f",
+  "lastmod": "2026-08-13"
+ },
+ "/library/wedding-anniversary-emojis/": {
+  "hash": "f22314ab72e6e0ec",
+  "lastmod": "2026-08-12"
+ },
+ "/library/whatsapp-symbols/": {
+  "hash": "40409e34712c2180",
+  "lastmod": "2026-08-15"
+ },
+ "/library/wink-emoji/": {
+  "hash": "32cada79e19cdb07",
+  "lastmod": "2026-08-16"
+ },
+ "/library/wink-kaomoji/": {
+  "hash": "d65c3adc767685f9",
+  "lastmod": "2026-08-12"
+ },
+ "/library/wirtz-emoji-combos/": {
+  "hash": "71e71ab2571f2227",
+  "lastmod": "2026-07-25"
+ },
+ "/library/witchy-occult-symbols/": {
+  "hash": "0ee7fae4f48c10f3",
+  "lastmod": "2026-08-13"
+ },
+ "/library/world-cup-emoji-combos/": {
+  "hash": "b45df11ad9b06b7c",
+  "lastmod": "2026-07-25"
+ },
+ "/library/x-twitter-symbols/": {
+  "hash": "8a1f1ee33db00bd5",
+  "lastmod": "2026-08-15"
+ },
+ "/library/y2k-symbols/": {
+  "hash": "1dfd772be7e54178",
+  "lastmod": "2026-08-14"
+ },
+ "/library/yamal-emoji-combos/": {
+  "hash": "0a06e05441f4d37b",
+  "lastmod": "2026-07-25"
+ },
+ "/library/zodiac-symbols/": {
+  "hash": "877e8dc79f00e26d",
+  "lastmod": "2026-08-15"
+ },
+ "/linkedin/": {
+  "hash": "254c836af7995147",
+  "lastmod": "2026-07-25"
+ },
+ "/ms/": {
+  "hash": "9a9f9ca86b3ee1ca",
+  "lastmod": "2026-08-07"
+ },
+ "/ms/answers/cara-buat-nama-kosong/": {
+  "hash": "e3da40df232739f2",
+  "lastmod": "2026-08-15"
+ },
+ "/ms/answers/kenapa-nama-game-ditolak/": {
+  "hash": "865db2dab4adf72b",
+  "lastmod": "2026-08-15"
+ },
+ "/ms/answers/nama-jadi-kotak-kosong/": {
+  "hash": "8fce2a9146d16997",
+  "lastmod": "2026-08-15"
+ },
+ "/ms/answers/username-atau-display-name/": {
+  "hash": "9df3ff7ad794427a",
+  "lastmod": "2026-08-15"
+ },
+ "/ms/font-discord/": {
+  "hash": "0473f263eba24d97",
+  "lastmod": "2026-08-16"
+ },
+ "/ms/guide/": {
+  "hash": "996cce569b66ff47",
+  "lastmod": "2026-08-15"
+ },
+ "/ms/guide/di-mana-font-discord-berfungsi/": {
+  "hash": "6d33fad4c4e9243e",
+  "lastmod": "2026-08-15"
+ },
+ "/ms/guide/format-teks-discord-dijelaskan/": {
+  "hash": "1a10190ec11ed968",
+  "lastmod": "2026-07-26"
+ },
+ "/ms/guide/nama-discord-selamat/": {
+  "hash": "2b893299b9b6076c",
+  "lastmod": "2026-08-15"
+ },
+ "/ms/huruf-besar-kecil/": {
+  "hash": "6606420704370387",
+  "lastmod": "2026-08-16"
+ },
+ "/ms/library/ruang-kosong/": {
+  "hash": "ba647c5588610563",
+  "lastmod": "2026-08-16"
+ },
+ "/ms/library/simbol-discord/": {
+  "hash": "24cec9d9bfdfb3dd",
+  "lastmod": "2026-08-15"
+ },
+ "/ms/library/simbol-ff/": {
+  "hash": "b81bd7cc354d9fce",
+  "lastmod": "2026-08-15"
+ },
+ "/ms/library/simbol-roblox/": {
+  "hash": "711a4fc01c81295e",
+  "lastmod": "2026-08-15"
+ },
+ "/ms/library/simbol-y2k/": {
+  "hash": "001d688ad6a8fd4b",
+  "lastmod": "2026-08-15"
+ },
+ "/ms/symbol/aksara-tak-nampak/": {
+  "hash": "884d1699fec1374c",
+  "lastmod": "2026-08-16"
+ },
+ "/ms/tulisan-condong/": {
+  "hash": "5f028b49717257f4",
+  "lastmod": "2026-08-16"
+ },
+ "/ms/tulisan-gotik/": {
+  "hash": "33222f7e45fa27ff",
+  "lastmod": "2026-08-16"
+ },
+ "/ms/tulisan-kecil/": {
+  "hash": "26f3eaa95e4a3840",
+  "lastmod": "2026-08-16"
+ },
+ "/ms/tulisan-tebal/": {
+  "hash": "a88264db56253178",
+  "lastmod": "2026-08-16"
+ },
+ "/ms/usecase/nama-ff-hebat/": {
+  "hash": "2b554321f226b088",
+  "lastmod": "2026-08-16"
+ },
+ "/ms/usecase/nama-ml-hebat/": {
+  "hash": "b8420cafaaa4729b",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/": {
+  "hash": "a9aadd2170b656f1",
+  "lastmod": "2026-08-15"
+ },
+ "/nl/answers/": {
+  "hash": "c7da3d74a729e923",
+  "lastmod": "2026-08-07"
+ },
+ "/nl/answers/gebruikersnaam-of-weergavenaam/": {
+  "hash": "d840259da8b7ac7c",
+  "lastmod": "2026-08-07"
+ },
+ "/nl/answers/lege-naam-maken/": {
+  "hash": "3f0c87db22fdbcc0",
+  "lastmod": "2026-08-15"
+ },
+ "/nl/answers/waarom-toont-mijn-naam-blokjes/": {
+  "hash": "2b6ef880da92a6a6",
+  "lastmod": "2026-08-07"
+ },
+ "/nl/answers/what-font-does-pinterest-use/": {
+  "hash": "7cc87d90aa39461f",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/answers/what-font-does-whatsapp-use/": {
+  "hash": "29ae3d49c7755409",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/cursieve-letters/": {
+  "hash": "45b3ce0719aed9ad",
+  "lastmod": "2026-08-15"
+ },
+ "/nl/facebook-lettertype/": {
+  "hash": "16c628b9d558aaf7",
+  "lastmod": "2026-08-07"
+ },
+ "/nl/gotische-letters/": {
+  "hash": "bdcb0512486c240a",
+  "lastmod": "2026-08-15"
+ },
+ "/nl/guide/": {
+  "hash": "f3b848a343b1976a",
+  "lastmod": "2026-08-11"
+ },
+ "/nl/guide/discord-naam-veilig-stylen/": {
+  "hash": "b19166d329e702cc",
+  "lastmod": "2026-07-26"
+ },
+ "/nl/guide/discord-tekstopmaak-uitgelegd/": {
+  "hash": "6f202ae069f675df",
+  "lastmod": "2026-07-26"
+ },
+ "/nl/guide/waar-lettertypes-werken-in-discord/": {
+  "hash": "e5c0466b0ed2c8d2",
+  "lastmod": "2026-07-26"
+ },
+ "/nl/instagram-lettertype/": {
+  "hash": "5f4763157f41b88a",
+  "lastmod": "2026-08-07"
+ },
+ "/nl/kleine-letters/": {
+  "hash": "436cfcba7313be28",
+  "lastmod": "2026-08-07"
+ },
+ "/nl/library/": {
+  "hash": "5be0118d2ebcb15f",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/library/alt-codes/": {
+  "hash": "12c1ed1d6618f3f4",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/library/angry-emoji/": {
+  "hash": "9335edda49a3462f",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/library/ascii-kunst/": {
+  "hash": "7dc0aa336a56a506",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/library/ascii-tabel/": {
+  "hash": "39eb8c8530700a28",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/library/cadeau-emoji/": {
+  "hash": "4dab68d4572044bf",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/library/clown-emoji/": {
+  "hash": "9741232b3cb8c634",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/library/crown-emoji/": {
+  "hash": "b8c6686280eb44d0",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/library/discord-symbolen/": {
+  "hash": "4c1d4c21aa3cb909",
+  "lastmod": "2026-08-14"
+ },
+ "/nl/library/duim-omhoog-emoji/": {
+  "hash": "5772e545585f481e",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/library/emoji-betekenis/": {
+  "hash": "8dbae169d6683e22",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/library/emoji-combos/": {
+  "hash": "b40d340eee1e3055",
+  "lastmod": "2026-08-07"
+ },
+ "/nl/library/emoji-vlaggen/": {
+  "hash": "311ffb62f4b20d5e",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/library/euroteken/": {
+  "hash": "a2c0d5bf6e12990b",
+  "lastmod": "2026-08-13"
+ },
+ "/nl/library/fire-emoji/": {
+  "hash": "b9367d6aa6994aa4",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/library/gender-symbolen/": {
+  "hash": "35f438abed6b88f4",
+  "lastmod": "2026-08-13"
+ },
+ "/nl/library/griekse-letters/": {
+  "hash": "a62a3252a646fdb7",
+  "lastmod": "2026-08-13"
+ },
+ "/nl/library/happy-emoji/": {
+  "hash": "7ef75532bc5df3cf",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/library/hartjes/": {
+  "hash": "dc76be0c5c2e3117",
+  "lastmod": "2026-08-13"
+ },
+ "/nl/library/huil-emoji/": {
+  "hash": "19921710c3c80bc7",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/library/instagram-bio-symbolen/": {
+  "hash": "29eaf693727f593c",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/library/iphone-emoji/": {
+  "hash": "113f961185745228",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/library/islamitische-symbolen/": {
+  "hash": "1e13761d00804166",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/library/kawaii-schattige-symbolen/": {
+  "hash": "3b6c51b78a443443",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/library/knipoog-emoji/": {
+  "hash": "35105064d5a941ba",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/library/kruis-symbool/": {
+  "hash": "4b2c5ec19ca34095",
+  "lastmod": "2026-08-15"
+ },
+ "/nl/library/kus-emoji/": {
+  "hash": "a1795bdc9938dad6",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/library/lach-emoji/": {
+  "hash": "b84a3672a9e179f2",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/library/latex-symbolen/": {
+  "hash": "342f0d9861e68b15",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/library/middelvinger-emoji/": {
+  "hash": "591efdfa3fcce3ea",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/library/money-emoji/": {
+  "hash": "957e234e3fede64a",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/library/muzieksymbolen/": {
+  "hash": "0377f25f372968fc",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/library/nerd-emoji/": {
+  "hash": "9aa1aa075c823981",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/library/ogen-emoji/": {
+  "hash": "24dd19ff1bf3fd34",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/library/opsommingstekens/": {
+  "hash": "edee8e7f06127011",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/library/pijl-symbolen/": {
+  "hash": "38290c3c65b92d83",
+  "lastmod": "2026-08-13"
+ },
+ "/nl/library/poep-emoji/": {
+  "hash": "2f1adf92843bdf6e",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/library/religieuze-symbolen/": {
+  "hash": "74b0bb5deafddd11",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/library/roblox-symbolen/": {
+  "hash": "1fa6fbbbe078542e",
+  "lastmod": "2026-08-14"
+ },
+ "/nl/library/rocket-emoji/": {
+  "hash": "6f982f0b4859228d",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/library/sad-emoji/": {
+  "hash": "d01cdeb3f6b72e03",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/library/schaaksymbolen/": {
+  "hash": "778cc8353361bdd6",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/library/seahorse-emoji/": {
+  "hash": "27101b879afe5031",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/library/shocked-emoji/": {
+  "hash": "8430cb653ccbeaec",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/library/skull-emoji/": {
+  "hash": "686ac19fdbb92a4e",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/library/speciale-tekens/": {
+  "hash": "622c506728ab6951",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/library/ster-symbolen/": {
+  "hash": "f5ab1aec12271a08",
+  "lastmod": "2026-08-13"
+ },
+ "/nl/library/sterrenbeeld-symbolen/": {
+  "hash": "a35bcb5c1c401c02",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/library/tekstgezichten-kaomoji/": {
+  "hash": "40aed3f03c7d3c27",
+  "lastmod": "2026-08-13"
+ },
+ "/nl/library/thinking-emoji/": {
+  "hash": "0903f702a7c93115",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/library/tiktok-symbolen/": {
+  "hash": "503b3b520d0607a2",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/library/tongue-emoji/": {
+  "hash": "64e4961c0b6c2c1c",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/library/vinkje/": {
+  "hash": "9d9811b58a785b7b",
+  "lastmod": "2026-08-15"
+ },
+ "/nl/library/vraagteken/": {
+  "hash": "c72add7d50989b51",
+  "lastmod": "2026-08-13"
+ },
+ "/nl/library/vrede-emoji/": {
+  "hash": "0fdd53c2565c1ec6",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/library/whatsapp-symbolen/": {
+  "hash": "4677cfc20f3bd45a",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/library/wiskunde-symbolen/": {
+  "hash": "cb50012280365b6b",
+  "lastmod": "2026-08-13"
+ },
+ "/nl/library/y2k-symbolen/": {
+  "hash": "83cb29e9b9d57bac",
+  "lastmod": "2026-08-14"
+ },
+ "/nl/mooie-letters/": {
+  "hash": "e61c0efef2dbd5c5",
+  "lastmod": "2026-08-07"
+ },
+ "/nl/onderstreepte-tekst/": {
+  "hash": "563f968a37412607",
+  "lastmod": "2026-08-15"
+ },
+ "/nl/onzichtbare-tekst/": {
+  "hash": "be569a4a58492089",
+  "lastmod": "2026-08-15"
+ },
+ "/nl/sierlijke-letters/": {
+  "hash": "4df5a5a56853f2aa",
+  "lastmod": "2026-08-12"
+ },
+ "/nl/snapchat-lettertype/": {
+  "hash": "56b968866048f3be",
+  "lastmod": "2026-08-11"
+ },
+ "/nl/symbol/": {
+  "hash": "94430234741b9fd6",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/aanhalingsteken/": {
+  "hash": "bcea801a28f7e5a5",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/alfa-symbool/": {
+  "hash": "18e3db7d6ada579e",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/alinea-teken/": {
+  "hash": "0f9136f667fe1e20",
+  "lastmod": "2026-08-06"
+ },
+ "/nl/symbol/ampersand/": {
+  "hash": "3cadec7011063940",
+  "lastmod": "2026-08-06"
+ },
+ "/nl/symbol/anarchie-symbool/": {
+  "hash": "a92619d9e6384dcb",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/ankh-symbool/": {
+  "hash": "f5264f26f8d56f84",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/apenstaartje/": {
+  "hash": "59683a3b9723b77e",
+  "lastmod": "2026-08-06"
+ },
+ "/nl/symbol/augurk-emoji/": {
+  "hash": "e9569bef5d06623b",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/autisme-symbool/": {
+  "hash": "3563b5891eac063c",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/barstend-gezicht-emoji/": {
+  "hash": "0701bf6b6e8c8187",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/biohazard-symbool/": {
+  "hash": "94444e460b2fe0e6",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/bitcoin-teken/": {
+  "hash": "ad70b4f8dd6332b5",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/boogschutter-symbool/": {
+  "hash": "01d416e84696547e",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/celsius-symbool/": {
+  "hash": "a694abe30252eaf7",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/centteken/": {
+  "hash": "161f382806a8b315",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/chi-symbool/": {
+  "hash": "18842b15ac8384f8",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/congruent-teken/": {
+  "hash": "5979aa5e6d185d49",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/copyright-symbool/": {
+  "hash": "1ec1cdfa2ee7f147",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/davidster/": {
+  "hash": "6afbd83b1c28f02e",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/deelteken/": {
+  "hash": "d754fe9c27ebe136",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/delta-symbool/": {
+  "hash": "3697914e634fa8f8",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/diameterteken/": {
+  "hash": "2fed9afb07235245",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/dirhamteken/": {
+  "hash": "9c9233bfe391cb13",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/dollarteken/": {
+  "hash": "c8dfff85fc2682b2",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/doodshoofd-symbool/": {
+  "hash": "5588a72e66a579e6",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/duim-wijsteken-emoji/": {
+  "hash": "5110ede5e4ae18ef",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/em-streep/": {
+  "hash": "6881a3c86895478e",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/en-streep/": {
+  "hash": "3e123f2347474f17",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/euro-symbool/": {
+  "hash": "9bf3d667066cd73a",
+  "lastmod": "2026-08-06"
+ },
+ "/nl/symbol/fahrenheit-symbool/": {
+  "hash": "ab9f57539b8308b3",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/fleur-de-lis-symbool/": {
+  "hash": "df61ac85a45bacf7",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/graden-symbool/": {
+  "hash": "3b23258d88953e60",
+  "lastmod": "2026-08-06"
+ },
+ "/nl/symbol/halvemaan-en-ster/": {
+  "hash": "64cf1bfa2a311b11",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/hamsa-symbool/": {
+  "hash": "6ef4f90addafb490",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/handelsmerk-symbool/": {
+  "hash": "35769b22321df708",
+  "lastmod": "2026-08-05"
+ },
+ "/nl/symbol/hart-symbool/": {
+  "hash": "c16f4cadb6afc5fc",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/interrobang/": {
+  "hash": "562ea9d6844ab304",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/kalender-emoji/": {
+  "hash": "a7c1004a779c36da",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/khanda-symbool/": {
+  "hash": "3aad7282b989882c",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/kleiner-dan-groter-dan-teken/": {
+  "hash": "b0cc35128e1736ec",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/kleiner-dan-of-gelijk-aan-teken/": {
+  "hash": "8f901256f1a46e3b",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/kreeft-symbool/": {
+  "hash": "51496109dce5e2cf",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/kwadraat-en-derdemacht/": {
+  "hash": "a7dffc02858c22dd",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/lambda-symbool/": {
+  "hash": "ee6dcfd8f6c58a39",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/latijns-kruis/": {
+  "hash": "350da49ad0a57e61",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/leeuw-symbool/": {
+  "hash": "0abfc8ceb651132f",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/maagd-symbool/": {
+  "hash": "fa002bea34b9c5f3",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/meteoor-emoji/": {
+  "hash": "c5874230a1bbe674",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/microfoon-emoji/": {
+  "hash": "0a7123d6621847d1",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/microteken/": {
+  "hash": "3d0e39ead7063150",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/monarchvlinder-emoji/": {
+  "hash": "53079ae2d7745098",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/ohm-symbool/": {
+  "hash": "6d2cc9d074ffa56b",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/om-symbool/": {
+  "hash": "770264df8e037d93",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/omaanse-rial-teken/": {
+  "hash": "2f738f3649a1fce9",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/omega-symbool/": {
+  "hash": "51a6f83ccb70eab1",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/omgekeerd-vraagteken/": {
+  "hash": "dc946fa89bde14d9",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/oneindigheidsteken/": {
+  "hash": "9a7ba8db5b32e147",
+  "lastmod": "2026-08-13"
+ },
+ "/nl/symbol/ongelijkteken/": {
+  "hash": "265e1f3a11735bc9",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/onzichtbaar-teken/": {
+  "hash": "dd4e5eaca827d412",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/orthodox-kruis/": {
+  "hash": "7bf2e57f439d9681",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/paragraafteken/": {
+  "hash": "499ba4b5abfc25d7",
+  "lastmod": "2026-08-06"
+ },
+ "/nl/symbol/pentagram-symbool/": {
+  "hash": "8a26030ba35a80bb",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/pesoteken/": {
+  "hash": "7f9423daa4bfeecb",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/phi-symbool/": {
+  "hash": "4a9e00f95cafed7a",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/pi-symbool/": {
+  "hash": "2294292e0acd8c70",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/pijl-naar-links/": {
+  "hash": "fd063159189feaff",
+  "lastmod": "2026-08-06"
+ },
+ "/nl/symbol/pijl-naar-rechts/": {
+  "hash": "f6c5975d2819ad85",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/pijl-omhoog/": {
+  "hash": "80c4c7169e7cf1ff",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/pijl-omlaag/": {
+  "hash": "e0810eccf09cd1e5",
+  "lastmod": "2026-08-06"
+ },
+ "/nl/symbol/pion-symbool/": {
+  "hash": "e55c800d6b165a6e",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/plusminus-teken/": {
+  "hash": "ed4727c7ef46e6eb",
+  "lastmod": "2026-08-06"
+ },
+ "/nl/symbol/pondteken/": {
+  "hash": "24b589bf94ad158f",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/psi-symbool/": {
+  "hash": "c6d7349bb62d0251",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/ram-symbool/": {
+  "hash": "933eb25b8ace8beb",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/recycling-symbool/": {
+  "hash": "39d9be58a542bf19",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/roebelteken/": {
+  "hash": "ee3017096afcd5ba",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/roepieteken/": {
+  "hash": "33e774681a36b2cc",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/rolstoel-symbool/": {
+  "hash": "5ed36e0cf5f838df",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/saudi-riyal-teken/": {
+  "hash": "b696475591643647",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/schoppen-symbool/": {
+  "hash": "efa39533f83dc36a",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/schorpioen-symbool/": {
+  "hash": "3f3be56db7bc35e6",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/sigma-symbool/": {
+  "hash": "a5c011b84c121db3",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/snapchat-hartjes-kleuren/": {
+  "hash": "58dc1730f99ffeab",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/steenbok-symbool/": {
+  "hash": "7c96cedc8eaf2433",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/ster-symbool/": {
+  "hash": "e4b8ae612692b415",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/sterretje-teken/": {
+  "hash": "215a2cf48b20b590",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/stier-symbool/": {
+  "hash": "46a8dce593461f5b",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/stopbord-emoji/": {
+  "hash": "77849b9ddd4f4def",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/theta-symbool/": {
+  "hash": "e9d895cbf9e0db1a",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/tilde-teken/": {
+  "hash": "556b3b6048500b56",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/tweelingen-symbool/": {
+  "hash": "1aefabd7ae8503ca",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/underscore-teken/": {
+  "hash": "94fc1e334157d93c",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/vermenigvuldigingsteken/": {
+  "hash": "e0d1d61f905f9d2d",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/verticale-streep/": {
+  "hash": "d691a2eda680c119",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/vierkantswortel/": {
+  "hash": "a793776752a97028",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/vinkje-symbool/": {
+  "hash": "30e49c04d2d535df",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/vissen-symbool/": {
+  "hash": "06c2680c0a550267",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/vredesteken/": {
+  "hash": "cf3e8a489c735cd1",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/waterman-symbool/": {
+  "hash": "adb7117851079098",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/weegschaal-symbool/": {
+  "hash": "4992ae0d2fb0801f",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/woede-symbool/": {
+  "hash": "17adb373ac05f29c",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/wonteken/": {
+  "hash": "03fa42594e714c59",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/yenteken/": {
+  "hash": "eefcd6ddb5aeb811",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/yin-yang-symbool/": {
+  "hash": "5a932688befd12a6",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/zonnebril-emoji/": {
+  "hash": "f42aa0b246751371",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/symbol/zwarte-maan-lilith/": {
+  "hash": "a3ed3528f88ffb46",
+  "lastmod": "2026-08-16"
+ },
+ "/nl/updates/dirham-symbool-unicode-18/": {
+  "hash": "0779595a5a166790",
+  "lastmod": "2026-07-25"
+ },
+ "/nl/updates/unicode-18-beta-van-start/": {
+  "hash": "ed59dfb60a295aa0",
+  "lastmod": "2026-08-05"
+ },
+ "/nl/updates/unicode-18-nieuwe-emoji-stemming/": {
+  "hash": "e6ee0db013e3016b",
+  "lastmod": "2026-08-12"
+ },
+ "/nl/updates/unicode-18-releasedatum-bevestigd/": {
+  "hash": "359adf3f469ef7e9",
+  "lastmod": "2026-08-15"
+ },
+ "/nl/updates/valutasymbolen-midden-oosten-unicode-18/": {
+  "hash": "24df631657e60da6",
+  "lastmod": "2026-07-25"
+ },
+ "/nl/usecase/": {
+  "hash": "79879ed5177929ad",
+  "lastmod": "2026-08-05"
+ },
+ "/nl/usecase/lettertype-voor-bio/": {
+  "hash": "d04e8634b2ac6d63",
+  "lastmod": "2026-08-15"
+ },
+ "/nl/usecase/tattoo-letters/": {
+  "hash": "3f6f47debc40fffb",
+  "lastmod": "2026-08-07"
+ },
+ "/nl/usecase/vertical-text/": {
+  "hash": "52a112d03c04bdeb",
+  "lastmod": "2026-08-15"
+ },
+ "/nl/usecase/zalgo-text/": {
+  "hash": "c8448337defeaff7",
+  "lastmod": "2026-08-15"
+ },
+ "/nl/vetgedrukte-letters/": {
+  "hash": "b272382874c94410",
+  "lastmod": "2026-08-07"
+ },
+ "/nl/woorden-en-tekens-tellen/": {
+  "hash": "74d67b4ea3b38f8d",
+  "lastmod": "2026-08-16"
+ },
+ "/no/": {
+  "hash": "f0fae3fa38db609e",
+  "lastmod": "2026-08-16"
+ },
+ "/no/guide/": {
+  "hash": "e7d608ea059e1829",
+  "lastmod": "2026-08-15"
+ },
+ "/no/guide/discord-tekstformatering-forklart/": {
+  "hash": "ce54eeae0034a0fd",
+  "lastmod": "2026-08-15"
+ },
+ "/no/guide/hvor-fungerer-skrifter-i-discord/": {
+  "hash": "8ceab99152405a38",
+  "lastmod": "2026-08-15"
+ },
+ "/no/guide/trygt-discord-navn/": {
+  "hash": "ecf4aa0c275493e0",
+  "lastmod": "2026-08-15"
+ },
+ "/no/kursiv-tekst/": {
+  "hash": "5df0ce300ec81a4d",
+  "lastmod": "2026-08-15"
+ },
+ "/no/library/": {
+  "hash": "6ecef43be20e99cb",
+  "lastmod": "2026-08-15"
+ },
+ "/no/library/facebook-symboler/": {
+  "hash": "534001fde71ad2b0",
+  "lastmod": "2026-08-15"
+ },
+ "/no/library/geometriske-symboler/": {
+  "hash": "90004bbb101b3923",
+  "lastmod": "2026-08-15"
+ },
+ "/no/library/greske-bokstaver/": {
+  "hash": "84d869efe2ebc88a",
+  "lastmod": "2026-08-15"
+ },
+ "/no/library/hakesymboler/": {
+  "hash": "828782cfdd289667",
+  "lastmod": "2026-08-15"
+ },
+ "/no/library/hjertesymboler/": {
+  "hash": "af8cad8cd3a441dc",
+  "lastmod": "2026-08-15"
+ },
+ "/no/library/julesymboler/": {
+  "hash": "e8aadf290c79add9",
+  "lastmod": "2026-08-15"
+ },
+ "/no/library/korssymboler/": {
+  "hash": "b04418461d97dce6",
+  "lastmod": "2026-08-15"
+ },
+ "/no/library/latter-emoji/": {
+  "hash": "8a80542c6fc0f0fd",
+  "lastmod": "2026-08-16"
+ },
+ "/no/library/matematiske-symboler/": {
+  "hash": "0d5c041fdacbb268",
+  "lastmod": "2026-08-15"
+ },
+ "/no/library/pilsymboler/": {
+  "hash": "7068ae5864525034",
+  "lastmod": "2026-08-15"
+ },
+ "/no/library/smilefjes/": {
+  "hash": "54b942bd2af30d6c",
+  "lastmod": "2026-08-15"
+ },
+ "/no/library/stjernesymboler/": {
+  "hash": "72154e5866666b35",
+  "lastmod": "2026-08-15"
+ },
+ "/no/library/tommel-opp-emoji/": {
+  "hash": "6fb956a874cfe323",
+  "lastmod": "2026-08-16"
+ },
+ "/no/symbol/": {
+  "hash": "8ed0c1305b4daf06",
+  "lastmod": "2026-08-05"
+ },
+ "/no/symbol/eurotegn/": {
+  "hash": "cf9f5f1baa42ff55",
+  "lastmod": "2026-08-15"
+ },
+ "/no/symbol/pundtegn/": {
+  "hash": "fa71a4a0d9a4a598",
+  "lastmod": "2026-08-15"
+ },
+ "/pinterest/": {
+  "hash": "94191418107587b9",
+  "lastmod": "2026-07-25"
+ },
+ "/pl/": {
+  "hash": "665b21cca1767afd",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/answers/": {
+  "hash": "3372f5b1b5a55c5d",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/answers/jak-zrobic-pusta-nazwe/": {
+  "hash": "bd5c48a2128bf518",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/answers/what-font-does-pinterest-use/": {
+  "hash": "8806f804b0783117",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/answers/what-font-does-whatsapp-use/": {
+  "hash": "8daf77903960038e",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/category/": {
+  "hash": "c011d2c714307385",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/czcionki-discord/": {
+  "hash": "dc87690b96a05f3e",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/czcionki-gotyckie/": {
+  "hash": "e5789f19b0617876",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/czcionki-na-facebook/": {
+  "hash": "93a23fd48714aca5",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/czcionki-na-instagram/": {
+  "hash": "3de5a457350c1c2d",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/czcionki-na-roblox/": {
+  "hash": "3ad9fc17a2735456",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/czcionki-na-snapchat/": {
+  "hash": "25c3399c1fcc16ba",
+  "lastmod": "2026-08-11"
+ },
+ "/pl/czcionki-na-tiktok/": {
+  "hash": "e80a131eeaadc071",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/czcionki-na-whatsapp/": {
+  "hash": "10193a4c37ead00f",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/do-druku/": {
+  "hash": "e5f4fb6c255f7797",
+  "lastmod": "2026-08-12"
+ },
+ "/pl/do-druku/alfabet-do-kolorowania/": {
+  "hash": "03b8ff780122d416",
+  "lastmod": "2026-08-12"
+ },
+ "/pl/do-druku/alfabet-hiszpanski/": {
+  "hash": "cc4b8fdd86733181",
+  "lastmod": "2026-08-12"
+ },
+ "/pl/do-druku/alfabet-kursywny/": {
+  "hash": "57e07e8d95d7918e",
+  "lastmod": "2026-08-12"
+ },
+ "/pl/do-druku/banery-z-literami/": {
+  "hash": "8dc4476cdc8b0f17",
+  "lastmod": "2026-07-25"
+ },
+ "/pl/do-druku/litery-bombelkowe/": {
+  "hash": "bacd3d3d79705da2",
+  "lastmod": "2026-08-12"
+ },
+ "/pl/do-druku/pisanie-imienia/": {
+  "hash": "333cb977c8d3ef3b",
+  "lastmod": "2026-07-25"
+ },
+ "/pl/do-druku/pokoloruj-imie/": {
+  "hash": "64836b3191baeed9",
+  "lastmod": "2026-07-25"
+ },
+ "/pl/estetyczne-czcionki/": {
+  "hash": "967bf9246b29170e",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/guide/": {
+  "hash": "f10c7e21d0a5b9dd",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/guide/bezpieczna-nazwa-na-discordzie/": {
+  "hash": "4a493ed5ab65e2be",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/guide/formatowanie-tekstu-na-discordzie/": {
+  "hash": "c2808f8c857678dd",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/guide/gdzie-dzialaja-czcionki-na-discordzie/": {
+  "hash": "8683d5065633ba99",
+  "lastmod": "2026-07-26"
+ },
+ "/pl/kursywa/": {
+  "hash": "f75c77facf7e4b4c",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/library/": {
+  "hash": "1ccbd6930243d49d",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/library/alfabet-grecki/": {
+  "hash": "45a505f8ad5733d7",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/library/cat-kaomoji/": {
+  "hash": "f8f4b57c585ad261",
+  "lastmod": "2026-08-10"
+ },
+ "/pl/library/cute-kaomoji/": {
+  "hash": "e0ca3b7ac3720753",
+  "lastmod": "2026-08-10"
+ },
+ "/pl/library/emoji-combos/": {
+  "hash": "ad1f9f9747dc602c",
+  "lastmod": "2026-08-07"
+ },
+ "/pl/library/emoji-flags/": {
+  "hash": "82997f7c79c0fc37",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/library/emoji-iphone/": {
+  "hash": "7a451f24c2a4e72e",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/library/emoji-pokoju/": {
+  "hash": "2c93188ae5b21ed6",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/library/emoji-prezent/": {
+  "hash": "979ea8f03a766e45",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/library/hieroglify-egipskie/": {
+  "hash": "8c0947e8cc5d0925",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/library/kaomoji/": {
+  "hash": "b1cfc27ccf03f98b",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/library/kody-alt/": {
+  "hash": "76f088f877834098",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/library/lenny-face/": {
+  "hash": "36bda3cf175c8fe9",
+  "lastmod": "2026-08-12"
+ },
+ "/pl/library/love-kaomoji/": {
+  "hash": "11f5132ec16fba27",
+  "lastmod": "2026-08-10"
+ },
+ "/pl/library/smutne-emoji/": {
+  "hash": "ef08de2f774bbfa2",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/library/symbol-ptaszka/": {
+  "hash": "138bbc76555fb642",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/library/symbole-coquette/": {
+  "hash": "f49cce462610bc25",
+  "lastmod": "2026-08-13"
+ },
+ "/pl/library/symbole-cottagecore/": {
+  "hash": "2bd4544a604caa5c",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/library/symbole-discord/": {
+  "hash": "f5d3aeeb840d1a87",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/library/symbole-dreamcore-weirdcore/": {
+  "hash": "bdade2869f645cbc",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/library/symbole-estetyczne/": {
+  "hash": "a3a28ef7ec1dfa08",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/library/symbole-facebook/": {
+  "hash": "e82c15813072ab00",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/library/symbole-fairycore/": {
+  "hash": "8b8197a1bb250c0a",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/library/symbole-goth-grunge/": {
+  "hash": "2482ab0811a70ecf",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/library/symbole-gwiazdek/": {
+  "hash": "7a041f320aa88bbc",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/library/symbole-halloween/": {
+  "hash": "8b71284a5b06b520",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/library/symbole-islamskie/": {
+  "hash": "c1c7835e7c29dda4",
+  "lastmod": "2026-08-13"
+ },
+ "/pl/library/symbole-kart/": {
+  "hash": "c6b28f005e12083d",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/library/symbole-kawaii-cute/": {
+  "hash": "8ce5608239879da7",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/library/symbole-kwiatow/": {
+  "hash": "cf7f2082f83d9aaf",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/library/symbole-matematyczne/": {
+  "hash": "943b9189038e3757",
+  "lastmod": "2026-08-13"
+ },
+ "/pl/library/symbole-muzyczne/": {
+  "hash": "3dc49b81be279397",
+  "lastmod": "2026-08-13"
+ },
+ "/pl/library/symbole-pogody/": {
+  "hash": "616457145846988a",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/library/symbole-punktowania/": {
+  "hash": "685be56811600886",
+  "lastmod": "2026-08-14"
+ },
+ "/pl/library/symbole-religijne/": {
+  "hash": "45dddc0b390783f7",
+  "lastmod": "2026-08-13"
+ },
+ "/pl/library/symbole-roblox/": {
+  "hash": "9f2a149d80ebf587",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/library/symbole-serca/": {
+  "hash": "e07dd9984761130a",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/library/symbole-strzalek/": {
+  "hash": "4500664dbcafda85",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/library/symbole-szachowe/": {
+  "hash": "e056d5ae523952a1",
+  "lastmod": "2026-08-13"
+ },
+ "/pl/library/symbole-therian/": {
+  "hash": "71ef9dec7e01e446",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/library/symbole-walut/": {
+  "hash": "cc18113aa9fd4a98",
+  "lastmod": "2026-08-07"
+ },
+ "/pl/library/symbole-witchy-occult/": {
+  "hash": "f2bcaf5ed15bb9a1",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/library/symbole-y2k/": {
+  "hash": "b96e17bb4b23f221",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/library/symbole-znakow-zodiaku/": {
+  "hash": "c039ea2511b2b17e",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/library/tabela-ascii/": {
+  "hash": "6245def527af1919",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/library/znaki-specjalne/": {
+  "hash": "01aec9a246bfb5e1",
+  "lastmod": "2026-08-07"
+ },
+ "/pl/licznik-slow-i-znakow/": {
+  "hash": "dcac5722fec34783",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/literki/": {
+  "hash": "0c3046035f3ba4af",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/litery-do-skopiowania/": {
+  "hash": "cebffd0ffd6ee6d1",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/male-litery/": {
+  "hash": "9cdb8a2a298ef33a",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/niewidzialny-znak/": {
+  "hash": "c6f7b4e9e5dc8d98",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/odwrocony-tekst/": {
+  "hash": "fc8eecbdab7d60dc",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/ozdobniki/": {
+  "hash": "1fe27ec360a43aab",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/podkreslony-tekst/": {
+  "hash": "2e8187e4a281cd7c",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/pogrubiona-czcionka/": {
+  "hash": "b208a983eff6d9e7",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/przekreslony-tekst/": {
+  "hash": "35ef3a5e51e7a8f0",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/symbol/": {
+  "hash": "402d51976c82ba8b",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/ampersand/": {
+  "hash": "04dddac1f4ea40ea",
+  "lastmod": "2026-08-13"
+ },
+ "/pl/symbol/anch/": {
+  "hash": "713270ec37f300be",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/cudzyslow-polski/": {
+  "hash": "de898314e16d5821",
+  "lastmod": "2026-08-13"
+ },
+ "/pl/symbol/czarny-ksiezyc-lilith/": {
+  "hash": "7ff8de26d80abe4a",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/czaszka-i-piszczele/": {
+  "hash": "d0a14f93c89a0190",
+  "lastmod": "2026-08-05"
+ },
+ "/pl/symbol/emoji-kalendarza/": {
+  "hash": "a39f452d93fa540f",
+  "lastmod": "2026-08-05"
+ },
+ "/pl/symbol/emoji-meteoru/": {
+  "hash": "4ea06d9201d16af8",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/emoji-mikrofonu/": {
+  "hash": "84d46b7971c4df23",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/emoji-motyla-monarchy/": {
+  "hash": "dcdaeba3bd18b9b2",
+  "lastmod": "2026-08-05"
+ },
+ "/pl/symbol/gwiazda-dawida/": {
+  "hash": "1c60d097cfa61af9",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/gwiazda-i-polksiezyc/": {
+  "hash": "d3e08307b186c116",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/hamsa/": {
+  "hash": "a7535ba5bbf8a907",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/interrobang/": {
+  "hash": "b09ebe4c66d0b906",
+  "lastmod": "2026-08-05"
+ },
+ "/pl/symbol/kciuk-kierunkowy/": {
+  "hash": "9955b12ede5d014f",
+  "lastmod": "2026-08-05"
+ },
+ "/pl/symbol/khanda/": {
+  "hash": "cbccb0d100cacf2d",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/kolory-serc-na-snapchacie/": {
+  "hash": "792a60ef853a31b4",
+  "lastmod": "2026-08-13"
+ },
+ "/pl/symbol/krzyz-lacinski/": {
+  "hash": "614081252f9d1943",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/krzyz-prawoslawny/": {
+  "hash": "d7198147c2214fbd",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/kwadrat-i-szescian/": {
+  "hash": "6ae8294d51cac44e",
+  "lastmod": "2026-07-25"
+ },
+ "/pl/symbol/lilia-heraldyczna/": {
+  "hash": "2418d84b1e44c7bd",
+  "lastmod": "2026-08-05"
+ },
+ "/pl/symbol/lustrzany-znak-zapytania/": {
+  "hash": "f8b4a6ea88ab10ba",
+  "lastmod": "2026-08-06"
+ },
+ "/pl/symbol/malpa/": {
+  "hash": "86d6ee4dd8e54c16",
+  "lastmod": "2026-08-13"
+ },
+ "/pl/symbol/mniejsze-i-wieksze/": {
+  "hash": "5a75c70ac0a52f60",
+  "lastmod": "2026-08-06"
+ },
+ "/pl/symbol/nieskonczonosc/": {
+  "hash": "2b6ff06376072c3e",
+  "lastmod": "2026-08-06"
+ },
+ "/pl/symbol/ogorek-kiszony/": {
+  "hash": "465625fa8176feea",
+  "lastmod": "2026-08-05"
+ },
+ "/pl/symbol/pauza/": {
+  "hash": "d0af565c74f33b7f",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/pekajaca-twarz/": {
+  "hash": "836aca42438120b4",
+  "lastmod": "2026-08-05"
+ },
+ "/pl/symbol/pentagram/": {
+  "hash": "14b99c6e57f45e22",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/pierwiastek-kwadratowy/": {
+  "hash": "dbd8bd813364cfc8",
+  "lastmod": "2026-08-13"
+ },
+ "/pl/symbol/pionowa-kreska/": {
+  "hash": "d608b60028888bc7",
+  "lastmod": "2026-08-13"
+ },
+ "/pl/symbol/podkreslenie/": {
+  "hash": "dcee7422e361341b",
+  "lastmod": "2026-08-05"
+ },
+ "/pl/symbol/polpauza/": {
+  "hash": "1438080fcf5efdeb",
+  "lastmod": "2026-08-05"
+ },
+ "/pl/symbol/pusty-znak-brajla/": {
+  "hash": "8f677c1ce5aee5f2",
+  "lastmod": "2026-08-13"
+ },
+ "/pl/symbol/stopnie-i-temperatura/": {
+  "hash": "db54b3e224efceca",
+  "lastmod": "2026-08-06"
+ },
+ "/pl/symbol/strzalka-w-dol/": {
+  "hash": "915f3c2d05e9c5fd",
+  "lastmod": "2026-08-13"
+ },
+ "/pl/symbol/strzalka-w-gore/": {
+  "hash": "7c44985f51834742",
+  "lastmod": "2026-08-13"
+ },
+ "/pl/symbol/strzalka-w-lewo/": {
+  "hash": "bc68966824d84ca0",
+  "lastmod": "2026-08-05"
+ },
+ "/pl/symbol/strzalka-w-prawo/": {
+  "hash": "bbc9423f7b53c653",
+  "lastmod": "2026-08-05"
+ },
+ "/pl/symbol/symbol-alfa/": {
+  "hash": "b2b5a4edacc17b16",
+  "lastmod": "2026-08-05"
+ },
+ "/pl/symbol/symbol-anarchii/": {
+  "hash": "0566bd06dc45f701",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/symbol-autyzmu/": {
+  "hash": "0d64cc5b165e37b6",
+  "lastmod": "2026-08-06"
+ },
+ "/pl/symbol/symbol-barana/": {
+  "hash": "c81e606568dc9a61",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/symbol-blizniat/": {
+  "hash": "11a743a581804981",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/symbol-byka/": {
+  "hash": "7b48c5ddbc0aa7b0",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/symbol-celsjusza/": {
+  "hash": "26911fd617f1f97e",
+  "lastmod": "2026-08-13"
+ },
+ "/pl/symbol/symbol-chi/": {
+  "hash": "087ac2a7bd6be13b",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/symbol-delta/": {
+  "hash": "53b50cd121d61ac2",
+  "lastmod": "2026-08-06"
+ },
+ "/pl/symbol/symbol-fahrenheita/": {
+  "hash": "ba0a41d1a516b0e3",
+  "lastmod": "2026-08-13"
+ },
+ "/pl/symbol/symbol-fi/": {
+  "hash": "d3bcd1a0643c9454",
+  "lastmod": "2026-08-05"
+ },
+ "/pl/symbol/symbol-gwiazdki/": {
+  "hash": "66d82edb1ef0f9ba",
+  "lastmod": "2026-08-05"
+ },
+ "/pl/symbol/symbol-gwiazdy/": {
+  "hash": "c4771a9287624bca",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/symbol-koziorozca/": {
+  "hash": "2a938ed248b546ad",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/symbol-lambda/": {
+  "hash": "3badc2a8533a08cf",
+  "lastmod": "2026-08-05"
+ },
+ "/pl/symbol/symbol-lwa/": {
+  "hash": "eae6b3b592fa7b2b",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/symbol-niepelnosprawnosci/": {
+  "hash": "c44f00a9c4932e9e",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/symbol-okularow-przeciwslonecznych/": {
+  "hash": "3dd3ccdd504162fb",
+  "lastmod": "2026-08-05"
+ },
+ "/pl/symbol/symbol-om/": {
+  "hash": "295efc0cf7b7d165",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/symbol-omega/": {
+  "hash": "31e255df4d8e3994",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/symbol-panny/": {
+  "hash": "bda84c1b6c1a79df",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/symbol-pi/": {
+  "hash": "9ad8cdadbd291f01",
+  "lastmod": "2026-08-06"
+ },
+ "/pl/symbol/symbol-pika/": {
+  "hash": "32888eb4c85e383a",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/symbol-piona/": {
+  "hash": "31b63e6f1a443ee8",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/symbol-pokoju/": {
+  "hash": "03c72becf1e3ed0d",
+  "lastmod": "2026-08-06"
+ },
+ "/pl/symbol/symbol-przystawania/": {
+  "hash": "2fb4baed55d878bf",
+  "lastmod": "2026-08-05"
+ },
+ "/pl/symbol/symbol-psi/": {
+  "hash": "fedb767eed2f24ff",
+  "lastmod": "2026-08-06"
+ },
+ "/pl/symbol/symbol-raka/": {
+  "hash": "498a4a0b2319a0b8",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/symbol-recyklingu/": {
+  "hash": "16e8673c13077bb5",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/symbol-ryb/": {
+  "hash": "82d17ec51c6979d2",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/symbol-serca/": {
+  "hash": "776ef3e162662d2a",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/symbol-sigma/": {
+  "hash": "c762a6160073479c",
+  "lastmod": "2026-08-06"
+ },
+ "/pl/symbol/symbol-skorpiona/": {
+  "hash": "a7b3edf27f980769",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/symbol-srednicy/": {
+  "hash": "219088ae36bf7216",
+  "lastmod": "2026-08-06"
+ },
+ "/pl/symbol/symbol-strzelca/": {
+  "hash": "8f89736660cdfd76",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/symbol-theta/": {
+  "hash": "4ab17b337184ab26",
+  "lastmod": "2026-08-06"
+ },
+ "/pl/symbol/symbol-wagi/": {
+  "hash": "fc591821805e9422",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/symbol-wodnika/": {
+  "hash": "bcef0b0c778a1ae8",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/symbol-zlosci/": {
+  "hash": "5a170a4b3be50442",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/tylda/": {
+  "hash": "b829c8ccb774dc8b",
+  "lastmod": "2026-08-05"
+ },
+ "/pl/symbol/yin-yang/": {
+  "hash": "08d9aa110e457535",
+  "lastmod": "2026-08-05"
+ },
+ "/pl/symbol/zagrozenie-biologiczne/": {
+  "hash": "d29778eb73378fd0",
+  "lastmod": "2026-08-06"
+ },
+ "/pl/symbol/znak-akapitu/": {
+  "hash": "719782807c096c58",
+  "lastmod": "2026-08-13"
+ },
+ "/pl/symbol/znak-bitcoina/": {
+  "hash": "478a79ad037630e6",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/znak-centa/": {
+  "hash": "25df06590ebc0d53",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/znak-copyright/": {
+  "hash": "f64db7149d0fa3d6",
+  "lastmod": "2026-08-13"
+ },
+ "/pl/symbol/znak-dirhama/": {
+  "hash": "c216214298d6b024",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/znak-dolara/": {
+  "hash": "494e21ce3b4dbd08",
+  "lastmod": "2026-08-06"
+ },
+ "/pl/symbol/znak-dzielenia/": {
+  "hash": "75da3840bdaf717c",
+  "lastmod": "2026-08-13"
+ },
+ "/pl/symbol/znak-euro/": {
+  "hash": "7b1f9839a57326b3",
+  "lastmod": "2026-08-06"
+ },
+ "/pl/symbol/znak-funta/": {
+  "hash": "95a82e4a363b432e",
+  "lastmod": "2026-08-06"
+ },
+ "/pl/symbol/znak-jena/": {
+  "hash": "5eab910895d4a521",
+  "lastmod": "2026-08-06"
+ },
+ "/pl/symbol/znak-mikro/": {
+  "hash": "5f41d4c2916f5613",
+  "lastmod": "2026-08-06"
+ },
+ "/pl/symbol/znak-mniejsze-lub-rowne/": {
+  "hash": "32935632fd66d90a",
+  "lastmod": "2026-08-05"
+ },
+ "/pl/symbol/znak-mnozenia/": {
+  "hash": "dfbb24971242d7b9",
+  "lastmod": "2026-08-13"
+ },
+ "/pl/symbol/znak-oma/": {
+  "hash": "e0c330284391a369",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/znak-paragrafu/": {
+  "hash": "b29112e75aca4749",
+  "lastmod": "2026-08-13"
+ },
+ "/pl/symbol/znak-peso/": {
+  "hash": "44771820b31f7d50",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/znak-plus-minus/": {
+  "hash": "e49f3778e6d03ebe",
+  "lastmod": "2026-08-13"
+ },
+ "/pl/symbol/znak-riala-omanskiego/": {
+  "hash": "7e1078ba0b6d9de0",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/znak-riala-saudyjskiego/": {
+  "hash": "c8f58827b334c5b5",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/znak-rozne-od/": {
+  "hash": "925d1c117543908c",
+  "lastmod": "2026-08-06"
+ },
+ "/pl/symbol/znak-rubla/": {
+  "hash": "be45710f4afd2b8b",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/znak-rupii/": {
+  "hash": "3973d4757f93457c",
+  "lastmod": "2026-08-06"
+ },
+ "/pl/symbol/znak-stop/": {
+  "hash": "1d2c4148e7c65e2f",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/znak-wona/": {
+  "hash": "b7a98813b56a6577",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/symbol/znak-zaznaczenia/": {
+  "hash": "0339581511399414",
+  "lastmod": "2026-08-11"
+ },
+ "/pl/symbol/znaki-tm-i-copyright/": {
+  "hash": "7dd737e39d351055",
+  "lastmod": "2026-08-06"
+ },
+ "/pl/updates/unicode-18-data-premiery-potwierdzona/": {
+  "hash": "63ed826761802096",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/updates/unicode-18-nowe-emoji-glosowanie/": {
+  "hash": "bcf47580b3810a7d",
+  "lastmod": "2026-08-12"
+ },
+ "/pl/usecase/": {
+  "hash": "149f554ac16b19c7",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/usecase/czcionki-tatuaze/": {
+  "hash": "7327afe4d9320f68",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/usecase/nazwy-do-kontaktu/": {
+  "hash": "f2b2295aeabf4ec9",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/usecase/nazwy-do-robloxa/": {
+  "hash": "bfddca1ee3150cb5",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/usecase/nazwy-do-stumble-guys/": {
+  "hash": "09ffd7491edd7436",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/usecase/nazwy-grupy/": {
+  "hash": "82dfcd0b5256150d",
+  "lastmod": "2026-08-16"
+ },
+ "/pl/usecase/tlumacz-emoji/": {
+  "hash": "db847a0c7d0b5b36",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/usecase/vertical-text/": {
+  "hash": "1cff79ef12eb19ff",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/usecase/zalgo-text/": {
+  "hash": "6572dea446fa896d",
+  "lastmod": "2026-08-15"
+ },
+ "/pl/wielkie-i-male-litery/": {
+  "hash": "cbd1cabd1f7a47da",
+  "lastmod": "2026-08-15"
+ },
+ "/printables/": {
+  "hash": "90ced3184ebdd9f4",
+  "lastmod": "2026-08-13"
+ },
+ "/printables/alphabet-coloring-pages/": {
+  "hash": "0083bc33eb1fc678",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/alphabet-coloring-pages/letter-a/": {
+  "hash": "c0c822da587d4d54",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/alphabet-coloring-pages/letter-b/": {
+  "hash": "71c99ed63c5a4437",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/alphabet-coloring-pages/letter-c/": {
+  "hash": "19f4457c7b02b8c9",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/alphabet-coloring-pages/letter-d/": {
+  "hash": "a83133e2cf301312",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/alphabet-coloring-pages/letter-e/": {
+  "hash": "58086303f9c9912a",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/alphabet-coloring-pages/letter-f/": {
+  "hash": "a6d4060384fad092",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/alphabet-coloring-pages/letter-g/": {
+  "hash": "754bd81c5d902155",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/alphabet-coloring-pages/letter-h/": {
+  "hash": "26a907c895779305",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/alphabet-coloring-pages/letter-i/": {
+  "hash": "d034058c7e4d60ba",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/alphabet-coloring-pages/letter-j/": {
+  "hash": "ea7f14ef1417387b",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/alphabet-coloring-pages/letter-k/": {
+  "hash": "ca26efb2a5bd3a37",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/alphabet-coloring-pages/letter-l/": {
+  "hash": "bcd30b23d6713057",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/alphabet-coloring-pages/letter-m/": {
+  "hash": "015b6fad406771ab",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/alphabet-coloring-pages/letter-n/": {
+  "hash": "998d0675eba22f86",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/alphabet-coloring-pages/letter-o/": {
+  "hash": "36b302274372fe49",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/alphabet-coloring-pages/letter-p/": {
+  "hash": "cb0efe5de4d31dcb",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/alphabet-coloring-pages/letter-q/": {
+  "hash": "9785b3e02083c8bf",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/alphabet-coloring-pages/letter-r/": {
+  "hash": "fc9d5c886b950c75",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/alphabet-coloring-pages/letter-s/": {
+  "hash": "768579324d1c5baf",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/alphabet-coloring-pages/letter-t/": {
+  "hash": "0c97e5f9bbc3fec1",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/alphabet-coloring-pages/letter-u/": {
+  "hash": "c60268c4ffdb86f3",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/alphabet-coloring-pages/letter-v/": {
+  "hash": "31531d446af15103",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/alphabet-coloring-pages/letter-w/": {
+  "hash": "4775bfc4967997e8",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/alphabet-coloring-pages/letter-x/": {
+  "hash": "d481eb4f1c868e55",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/alphabet-coloring-pages/letter-y/": {
+  "hash": "6ce9429e8ad1b8a3",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/alphabet-coloring-pages/letter-z/": {
+  "hash": "2031f0e98f661e9e",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/alphabet-coloring-pages/number-0/": {
+  "hash": "482e35793d428924",
+  "lastmod": "2026-08-13"
+ },
+ "/printables/alphabet-coloring-pages/number-1/": {
+  "hash": "9f851475fab1776d",
+  "lastmod": "2026-08-13"
+ },
+ "/printables/alphabet-coloring-pages/number-2/": {
+  "hash": "63e4efc9165953a2",
+  "lastmod": "2026-08-13"
+ },
+ "/printables/alphabet-coloring-pages/number-3/": {
+  "hash": "30b14430a615da53",
+  "lastmod": "2026-08-13"
+ },
+ "/printables/alphabet-coloring-pages/number-4/": {
+  "hash": "69b295f979de78e2",
+  "lastmod": "2026-08-13"
+ },
+ "/printables/alphabet-coloring-pages/number-5/": {
+  "hash": "d4fd2f35282f0856",
+  "lastmod": "2026-08-13"
+ },
+ "/printables/alphabet-coloring-pages/number-6/": {
+  "hash": "ceae4a113246e624",
+  "lastmod": "2026-08-13"
+ },
+ "/printables/alphabet-coloring-pages/number-7/": {
+  "hash": "6a036abc33354158",
+  "lastmod": "2026-08-13"
+ },
+ "/printables/alphabet-coloring-pages/number-8/": {
+  "hash": "3fc22071f41e2443",
+  "lastmod": "2026-08-13"
+ },
+ "/printables/alphabet-coloring-pages/number-9/": {
+  "hash": "a0784b7818ceb559",
+  "lastmod": "2026-08-13"
+ },
+ "/printables/banner-maker/": {
+  "hash": "2ac459951fbe4516",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/best-friend-in-cursive/": {
+  "hash": "e5dbc2596722f03e",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/block-letters/": {
+  "hash": "81dc746df72c0c22",
+  "lastmod": "2026-08-13"
+ },
+ "/printables/block-letters/letter-a/": {
+  "hash": "4c015986ad4a1a47",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/block-letters/letter-b/": {
+  "hash": "900e2cd862f6ffc9",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/block-letters/letter-c/": {
+  "hash": "b0a9af90584c7987",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/block-letters/letter-d/": {
+  "hash": "95383710c813fee8",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/block-letters/letter-e/": {
+  "hash": "e78de9ec992f965c",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/block-letters/letter-f/": {
+  "hash": "86e6697d6ea790ee",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/block-letters/letter-g/": {
+  "hash": "e802bc674c6bef43",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/block-letters/letter-h/": {
+  "hash": "f5dfc1ce05d9ad45",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/block-letters/letter-i/": {
+  "hash": "781a46d7601444f4",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/block-letters/letter-j/": {
+  "hash": "f3312b93bb28d7c9",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/block-letters/letter-k/": {
+  "hash": "8ec4d443186396ee",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/block-letters/letter-l/": {
+  "hash": "38aef42b651175c6",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/block-letters/letter-m/": {
+  "hash": "a1e6a3600661fa2d",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/block-letters/letter-n/": {
+  "hash": "b4c2f73d268dc06f",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/block-letters/letter-o/": {
+  "hash": "a2410b7ca3f1fc54",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/block-letters/letter-p/": {
+  "hash": "15503bd7bb79a9f4",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/block-letters/letter-q/": {
+  "hash": "86a357773f03c18e",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/block-letters/letter-r/": {
+  "hash": "4b14d76c1fc0b29d",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/block-letters/letter-s/": {
+  "hash": "d220f7b3be2c6e3b",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/block-letters/letter-t/": {
+  "hash": "8293ae1b020ba25e",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/block-letters/letter-u/": {
+  "hash": "ceaf289a38a083d7",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/block-letters/letter-v/": {
+  "hash": "e2b14bdbfb572638",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/block-letters/letter-w/": {
+  "hash": "95ccdd3eebc53229",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/block-letters/letter-x/": {
+  "hash": "45b40da02ac70d43",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/block-letters/letter-y/": {
+  "hash": "8c93243251812a5e",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/block-letters/letter-z/": {
+  "hash": "2996b871af56ed22",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/block-letters/number-0/": {
+  "hash": "e9eb55e6e21cf184",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/block-letters/number-1/": {
+  "hash": "31a72a0cbefcbb71",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/block-letters/number-2/": {
+  "hash": "1f1cf6c8df7fbd2f",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/block-letters/number-3/": {
+  "hash": "8ff5c3d595664f3b",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/block-letters/number-4/": {
+  "hash": "09ae03d6690f7747",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/block-letters/number-5/": {
+  "hash": "a431471583ec3284",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/block-letters/number-6/": {
+  "hash": "dd73dc7fde03e4ce",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/block-letters/number-7/": {
+  "hash": "3add0d4b467506a7",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/block-letters/number-8/": {
+  "hash": "bf59871ea027e4a6",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/block-letters/number-9/": {
+  "hash": "771f87d047be2349",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/bubble-letters/": {
+  "hash": "beae19823bce01d4",
+  "lastmod": "2026-08-13"
+ },
+ "/printables/bubble-letters/letter-a/": {
+  "hash": "cc9a2d5d76105794",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/bubble-letters/letter-b/": {
+  "hash": "f0ff58144cb485c4",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/bubble-letters/letter-c/": {
+  "hash": "06ccef5c9eaf0e6a",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/bubble-letters/letter-d/": {
+  "hash": "dd0f9dea237e8c40",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/bubble-letters/letter-e/": {
+  "hash": "14b1b21e775b1dc6",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/bubble-letters/letter-f/": {
+  "hash": "510ed4acfccd4ef0",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/bubble-letters/letter-g/": {
+  "hash": "4ad028ccd7cde4be",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/bubble-letters/letter-h/": {
+  "hash": "fc13e1274dfaf928",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/bubble-letters/letter-i/": {
+  "hash": "e969b827efd7fc70",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/bubble-letters/letter-j/": {
+  "hash": "6872996fe9c5b3e1",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/bubble-letters/letter-k/": {
+  "hash": "9fa5d061d2d3f9d2",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/bubble-letters/letter-l/": {
+  "hash": "3e346a6805f3284a",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/bubble-letters/letter-m/": {
+  "hash": "d99867b1a10f9058",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/bubble-letters/letter-n/": {
+  "hash": "872bed031d3f397e",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/bubble-letters/letter-o/": {
+  "hash": "49acfe30187b8076",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/bubble-letters/letter-p/": {
+  "hash": "fa53cebf15c1920a",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/bubble-letters/letter-q/": {
+  "hash": "d6aa255a44e72a83",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/bubble-letters/letter-r/": {
+  "hash": "1d5725c003aa24c2",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/bubble-letters/letter-s/": {
+  "hash": "d32e8853f8b4bc82",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/bubble-letters/letter-t/": {
+  "hash": "b2604c6b2395d8af",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/bubble-letters/letter-u/": {
+  "hash": "a87be9233201a4f8",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/bubble-letters/letter-v/": {
+  "hash": "b2361c9995e1a8b7",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/bubble-letters/letter-w/": {
+  "hash": "c6224baae521f050",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/bubble-letters/letter-x/": {
+  "hash": "870eea5b9f82fd7d",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/bubble-letters/letter-y/": {
+  "hash": "907bfbe143d2e89c",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/bubble-letters/letter-z/": {
+  "hash": "f79008b24a5ca26d",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/bubble-letters/number-0/": {
+  "hash": "cc596a514936338a",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/bubble-letters/number-1/": {
+  "hash": "e8b6fb5707d618d0",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/bubble-letters/number-2/": {
+  "hash": "efb8f82edea33d21",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/bubble-letters/number-3/": {
+  "hash": "37fb36ccc940be9f",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/bubble-letters/number-4/": {
+  "hash": "04dd0eae7acf1c0e",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/bubble-letters/number-5/": {
+  "hash": "02facab1f4ed248a",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/bubble-letters/number-6/": {
+  "hash": "a325cce7713a4322",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/bubble-letters/number-7/": {
+  "hash": "90e313ed6dbced67",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/bubble-letters/number-8/": {
+  "hash": "e7073e59b7e5c519",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/bubble-letters/number-9/": {
+  "hash": "fe46eb3809e8d54c",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/calligraphy-alphabet/": {
+  "hash": "b559caed9109529a",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/calligraphy-alphabet/letter-a/": {
+  "hash": "f16fdc6c961a2391",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/calligraphy-alphabet/letter-b/": {
+  "hash": "7b2b18ef9eabfead",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/calligraphy-alphabet/letter-c/": {
+  "hash": "f1910c282e6824fa",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/calligraphy-alphabet/letter-d/": {
+  "hash": "b4219584aa265b41",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/calligraphy-alphabet/letter-e/": {
+  "hash": "fbf159137e3efa82",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/calligraphy-alphabet/letter-f/": {
+  "hash": "bb458f19ccdd8c38",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/calligraphy-alphabet/letter-g/": {
+  "hash": "6e14fd7803afb716",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/calligraphy-alphabet/letter-h/": {
+  "hash": "3e18b8ae55a11f9f",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/calligraphy-alphabet/letter-i/": {
+  "hash": "74a98425755a9a84",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/calligraphy-alphabet/letter-j/": {
+  "hash": "26192a75d974fde3",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/calligraphy-alphabet/letter-k/": {
+  "hash": "3dc2d033118db34d",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/calligraphy-alphabet/letter-l/": {
+  "hash": "78caa736781f4df5",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/calligraphy-alphabet/letter-m/": {
+  "hash": "5a9ff16de1c1ec55",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/calligraphy-alphabet/letter-n/": {
+  "hash": "9ee6bf9bc65ae48c",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/calligraphy-alphabet/letter-o/": {
+  "hash": "8f5ae3484eb3c069",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/calligraphy-alphabet/letter-p/": {
+  "hash": "7c969257d4b7ab6a",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/calligraphy-alphabet/letter-q/": {
+  "hash": "bfd2983b91c580ac",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/calligraphy-alphabet/letter-r/": {
+  "hash": "fb1f0813bf6b66b0",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/calligraphy-alphabet/letter-s/": {
+  "hash": "e95efa2804d7dc19",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/calligraphy-alphabet/letter-t/": {
+  "hash": "d1e498fbd165f514",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/calligraphy-alphabet/letter-u/": {
+  "hash": "5aa52baae87ccfe1",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/calligraphy-alphabet/letter-v/": {
+  "hash": "073d81da7286d0e7",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/calligraphy-alphabet/letter-w/": {
+  "hash": "7824ac5a618c5ea8",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/calligraphy-alphabet/letter-x/": {
+  "hash": "3072b0c65f54161d",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/calligraphy-alphabet/letter-y/": {
+  "hash": "46994e79ff4fd3fa",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/calligraphy-alphabet/letter-z/": {
+  "hash": "affa1f4cfd78a39d",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/coloring-page-maker/": {
+  "hash": "0d23ce220fce49a7",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/cross-stitch-letters/": {
+  "hash": "29f6bc3167a78c83",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/cursive-alphabet/": {
+  "hash": "66c4facd27beb918",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/cursive-alphabet/letter-a/": {
+  "hash": "c8e5373baddcf701",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/cursive-alphabet/letter-b/": {
+  "hash": "3d4c36881f056670",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/cursive-alphabet/letter-c/": {
+  "hash": "e8511a2fc84ff267",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/cursive-alphabet/letter-d/": {
+  "hash": "25d7ce86bfc2306b",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/cursive-alphabet/letter-e/": {
+  "hash": "966275223546d22e",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/cursive-alphabet/letter-f/": {
+  "hash": "9ab2d2c82e4cd7d0",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/cursive-alphabet/letter-g/": {
+  "hash": "3738de713da6b1e5",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/cursive-alphabet/letter-h/": {
+  "hash": "40d970a3fdeebb61",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/cursive-alphabet/letter-i/": {
+  "hash": "269698ef8616d720",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/cursive-alphabet/letter-j/": {
+  "hash": "6de1c11bbe6728c7",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/cursive-alphabet/letter-k/": {
+  "hash": "d4af20479cdf1773",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/cursive-alphabet/letter-l/": {
+  "hash": "1a96534c5e5e7590",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/cursive-alphabet/letter-m/": {
+  "hash": "974378b993816716",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/cursive-alphabet/letter-n/": {
+  "hash": "41e97d9040c05834",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/cursive-alphabet/letter-o/": {
+  "hash": "89b82e0f9c0b368e",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/cursive-alphabet/letter-p/": {
+  "hash": "f9f48bb86d3b0481",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/cursive-alphabet/letter-q/": {
+  "hash": "123bb1656af5f5ae",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/cursive-alphabet/letter-r/": {
+  "hash": "e4624683fb6e7c1a",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/cursive-alphabet/letter-s/": {
+  "hash": "5754a9fc15486069",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/cursive-alphabet/letter-t/": {
+  "hash": "945bf8b0875f7122",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/cursive-alphabet/letter-u/": {
+  "hash": "d9ec4fb84b420b05",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/cursive-alphabet/letter-v/": {
+  "hash": "cd7fe01bfdc6a095",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/cursive-alphabet/letter-w/": {
+  "hash": "f1666c39071bb092",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/cursive-alphabet/letter-x/": {
+  "hash": "867946eca0d19976",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/cursive-alphabet/letter-y/": {
+  "hash": "715910c11c18e4b7",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/cursive-alphabet/letter-z/": {
+  "hash": "5ee91eec62971c97",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/dad-in-cursive/": {
+  "hash": "4e01e05aadcb2006",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/dot-to-dot-alphabet/": {
+  "hash": "f54ae7de7fa716b4",
+  "lastmod": "2026-08-13"
+ },
+ "/printables/dot-to-dot-alphabet/letter-a/": {
+  "hash": "68c386c2b86d39af",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/dot-to-dot-alphabet/letter-b/": {
+  "hash": "4ef0da3b1b3fdf9d",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/dot-to-dot-alphabet/letter-c/": {
+  "hash": "e0ec60f361aa2b7d",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/dot-to-dot-alphabet/letter-d/": {
+  "hash": "1ebc745e887d2d9a",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/dot-to-dot-alphabet/letter-e/": {
+  "hash": "a0687a4c1a3ef4a7",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/dot-to-dot-alphabet/letter-f/": {
+  "hash": "997887082ae737e4",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/dot-to-dot-alphabet/letter-g/": {
+  "hash": "489d441ca2bdfb59",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/dot-to-dot-alphabet/letter-h/": {
+  "hash": "1b78b589260b8814",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/dot-to-dot-alphabet/letter-i/": {
+  "hash": "9a9f0af7680638f0",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/dot-to-dot-alphabet/letter-j/": {
+  "hash": "f05e0e230c8f6adc",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/dot-to-dot-alphabet/letter-k/": {
+  "hash": "a33feb013bbe769a",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/dot-to-dot-alphabet/letter-l/": {
+  "hash": "f55452b76ccf0bcf",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/dot-to-dot-alphabet/letter-m/": {
+  "hash": "5c7f33d84e5a4c8e",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/dot-to-dot-alphabet/letter-n/": {
+  "hash": "b7a7c213a788d5a8",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/dot-to-dot-alphabet/letter-o/": {
+  "hash": "048a5fcad738863d",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/dot-to-dot-alphabet/letter-p/": {
+  "hash": "02afe4519ad32b82",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/dot-to-dot-alphabet/letter-q/": {
+  "hash": "40d5ee405ca41814",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/dot-to-dot-alphabet/letter-r/": {
+  "hash": "d2b280d43d811c8d",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/dot-to-dot-alphabet/letter-s/": {
+  "hash": "904b913af9b4994d",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/dot-to-dot-alphabet/letter-t/": {
+  "hash": "a66ef5392434dfb8",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/dot-to-dot-alphabet/letter-u/": {
+  "hash": "b511f73811160823",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/dot-to-dot-alphabet/letter-v/": {
+  "hash": "d1d35a14af33f026",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/dot-to-dot-alphabet/letter-w/": {
+  "hash": "272e7f99cb2efbc4",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/dot-to-dot-alphabet/letter-x/": {
+  "hash": "15d1412a40e0e14b",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/dot-to-dot-alphabet/letter-y/": {
+  "hash": "4a352510899d492d",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/dot-to-dot-alphabet/letter-z/": {
+  "hash": "ed54786ee1e40356",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/dot-to-dot-name/": {
+  "hash": "e33270d08cb60ec2",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/family-in-cursive/": {
+  "hash": "0a2aaf8864c1fcec",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/graffiti-letters/": {
+  "hash": "5e885e6ce5bf5a6a",
+  "lastmod": "2026-08-13"
+ },
+ "/printables/handwriting-worksheet-generator/": {
+  "hash": "8cc1df7d0c8a3544",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/happy-birthday-in-cursive/": {
+  "hash": "83fd0be8fc8ec7a4",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/love-in-cursive/": {
+  "hash": "60d4b1cd64d4abbe",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/mom-in-cursive/": {
+  "hash": "c563e0e1b842f606",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/monogram-maker/": {
+  "hash": "52c9ac7c72f275fb",
+  "lastmod": "2026-08-12"
+ },
+ "/printables/name-puzzle-maker/": {
+  "hash": "29271322f33dee65",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/name-tracing/": {
+  "hash": "ac6a25f20b938701",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/sight-word-tracing/": {
+  "hash": "58960010e33af827",
+  "lastmod": "2026-07-25"
+ },
+ "/printables/spanish-alphabet-chart/": {
+  "hash": "96e341d2f34d0dbd",
+  "lastmod": "2026-08-12"
+ },
+ "/privacy/": {
+  "hash": "55a01de57ad494ff",
+  "lastmod": "2026-07-25"
+ },
+ "/pt/": {
+  "hash": "a18b188bf4c6ce64",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/answers/": {
+  "hash": "c8bd05a1d3225b7d",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/answers/como-fazer-um-nome-em-branco/": {
+  "hash": "4708e7d3d8c65d66",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/answers/como-mudar-o-nome-do-canal-do-youtube/": {
+  "hash": "03a1c58a9f5b85b2",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/answers/handle-ou-nome-do-canal-do-youtube/": {
+  "hash": "f89fa03aa547a2df",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/answers/por-que-meu-nome-foi-rejeitado-no-jogo/": {
+  "hash": "5994b3e83c0d931b",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/answers/what-font-does-pinterest-use/": {
+  "hash": "6063324387cd788a",
+  "lastmod": "2026-08-16"
+ },
+ "/pt/answers/what-font-does-whatsapp-use/": {
+  "hash": "c7f0373079431aa2",
+  "lastmod": "2026-08-16"
+ },
+ "/pt/category/": {
+  "hash": "be173c0cb79a12a8",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/contador-de-palavras-e-caracteres/": {
+  "hash": "263f65b3751eae3a",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/conversor-de-letras/": {
+  "hash": "17ce2e1cbb1d776f",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/fonte-gotica/": {
+  "hash": "1c1e7427d4e4e5e4",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/fontes-para-discord/": {
+  "hash": "4c5f52ec5352d46b",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/fontes-para-facebook/": {
+  "hash": "d6b5c47064fe9a97",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/fontes-para-instagram/": {
+  "hash": "c581f2575c45b773",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/fontes-para-telegram/": {
+  "hash": "06dc4421915e64da",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/fontes-para-tiktok/": {
+  "hash": "d8acf00f9a911209",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/fontes-para-whatsapp/": {
+  "hash": "3ee8bcb54af8c256",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/gerador-de-nomes/": {
+  "hash": "fc716a93162825f4",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/guide/": {
+  "hash": "0582abb5d16288bc",
+  "lastmod": "2026-08-11"
+ },
+ "/pt/guide/formatacao-de-texto-no-discord/": {
+  "hash": "3d266c2e9bb43b00",
+  "lastmod": "2026-07-26"
+ },
+ "/pt/guide/nome-discord-sem-risco/": {
+  "hash": "72c8ebe3355463e1",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/guide/onde-as-fontes-funcionam-no-discord/": {
+  "hash": "8604f4094527444f",
+  "lastmod": "2026-07-26"
+ },
+ "/pt/imprimiveis/": {
+  "hash": "53ad5f341cde0cd4",
+  "lastmod": "2026-08-12"
+ },
+ "/pt/imprimiveis/alfabeto-cursivo/": {
+  "hash": "020c7b3ba7b67e6e",
+  "lastmod": "2026-08-12"
+ },
+ "/pt/imprimiveis/alfabeto-espanhol/": {
+  "hash": "129cfbe45a087f9e",
+  "lastmod": "2026-08-12"
+ },
+ "/pt/imprimiveis/alfabeto-para-colorir/": {
+  "hash": "4fc0e52154dce09c",
+  "lastmod": "2026-08-12"
+ },
+ "/pt/imprimiveis/letras-bolha/": {
+  "hash": "04ba1b90c5fbfdbf",
+  "lastmod": "2026-08-12"
+ },
+ "/pt/imprimiveis/nome-para-tracar/": {
+  "hash": "29ef33bc555223ab",
+  "lastmod": "2026-08-06"
+ },
+ "/pt/letra-cursiva/": {
+  "hash": "836bec94e99e7c6e",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/letra-tachada/": {
+  "hash": "ce11176aaabbc965",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/letras-aesthetic/": {
+  "hash": "a996c73db15e367c",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/letras-diferentes/": {
+  "hash": "d2c930b34fc5d4a2",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/letras-italicas/": {
+  "hash": "9146d11c617635ec",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/letras-negrito/": {
+  "hash": "9b3c892156986f33",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/letras-pequenas/": {
+  "hash": "5a9d8fbec362e5d0",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/library/": {
+  "hash": "a3d76cb497641e47",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/library/alfabeto-grego/": {
+  "hash": "e745e7cdae90e916",
+  "lastmod": "2026-08-07"
+ },
+ "/pt/library/arte-de-texto/": {
+  "hash": "a64f6a7e000ab9ca",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/library/caracteres-especiais/": {
+  "hash": "534ec311d935bd3f",
+  "lastmod": "2026-08-07"
+ },
+ "/pt/library/cat-kaomoji/": {
+  "hash": "3d95460a139f0497",
+  "lastmod": "2026-08-10"
+ },
+ "/pt/library/codigos-alt/": {
+  "hash": "cb26379406732573",
+  "lastmod": "2026-08-16"
+ },
+ "/pt/library/cute-kaomoji/": {
+  "hash": "3ceb4ba9fdd4b8cd",
+  "lastmod": "2026-08-10"
+ },
+ "/pt/library/emoji-caveira/": {
+  "hash": "3c5edc4fc468dfa1",
+  "lastmod": "2026-08-16"
+ },
+ "/pt/library/emoji-combos/": {
+  "hash": "06463cfb3b378225",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/library/emoji-de-flores/": {
+  "hash": "2878d9da5ab0bc07",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/library/emoji-feliz/": {
+  "hash": "5bb758c65b0394f9",
+  "lastmod": "2026-08-16"
+ },
+ "/pt/library/emoji-flags/": {
+  "hash": "559eefc4f3e73d3a",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/library/emoji-triste/": {
+  "hash": "91577fbdc4b6de95",
+  "lastmod": "2026-08-16"
+ },
+ "/pt/library/emojis-de-rosto/": {
+  "hash": "d6c188e33927ee69",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/library/emojis-iphone/": {
+  "hash": "b65c77bca88525a7",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/library/happy-kaomoji/": {
+  "hash": "a9e90fda6289f3fa",
+  "lastmod": "2026-08-06"
+ },
+ "/pt/library/hieroglifos-egipcios/": {
+  "hash": "d66db4c3b42760fd",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/library/kaomoji/": {
+  "hash": "929fada145f217b1",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/library/love-kaomoji/": {
+  "hash": "78d7ebf4bae858f8",
+  "lastmod": "2026-08-10"
+ },
+ "/pt/library/naipes-de-baralho/": {
+  "hash": "76711f815de27856",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/library/neymar-emoji-combos/": {
+  "hash": "3ac301d80ce5f05f",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/library/ronaldo-emoji-combos/": {
+  "hash": "e11e6d010c5c25dd",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/library/sad-kaomoji/": {
+  "hash": "acd4849ed4a4e432",
+  "lastmod": "2026-08-10"
+ },
+ "/pt/library/setas/": {
+  "hash": "3f210ef723cea8e6",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/library/simbolos-copyright-marca-registrada/": {
+  "hash": "845795c36a16ac2d",
+  "lastmod": "2026-08-16"
+ },
+ "/pt/library/simbolos-coquette/": {
+  "hash": "fd0dbe44c3ecbca7",
+  "lastmod": "2026-08-13"
+ },
+ "/pt/library/simbolos-cottagecore/": {
+  "hash": "dbe639586c14afee",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/library/simbolos-de-confirmacao/": {
+  "hash": "2ed4dcfda27c06c2",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/library/simbolos-de-coracao/": {
+  "hash": "f811a49a45a6dac3",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/library/simbolos-de-cruz-e-x/": {
+  "hash": "b5b945247edb22b9",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/library/simbolos-de-estrela/": {
+  "hash": "7a92fad68f26d523",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/library/simbolos-de-marcadores/": {
+  "hash": "01fcae3d73e4b86d",
+  "lastmod": "2026-08-13"
+ },
+ "/pt/library/simbolos-de-moeda/": {
+  "hash": "36d735e0a87a8b1e",
+  "lastmod": "2026-08-07"
+ },
+ "/pt/library/simbolos-de-natal/": {
+  "hash": "77244dcbd9b789bb",
+  "lastmod": "2026-08-16"
+ },
+ "/pt/library/simbolos-de-paz/": {
+  "hash": "e6545dfcba4fe3b8",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/library/simbolos-de-xadrez/": {
+  "hash": "41ecfc2ac2b357a7",
+  "lastmod": "2026-08-16"
+ },
+ "/pt/library/simbolos-discord/": {
+  "hash": "81ad36e79f86daaa",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/library/simbolos-dreamcore-weirdcore/": {
+  "hash": "924ea21aa72f16bb",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/library/simbolos-fairycore/": {
+  "hash": "feeeab37a60b877e",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/library/simbolos-geometricos/": {
+  "hash": "2d45038786266f70",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/library/simbolos-goth-grunge/": {
+  "hash": "469b086bfcd64876",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/library/simbolos-islamicos/": {
+  "hash": "c276aac49e18d650",
+  "lastmod": "2026-08-13"
+ },
+ "/pt/library/simbolos-japoneses/": {
+  "hash": "16c1cde3613acf6d",
+  "lastmod": "2026-08-06"
+ },
+ "/pt/library/simbolos-kawaii-cute/": {
+  "hash": "4df0630268d38446",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/library/simbolos-matematicos/": {
+  "hash": "ce27e91b14f79f32",
+  "lastmod": "2026-08-07"
+ },
+ "/pt/library/simbolos-musicais/": {
+  "hash": "5be0dd699f872447",
+  "lastmod": "2026-08-13"
+ },
+ "/pt/library/simbolos-para-facebook/": {
+  "hash": "e3529d660959116e",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/library/simbolos-para-free-fire/": {
+  "hash": "108eebd6a4493d69",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/library/simbolos-para-instagram/": {
+  "hash": "e7aad940da742391",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/library/simbolos-para-twitter/": {
+  "hash": "a7e41edcf2251e81",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/library/simbolos-religiosos/": {
+  "hash": "41a7100f7fd354c4",
+  "lastmod": "2026-08-13"
+ },
+ "/pt/library/simbolos-roblox/": {
+  "hash": "5d4e52e38b88ea73",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/library/simbolos-therian/": {
+  "hash": "197e099b990c381f",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/library/simbolos-witchy-occult/": {
+  "hash": "e3c307c03f0f4757",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/library/simbolos-y2k/": {
+  "hash": "b6cf54f701613978",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/library/simbolos/": {
+  "hash": "1d53617f29c603d0",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/library/tabela-ascii/": {
+  "hash": "880858cc44f56453",
+  "lastmod": "2026-08-16"
+ },
+ "/pt/library/vinicius-emoji-combos/": {
+  "hash": "3e6259edb2576ec2",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/maiusculas-e-minusculas/": {
+  "hash": "91f0f8ab1117e73d",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/simbolos-para-nick/": {
+  "hash": "b1e1ff18f22702b2",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/": {
+  "hash": "9771b48390666fc4",
+  "lastmod": "2026-08-16"
+ },
+ "/pt/symbol/arroba/": {
+  "hash": "b0b1452ddad1e80b",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/caveira-com-ossos-cruzados/": {
+  "hash": "640427dc5ed613da",
+  "lastmod": "2026-08-05"
+ },
+ "/pt/symbol/cores-dos-coracoes-do-snapchat/": {
+  "hash": "3cdbc4683527ba3b",
+  "lastmod": "2026-08-05"
+ },
+ "/pt/symbol/cruz-ortodoxa/": {
+  "hash": "f16237101b488558",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/e-comercial/": {
+  "hash": "e3cb1c9f0606f05a",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/emoji-de-borboleta-monarca/": {
+  "hash": "f9103fd49b3db681",
+  "lastmod": "2026-08-06"
+ },
+ "/pt/symbol/emoji-de-calendario/": {
+  "hash": "7d3c1b94735653a6",
+  "lastmod": "2026-08-05"
+ },
+ "/pt/symbol/emoji-de-meteoro/": {
+  "hash": "996d3195ffb0bb7a",
+  "lastmod": "2026-08-06"
+ },
+ "/pt/symbol/emoji-de-microfone/": {
+  "hash": "cad9604044225d12",
+  "lastmod": "2026-08-05"
+ },
+ "/pt/symbol/emoji-de-oculos-de-sol/": {
+  "hash": "263d5d1786c18bf5",
+  "lastmod": "2026-08-05"
+ },
+ "/pt/symbol/emoji-de-picles/": {
+  "hash": "b27f6d012fd0a1ab",
+  "lastmod": "2026-08-06"
+ },
+ "/pt/symbol/emoji-de-polegar-direcional/": {
+  "hash": "8d63319c286c0721",
+  "lastmod": "2026-08-06"
+ },
+ "/pt/symbol/emoji-de-rosto-derretendo/": {
+  "hash": "165b96c79cd180c5",
+  "lastmod": "2026-08-06"
+ },
+ "/pt/symbol/emoji-de-rosto-distorcido/": {
+  "hash": "852f7d536e7aa078",
+  "lastmod": "2026-08-05"
+ },
+ "/pt/symbol/emoji-de-rosto-rachado/": {
+  "hash": "a288609771d5faa8",
+  "lastmod": "2026-08-06"
+ },
+ "/pt/symbol/estrela-de-davi/": {
+  "hash": "461da5b7fc98bcf2",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/estrela-e-crescente/": {
+  "hash": "9a7310c3bd2ae210",
+  "lastmod": "2026-08-05"
+ },
+ "/pt/symbol/interrobang/": {
+  "hash": "66a8f30717568fb2",
+  "lastmod": "2026-08-05"
+ },
+ "/pt/symbol/interrogacao-invertida/": {
+  "hash": "8f3d45bbb646029e",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/linha-vertical/": {
+  "hash": "677d7316c86faec9",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/lua-negra-lilith/": {
+  "hash": "d5c504b1f6bb152a",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/quadrado-e-cubo/": {
+  "hash": "2591d7fc055578c5",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/raiz-quadrada/": {
+  "hash": "7828c8dc58c4ac28",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/seta-para-baixo/": {
+  "hash": "4e63af091ed527f5",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/seta-para-cima/": {
+  "hash": "35f2dce4dd8db360",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/seta-para-direita/": {
+  "hash": "9f06c924172ac63e",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/seta-para-esquerda/": {
+  "hash": "3bfc7ab35e34718a",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-alfa/": {
+  "hash": "03a6de4f1936417e",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-ankh/": {
+  "hash": "e080a4f17e255db5",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-da-anarquia/": {
+  "hash": "9ace1c87fc29e330",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-da-cruz/": {
+  "hash": "1319a5ba1c953fa0",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-da-paz/": {
+  "hash": "43eda36c73a01294",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-de-aquario/": {
+  "hash": "f85f762bfb0df3eb",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-de-aries/": {
+  "hash": "f42d2b20525a6fe2",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-de-aspas/": {
+  "hash": "90ab2ef1439b2eed",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-de-asterisco/": {
+  "hash": "b370deaa7f17f404",
+  "lastmod": "2026-08-05"
+ },
+ "/pt/symbol/simbolo-de-bitcoin/": {
+  "hash": "b6d5a838410b3067",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-de-cadeira-de-rodas/": {
+  "hash": "302789fe61206115",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-de-cancer/": {
+  "hash": "ff3e3827af6574a8",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-de-capricornio/": {
+  "hash": "c0579f962c674064",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-de-caractere-invisivel/": {
+  "hash": "f75add2a56349e90",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-de-celsius/": {
+  "hash": "216ccdbb68ab441a",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-de-centavo/": {
+  "hash": "1a690c1ced9cbddf",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-de-congruencia/": {
+  "hash": "5b2185cf0672e4f1",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-de-copyright/": {
+  "hash": "7ebc2d41594a8ab9",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-de-coracao/": {
+  "hash": "80f9e23fc2852bcd",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-de-diametro/": {
+  "hash": "46383be25d1d42cf",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-de-dolar/": {
+  "hash": "327b970032d0786f",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-de-escorpiao/": {
+  "hash": "e20202dc87b4751a",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-de-espadas/": {
+  "hash": "9d87ced626cb0027",
+  "lastmod": "2026-08-05"
+ },
+ "/pt/symbol/simbolo-de-estrela/": {
+  "hash": "f311c8b000af354b",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-de-euro/": {
+  "hash": "8997375f87d74728",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-de-fahrenheit/": {
+  "hash": "bda053ca8c78a892",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-de-gemeos/": {
+  "hash": "eac08396f6adedbe",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-de-grau/": {
+  "hash": "48236b634b411d47",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-de-iene/": {
+  "hash": "d017ad54efd620ba",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-de-infinito/": {
+  "hash": "55391db4a95324fb",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-de-leao/": {
+  "hash": "c24fd0f89c5d5509",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-de-libra-esterlina/": {
+  "hash": "f6a56ce9b660eb15",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-de-libra/": {
+  "hash": "a5efa20eaacbf69b",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-de-marca-registrada/": {
+  "hash": "312582807e10c8db",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-de-menor-ou-igual/": {
+  "hash": "e04cb9e0971aa0a1",
+  "lastmod": "2026-08-05"
+ },
+ "/pt/symbol/simbolo-de-paragrafo/": {
+  "hash": "391a3a557d01bbc1",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-de-peao/": {
+  "hash": "c686ae3f2b61475d",
+  "lastmod": "2026-08-05"
+ },
+ "/pt/symbol/simbolo-de-peixes/": {
+  "hash": "e56c9b6ccec7d14b",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-de-raiva/": {
+  "hash": "0679873ee50304c2",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-de-reciclagem/": {
+  "hash": "1b653d2385aa79d2",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-de-risco-biologico/": {
+  "hash": "8e3f2a57d5553e58",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-de-rupia/": {
+  "hash": "651bde1cef1a3c1c",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-de-sagitario/": {
+  "hash": "e577dcc37c9f6568",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-de-secao/": {
+  "hash": "8457461b92940407",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-de-touro/": {
+  "hash": "5789803264dc5e9a",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-de-verificacao/": {
+  "hash": "ba226387f8289712",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-de-virgem/": {
+  "hash": "effbc9f8b3209a92",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-de-won/": {
+  "hash": "9850d5cb21881539",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-delta/": {
+  "hash": "da4677c2ee419f67",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-do-autismo/": {
+  "hash": "d8b7e70e8aee4fcb",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-do-pentagrama/": {
+  "hash": "6815c2582047de16",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-fi/": {
+  "hash": "f242bb12d29bf5bd",
+  "lastmod": "2026-08-05"
+ },
+ "/pt/symbol/simbolo-fleur-de-lis/": {
+  "hash": "d41b585cd66d6174",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-hamsa/": {
+  "hash": "2d0ccd452589fb55",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-khanda/": {
+  "hash": "04154c81b04683ed",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-lambda/": {
+  "hash": "faec1e9a86dbcaf1",
+  "lastmod": "2026-08-05"
+ },
+ "/pt/symbol/simbolo-ohm/": {
+  "hash": "4e685500784a629a",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-om/": {
+  "hash": "a27fdbc8a82cb255",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-omega/": {
+  "hash": "716d6c5f11391f4f",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-pi/": {
+  "hash": "8aaff7440b2f5a03",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-psi/": {
+  "hash": "604ceeb890fde4a2",
+  "lastmod": "2026-08-05"
+ },
+ "/pt/symbol/simbolo-qui/": {
+  "hash": "8509aaf2992ee155",
+  "lastmod": "2026-08-05"
+ },
+ "/pt/symbol/simbolo-sigma/": {
+  "hash": "510fd266f5993e80",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/simbolo-teta/": {
+  "hash": "82e3149b584b3575",
+  "lastmod": "2026-08-05"
+ },
+ "/pt/symbol/simbolo-yin-yang/": {
+  "hash": "e7bb273cfd668b71",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/sinais-de-menor-e-maior/": {
+  "hash": "fe0f67762de5a3a4",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/sinal-de-diferente/": {
+  "hash": "07c641bcdb40d7ef",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/sinal-de-divisao/": {
+  "hash": "b414d4076e908c5c",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/sinal-de-mais-menos/": {
+  "hash": "29cfe685d8786eab",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/sinal-de-micro/": {
+  "hash": "959fb817fc54e56f",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/sinal-de-multiplicacao/": {
+  "hash": "de768fa896cef112",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/sinal-de-pare/": {
+  "hash": "cd868f102898bfe1",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/symbol/sinal-de-peso/": {
+  "hash": "80e4cba1e6382ad5",
+  "lastmod": "2026-08-05"
+ },
+ "/pt/symbol/sinal-de-rublo/": {
+  "hash": "6657d2890decdacf",
+  "lastmod": "2026-08-05"
+ },
+ "/pt/symbol/sinal-do-dirham/": {
+  "hash": "8e130f603a74b3a4",
+  "lastmod": "2026-08-06"
+ },
+ "/pt/symbol/sinal-do-rial-omanense/": {
+  "hash": "a09ac0c3e9bd6836",
+  "lastmod": "2026-08-06"
+ },
+ "/pt/symbol/sinal-do-rial-saudita/": {
+  "hash": "7c8b7763031e60b6",
+  "lastmod": "2026-08-06"
+ },
+ "/pt/symbol/sinal-do-rufiyaa/": {
+  "hash": "91693de195026a41",
+  "lastmod": "2026-08-06"
+ },
+ "/pt/symbol/sublinhado/": {
+  "hash": "db2dfe0edff02a33",
+  "lastmod": "2026-08-05"
+ },
+ "/pt/symbol/til/": {
+  "hash": "c98cd2b4709e7d1d",
+  "lastmod": "2026-08-05"
+ },
+ "/pt/symbol/travessao-curto/": {
+  "hash": "540ef6dcd80c9dc6",
+  "lastmod": "2026-08-05"
+ },
+ "/pt/symbol/travessao-longo/": {
+  "hash": "4d424434bd80969a",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/texto-ao-contrario/": {
+  "hash": "d347ce6117aa9627",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/texto-invisivel/": {
+  "hash": "830c58d18f666db6",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/texto-sublinhado/": {
+  "hash": "0d358221eff4eb48",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/updates/data-de-lancamento-unicode-18-confirmada/": {
+  "hash": "e3b0d418543e1fdd",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/updates/unicode-18-novos-emojis-votacao/": {
+  "hash": "560a4024f723f05c",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/usecase/": {
+  "hash": "7a8f8df01925ed88",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/usecase/fontes-para-bio/": {
+  "hash": "4565476558add872",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/usecase/letras-para-tatuagem/": {
+  "hash": "8fb8b21b18f987c7",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/usecase/nick-ff/": {
+  "hash": "dd9125ba38938119",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/usecase/nomes-de-contato-aesthetic/": {
+  "hash": "91db525ba713f164",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/usecase/nomes-para-grupo/": {
+  "hash": "13714dbe5428bdd3",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/usecase/nomes-para-guilda-ff/": {
+  "hash": "3adb7e74c8f31c54",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/usecase/nomes-para-mobile-legends/": {
+  "hash": "df6bf9b4ea327233",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/usecase/nomes-para-roblox/": {
+  "hash": "e78cb9fcb9f21f1f",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/usecase/nomes-para-stumble-guys/": {
+  "hash": "78fae16e1dca6440",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/usecase/tag-de-cla-ff/": {
+  "hash": "f092bc39a321c5a5",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/usecase/tradutor-de-emojis/": {
+  "hash": "9052a2269ff23ad8",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/usecase/vertical-text/": {
+  "hash": "ad499a37065fcbdb",
+  "lastmod": "2026-08-15"
+ },
+ "/pt/usecase/zalgo-text/": {
+  "hash": "ddd841b7c9beb63f",
+  "lastmod": "2026-08-15"
+ },
+ "/ro/": {
+  "hash": "bb84a1923912ebd0",
+  "lastmod": "2026-08-15"
+ },
+ "/ro/caractere-speciale/": {
+  "hash": "ede643c4395223b5",
+  "lastmod": "2026-08-15"
+ },
+ "/ro/fonturi-pentru-discord/": {
+  "hash": "de840dada7e7b306",
+  "lastmod": "2026-08-16"
+ },
+ "/ro/fonturi-pentru-instagram/": {
+  "hash": "973e128dc26781d2",
+  "lastmod": "2026-08-16"
+ },
+ "/ro/guide/": {
+  "hash": "56b221ba2aa8e952",
+  "lastmod": "2026-08-15"
+ },
+ "/ro/guide/formatare-text-discord-explicat/": {
+  "hash": "62ab021986580dc9",
+  "lastmod": "2026-08-15"
+ },
+ "/ro/guide/nume-discord-fara-riscuri/": {
+  "hash": "fdeffd6f86450e27",
+  "lastmod": "2026-08-15"
+ },
+ "/ro/guide/unde-functioneaza-fonturile-discord/": {
+  "hash": "5b7e44419229377c",
+  "lastmod": "2026-08-15"
+ },
+ "/ro/nume-pentru-free-fire/": {
+  "hash": "e165277e79af23e8",
+  "lastmod": "2026-08-15"
+ },
+ "/ro/scriere-gotica/": {
+  "hash": "68a118b38e99b16f",
+  "lastmod": "2026-08-16"
+ },
+ "/ro/text-cursiv/": {
+  "hash": "6a16d88bd6a47d11",
+  "lastmod": "2026-08-16"
+ },
+ "/ro/text-ingrosat/": {
+  "hash": "f4ef7e478765b3cc",
+  "lastmod": "2026-08-16"
+ },
+ "/ro/text-mic/": {
+  "hash": "e1866c2cf086401a",
+  "lastmod": "2026-08-16"
+ },
+ "/roblox/": {
+  "hash": "3eaa7284b428297f",
+  "lastmod": "2026-08-15"
+ },
+ "/roblox/name-generator/": {
+  "hash": "4c3b784954f8f824",
+  "lastmod": "2026-08-13"
+ },
+ "/roblox/old-roblox-font/": {
+  "hash": "4068e505c093f41a",
+  "lastmod": "2026-07-25"
+ },
+ "/ru/": {
+  "hash": "be207915cdbea2f8",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/answers/": {
+  "hash": "becb2f0c1734eeda",
+  "lastmod": "2026-08-07"
+ },
+ "/ru/answers/kak-sdelat-nevidimyy-nik/": {
+  "hash": "50ee2bd50e92d574",
+  "lastmod": "2026-08-07"
+ },
+ "/ru/answers/pochemu-nik-otobrazhaetsya-kvadratikami/": {
+  "hash": "fb04bc0d3bf34f66",
+  "lastmod": "2026-08-07"
+ },
+ "/ru/answers/pochemu-otklonili-moy-igrovoy-nik/": {
+  "hash": "a9fcf5cfd907c574",
+  "lastmod": "2026-08-07"
+ },
+ "/ru/answers/what-font-does-pinterest-use/": {
+  "hash": "593c25c4c3bc94c7",
+  "lastmod": "2026-08-16"
+ },
+ "/ru/answers/what-font-does-whatsapp-use/": {
+  "hash": "74e711d79a536932",
+  "lastmod": "2026-08-16"
+ },
+ "/ru/generator-nikov/": {
+  "hash": "7ab0533187ca361a",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/goticheskiy-shrift/": {
+  "hash": "1599b69509c85319",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/guide/": {
+  "hash": "8d48024ccecfec43",
+  "lastmod": "2026-08-11"
+ },
+ "/ru/guide/bezopasnyy-nik-discord/": {
+  "hash": "c1d022341c96cbfa",
+  "lastmod": "2026-07-26"
+ },
+ "/ru/guide/formatirovanie-teksta-discord/": {
+  "hash": "8047f373f62c4603",
+  "lastmod": "2026-07-26"
+ },
+ "/ru/guide/gde-rabotayut-shrifty-discord/": {
+  "hash": "628860ddcfa8ac9e",
+  "lastmod": "2026-07-26"
+ },
+ "/ru/krasivyy-shrift/": {
+  "hash": "e094d1f6cfc1f9fc",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/kursiv/": {
+  "hash": "0d11d6e46f2f39c5",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/library/": {
+  "hash": "d4014ec6e3c3ff5d",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/library/alt-kody/": {
+  "hash": "e222891c3d65ba4f",
+  "lastmod": "2026-07-30"
+ },
+ "/ru/library/anime-simvoly/": {
+  "hash": "5daffe6da657bb38",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/library/egipetskie-ieroglify/": {
+  "hash": "9c952a7793d0f5b0",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/library/emodzi-ayfon/": {
+  "hash": "8400340e1607040c",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/library/emodzi-flagi/": {
+  "hash": "e32ec856b1b98bf2",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/library/emodzi-mira/": {
+  "hash": "c3fdfc6d5871cc16",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/library/emodzi-podarok/": {
+  "hash": "1c044bdfabccf93e",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/library/emoji-combos/": {
+  "hash": "a9f2268cf36a88bc",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/library/esteticheskie-simvoly/": {
+  "hash": "a0c15148dde64f38",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/library/geometricheskie-simvoly/": {
+  "hash": "90c59bbad4636a2b",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/library/grecheskiy-alfavit/": {
+  "hash": "d189035f2a4d8f9c",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/library/html-spetssimvoly/": {
+  "hash": "c9330aade381815c",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/library/islamskie-simvoly/": {
+  "hash": "cb03fb410fe9b379",
+  "lastmod": "2026-08-16"
+ },
+ "/ru/library/kaomoji/": {
+  "hash": "b66c6acb3eafea05",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/library/kawaii-simvoly/": {
+  "hash": "ca28796146ce1d3a",
+  "lastmod": "2026-08-11"
+ },
+ "/ru/library/kot-iz-simvolov/": {
+  "hash": "9a400e20cf294da1",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/library/krasivye-ramki/": {
+  "hash": "5d0537a5cf6d4ad0",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/library/magicheskie-simvoly/": {
+  "hash": "ef952b65b8d4d573",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/library/markery-spiska/": {
+  "hash": "ca6890981ddecf57",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/library/matematicheskie-simvoly/": {
+  "hash": "f257a2fd6c5fe9a9",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/library/meditsinskie-simvoly/": {
+  "hash": "6ff51de86914b71a",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/library/muzykalnye-simvoly/": {
+  "hash": "fa7a066b2d43653c",
+  "lastmod": "2026-08-13"
+ },
+ "/ru/library/religioznye-simvoly/": {
+  "hash": "3d66b5046943ea48",
+  "lastmod": "2026-08-13"
+ },
+ "/ru/library/serdechki/": {
+  "hash": "6714fea4f837b15f",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/library/serdechko-iz-simvolov/": {
+  "hash": "c3dcc2806d929010",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/library/shakhmatnye-simvoly/": {
+  "hash": "fddd5bbb4420e272",
+  "lastmod": "2026-08-13"
+ },
+ "/ru/library/simvol-galochki/": {
+  "hash": "8501d1ce16e8dbb4",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/library/simvol-korony/": {
+  "hash": "2e9b4ea782361365",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/library/simvoly-discord/": {
+  "hash": "124050cc4b676700",
+  "lastmod": "2026-08-14"
+ },
+ "/ru/library/simvoly-dlya-nika/": {
+  "hash": "bc9fccccda62fd17",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/library/simvoly-luny/": {
+  "hash": "026a04cc15580e28",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/library/simvoly-na-klaviature/": {
+  "hash": "3d88fbd8f8938f99",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/library/simvoly-roblox/": {
+  "hash": "1b12564240bcd2c2",
+  "lastmod": "2026-08-16"
+ },
+ "/ru/library/simvoly-ruk/": {
+  "hash": "ffe4d3e713b8da7b",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/library/simvoly-tsvetov/": {
+  "hash": "f2b294478abb05f0",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/library/simvoly-valyut/": {
+  "hash": "eac0e3d9970a584c",
+  "lastmod": "2026-08-07"
+ },
+ "/ru/library/simvoly-y2k/": {
+  "hash": "dbfbba8e1eb1407a",
+  "lastmod": "2026-08-14"
+ },
+ "/ru/library/skobki-simvoly/": {
+  "hash": "ee53168d23aecb7d",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/library/special-characters/": {
+  "hash": "a950ba62b19fdfe8",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/library/strelki/": {
+  "hash": "59f159942191263f",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/library/tablica-ascii/": {
+  "hash": "6d2d527a21f1ed0b",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/library/znaki-zodiaka/": {
+  "hash": "aa84c91627fac423",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/library/zvyozdochki/": {
+  "hash": "a231f7f7e95fa7e2",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/malenkiy-tekst/": {
+  "hash": "8e036c82601e366b",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/nevidimyy-tekst/": {
+  "hash": "39f2a99ff6e3685c",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/niki-standoff-2/": {
+  "hash": "f142ff468345bdcd",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/podcherknutyy-tekst/": {
+  "hash": "5de65d3862182ff0",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/schetchik-slov-i-simvolov/": {
+  "hash": "4beae4e918cea345",
+  "lastmod": "2026-08-12"
+ },
+ "/ru/shrift-dlya-instagram/": {
+  "hash": "eb4f97b96fd74d18",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/shrift-dlya-telegram/": {
+  "hash": "13a9862e2c5d6171",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/shrift-dlya-tiktok/": {
+  "hash": "df5dd4081f685dfe",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/": {
+  "hash": "2e886b4ca9c1c80d",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/alfa/": {
+  "hash": "020cdc03b0c4f4ac",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/amperand/": {
+  "hash": "2adeee31736a1e63",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/ankh/": {
+  "hash": "d76d1a5d90623873",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/beskonechnost/": {
+  "hash": "fa8c410861a8a51a",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/cherep-i-kosti/": {
+  "hash": "094dec28eb70cfb0",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/chernaya-luna-lilit/": {
+  "hash": "1497a1ac9ecefd23",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/cveta-serdec-snapchat/": {
+  "hash": "6b6e65da65e6fe94",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/dlinnoe-tire/": {
+  "hash": "b4d505f932f17044",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/emodzi-babochka-monarkh/": {
+  "hash": "d2122ac710b5c46c",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/emodzi-kalendarya/": {
+  "hash": "b48b30356ee63a34",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/emodzi-marinovannogo-ogurtsa/": {
+  "hash": "075e7b41b7b6bdd2",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/emodzi-meteor/": {
+  "hash": "5a61888c1a17f67e",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/emodzi-mikrofon/": {
+  "hash": "1c41729118809b31",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/emodzi-treskayushcheesya-litso/": {
+  "hash": "35a9e001a11a6084",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/emodzi-v-ochkah/": {
+  "hash": "1772e72099f3634b",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/fi/": {
+  "hash": "587a801b6bf68d70",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/fler-de-lis/": {
+  "hash": "2c68b81db8c372ca",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/gradus/": {
+  "hash": "46146b096e7e59b0",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/in-yan/": {
+  "hash": "5f88568a18b2cd71",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/interrobang/": {
+  "hash": "db3ecba232144aba",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/kavychki/": {
+  "hash": "76d57c028c35d072",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/khamsa/": {
+  "hash": "f4af3ec5fab7f0bf",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/khanda/": {
+  "hash": "b6f40fd3468094d7",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/khi/": {
+  "hash": "7108a7fc2330d08a",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/korotkoe-tire/": {
+  "hash": "82ac6cdeeb998d84",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/kvadrat-i-kub/": {
+  "hash": "e5b7f636aeb210b0",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/kvadratnyy-koren/": {
+  "hash": "1735803ba5c67cb0",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/lambda/": {
+  "hash": "61f36425de1922af",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/latinskiy-krest/": {
+  "hash": "6f18cd8d7b1d6c26",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/nevidimyy-simvol/": {
+  "hash": "65d2498e7e655c00",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/nizhnee-podcherkivanie/": {
+  "hash": "031628bd41d12cc6",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/omega/": {
+  "hash": "86f5f1eed51a43e3",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/pentagramma/": {
+  "hash": "4e3b0801a266d720",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/pi/": {
+  "hash": "437cafb06c20b224",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/plyus-minus/": {
+  "hash": "9a1edf2fe83928ee",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/polumesyats-i-zvezda/": {
+  "hash": "2e3506c4a9bea1ff",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/pravoslavnyy-krest/": {
+  "hash": "2292d8ccae62c73a",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/psi/": {
+  "hash": "ae78facf9c719fd7",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/sigma/": {
+  "hash": "cf4998050f5fccf0",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/simvol-autizma/": {
+  "hash": "db0c3e7e5dee8094",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/simvol-om/": {
+  "hash": "8c5a421458e49870",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/strelka-vlevo/": {
+  "hash": "cb9e334ebb778305",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/strelka-vniz/": {
+  "hash": "e5bd57f8d33ad7c6",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/strelka-vpravo/": {
+  "hash": "c927ff271d743070",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/strelka-vverkh/": {
+  "hash": "f04e4d9875a51919",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/teta/": {
+  "hash": "fc86d5d77f937a6e",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/tilda/": {
+  "hash": "c5b6f3b7fed1edfb",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/vertikalnaya-cherta/": {
+  "hash": "2994caa2830a34f8",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/zerkalnyy-znak-voprosa/": {
+  "hash": "cbd8a9c8bf135a34",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-abzatsa/": {
+  "hash": "56b2f94a8eab10e2",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-anarkhii/": {
+  "hash": "8c5bdee662c51a18",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-avtorskogo-prava/": {
+  "hash": "542509e124f3650f",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-belorusskogo-rublya/": {
+  "hash": "e3d63890bf6b7371",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-biologicheskoy-opasnosti/": {
+  "hash": "6d6c0252685b9063",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-bitkoina/": {
+  "hash": "1407f4070a4bbfd4",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-bliznetsov/": {
+  "hash": "ae7c78d724ceecc0",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-bolshogo-paltsa/": {
+  "hash": "73161c058ba3d005",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-deleniya/": {
+  "hash": "fd696cf598eaf3c9",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-delta/": {
+  "hash": "3c864b8ef2b34e5d",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-devy/": {
+  "hash": "d2d245a02bb266a1",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-diametra/": {
+  "hash": "96c6499896d2be42",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-dirkhama/": {
+  "hash": "75c08bfa8fddf741",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-dollara/": {
+  "hash": "b275cfdff4bd06ab",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-evro/": {
+  "hash": "eb957b7d15d35b89",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-farengeyta/": {
+  "hash": "12ddcaf12d0871ca",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-funta/": {
+  "hash": "1675229978a860cf",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-galochki/": {
+  "hash": "d1027c3f84abbe50",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-gneva/": {
+  "hash": "0af1ce02d247e67a",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-ieny/": {
+  "hash": "f7c09fc89deb28d5",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-invalidnoy-kolyaski/": {
+  "hash": "ecc3cc4e1a3c9ca8",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-kongruentnosti/": {
+  "hash": "708cf8a018aabd10",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-kozeroga/": {
+  "hash": "2942395e55cd3657",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-lva/": {
+  "hash": "f5f91ea5438339d0",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-menshe-ili-ravno/": {
+  "hash": "38db5f32cd61907b",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-mikro/": {
+  "hash": "007ceb3263b20908",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-mira/": {
+  "hash": "720f44308c1219cf",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-ne-ravno/": {
+  "hash": "336f2139630f5aba",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-oma/": {
+  "hash": "9431904316c6e618",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-omanskogo-riala/": {
+  "hash": "20f34d099a181b4b",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-ovna/": {
+  "hash": "c66fc5853fe247e5",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-paragrafa/": {
+  "hash": "9108ef0875d69951",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-pererabotki/": {
+  "hash": "1e1a2a8ed78fc266",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-peshki/": {
+  "hash": "184a0eece00f7c9a",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-peso/": {
+  "hash": "e793fc085e43e38e",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-piki/": {
+  "hash": "a0e7b1a1dc54a4c0",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-raka/": {
+  "hash": "3e54a3b59a883dce",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-rublya/": {
+  "hash": "7cdef589a3e0b320",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-rupii/": {
+  "hash": "a470a77a86193eaf",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-ryb/": {
+  "hash": "ca67ad2eadd34cc0",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-saudovskogo-riala/": {
+  "hash": "57fc07f3a522afbe",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-serdtsa/": {
+  "hash": "f1a5a93147c80d9c",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-skorpiona/": {
+  "hash": "ec44b3702b468926",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-sobaki/": {
+  "hash": "9e1b38933bc53e46",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-stop/": {
+  "hash": "3324d5cd786f8fa0",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-strelca/": {
+  "hash": "60f6dc6e1b6d5139",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-telca/": {
+  "hash": "7749c7e1d0d17aef",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-tovarnogo-znaka/": {
+  "hash": "a5d3261ea91080b5",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-tselsiya/": {
+  "hash": "c08cc21475da21a4",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-tsenta/": {
+  "hash": "d9d313d1f17f8a2f",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-umnozheniya/": {
+  "hash": "04213c68045901d0",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-vesov/": {
+  "hash": "d732b69788c239c6",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-vodoleya/": {
+  "hash": "421d83b283529f68",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-vony/": {
+  "hash": "ac6fdec8024083fe",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znak-zvezdy/": {
+  "hash": "2cb620a1124b365a",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/znaki-menshe-i-bolshe/": {
+  "hash": "93683dc38f9d2c3b",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/zvezda-davida/": {
+  "hash": "74f1d19bb79ecde1",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/symbol/zvezdochka/": {
+  "hash": "70845b433d20b93f",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/updates/unicode-18-most-anticipated-emoji/": {
+  "hash": "380885728b7bbbaa",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/updates/unicode-18-release-date-confirmed/": {
+  "hash": "ee356aeaac63cd0e",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/zacherknutyy-tekst/": {
+  "hash": "7beb5eb63735afd2",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/zalgo-text/": {
+  "hash": "2f9ef00266d8ad6d",
+  "lastmod": "2026-08-15"
+ },
+ "/ru/zhirnyy-shrift/": {
+  "hash": "65cb036448e0f006",
+  "lastmod": "2026-08-15"
+ },
+ "/sk/": {
+  "hash": "00932e3631d191a6",
+  "lastmod": "2026-08-15"
+ },
+ "/sk/goticke-pismo/": {
+  "hash": "ff8f94a084d206d3",
+  "lastmod": "2026-08-15"
+ },
+ "/sk/guide/": {
+  "hash": "13e56e3fdab46871",
+  "lastmod": "2026-08-11"
+ },
+ "/sk/guide/bezpecny-nick-na-discorde/": {
+  "hash": "50b84a825386bb03",
+  "lastmod": "2026-07-26"
+ },
+ "/sk/guide/formatovanie-textu-na-discorde/": {
+  "hash": "44b04ef97d36231e",
+  "lastmod": "2026-07-26"
+ },
+ "/sk/guide/kde-funguje-pismo-na-discorde/": {
+  "hash": "9ef67f34a5fa88e8",
+  "lastmod": "2026-07-26"
+ },
+ "/sk/kurziva/": {
+  "hash": "5c6f7febd29b79b4",
+  "lastmod": "2026-08-15"
+ },
+ "/sk/male-pismo/": {
+  "hash": "85e44ae2c9632bce",
+  "lastmod": "2026-08-15"
+ },
+ "/sk/pismo-pre-discord/": {
+  "hash": "a4aad5a6291d2a8c",
+  "lastmod": "2026-08-15"
+ },
+ "/sk/pismo-pre-instagram/": {
+  "hash": "806b9693b692f2b2",
+  "lastmod": "2026-08-15"
+ },
+ "/sk/tucne-pismo/": {
+  "hash": "c43bc0d239b75d7e",
+  "lastmod": "2026-08-15"
+ },
+ "/sk/usecase/pismo-pre-bio/": {
+  "hash": "0477a902429d9541",
+  "lastmod": "2026-08-15"
+ },
+ "/snapchat/": {
+  "hash": "ec30d61e8cda056c",
+  "lastmod": "2026-07-25"
+ },
+ "/sr/": {
+  "hash": "151338d1b231b8a1",
+  "lastmod": "2026-08-15"
+ },
+ "/sr/fontovi-za-discord/": {
+  "hash": "f17636f044226aaa",
+  "lastmod": "2026-08-15"
+ },
+ "/sr/fontovi-za-instagram/": {
+  "hash": "addb1dd0a4227c62",
+  "lastmod": "2026-08-15"
+ },
+ "/sr/goticka-slova/": {
+  "hash": "145c660b3cf81fe8",
+  "lastmod": "2026-08-15"
+ },
+ "/sr/guide/": {
+  "hash": "8a2778b5e497bf14",
+  "lastmod": "2026-08-11"
+ },
+ "/sr/guide/bezbedan-nadimak-na-discordu/": {
+  "hash": "5a22304d04141b12",
+  "lastmod": "2026-07-26"
+ },
+ "/sr/guide/formatiranje-teksta-na-discordu/": {
+  "hash": "faa1cad8b6db0c47",
+  "lastmod": "2026-07-26"
+ },
+ "/sr/guide/gde-fontovi-rade-na-discordu/": {
+  "hash": "b6dfbad368654859",
+  "lastmod": "2026-07-26"
+ },
+ "/sr/kurziv/": {
+  "hash": "d69344326f8218ef",
+  "lastmod": "2026-08-15"
+ },
+ "/sr/mala-slova/": {
+  "hash": "f813e8d9d1a71ed8",
+  "lastmod": "2026-08-15"
+ },
+ "/sr/podebljana-slova/": {
+  "hash": "0a1c8db154b15063",
+  "lastmod": "2026-08-15"
+ },
+ "/sv/": {
+  "hash": "1cb6a7df3d2b6f54",
+  "lastmod": "2026-08-15"
+ },
+ "/sv/guide/": {
+  "hash": "1cf885617bddb8fa",
+  "lastmod": "2026-08-15"
+ },
+ "/sv/guide/discord-namn-utan-risk/": {
+  "hash": "9bdc98a6e5a4ac52",
+  "lastmod": "2026-08-15"
+ },
+ "/sv/guide/discord-textformatering-forklarad/": {
+  "hash": "b85dc159f71c58b9",
+  "lastmod": "2026-08-15"
+ },
+ "/sv/guide/var-typsnitt-fungerar-i-discord/": {
+  "hash": "4d420e0aa6e2ac5c",
+  "lastmod": "2026-08-15"
+ },
+ "/sv/instagram-typsnitt/": {
+  "hash": "46547232bb668f03",
+  "lastmod": "2026-08-15"
+ },
+ "/sv/library/": {
+  "hash": "1ccbc6b2ce524551",
+  "lastmod": "2026-08-15"
+ },
+ "/sv/library/bock-symboler/": {
+  "hash": "f4c8cfeca1b99385",
+  "lastmod": "2026-08-15"
+ },
+ "/sv/library/discord-symboler/": {
+  "hash": "26353a1943124275",
+  "lastmod": "2026-08-15"
+ },
+ "/sv/library/emoji-combos/": {
+  "hash": "2dbbd3615068783c",
+  "lastmod": "2026-08-15"
+ },
+ "/sv/library/grekiska-bokstaver/": {
+  "hash": "6ad3ad07fde2b300",
+  "lastmod": "2026-08-15"
+ },
+ "/sv/library/hjarta-symboler/": {
+  "hash": "257d8335bc0c0a60",
+  "lastmod": "2026-08-15"
+ },
+ "/sv/library/konssymboler/": {
+  "hash": "17de07fb2bd54c5c",
+  "lastmod": "2026-08-15"
+ },
+ "/sv/library/matematiska-symboler/": {
+  "hash": "6751e046dc472933",
+  "lastmod": "2026-08-15"
+ },
+ "/sv/library/pil-symboler/": {
+  "hash": "3c3bc94a02d4a40f",
+  "lastmod": "2026-08-15"
+ },
+ "/sv/library/roblox-symboler/": {
+  "hash": "9385fc0bc6c4a12a",
+  "lastmod": "2026-08-15"
+ },
+ "/sv/library/stjarna-symboler/": {
+  "hash": "d961abc457460fcb",
+  "lastmod": "2026-08-15"
+ },
+ "/sv/library/valuta-symboler/": {
+  "hash": "d5e0ea0e82b29f41",
+  "lastmod": "2026-08-15"
+ },
+ "/sv/library/y2k-symboler/": {
+  "hash": "1acc8a59c394cb0d",
+  "lastmod": "2026-08-15"
+ },
+ "/sv/updates/dirham-symbol-unicode-18/": {
+  "hash": "a62494eca5c6ca83",
+  "lastmod": "2026-08-15"
+ },
+ "/sv/updates/unicode-18-betagranskning-oppnar/": {
+  "hash": "7f97f3606b1b4ae7",
+  "lastmod": "2026-08-15"
+ },
+ "/sv/updates/valutasymboler-mellanostern-unicode-18/": {
+  "hash": "7538cf860195adee",
+  "lastmod": "2026-08-15"
+ },
+ "/symbol/": {
+  "hash": "8dc1eb465d5a7ba1",
+  "lastmod": "2026-08-05"
+ },
+ "/symbol/alpha-symbol/": {
+  "hash": "9567267a932ddd5a",
+  "lastmod": "2026-08-03"
+ },
+ "/symbol/ampersand/": {
+  "hash": "7002b59d521b5ce7",
+  "lastmod": "2026-08-13"
+ },
+ "/symbol/anarchy-symbol/": {
+  "hash": "9cf63cd4e4c07b36",
+  "lastmod": "2026-08-13"
+ },
+ "/symbol/anger-symbol/": {
+  "hash": "ce2567a72805f48d",
+  "lastmod": "2026-07-27"
+ },
+ "/symbol/ankh-symbol/": {
+  "hash": "e7bdee7740d5abc0",
+  "lastmod": "2026-07-27"
+ },
+ "/symbol/aquarius-symbol/": {
+  "hash": "ca628ce139ed2cea",
+  "lastmod": "2026-08-06"
+ },
+ "/symbol/aries-symbol/": {
+  "hash": "5e6322608cbac97f",
+  "lastmod": "2026-07-27"
+ },
+ "/symbol/asterisk-symbol/": {
+  "hash": "6d571ea0ceb7718d",
+  "lastmod": "2026-07-27"
+ },
+ "/symbol/at-symbol/": {
+  "hash": "50cd230fb9516751",
+  "lastmod": "2026-08-13"
+ },
+ "/symbol/autism-symbol/": {
+  "hash": "65b1f305ab1a428d",
+  "lastmod": "2026-08-06"
+ },
+ "/symbol/backwards-question-mark/": {
+  "hash": "e160599d127a95ee",
+  "lastmod": "2026-08-06"
+ },
+ "/symbol/belarusian-ruble-sign/": {
+  "hash": "30952e402eda5e89",
+  "lastmod": "2026-08-05"
+ },
+ "/symbol/biohazard-symbol/": {
+  "hash": "98305d2f67f0dbf3",
+  "lastmod": "2026-08-13"
+ },
+ "/symbol/bitcoin-symbol/": {
+  "hash": "6fddf9015c2ccc3d",
+  "lastmod": "2026-08-13"
+ },
+ "/symbol/black-moon-lilith/": {
+  "hash": "50f8d930254bc20c",
+  "lastmod": "2026-07-27"
+ },
+ "/symbol/calendar-emoji/": {
+  "hash": "a00e85ca48047110",
+  "lastmod": "2026-07-27"
+ },
+ "/symbol/cancer-symbol/": {
+  "hash": "24956ec87e7550ce",
+  "lastmod": "2026-07-27"
+ },
+ "/symbol/capricorn-symbol/": {
+  "hash": "62db57308fe4ce95",
+  "lastmod": "2026-07-27"
+ },
+ "/symbol/celsius-symbol/": {
+  "hash": "65feb7f15eb5cd1c",
+  "lastmod": "2026-08-13"
+ },
+ "/symbol/cent-sign/": {
+  "hash": "760713398b5ff958",
+  "lastmod": "2026-08-03"
+ },
+ "/symbol/checkmark-symbol/": {
+  "hash": "422a76efa2c78370",
+  "lastmod": "2026-08-11"
+ },
+ "/symbol/chi-symbol/": {
+  "hash": "8a7396980a31005f",
+  "lastmod": "2026-07-27"
+ },
+ "/symbol/congruent-symbol/": {
+  "hash": "5a84136f2b4e1d51",
+  "lastmod": "2026-07-27"
+ },
+ "/symbol/copyright-symbol/": {
+  "hash": "d292bb88647c8dc4",
+  "lastmod": "2026-08-13"
+ },
+ "/symbol/cracking-face-emoji/": {
+  "hash": "c1e7969f0585966d",
+  "lastmod": "2026-08-05"
+ },
+ "/symbol/crescent-and-star/": {
+  "hash": "2642350cbef21f44",
+  "lastmod": "2026-07-27"
+ },
+ "/symbol/cross-symbol/": {
+  "hash": "c7e755912ae8e7d2",
+  "lastmod": "2026-08-06"
+ },
+ "/symbol/degree-symbol/": {
+  "hash": "1fd1de58f55ad4bf",
+  "lastmod": "2026-08-13"
+ },
+ "/symbol/delta-symbol/": {
+  "hash": "c04f55dd559b71fd",
+  "lastmod": "2026-08-06"
+ },
+ "/symbol/diameter-symbol/": {
+  "hash": "1bc2208868ca92c3",
+  "lastmod": "2026-08-03"
+ },
+ "/symbol/dirham-sign/": {
+  "hash": "d8aafc475e2c0023",
+  "lastmod": "2026-08-06"
+ },
+ "/symbol/distorted-face-emoji/": {
+  "hash": "b032704a3babdf27",
+  "lastmod": "2026-08-06"
+ },
+ "/symbol/division-sign/": {
+  "hash": "27839bf0c8cf079b",
+  "lastmod": "2026-08-13"
+ },
+ "/symbol/dollar-sign/": {
+  "hash": "0c868d870b3d547c",
+  "lastmod": "2026-08-06"
+ },
+ "/symbol/down-arrow/": {
+  "hash": "f2c3f80a20ab26cf",
+  "lastmod": "2026-08-13"
+ },
+ "/symbol/ellipsis/": {
+  "hash": "08099b7094fa0156",
+  "lastmod": "2026-08-11"
+ },
+ "/symbol/em-dash/": {
+  "hash": "c499d6833a2e39e2",
+  "lastmod": "2026-08-13"
+ },
+ "/symbol/en-dash/": {
+  "hash": "9604442412efa513",
+  "lastmod": "2026-07-27"
+ },
+ "/symbol/euro-sign/": {
+  "hash": "26bdbece099f7335",
+  "lastmod": "2026-08-13"
+ },
+ "/symbol/fahrenheit-symbol/": {
+  "hash": "4ea78145090a0361",
+  "lastmod": "2026-08-13"
+ },
+ "/symbol/fleur-de-lis-symbol/": {
+  "hash": "e74ae7b1a482c1b7",
+  "lastmod": "2026-07-27"
+ },
+ "/symbol/gemini-symbol/": {
+  "hash": "86b12854d32b199f",
+  "lastmod": "2026-08-06"
+ },
+ "/symbol/hamsa-symbol/": {
+  "hash": "de2884c6cb265539",
+  "lastmod": "2026-08-06"
+ },
+ "/symbol/heart-symbol/": {
+  "hash": "c06e186de35cd049",
+  "lastmod": "2026-08-06"
+ },
+ "/symbol/ideographic-comma/": {
+  "hash": "4d742b582e2ac658",
+  "lastmod": "2026-08-11"
+ },
+ "/symbol/infinity/": {
+  "hash": "142dec7d11d4c178",
+  "lastmod": "2026-08-13"
+ },
+ "/symbol/interrobang/": {
+  "hash": "950ca02093aa22bf",
+  "lastmod": "2026-07-27"
+ },
+ "/symbol/invisible-character/": {
+  "hash": "065f2e7bb178138f",
+  "lastmod": "2026-08-13"
+ },
+ "/symbol/khanda-symbol/": {
+  "hash": "89616d52ceca4685",
+  "lastmod": "2026-08-06"
+ },
+ "/symbol/lambda-symbol/": {
+  "hash": "d1ca0f1ec03fc6cc",
+  "lastmod": "2026-08-01"
+ },
+ "/symbol/left-arrow/": {
+  "hash": "9e1c3da0564f8135",
+  "lastmod": "2026-08-13"
+ },
+ "/symbol/leo-symbol/": {
+  "hash": "7bc19258dd178f38",
+  "lastmod": "2026-08-06"
+ },
+ "/symbol/less-than-greater-than/": {
+  "hash": "675f0db28faa4c9c",
+  "lastmod": "2026-08-13"
+ },
+ "/symbol/less-than-or-equal-to-symbol/": {
+  "hash": "94bb31a7e47fb440",
+  "lastmod": "2026-07-26"
+ },
+ "/symbol/libra-symbol/": {
+  "hash": "a9a86c386d62a5bd",
+  "lastmod": "2026-08-06"
+ },
+ "/symbol/lighthouse-emoji/": {
+  "hash": "03aa725dac938e3e",
+  "lastmod": "2026-08-05"
+ },
+ "/symbol/melting-face-emoji/": {
+  "hash": "bb46bbcb8361054c",
+  "lastmod": "2026-08-04"
+ },
+ "/symbol/meteor-emoji/": {
+  "hash": "885974ce11be923a",
+  "lastmod": "2026-08-05"
+ },
+ "/symbol/micro-sign/": {
+  "hash": "7ecdc1daddc43c16",
+  "lastmod": "2026-08-06"
+ },
+ "/symbol/microphone-emoji/": {
+  "hash": "6556a87d69688de7",
+  "lastmod": "2026-07-26"
+ },
+ "/symbol/monarch-butterfly-emoji/": {
+  "hash": "65d910e4fdc02013",
+  "lastmod": "2026-07-26"
+ },
+ "/symbol/multiplication-sign/": {
+  "hash": "eb2910afb4d59a7e",
+  "lastmod": "2026-08-13"
+ },
+ "/symbol/not-equal-sign/": {
+  "hash": "650ece0468bcfe7d",
+  "lastmod": "2026-08-06"
+ },
+ "/symbol/ohm-symbol/": {
+  "hash": "724c8bc54e6f96c5",
+  "lastmod": "2026-08-11"
+ },
+ "/symbol/om-symbol/": {
+  "hash": "7e8d204485e997f6",
+  "lastmod": "2026-07-26"
+ },
+ "/symbol/omani-rial-sign/": {
+  "hash": "3b98da1d0e0d7dff",
+  "lastmod": "2026-08-06"
+ },
+ "/symbol/omega-symbol/": {
+  "hash": "7306323b35551475",
+  "lastmod": "2026-08-06"
+ },
+ "/symbol/orthodox-cross/": {
+  "hash": "4640f412d2c93318",
+  "lastmod": "2026-07-26"
+ },
+ "/symbol/pawn-symbol/": {
+  "hash": "a469b1210c09c674",
+  "lastmod": "2026-07-26"
+ },
+ "/symbol/peace-sign/": {
+  "hash": "2e95f8e135c2bbf5",
+  "lastmod": "2026-08-13"
+ },
+ "/symbol/pentagram-symbol/": {
+  "hash": "ce5bae0ae0661aff",
+  "lastmod": "2026-08-13"
+ },
+ "/symbol/peso-sign/": {
+  "hash": "b1f5fb6ac8097836",
+  "lastmod": "2026-08-01"
+ },
+ "/symbol/phi-symbol/": {
+  "hash": "58f7d1e34409b6ea",
+  "lastmod": "2026-08-01"
+ },
+ "/symbol/pi-symbol/": {
+  "hash": "245c69364270af82",
+  "lastmod": "2026-08-06"
+ },
+ "/symbol/pickle-emoji/": {
+  "hash": "4845007d8b477817",
+  "lastmod": "2026-08-05"
+ },
+ "/symbol/pilcrow/": {
+  "hash": "9ccecce95d7087c6",
+  "lastmod": "2026-08-13"
+ },
+ "/symbol/pisces-symbol/": {
+  "hash": "72ca02e3b72d6e06",
+  "lastmod": "2026-07-26"
+ },
+ "/symbol/plus-minus/": {
+  "hash": "9bf4464302e52787",
+  "lastmod": "2026-08-13"
+ },
+ "/symbol/pound-sign/": {
+  "hash": "b16b306e3695b3c9",
+  "lastmod": "2026-08-13"
+ },
+ "/symbol/psi-symbol/": {
+  "hash": "367fb1b0c979866b",
+  "lastmod": "2026-07-26"
+ },
+ "/symbol/quotation-mark/": {
+  "hash": "80d0872ae47491ac",
+  "lastmod": "2026-08-11"
+ },
+ "/symbol/recycling-symbol/": {
+  "hash": "ba99dde4b10173aa",
+  "lastmod": "2026-07-26"
+ },
+ "/symbol/right-arrow/": {
+  "hash": "4d2ba65e24e491c3",
+  "lastmod": "2026-08-13"
+ },
+ "/symbol/ruble-sign/": {
+  "hash": "892c627b99c59df3",
+  "lastmod": "2026-07-26"
+ },
+ "/symbol/rufiyaa-sign/": {
+  "hash": "8f36da3b9701a4e3",
+  "lastmod": "2026-08-04"
+ },
+ "/symbol/rupee-sign/": {
+  "hash": "03caffc09dc75ef2",
+  "lastmod": "2026-08-13"
+ },
+ "/symbol/sagittarius-symbol/": {
+  "hash": "9afada80dd766d11",
+  "lastmod": "2026-08-06"
+ },
+ "/symbol/saudi-riyal-sign/": {
+  "hash": "d0d68b0bd615f299",
+  "lastmod": "2026-08-06"
+ },
+ "/symbol/scorpio-symbol/": {
+  "hash": "0558a57c87973874",
+  "lastmod": "2026-07-26"
+ },
+ "/symbol/section-sign/": {
+  "hash": "ae5813645d2e65f8",
+  "lastmod": "2026-08-13"
+ },
+ "/symbol/sigma-symbol/": {
+  "hash": "50e39a914bdd6860",
+  "lastmod": "2026-08-13"
+ },
+ "/symbol/skull-and-crossbones/": {
+  "hash": "1fd1ee95245223de",
+  "lastmod": "2026-07-26"
+ },
+ "/symbol/snapchat-heart-colors/": {
+  "hash": "8ac538ab58abef3d",
+  "lastmod": "2026-08-13"
+ },
+ "/symbol/spade-symbol/": {
+  "hash": "4c22624917669002",
+  "lastmod": "2026-07-26"
+ },
+ "/symbol/square-root/": {
+  "hash": "b51be015bebd8ce9",
+  "lastmod": "2026-08-13"
+ },
+ "/symbol/squared-cubed/": {
+  "hash": "642d73daa61d2115",
+  "lastmod": "2026-07-25"
+ },
+ "/symbol/star-of-david/": {
+  "hash": "d37972d1b1c539d0",
+  "lastmod": "2026-08-13"
+ },
+ "/symbol/star-symbol/": {
+  "hash": "c947313bc2b29073",
+  "lastmod": "2026-08-06"
+ },
+ "/symbol/stop-sign/": {
+  "hash": "d2950cd4ab670427",
+  "lastmod": "2026-08-06"
+ },
+ "/symbol/sunglasses-symbol/": {
+  "hash": "7bcbcb4dda302abe",
+  "lastmod": "2026-07-26"
+ },
+ "/symbol/taurus-symbol/": {
+  "hash": "f621534b5ec05e8a",
+  "lastmod": "2026-08-06"
+ },
+ "/symbol/theta-symbol/": {
+  "hash": "720fa8ebcfdfe4f4",
+  "lastmod": "2026-08-01"
+ },
+ "/symbol/thumb-sign-emoji/": {
+  "hash": "9e1bd674ce9fd639",
+  "lastmod": "2026-07-26"
+ },
+ "/symbol/tilde-symbol/": {
+  "hash": "d3fb1b1a92e594e1",
+  "lastmod": "2026-07-26"
+ },
+ "/symbol/trademark-symbol/": {
+  "hash": "b17c3f1d9f0efb42",
+  "lastmod": "2026-08-13"
+ },
+ "/symbol/underscore-symbol/": {
+  "hash": "6a8d812751336663",
+  "lastmod": "2026-07-26"
+ },
+ "/symbol/up-arrow/": {
+  "hash": "cf45c69c4d279581",
+  "lastmod": "2026-08-13"
+ },
+ "/symbol/vertical-line/": {
+  "hash": "0df47c23fc3b0485",
+  "lastmod": "2026-08-13"
+ },
+ "/symbol/virgo-symbol/": {
+  "hash": "d8d60a0bc259edd3",
+  "lastmod": "2026-07-26"
+ },
+ "/symbol/wheelchair-symbol/": {
+  "hash": "38f6bb877cf8f7f9",
+  "lastmod": "2026-08-13"
+ },
+ "/symbol/won-sign/": {
+  "hash": "94903661d99e494b",
+  "lastmod": "2026-08-03"
+ },
+ "/symbol/yen-sign/": {
+  "hash": "9133b1aed0ed35b5",
+  "lastmod": "2026-08-13"
+ },
+ "/symbol/yin-yang/": {
+  "hash": "cff61deda6220055",
+  "lastmod": "2026-08-13"
+ },
+ "/telegram/": {
+  "hash": "26d96aa9376b8a04",
+  "lastmod": "2026-07-25"
+ },
+ "/terms/": {
+  "hash": "7962a24376471005",
+  "lastmod": "2026-07-25"
+ },
+ "/th/": {
+  "hash": "8386204717e50daa",
+  "lastmod": "2026-08-15"
+ },
+ "/th/answers/": {
+  "hash": "62c82f6be5cc733e",
+  "lastmod": "2026-08-15"
+ },
+ "/th/answers/sang-chue-wang/": {
+  "hash": "5404bd9e248c7c13",
+  "lastmod": "2026-08-15"
+ },
+ "/th/answers/what-font-does-pinterest-use/": {
+  "hash": "0f7e14099615cc6d",
+  "lastmod": "2026-08-16"
+ },
+ "/th/answers/what-font-does-whatsapp-use/": {
+  "hash": "b273cf051577cb6a",
+  "lastmod": "2026-08-16"
+ },
+ "/th/guide/": {
+  "hash": "feff8c2905fbb9f4",
+  "lastmod": "2026-08-15"
+ },
+ "/th/guide/discord-font-thamngan-thinai/": {
+  "hash": "f1abfc0b7e88336f",
+  "lastmod": "2026-08-15"
+ },
+ "/th/guide/discord-rupbaep-khokhwam/": {
+  "hash": "f8c961a6d88b0ac1",
+  "lastmod": "2026-08-15"
+ },
+ "/th/guide/discord-tang-chue-plodphai/": {
+  "hash": "1c958414a78e793a",
+  "lastmod": "2026-08-15"
+ },
+ "/th/khokhwam-long-hon/": {
+  "hash": "9434ef135365fa94",
+  "lastmod": "2026-08-15"
+ },
+ "/th/library/": {
+  "hash": "03b2f8f4f7324a58",
+  "lastmod": "2026-08-15"
+ },
+ "/th/library/aesthetic-symbols/": {
+  "hash": "5853c49f42a9ef01",
+  "lastmod": "2026-08-15"
+ },
+ "/th/library/alt-codes/": {
+  "hash": "e542c8cc2b151b70",
+  "lastmod": "2026-08-15"
+ },
+ "/th/library/animal-emojis/": {
+  "hash": "64a7fd141d68750c",
+  "lastmod": "2026-08-15"
+ },
+ "/th/library/arrow-symbols/": {
+  "hash": "41bccced2100e733",
+  "lastmod": "2026-08-15"
+ },
+ "/th/library/ascii-table/": {
+  "hash": "88e4bd2b222f0c8e",
+  "lastmod": "2026-08-15"
+ },
+ "/th/library/bullet-point-symbols/": {
+  "hash": "5b418300aa78dca3",
+  "lastmod": "2026-08-15"
+ },
+ "/th/library/cat-kaomoji/": {
+  "hash": "1cfd4be499b602f8",
+  "lastmod": "2026-08-16"
+ },
+ "/th/library/chess-symbols/": {
+  "hash": "e1c85a0709a05342",
+  "lastmod": "2026-08-13"
+ },
+ "/th/library/currency-symbols/": {
+  "hash": "26d3e727b22d95eb",
+  "lastmod": "2026-08-15"
+ },
+ "/th/library/cute-kaomoji/": {
+  "hash": "9d64ed354a65f727",
+  "lastmod": "2026-08-16"
+ },
+ "/th/library/discord-symbols/": {
+  "hash": "17aaec82735a3441",
+  "lastmod": "2026-08-15"
+ },
+ "/th/library/emoji-combos/": {
+  "hash": "a07dc008b13dd19d",
+  "lastmod": "2026-08-15"
+ },
+ "/th/library/emoji-flags/": {
+  "hash": "ec62a034d08dd7af",
+  "lastmod": "2026-08-15"
+ },
+ "/th/library/emoji-sao/": {
+  "hash": "90423e92d50bd886",
+  "lastmod": "2026-08-16"
+ },
+ "/th/library/facebook-symbols/": {
+  "hash": "90008553a86c9117",
+  "lastmod": "2026-08-15"
+ },
+ "/th/library/flower-symbols/": {
+  "hash": "a424eda67707d5f7",
+  "lastmod": "2026-08-15"
+ },
+ "/th/library/food-drink-emojis/": {
+  "hash": "c8350c7444ec7d7c",
+  "lastmod": "2026-08-15"
+ },
+ "/th/library/greek-letter-symbols/": {
+  "hash": "140a28c13ba16966",
+  "lastmod": "2026-08-15"
+ },
+ "/th/library/heart-symbols/": {
+  "hash": "b8e179add4371c3e",
+  "lastmod": "2026-08-16"
+ },
+ "/th/library/islamic-symbols/": {
+  "hash": "0b08d9c6565184e6",
+  "lastmod": "2026-08-13"
+ },
+ "/th/library/kaomoji/": {
+  "hash": "e2d3ce24ce7b6921",
+  "lastmod": "2026-08-15"
+ },
+ "/th/library/kawaii-cute-symbols/": {
+  "hash": "923683417834dcbc",
+  "lastmod": "2026-08-07"
+ },
+ "/th/library/love-kaomoji/": {
+  "hash": "3faad920f54b829f",
+  "lastmod": "2026-08-16"
+ },
+ "/th/library/math-symbols/": {
+  "hash": "f06a680441be3a7b",
+  "lastmod": "2026-08-15"
+ },
+ "/th/library/music-symbols/": {
+  "hash": "70a54ba13ef80b47",
+  "lastmod": "2026-08-13"
+ },
+ "/th/library/religious-symbols/": {
+  "hash": "604169827136d303",
+  "lastmod": "2026-08-13"
+ },
+ "/th/library/roblox-symbols/": {
+  "hash": "432715e30ae6fac7",
+  "lastmod": "2026-08-15"
+ },
+ "/th/library/sanyalak-rasi/": {
+  "hash": "78c7ecece1d64d38",
+  "lastmod": "2026-08-15"
+ },
+ "/th/library/special-characters/": {
+  "hash": "e8e7989758f13f19",
+  "lastmod": "2026-08-15"
+ },
+ "/th/library/star-symbols/": {
+  "hash": "2b97fab137d9fe50",
+  "lastmod": "2026-08-15"
+ },
+ "/th/library/text-art/": {
+  "hash": "cddc3257041e19fb",
+  "lastmod": "2026-08-15"
+ },
+ "/th/library/y2k-symbols/": {
+  "hash": "75b1a24c3fcfaf99",
+  "lastmod": "2026-08-15"
+ },
+ "/th/nap-kham-lae-tua-akson/": {
+  "hash": "a1535dbd9c93554a",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/": {
+  "hash": "a69a642af23a199e",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/dao-haeng-david/": {
+  "hash": "511c869f7ebb38a2",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/degree-symbol/": {
+  "hash": "b18e26abfeadd4f9",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/division-sign/": {
+  "hash": "9f460ebc71381baf",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/duean-siao-lae-dao/": {
+  "hash": "175568a6bc01f5fb",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/hua-kalok-khwai-kraduk/": {
+  "hash": "fed974545d513af4",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/imoji-dao-tok/": {
+  "hash": "4812617f7f78fe4d",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/imoji-maikhrofon/": {
+  "hash": "fc65ad8d768e1a0d",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/imoji-na-raoi/": {
+  "hash": "47345ffde6931404",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/imoji-niu-pong-chithang/": {
+  "hash": "cfef05c5367419ef",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/imoji-pathitin/": {
+  "hash": "92c7ee7c3802ea24",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/imoji-phi-suea-monark/": {
+  "hash": "ffaa1317e9694bb9",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/imoji-taengkwa-dong/": {
+  "hash": "a4d7c3597f1363a8",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/imoji-waen-kandaed/": {
+  "hash": "8230d92303b0932e",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/infinity/": {
+  "hash": "d190a3b107775e65",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/kang-khen-orthodox/": {
+  "hash": "e012f6f880a60014",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/khreuangmai-ampersand/": {
+  "hash": "d521b76aa28cb056",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/khreuangmai-at/": {
+  "hash": "1c97ac0574b40fe6",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/khreuangmai-bitcoin/": {
+  "hash": "43666bb8a2e139cb",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/khreuangmai-buak-lop/": {
+  "hash": "209a679405e52882",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/khreuangmai-dirham/": {
+  "hash": "ae8e242da15e5c1c",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/khreuangmai-dokchan/": {
+  "hash": "28b63d04a1555e83",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/khreuangmai-dollar/": {
+  "hash": "808340239471357a",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/khreuangmai-em-daesh/": {
+  "hash": "b8510be724c1fe0e",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/khreuangmai-en-daesh/": {
+  "hash": "0553d1b8823fc080",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/khreuangmai-euro/": {
+  "hash": "efcdb96e16ad18d6",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/khreuangmai-interrobang/": {
+  "hash": "b81aff5af5e06b3f",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/khreuangmai-kanka/": {
+  "hash": "c0c1d4eafe0d9319",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/khreuangmai-kham-tham-klapdan/": {
+  "hash": "1149c936f3f4a773",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/khreuangmai-khamphut/": {
+  "hash": "ffd580676600bd14",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/khreuangmai-khidlang/": {
+  "hash": "c426446507bb53b8",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/khreuangmai-laikhasit/": {
+  "hash": "cbb6ef2c06404570",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/khreuangmai-mai-thaokap/": {
+  "hash": "c87197a95d96e76a",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/khreuangmai-matra/": {
+  "hash": "052cfb13f5bc8f12",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/khreuangmai-noikwa-makkwa/": {
+  "hash": "74436f664425699b",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/khreuangmai-noikwa-thaokap/": {
+  "hash": "695ec6b965b9ee6d",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/khreuangmai-peso/": {
+  "hash": "1219fe841cb6fcf5",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/khreuangmai-pound/": {
+  "hash": "5cf2313e57939c63",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/khreuangmai-rial-oman/": {
+  "hash": "089599e1f61ee5da",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/khreuangmai-riyal-saudi/": {
+  "hash": "45ae6ffaf5c8162a",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/khreuangmai-ruble/": {
+  "hash": "ca50097dddc59582",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/khreuangmai-rupee-india/": {
+  "hash": "fa81ebd0d8f3219e",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/khreuangmai-santiphap/": {
+  "hash": "65c125748075ad66",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/khreuangmai-sen-tang/": {
+  "hash": "dd9298dc509da043",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/khreuangmai-sen/": {
+  "hash": "8b278da5015f47fa",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/khreuangmai-thuk/": {
+  "hash": "8798c91646f30ffb",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/khreuangmai-tilde/": {
+  "hash": "1071f059682951ea",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/khreuangmai-won/": {
+  "hash": "c1c60a42a6fd1672",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/khreuangmai-yen/": {
+  "hash": "3ad415c43f986ba3",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/khreuangmai-yo-na/": {
+  "hash": "0a061647d8a06c14",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/luksorn-khuen/": {
+  "hash": "ce81e5ffb97c71b4",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/luksorn-khwa/": {
+  "hash": "fe6ce6d504f69527",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/luksorn-long/": {
+  "hash": "5e6902ffde462e81",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/luksorn-sai/": {
+  "hash": "847c6d17b1366a07",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/mai-kang-khen/": {
+  "hash": "a6272f496688b61e",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/multiplication-sign/": {
+  "hash": "fb74b27af05c0f33",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/pho-dam/": {
+  "hash": "c35f8e0f756a9b3e",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/rasi-kan/": {
+  "hash": "7227aa751fd291db",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/rasi-karakot/": {
+  "hash": "7ca310484339878f",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/rasi-kumpha/": {
+  "hash": "f9535ca6ed32c016",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/rasi-mangkon/": {
+  "hash": "3d4e2c01b3d7bb85",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/rasi-mesa/": {
+  "hash": "23e407ef95f50074",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/rasi-methun/": {
+  "hash": "ef69ae06b45738ac",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/rasi-min/": {
+  "hash": "39f54cab680664d8",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/rasi-phichik/": {
+  "hash": "44d4215aa3f78f22",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/rasi-phruesop/": {
+  "hash": "41109e12db64de1e",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/rasi-sing/": {
+  "hash": "0af094c5a3eed09b",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/rasi-thanu/": {
+  "hash": "5964d1725cdd6aad",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/rasi-tun/": {
+  "hash": "5d293f5a49c3cfa8",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/sanyalak-alpha/": {
+  "hash": "ff5617528fef9933",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/sanyalak-anathipatai/": {
+  "hash": "939cb9640499aad1",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/sanyalak-ankh/": {
+  "hash": "6c6f8b05490924a6",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/sanyalak-autism/": {
+  "hash": "c7e0eec086a9d7a9",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/sanyalak-bia-makruk/": {
+  "hash": "dcba9e7229616c93",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/sanyalak-celsius/": {
+  "hash": "349e39686c82622b",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/sanyalak-dao/": {
+  "hash": "c126bd9dec3b42a5",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/sanyalak-delta/": {
+  "hash": "2e86c6cb433b715b",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/sanyalak-duean-dam-lilit/": {
+  "hash": "da4551b89e6a7726",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/sanyalak-fahrenheit/": {
+  "hash": "c3b77cf89d939139",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/sanyalak-fai/": {
+  "hash": "7d0c668ac64f6e55",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/sanyalak-fleur-de-lis/": {
+  "hash": "5e66cc4d1f3eb629",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/sanyalak-hamsa/": {
+  "hash": "28b56901b64d5504",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/sanyalak-hua-jai/": {
+  "hash": "e91f75cd51d52bac",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/sanyalak-khai/": {
+  "hash": "4323fdc25b452512",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/sanyalak-khanda/": {
+  "hash": "8ca45cd1f2507511",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/sanyalak-khon-phikan/": {
+  "hash": "1d93fc570544fefb",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/sanyalak-krot/": {
+  "hash": "a380864ef98fe137",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/sanyalak-lambda/": {
+  "hash": "5236faac3aa65d93",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/sanyalak-maikhro/": {
+  "hash": "9d6065123bbd0029",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/sanyalak-ohm/": {
+  "hash": "16eac8ef9c3e20bb",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/sanyalak-om/": {
+  "hash": "0179c87c08d1b433",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/sanyalak-omega/": {
+  "hash": "af0b2c550833cd30",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/sanyalak-pai-yut/": {
+  "hash": "4b38d139f496aff8",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/sanyalak-pentakram/": {
+  "hash": "db497308de8ce357",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/sanyalak-phai-chiwaphap/": {
+  "hash": "7c577f5be71bdaa7",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/sanyalak-phai/": {
+  "hash": "54ad82bfe237cdfa",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/sanyalak-psi/": {
+  "hash": "eaf69caddf493e96",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/sanyalak-risaikoen/": {
+  "hash": "62af4b522c6d1ff4",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/sanyalak-samphak/": {
+  "hash": "634ab531d10b56f4",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/sanyalak-sen-phan-sun-klang/": {
+  "hash": "b8df3be79eba98a5",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/sanyalak-sigma/": {
+  "hash": "44cb453b44119378",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/sanyalak-theta/": {
+  "hash": "58c9a215b5195aa4",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/sanyalak-yin-yang/": {
+  "hash": "464fcc14cd6ed729",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/si-huachai-snapchat/": {
+  "hash": "ff2023a392481598",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/square-root/": {
+  "hash": "e164b6f40599592b",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/squared-cubed/": {
+  "hash": "ef073628bd231931",
+  "lastmod": "2026-08-15"
+ },
+ "/th/symbol/tua-akson-long-hon/": {
+  "hash": "4f78a49e7ec55f52",
+  "lastmod": "2026-08-15"
+ },
+ "/th/updates/unicode-18-most-anticipated-emoji/": {
+  "hash": "394a762c98545ec9",
+  "lastmod": "2026-08-15"
+ },
+ "/th/updates/unicode-18-release-date-confirmed/": {
+  "hash": "4ab35add7df37735",
+  "lastmod": "2026-08-15"
+ },
+ "/th/usecase/": {
+  "hash": "304d7afc57d00a86",
+  "lastmod": "2026-08-15"
+ },
+ "/th/usecase/bio-font-ig/": {
+  "hash": "682982e60483d972",
+  "lastmod": "2026-08-15"
+ },
+ "/th/usecase/free-fire-name-generator/": {
+  "hash": "d5e4f1c76219f9dd",
+  "lastmod": "2026-08-16"
+ },
+ "/th/usecase/mobile-legends-name-generator/": {
+  "hash": "77a775cfbe5eb4f7",
+  "lastmod": "2026-08-15"
+ },
+ "/threads/": {
+  "hash": "cd2beb4065cdc0d4",
+  "lastmod": "2026-07-25"
+ },
+ "/tiktok/": {
+  "hash": "8bc05a38bb77e83e",
+  "lastmod": "2026-07-26"
+ },
+ "/tiktok/name-generator/": {
+  "hash": "3332644f0037a2f7",
+  "lastmod": "2026-07-26"
+ },
+ "/tl/": {
+  "hash": "7b31a0443687958a",
+  "lastmod": "2026-08-15"
+ },
+ "/tl/guide/": {
+  "hash": "014edd2031f9e347",
+  "lastmod": "2026-08-15"
+ },
+ "/tl/guide/discord-name-na-safe/": {
+  "hash": "b9f7ce797689bc9a",
+  "lastmod": "2026-08-15"
+ },
+ "/tl/guide/discord-text-formatting-paliwanag/": {
+  "hash": "25868c3b83cf0cf4",
+  "lastmod": "2026-08-15"
+ },
+ "/tl/guide/saan-gumagana-ang-font-sa-discord/": {
+  "hash": "e56f409df06a7293",
+  "lastmod": "2026-08-15"
+ },
+ "/tl/usecase/bio-font/": {
+  "hash": "a55166074e7ba9ca",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/": {
+  "hash": "1c62d9f0947260d3",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/alti-cizili-yazi/": {
+  "hash": "fe76b50be70d5b05",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/answers/": {
+  "hash": "e70cfb08caf1cb6d",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/answers/bos-gorunmez-isim-nasil-yapilir/": {
+  "hash": "b2df8560b3df9e6c",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/answers/isim-neden-kutu-olarak-gorunuyor/": {
+  "hash": "c32e87669a6b2d6a",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/answers/kullanici-adi-mi-goruntulenen-ad-mi/": {
+  "hash": "9522d7b2ba56c574",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/answers/oyun-ismi-neden-reddedildi/": {
+  "hash": "f3b5b58e09c6cdb5",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/answers/what-font-does-pinterest-use/": {
+  "hash": "d059b076f6a8f4a5",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/answers/what-font-does-whatsapp-use/": {
+  "hash": "e65e5dd0609c86ce",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/answers/youtube-handle-mi-kanal-adi-mi/": {
+  "hash": "eafe547d09c90558",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/answers/youtube-kanal-adi-nasil-degistirilir/": {
+  "hash": "ca6c48412d7b7f58",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/buyuk-kucuk-harf/": {
+  "hash": "aae61f7aec335a19",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/category/": {
+  "hash": "f31ec280538b8ead",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/el-yazisi-fontu/": {
+  "hash": "694f2b1a20257f8c",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/estetik-yazi/": {
+  "hash": "d25ad27c5a2d50f7",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/gorunmez-karakter/": {
+  "hash": "f9214dbdabf51e4f",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/gotik-yazi/": {
+  "hash": "092c3681df1e34b9",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/guide/": {
+  "hash": "5916a7905f2cd11d",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/guide/discord-fontlari-nerede-calisir/": {
+  "hash": "75e7282a2111db16",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/guide/discord-metin-bicimlendirme/": {
+  "hash": "539b9161a24f7db3",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/guide/guvenli-discord-ismi/": {
+  "hash": "5b6db0af5dd270d0",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/instagram-yazi-tipi/": {
+  "hash": "74f24393b9781f92",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/italik-yazi/": {
+  "hash": "26eb1c65d421ba58",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/kalin-yazi/": {
+  "hash": "15884cf40ab248ad",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/karakter-sayaci/": {
+  "hash": "5b208ae54ec1ce19",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/kucuk-yazi/": {
+  "hash": "931639ca8ec7aab1",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/library/": {
+  "hash": "12033032be65e60f",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/library/aglayan-emoji/": {
+  "hash": "8ba76a11bb021aeb",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/library/alt-kodlari/": {
+  "hash": "c53fd583a2130f35",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/library/ascii-tablosu/": {
+  "hash": "44e7e0af4fe6440c",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/library/ates-emoji/": {
+  "hash": "3f076d0d267dce65",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/library/ay-sembolleri/": {
+  "hash": "29481b512a228e0a",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/library/baris-sembolu/": {
+  "hash": "ce933cad0f7499d5",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/library/cat-kaomoji/": {
+  "hash": "922c9430ce0bc7dd",
+  "lastmod": "2026-08-10"
+ },
+ "/tr/library/cicek-emojileri/": {
+  "hash": "0bb2ae1152e5b14a",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/library/coquette-sembolleri/": {
+  "hash": "ffd12c28aec3a313",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/library/cottagecore-sembolleri/": {
+  "hash": "dca19bc93d1eff2f",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/library/cute-kaomoji/": {
+  "hash": "0f6f68a476511a9a",
+  "lastmod": "2026-08-10"
+ },
+ "/tr/library/derece-isareti/": {
+  "hash": "25b4508a71927bfa",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/library/dini-semboller/": {
+  "hash": "5cf59119cde54cf9",
+  "lastmod": "2026-08-13"
+ },
+ "/tr/library/discord-sembolleri/": {
+  "hash": "f7ea262cd4edb7d7",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/library/dreamcore-weirdcore-sembolleri/": {
+  "hash": "ae1f27fc83cbea47",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/library/emoji-anlamlari/": {
+  "hash": "5aa8cc8545c7191c",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/library/emoji-bayraklar/": {
+  "hash": "38efa52ac8059f32",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/library/emoji-combos/": {
+  "hash": "fd7c71c5fb9d267e",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/library/estetik-semboller/": {
+  "hash": "acf44f67b8f9d8d5",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/library/facebook-sembolleri/": {
+  "hash": "dc04263131f377bb",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/library/fairycore-sembolleri/": {
+  "hash": "4a74bf6352f59dc6",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/library/geometrik-semboller/": {
+  "hash": "c5be1bef4403363f",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/library/goth-grunge-sembolleri/": {
+  "hash": "ad572ab158676134",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/library/goz-kirpan-emoji/": {
+  "hash": "1a951411eff04315",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/library/gulen-emoji/": {
+  "hash": "e796a6c96c5643aa",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/library/hayvan-emojileri/": {
+  "hash": "54611e74e54e635c",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/library/instagram-sembolleri/": {
+  "hash": "ff0767f9d328037f",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/library/iphone-emojileri/": {
+  "hash": "4d2ed5de79bbaffe",
+  "lastmod": "2026-08-10"
+ },
+ "/tr/library/isim-sembolleri/": {
+  "hash": "e66648ddbdf4be82",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/library/iskambil-sembolleri/": {
+  "hash": "e3f061d371ecbdcb",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/library/islami-semboller/": {
+  "hash": "0aa3d893af8995a6",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/library/japon-alfabesi/": {
+  "hash": "dca04cc146ccdc1f",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/library/kalp-sembolleri/": {
+  "hash": "8123e2f7fc77893b",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/library/kaomoji/": {
+  "hash": "b5cfbe1b9d71f212",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/library/kawaii-cute-sembolleri/": {
+  "hash": "b336134c743d588b",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/library/kizgin-emoji/": {
+  "hash": "800705c823d1a055",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/library/klavye-sembolleri/": {
+  "hash": "4e6f7bc5cc9a2fc9",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/library/kurukafa-emoji/": {
+  "hash": "5134dba07cc142d7",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/library/love-kaomoji/": {
+  "hash": "2939adb9961da363",
+  "lastmod": "2026-08-10"
+ },
+ "/tr/library/madde-imi-sembolleri/": {
+  "hash": "efe5d2da95191caa",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/library/matematik-sembolleri/": {
+  "hash": "539cdcd0e8431957",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/library/mutlu-emoji/": {
+  "hash": "ba1389321b19e30d",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/library/muzik-sembolleri/": {
+  "hash": "e475e8cb29a71c8e",
+  "lastmod": "2026-08-13"
+ },
+ "/tr/library/nazar-sembolleri/": {
+  "hash": "d1204c1e5f065ad4",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/library/ok-isaretleri/": {
+  "hash": "44bd300bc9d48c43",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/library/onay-isaretleri/": {
+  "hash": "b6dfd163c8d6118e",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/library/opucuk-emoji/": {
+  "hash": "1b275d06280fafbd",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/library/para-birimi-sembolleri/": {
+  "hash": "e1fbcfbfe7b8879f",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/library/para-emojileri/": {
+  "hash": "01b653bd73b9849b",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/library/parti-emojileri/": {
+  "hash": "2dc9f6b7197a7bde",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/library/pubg-sembolleri/": {
+  "hash": "f2c1c4f1a0d33067",
+  "lastmod": "2026-08-14"
+ },
+ "/tr/library/roblox-sembolleri/": {
+  "hash": "e497142cf294d831",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/library/satranc-sembolleri/": {
+  "hash": "a10cd2c5d06daa47",
+  "lastmod": "2026-08-13"
+ },
+ "/tr/library/semboller/": {
+  "hash": "f33c9d3adece86f8",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/library/tac-emoji/": {
+  "hash": "d576de8353ca8b3b",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/library/therian-sembolleri/": {
+  "hash": "538610c73b567906",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/library/uyari-sembolleri/": {
+  "hash": "f20508449132352f",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/library/uzgun-emoji/": {
+  "hash": "d8076da2084e987a",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/library/witchy-occult-sembolleri/": {
+  "hash": "664e70f3e8a32498",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/library/y2k-sembolleri/": {
+  "hash": "123f23fe2466dae5",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/library/yazi-sanati/": {
+  "hash": "08271188fcc9f017",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/library/yemek-emojileri/": {
+  "hash": "25945c9ba4323ae9",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/library/yildiz-sembolleri/": {
+  "hash": "68babdb846f8d59e",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/library/yunan-alfabesi-sembolleri/": {
+  "hash": "a4119de0fbd01129",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/library/yuz-emojileri/": {
+  "hash": "32c24148cd1e36ee",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/library/zodyak-sembolleri/": {
+  "hash": "5c798429ddeea58c",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/metin-susleme/": {
+  "hash": "e376d76a9b3005e9",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/sekilli-nick/": {
+  "hash": "dddbeee6d7d4cca9",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/sekilli-yazi/": {
+  "hash": "b32afedcfed71560",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/snapchat-yazi-tipi/": {
+  "hash": "c9c443ab3f5eb8df",
+  "lastmod": "2026-08-11"
+ },
+ "/tr/symbol/": {
+  "hash": "052ceb463f051aaf",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/akrep-burcu-sembolu/": {
+  "hash": "4c85cb68115bc145",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/alfa-sembolu/": {
+  "hash": "a62b62a09b813473",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/alt-cizgi-isareti/": {
+  "hash": "fd2672e243c0d973",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/symbol/anarsi-sembolu/": {
+  "hash": "2c653993eee911f9",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/ankh-sembolu/": {
+  "hash": "718ddda403869121",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/arti-eksi-isareti/": {
+  "hash": "3952dd66e2e82763",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/asagi-ok-isareti/": {
+  "hash": "4ca7e642cdfd1ef2",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/aslan-burcu-sembolu/": {
+  "hash": "f5dee35237f490b7",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/asteriks-sembolu/": {
+  "hash": "d2504e4c2f8bba6d",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/symbol/at-isareti/": {
+  "hash": "2fab865c85f68a95",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/balik-burcu-sembolu/": {
+  "hash": "0e3c50bee3480c32",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/baris-isareti/": {
+  "hash": "e65d7eacdf91992a",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/basak-burcu-sembolu/": {
+  "hash": "50c677438ff9bb61",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/basparmak-isareti-emojisi/": {
+  "hash": "2699519b47973349",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/symbol/bitcoin-sembolu/": {
+  "hash": "23d354f5ae770371",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/biyolojik-tehlike-sembolu/": {
+  "hash": "a6a6468c1e3f1bfe",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/boga-burcu-sembolu/": {
+  "hash": "11027c2f4049ea2e",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/bolme-isareti/": {
+  "hash": "35012c7ddd62181a",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/bolum-isareti/": {
+  "hash": "f92a1481b4af68b6",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/cap-isareti/": {
+  "hash": "ff634f01d2acc0e3",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/carpik-yuz-emojisi/": {
+  "hash": "9ac7d9def7dd5528",
+  "lastmod": "2026-08-05"
+ },
+ "/tr/symbol/carpma-isareti/": {
+  "hash": "9dc8ce2ba40c63f8",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/catlayan-yuz-emojisi/": {
+  "hash": "3363a87ab3ef4951",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/symbol/celsius-isareti/": {
+  "hash": "b88da9ffb08fb5cb",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/davut-yildizi/": {
+  "hash": "e3313446ba10c2c4",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/delta-sembolu/": {
+  "hash": "d7c313622619e291",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/derece-isareti/": {
+  "hash": "74c0a25f8099a22c",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/dikey-cizgi-isareti/": {
+  "hash": "1f31cbec4391a095",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/dirhem-isareti/": {
+  "hash": "f1253b68d32493ab",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/symbol/dolar-isareti/": {
+  "hash": "d5bdba42eb647dc3",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/dur-isareti/": {
+  "hash": "b0a50fe9e5593ab7",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/eriyen-yuz-emojisi/": {
+  "hash": "9e9a53a7b3d7b812",
+  "lastmod": "2026-08-05"
+ },
+ "/tr/symbol/esit-degil-isareti/": {
+  "hash": "48c7310dd752b70d",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/eslik-isareti/": {
+  "hash": "293097469edd98e8",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/euro-isareti/": {
+  "hash": "874a8dccb8d47d00",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/fahrenheit-isareti/": {
+  "hash": "df4609e77b2398f5",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/fi-sembolu/": {
+  "hash": "4b0561a5b41589bb",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/symbol/fleur-de-lis-sembolu/": {
+  "hash": "c2adf6ff3bb6d58f",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/geri-donusum-sembolu/": {
+  "hash": "2f36884b034537d5",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/gorunmez-yazi-karakteri/": {
+  "hash": "ed2d1433962f26f5",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/gunes-gozlugu-emojisi/": {
+  "hash": "d18a01c01f94e313",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/symbol/hac-sembolu/": {
+  "hash": "1acc1681fe2dccd4",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/hamsa-sembolu/": {
+  "hash": "dd69fb43390eda6b",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/hilal-ve-yildiz-sembolu/": {
+  "hash": "886628cf46e44c88",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/symbol/ikizler-burcu-sembolu/": {
+  "hash": "4940eac378e6549a",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/interrobang-isareti/": {
+  "hash": "15c0804dd2a204ae",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/symbol/kalp-sembolu/": {
+  "hash": "6edc03cde5662f1b",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/kara-ay-lilith-sembolu/": {
+  "hash": "897033e821e36b0b",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/kare-kup-isaretleri/": {
+  "hash": "a18221c7e96f7cdd",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/karekok-isareti/": {
+  "hash": "f6bec42cebf04a2f",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/khanda-sembolu/": {
+  "hash": "86d3f0a2d50cc93c",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/ki-sembolu/": {
+  "hash": "651d9ee5a7b759be",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/symbol/koc-burcu-sembolu/": {
+  "hash": "33abe530733031b5",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/kova-burcu-sembolu/": {
+  "hash": "119f70eb49523895",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/kucuktur-buyuktur-isareti/": {
+  "hash": "c284f06dce862d06",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/kucuktur-esittir-isareti/": {
+  "hash": "f1c8938d854d3664",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/symbol/kurukafa-kemikler-sembolu/": {
+  "hash": "32c55fde8b68a753",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/symbol/lambda-sembolu/": {
+  "hash": "50729ec0cc40df4b",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/symbol/maca-sembolu/": {
+  "hash": "9e98a5dba62b13bc",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/symbol/meteor-emojisi/": {
+  "hash": "bb1df1998ad3cf9b",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/symbol/mikro-isareti/": {
+  "hash": "aaab808d16bfea9b",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/mikrofon-emojisi/": {
+  "hash": "da0be92f3564faf2",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/symbol/monark-kelebegi-emojisi/": {
+  "hash": "9f7abe80a1335a07",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/symbol/ofke-sembolu/": {
+  "hash": "a306b59947a5aaa7",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/oglak-burcu-sembolu/": {
+  "hash": "97ea74b84f683882",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/ohm-isareti/": {
+  "hash": "132ea8047aa90eb3",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/om-sembolu/": {
+  "hash": "6f39a533205d58ea",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/omega-sembolu/": {
+  "hash": "35179c86c31b2c26",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/onay-isareti/": {
+  "hash": "72705105d8cb95eb",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/orta-tire-isareti/": {
+  "hash": "609c681f71afb454",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/symbol/ortodoks-hac-sembolu/": {
+  "hash": "a9fb3fdd7df04647",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/otizm-sembolu/": {
+  "hash": "aca30ba7fab80765",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/paragraf-isareti/": {
+  "hash": "b5b063a8d409892c",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/pentagram-sembolu/": {
+  "hash": "6da98843530df9a2",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/peso-isareti/": {
+  "hash": "03368ea83032de90",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/symbol/pi-sembolu/": {
+  "hash": "6ab6e5507064a12b",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/piyon-sembolu/": {
+  "hash": "e10dbc526e81d25c",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/symbol/psi-sembolu/": {
+  "hash": "41a1e4366452f1f4",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/symbol/ruble-isareti/": {
+  "hash": "8eb041bbacdebb48",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/symbol/rufiya-isareti/": {
+  "hash": "0526fa230aad97ae",
+  "lastmod": "2026-08-05"
+ },
+ "/tr/symbol/rupi-isareti/": {
+  "hash": "32a25e52c3183728",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/sag-ok-isareti/": {
+  "hash": "d3cc2015dd5afb1e",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/sent-isareti/": {
+  "hash": "6cb0f035618c29a9",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/sigma-sembolu/": {
+  "hash": "7d3f3cffd7d7d79e",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/snapchat-kalp-renkleri/": {
+  "hash": "c3f1e7f66a275da9",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/symbol/sol-ok-isareti/": {
+  "hash": "b19e173b982f8e8c",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/sonsuzluk-isareti/": {
+  "hash": "e6835d37e50edb66",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/sterlin-isareti/": {
+  "hash": "de5175fec19999f2",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/suudi-riyali-isareti/": {
+  "hash": "221e7aede60089a2",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/symbol/takvim-emojisi/": {
+  "hash": "f10801657ee6b742",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/symbol/tekerlekli-sandalye-sembolu/": {
+  "hash": "3f6a78cb8f3f877b",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/telif-hakki-isareti/": {
+  "hash": "9529f53cd79cc125",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/terazi-burcu-sembolu/": {
+  "hash": "3bcb358618566c5c",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/ters-soru-isareti/": {
+  "hash": "4d0c44196e20002b",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/teta-sembolu/": {
+  "hash": "20f230641f668bc2",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/symbol/ticari-marka-isareti/": {
+  "hash": "a4a7512a8dfe085e",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/tilde-isareti/": {
+  "hash": "c42ef174ca6e4473",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/symbol/tirnak-isareti/": {
+  "hash": "f6c32cadfb843424",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/tursu-emojisi/": {
+  "hash": "a0664878768dae00",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/symbol/umman-riyali-isareti/": {
+  "hash": "864523655060ae90",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/symbol/uzun-tire-isareti/": {
+  "hash": "6e9f646be521c038",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/ve-isareti/": {
+  "hash": "b71dcd50f6b25d23",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/won-isareti/": {
+  "hash": "f67e106f5bf8b99e",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/yay-burcu-sembolu/": {
+  "hash": "568ba9a25fba6ee9",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/yen-isareti/": {
+  "hash": "3576a0f6d4964874",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/yengec-burcu-sembolu/": {
+  "hash": "929b7be1124691e7",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/yildiz-sembolu/": {
+  "hash": "7c197da2d21d5c88",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/yin-yang-sembolu/": {
+  "hash": "88ca144a7986efbf",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/symbol/yukari-ok-isareti/": {
+  "hash": "76946c36e826f5c8",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/tiktok-yazi-tipi/": {
+  "hash": "371329c3424c4610",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/updates/dirhem-sembolu-unicode-18/": {
+  "hash": "7f2ae91e7ad5a291",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/updates/orta-dogu-para-birimi-sembolleri-unicode-18/": {
+  "hash": "44e6224c7aef3618",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/updates/unicode-18-beta-inceleme-basliyor/": {
+  "hash": "142a3c89a23279a8",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/updates/unicode-18-cikis-tarihi-onaylandi/": {
+  "hash": "18144ed99a23756c",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/updates/unicode-18-yeni-emoji-oylama/": {
+  "hash": "f678f1340645976a",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/usecase/": {
+  "hash": "3af5f56293e5350d",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/usecase/biyografi-yazi-tipi/": {
+  "hash": "bbe319d7898107da",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/usecase/coc-nick/": {
+  "hash": "61d222373c3d71d1",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/usecase/dovme-yazi-fontlari/": {
+  "hash": "4acffb73b8a62e28",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/usecase/emoji-ceviri/": {
+  "hash": "f6670cecf54f20ad",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/usecase/emoji-harfler/": {
+  "hash": "d5eb0f91fcd4a455",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/usecase/free-fire-nick/": {
+  "hash": "08101eb7114a0708",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/usecase/grup-ismi/": {
+  "hash": "cd1ecdb40490431b",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/usecase/mobile-legends-nick/": {
+  "hash": "8a9b881dc1a5d0c4",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/usecase/pubg-nick/": {
+  "hash": "e07ed2979f466912",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/usecase/rehber-adi-estetik/": {
+  "hash": "b2beb7bd610b4f81",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/usecase/stumble-guys-nick/": {
+  "hash": "b2ea0824630a137d",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/usecase/valorant-nick/": {
+  "hash": "8aac20ebad032a41",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/usecase/vertical-text/": {
+  "hash": "a88b5cc1ab31ba56",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/usecase/zalgo-text/": {
+  "hash": "8a961a406fcacf95",
+  "lastmod": "2026-08-15"
+ },
+ "/tr/ustu-cizili-yazi/": {
+  "hash": "7dcad467f0b0f4e7",
+  "lastmod": "2026-08-16"
+ },
+ "/tr/whatsapp-yazi-tipi/": {
+  "hash": "4606b2e68c59c8b8",
+  "lastmod": "2026-08-16"
+ },
+ "/updates/": {
+  "hash": "c58f7449ea9d3d10",
+  "lastmod": "2026-08-12"
+ },
+ "/updates/forza-horizon-6-gamertag-rules/": {
+  "hash": "577d5e5ad7c66f2c",
+  "lastmod": "2026-07-25"
+ },
+ "/updates/lienquan-mobile-name-penalty-update/": {
+  "hash": "f1eb251fabbbe487",
+  "lastmod": "2026-08-12"
+ },
+ "/updates/middle-east-currency-symbols-scorecard/": {
+  "hash": "da7e322e6014b89c",
+  "lastmod": "2026-07-25"
+ },
+ "/updates/telegram-premium-message-limit/": {
+  "hash": "0c085522d6e08d2d",
+  "lastmod": "2026-08-12"
+ },
+ "/updates/uae-dirham-symbol-unicode-18/": {
+  "hash": "5a9f4f16d5cc0053",
+  "lastmod": "2026-07-25"
+ },
+ "/updates/unicode-17-new-emoji-rollout/": {
+  "hash": "a33903317cbd572e",
+  "lastmod": "2026-07-25"
+ },
+ "/updates/unicode-18-beta-review-opens/": {
+  "hash": "51b4c306797c81aa",
+  "lastmod": "2026-08-05"
+ },
+ "/updates/unicode-18-most-anticipated-emoji/": {
+  "hash": "50a08df67e4428fc",
+  "lastmod": "2026-08-12"
+ },
+ "/updates/unicode-18-release-date-confirmed/": {
+  "hash": "a6180d49f7056eaf",
+  "lastmod": "2026-08-12"
+ },
+ "/updates/whatsapp-usernames-rollout/": {
+  "hash": "09cd8ef89372a695",
+  "lastmod": "2026-07-25"
+ },
+ "/updates/xbox-gamertag-15-character-limit/": {
+  "hash": "5ac6759480e012af",
+  "lastmod": "2026-07-31"
+ },
+ "/usecase/": {
+  "hash": "bdb5b114e39f074b",
+  "lastmod": "2026-08-07"
+ },
+ "/usecase/aesthetic-contact-names/": {
+  "hash": "91fc9ece5c49b75e",
+  "lastmod": "2026-07-26"
+ },
+ "/usecase/aesthetic-instagram-names/": {
+  "hash": "101ce97e2f35fb5f",
+  "lastmod": "2026-07-26"
+ },
+ "/usecase/before-after-emoji/": {
+  "hash": "aec2e518fdd51f6a",
+  "lastmod": "2026-07-26"
+ },
+ "/usecase/bio-font/": {
+  "hash": "7fdd990514f8993c",
+  "lastmod": "2026-07-26"
+ },
+ "/usecase/bio-font/discord/": {
+  "hash": "e4214428d2579315",
+  "lastmod": "2026-07-26"
+ },
+ "/usecase/bio-font/instagram/": {
+  "hash": "702c4b2da58aef10",
+  "lastmod": "2026-08-01"
+ },
+ "/usecase/bio-font/tiktok/": {
+  "hash": "54080c9360fd8666",
+  "lastmod": "2026-07-26"
+ },
+ "/usecase/bio-font/whatsapp/": {
+  "hash": "888a173ee64d3ff3",
+  "lastmod": "2026-07-26"
+ },
+ "/usecase/clan-tag-generator/": {
+  "hash": "d1627f4aacd15cd5",
+  "lastmod": "2026-08-05"
+ },
+ "/usecase/clash-of-clans-name-generator/": {
+  "hash": "5f8a24103b0d4474",
+  "lastmod": "2026-07-26"
+ },
+ "/usecase/clash-royale-name-generator/": {
+  "hash": "2d50cc6cfc7d0481",
+  "lastmod": "2026-07-31"
+ },
+ "/usecase/comment-font/": {
+  "hash": "a9e93c00b32395c9",
+  "lastmod": "2026-08-05"
+ },
+ "/usecase/emoji-combinations/": {
+  "hash": "51bc64a4d411fe3c",
+  "lastmod": "2026-07-26"
+ },
+ "/usecase/emoji-letters/": {
+  "hash": "1153e992e1a4a5d3",
+  "lastmod": "2026-07-25"
+ },
+ "/usecase/emoji-to-text/": {
+  "hash": "d73a8b95b7eb9cee",
+  "lastmod": "2026-07-25"
+ },
+ "/usecase/football-font/": {
+  "hash": "365e7b7a4e1cb39d",
+  "lastmod": "2026-07-25"
+ },
+ "/usecase/fortnite-name-generator/": {
+  "hash": "ccd038d8cfb336c8",
+  "lastmod": "2026-07-31"
+ },
+ "/usecase/free-fire-clan-tag-generator/": {
+  "hash": "ce52956a3a4b5018",
+  "lastmod": "2026-08-06"
+ },
+ "/usecase/free-fire-guild-name-generator/": {
+  "hash": "8cced9698c4c6117",
+  "lastmod": "2026-08-05"
+ },
+ "/usecase/free-fire-name-generator/": {
+  "hash": "6da54b323cc658ca",
+  "lastmod": "2026-08-07"
+ },
+ "/usecase/group-name-generator/": {
+  "hash": "47dd9fb0c099b203",
+  "lastmod": "2026-07-26"
+ },
+ "/usecase/linkedin-headline/": {
+  "hash": "dcba07023ff25064",
+  "lastmod": "2026-08-06"
+ },
+ "/usecase/mobile-legends-name-generator/": {
+  "hash": "09e7e4337e9850a0",
+  "lastmod": "2026-07-26"
+ },
+ "/usecase/mobile-legends-squad-name-generator/": {
+  "hash": "8c31b2a91c72d9d8",
+  "lastmod": "2026-07-26"
+ },
+ "/usecase/name-to-symbols/": {
+  "hash": "fbd803db333d1645",
+  "lastmod": "2026-08-07"
+ },
+ "/usecase/nickname-generator/": {
+  "hash": "eb07f50939489fec",
+  "lastmod": "2026-08-07"
+ },
+ "/usecase/old-english-translator/": {
+  "hash": "a8bfa8ba3bcdba88",
+  "lastmod": "2026-07-25"
+ },
+ "/usecase/pirate-translator/": {
+  "hash": "20bb49b6e61d9f6c",
+  "lastmod": "2026-07-25"
+ },
+ "/usecase/playstation-name-generator/": {
+  "hash": "64c4fb2ccd43e999",
+  "lastmod": "2026-07-31"
+ },
+ "/usecase/pubg-name-generator/": {
+  "hash": "e94c97a1287c5db2",
+  "lastmod": "2026-08-01"
+ },
+ "/usecase/repeat-text/": {
+  "hash": "91fd6eaf73a02e27",
+  "lastmod": "2026-07-25"
+ },
+ "/usecase/scrolling-text/": {
+  "hash": "b755008383d21156",
+  "lastmod": "2026-07-26"
+ },
+ "/usecase/stumble-guys-name-generator/": {
+  "hash": "50c3e76a1e7aa8c8",
+  "lastmod": "2026-07-26"
+ },
+ "/usecase/stylish-name/": {
+  "hash": "094f23c4fe6a2cc2",
+  "lastmod": "2026-08-01"
+ },
+ "/usecase/tattoo-fonts/": {
+  "hash": "dd28efc5197ebb48",
+  "lastmod": "2026-07-25"
+ },
+ "/usecase/text-to-emoji/": {
+  "hash": "3f35e126defd4940",
+  "lastmod": "2026-07-25"
+ },
+ "/usecase/valorant-name-generator/": {
+  "hash": "d2cb9ccc9c6c2205",
+  "lastmod": "2026-07-26"
+ },
+ "/usecase/vertical-text/": {
+  "hash": "c7171e89175d13b7",
+  "lastmod": "2026-07-26"
+ },
+ "/usecase/xbox-name-generator/": {
+  "hash": "5b870c38fbbf4574",
+  "lastmod": "2026-07-31"
+ },
+ "/usecase/zalgo-text/": {
+  "hash": "7bd81c2e4e915dba",
+  "lastmod": "2026-07-25"
+ },
+ "/vi/": {
+  "hash": "628b6da9512939cd",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/answers/cach-tao-ten-trong-vo-hinh/": {
+  "hash": "3b73d618432761dc",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/answers/username-hay-ten-hien-thi/": {
+  "hash": "062776a83f0e869b",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/answers/vi-sao-ten-game-bi-tu-choi/": {
+  "hash": "4ee2700a59f80f34",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/answers/vi-sao-ten-hien-o-vuong/": {
+  "hash": "5eed71be8a5409ed",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/chu-gach-ngang/": {
+  "hash": "2a25677cd7374783",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/chu-hoa-chu-thuong/": {
+  "hash": "da2ce47969684430",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/chu-in-dam/": {
+  "hash": "52f44cdccbdfaf16",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/chu-kieu-tiktok/": {
+  "hash": "814f3fa0f68cf483",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/chu-nghieng/": {
+  "hash": "83e46785954bc71c",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/chu-nguoc/": {
+  "hash": "464566faae441ce2",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/chu-nho/": {
+  "hash": "8f2988e48d8de876",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/combo-emoji/": {
+  "hash": "1f373e63e419b4f6",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/dem-tu-dem-ky-tu/": {
+  "hash": "59b10c5ea963607d",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/font-chu-dep/": {
+  "hash": "e5a46c69592a7369",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/font-discord/": {
+  "hash": "d262165043b95e3c",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/font-facebook/": {
+  "hash": "44b47b59a18c8bf6",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/font-gothic/": {
+  "hash": "2fda3a9618bdc052",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/font-ig/": {
+  "hash": "543977acefa5159e",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/font-roblox/": {
+  "hash": "762d673f76fb45be",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/font-whatsapp/": {
+  "hash": "0bc3eab00e6da491",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/guide/": {
+  "hash": "fe07aca6e6d5d1b0",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/guide/dat-ten-discord-an-toan/": {
+  "hash": "b7635c77fd170014",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/guide/dinh-dang-chu-discord/": {
+  "hash": "4026096619eba1c1",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/guide/font-discord-dung-o-dau/": {
+  "hash": "2d4be0a8e251a4b9",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/ki-tu-dac-biet-ff/": {
+  "hash": "474f473c1b0faf02",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/ki-tu-dac-biet-lien-quan/": {
+  "hash": "590f88b8ba8ebcfa",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/ki-tu-dac-biet/": {
+  "hash": "58358e20e7b8261d",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/ki-tu-discord/": {
+  "hash": "677f5d140b8c0074",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/ki-tu-facebook/": {
+  "hash": "2137065430667987",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/ki-tu-mui-ten/": {
+  "hash": "d3479b900b60fa14",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/ki-tu-ngoi-sao/": {
+  "hash": "cbdb1cd9b479500e",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/ki-tu-roblox/": {
+  "hash": "d4b1c98e55cfb2d4",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/ki-tu-trai-tim/": {
+  "hash": "26e647eed194f338",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/ki-tu-y2k/": {
+  "hash": "2b8b71619f87e19f",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/ky-tu-vo-hinh/": {
+  "hash": "154b2d87db51792c",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/library/": {
+  "hash": "4c12af3637c3383f",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/library/bang-ma-ascii/": {
+  "hash": "e647373106cc7a03",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/library/bullet-point-symbols/": {
+  "hash": "5000a5e41c07d2dd",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/library/cat-kaomoji/": {
+  "hash": "d9e0d5b4470e77b8",
+  "lastmod": "2026-08-10"
+ },
+ "/vi/library/chu-tuong-hinh-ai-cap/": {
+  "hash": "36fa35661a3ed35a",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/library/cute-kaomoji/": {
+  "hash": "d100d37b69652512",
+  "lastmod": "2026-08-10"
+ },
+ "/vi/library/emoji-buon/": {
+  "hash": "eea827626e3a1603",
+  "lastmod": "2026-08-16"
+ },
+ "/vi/library/emoji-flags/": {
+  "hash": "62b124bf68ebf47b",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/library/emoji-hoa/": {
+  "hash": "ad6d6befb0bac92f",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/library/emoji-iphone/": {
+  "hash": "6ed469c9792f0ed2",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/library/emoji-lua/": {
+  "hash": "db1a399e448d1aa1",
+  "lastmod": "2026-08-16"
+ },
+ "/vi/library/emoji-mat-cuoi/": {
+  "hash": "afaaed486d37be7d",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/library/emoji-tuc-gian/": {
+  "hash": "907d484c1ad97875",
+  "lastmod": "2026-08-16"
+ },
+ "/vi/library/kaomoji/": {
+  "hash": "d4784094e614e2b5",
+  "lastmod": "2026-08-02"
+ },
+ "/vi/library/ky-hieu-am-nhac/": {
+  "hash": "2c43efe141e6528e",
+  "lastmod": "2026-08-13"
+ },
+ "/vi/library/ky-hieu-co-vua/": {
+  "hash": "58f9a5f6a1a5a257",
+  "lastmod": "2026-08-13"
+ },
+ "/vi/library/ky-hieu-cung-hoang-dao/": {
+  "hash": "8b1abd9b3e99a010",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/library/ky-hieu-hoi-giao/": {
+  "hash": "84f0e30f45a06976",
+  "lastmod": "2026-08-13"
+ },
+ "/vi/library/ky-hieu-tien-te/": {
+  "hash": "4bdd43b9386f42c2",
+  "lastmod": "2026-08-07"
+ },
+ "/vi/library/ky-hieu-ton-giao/": {
+  "hash": "c4f25c200dd32958",
+  "lastmod": "2026-08-13"
+ },
+ "/vi/library/ky-tu-dac-biet-free-fire/": {
+  "hash": "ee0c0ff1afdafce4",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/library/ky-tu-dac-biet-ten/": {
+  "hash": "82247e944676ebdb",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/library/ky-tu-dac-biet-unicode/": {
+  "hash": "f2a5ee7b7ef13fc2",
+  "lastmod": "2026-08-07"
+ },
+ "/vi/library/ky-tu-game/": {
+  "hash": "1f90fa956baf1b9e",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/library/ky-tu-hy-lap/": {
+  "hash": "2e1fea9d40a8dad3",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/library/ky-tu-kawaii-de-thuong/": {
+  "hash": "743bf667643109a4",
+  "lastmod": "2026-08-07"
+ },
+ "/vi/library/ky-tu-so/": {
+  "hash": "a220983a7c26d69e",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/library/love-kaomoji/": {
+  "hash": "6bbd159eb0c323ba",
+  "lastmod": "2026-08-10"
+ },
+ "/vi/library/math-symbols/": {
+  "hash": "33ddfc3fe64886a9",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/library/ten-roblox-dep/": {
+  "hash": "c3b5148a5d2bd034",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/library/text-art/": {
+  "hash": "064227520345fb4c",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/symbol/": {
+  "hash": "0f3610bd054e11ce",
+  "lastmod": "2026-08-16"
+ },
+ "/vi/symbol/alpha-symbol/": {
+  "hash": "6c4683811bf0464b",
+  "lastmod": "2026-08-11"
+ },
+ "/vi/symbol/ampersand/": {
+  "hash": "1344a9407597d1a3",
+  "lastmod": "2026-08-11"
+ },
+ "/vi/symbol/anarchy-symbol/": {
+  "hash": "541e8dae14759602",
+  "lastmod": "2026-08-05"
+ },
+ "/vi/symbol/anger-symbol/": {
+  "hash": "055eaaf1447b3013",
+  "lastmod": "2026-08-05"
+ },
+ "/vi/symbol/ankh-symbol/": {
+  "hash": "7016ca305ea96af5",
+  "lastmod": "2026-08-11"
+ },
+ "/vi/symbol/aquarius-symbol/": {
+  "hash": "6b237e3830454a44",
+  "lastmod": "2026-08-11"
+ },
+ "/vi/symbol/aries-symbol/": {
+  "hash": "0eb0d53f34b74641",
+  "lastmod": "2026-08-11"
+ },
+ "/vi/symbol/asterisk-symbol/": {
+  "hash": "fc59ed4824a68adf",
+  "lastmod": "2026-08-05"
+ },
+ "/vi/symbol/at-symbol/": {
+  "hash": "0982ee9202433ea3",
+  "lastmod": "2026-08-06"
+ },
+ "/vi/symbol/autism-symbol/": {
+  "hash": "12d2932141da4dcf",
+  "lastmod": "2026-08-06"
+ },
+ "/vi/symbol/backwards-question-mark/": {
+  "hash": "6d136c9ec3f29271",
+  "lastmod": "2026-08-06"
+ },
+ "/vi/symbol/biohazard-symbol/": {
+  "hash": "509025a6c7909396",
+  "lastmod": "2026-08-06"
+ },
+ "/vi/symbol/bitcoin-symbol/": {
+  "hash": "b052484d19fb7f29",
+  "lastmod": "2026-08-13"
+ },
+ "/vi/symbol/black-moon-lilith/": {
+  "hash": "ef0f4cffe19580af",
+  "lastmod": "2026-08-11"
+ },
+ "/vi/symbol/calendar-emoji/": {
+  "hash": "ba5e600a477c5c0a",
+  "lastmod": "2026-08-05"
+ },
+ "/vi/symbol/cancer-symbol/": {
+  "hash": "90be602798dc1e96",
+  "lastmod": "2026-08-11"
+ },
+ "/vi/symbol/capricorn-symbol/": {
+  "hash": "40272b76b9276f73",
+  "lastmod": "2026-08-11"
+ },
+ "/vi/symbol/celsius-symbol/": {
+  "hash": "820d2d12328ba74c",
+  "lastmod": "2026-08-13"
+ },
+ "/vi/symbol/cent-sign/": {
+  "hash": "98d5e8c9521edde7",
+  "lastmod": "2026-08-06"
+ },
+ "/vi/symbol/checkmark-symbol/": {
+  "hash": "abc75947e92337f1",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/symbol/chi-symbol/": {
+  "hash": "b9cc23270fb0cd15",
+  "lastmod": "2026-08-11"
+ },
+ "/vi/symbol/congruent-symbol/": {
+  "hash": "678ae2cd1ac9a4c6",
+  "lastmod": "2026-08-05"
+ },
+ "/vi/symbol/copyright-symbol/": {
+  "hash": "fe5bde346479af25",
+  "lastmod": "2026-08-11"
+ },
+ "/vi/symbol/cracking-face-emoji/": {
+  "hash": "a8d7c2ab66dbf294",
+  "lastmod": "2026-08-11"
+ },
+ "/vi/symbol/crescent-and-star/": {
+  "hash": "33a2e2d8de482e06",
+  "lastmod": "2026-08-11"
+ },
+ "/vi/symbol/cross-symbol/": {
+  "hash": "1cf70e25b8a41c17",
+  "lastmod": "2026-08-06"
+ },
+ "/vi/symbol/degree-symbol/": {
+  "hash": "afdd5c3b87415548",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/symbol/delta-symbol/": {
+  "hash": "a37d2f40a1010105",
+  "lastmod": "2026-08-11"
+ },
+ "/vi/symbol/diameter-symbol/": {
+  "hash": "eb40782001c41ed6",
+  "lastmod": "2026-08-06"
+ },
+ "/vi/symbol/dirham-sign/": {
+  "hash": "263a38258a4b8a72",
+  "lastmod": "2026-08-11"
+ },
+ "/vi/symbol/division-sign/": {
+  "hash": "eb73bebadd9b3f22",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/symbol/dollar-sign/": {
+  "hash": "ca50be1ecc3bb2af",
+  "lastmod": "2026-08-06"
+ },
+ "/vi/symbol/down-arrow/": {
+  "hash": "4a69de57f1f2414d",
+  "lastmod": "2026-08-05"
+ },
+ "/vi/symbol/em-dash/": {
+  "hash": "e6a67467ef8b6b99",
+  "lastmod": "2026-08-16"
+ },
+ "/vi/symbol/en-dash/": {
+  "hash": "629b4612affe366f",
+  "lastmod": "2026-08-05"
+ },
+ "/vi/symbol/euro-sign/": {
+  "hash": "03b3977fbfda970d",
+  "lastmod": "2026-08-06"
+ },
+ "/vi/symbol/fahrenheit-symbol/": {
+  "hash": "11a44529b490ab6f",
+  "lastmod": "2026-08-13"
+ },
+ "/vi/symbol/fleur-de-lis-symbol/": {
+  "hash": "dac3e5407843f45c",
+  "lastmod": "2026-08-05"
+ },
+ "/vi/symbol/gemini-symbol/": {
+  "hash": "0fd7af98c565c31c",
+  "lastmod": "2026-08-11"
+ },
+ "/vi/symbol/hamsa-symbol/": {
+  "hash": "feb8f2f251aa33ef",
+  "lastmod": "2026-08-06"
+ },
+ "/vi/symbol/heart-symbol/": {
+  "hash": "be5d7c1a1c643f1f",
+  "lastmod": "2026-08-06"
+ },
+ "/vi/symbol/infinity/": {
+  "hash": "1535a0b4d6401bb1",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/symbol/interrobang/": {
+  "hash": "dd7d21f072a362ab",
+  "lastmod": "2026-08-16"
+ },
+ "/vi/symbol/invisible-character/": {
+  "hash": "b070e14eabf2176f",
+  "lastmod": "2026-08-13"
+ },
+ "/vi/symbol/khanda-symbol/": {
+  "hash": "d2fb6cf5970d4258",
+  "lastmod": "2026-08-06"
+ },
+ "/vi/symbol/lambda-symbol/": {
+  "hash": "cdce4436a535a225",
+  "lastmod": "2026-08-11"
+ },
+ "/vi/symbol/left-arrow/": {
+  "hash": "105bfc06d2b72f46",
+  "lastmod": "2026-08-05"
+ },
+ "/vi/symbol/leo-symbol/": {
+  "hash": "bd96e64cb320f14b",
+  "lastmod": "2026-08-11"
+ },
+ "/vi/symbol/less-than-greater-than/": {
+  "hash": "05834b1edad2b198",
+  "lastmod": "2026-08-06"
+ },
+ "/vi/symbol/less-than-or-equal-to-symbol/": {
+  "hash": "955d6f40e4105795",
+  "lastmod": "2026-08-05"
+ },
+ "/vi/symbol/libra-symbol/": {
+  "hash": "3101b04e7623b9dc",
+  "lastmod": "2026-08-11"
+ },
+ "/vi/symbol/meteor-emoji/": {
+  "hash": "03243c32de27915c",
+  "lastmod": "2026-08-05"
+ },
+ "/vi/symbol/micro-sign/": {
+  "hash": "23211e045908c0b3",
+  "lastmod": "2026-08-11"
+ },
+ "/vi/symbol/microphone-emoji/": {
+  "hash": "f5642927c76e6332",
+  "lastmod": "2026-08-11"
+ },
+ "/vi/symbol/monarch-butterfly-emoji/": {
+  "hash": "87b8a8634eff31e0",
+  "lastmod": "2026-08-05"
+ },
+ "/vi/symbol/multiplication-sign/": {
+  "hash": "2613373e31004d09",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/symbol/not-equal-sign/": {
+  "hash": "55ea4cc52d0e35d7",
+  "lastmod": "2026-08-06"
+ },
+ "/vi/symbol/ohm-symbol/": {
+  "hash": "b000c1aa0b057d6f",
+  "lastmod": "2026-08-13"
+ },
+ "/vi/symbol/om-symbol/": {
+  "hash": "5e0276e09a3ab9af",
+  "lastmod": "2026-08-11"
+ },
+ "/vi/symbol/omani-rial-sign/": {
+  "hash": "56faa6d2ebb2e9fe",
+  "lastmod": "2026-08-11"
+ },
+ "/vi/symbol/omega-symbol/": {
+  "hash": "c363ffcd18fffd4d",
+  "lastmod": "2026-08-13"
+ },
+ "/vi/symbol/orthodox-cross/": {
+  "hash": "be85747da9ad00f5",
+  "lastmod": "2026-08-11"
+ },
+ "/vi/symbol/pawn-symbol/": {
+  "hash": "8ddb56ff15115e15",
+  "lastmod": "2026-08-11"
+ },
+ "/vi/symbol/peace-sign/": {
+  "hash": "167970e4a9348d43",
+  "lastmod": "2026-08-06"
+ },
+ "/vi/symbol/pentagram-symbol/": {
+  "hash": "68ecc98cc8658ce8",
+  "lastmod": "2026-08-06"
+ },
+ "/vi/symbol/peso-sign/": {
+  "hash": "fb993827622a4d0e",
+  "lastmod": "2026-08-11"
+ },
+ "/vi/symbol/phi-symbol/": {
+  "hash": "75b2af1171d38104",
+  "lastmod": "2026-08-11"
+ },
+ "/vi/symbol/pi-symbol/": {
+  "hash": "38c7cfced68fe4f7",
+  "lastmod": "2026-08-11"
+ },
+ "/vi/symbol/pickle-emoji/": {
+  "hash": "c0209398b093878e",
+  "lastmod": "2026-08-05"
+ },
+ "/vi/symbol/pilcrow/": {
+  "hash": "240397deebb33cae",
+  "lastmod": "2026-08-06"
+ },
+ "/vi/symbol/pisces-symbol/": {
+  "hash": "ae674165f5980fe7",
+  "lastmod": "2026-08-11"
+ },
+ "/vi/symbol/plus-minus/": {
+  "hash": "d2733038a5609252",
+  "lastmod": "2026-08-06"
+ },
+ "/vi/symbol/pound-sign/": {
+  "hash": "85bc3390fc4943ee",
+  "lastmod": "2026-08-06"
+ },
+ "/vi/symbol/psi-symbol/": {
+  "hash": "98b38c868c7a5ced",
+  "lastmod": "2026-08-11"
+ },
+ "/vi/symbol/quotation-mark/": {
+  "hash": "f5ea467c6407c1dc",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/symbol/recycling-symbol/": {
+  "hash": "208639b1b44c91df",
+  "lastmod": "2026-08-05"
+ },
+ "/vi/symbol/right-arrow/": {
+  "hash": "1d605ff8ce4c13e8",
+  "lastmod": "2026-08-05"
+ },
+ "/vi/symbol/ruble-sign/": {
+  "hash": "5d6691bd924bb9e1",
+  "lastmod": "2026-08-11"
+ },
+ "/vi/symbol/rupee-sign/": {
+  "hash": "fe03d8009cf1f504",
+  "lastmod": "2026-08-06"
+ },
+ "/vi/symbol/sagittarius-symbol/": {
+  "hash": "6a9cba9e480a0241",
+  "lastmod": "2026-08-11"
+ },
+ "/vi/symbol/saudi-riyal-sign/": {
+  "hash": "5b0c4b8dfcbf32bf",
+  "lastmod": "2026-08-11"
+ },
+ "/vi/symbol/scorpio-symbol/": {
+  "hash": "7ae6e3db594253a8",
+  "lastmod": "2026-08-11"
+ },
+ "/vi/symbol/section-sign/": {
+  "hash": "07dfe7d99b9b8c27",
+  "lastmod": "2026-08-06"
+ },
+ "/vi/symbol/sigma-symbol/": {
+  "hash": "e7eb56fb5acb146e",
+  "lastmod": "2026-08-11"
+ },
+ "/vi/symbol/skull-and-crossbones/": {
+  "hash": "7f05d864782d4b00",
+  "lastmod": "2026-08-05"
+ },
+ "/vi/symbol/snapchat-heart-colors/": {
+  "hash": "153e8725ed166dfc",
+  "lastmod": "2026-08-13"
+ },
+ "/vi/symbol/spade-symbol/": {
+  "hash": "8ddaf7836897c01a",
+  "lastmod": "2026-08-05"
+ },
+ "/vi/symbol/square-root/": {
+  "hash": "30388b61738f883f",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/symbol/squared-cubed/": {
+  "hash": "e6277560156b5dbb",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/symbol/star-of-david/": {
+  "hash": "2759bb4ee4bc9771",
+  "lastmod": "2026-08-06"
+ },
+ "/vi/symbol/star-symbol/": {
+  "hash": "5b15f4806ec62c75",
+  "lastmod": "2026-08-06"
+ },
+ "/vi/symbol/stop-sign/": {
+  "hash": "8ed6b61eda6a41e8",
+  "lastmod": "2026-08-06"
+ },
+ "/vi/symbol/sunglasses-symbol/": {
+  "hash": "e7cdbf5df90e301b",
+  "lastmod": "2026-08-05"
+ },
+ "/vi/symbol/taurus-symbol/": {
+  "hash": "29afd7d65d9e8b9e",
+  "lastmod": "2026-08-11"
+ },
+ "/vi/symbol/theta-symbol/": {
+  "hash": "9395f4b7404069be",
+  "lastmod": "2026-08-11"
+ },
+ "/vi/symbol/thumb-sign-emoji/": {
+  "hash": "f49973e67f5b2443",
+  "lastmod": "2026-08-05"
+ },
+ "/vi/symbol/tilde-symbol/": {
+  "hash": "8e64c2611af93528",
+  "lastmod": "2026-08-05"
+ },
+ "/vi/symbol/trademark-symbol/": {
+  "hash": "2f2dc87dd3cd1ae7",
+  "lastmod": "2026-08-11"
+ },
+ "/vi/symbol/underscore-symbol/": {
+  "hash": "6bb220c31539c0c4",
+  "lastmod": "2026-08-05"
+ },
+ "/vi/symbol/up-arrow/": {
+  "hash": "43f5ebe757850fae",
+  "lastmod": "2026-08-05"
+ },
+ "/vi/symbol/vertical-line/": {
+  "hash": "196eea2f0b0b79c2",
+  "lastmod": "2026-08-06"
+ },
+ "/vi/symbol/virgo-symbol/": {
+  "hash": "a9f04bbb394e67b6",
+  "lastmod": "2026-08-11"
+ },
+ "/vi/symbol/wheelchair-symbol/": {
+  "hash": "5c2986e5f47b50ee",
+  "lastmod": "2026-08-06"
+ },
+ "/vi/symbol/won-sign/": {
+  "hash": "c7c6bd1dd4602fc3",
+  "lastmod": "2026-08-11"
+ },
+ "/vi/symbol/yen-sign/": {
+  "hash": "22bc73caaaed121e",
+  "lastmod": "2026-08-06"
+ },
+ "/vi/symbol/yin-yang/": {
+  "hash": "108b708208dad761",
+  "lastmod": "2026-08-11"
+ },
+ "/vi/updates/emoji-moi-unicode-18/": {
+  "hash": "a37cc70b76d846ed",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/updates/lien-quan-khoa-doi-ten/": {
+  "hash": "32874619c68a3a33",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/updates/unicode-18-xac-nhan-ngay-phat-hanh/": {
+  "hash": "a4d6c0ea8a3c4518",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/usecase/dich-emoji/": {
+  "hash": "f8cafd1af02d80ae",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/usecase/nick-ff/": {
+  "hash": "66225f1604dbb01d",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/usecase/ten-game-hay/": {
+  "hash": "fec40ccf900f5af7",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/usecase/ten-lien-quan-dep/": {
+  "hash": "f047c3425046f750",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/usecase/ten-pubg-dep/": {
+  "hash": "b2cc64e6325509cb",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/usecase/ten-quan-doan-ff/": {
+  "hash": "ffb0cd29bed5eb70",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/usecase/vertical-text/": {
+  "hash": "3b4968a83c5664ab",
+  "lastmod": "2026-08-15"
+ },
+ "/vi/usecase/zalgo-text/": {
+  "hash": "29e974c3b72badae",
+  "lastmod": "2026-08-15"
+ },
+ "/whatsapp/": {
+  "hash": "eb2842f53960cb30",
+  "lastmod": "2026-07-25"
+ },
+ "/x/": {
+  "hash": "dd27a636ff971544",
+  "lastmod": "2026-08-06"
+ },
+ "/youtube/": {
+  "hash": "0aab7cf7c3d209bd",
+  "lastmod": "2026-08-05"
+ },
+ "/youtube/name-generator/": {
+  "hash": "c727351d132c560c",
+  "lastmod": "2026-08-05"
+ },
+ "/zh-tw/": {
+  "hash": "5aca4153b77eadd5",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/answers/kongbai-mingcheng-zenme-nong/": {
+  "hash": "dbae16edb0c25701",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/da-xiao-xie-zhuanhuan/": {
+  "hash": "356223fb16e5588a",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/guide/": {
+  "hash": "1d316f3e1b3d5ca3",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/guide/discord-anquan-nicheng/": {
+  "hash": "5a6c35f8b81cb1ec",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/guide/discord-wenzi-geshi/": {
+  "hash": "4f8963be794bca4c",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/guide/discord-ziti-nali-nengyong/": {
+  "hash": "bdf8973eac684e9f",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/ig-ziti/": {
+  "hash": "d43d0b19a6f9f347",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/keai-ziti/": {
+  "hash": "8a7e4a1c4a9d3123",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/library/": {
+  "hash": "445909693225bdd4",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/library/aixin-fuhao/": {
+  "hash": "731d6dbf8934849f",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/library/ascii-biao/": {
+  "hash": "86841efca906bba0",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/library/biaoqing-emoji/": {
+  "hash": "1907ec8fa1f3aa9b",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/library/biaoqing-fuhao-zuhe/": {
+  "hash": "167709ab7516e7b9",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/library/cat-kaomoji/": {
+  "hash": "7eff6d9411c8f808",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/library/crying-kaomoji/": {
+  "hash": "08827964a51d2681",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/library/cute-kaomoji/": {
+  "hash": "3c14862c4fe4b1f8",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/library/discord-fuhao/": {
+  "hash": "01b2b498125bb655",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/library/divider-kaomoji/": {
+  "hash": "f97a87b987b7dbbf",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/library/facebook-fuhao/": {
+  "hash": "6a7640b45e5055a7",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/library/fanbaiyan-emoji/": {
+  "hash": "06fc037a057d4db0",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/library/guojixiangqi-fuhao/": {
+  "hash": "9100aca7e15c39ed",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/library/guoqi-emoji/": {
+  "hash": "ff81d0e2293162f3",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/library/happy-kaomoji/": {
+  "hash": "232a435e6509392f",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/library/heart-kaomoji/": {
+  "hash": "333ee1354ae7d2a4",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/library/hua-fuhao/": {
+  "hash": "622e1fe83d722605",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/library/huangguan-emoji/": {
+  "hash": "fdb86813f0f2f04d",
+  "lastmod": "2026-08-16"
+ },
+ "/zh-tw/library/huobi-fuhao/": {
+  "hash": "81b312e34be49d26",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/library/iphone-emoji/": {
+  "hash": "2ce66071038aea5e",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/library/jiantou-fuhao/": {
+  "hash": "d3649c9289d2d7f6",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/library/kaomoji/": {
+  "hash": "332affdfd85e0f6c",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/library/keai-mengxi-fuhao/": {
+  "hash": "0051520c71b80127",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/library/kongbai-fuhao/": {
+  "hash": "81ddc329652e8e50",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/library/liwu-emoji/": {
+  "hash": "4b03a3f5a607f8d8",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/library/love-kaomoji/": {
+  "hash": "8007c20b0dd91da2",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/library/roblox-fuhao/": {
+  "hash": "7cb45444bce5486c",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/library/sad-kaomoji/": {
+  "hash": "8863c599cd7b68cf",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/library/shrug-kaomoji/": {
+  "hash": "98117feeded80488",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/library/shuxue-fuhao/": {
+  "hash": "8b1d3a4c59152a96",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/library/shuzi-fuhao/": {
+  "hash": "d2f206c45c2e5a9c",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/library/teshu-fuhao/": {
+  "hash": "437c76c074c4340f",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/library/xiangmu-fuhao/": {
+  "hash": "052480ea31c1e572",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/library/xila-zimu-fuhao/": {
+  "hash": "0814b5f65423d1f1",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/library/xingxing-fuhao/": {
+  "hash": "989dc41638afa3a8",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/library/xingzuo-fuhao/": {
+  "hash": "a3a9aa45d91e9e5d",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/library/y2k-fuhao/": {
+  "hash": "196e5046ac66ec9e",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/library/yanjing-emoji/": {
+  "hash": "aee3499628b1c4ad",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/library/yinyue-fuhao/": {
+  "hash": "f9b1a0636ac71c88",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/library/yisilan-fuhao/": {
+  "hash": "1e4ed0498869e10b",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/library/zongjiao-fuhao/": {
+  "hash": "430eb998fce4a7b1",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/shufa-ziti/": {
+  "hash": "2f5575acf7f9740c",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/symbol/": {
+  "hash": "55506b72048919e2",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/symbol/alpha-symbol/": {
+  "hash": "19947be982c74ad2",
+  "lastmod": "2026-08-16"
+ },
+ "/zh-tw/symbol/bitcoin-symbol/": {
+  "hash": "21ccb5972ee3e467",
+  "lastmod": "2026-08-16"
+ },
+ "/zh-tw/symbol/celsius-symbol/": {
+  "hash": "860f476647e27167",
+  "lastmod": "2026-08-16"
+ },
+ "/zh-tw/symbol/cent-sign/": {
+  "hash": "6e9718f38d905e29",
+  "lastmod": "2026-08-16"
+ },
+ "/zh-tw/symbol/checkmark-symbol/": {
+  "hash": "ba626e1b6bd3f768",
+  "lastmod": "2026-08-16"
+ },
+ "/zh-tw/symbol/copyright-symbol/": {
+  "hash": "1a4bb07ac42aa07d",
+  "lastmod": "2026-08-16"
+ },
+ "/zh-tw/symbol/degree-symbol/": {
+  "hash": "ab68ef8f97731493",
+  "lastmod": "2026-08-16"
+ },
+ "/zh-tw/symbol/delta-symbol/": {
+  "hash": "e81d9da192208c79",
+  "lastmod": "2026-08-16"
+ },
+ "/zh-tw/symbol/diameter-symbol/": {
+  "hash": "82fafed6667011fa",
+  "lastmod": "2026-08-16"
+ },
+ "/zh-tw/symbol/division-sign/": {
+  "hash": "01a882b74707a478",
+  "lastmod": "2026-08-16"
+ },
+ "/zh-tw/symbol/dun-hao/": {
+  "hash": "fb97111122b9999f",
+  "lastmod": "2026-08-16"
+ },
+ "/zh-tw/symbol/euro-sign/": {
+  "hash": "ca25bd1650acb097",
+  "lastmod": "2026-08-16"
+ },
+ "/zh-tw/symbol/fahrenheit-symbol/": {
+  "hash": "adcc3a856f5fc5cd",
+  "lastmod": "2026-08-16"
+ },
+ "/zh-tw/symbol/infinity/": {
+  "hash": "a30ff76f99e94cd6",
+  "lastmod": "2026-08-16"
+ },
+ "/zh-tw/symbol/invisible-character/": {
+  "hash": "31c19905fd017a0a",
+  "lastmod": "2026-08-16"
+ },
+ "/zh-tw/symbol/lambda-symbol/": {
+  "hash": "3d6793e633d3c099",
+  "lastmod": "2026-08-16"
+ },
+ "/zh-tw/symbol/micro-sign/": {
+  "hash": "6c373ac0e04349a6",
+  "lastmod": "2026-08-16"
+ },
+ "/zh-tw/symbol/multiplication-sign/": {
+  "hash": "d0bc8d07c19c6eca",
+  "lastmod": "2026-08-16"
+ },
+ "/zh-tw/symbol/not-equal-sign/": {
+  "hash": "63c4d07ff8be570c",
+  "lastmod": "2026-08-16"
+ },
+ "/zh-tw/symbol/ohm-symbol/": {
+  "hash": "a1a976c919183a41",
+  "lastmod": "2026-08-16"
+ },
+ "/zh-tw/symbol/omega-symbol/": {
+  "hash": "676883830072d81c",
+  "lastmod": "2026-08-16"
+ },
+ "/zh-tw/symbol/peso-sign/": {
+  "hash": "06651be72c17db04",
+  "lastmod": "2026-08-16"
+ },
+ "/zh-tw/symbol/phi-symbol/": {
+  "hash": "6d099c92351d208e",
+  "lastmod": "2026-08-16"
+ },
+ "/zh-tw/symbol/plus-minus/": {
+  "hash": "02b85ba0165ef2cd",
+  "lastmod": "2026-08-16"
+ },
+ "/zh-tw/symbol/pound-sign/": {
+  "hash": "378ab40a6c600351",
+  "lastmod": "2026-08-16"
+ },
+ "/zh-tw/symbol/section-sign/": {
+  "hash": "3786ea2f32626a2e",
+  "lastmod": "2026-08-16"
+ },
+ "/zh-tw/symbol/shan-jie-hao/": {
+  "hash": "cdfed28297a1d93c",
+  "lastmod": "2026-08-16"
+ },
+ "/zh-tw/symbol/sigma-symbol/": {
+  "hash": "f591290ef3bf7524",
+  "lastmod": "2026-08-16"
+ },
+ "/zh-tw/symbol/square-root/": {
+  "hash": "35fd1b977b3c0ae4",
+  "lastmod": "2026-08-16"
+ },
+ "/zh-tw/symbol/theta-symbol/": {
+  "hash": "7a0bc2af55aacf30",
+  "lastmod": "2026-08-16"
+ },
+ "/zh-tw/symbol/trademark-symbol/": {
+  "hash": "b5d84a06e56b13ed",
+  "lastmod": "2026-08-16"
+ },
+ "/zh-tw/symbol/won-sign/": {
+  "hash": "3ec3dac475aaea6b",
+  "lastmod": "2026-08-16"
+ },
+ "/zh-tw/symbol/yen-sign/": {
+  "hash": "092b4372c2e133ba",
+  "lastmod": "2026-08-16"
+ },
+ "/zh-tw/updates/unicode-18-fabu-riqi-queren/": {
+  "hash": "f3e0308f024074ad",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/updates/unicode-18-xin-biaoqing-fuhao/": {
+  "hash": "187324fee4b5e50e",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/usecase/chuanshuo-duijue-mingzi-fuhao/": {
+  "hash": "33ec327f6f218281",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/usecase/ciqing-ziti/": {
+  "hash": "244dafef080d548b",
+  "lastmod": "2026-08-16"
+ },
+ "/zh-tw/usecase/tongxunlu-nicheng/": {
+  "hash": "6676c23cfcc6bd13",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/usecase/youxi-mingzi-fuhao/": {
+  "hash": "f11a72534a86f81d",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/yingwen-ziti/": {
+  "hash": "9b1569be83da05d8",
+  "lastmod": "2026-08-15"
+ },
+ "/zh-tw/zishu-tongji/": {
+  "hash": "8265c00fbd455db5",
+  "lastmod": "2026-08-12"
+ }
+}

--- a/scripts/lib/content-significance.js
+++ b/scripts/lib/content-significance.js
@@ -1,0 +1,64 @@
+'use strict';
+/**
+ * content-significance.js — "did this page meaningfully change?"
+ *
+ * Deliberately SEPARATE from content-fingerprint.js. That module is
+ * language-INDEPENDENT on purpose: it compares an EN page against its
+ * translations, so it ignores prose. Reusing it here would make every
+ * translation fix invisible to <lastmod> — the exact opposite of what this
+ * is for. Do not merge the two.
+ *
+ * Significant (bumps lastmod): visible text, <title>, H1, meta description,
+ * the internal link set, and copy payloads (data-symbol/text/copy/char) —
+ * anything a reader reads, pastes, or follows.
+ *
+ * Not significant (must NOT bump): aria-label and other a11y attributes,
+ * hreflang <link> tags, canonical/OG/Twitter meta, JSON-LD, GTM/ad/consent
+ * script tags, whitespace and comments.
+ *
+ * Encoded from a measured failure: on 2026-08-15/16 two cosmetic passes
+ * (breadcrumb aria-labels, three template strings) bumped 2,533 pages'
+ * lastmod without changing a word a reader could see.
+ */
+
+const crypto = require('crypto');
+
+const COPY_ATTR_RE = /\bdata-(?:symbol|text|copy|char)="([^"]*)"/gi;
+const HREF_RE      = /<a\s[^>]*href="(\/[^"#?]*)"/gi;
+const TITLE_RE     = /<title>([\s\S]*?)<\/title>/i;
+const H1_RE        = /<h1\b[^>]*>([\s\S]*?)<\/h1>/i;
+const DESC_RE      = /<meta\s+name="description"\s+content="([^"]*)"/i;
+
+function visibleText(html) {
+  let h = html;
+  h = h.replace(/<script[\s\S]*?<\/script>/gi, ' ');
+  h = h.replace(/<style[\s\S]*?<\/style>/gi, ' ');
+  h = h.replace(/<head[\s\S]*?<\/head>/i, ' ');
+  h = h.replace(/<!--[\s\S]*?-->/g, ' ');
+  h = h.replace(/<[^>]+>/g, ' ');            // drops ALL attributes, incl. aria-label
+  h = h.replace(/&[a-z#0-9]+;/gi, ' ');
+  return h.replace(/\s+/g, ' ').trim();
+}
+
+function collect(re, html) {
+  const out = [];
+  let m;
+  re.lastIndex = 0;
+  while ((m = re.exec(html)) !== null) out.push(m[1]);
+  return out;
+}
+
+/** Stable short hash of everything that counts as a meaningful change. */
+function significanceHash(html) {
+  const parts = [
+    visibleText(html),
+    (TITLE_RE.exec(html) || ['', ''])[1].trim(),
+    (H1_RE.exec(html)    || ['', ''])[1].replace(/<[^>]+>/g, '').trim(),
+    (DESC_RE.exec(html)  || ['', ''])[1].trim(),
+    collect(HREF_RE, html).sort().join('\n'),
+    collect(COPY_ATTR_RE, html).sort().join('\n'),
+  ];
+  return crypto.createHash('sha1').update(parts.join(' ')).digest('hex').slice(0, 16);
+}
+
+module.exports = { significanceHash, visibleText };

--- a/scripts/lib/content-significance.test.js
+++ b/scripts/lib/content-significance.test.js
@@ -1,0 +1,77 @@
+'use strict';
+/**
+ * node scripts/lib/content-significance.test.js
+ *
+ * Zero-dependency assertions for the lastmod significance hash. This module
+ * decides whether <lastmod> advances, so a silent regression here re-creates
+ * the exact defect it was written for: 2,533 pages bumped on 2026-08-15/16 by
+ * cosmetic passes, and 69% of pages advertising a lastmod newer than their
+ * real content change.
+ *
+ * The two halves matter equally. Over-sensitivity re-floods the sitemap with
+ * meaningless bumps; under-sensitivity hides genuine copy fixes from Google,
+ * which would make a translation repair pass invisible.
+ */
+
+const { significanceHash } = require('./content-significance');
+
+const PAGE = [
+  '<!DOCTYPE html><html lang="id"><head>',
+  '<title>Nama FF Keren</title>',
+  '<meta name="description" content="Generator nama">',
+  '<link rel="canonical" href="https://ultratextgen.com/id/">',
+  '<link rel="alternate" hreflang="en" href="https://ultratextgen.com/">',
+  '<script>var gtm=1;</script>',
+  '<script type="application/ld+json">{"@type":"FAQPage"}</script>',
+  '</head><body>',
+  '<nav aria-label="Breadcrumb"><a href="/id/">Beranda</a></nav>',
+  '<h1>Nama FF Keren</h1>',
+  '<p>Buat nama keren untuk Free Fire.</p>',
+  '<button data-symbol="♥" aria-label="Salin hati">Salin</button>',
+  '<span class="flag-label">Hati</span>',
+  '<a href="/id/usecase/nama-tiktok-keren/">Nama TikTok</a>',
+  '</body></html>',
+].join('\n');
+
+const IGNORED = [
+  ['aria-label rewritten',   h => h.replace(/aria-label="Breadcrumb"/, 'aria-label="Navigasi remah"')],
+  ['hreflang entry added',   h => h.replace('</head>', '<link rel="alternate" hreflang="de" href="https://x/"></head>')],
+  ['canonical changed',      h => h.replace(/rel="canonical" href="[^"]*"/, 'rel="canonical" href="https://y/"')],
+  ['JSON-LD edited',         h => h.replace('"FAQPage"', '"QAPage"')],
+  ['inline script changed',  h => h.replace('var gtm=1;', 'var gtm=2;')],
+  ['whitespace reflowed',    h => h.replace(/\n/g, '\n  ')],
+  ['HTML comment added',     h => h.replace('<body>', '<body><!-- build 42 -->')],
+];
+
+const DETECTED = [
+  ['visible prose changed',  h => h.replace('Buat nama keren', 'Bikin nama keren')],
+  ['H1 changed',             h => h.replace('<h1>Nama FF Keren</h1>', '<h1>Nama FF Terbaik</h1>')],
+  ['title changed',          h => h.replace('<title>Nama FF Keren</title>', '<title>Nama FF Baru</title>')],
+  ['meta description',       h => h.replace('content="Generator nama"', 'content="Generator nama FF"')],
+  ['clipboard payload',      h => h.replace('data-symbol="♥"', 'data-symbol="❤"')],
+  ['visible tile label',     h => h.replace('>Hati<', '>Cinta<')],
+  ['internal link added',    h => h.replace('</body>', '<a href="/id/font-tiktok/">x</a></body>')],
+  ['internal link removed',  h => h.replace(/<a href="\/id\/usecase\/nama-tiktok-keren\/">[^<]*<\/a>/, '')],
+];
+
+const base = significanceHash(PAGE);
+let pass = 0;
+const fails = [];
+
+for (const [name, mutate] of IGNORED) {
+  const same = significanceHash(mutate(PAGE)) === base;
+  same ? pass++ : fails.push(`IGNORED "${name}" changed the hash (would bump lastmod for nothing)`);
+}
+for (const [name, mutate] of DETECTED) {
+  const moved = significanceHash(mutate(PAGE)) !== base;
+  moved ? pass++ : fails.push(`DETECTED "${name}" did not change the hash (real edit would stay invisible)`);
+}
+
+const total = IGNORED.length + DETECTED.length;
+if (fails.length) {
+  console.error(`content-significance: ${pass}/${total} passed\n`);
+  for (const f of fails) console.error('  FAIL  ' + f);
+  process.exit(1);
+}
+console.log(`content-significance: ${pass}/${total} assertions pass ` +
+            `(${IGNORED.length} cosmetic ignored, ${DETECTED.length} real changes detected)`);

--- a/scripts/update-sitemap.js
+++ b/scripts/update-sitemap.js
@@ -3,10 +3,12 @@
 const fs   = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
+const { significanceHash } = require('./lib/content-significance');
 
 const BASE_URL     = 'https://ultratextgen.com';
 const SITEMAP_PATH = path.resolve(__dirname, '..', 'sitemap.xml');
 const REPO_ROOT    = path.resolve(__dirname, '..');
+const LASTMOD_CACHE = path.resolve(__dirname, '..', 'data', 'sitemap-lastmod-cache.json');
 
 const EXCLUDED_FOLDERS = [
   'assets', 'css', 'js', 'images', 'img',
@@ -160,6 +162,51 @@ function todayDate() {
   return new Date().toISOString().slice(0, 10);
 }
 
+// ─── lastmod significance cache ───────────────────────────────────────────────
+//
+// <lastmod> must mean "the content meaningfully changed", not "some byte in the
+// file moved". getGitLastMod() alone cannot tell the difference: on 2026-08-15/16
+// two cosmetic passes (breadcrumb aria-labels, three template strings) bumped
+// 2,533 pages without altering a word a reader could see, and 69% of pages were
+// advertising a lastmod newer than their real content change, median 11 days.
+//
+// So we keep {url: {hash, lastmod}} beside the sitemap. Each run hashes the page
+// (scripts/lib/content-significance.js) and only advances lastmod when the hash
+// moves. O(1) per page, no history walking.
+//
+// SEEDING: on the very first run the cache does not exist. Do NOT stamp today —
+// that would bump every URL at once, which is precisely the failure being fixed.
+// Seed from the lastmod values already in sitemap.xml instead, so the first run
+// after this change writes an identical file.
+
+function loadLastmodCache() {
+  try {
+    return JSON.parse(fs.readFileSync(LASTMOD_CACHE, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function seedFromExistingSitemap() {
+  const seed = {};
+  try {
+    const xml = fs.readFileSync(SITEMAP_PATH, 'utf8');
+    const re = /<loc>([^<]+)<\/loc>\s*<lastmod>([^<]+)<\/lastmod>/g;
+    let m;
+    while ((m = re.exec(xml)) !== null) seed[m[1].replace(BASE_URL, '')] = m[2];
+  } catch {
+    /* no sitemap yet — every page is genuinely new */
+  }
+  return seed;
+}
+
+function saveLastmodCache(cache) {
+  fs.mkdirSync(path.dirname(LASTMOD_CACHE), { recursive: true });
+  const ordered = {};
+  for (const k of Object.keys(cache).sort()) ordered[k] = cache[k];
+  fs.writeFileSync(LASTMOD_CACHE, JSON.stringify(ordered, null, 1) + '\n', 'utf8');
+}
+
 // ─── XML builder ──────────────────────────────────────────────────────────────
 
 function buildUrlBlock(url, lastmod, changefreq, priority, images) {
@@ -202,10 +249,52 @@ function urlSortKey(url) {
   return url;
 }
 
+let resolveLastMod; // assigned inside generateSitemap (closes over the cache)
+
 // ─── Main ─────────────────────────────────────────────────────────────────────
 
 function generateSitemap() {
   console.log('🔍 Scanning for index.html pages...');
+
+  const priorCache = loadLastmodCache();
+  const cache      = priorCache || {};
+  const seed       = priorCache ? null : seedFromExistingSitemap();
+  const nextCache  = {};
+  let bumped = 0;
+  let held   = 0;
+
+  resolveLastMod = function (filePath, url) {
+    let html = '';
+    try {
+      html = fs.readFileSync(path.join(REPO_ROOT, filePath), 'utf8');
+    } catch {
+      return getGitLastMod(filePath);
+    }
+    const hash = significanceHash(html);
+    const prev = cache[url];
+
+    let lastmod;
+    if (prev && prev.hash === hash) {
+      lastmod = prev.lastmod;                 // unchanged content — hold the date
+      held++;
+    } else if (!prev && seed && seed[url]) {
+      lastmod = seed[url];                    // first run — inherit, never mass-bump
+      held++;
+    } else {
+      // Real change, or a genuinely new page. getGitLastMod is right in CI, where
+      // the sitemap job runs after the commit lands. But if the edit is still only
+      // in the working tree, git reports the PREVIOUS commit's date — older than
+      // the date we already cached — and lastmod would silently fail to advance
+      // even though the content moved. Fall back to today in exactly that case.
+      const gitDate = getGitLastMod(filePath);
+      lastmod = (prev && gitDate <= prev.lastmod) ? todayDate() : gitDate;
+      bumped++;
+    }
+    nextCache[url] = { hash, lastmod };
+    return lastmod;
+  };
+
+  generateSitemap._report = () => ({ bumped, held, nextCache });
 
   const discovered = findIndexFiles(REPO_ROOT);
   const indexFiles = discovered.filter(f => !isNoindex(f));
@@ -218,7 +307,7 @@ function generateSitemap() {
   const urlEntries = indexFiles
     .map(filePath => {
       const url      = pathToUrl(filePath);
-      const lastmod  = getGitLastMod(filePath);
+      const lastmod  = resolveLastMod(filePath, url);
       const defaults = getUrlDefaults(url);
       const images   = getPageImages(filePath);
       return { url, lastmod, images, ...defaults };
@@ -229,7 +318,12 @@ function generateSitemap() {
 
   fs.writeFileSync(SITEMAP_PATH, xml, 'utf8');
 
+  const { bumped: b, held: h, nextCache: nc } = generateSitemap._report();
+  saveLastmodCache(nc);
+
   console.log(`   URLs written:     ${urlEntries.length}`);
+  console.log(`   lastmod advanced: ${b}  (content actually changed)`);
+  console.log(`   lastmod held:     ${h}  (no meaningful change)`);
   console.log(`   Output path:      ${SITEMAP_PATH}`);
   console.log('✅ sitemap.xml fully regenerated.');
 }


### PR DESCRIPTION
getGitLastMod() runs `git log -1`, so ANY byte touch advanced <lastmod> -- an aria-label, an hreflang link, a whitespace reflow, all weighted the same as a rewrite. Measured consequence: 69% of pages were advertising a lastmod newer than their last real content change, median 11 days adrift, and the 2026-08-15/16 cosmetic passes bumped 2,533 pages without altering a word a reader could see.

Adds scripts/lib/content-significance.js and a {url: {hash, lastmod}} cache beside the sitemap. Each run hashes visible text, title, H1, meta description, the internal link set and data-symbol/text/copy/char payloads, and only advances lastmod when that hash moves. O(1) per page, no history walking.

Deliberately NOT reusing scripts/lib/content-fingerprint.js. That module is language-independent by design -- it diffs an EN page against translations, so it ignores prose. Reused here it would make every translation fix invisible to lastmod, which is the opposite of the point. Two modules, two definitions of "changed", on purpose.

Seeding matters as much as the hash. On the first run there is no cache, and stamping today would bump all 4,576 URLs at once -- precisely the failure being fixed. It seeds from the lastmod values already in sitemap.xml instead; verified that the first run rewrites the file byte-identically (0 advanced, 4,576 held).

One edge case found while testing and fixed: when an edit is only in the working tree, git reports the previous commit's date, so a changed page would silently fail to advance. Falls back to today when the git date is not newer than the cached one.

Behaviour verified end to end: a cosmetic aria-label edit on /de/ and a real H1 text edit on /id/ in the same run bumped /id/ alone. 15 assertions in content-significance.test.js pin both halves -- 7 cosmetic edits that must be ignored, 8 real edits that must be caught -- because over-sensitivity refloods the sitemap and under-sensitivity hides genuine copy fixes.