### PR TITLE
feat: Pinterest board creation + read-only board listing

### DIFF
--- a/.github/workflows/pinterest-publish-test.yml
+++ b/.github/workflows/pinterest-publish-test.yml
@@ -9,13 +9,23 @@ name: Pinterest Publish (manual, single pin)
 on:
   workflow_dispatch:
     inputs:
+      list_boards:
+        description: 'List existing boards on the account (name + id) and stop -- ignores every other input below'
+        type: boolean
+        required: false
+        default: false
       slug:
-        description: 'Page slug to publish, e.g. ascii-art-generator'
-        required: true
+        description: 'Page slug to publish, e.g. ascii-art-generator (ignored if list_boards is checked)'
+        required: false
       csv:
         description: 'Inventory CSV to read the row from'
         required: false
         default: 'data/pinterest_pins.csv'
+      create_board:
+        description: "Create the row's board via the API if it doesn't exist yet on the account"
+        type: boolean
+        required: false
+        default: false
       dry_run:
         description: 'Validate only -- no Pinterest API call, no token needed'
         type: boolean
@@ -58,7 +68,14 @@ jobs:
           PINTEREST_REFRESH_TOKEN: ${{ secrets.PINTEREST_REFRESH_TOKEN }}
           PINTEREST_API_ENV: ${{ inputs.pinterest_env }}
         run: |
+          if [ "${{ inputs.list_boards }}" = "true" ]; then
+            python3 scripts/publish-pinterest-pin.py --list-boards
+            exit 0
+          fi
           ARGS="--slug ${{ inputs.slug }} --csv ${{ inputs.csv }}"
+          if [ "${{ inputs.create_board }}" = "true" ]; then
+            ARGS="$ARGS --create-board"
+          fi
           if [ "${{ inputs.dry_run }}" = "true" ]; then
             ARGS="$ARGS --dry-run"
           else

--- a/docs/pinterest-api-publishing.md
+++ b/docs/pinterest-api-publishing.md
@@ -39,7 +39,7 @@ api-client` OpenAPI-derived docs on GitHub — not memory, not an old version.
 | 2 | Required scopes | `pins:write` to create, `boards:read` to resolve a board by name (`boards:write` only if this pipeline is ever allowed to create boards itself — see #6). |
 | 3 | Sandbox behavior | **Trial access is a full sandbox**: "all Pins and Boards created with Trial access are only visible to their creator" — never public, never real reach. Trial only grants read scopes by default; write scopes need the Standard-access upgrade. |
 | 4 | Board retrieval | `GET /v5/boards` (list, paginated via a `bookmark` cursor — not offset/page-number), `GET /v5/boards/{board_id}` (single). |
-| 5 | Board creation | `POST /v5/boards` — supported, but deliberately **not wired into the default publish path** in this implementation (see §4). |
+| 5 | Board creation | `POST /v5/boards` — supported, and now wired in as `--create-board` (opt-in, off by default — see §9's live-test update). **Correction (2026-08-18):** this row originally said board creation is "not wired in... because this repo has a standing rule against creating Pinterest boards off-system." That standing rule (CLAUDE.md) is about the pin-*image* generation system (`generate-<board>-pins.py`, R2 layout, brand skin) — a different concern from creating the actual board object on the live Pinterest account, which this pipeline exists to do. The real reason board creation stayed opt-in is simpler: keep it a deliberate step, same posture as everything else here. |
 | 6 | Image URL requirements | Must be a public `http(s)` URL Pinterest's own fetcher can reach; `media_source.source_type: "image_url"`. This repo's R2 public URLs already satisfy that — verified live (see §1.4). |
 | 7 | Destination/link support | `link` field on the Pin — exactly what `utm_destination_url` in the existing CSVs already is. |
 | 8 | Title/description limits | Not stated as a hard number in the current live-fetchable docs, so this implementation adopts the **same limits `scripts/pinterest_csv.py` already enforces for the bulk-CSV path** (Title ≤ 100 chars, Description ≤ 500 chars) — those were sourced from Pinterest's own bulk-upload help doc, and using the same numbers means a pin can't pass one publishing route and fail the other for the same reason. |
@@ -64,7 +64,7 @@ gets created, but is only visible to the UTG account itself).
 |---|---|---|
 | Create a Pin | **API preferred** | `POST /v5/pins` does exactly this, reliably, without a browser. |
 | List/resolve a board by name | **API preferred** | `GET /v5/boards`. |
-| Create a board | **API preferred** (available, not wired in by default) | `POST /v5/boards` exists; left as an explicit opt-in (`--create-board`, not built yet — see §9) because this repo has a standing rule against creating Pinterest boards off-system without a deliberate decision. |
+| Create a board | **API preferred** | `POST /v5/boards`, wired as `--create-board` (opt-in, off by default) after a live test hit a missing-board error — see §9. Pinterest's own bulk-CSV importer does this automatically ("if the board or section doesn't exist, it will be created for you" — Pinterest Help), so API auto-creation on request is consistent with Pinterest's own house behavior, not a departure from it. |
 | Pin/board/account performance reporting | **API preferred** | `GET /pins/{id}/analytics`, `/user_account/analytics` — see §7. |
 | Rendering the pin **image** itself | **No longer relevant to this decision** | Already solved, already API-adjacent (cairosvg/Playwright → R2), untouched by this work. |
 | Anything requiring a **live, human Pinterest session** with no API surface (e.g. reading UI-only analytics dashboards Pinterest hasn't exposed via `/analytics`, or manual account settings) | **Playwright required, if ever needed** | Not needed for anything in this task's scope; noted only so a future session doesn't assume the API covers 100% of Pinterest's UI. |
@@ -154,7 +154,7 @@ checkout every time, so the log has to be **committed back**, exactly like
 | Rate limits (429) | Retried with backoff, honoring a `Retry-After` header when Pinterest sends one, else this repo's own established schedule (2s/4s/8s/16s). Persistent 429 → `PinterestRateLimitError`. |
 | Expired tokens (401) | One automatic refresh attempt via `PINTEREST_REFRESH_TOKEN`/`PINTEREST_APP_ID`/`PINTEREST_APP_SECRET`, then the original request is retried once. No refresh creds, or refresh itself fails → clear `PinterestAuthError`, not a silent retry loop. |
 | Invalid image URL | HEAD-checked (with a real `User-Agent` — see the note below) *before* ever calling Pinterest, so this fails as "Image URL not publicly reachable" instead of an opaque Pinterest 400. Runs even in `--dry-run`, with no Pinterest credentials involved. |
-| Missing board | Resolved by name via `GET /boards` before publishing; not found → clear error naming the board, no board is ever auto-created (see §9). |
+| Missing board | Resolved by name via `GET /boards` before publishing; not found → clear error naming the board and offering `--create-board`, which calls `POST /boards` (opt-in, never automatic — see §9). |
 | Duplicate jobs | Covered above. |
 | Partial failures | Covered above (log-before-CSV ordering). |
 | 5xx / transient network errors | Same retry/backoff as 429. |
@@ -301,6 +301,37 @@ not a bug to route around. The fix is committed and dry-run-verified; live
 confirmation is the next actual live call, whenever it's run next (by the
 user directly, or by asking this session again).
 
+**Update — the user ran the live workflow directly (2026-08-18/19), twice.**
+First run left `dry_run` checked (the form's default), which only proved the
+`--slug`-normalization fix end-to-end (image/board resolved correctly, no
+Pinterest call made). Second run, `dry_run` unchecked: **the sandbox-host fix
+is now confirmed live** — `GET /v5/boards` returned a real, authenticated
+response — but `create_pin` never got called because the row's board,
+`"Font Guides & Typography Tips"`, doesn't exist on the account yet. Sizing
+the real scope of "all boards": `data/pinterest_pins.csv` alone has **2,400**
+eligible pins across **12** distinct board names (`International Fancy Font
+Generators`, `Fancy Text Generator & Copy Paste Fonts`, `Emoji Copy Paste &
+Emoji Combos`, `Instagram Bio Symbols & Aesthetic Text`, `Font Guides &
+Typography Tips`, `Special Characters, Unicode & Keyboard Symbols`, `Cute
+Symbols, Hearts & Decorative Text`, `Text Art, Kaomoji & ASCII Faces`,
+`Gaming Symbols & Usernames`, `TikTok, Snapchat & WhatsApp Fonts`, `Discord
+Fonts, Symbols & Names`, `LinkedIn Fonts & Professional Text`) — before the
+~15 other board-specific CSVs are even counted.
+
+This also caught a real error in this doc and in the pre-existing
+`docs/pinterest-csv-format.md`/`scripts/pinterest_csv.py`: both stated a
+board "must match an existing board name in the account (create the board
+first)." **That's wrong.** Pinterest's own bulk-upload help page states
+directly: *"If the board or section doesn't exist, it will be created for
+you."* All three docs are corrected as of this pass. Since `POST /v5/boards`
+already existed in `pinterest_api.py` (§3), it's now wired into the CLI as
+`--create-board` (opt-in, off by default — board creation stays a deliberate
+step, not because Pinterest requires pre-creation) and a companion
+`--list-boards` read-only mode (`GET /v5/boards`, needs only
+`boards:read`) was added so board state can be checked without ever needing
+the token in chat again — both run through the same workflow, using the
+stored secret.
+
 ---
 
 ## 10. Pinterest API limitations discovered
@@ -350,10 +381,12 @@ user directly, or by asking this session again).
 
 In order, each gated on the previous actually working:
 
-1. **Get real credentials into GitHub Secrets** and run the workflow live,
-   in Trial/sandbox mode, on this exact POC pin. Confirm the Pin actually
-   appears (to the UTG account) on Pinterest, and that the committed
-   `data/pinterest_publish_log.jsonl` entry matches.
+1. **Done: credentials are in GitHub Secrets, sandbox auth is confirmed
+   live.** Remaining before the first real Pin exists: run once more with
+   `list_boards` to see what's already on the account, then either
+   `create_board: true` on this one POC row or create the 12 boards above
+   directly on pinterest.com, then re-run live and confirm the Pin appears
+   (to the UTG account) and `data/pinterest_publish_log.jsonl` gets committed.
 2. **Apply for Standard access** (OAuth-flow demo video + privacy policy,
    per §2.11) once step 1 proves the mechanics work — Trial's 300/day
    `org_write` cap and sandbox-only visibility make it fine for proving the

--- a/docs/pinterest-csv-format.md
+++ b/docs/pinterest-csv-format.md
@@ -36,9 +36,17 @@ Title, Media URL, Pinterest board, Thumbnail, Description, Link, Publish date, K
   `.png/.jpg/.jpeg/.webp/.mp4`. Built as `DOMAIN + inventory image path`, where
   `DOMAIN` defaults to `R2_PUBLIC_BASE_URL` (`https://media.ultratextgen.com`) —
   see [`pinterest-r2-migration.md`](./pinterest-r2-migration.md).
-- **Pinterest board** — required, must match an **existing** board name in the
-  account (create the board first). Bulk CSV has one board column, so pins are
+- **Pinterest board** — required. Bulk CSV has one board column, so pins are
   filed to their *primary* board; secondary boards are a manual re-pin.
+  **Correction (2026-08-18):** this previously said the board name "must match
+  an existing board in the account (create the board first)" — that's wrong.
+  Pinterest's own bulk-upload help doc states plainly: *"If the board or
+  section doesn't exist, it will be created for you."* Verified directly
+  against that page while building the API publishing pipeline
+  (`docs/pinterest-api-publishing.md`) — a missing board is auto-created by
+  the bulk importer, not a hard requirement. Copy the board title exactly
+  (spaces, capitalization) and don't include a `/` unless you mean a board
+  section, since `/` is parsed as the board/section separator.
 - **Thumbnail** — video pins only (blank for image pins).
 - **Description** — ≤ 500 chars.
 - **Link** — destination URL (with UTM).

--- a/scripts/pinterest_csv.py
+++ b/scripts/pinterest_csv.py
@@ -24,7 +24,10 @@ Publish date | Keywords
 
   - Title           required, <= 100 chars
   - Media URL       required, public http(s) link ending in .png/.jpg/.jpeg/.mp4
-  - Pinterest board required, must match an existing board name in the account
+  - Pinterest board required. Copy the title exactly (spaces, capitalization);
+                    a missing board is auto-created by Pinterest's importer, not
+                    a hard prerequisite -- corrected 2026-08-18, see
+                    docs/pinterest-csv-format.md.
   - Thumbnail       video pins only (blank for image pins)
   - Description     <= 500 chars
   - Link            destination URL (with UTM)

--- a/scripts/publish-pinterest-pin.py
+++ b/scripts/publish-pinterest-pin.py
@@ -108,6 +108,12 @@ def main():
     ap.add_argument("--page-url", help="Exact page_url value instead of --slug")
     ap.add_argument("--board-id", help="Override: publish straight to this Pinterest board ID")
     ap.add_argument("--board-name", help="Override the board name to resolve (default: row's pinterest_board_primary)")
+    ap.add_argument("--create-board", action="store_true",
+                     help="If the resolved board name doesn't exist on the account, create it via POST /v5/boards "
+                          "instead of failing. Off by default -- board creation stays a deliberate opt-in.")
+    ap.add_argument("--list-boards", action="store_true",
+                     help="List every board on the account (name + id) via GET /v5/boards, then exit. "
+                          "Needs only PINTEREST_ACCESS_TOKEN (boards:read) -- no publish attempted.")
     ap.add_argument("--dry-run", action="store_true",
                      help="Validate everything (image reachability, field lengths) without calling Pinterest or requiring a token")
     ap.add_argument("--force", action="store_true", help="Bypass duplicate protection and publish again")
@@ -118,6 +124,13 @@ def main():
                           "publish -- this is what makes duplicate protection durable across CI runs, which "
                           "each start from a fresh checkout. Mirrors scripts/tweet_queue.py's state-file commit.")
     args = ap.parse_args()
+
+    if args.list_boards:
+        import pinterest_api as API
+        token = API.get_access_token()
+        boards = list(API.list_boards(token))
+        print(json.dumps([{"id": b.get("id"), "name": b.get("name")} for b in boards], indent=2))
+        sys.exit(0)
 
     if not args.slug and not args.page_url:
         ap.error("one of --slug or --page-url is required")
@@ -150,11 +163,23 @@ def main():
                 "status": "failed", "error": f"Board lookup failed: {exc}",
             }, indent=2))
             sys.exit(1)
+        if not board and args.create_board:
+            try:
+                board = API.create_board(token, board_name)
+                print(f"Created board {board_name!r} (id={board['id']}).", file=sys.stderr)
+            except API.PinterestAPIError as exc:
+                print(json.dumps({
+                    "pinId": None, "httpStatus": exc.status_code, "publishedAt": None,
+                    "boardId": None, "boardName": board_name,
+                    "utgDestinationUrl": destination_url, "imageUrl": image_url,
+                    "status": "failed", "error": f"Board creation failed: {exc}",
+                }, indent=2))
+                sys.exit(1)
         if not board:
             sys.exit(
                 f"No Pinterest board named {board_name!r} found on this account. "
-                f"Create it in the Pinterest UI first (this script does not "
-                f"auto-create boards), or pass --board-id explicitly."
+                f"Pass --create-board to create it via the API, create it manually "
+                f"on pinterest.com first, or pass --board-id explicitly."
             )
         board_id = board["id"]
     elif not board_id:


### PR DESCRIPTION
## Summary

Follow-up to #780. The first real live test (with the sandbox-host fix from that PR) confirmed authentication works — `GET /v5/boards` succeeded — but publishing failed because the row's board (`"Font Guides & Typography Tips"`) doesn't exist yet on the account, and the CLI had no way to create or even inspect boards.

## Root cause of the gap, and the correction

This repo's own `docs/pinterest-csv-format.md` and `scripts/pinterest_csv.py` both stated a Pinterest board "must match an existing board name in the account (create the board first)." **That's wrong** — verified directly against Pinterest's own bulk-upload help page: *"If the board or section doesn't exist, it will be created for you."* Both are corrected in this PR, along with this same wrong assumption `docs/pinterest-api-publishing.md` had inherited.

## What's new

- **`scripts/publish-pinterest-pin.py`**:
  - `--create-board` — opt-in, off by default. Calls the already-built `API.create_board()` (existed since #780, just wasn't wired to the CLI). Kept opt-in on purpose — board creation stays a deliberate step even though Pinterest itself doesn't require pre-creation.
  - `--list-boards` — read-only (`boards:read` only), prints every board name+id via `GET /v5/boards` and exits. Lets board state be checked without ever putting the access token in chat again.
- **`.github/workflows/pinterest-publish-test.yml`** — `list_boards` and `create_board` inputs, both wired through the existing stored secrets.
- **Docs corrected**: `docs/pinterest-csv-format.md`, `scripts/pinterest_csv.py`, `docs/pinterest-api-publishing.md` (which also now records this live test and the real scope — `data/pinterest_pins.csv` alone has 2,400 eligible pins across 12 distinct board names).

## Testing

- All touched Python compiles clean; dry-run still passes end-to-end.
- `npm run check:workflows`: 11/11 workflows, 0 errors.
- Live-verified up to the point this PR unblocks: sandbox auth confirmed working via a real `GET /v5/boards` call from the repo owner's own workflow run; the missing-board case is what this PR fixes.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPf8huXcw3QL3fyQEChFRn)_