### PR TITLE
fix: correct pinterest-insights.py's sys.path root (ModuleNotFoundError)

### DIFF
--- a/scripts/pinterest-insights.py
+++ b/scripts/pinterest-insights.py
@@ -34,7 +34,7 @@ import os
 import sys
 
 HERE = os.path.dirname(os.path.abspath(__file__))
-ROOT = HERE
+ROOT = os.path.dirname(HERE)
 sys.path.insert(0, os.path.join(ROOT, "scripts", "lib"))
 import pinterest_api as API  # noqa: E402
 


### PR DESCRIPTION
## What broke

The [Pinterest Insights workflow run](https://github.com/ychowdhrey/ultratextgen/actions/runs/32213351162/job/95950173002) failed immediately with:

```
ModuleNotFoundError: No module named 'pinterest_api'
```

## Root cause

`scripts/pinterest-insights.py` had:

```python
HERE = os.path.dirname(os.path.abspath(__file__))
ROOT = HERE
sys.path.insert(0, os.path.join(ROOT, "scripts", "lib"))
```

`HERE` is already `.../ultratextgen/scripts`, so this pointed at
`.../ultratextgen/scripts/scripts/lib` — a path that doesn't exist. This is
the exact same bug already found and fixed earlier the same day in
`scripts/publish-pinterest-pin.py` (`ROOT = os.path.dirname(HERE)`), copy-pasted
into this new file without re-checking it.

## Fix

```python
HERE = os.path.dirname(os.path.abspath(__file__))
ROOT = os.path.dirname(HERE)
sys.path.insert(0, os.path.join(ROOT, "scripts", "lib"))
```

One-line change, matching the already-fixed pattern in `publish-pinterest-pin.py`.

## Verification

- `python3 -m py_compile scripts/pinterest-insights.py` — passes
- Ran the script's actual import lines via `runpy` exactly as the workflow
  invokes it (`python3 scripts/pinterest-insights.py --help`) — resolves
  `pinterest_api` to `scripts/lib/pinterest_api.py` and prints `--help`
  cleanly instead of `ModuleNotFoundError`
- Re-ran `analyze()`/`render_report()` against synthetic pin data — ranked/
  below-sample-floor/zero-impression buckets all still compute and render
  correctly
- `npm run check:workflows` — 12 workflows checked, 0 errors
- Grepped `scripts/` for any other file carrying the same `ROOT = HERE`
  (undereferenced) pattern — none found; this was the only occurrence

## Scope

Path fix only — no behavior change to what the script reports.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPf8huXcw3QL3fyQEChFRn)_