### PR TITLE
fix: make the parity gate honour the `suppress` field it already documents

### DIFF
--- a/scripts/audit-translation-parity.js
+++ b/scripts/audit-translation-parity.js
@@ -31,9 +31,9 @@ const path = require('path');
 const { execFileSync } = require('child_process');
 const { discoverClusters } = require('./lib/translation-clusters');
 const { createFingerprinter } = require('./lib/content-fingerprint');
+const { loadExceptions, createExceptionResolver, EXCEPTIONS_PATH } = require('./lib/parity-exceptions');
 
 const ROOT = path.resolve(__dirname, '..');
-const EXCEPTIONS_PATH = path.join(ROOT, 'data', 'translation_parity_exceptions.json');
 
 const args = process.argv.slice(2);
 const reportIdx = args.indexOf('--report');
@@ -72,39 +72,12 @@ function lastCommit(rel) {
 }
 
 // ─── Exceptions ledger ──────────────────────────────────────────────────
+// Semantics (including what `suppress` scopes) live in
+// scripts/lib/parity-exceptions.js, shared with check-translation-parity.js
+// so the audit and the gate can't read the same entry two different ways.
 
-let exceptions = [];
-if (fs.existsSync(EXCEPTIONS_PATH)) {
-  try {
-    const parsed = JSON.parse(fs.readFileSync(EXCEPTIONS_PATH, 'utf8'));
-    exceptions = Array.isArray(parsed) ? parsed : parsed.exceptions || [];
-  } catch (e) {
-    console.error(`WARNING: could not parse ${path.relative(ROOT, EXCEPTIONS_PATH)}: ${e.message}`);
-  }
-}
-
-function findException(enUrl, localeUrl) {
-  return exceptions.find((ex) => ex.enUrl === enUrl && ex.localeUrl === localeUrl) || null;
-}
-
-function applySuppression(ex, diff) {
-  if (!ex) return diff;
-  const sup = ex.suppress || null;
-  if (!sup) {
-    // blanket exception: whole pair excused
-    return { onlyInEN: [], onlyInLocale: [], h2Delta: 0, faqDelta: 0, symbolTilesDelta: 0, suppressedAll: true };
-  }
-  const onlyInEN = diff.onlyInEN.filter((h) => !(sup.onlyInEN || []).includes(h));
-  const onlyInLocale = diff.onlyInLocale.filter((h) => !(sup.onlyInLocale || []).includes(h));
-  return {
-    onlyInEN,
-    onlyInLocale,
-    h2Delta: sup.h2Delta ? 0 : diff.h2Delta,
-    faqDelta: sup.faqDelta ? 0 : diff.faqDelta,
-    symbolTilesDelta: sup.symbolTilesDelta ? 0 : diff.symbolTilesDelta,
-    suppressedAll: false,
-  };
-}
+const exceptions = loadExceptions(EXCEPTIONS_PATH);
+const { findException, applySuppression } = createExceptionResolver(exceptions);
 
 // ─── Diff every cluster ────────────────────────────────────────────────
 

--- a/scripts/check-translation-parity.js
+++ b/scripts/check-translation-parity.js
@@ -36,9 +36,9 @@ const { discoverClusters, normalizeUrl } = require('./lib/translation-clusters')
 
 const SITE = 'https://ultratextgen.com';
 const { createFingerprinter } = require('./lib/content-fingerprint');
+const { loadExceptions, createExceptionResolver, EXCEPTIONS_PATH } = require('./lib/parity-exceptions');
 
 const ROOT = path.resolve(__dirname, '..');
-const EXCEPTIONS_PATH = path.join(ROOT, 'data', 'translation_parity_exceptions.json');
 
 const args = process.argv.slice(2);
 const baseIdx = args.indexOf('--base');
@@ -110,19 +110,42 @@ for (const [enUrl, members] of clusters) {
 }
 
 // ─── Exceptions ledger ──────────────────────────────────────────────────
+// Semantics (including what `suppress` scopes) live in
+// scripts/lib/parity-exceptions.js, shared with audit-translation-parity.js
+// so the audit and the gate can't read the same entry two different ways.
 
-let exceptions = [];
-if (fs.existsSync(EXCEPTIONS_PATH)) {
-  try {
-    const parsed = JSON.parse(fs.readFileSync(EXCEPTIONS_PATH, 'utf8'));
-    exceptions = Array.isArray(parsed) ? parsed : parsed.exceptions || [];
-  } catch (e) {
-    console.error(`WARNING: could not parse ${path.relative(ROOT, EXCEPTIONS_PATH)}: ${e.message}`);
-  }
-}
+const exceptions = loadExceptions(EXCEPTIONS_PATH);
+const { findException, isBlanket, applySuppression } = createExceptionResolver(exceptions);
 
-function hasException(enUrl, localeUrl) {
-  return exceptions.some((ex) => ex.enUrl === enUrl && ex.localeUrl === localeUrl);
+const partiallyExcused = []; // { enUrl, localeUrl } — entry exists but doesn't cover this change
+
+/**
+ * Does this pair's ledger entry excuse THIS branch's change to the page?
+ *
+ * An entry with no `suppress` block excuses the pair outright, as it always
+ * has. A scoped entry excuses only what it names: `suppress` is subtracted
+ * from the page's own before/after diff, and the pair is excused only if
+ * nothing is left over. So an entry agreed for an <h2> difference stops
+ * covering that pair the moment the same page loses an FAQ or a symbol tile.
+ *
+ * Before this, the gate matched on (enUrl, localeUrl) and ignored `suppress`
+ * entirely, making all 98 scoped entries behave as blanket ones in CI while
+ * the audit read them as written.
+ *
+ * `structuralDiff` is null for a page this branch adds — there is no prior
+ * state to scope against, so an entry excuses it outright.
+ */
+function pairExcused(enUrl, localeUrl, structuralDiff) {
+  const ex = findException(enUrl, localeUrl);
+  if (!ex) return false;
+  if (isBlanket(ex) || structuralDiff === null) return true;
+  // linksDirectionless: the gate's diff is before-vs-after of one page, so its
+  // onlyInEN/onlyInLocale mean removed/added rather than the audit's
+  // EN-side/locale-side. See parity-exceptions.js, "TWO DIFFS, ONE LEDGER".
+  const left = applySuppression(ex, structuralDiff, { linksDirectionless: true });
+  if (score(left) === 0) return true;
+  partiallyExcused.push({ enUrl, localeUrl });
+  return false;
 }
 
 /**
@@ -234,7 +257,7 @@ for (const rel of changedFiles) {
     const pairKey = `${enAnchor}|${rec.canonical}`;
     if (checkedPairs.has(pairKey)) continue;
     checkedPairs.add(pairKey);
-    if (hasException(enAnchor, rec.canonical)) continue;
+    if (pairExcused(enAnchor, rec.canonical, structuralDiff)) continue;
     if (changedSet.has(enRec.rel)) continue; // EN parent touched — presumed synced
 
     // Repairing drift is not creating it — see convergedTowards().
@@ -248,7 +271,7 @@ for (const rel of changedFiles) {
     // EN parent changed — any touched locale sibling counts as the sync
     const siblingRecs = members.map((u) => ({ url: u, rec: byUrl.get(u) })).filter((s) => s.rec);
     if (siblingRecs.length === 0) continue;
-    const nonExcepted = siblingRecs.filter((s) => !hasException(rec.canonical, s.url));
+    const nonExcepted = siblingRecs.filter((s) => !pairExcused(rec.canonical, s.url, structuralDiff));
     if (nonExcepted.length === 0) continue; // every pair individually excepted
 
     // EN is the source locale: a new EN page gets linked from existing EN
@@ -308,10 +331,19 @@ if (converged.length) {
 }
 
 if (flagged.length) {
+  const partial = new Set(partiallyExcused.map((p) => `${p.enUrl}|${p.localeUrl}`));
   for (const f of flagged) {
     console.log(`✗ ${f.changedRel} changed content, but its translation sibling was not updated in this branch:`);
     console.log(`    EN:     ${f.enRel}`);
     console.log(`    locale: ${f.localeRel}`);
+    if (partial.has(`${f.enUrl}|${f.localeUrl}`)) {
+      // Without this line a scoped entry reads as a ledger that isn't working.
+      console.log(
+        `    NOTE: this pair HAS a translation_parity_exceptions.json entry, but its` +
+          ` "suppress" block does not cover what changed here. Widen the entry only if` +
+          ` the new divergence was also discussed and agreed.`
+      );
+    }
     console.log(
       `    Fix: update the sibling in this PR, or add an entry to data/translation_parity_exceptions.json` +
         ` documenting why they're allowed to diverge (see CLAUDE.md, "Translation Parity").`

--- a/scripts/lib/parity-exceptions.js
+++ b/scripts/lib/parity-exceptions.js
@@ -1,0 +1,124 @@
+'use strict';
+
+/**
+ * parity-exceptions.js
+ *
+ * One definition of what data/translation_parity_exceptions.json MEANS,
+ * shared by audit-translation-parity.js (site sweep) and
+ * check-translation-parity.js (per-PR gate).
+ *
+ * WHY THIS FILE EXISTS
+ * --------------------
+ * The ledger's own `_readme` advertises a `suppress` field that scopes an
+ * entry to the specific divergence that was discussed:
+ *
+ *   suppress: { onlyInEN: [...hrefs], onlyInLocale: [...hrefs],
+ *               h2Delta: true, faqDelta: true, symbolTilesDelta: true }
+ *
+ * Omitting `suppress` means the whole pair is excused. The audit implemented
+ * that. The gate did not — it matched on (enUrl, localeUrl) and returned a
+ * boolean, so in CI every scoped entry behaved as a blanket one. 98 of the
+ * ledger's 177 entries carry a `suppress` block, so the field was being
+ * ignored on the majority of the ledger, and a pair excused for (say) an
+ * `<h2>` difference silently also excused a deleted FAQ or a dropped symbol
+ * tile on the same pair.
+ *
+ * CLAUDE.md's "Translation Parity" section requires that the audit and the
+ * gate never define "changed" differently, which is why the fingerprint/diff
+ * logic already lives in content-fingerprint.js. The ledger's semantics are
+ * the same kind of shared definition, so they live here rather than being
+ * copied into the gate.
+ *
+ * TWO DIFFS, ONE LEDGER
+ * ---------------------
+ * The two callers feed structurally different diffs into the same entry:
+ *
+ *   audit — diff(EN fingerprint, locale fingerprint).
+ *           onlyInEN   = "EN links it, the locale page doesn't"
+ *           onlyInLocale = "the locale page links it, EN doesn't"
+ *
+ *   gate  — diff(page before, page after) for ONE page.
+ *           onlyInEN   = "this branch removed this link"
+ *           onlyInLocale = "this branch added this link"
+ *
+ * The boolean counters (h2Delta/faqDelta/symbolTilesDelta) carry over
+ * unchanged — "this pair may differ in section count" excuses a section
+ * count that moved. The link lists don't: an entry naming a target under
+ * `onlyInEN` is recording that *this pair is allowed to differ on that
+ * target*, not which way a future edit will move it. So the gate reads both
+ * link lists as one set (`linksDirectionless`), and the audit keeps the
+ * directional reading its diff actually has. Same ledger, same fields, one
+ * documented difference in how a link list is applied.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const EXCEPTIONS_PATH = path.join(__dirname, '..', '..', 'data', 'translation_parity_exceptions.json');
+
+/** Read the ledger. A missing or malformed file yields [] with a warning. */
+function loadExceptions(filePath = EXCEPTIONS_PATH) {
+  if (!fs.existsSync(filePath)) return [];
+  try {
+    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    return Array.isArray(parsed) ? parsed : parsed.exceptions || [];
+  } catch (e) {
+    console.error(`WARNING: could not parse ${filePath}: ${e.message}`);
+    return [];
+  }
+}
+
+function createExceptionResolver(exceptions) {
+  /** The ledger entry for this exact (EN, locale) pair, or null. */
+  function findException(enUrl, localeUrl) {
+    return exceptions.find((ex) => ex.enUrl === enUrl && ex.localeUrl === localeUrl) || null;
+  }
+
+  /** An entry with no `suppress` block excuses the pair entirely. */
+  function isBlanket(ex) {
+    return Boolean(ex) && !ex.suppress;
+  }
+
+  /**
+   * Remove from `diff` exactly what this entry says the pair may differ on.
+   *
+   * @param {object|null} ex   ledger entry, or null for "no exception"
+   * @param {object} diff      a diff from content-fingerprint.js
+   * @param {object} [opts]
+   * @param {boolean} [opts.linksDirectionless]  treat suppress.onlyInEN and
+   *        suppress.onlyInLocale as one set of allowed-to-differ targets —
+   *        see "TWO DIFFS, ONE LEDGER" above. The gate sets this; the audit
+   *        does not.
+   * @returns {object} a diff of the same shape, safe to pass to score()
+   */
+  function applySuppression(ex, diff, opts = {}) {
+    if (!ex) return diff;
+    if (isBlanket(ex)) {
+      return {
+        onlyInEN: [],
+        onlyInLocale: [],
+        h2Delta: 0,
+        faqDelta: 0,
+        symbolTilesDelta: 0,
+        suppressedAll: true,
+      };
+    }
+    const sup = ex.suppress;
+    const supEN = sup.onlyInEN || [];
+    const supLocale = sup.onlyInLocale || [];
+    const allowedEN = opts.linksDirectionless ? [...supEN, ...supLocale] : supEN;
+    const allowedLocale = opts.linksDirectionless ? [...supEN, ...supLocale] : supLocale;
+    return {
+      onlyInEN: diff.onlyInEN.filter((h) => !allowedEN.includes(h)),
+      onlyInLocale: diff.onlyInLocale.filter((h) => !allowedLocale.includes(h)),
+      h2Delta: sup.h2Delta ? 0 : diff.h2Delta,
+      faqDelta: sup.faqDelta ? 0 : diff.faqDelta,
+      symbolTilesDelta: sup.symbolTilesDelta ? 0 : diff.symbolTilesDelta,
+      suppressedAll: false,
+    };
+  }
+
+  return { exceptions, findException, isBlanket, applySuppression };
+}
+
+module.exports = { loadExceptions, createExceptionResolver, EXCEPTIONS_PATH };


### PR DESCRIPTION
## The bug

`data/translation_parity_exceptions.json`'s own `_readme` advertises an optional `suppress` block that scopes an entry to the divergence that was actually discussed:

```
suppress: { onlyInEN: [...], onlyInLocale: [...],
            h2Delta: true, faqDelta: true, symbolTilesDelta: true }
```

`audit-translation-parity.js` implemented that. `check-translation-parity.js` — the half wired into CI — did not. It matched on `(enUrl, localeUrl)` and returned a boolean:

```js
function hasException(enUrl, localeUrl) {
  return exceptions.some((ex) => ex.enUrl === enUrl && ex.localeUrl === localeUrl);
}
```

So in CI, every scoped entry behaved as a blanket one.

**98 of the ledger's 177 entries carry a `suppress` block**, so the field was being ignored on the majority of the ledger. A pair excused for an `<h2>` difference also silently excused a deleted FAQ or a dropped symbol tile on that same pair — the gate could not tell them apart.

## The fix

The ledger's semantics now live in `scripts/lib/parity-exceptions.js`, and both scripts read them from there — the same reasoning that already put the fingerprint logic in `content-fingerprint.js`. Per CLAUDE.md, *"the audit and the enforcement gate must never define 'changed' or 'cluster' differently, so that shared logic lives in one place."* The ledger's meaning is that same kind of shared definition.

In the gate, a scoped entry is subtracted from the page's own before/after diff, and the pair is excused only if nothing is left over. A blanket entry (no `suppress`) still excuses the pair outright, exactly as before.

**One documented asymmetry.** The two callers feed structurally different diffs into the same entry — the audit compares EN against locale (`onlyInEN` = "EN links it, the locale doesn't"), while the gate compares one page before against after (`onlyInEN` = "this branch removed it"). The boolean counters carry over unchanged. The link lists don't, so the gate reads both lists as one set of allowed-to-differ targets: an entry naming a target is recording *that the pair may differ on it*, not which way a future edit will move it. Same ledger, one difference in application, written down in one place.

An entry whose `suppress` block doesn't cover what changed now says so in the failure output, so a scoped entry can't be mistaken for a ledger that isn't working.

## Verification

Per CLAUDE.md's own rule — *"Adding a validator script is not the same as gating on it. Before trusting a new check, confirm it actually fails a PR."*

**The refactor is behaviour-neutral for the audit:** full output diffed before and after — 25,066 lines, zero difference.

**Four probes against the gate**, each a real committed edit (file-change count asserted, so a probe that silently fails to apply can't read as a pass):

| probe | change | expected | result |
|---|---|---|---|
| A | add `/events/christmas/` to `vi/index.html` — a link that pair's entry explicitly names | pass | ✅ pass |
| B | drop `/usecase/bio-font/` from `vi/index.html` — **not** named by that entry | fail | ✅ fail, with the new NOTE |
| C | add a link on a **blanket**-excepted pair (`zh-tw/usecase/youxi-mingzi-fuhao`) | pass | ✅ pass |
| D | add a link on a pair with **no** ledger entry (`de/symbol/alpha-symbol`) | fail | ✅ fail |

Probe B is the demonstration: **the same input against the pre-fix gate exits 0 and reports `pairs with unsynced content change: 0`.** Old gate passes it, new gate catches it.

## Blast radius

The gate's trigger is per-edit, not per-pair state: it fires only when *this branch's* structural edit to a page falls outside what that pair's entry names. Existing EN↔locale divergence on an excepted pair does not trip it — probe A confirms this directly, passing on `vi/index.html`, a page carrying a residual audit score of 42.

So nothing turns red on merge. What changes is that a PR structurally editing one of the 97 scoped pairs **beyond what was agreed** now fails instead of passing silently.

No HTML changes; the parity gate reports "no changed HTML files" on this PR itself. `check:external-refs` and `check:workflows` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Z5v7CYFLxwgwo5H9K9tm5

---
_Generated by [Claude Code](https://claude.ai/code/session_016Z5v7CYFLxwgwo5H9K9tm5)_