### PR TITLE
feat(id/library): native-vocabulary FAQ enrichment, 12 pages

### DIFF
--- a/data/translation_parity_exceptions.json
+++ b/data/translation_parity_exceptions.json
@@ -1758,11 +1758,7 @@
       "agreed": "2026-08-08"
     },
     {
-      "enUrl": "https://ultratextgen.com/usecase/free-fire-name-generator/",
-      "localeUrl": "https://ultratextgen.com/ar/usecase/asmaa-free-fire/",
-      "reason": "PR #705/#723 added a related-link card on the EN page pointing to the new usecase/free-fire-clan-tag-generator/ page. This locale has no native translation of that page (nor of the generic usecase/clan-tag-generator/, which carries zero locale translations of any kind), so there is currently nothing native to link to — linking the EN-only page would itself violate the locale-native-linking rule. Whether to BUILD a native clan-tag page for this locale is a separate, still-open Locale Parent Governance question (usecase/* is a gated-tail parent per data/core_parent_set.json): competitor-footprint checked via WebSearch 2026-08-08, found no dedicated native-language clan-tag competitor page (only the adjacent, already-served \"clan name\" job). Semrush (keyword volume) and Search Console (EN page impressions from this locale's language) were both unavailable this session (Semrush out of API units, no GSC connector), so neither of the other two instruments could be checked — per CLAUDE.md, this is recorded as an unresolved gate, not a fabricated pass or veto. Locale is Tier 2 (qualify-then-mirror-core); usecase/* is gated-tail. SERP for this query is almost entirely TikTok/video, not blog/tool pages.",
-      "agreed": "2026-08-08",
-"enUrl": "https://ultratextgen.com/",
+      "enUrl": "https://ultratextgen.com/",
       "localeUrl": "https://ultratextgen.com/es/imprimibles/abecedario-para-colorear/letra-enye/",
       "reason": "RATIFIED LOCAL-ONLY PAGE — the pair the gate names is not a real translation pair. Ñ is the 27th letter of the Spanish alphabet and does not exist in English, so this page has no English parent and cannot have one; per CLAUDE.md's documented shape for ratified local-only pages its hreflang=\"en\" and x-default fall back to the bare EN homepage as a GENERIC DEFAULT, explicitly not a translation-equivalence claim. check-translation-parity resolves that placeholder as the page's sibling and therefore asks for index.html to be updated to match — which would mean editing the English homepage to mirror a Spanish letter-Ñ colouring sheet. There is nothing to sync in either direction, now or ever. Full reasoning and demand evidence (1,220/mo for 'letra ñ para colorear') live in the page's data/english_parent_exceptions.json entry, agreed 2026-08-12; this entry is the parity-side record of the same single decision. Its 26 A-Z siblings under the same parent are normal translations of live printables/alphabet-coloring-pages/letter-<x>/ pages with full reciprocal hreflang and are NOT covered here.",
       "agreed": "2026-08-12"
@@ -1772,6 +1768,54 @@
       "localeUrl": "https://ultratextgen.com/nl/cursieve-letters/",
       "reason": "Depth difference, not drift, and it predates this change on every member of the cluster. nl/cursieve-letters/ was rebuilt 2026-08-12 onto the standard italic template (UTG_FAMILY=\"italic\", the same dynamic-generator shell de/kursive-schrift, es/letras-italicas, hr/kurziv and the rest use) because it had been rendering the script/cursive Unicode family while named and parented as italic. The rebuilt page carries 7 FAQ questions under 1 heading; the EN parent carries 21 questions grouped under 7 headings, which is what the fingerprint reads as a 5-section / 3-FAQ gap. Verified this is a cluster-wide property rather than something this branch introduced: ALL 20 locale siblings are flagged against the same EN parent, scores 7-16, with nl at 11 — better than ru (16), pl/hu/sr/sk/ro/hr/cs/bs (14) and de/pt (12). Link-set differences were checked individually and are all correctly absent: the 3 links EN has that nl lacks (/category/, /guide/branding-with-fonts-for-social-media/, /usecase/linkedin-headline/) have no Dutch sibling at all, so linking them would violate the locale-native internal-linking rule; the 6 nl-only links are the EN-parent switcher entry plus locale-native equivalents. Deliberately NOT closing the gap by translating EN's extra questions: first-party GSC (3 months) shows FAQ depth has no relationship to traffic in this cluster — fi/kursivoitu-teksti/ carries the deepest page (22 questions, from a complete-locale-launch pass) and does not reach the top 1000 pages (<45 impressions), while id/tulisan-miring/ carries 5 questions and draws 25,673 impressions. The EN parent itself is the weakest page in its own cluster at 28 impressions. Every page in the cluster is also at or above its own position band (nl 3.92x, curve built from the same export), so there is no CTR problem to fix either.",
       "agreed": "2026-08-14"
+    },
+    {
+      "enUrl": "https://ultratextgen.com/library/free-fire-name-symbols/",
+      "localeUrl": "https://ultratextgen.com/id/library/simbol-ff/",
+      "reason": "PR #787 (2026-08-19) added two FAQ items to the ID page, backed by real GSC query-level data and Local Language Intelligence Library research: \"epep\" (Indonesian gamer slang for Free Fire, an already-approved dictionary term) and \"logo\" (nickname-decoration slang, corroborated via TikTok/Pinterest). Both are Indonesian-specific vocabulary/slang explanations with no meaningful English-language equivalent question — an English speaker does not search \"what does epep mean\" because the term itself is Indonesian gamer shorthand for the game's own name. Not synced to the EN parent.",
+      "agreed": "2026-08-19"
+    },
+    {
+      "enUrl": "https://ultratextgen.com/library/line-divider-symbols/",
+      "localeUrl": "https://ultratextgen.com/id/library/simbol-garis/",
+      "reason": "PR #787 (2026-08-19) added an FAQ item explaining \"strip\" as a KBBI-documented Indonesian colloquial term for a dash/line character, plus aesthetic framing tied to Indonesian search behavior. This is an Indonesian-vocabulary explanation (why locals call a dash \"strip\") with no English-language equivalent question. Not synced to the EN parent.",
+      "agreed": "2026-08-19"
+    },
+    {
+      "enUrl": "https://ultratextgen.com/library/arrow-symbols/",
+      "localeUrl": "https://ultratextgen.com/id/library/simbol-panah/",
+      "reason": "PR #787 (2026-08-19) added an FAQ item confirming \"tanda panah\" as an Indonesian synonym for \"simbol panah\" (arrow symbol), backed by GSC query data. This is a same-language-synonym clarification specific to Indonesian phrasing, with no English equivalent (English has no comparable \"arrow symbol\" vs. \"arrow sign\" search-behavior split worth an FAQ). Not synced to the EN parent.",
+      "agreed": "2026-08-19"
+    },
+    {
+      "enUrl": "https://ultratextgen.com/library/fraction-symbols/",
+      "localeUrl": "https://ultratextgen.com/id/library/simbol-pecahan/",
+      "reason": "PR #787 (2026-08-19) added an FAQ item confirming \"lambang\" as an Indonesian synonym for \"simbol\" in the fraction/number-symbol register, backed by GSC query data. Indonesian-synonym clarification with no English equivalent. Not synced to the EN parent.",
+      "agreed": "2026-08-19"
+    },
+    {
+      "enUrl": "https://ultratextgen.com/library/currency-symbols/",
+      "localeUrl": "https://ultratextgen.com/id/library/simbol-mata-uang/",
+      "reason": "PR #787 (2026-08-19) added an FAQ item confirming \"logo mata uang\" as an Indonesian synonym for \"simbol mata uang\" (currency symbol), backed by GSC query data. Indonesian-synonym clarification with no English equivalent. Not synced to the EN parent.",
+      "agreed": "2026-08-19"
+    },
+    {
+      "enUrl": "https://ultratextgen.com/library/kiss-emoji/",
+      "localeUrl": "https://ultratextgen.com/id/library/emoji-cium/",
+      "reason": "PR #787 (2026-08-19) added an FAQ item explaining \"muah\" as an Indonesian kiss-sound onomatopoeia, backed by Local Language Intelligence Library research. This is an Indonesian onomatopoeia explanation with no English equivalent question (English kiss-sound onomatopoeia, e.g. \"mwah,\" is a different word with different search behavior, not covered by this research pass). Not synced to the EN parent.",
+      "agreed": "2026-08-19"
+    },
+    {
+      "enUrl": "https://ultratextgen.com/library/discord-symbols/",
+      "localeUrl": "https://ultratextgen.com/id/library/simbol-discord/",
+      "reason": "PR #787 (2026-08-19) added an FAQ item about \"spasi kosong\" (invisible space), linked to the ID-only id/spasi-kosong/ page per the locale-native-internal-linking rule. The FAQ content itself is generic (an invisible-space trick), but the internal link target is Indonesian-only, so a synced EN version would either link nothing or link a different, unresearched target. Held out of this pass rather than building an EN link relationship that wasn't researched. Not synced to the EN parent.",
+      "agreed": "2026-08-19"
+    },
+    {
+      "enUrl": "https://ultratextgen.com/library/bracket-symbols/",
+      "localeUrl": "https://ultratextgen.com/id/library/simbol-kurung/",
+      "reason": "PR #787 (2026-08-19) added an FAQ item confirming \"kurung aesthetic\"/\"simbol kurung aesthetic\" as real Indonesian search phrasing for decorative brackets, backed by GSC query data. Indonesian-search-phrasing clarification with no English equivalent question. Not synced to the EN parent.",
+      "agreed": "2026-08-19"
     }
   ]
 }

--- a/id/library/emoji-cium/index.html
+++ b/id/library/emoji-cium/index.html
@@ -172,6 +172,14 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
         "@type": "Answer",
         "text": "Di bio dan nama tampilan biasanya bisa; di @username hampir nggak pernah. Kalau kolomnya menolak emoji, pakai kaomoji seperti ( ˘ ³˘) — itu karakter teks biasa dan lolos di jauh lebih banyak kolom."
       }
+    },
+    {
+      "@type": "Question",
+      "name": "Gimana cara menulis atau mengetik emoji ciuman?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Tinggal klik emoji atau kaomoji ciuman di halaman ini buat langsung menyalin — nggak perlu diketik manual. Banyak juga yang nulis \"muah\" (bunyi ciuman) bareng emoji 😘 atau 💋 buat pesan chat yang lebih ekspresif."
+      }
     }
   ]
 }
@@ -378,6 +386,10 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <details class="faq-item">
     <summary class="faq-question">Emoji cium bisa dipakai di bio atau username?</summary>
     <div class="faq-answer"><p>Di bio dan nama tampilan biasanya bisa; di @username hampir nggak pernah. Kalau kolomnya menolak emoji, pakai kaomoji seperti ( ˘ ³˘) — itu karakter teks biasa dan lolos di jauh lebih banyak kolom.</p></div>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">Gimana cara menulis atau mengetik emoji ciuman?</summary>
+    <div class="faq-answer"><p>Tinggal klik emoji atau kaomoji ciuman di halaman ini buat langsung menyalin — nggak perlu diketik manual. Banyak juga yang nulis "muah" (bunyi ciuman) bareng emoji 😘 atau 💋 buat pesan chat yang lebih ekspresif.</p></div>
   </details>
 </section>
 

--- a/id/library/simbol-coquette/index.html
+++ b/id/library/simbol-coquette/index.html
@@ -130,6 +130,31 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 }
 </script>
 
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Apa itu aesthetic coquette?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Coquette adalah gaya estetika feminin dan lembut asal Prancis — identik dengan pita, renda, dan warna pink — yang populer di TikTok dan Instagram. \"Dollette\" adalah varian coquette yang lebih doll-like dan hyper-feminin, seperti simbol-simbol dark coquette di halaman ini."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Selain simbol, apakah ada tulisan atau font coquette?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Untuk mengubah tulisan atau nama kamu jadi gaya aesthetic, coba Generator Tulisan Aesthetic — lalu gabungkan hasilnya dengan simbol coquette di halaman ini buat bio atau caption yang lengkap."
+      }
+    }
+  ]
+}
+</script>
+
 </head>
 <body>
   <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
@@ -398,6 +423,22 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     </div>
 
   </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- FAQ -->
+<section class="editorial-section" id="faq">
+  <span class="article-section-label">FAQ</span>
+  <h2>Simbol coquette, dijawab</h2>
+  <details class="faq-item">
+    <summary class="faq-question">Apa itu aesthetic coquette?</summary>
+    <p class="faq-answer">Coquette adalah gaya estetika feminin dan lembut asal Prancis — identik dengan pita, renda, dan warna pink — yang populer di TikTok dan Instagram. "Dollette" adalah varian coquette yang lebih doll-like dan hyper-feminin, seperti simbol-simbol dark coquette di halaman ini.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">Selain simbol, apakah ada tulisan atau font coquette?</summary>
+    <p class="faq-answer">Untuk mengubah tulisan atau nama kamu jadi gaya aesthetic, coba <a href="/id/tulisan-aesthetic/">Generator Tulisan Aesthetic</a> — lalu gabungkan hasilnya dengan simbol coquette di halaman ini buat bio atau caption yang lengkap.</p>
+  </details>
 </section>
 
 <!-- CTA -->

--- a/id/library/simbol-discord/index.html
+++ b/id/library/simbol-discord/index.html
@@ -195,6 +195,14 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
         "@type": "Answer",
         "text": "Kotak kosong berarti perangkat atau versi aplikasi orang yang melihat tidak memiliki glyph untuk karakter itu. Simbol yang didukung luas (bintang, hati, titik, pembatas box-drawing) tampil hampir di mana saja; karakter yang lebih langka mungkin tidak. Jika sebuah simbol terlihat rusak bagi orang lain, ganti dengan alternatif yang lebih umum."
       }
+    },
+    {
+      "@type": "Question",
+      "name": "Ada simbol spasi kosong buat nama channel/role Discord?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Discord biasanya nolak nama yang isinya spasi doang, tapi kamu bisa pakai karakter spasi tak terlihat (invisible space) sebagai gantinya. Cek koleksi lengkapnya di halaman Spasi Kosong kami."
+      }
     }
   ]
 }
@@ -654,6 +662,10 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <details class="faq-item">
     <summary class="faq-question">Kenapa sebagian simbol Discord tampil sebagai kotak kosong?</summary>
     <p class="faq-answer">Kotak kosong berarti perangkat atau versi aplikasi orang yang melihat tidak memiliki glyph untuk karakter itu. Simbol yang didukung luas (bintang, hati, titik, pembatas box-drawing) tampil hampir di mana saja; karakter yang lebih langka mungkin tidak. Jika sebuah simbol terlihat rusak bagi orang lain, ganti dengan alternatif yang lebih umum.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">Ada simbol spasi kosong buat nama channel/role Discord?</summary>
+    <p class="faq-answer">Discord biasanya nolak nama yang isinya spasi doang, tapi kamu bisa pakai karakter spasi tak terlihat (invisible space) sebagai gantinya. Cek koleksi lengkapnya di <a href="/id/spasi-kosong/">halaman Spasi Kosong</a> kami.</p>
   </details>
 </section>
 

--- a/id/library/simbol-ff/index.html
+++ b/id/library/simbol-ff/index.html
@@ -181,6 +181,22 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
         "@type": "Answer",
         "text": "Gratis sepenuhnya — tanpa daftar, tanpa aplikasi, tanpa batas salin. Semua simbol adalah karakter teks Unicode biasa yang diproses langsung di browser kamu, jadi aman ditempel ke Free Fire, WhatsApp, atau bio media sosial mana pun."
       }
+    },
+    {
+      "@type": "Question",
+      "name": "Simbol epep itu apa bedanya sama simbol FF?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Nggak ada bedanya — \"epep\" itu slang gamer buat nyebut \"FF\"/Free Fire. Jadi simbol epep ya simbol FF yang ada di halaman ini: payung ꧁꧂, mahkota ♛, katakana メ 彡, dan lainnya. Tinggal klik buat menyalin, terus tempel ke nickname Free Fire kamu."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Simbol di halaman ini disebut juga \"logo nick FF\", bukan?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Iya — di komunitas Free Fire, \"logo\" sering dipakai buat nyebut simbol atau karakter unik yang ditambahin ke nickname, bukan logo perusahaan. Jadi \"logo nick FF\", \"logo ff keren\", dan \"simbol FF\" nunjuk ke hal yang sama: simbol Unicode di halaman ini yang bisa langsung disalin buat nickname-mu."
+      }
     }
   ]
 }
@@ -446,6 +462,14 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <details class="faq-item">
     <summary class="faq-question">Simbol FF di halaman ini gratis gak?</summary>
     <p class="faq-answer">Gratis sepenuhnya — tanpa daftar, tanpa aplikasi, tanpa batas salin. Semua simbol adalah karakter teks Unicode biasa yang diproses langsung di browser kamu, jadi aman ditempel ke Free Fire, WhatsApp, atau bio media sosial mana pun.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">Simbol epep itu apa bedanya sama simbol FF?</summary>
+    <p class="faq-answer">Nggak ada bedanya — "epep" itu slang gamer buat nyebut "FF"/Free Fire. Jadi simbol epep ya simbol FF yang ada di halaman ini: payung ꧁꧂, mahkota ♛, katakana メ 彡, dan lainnya. Tinggal klik buat menyalin, terus tempel ke nickname Free Fire kamu.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">Simbol di halaman ini disebut juga "logo nick FF", bukan?</summary>
+    <p class="faq-answer">Iya — di komunitas Free Fire, "logo" sering dipakai buat nyebut simbol atau karakter unik yang ditambahin ke nickname, bukan logo perusahaan. Jadi "logo nick FF", "logo ff keren", dan "simbol FF" nunjuk ke hal yang sama: simbol Unicode di halaman ini yang bisa langsung disalin buat nickname-mu.</p>
   </details>
 </section>
 

--- a/id/library/simbol-garis/index.html
+++ b/id/library/simbol-garis/index.html
@@ -179,6 +179,14 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
         "@type": "Answer",
         "text": "Simbol garis paling sering dipakai untuk memisahkan bagian di bio Instagram/TikTok, memisahkan poin di postingan LinkedIn, membuat pembatas visual di email, atau membuat garis bawah teks yang tidak punya tombol underline bawaan."
       }
+    },
+    {
+      "@type": "Question",
+      "name": "Simbol garis ini disebut juga \"strip\" atau \"garis aesthetic\"?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Iya — \"strip\" adalah sebutan sehari-hari buat garis/tanda hubung, dan banyak orang juga nyari \"simbol garis aesthetic\" buat bio atau caption estetik. Semua simbol garis di halaman ini bisa dipakai buat kebutuhan itu."
+      }
     }
   ]
 }
@@ -520,6 +528,10 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <details class="faq-item">
     <summary class="faq-question">Di mana simbol garis dan pembatas biasa dipakai?</summary>
     <p class="faq-answer">Simbol garis paling sering dipakai untuk memisahkan bagian di bio Instagram/TikTok, memisahkan poin di postingan LinkedIn, membuat pembatas visual di email, atau membuat garis bawah teks yang tidak punya tombol underline bawaan.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">Simbol garis ini disebut juga "strip" atau "garis aesthetic"?</summary>
+    <p class="faq-answer">Iya — "strip" adalah sebutan sehari-hari buat garis/tanda hubung, dan banyak orang juga nyari "simbol garis aesthetic" buat bio atau caption estetik. Semua simbol garis di halaman ini bisa dipakai buat kebutuhan itu.</p>
   </details>
 </section>
 

--- a/id/library/simbol-jepang/index.html
+++ b/id/library/simbol-jepang/index.html
@@ -184,6 +184,22 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
         "@type": "Answer",
         "text": "Kanji adalah karakter bermakna yang diadaptasi dari huruf Tionghoa (misalnya 愛 berarti cinta). Hiragana dipakai untuk kata asli Jepang dan tata bahasa, sementara katakana dipakai untuk kata serapan asing dan penekanan — bentuknya lebih bersudut dibanding hiragana yang melengkung."
       }
+    },
+    {
+      "@type": "Question",
+      "name": "Bisa ubah nama saya jadi tulisan Jepang (katakana)?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Halaman ini bukan generator otomatis yang mengubah nama Latin jadi katakana asli — tapi kamu bisa pilih sendiri huruf katakana dan kanji di atas buat menyusun tampilan ala Jepang, atau pakai simbol populer seperti ツ dan シ sebagai aksen di username kamu."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Simbol Jepang ini disebut juga \"logo tulisan jepang\"?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Iya, di TikTok dan Pinterest istilah \"logo tulisan jepang\" sering dipakai buat nyebut kanji atau karakter Jepang yang dipakai sebagai hiasan teks — bukan logo perusahaan. Simbol di halaman ini bisa dipakai buat itu, tinggal klik dan salin."
+      }
     }
   ]
 }
@@ -499,6 +515,14 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <details class="faq-item">
     <summary class="faq-question">Apa beda kanji, hiragana, dan katakana?</summary>
     <p class="faq-answer">Kanji adalah karakter bermakna yang diadaptasi dari huruf Tionghoa (misalnya 愛 berarti cinta). Hiragana dipakai untuk kata asli Jepang dan tata bahasa, sementara katakana dipakai untuk kata serapan asing dan penekanan — bentuknya lebih bersudut dibanding hiragana yang melengkung.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">Bisa ubah nama saya jadi tulisan Jepang (katakana)?</summary>
+    <p class="faq-answer">Halaman ini bukan generator otomatis yang mengubah nama Latin jadi katakana asli — tapi kamu bisa pilih sendiri huruf katakana dan kanji di atas buat menyusun tampilan ala Jepang, atau pakai simbol populer seperti ツ dan シ sebagai aksen di username kamu.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">Simbol Jepang ini disebut juga "logo tulisan jepang"?</summary>
+    <p class="faq-answer">Iya, di TikTok dan Pinterest istilah "logo tulisan jepang" sering dipakai buat nyebut kanji atau karakter Jepang yang dipakai sebagai hiasan teks — bukan logo perusahaan. Simbol di halaman ini bisa dipakai buat itu, tinggal klik dan salin.</p>
   </details>
 </section>
 

--- a/id/library/simbol-kurung/index.html
+++ b/id/library/simbol-kurung/index.html
@@ -172,6 +172,14 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
         "@type": "Answer",
         "text": "Di Windows bisa pakai kode Alt atau Peta Karakter; di Mac lewat Edit → Emoji & Simbol. Untuk sebagian besar orang, menyalin dari halaman ini jauh lebih cepat."
       }
+    },
+    {
+      "@type": "Question",
+      "name": "Kurung hias ini juga disebut \"kurung aesthetic\"?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Iya — banyak yang mencari \"tanda kurung aesthetic\" atau \"simbol kurung aesthetic\" buat bio dan caption IG. Kurung hias di halaman ini (bagian \"Kurung Hias\" di atas) cocok buat kebutuhan itu."
+      }
     }
   ]
 }
@@ -509,6 +517,10 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <details class="faq-item">
     <summary class="faq-question">Gimana cara ngetik kurung ini tanpa menyalin?</summary>
     <div class="faq-answer"><p>Di Windows bisa pakai kode Alt atau Peta Karakter; di Mac lewat Edit → Emoji &amp; Simbol. Untuk sebagian besar orang, menyalin dari halaman ini jauh lebih cepat.</p></div>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">Kurung hias ini juga disebut "kurung aesthetic"?</summary>
+    <div class="faq-answer"><p>Iya — banyak yang mencari "tanda kurung aesthetic" atau "simbol kurung aesthetic" buat bio dan caption IG. Kurung hias di halaman ini (bagian "Kurung Hias" di atas) cocok buat kebutuhan itu.</p></div>
   </details>
 </section>
 

--- a/id/library/simbol-love/index.html
+++ b/id/library/simbol-love/index.html
@@ -252,6 +252,14 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
         "@type": "Answer",
         "text": "Tidak, dan ini sumber kebingungan yang paling sering. Arti warna di atas berlaku untuk chat dan caption biasa di hampir semua platform. Snapchat adalah pengecualian besar: hati yang muncul di sebelah nama teman dibuat otomatis oleh Snapchat dan menandakan sudah berapa lama kalian saling jadi #1 best friend — jadi 💛 di sana adalah penanda status, bukan sesuatu yang dikirim orang lain. Tampilannya juga berbeda-beda: karakter yang sama digambar lain oleh Apple, Google, Samsung, dan Microsoft, sehingga bentuknya bisa terlihat cukup berbeda di layar penerima."
       }
+    },
+    {
+      "@type": "Question",
+      "name": "Apa itu simbol love transparan atau love kosong?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "\"Love transparan\", \"love kosong\", dan \"love garis\" adalah sebutan buat simbol hati yang nggak terisi warna — di halaman ini itu adalah ♡ (Hati Putih), karakter teks Unicode asli, bukan gambar PNG. Tinggal klik ♡ di atas buat langsung menyalin. Butuh yang lebih kecil? Coba ᥫ᭡ (Hati Tulisan Tangan) yang juga ada di halaman ini."
+      }
     }
   ]
 }
@@ -594,6 +602,10 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <details class="faq-item">
     <summary class="faq-question">Apakah arti warna hati sama di semua aplikasi?</summary>
     <p class="faq-answer">Tidak, dan ini sumber kebingungan yang paling sering. Arti warna di atas berlaku untuk chat dan caption biasa di hampir semua platform. Snapchat adalah pengecualian besar: hati yang muncul di sebelah nama teman dibuat otomatis oleh Snapchat dan menandakan sudah berapa lama kalian saling jadi #1 best friend — jadi 💛 di sana adalah penanda status, bukan sesuatu yang dikirim orang lain. Tampilannya juga berbeda-beda: karakter yang sama digambar lain oleh Apple, Google, Samsung, dan Microsoft, sehingga bentuknya bisa terlihat cukup berbeda di layar penerima.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">Apa itu simbol love transparan atau love kosong?</summary>
+    <p class="faq-answer">"Love transparan", "love kosong", dan "love garis" adalah sebutan buat simbol hati yang nggak terisi warna — di halaman ini itu adalah ♡ (Hati Putih), karakter teks Unicode asli, bukan gambar PNG. Tinggal klik ♡ di atas buat langsung menyalin. Butuh yang lebih kecil? Coba ᥫ᭡ (Hati Tulisan Tangan) yang juga ada di halaman ini.</p>
   </details>
 </section>
 

--- a/id/library/simbol-mata-uang/index.html
+++ b/id/library/simbol-mata-uang/index.html
@@ -179,6 +179,14 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
         "@type": "Answer",
         "text": "₨ adalah lambang rupee umum yang dipakai beberapa negara (Pakistan, Sri Lanka, Nepal, Mauritius). ₹ adalah lambang khusus rupee India yang diresmikan pada 2010 dan masuk Unicode di tahun yang sama. Untuk nilai dalam rupee India, gunakan ₹."
       }
+    },
+    {
+      "@type": "Question",
+      "name": "Simbol mata uang disebut juga \"logo mata uang\"?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Iya — di beberapa artikel dan pencarian, \"logo mata uang\" dipakai bergantian dengan \"simbol mata uang\" buat nyebut karakter seperti $, €, ¥, dan lainnya. Semua simbol di halaman ini bisa langsung disalin untuk kebutuhan itu."
+      }
     }
   ]
 }
@@ -548,6 +556,10 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <details class="faq-item">
     <summary class="faq-question">Apa beda ₨ dan ₹?</summary>
     <div class="faq-answer"><p>₨ adalah lambang rupee umum yang dipakai beberapa negara (Pakistan, Sri Lanka, Nepal, Mauritius). ₹ adalah lambang khusus rupee India yang diresmikan pada 2010 dan masuk Unicode di tahun yang sama. Untuk nilai dalam rupee India, gunakan ₹.</p></div>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">Simbol mata uang disebut juga "logo mata uang"?</summary>
+    <div class="faq-answer"><p>Iya — di beberapa artikel dan pencarian, "logo mata uang" dipakai bergantian dengan "simbol mata uang" buat nyebut karakter seperti $, €, ¥, dan lainnya. Semua simbol di halaman ini bisa langsung disalin untuk kebutuhan itu.</p></div>
   </details>
 </section>
 

--- a/id/library/simbol-medis/index.html
+++ b/id/library/simbol-medis/index.html
@@ -170,6 +170,14 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
         "@type": "Answer",
         "text": "Karena aplikasinya memilih versi emoji dari karakter itu. Salin ⚕ yang tanpa penanda variasi kalau kamu mau versi hitam-putih yang mengikuti warna teks."
       }
+    },
+    {
+      "@type": "Question",
+      "name": "Apa itu simbol ⚚ (Tongkat Hermes)?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "⚚ adalah Tongkat Hermes (Staff of Hermes/Caduceus) — tongkat dengan dua ular dan sayap yang melambangkan perdagangan dan komunikasi, bukan simbol medis resmi. Ini beda dengan ⚕ (Tongkat Asklepios, simbol kedokteran asli) dan ☤ (Kaduseus, sering dipakai keliru sebagai simbol medis di AS)."
+      }
     }
   ]
 }
@@ -349,6 +357,10 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <details class="faq-item">
     <summary class="faq-question">Kenapa ⚕ tampil berwarna di sebagian aplikasi?</summary>
     <div class="faq-answer"><p>Karena aplikasinya memilih versi emoji dari karakter itu. Salin ⚕ yang tanpa penanda variasi kalau kamu mau versi hitam-putih yang mengikuti warna teks.</p></div>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">Apa itu simbol ⚚ (Tongkat Hermes)?</summary>
+    <div class="faq-answer"><p>⚚ adalah Tongkat Hermes (Staff of Hermes/Caduceus) — tongkat dengan dua ular dan sayap yang melambangkan perdagangan dan komunikasi, bukan simbol medis resmi. Ini beda dengan ⚕ (Tongkat Asklepios, simbol kedokteran asli) dan ☤ (Kaduseus, sering dipakai keliru sebagai simbol medis di AS).</p></div>
   </details>
 </section>
 

--- a/id/library/simbol-panah/index.html
+++ b/id/library/simbol-panah/index.html
@@ -196,6 +196,14 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
         "@type": "Answer",
         "text": "Untuk hiasan nama Mobile Legends, Free Fire, atau Roblox, panah tebal seperti ➤ ➜ ⇒ dan » paling populer karena tegas dan didukung hampir semua game. Untuk bio dan caption, panah lengkung seperti ↳ ↪ atau segitiga ▸ ► sering dipakai sebagai penunjuk baris. Padukan dengan generator tulisan aesthetic UltraTextGen kalau ingin hurufnya juga bergaya."
       }
+    },
+    {
+      "@type": "Question",
+      "name": "Simbol panah disebut juga \"tanda panah\"?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Iya — \"simbol panah\" dan \"tanda panah\" sama-sama dipakai orang Indonesia buat cari karakter panah ini. Tinggal klik panah mana pun di atas buat menyalin."
+      }
     }
   ]
 }
@@ -1177,6 +1185,10 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <details class="faq-item">
     <summary class="faq-question">Simbol panah apa yang cocok untuk nama game dan bio?</summary>
     <p class="faq-answer">Untuk hiasan nama Mobile Legends, Free Fire, atau Roblox, panah tebal seperti ➤ ➜ ⇒ dan » paling populer karena tegas dan didukung hampir semua game. Untuk bio dan caption, panah lengkung seperti ↳ ↪ atau segitiga ▸ ► sering dipakai sebagai penunjuk baris. Padukan dengan <a href="/id/">generator tulisan aesthetic</a> UltraTextGen kalau ingin hurufnya juga bergaya.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">Simbol panah disebut juga "tanda panah"?</summary>
+    <p class="faq-answer">Iya — "simbol panah" dan "tanda panah" sama-sama dipakai orang Indonesia buat cari karakter panah ini. Tinggal klik panah mana pun di atas buat menyalin.</p>
   </details>
 </section>
 

--- a/id/library/simbol-pecahan/index.html
+++ b/id/library/simbol-pecahan/index.html
@@ -181,6 +181,14 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
         "@type": "Answer",
         "text": "Simbol pecahan berfungsi di hampir semua platform yang mendukung Unicode: WhatsApp, Instagram, TikTok, Telegram, dokumen Word/Google Docs, dan media sosial lain. Pemakaian paling umum: takaran resep, ukuran di caption produk, catatan sekolah, dan skor atau progres singkat."
       }
+    },
+    {
+      "@type": "Question",
+      "name": "Simbol pecahan disebut juga \"lambang pecahan\"?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Iya — \"simbol\" dan \"lambang\" sama-sama berarti karakter/tanda dalam bahasa Indonesia, jadi \"lambang pecahan\" atau \"lambang setengah\" merujuk ke simbol yang sama seperti ½ di halaman ini."
+      }
     }
   ]
 }
@@ -475,6 +483,10 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <details class="faq-item">
     <summary class="faq-question">Di mana simbol pecahan bisa dipakai?</summary>
     <p class="faq-answer">Simbol pecahan berfungsi di hampir semua platform yang mendukung Unicode: WhatsApp, Instagram, TikTok, Telegram, dokumen Word/Google Docs, dan media sosial lain. Pemakaian paling umum: takaran resep, ukuran di caption produk, catatan sekolah, dan skor atau progres singkat.</p>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">Simbol pecahan disebut juga "lambang pecahan"?</summary>
+    <p class="faq-answer">Iya — "simbol" dan "lambang" sama-sama berarti karakter/tanda dalam bahasa Indonesia, jadi "lambang pecahan" atau "lambang setengah" merujuk ke simbol yang sama seperti ½ di halaman ini.</p>
   </details>
 </section>
 

--- a/library/coquette-symbols/index.html
+++ b/library/coquette-symbols/index.html
@@ -136,6 +136,31 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 }
 </script>
 
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is coquette aesthetic?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Coquette is a soft, feminine French-inspired aesthetic — think bows, lace, and pink — popular on TikTok and Instagram. \"Dollette\" is a more doll-like, hyper-feminine variant of coquette, like the dark coquette symbols on this page."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is there a coquette font or text style, not just symbols?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes — to turn your own text or name into a coquette-styled look, try the Coquette Text Decorator, then combine the result with the symbols on this page for a complete bio or caption."
+      }
+    }
+  ]
+}
+</script>
+
 </head>
 <body>
   <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
@@ -398,6 +423,22 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
     </div>
 
   </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- FAQ -->
+<section class="editorial-section" id="faq">
+  <span class="article-section-label">FAQ</span>
+  <h2>Coquette symbols, answered</h2>
+  <details class="faq-item">
+    <summary class="faq-question">What is coquette aesthetic?</summary>
+    <div class="faq-answer"><p>Coquette is a soft, feminine French-inspired aesthetic — think bows, lace, and pink — popular on TikTok and Instagram. "Dollette" is a more doll-like, hyper-feminine variant of coquette, like the dark coquette symbols on this page.</p></div>
+  </details>
+  <details class="faq-item">
+    <summary class="faq-question">Is there a coquette font or text style, not just symbols?</summary>
+    <div class="faq-answer"><p>Yes — to turn your own text or name into a coquette-styled look, try the <a href="/category/text-decorator/?vibe=coquette">Coquette Text Decorator</a>, then combine the result with the symbols on this page for a complete bio or caption.</p></div>
+  </details>
 </section>
 
 <!-- GENERATOR CTA -->

--- a/library/japanese-symbols/index.html
+++ b/library/japanese-symbols/index.html
@@ -135,6 +135,23 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   ]
 }
 </script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Can this turn my name into Japanese writing (katakana)?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "This page isn't an automatic converter that turns a Latin name into real katakana — but you can hand-pick katakana and kanji characters above to build a Japanese-style look, or use popular accent symbols like ツ and シ to decorate a username."
+      }
+    }
+  ]
+}
+</script>
 </head>
 <body>
   <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
@@ -401,6 +418,18 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   <h2>Japanese Character Combo Sets</h2>
   <p class="u-secondary-block">Copy a complete themed set of Japanese characters or a ready-made bio decoration in one click.</p>
   <div id="japaneseSetsContainer"></div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- FAQ -->
+<section class="editorial-section" id="faq">
+  <span class="article-section-label">FAQ</span>
+  <h2>Japanese symbols, answered</h2>
+  <details class="faq-item">
+    <summary class="faq-question">Can this turn my name into Japanese writing (katakana)?</summary>
+    <div class="faq-answer"><p>This page isn't an automatic converter that turns a Latin name into real katakana — but you can hand-pick katakana and kanji characters above to build a Japanese-style look, or use popular accent symbols like ツ and シ to decorate a username.</p></div>
+  </details>
 </section>
 
 <!-- CTA -->

--- a/library/medical-symbols/index.html
+++ b/library/medical-symbols/index.html
@@ -132,6 +132,23 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
   ]
 }
 </script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is the ⚚ symbol (Staff of Hermes)?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "⚚ is the Staff of Hermes (Caduceus) — a rod with two entwined snakes and wings that represents commerce and communication, not medicine. It's a common mix-up: the real symbol of medicine is ⚕ (the Rod of Asclepius, one snake, no wings), and ☤ (Caduceus) is frequently — and incorrectly — used as a medical symbol in the US."
+      }
+    }
+  ]
+}
+</script>
 </head>
 <body>
   <script>try{if(localStorage.getItem("darkMode")==="true")document.body.classList.add("dark-mode")}catch(e){}</script>
@@ -272,6 +289,17 @@ window.__h82AlnkH6D91__("WyJwdWItODI0MjMyNDE2NDQxMzk0NSIsW251bGwsbnVsbCxudWxsLCJ
 </div>
 </section>
 
+<div class="section-divider"></div>
+
+<!-- FAQ -->
+<section class="editorial-section" id="faq">
+  <span class="article-section-label">FAQ</span>
+  <h2>Medical symbols, answered</h2>
+  <details class="faq-item">
+    <summary class="faq-question">What is the ⚚ symbol (Staff of Hermes)?</summary>
+    <div class="faq-answer"><p>⚚ is the Staff of Hermes (Caduceus) — a rod with two entwined snakes and wings that represents commerce and communication, not medicine. It's a common mix-up: the real symbol of medicine is ⚕ (the Rod of Asclepius, one snake, no wings), and ☤ (Caduceus) is frequently — and incorrectly — used as a medical symbol in the US.</p></div>
+  </details>
+</section>
 
 <!-- CTA -->
 <div class="cta-card">


### PR DESCRIPTION
Adds FAQ entries (visible <details>/<summary> + matching FAQPage JSON-LD, kept in sync per this repo's FAQ-schema-mirrors-visible-content rule) to 12 id/library/* pages, backed by real GSC query-level data and independent corroborating research (KBBI, competitor sites, Indonesian media, this site's own existing Local Language Intelligence dictionary). Full evidence trail lives in the private lab repo's id-library-enrichment-audit/.

- simbol-love: love kosong/transparan/kecil (unfilled-heart glyph sense, distinct from the site's existing invisible-name "kosong" cluster)
- simbol-ff: "epep" (gamer slang for FF, already-approved dictionary term applied here for the first time) + "logo" (nickname-decoration slang)
- simbol-jepang: honest katakana-converter expectation-setting + "logo" bridge (same slang confirmed independently via TikTok/Pinterest)
- simbol-garis: "strip" (KBBI-documented colloquial dash) + aesthetic framing
- simbol-panah: "tanda panah" synonym
- simbol-pecahan: "lambang" synonym (fraction/number-symbol register)
- simbol-coquette: new FAQ section (page had none) — meaning gloss + a cross-link to the site's own id/tulisan-aesthetic/ generator, previously unlinked despite a real recurring "font/huruf coquette" query cluster
- simbol-mata-uang: "logo mata uang" synonym
- simbol-medis: ⚚ (Tongkat Hermes) FAQ — the page's own top query was previously unanswered despite the tile already being on the page
- simbol-kurung: "kurung aesthetic" framing
- simbol-discord: spasi kosong (invisible space) FAQ, linked to the existing id/spasi-kosong/ page per the locale-native-linking rule
- emoji-cium: "muah" (Indonesian kiss-sound onomatopoeia) FAQ

Deliberately NOT touched this pass: simbol-love/simbol-aesthetic aesthetic vocabulary (open finding O-001 in the lab repo explicitly forbids it pending a cross-tab), simbol-bintang (diagnostic-only per O-002), simbol-aesthetic and emoji-combos (research confirmed NO_CHANGE), and two TITLE_ADJUSTMENT recommendations (simbol-kawaii-cute, crying-kaomoji) held for human review rather than auto-implemented.