### PR TITLE
Pause the daily sitemap cron until 2026-08-27

### DIFF
--- a/.github/workflows/update-sitemap.yml
+++ b/.github/workflows/update-sitemap.yml
@@ -1,8 +1,38 @@
 name: Update Sitemap
 
 on:
-  schedule:
-    - cron: '0 0 * * *'  # every day at midnight UTC
+  # ── PAUSED 2026-08-20, resume on or after 2026-08-27 ──────────────────────
+  #
+  # The daily schedule is deliberately commented out, not deleted. Restore it
+  # by uncommenting the two lines below.
+  #
+  # Why: organic search collapsed on 2026-08-16 and the cause is still open.
+  # PR #790 touched all 4,582 pages (it added the footer's ~27 internal links
+  # to every page's HTML), and the significance hash counts visible text and
+  # the internal link set — so the next run would advance <lastmod> on 4,576
+  # of 4,576 URLs and advertise "the entire site changed today" in the middle
+  # of an unresolved incident. Measured, not assumed:
+  #     lastmod advanced: 4576   lastmod held: 0
+  #
+  # That is the exact signal scripts/lib/content-significance.js was written
+  # to prevent — a 15–16 August cosmetic pass bumped 2,533 pages the day
+  # before onset, and "deployment regression" is still a live hypothesis.
+  # The bump here is honest (the links are real), but the signal Google
+  # receives is identical, so it waits.
+  #
+  # Pausing costs very little: Crawl Stats for the 90 days to 2026-08-15 show
+  # 84% of crawling is Refresh, ~877 refresh HTML fetches/day against ~4,576
+  # pages — a full re-crawl pass roughly every 5 days with no sitemap ping at
+  # all. No new URLs are being added during the pause, so there is nothing
+  # the sitemap needs to announce. (Caveat: that export ends 08-15 and
+  # contains no day of the event window.)
+  #
+  # workflow_dispatch is kept so the sitemap can still be regenerated on
+  # demand while the schedule is off.
+  #
+  # schedule:
+  #   - cron: '0 0 * * *'  # every day at midnight UTC
+  workflow_dispatch:
 
 jobs:
   update-sitemap:


### PR DESCRIPTION
## Why

Organic search collapsed on 2026-08-16 and the cause is still open. PR #790 touched all 4,582 pages — it added the footer's ~27 internal links to every page's HTML — and `scripts/lib/content-significance.js` counts **visible text and the internal link set** as significant. So the next scheduled run advances `<lastmod>` on every URL at once.

Measured against the merged tree, not assumed:

```
lastmod advanced: 4576  (content actually changed)
lastmod held:     0     (no meaningful change)
```

That is exactly the signal the significance hash was written to suppress. A 15–16 August cosmetic pass bumped 2,533 pages the day before onset, and "deployment regression" is still a live hypothesis for the collapse. The bump here is **honest** — the links are real and the hash is right to move — but what Google receives is indistinguishable from the cosmetic case. So it waits a week.

## Why pausing is close to free

Crawl Stats, 90 days to 2026-08-15:

| Signal | Value |
|---|---|
| Purpose: **Refresh** | **84%** |
| HTML share of crawling | 63% |
| Refresh HTML fetches/day | **~877** |
| Indexable pages | ~4,576 |
| **Implied full re-crawl pass** | **~5 days, with no sitemap ping** |

Google re-crawls this site end-to-end about every five days on its own. The sitemap is not the discovery mechanism, and **no new URLs are being added during the pause**, so it has nothing to announce.

**Caveat, stated plainly:** that export ends **2026-08-15** and contains **zero days of the event window** — the same gap the evidence artifact already flagged for Performance and Page Indexing. The crawl cadence above is established *pre-collapse*. It is a reasonable assumption that it held (the 08-20 Coverage export shows indexed count flat at 4,238 through the collapse), but this file does not prove it.

One incidental finding from the same export: **AdsBot is the single largest crawler at 29%** — that is AdSense ad-quality crawling, not search indexing. Search-relevant crawling (Smartphone 26% + Desktop 13%) is 39%. It doesn't change this decision, but the headline 59.1K overstates search-crawl activity.

## What changed

The `schedule:` trigger is **commented out, not deleted**, with the resume date inline, and `workflow_dispatch` is added so the sitemap can still be regenerated on demand while the schedule is off.

**To resume:** uncomment the two `cron` lines. On or after **2026-08-27**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Z5v7CYFLxwgwo5H9K9tm5

---
_Generated by [Claude Code](https://claude.ai/code/session_016Z5v7CYFLxwgwo5H9K9tm5)_