### PR TITLE
fix: board-already-exists fallback for --create-board

### DIFF
--- a/scripts/lib/pinterest_api.py
+++ b/scripts/lib/pinterest_api.py
@@ -306,11 +306,26 @@ def get_board_by_name(token, name):
 
 def create_board(token, name, description="", privacy="PUBLIC"):
     """POST /boards -- off the default publish path; only called when a
-    caller explicitly opts in (--create-board), per this repo's standing
-    rule against creating Pinterest boards off-system without a deliberate
-    decision (see CLAUDE.md's Pinterest-board section)."""
+    caller explicitly opts in (--create-board). Kept opt-in as a deliberate
+    choice, not because Pinterest requires pre-creation -- its own bulk-CSV
+    importer auto-creates a missing board ("if the board or section doesn't
+    exist, it will be created for you" -- Pinterest Help)."""
     body = {"name": name, "description": description, "privacy": privacy}
     return _request("POST", "/boards", token, body=body)
+
+
+def is_duplicate_board_error(exc):
+    """True if a create_board() PinterestAPIError means 'a board with this
+    name already exists' (Pinterest error code 58) rather than a real
+    failure. Real case (2026-08-19): a live create_board() call hit this
+    immediately after get_board_by_name() had just reported no match for
+    the same name -- board listing can lag a just-created (or otherwise
+    already-existing) board. Callers should treat this as 'go look it up
+    again and use it', not a terminal error."""
+    body = getattr(exc, "body", None)
+    if isinstance(body, dict) and body.get("code") == 58:
+        return True
+    return "already have a board with this name" in str(exc).lower()
 
 
 # --------------------------------------------------------------------------

--- a/scripts/publish-pinterest-pin.py
+++ b/scripts/publish-pinterest-pin.py
@@ -168,13 +168,22 @@ def main():
                 board = API.create_board(token, board_name)
                 print(f"Created board {board_name!r} (id={board['id']}).", file=sys.stderr)
             except API.PinterestAPIError as exc:
-                print(json.dumps({
-                    "pinId": None, "httpStatus": exc.status_code, "publishedAt": None,
-                    "boardId": None, "boardName": board_name,
-                    "utgDestinationUrl": destination_url, "imageUrl": image_url,
-                    "status": "failed", "error": f"Board creation failed: {exc}",
-                }, indent=2))
-                sys.exit(1)
+                if API.is_duplicate_board_error(exc):
+                    # Pinterest says a board with this name already exists,
+                    # even though the lookup just above found none -- listing
+                    # can lag. Look it up again and use it instead of failing.
+                    print(f"Board {board_name!r} already exists per Pinterest "
+                          f"(listing hadn't caught up) -- re-resolving instead of creating.",
+                          file=sys.stderr)
+                    board = API.get_board_by_name(token, board_name)
+                if not board:
+                    print(json.dumps({
+                        "pinId": None, "httpStatus": exc.status_code, "publishedAt": None,
+                        "boardId": None, "boardName": board_name,
+                        "utgDestinationUrl": destination_url, "imageUrl": image_url,
+                        "status": "failed", "error": f"Board creation failed: {exc}",
+                    }, indent=2))
+                    sys.exit(1)
         if not board:
             sys.exit(
                 f"No Pinterest board named {board_name!r} found on this account. "


### PR DESCRIPTION
## Summary

Follow-up to #781. Your live run with `create_board` checked hit a real bug:

```
"error": "Board creation failed: POST /boards -> HTTP 400: {'code': 58, 'message': 'Try a different name. You already have a board with this name!'}"
```

`GET /boards` found no match for `"Font Guides & Typography Tips"`, but Pinterest says the board already exists on your account — the listing just hadn't surfaced it at lookup time (or an earlier partial run created it and something else failed before publish completed).

## Fix

- `scripts/lib/pinterest_api.py`: `is_duplicate_board_error()` recognizes Pinterest's error code `58` (with a message-substring fallback).
- `scripts/publish-pinterest-pin.py`: when `create_board()` hits that specific error, re-run `get_board_by_name()` and use the result instead of failing outright. Converges to "use the board with this name, however it came to exist" regardless of root cause.

## Testing

- Unit-tested `is_duplicate_board_error()` offline against a structured code-58 body, a message-only fallback, and an unrelated 403 (correctly *not* flagged) — all three correct.
- Dry-run still passes end-to-end.
- `npm run check:workflows`: 11/11, 0 errors.

Once merged, re-running your exact same workflow inputs (`create_board` checked, `dry_run` unchecked) should now resolve the existing board and actually publish the pin.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPf8huXcw3QL3fyQEChFRn)_