### PR TITLE
feat: Pinterest API v5 publishing pipeline

### DIFF
--- a/scripts/publish-pinterest-pin.py
+++ b/scripts/publish-pinterest-pin.py
@@ -34,6 +34,25 @@ import r2_pinterest as R2  # noqa: E402
 import pinterest_publisher as PUB  # noqa: E402
 
 
+_IMAGE_EXT = (".png", ".jpg", ".jpeg", ".webp")
+
+
+def _normalize_slug(value):
+    """--slug is documented as a bare slug ('ascii-art-generator'), but the
+    most natural thing to paste is the R2 image URL or path itself (that's
+    what a first live test actually did: 'https://media.ultratextgen.com/
+    pinterest/base/answers-can-you-search-fancy-text.png'). Accept that too
+    -- take the last path segment and strip a known image extension -- so
+    the obvious input just works instead of failing with 'no row found'."""
+    if not value:
+        return value
+    tail = value.rstrip("/").split("/")[-1] if ("://" in value or "/" in value) else value
+    for ext in _IMAGE_EXT:
+        if tail.lower().endswith(ext):
+            return tail[: -len(ext)]
+    return tail
+
+
 def _find_row(csv_path, slug=None, page_url=None):
     with open(csv_path, newline="", encoding="utf-8") as f:
         for row in csv.DictReader(f):
@@ -103,6 +122,7 @@ def main():
     if not args.slug and not args.page_url:
         ap.error("one of --slug or --page-url is required")
 
+    args.slug = _normalize_slug(args.slug)
     row = _find_row(args.csv, slug=args.slug, page_url=args.page_url)
     if not row:
         sys.exit(f"No row found in {args.csv} matching slug={args.slug!r} page_url={args.page_url!r}")


### PR DESCRIPTION
## Summary

Adds the official Pinterest API v5 publishing pipeline: R2 image → API → UTG's Pinterest account → the matching `ultratextgen.com` page. Additive only — no existing file is modified; nothing about the existing image-generation/R2/CSV pipeline changes.

Full write-up (repo audit, live Pinterest API v5 verification, API-vs-Playwright classification, reliability/idempotency design, reporting findings, and live test results) is in **`docs/pinterest-api-publishing.md`**.

## What's new

- **`scripts/lib/pinterest_api.py`** — stdlib-only API v5 client (no new dependency). OAuth token read + auto-refresh, retryable HTTP with backoff, `list_boards()` / `get_board_by_name()` / `create_board()` / `create_pin()` / `get_pin_analytics()` / `get_account_analytics()`. Mirrors `scripts/lib/r2_pinterest.py`'s shape (env-var-only config, fail loud on missing creds). Selects the **sandbox** (`api-sandbox.pinterest.com`) or **production** (`api.pinterest.com`) host via `PINTEREST_API_ENV` — these are separate Pinterest hosts and a token from one 401s against the other, found via a real live test (see below).
- **`scripts/lib/pinterest_publisher.py`** — `publish_pinterest_pin()`, the reusable, idempotent publisher. Dedup key = `sha256(source_page + image_url)` checked against an append-only JSONL log (`data/pinterest_publish_log.jsonl`, source of truth, written the instant the API call succeeds — before the CSV mirror — so a partial failure can't double-publish).
- **`scripts/publish-pinterest-pin.py`** — CLI/Phase-3 runner. Reads a row straight out of an existing inventory CSV (`data/pinterest_pins.csv` by default, or any board CSV), resolves the R2 image URL + board by name, publishes, optionally syncs `pin_status`/`published_pin_url` back and commits the publish log (mirrors `scripts/tweet_queue.py`'s state-file-commit pattern for CI durability). `--slug` accepts either a bare slug or a full R2 image URL/path.
- **`.github/workflows/pinterest-publish-test.yml`** — `workflow_dispatch`-only (no `schedule:`, no bulk loop), dry-run by default, `pinterest_env` input to pick sandbox/production. Passes `npm run check:workflows` (0 errors).
- **`docs/pinterest-api-publishing.md`** — the full audit + verification + test report.

## Why no Playwright

Audited first: no prior Pinterest publishing automation exists at all (only `pin_status`/`published_pin_url` CSV columns sitting unused since creation). The one existing Playwright use (`generate-collection-pins.py`) only screenshots a pin *image* — unrelated to publishing, untouched here. The Pinterest API v5 covers every operation this task needs, so zero new Playwright code was added.

## Testing

- All new Python compiles clean; dry-run (`--dry-run`, needs no credentials) verified end-to-end, including duplicate-protection skip/force, invalid-image-URL handling, and clean structured errors on auth failure.
- **Live-tested twice** by the repo owner via the Actions UI with real sandbox credentials (never committed, never logged): first run caught the sandbox-vs-production host bug (fixed same-day), second run caught a `--slug` usability gap when a full image URL was pasted instead of a bare slug (fixed same-day, verified against the exact failing input).
- `npm run check:workflows`: 11/11 workflows, 0 errors.

## Secrets

`PINTEREST_ACCESS_TOKEN` (required), `PINTEREST_APP_ID` / `PINTEREST_APP_SECRET` / `PINTEREST_REFRESH_TOKEN` (optional, enable auto-refresh) — already set as repo secrets by the owner, matching the existing `R2_*` naming convention. None hardcoded anywhere.

## Scope note

Deliberately does not build bulk/scheduled publishing — per the task, this proves one image → one API call → one Pin, plus the reusable module a future queue would call. See the doc's "Recommended next phase" for the proposed next step.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPf8huXcw3QL3fyQEChFRn)_