### PR TITLE
feat(seo): add Naver Search Advisor site-verification file

### DIFF
--- a/naverfc08aab480545cfd1d61489b3536a5e6.html
+++ b/naverfc08aab480545cfd1d61489b3536a5e6.html
@@ -1,0 +1,1 @@
+naver-site-verification: naverfc08aab480545cfd1d61489b3536a5e6.html


### PR DESCRIPTION
Adds the HTML verification file Naver Search Advisor issued for ownership verification of https://ultratextgen.com/. Served as a static asset at the site root; not intercepted by functions/_middleware.js (scoped to "/" only via _routes.json) or by the _redirects catch-all, since Cloudflare Pages resolves an exact static-file match first.


Claude-Session: https://claude.ai/code/session_01YSYpujRG2btM69QM4VGhwz